### PR TITLE
chore: remove ucx-py from requirements and fix UCX env variable

### DIFF
--- a/container/Dockerfile.vllm_nixl
+++ b/container/Dockerfile.vllm_nixl
@@ -127,6 +127,7 @@ RUN cd /opt/nixl && \
 ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
 ENV PYTHONPATH=/usr/local/nixl/lib/python3/dist-packages/:/opt/nixl/test/python/:$PYTHONPATH
 ENV UCX_TLS=^cuda_ipc
+ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/x86_64-linux-gnu/plugins
 
 RUN ls -l /usr/local/nixl/
 RUN ls -l /usr/local/nixl/include/

--- a/container/Dockerfile.vllm_nixl
+++ b/container/Dockerfile.vllm_nixl
@@ -115,7 +115,6 @@ ENV CPATH=/usr/local/ompi/include:$CPATH
 ENV PATH=/usr/local/ompi/bin:$PATH
 ENV PKG_CONFIG_PATH=/usr/local/ompi/lib/pkgconfig:$PKG_CONFIG_PATH
 
-
 COPY --from=nixl . /opt/nixl
 
 RUN cd /opt/nixl && \
@@ -127,6 +126,7 @@ RUN cd /opt/nixl && \
 
 ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
 ENV PYTHONPATH=/usr/local/nixl/lib/python3/dist-packages/:/opt/nixl/test/python/:$PYTHONPATH
+ENV UCX_TLS=^cuda_ipc
 
 RUN ls -l /usr/local/nixl/
 RUN ls -l /usr/local/nixl/include/

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -31,6 +31,4 @@ sentencepiece
 transformers
 tritonclient==2.53.0
 types-PyYAML
-# TODO: See whether TRT-LLM installs a different version of UCX. Need to revisit and track this dependency.
-ucx-py-cu12
 uvicorn


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

`ENV UCX_TLS=^cuda_ipc` fixes longer request post time when transferring intra node.

ucx-py is not used anywhere and can potentially have some conflicts with ucx installed in the docker.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
