### PR TITLE
CI: setup caching for any merge to main

### DIFF
--- a/.github/workflows/cache_image.yaml
+++ b/.github/workflows/cache_image.yaml
@@ -47,7 +47,6 @@ jobs:
     - name: Set Default cache location
       id: which_cache
       run: |
-        set +e
         echo "cache_from_location=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
         echo "cache_to_location=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
     - name: Build image

--- a/.github/workflows/cache_image.yaml
+++ b/.github/workflows/cache_image.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Cache base image
+
+on:
+  push:
+    branches:
+    - main
+
+  workflow_dispatch:
+    
+jobs:
+  build-test:
+    runs-on: ${{ fromJSON(vars.PR_FASTCHECK_RUNNERS) }}
+    strategy:
+      matrix:
+        framework:
+          - standard
+          - vllm
+    name: Build and Test - ${{ matrix.framework }}
+    env:
+      IMAGE_TAG: ghcr.io/dynemo-ai/dynemo:latest-${{ matrix.framework }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set Default cache location
+        id: which_cache
+        run: |
+          set +e
+          echo "cache_from_location=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
+          echo "cache_to_location=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
+      - name: Build image
+        env:
+          CACHE_FROM: "type=registry,ref=${{ steps.which_cache.outputs.cache_from_location }}"
+          CACHE_TO: "type=registry,ref=${{ steps.which_cache.outputs.cache_to_location }},image-manifest=true,mode=max"
+        run: |
+          ./container/build.sh --tag ${{ env.IMAGE_TAG }} --framework ${{ matrix.framework }} --cache-from "${{ env.CACHE_FROM }}" --cache-to "${{ env.CACHE_TO }}"

--- a/.github/workflows/cache_image.yaml
+++ b/.github/workflows/cache_image.yaml
@@ -26,33 +26,33 @@ jobs:
     strategy:
       matrix:
         framework:
-          - standard
-          - vllm
+        - standard
+        - vllm
     name: Build and Test - ${{ matrix.framework }}
     env:
       IMAGE_TAG: ghcr.io/dynemo-ai/dynemo:latest-${{ matrix.framework }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: main
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set Default cache location
-        id: which_cache
-        run: |
-          set +e
-          echo "cache_from_location=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
-          echo "cache_to_location=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
-      - name: Build image
-        env:
-          CACHE_FROM: "type=registry,ref=${{ steps.which_cache.outputs.cache_from_location }}"
-          CACHE_TO: "type=registry,ref=${{ steps.which_cache.outputs.cache_to_location }},image-manifest=true,mode=max"
-        run: |
-          ./container/build.sh --tag ${{ env.IMAGE_TAG }} --framework ${{ matrix.framework }} --cache-from "${{ env.CACHE_FROM }}" --cache-to "${{ env.CACHE_TO }}"
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: main
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set Default cache location
+      id: which_cache
+      run: |
+        set +e
+        echo "cache_from_location=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
+        echo "cache_to_location=${{ env.IMAGE_TAG }}" >> $GITHUB_OUTPUT
+    - name: Build image
+      env:
+        CACHE_FROM: "type=registry,ref=${{ steps.which_cache.outputs.cache_from_location }}"
+        CACHE_TO: "type=registry,ref=${{ steps.which_cache.outputs.cache_to_location }},image-manifest=true,mode=max"
+      run: |
+        ./container/build.sh --tag ${{ env.IMAGE_TAG }} --framework ${{ matrix.framework }} --cache-from "${{ env.CACHE_FROM }}" --cache-to "${{ env.CACHE_TO }}"

--- a/.github/workflows/cache_image.yaml
+++ b/.github/workflows/cache_image.yaml
@@ -16,12 +16,8 @@
 name: Cache base image
 
 on:
-  push:
-    branches:
-    - main
+  pull_request:
 
-  workflow_dispatch:
-    
 jobs:
   build-test:
     runs-on: ${{ fromJSON(vars.PR_FASTCHECK_RUNNERS) }}

--- a/.github/workflows/cache_image.yaml
+++ b/.github/workflows/cache_image.yaml
@@ -16,7 +16,9 @@
 name: Cache base image
 
 on:
-  pull_request:
+  push:
+    branches:
+    - main
 
 jobs:
   build-test:

--- a/.github/workflows/pr_github_validation.yaml
+++ b/.github/workflows/pr_github_validation.yaml
@@ -65,7 +65,7 @@ jobs:
           CACHE_FROM: "type=registry,ref=${{ steps.which_cache.outputs.cache_from_location }}"
           CACHE_TO: "type=registry,ref=${{ steps.which_cache.outputs.cache_to_location }},image-manifest=true,mode=max"
         run: |
-          ./container/build.sh --tag $IMAGE_TAG --framework ${{ matrix.framework }} --cache-from "${{ env.CACHE_FROM }}" --cache-to "${{ env.CACHE_TO }}"
+          ./container/build.sh --tag ${{ env.IMAGE_TAG }} --framework ${{ matrix.framework }} --cache-from "${{ env.CACHE_FROM }}" --cache-to "${{ env.CACHE_TO }}"
       - name: Run pytest
         env:
           PYTEST_MARKS: "pre_merge or mypy"


### PR DESCRIPTION
This will build a framework-specific image cache for each push onto `main` which should speed up building the image for the first CI run of a PR.