### PR TITLE
feat: make block_size input for indexer, router, publisher

### DIFF
--- a/container/deps/vllm/vllm_v0.7.2-dynamo-kv-disagg-patch.patch
+++ b/container/deps/vllm/vllm_v0.7.2-dynamo-kv-disagg-patch.patch
@@ -247,7 +247,7 @@ index 1ca9e49d..b1591c0c 100644
  
          # Reuse the cached content hash
 diff --git a/vllm/core/block_manager.py b/vllm/core/block_manager.py
-index c5b3b04f..c72001f7 100644
+index c5b3b04f..12cd4dc9 100644
 --- a/vllm/core/block_manager.py
 +++ b/vllm/core/block_manager.py
 @@ -10,7 +10,10 @@ from vllm.core.block.interfaces import Block
@@ -269,7 +269,7 @@ index c5b3b04f..c72001f7 100644
          block_size: int,
          num_gpu_blocks: int,
          num_cpu_blocks: int,
-@@ -91,11 +95,28 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
+@@ -91,11 +95,29 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
  
          self.watermark_blocks = int(watermark * num_gpu_blocks)
  
@@ -285,7 +285,8 @@ index c5b3b04f..c72001f7 100644
 +                namespace=VLLM_KV_NAMESPACE,
 +                component=VLLM_KV_COMPONENT,
 +                worker_id=VLLM_WORKER_ID,
-+                lib_path=VLLM_KV_CAPI_PATH)
++                lib_path=VLLM_KV_CAPI_PATH,
++                kv_block_size=block_size)
 +        else:
 +            self.event_manager = None
 +
@@ -300,10 +301,10 @@ index c5b3b04f..c72001f7 100644
          self.block_tables: Dict[SeqId, BlockTable] = {}
 diff --git a/vllm/core/event_manager.py b/vllm/core/event_manager.py
 new file mode 100644
-index 00000000..d3706700
+index 00000000..a27af580
 --- /dev/null
 +++ b/vllm/core/event_manager.py
-@@ -0,0 +1,102 @@
+@@ -0,0 +1,108 @@
 +# SPDX-License-Identifier: Apache-2.0
 +import ctypes
 +import logging
@@ -324,16 +325,22 @@ index 00000000..d3706700
 +class KVCacheEventManager:
 +
 +    def __init__(self, namespace: str, component: str, worker_id: int,
-+                 lib_path: str):
++                 lib_path: str, kv_block_size: int):
 +        self.lib = None
 +
 +        try:
 +            self.lib = ctypes.CDLL(lib_path)
-+            self.lib.dynamo_llm_init.argtypes = [c_char_p, c_char_p, c_int64]
++            self.lib.dynamo_llm_init.argtypes = [
++                c_char_p,
++                c_char_p,
++                c_int64,
++                c_uint32,
++            ]
 +            self.lib.dynamo_llm_init.restype = c_uint32
 +
-+            result = self.lib.dynamo_llm_init(namespace.encode(),
-+                                              component.encode(), worker_id)
++            result = self.lib.dynamo_llm_init(
++                namespace.encode(), component.encode(), worker_id, kv_block_size
++            )
 +            if result == DynamoResult.OK:
 +                logger.info(
 +                    "KVCacheEventManager initialized successfully. Ready to publish KV Cache Events"

--- a/examples/python_rs/llm/vllm/README.md
+++ b/examples/python_rs/llm/vllm/README.md
@@ -261,7 +261,8 @@ cd /workspace/examples/python_rs/llm/vllm
 RUST_LOG=info python3 -m kv_router.router \
     --routing-strategy prefix \
     --model-name deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
-    --min-workers 1
+    --min-workers 1 \
+    --block-size 64
 ```
 
 You can choose only the prefix strategy for now:

--- a/examples/python_rs/llm/vllm/scripts/kv-router-run.sh
+++ b/examples/python_rs/llm/vllm/scripts/kv-router-run.sh
@@ -63,7 +63,7 @@ PROCESSOR_CMD="RUST_LOG=info python3 -m kv_router.processor \
     --model $MODEL_NAME \
     --tokenizer $MODEL_NAME \
     --enable-prefix-caching \
-    --block-size 64 \
+    --block-size 32 \
     --max-model-len 16384 "
 tmux new-session -d -s "$SESSION_NAME-processor"
 tmux send-keys -t "$SESSION_NAME-processor" "$INIT_CMD && $PROCESSOR_CMD" C-m
@@ -74,7 +74,8 @@ tmux send-keys -t "$SESSION_NAME-processor" "$INIT_CMD && $PROCESSOR_CMD" C-m
 ROUTER_CMD="RUST_LOG=info python3 -m kv_router.router \
     --model $MODEL_NAME \
     --routing-strategy $ROUTING_STRATEGY \
-    --min-workers $NUM_WORKERS "
+    --min-workers $NUM_WORKERS \
+    --block-size 32"
 
 tmux new-session -d -s "$SESSION_NAME-router"
 tmux send-keys -t "$SESSION_NAME-router" "$INIT_CMD && $ROUTER_CMD" C-m

--- a/examples/python_rs/llm/vllm/sdk_kv_router/router.py
+++ b/examples/python_rs/llm/vllm/sdk_kv_router/router.py
@@ -51,6 +51,7 @@ class Router:
         self.routing_strategy = RoutingStrategy.PREFIX
         self.runtime = dynamo_context["runtime"]
         self.min_workers = 1
+        self.kv_block_size = 64
 
     @async_onstart
     async def init_engine(self):
@@ -77,7 +78,7 @@ class Router:
 
         kv_listener = self.runtime.namespace("dynamo").component(self.model_name)
         await kv_listener.create_service()
-        self.router = KvRouter(self.runtime, kv_listener)
+        self.router = KvRouter(self.runtime, kv_listener, self.kv_block_size)
 
     @dynamo_endpoint()
     async def generate(self, request: Tokens):

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -53,6 +53,7 @@ pub unsafe extern "C" fn dynamo_llm_init(
     namespace_c_str: *const c_char,
     component_c_str: *const c_char,
     worker_id: i64,
+    kv_block_size: u32,
 ) -> DynamoLlmResult {
     initialize_tracing();
     let wk = match WK.get_or_try_init(Worker::from_settings) {
@@ -94,9 +95,9 @@ pub unsafe extern "C" fn dynamo_llm_init(
     };
 
     match result {
-        Ok(_) => match KV_PUB
-            .get_or_try_init(move || dynamo_create_kv_publisher(namespace, component, worker_id))
-        {
+        Ok(_) => match KV_PUB.get_or_try_init(move || {
+            dynamo_create_kv_publisher(namespace, component, worker_id, kv_block_size as usize)
+        }) {
             Ok(_) => DynamoLlmResult::OK,
             Err(e) => {
                 eprintln!("Failed to initialize distributed runtime: {:?}", e);
@@ -138,6 +139,7 @@ fn dynamo_create_kv_publisher(
     namespace: String,
     component: String,
     worker_id: i64,
+    kv_block_size: usize,
 ) -> Result<KvEventPublisher, anyhow::Error> {
     tracing::info!("Creating KV Publisher for model: {}", component);
     match DRT
@@ -146,7 +148,7 @@ fn dynamo_create_kv_publisher(
     {
         Ok(drt) => {
             let backend = drt.namespace(namespace)?.component(component)?;
-            KvEventPublisher::new(drt.clone(), backend, worker_id)
+            KvEventPublisher::new(drt.clone(), backend, worker_id, kv_block_size)
         }
         Err(e) => Err(e),
     }
@@ -156,10 +158,13 @@ fn kv_event_create_stored_block_from_parts(
     block_hash: u64,
     token_ids: *const u32,
     num_tokens: usize,
+    kv_block_size: usize,
     _lora_id: u64,
 ) -> KvCacheStoredBlockData {
-    let tokens_hash =
-        compute_block_hash_for_seq(unsafe { std::slice::from_raw_parts(token_ids, num_tokens) })[0];
+    let tokens_hash = compute_block_hash_for_seq(
+        unsafe { std::slice::from_raw_parts(token_ids, num_tokens) },
+        kv_block_size,
+    )[0];
     KvCacheStoredBlockData {
         block_hash: ExternalSequenceBlockHash(block_hash),
         tokens_hash,
@@ -168,23 +173,22 @@ fn kv_event_create_stored_block_from_parts(
 static WARN_COUNT: AtomicU32 = AtomicU32::new(0);
 
 fn kv_event_create_stored_from_parts(
-    event_id: u64,
-    token_ids: *const u32,
-    num_block_tokens: *const usize,
-    block_ids: *const u64,
-    num_blocks: usize,
-    parent_hash: Option<u64>,
-    lora_id: u64,
+    kv_params: DynamoKvStoredEventParams,
+    kv_block_size: usize,
 ) -> KvCacheEvent {
     let mut blocks: Vec<KvCacheStoredBlockData> = Vec::new();
 
     let mut token_offset: usize = 0;
-    for block_idx in 0..num_blocks {
-        let block_hash = unsafe { *block_ids.offset(block_idx.try_into().unwrap()) };
-        let tokens = unsafe { token_ids.offset(token_offset.try_into().unwrap()) };
-        let num_toks = unsafe { *num_block_tokens.offset(block_idx.try_into().unwrap()) };
-        // compute hash only apply to full block (KV_BLOCK_SIZE token)
-        if num_toks != 64 {
+    for block_idx in 0..kv_params.num_blocks {
+        let block_hash = unsafe { *kv_params.block_ids.offset(block_idx.try_into().unwrap()) };
+        let tokens = unsafe { kv_params.token_ids.offset(token_offset.try_into().unwrap()) };
+        let num_toks = unsafe {
+            *kv_params
+                .num_block_tokens
+                .offset(block_idx.try_into().unwrap())
+        };
+
+        if num_toks != kv_block_size {
             if WARN_COUNT
                 .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |c| {
                     if c < 3 {
@@ -196,7 +200,8 @@ fn kv_event_create_stored_from_parts(
                 .is_ok()
             {
                 tracing::warn!(
-                    "Block size must be 64 tokens to be published. Block size is: {}",
+                    "Block not published. Block size must be {} tokens to be published. Block size is: {}",
+                    kv_block_size,
                     num_toks
                 );
             }
@@ -204,16 +209,20 @@ fn kv_event_create_stored_from_parts(
         }
         token_offset += num_toks;
         blocks.push(kv_event_create_stored_block_from_parts(
-            block_hash, tokens, num_toks, lora_id,
+            block_hash,
+            tokens,
+            num_toks,
+            kv_block_size,
+            kv_params.lora_id,
         ));
     }
 
     KvCacheEvent {
         data: KvCacheEventData::Stored(KvCacheStoreData {
             blocks,
-            parent_hash: parent_hash.map(ExternalSequenceBlockHash),
+            parent_hash: kv_params.parent_hash.map(ExternalSequenceBlockHash),
         }),
-        event_id,
+        event_id: kv_params.event_id,
     }
 }
 
@@ -234,6 +243,16 @@ fn kv_event_create_removed_from_parts(
     }
 }
 
+pub struct DynamoKvStoredEventParams {
+    pub event_id: u64,
+    pub token_ids: *const u32,
+    pub num_block_tokens: *const usize,
+    pub block_ids: *const u64,
+    pub num_blocks: usize,
+    pub parent_hash: Option<u64>,
+    pub lora_id: u64,
+}
+
 /// # Safety
 /// parent_hash is passed as pointer to indicate whether the blocks
 /// has a parent hash or not. nullptr is used to represent no parent hash
@@ -247,7 +266,6 @@ pub unsafe extern "C" fn dynamo_kv_event_publish_stored(
     parent_hash: *const u64,
     lora_id: u64,
 ) -> DynamoLlmResult {
-    let publisher = KV_PUB.get().unwrap();
     let parent_hash = {
         if parent_hash.is_null() {
             None
@@ -255,7 +273,7 @@ pub unsafe extern "C" fn dynamo_kv_event_publish_stored(
             Some(unsafe { *parent_hash })
         }
     };
-    let event = kv_event_create_stored_from_parts(
+    let kv_params = DynamoKvStoredEventParams {
         event_id,
         token_ids,
         num_block_tokens,
@@ -263,7 +281,9 @@ pub unsafe extern "C" fn dynamo_kv_event_publish_stored(
         num_blocks,
         parent_hash,
         lora_id,
-    );
+    };
+    let publisher = KV_PUB.get().unwrap();
+    let event = kv_event_create_stored_from_parts(kv_params, publisher.kv_block_size());
     match publisher.publish(event) {
         Ok(_) => DynamoLlmResult::OK,
         Err(e) => {
@@ -290,68 +310,33 @@ pub extern "C" fn dynamo_kv_event_publish_removed(
     }
 }
 
-// #[no_mangle]
-// pub extern "C" fn dynamo_kv_publish_store_event(
-//     event_id: u64,
-//     token_ids: *const u32,
-//     num_tokens: usize,
-//     lora_id: u64,
-// ) -> DynamoLlmResult {
-//     // if event.is_null() || token_ids.is_null() {
-//     //     return dynamoKvErrorType::INVALID_TOKEN_IDS;
-//     // }
+// Need to setup etcd and nats to run these tests
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use std::ffi::CString;
 
-//     // let tokens = unsafe { std::slice::from_raw_parts(token_ids, num_tokens) }.to_vec();
-//     // let new_event = Box::new(KvCacheStoreData {
-//     //     event_id,
-//     //     lora_id,
-//     //     token_ids: tokens,
-//     //     block_hashes: Vec::new(),
-//     // });
+//     #[test]
+//     fn test_dynamo_llm_init() {
+//         // Create C-compatible strings
+//         let namespace = CString::new("test_namespace").unwrap();
+//         let component = CString::new("test_component").unwrap();
 
-//     // unsafe { *event = Box::into_raw(new_event) };
+//         // Call the init function
+//         let result = unsafe {
+//             dynamo_llm_init(
+//                 namespace.as_ptr(),
+//                 component.as_ptr(),
+//                 1,  // worker_id
+//                 32, // kv_block_size
+//             )
+//         };
 
-//     DynamoLlmResult::OK
-// }
+//         assert_eq!(result as u32, DynamoLlmResult::OK as u32);
 
-// #[no_mangle]
-// pub extern "C" fn dynamo_kv_event_create_removed(
-//     event_id: u64,
-//     block_hashes: *const u64,
-//     num_hashes: usize,
-// ) -> DynamoLlmResult {
-//     // if event.is_null() || block_hashes.is_null() {
-//     //     return -1;
-//     // }
+//         assert!(WK.get().is_some());
 
-//     // let hashes = unsafe { std::slice::from_raw_parts(block_hashes, num_hashes) }.to_vec();
-//     // let new_event = Box::new(KvCacheRemoveData {
-//     //     event_id,
-//     //     lora_id: 0,
-//     //     token_ids: Vec::new(),
-//     //     block_hashes: hashes,
-//     // });
-
-//     // unsafe { *event = Box::into_raw(new_event) };
-//     // 0
-//     DynamoLlmResult::OK
-// }
-
-// /// create load publisher object and return a handle
-// /// load publisher will instantiate the nats service and tie its stats handler to
-// /// a watch channel receiver.  the watch channel sender will be attach to the
-// /// handle and calls to [`dynamo_load_stats_publish`] issue the stats to the watch t
-// pub extern "C" fn dynamo_load_publisher_create() -> *mut LoadPublisher {
-//     // let publisher = Box::new(LoadPublisher::new());
-//     // Box::into_raw(publisher)
-// }
-
-// pub extern "C" fn dynamo_load_stats_publish(
-//     publisher: *mut LoadPublisher,
-//     active_slots: u64,
-//     total_slots: u64,
-//     active_kv: u64,
-//     total_kv: u64,
-// ) {
-//     // let publisher = unsafe { &mut *publisher };
+//         let shutdown_result = dynamo_llm_shutdown();
+//         assert_eq!(shutdown_result as u32, DynamoLlmResult::OK as u32);
+//     }
 // }

--- a/lib/llm/Cargo.lock
+++ b/lib/llm/Cargo.lock
@@ -1447,6 +1447,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rstest",
+ "rstest_reuse",
  "semver",
  "sentencepiece",
  "serde",
@@ -4645,6 +4646,17 @@ dependencies = [
  "rustc_version",
  "syn 2.0.98",
  "unicode-ident",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
+dependencies = [
+ "quote",
+ "rand",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -164,6 +164,7 @@ pythonize = { version = "0.23", optional = true }
 proptest = "1.5.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 rstest = "0.18.2"
+rstest_reuse = "0.7.0"
 tempfile = "3.17.1"
 hf-hub = "0.4.1"
 insta = { version = "1.41", features = [

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -54,6 +54,7 @@ impl KvRouter {
     pub async fn from_runtime(
         runtime: DistributedRuntime,
         backend: Component,
+        kv_block_size: usize,
     ) -> Result<Arc<Self>> {
         let nats_client = runtime.nats_client();
         let service_name = backend.service_name();
@@ -63,7 +64,14 @@ impl KvRouter {
         tracing::info!("Component Namespace {}", backend.namespace());
         tracing::info!("Component Service Name {}", service_name);
         tracing::info!("KV Subject {}", kv_subject);
-        Self::new(nats_client, service_name, kv_subject, namespace).await
+        Self::new(
+            nats_client,
+            service_name,
+            kv_subject,
+            namespace,
+            kv_block_size,
+        )
+        .await
     }
 
     pub async fn new(
@@ -71,6 +79,7 @@ impl KvRouter {
         service_name: String,
         kv_subject: String,
         namespace: Namespace,
+        kv_block_size: usize,
     ) -> Result<Arc<Self>> {
         let cancellation_token = CancellationToken::new();
         let (ep_tx, ep_rx) = tokio::sync::mpsc::channel(128);
@@ -82,8 +91,8 @@ impl KvRouter {
             cancellation_token.clone(),
         ));
 
-        let indexer = KvIndexer::new(cancellation_token.clone());
-        let scheduler = KvScheduler::start(ep_rx, namespace).await?;
+        let indexer = KvIndexer::new(cancellation_token.clone(), kv_block_size);
+        let scheduler = KvScheduler::start(ep_rx, namespace, kv_block_size).await?;
 
         tracing::debug!("subscribing to kv events: {}", kv_subject);
         let mut kv_events_rx = nats_client.client().subscribe(kv_subject).await?;

--- a/lib/llm/src/kv_router/protocols.rs
+++ b/lib/llm/src/kv_router/protocols.rs
@@ -15,13 +15,6 @@
 
 use serde::{Deserialize, Serialize};
 
-// Currently hard-coding the block size to be 64 tokens, and
-// assuming the LLM framework aligns with this size.
-// The KV publisher and subscriber conveys hash values of the tokens,
-// for performance reason, therefore the block size needs to be consistent
-// so that the computed hash value is the same on both sizes.
-pub const KV_BLOCK_SIZE: usize = 64;
-
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ForwardPassMetrics {
     pub request_active_slots: u64,

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -31,12 +31,18 @@ use tracing as log;
 
 pub struct KvEventPublisher {
     tx: mpsc::UnboundedSender<KvCacheEvent>,
+    kv_block_size: usize,
 }
 
 impl KvEventPublisher {
-    pub fn new(drt: DistributedRuntime, backend: Component, worker_id: i64) -> Result<Self> {
+    pub fn new(
+        drt: DistributedRuntime,
+        backend: Component,
+        worker_id: i64,
+        kv_block_size: usize,
+    ) -> Result<Self> {
         let (tx, rx) = mpsc::unbounded_channel::<KvCacheEvent>();
-        let p = KvEventPublisher { tx };
+        let p = KvEventPublisher { tx, kv_block_size };
 
         start_publish_task(drt, backend, worker_id, rx);
         Ok(p)
@@ -45,6 +51,10 @@ impl KvEventPublisher {
     pub fn publish(&self, event: KvCacheEvent) -> Result<(), mpsc::error::SendError<KvCacheEvent>> {
         log::debug!("Publish event: {:?}", event);
         self.tx.send(event)
+    }
+
+    pub fn kv_block_size(&self) -> usize {
+        self.kv_block_size
     }
 }
 

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -20,7 +20,7 @@ use std::borrow::BorrowMut;
 use std::cmp::min;
 
 use crate::kv_router::indexer::OverlapScores;
-pub use crate::kv_router::protocols::{ForwardPassMetrics, KV_BLOCK_SIZE};
+pub use crate::kv_router::protocols::ForwardPassMetrics;
 use crate::kv_router::scoring::ProcessedEndpoints;
 use crate::kv_router::KV_HIT_RATE_SUBJECT;
 
@@ -112,6 +112,7 @@ impl KvScheduler {
     pub async fn start(
         endpoints_rx: tokio::sync::mpsc::Receiver<ProcessedEndpoints>,
         ns: Namespace,
+        kv_block_size: usize,
     ) -> Result<Self, KvSchedulerError> {
         let mut endpoints_rx = endpoints_rx;
 
@@ -178,7 +179,8 @@ impl KvScheduler {
                 };
                 tracing::debug!("selected");
                 loop {
-                    match select_worker(endpoints.borrow_mut(), &request, &event_tx) {
+                    match select_worker(endpoints.borrow_mut(), &request, &event_tx, kv_block_size)
+                    {
                         Ok(worker_id) => {
                             request.respond(worker_id);
                             continue 'outer;
@@ -237,6 +239,7 @@ pub fn select_worker(
     workers: &mut ProcessedEndpoints,
     request: &SchedulingRequest,
     event_tx: &tokio::sync::mpsc::UnboundedSender<KVHitRateEvent>,
+    kv_block_size: usize,
 ) -> Result<i64, KvSchedulerError> {
     // balance mode prioritizes balancing load across workers
     let balance_threshold: f64 = 0.1;
@@ -249,7 +252,7 @@ pub fn select_worker(
     // Compute each worker's score
     let mut best_index = None;
     let mut best_cost = f64::INFINITY;
-
+    // [FIXME] REMOVE ONLY FOR TESTING
     if workers.endpoints.is_empty() {
         return Err(KvSchedulerError::NoEndpoints);
     }
@@ -268,7 +271,7 @@ pub fn select_worker(
         // [FIXME] multiple endpoints of the same worker cause out of bound error
         let worker_id = workers.worker_ids[i];
         let overlap_score = request.overlap.scores.get(&worker_id).map_or(0, |x| *x);
-        let overlap_score = overlap_score as usize * KV_BLOCK_SIZE;
+        let overlap_score = overlap_score as usize * kv_block_size;
 
         let new_tokens = request.isl_tokens.saturating_sub(overlap_score);
         let normalized_new_tokens = new_tokens as f64 / request.isl_tokens as f64;
@@ -296,14 +299,14 @@ pub fn select_worker(
     }
 
     if let Some(best_index) = best_index {
-        let total_blocks = min(request.isl_tokens / KV_BLOCK_SIZE, 1);
+        let total_blocks = min(request.isl_tokens / kv_block_size, 1);
 
         workers.endpoints[best_index].data.request_active_slots += 1;
         workers.endpoints[best_index].data.kv_active_blocks += total_blocks as u64;
 
         // Optimization - pass this to a channel for emitting events, async task, etc. to avoid blocking the scheduler
         let best_worker_id = workers.endpoints[best_index].worker_id();
-        let isl_blocks = request.isl_tokens / KV_BLOCK_SIZE;
+        let isl_blocks = request.isl_tokens / kv_block_size;
         let overlap_blocks = request
             .overlap
             .scores


### PR DESCRIPTION
#### Overview:

Block size was fixed to 64, this PR supports arbitrary block size as long as block_size chosen for publishing and indexing match and all the engines tied to one router have the same block size.

#### Details:

1) The indexer takes block size as an argument
2) The rust KV Router takes block size as an argument
3) The publisher in the c bindings takes block size as an argument

Updates vLLM to pass block_size parameter to the publisher and create patch.

Patch created off of:
Commit ID: ed3d70a501e8c1ee59c95ee6ed2ca58314b18eda
PR: https://gitlab-master.nvidia.com/dl/vllm/vllm/-/merge_requests/303
