### PR TITLE
fix(dynamo-run): Text input doesn't need a name

### DIFF
--- a/launch/dynamo-run/README.md
+++ b/launch/dynamo-run/README.md
@@ -170,12 +170,12 @@ Build: `cargo build --release --features python`
 If the Python engine wants to receive and returns strings - it will do the prompt templating and tokenization itself - run it like this:
 
 ```
-dynamo-run out=pystr:/home/user/my_python_engine.py --name <model-name>
+dynamo-run out=pystr:/home/user/my_python_engine.py
 ```
 
 - The `request` parameter is a map, an OpenAI compatible create chat completion request: https://platform.openai.com/docs/api-reference/chat/create
 - The function must `yield` a series of maps conforming to create chat completion stream response (example below).
-- The `--name` flag is the name we serve the model under, if using an HTTP front end.
+- If using an HTTP front-end add the `--model-name` flag. This is the name we serve the model under.
 
 The file is loaded once at startup and kept in memory.
 
@@ -218,7 +218,7 @@ dynamo-run out=pytok:/home/user/my_python_engine.py --model-path <hf-repo-checko
 {"token_ids":[791],"tokens":None,"text":None,"cum_log_probs":None,"log_probs":None,"finish_reason":None}
 ```
 
-- Command like flag `--model-path` which must point to a Hugging Face repo checkout containing the `tokenizer.json`. The `--name` flag is optional. If not provided we use the HF repo name (directory name) as the model name.
+- Command like flag `--model-path` which must point to a Hugging Face repo checkout containing the `tokenizer.json`. The `--model-name` flag is optional. If not provided we use the HF repo name (directory name) as the model name.
 
 Example engine:
 ```

--- a/launch/dynamo-run/src/opt.rs
+++ b/launch/dynamo-run/src/opt.rs
@@ -17,6 +17,7 @@ use std::fmt;
 
 use crate::ENDPOINT_SCHEME;
 
+#[derive(PartialEq)]
 pub enum Input {
     /// Run an OpenAI compatible HTTP server
     Http,


### PR DESCRIPTION
For the `echo` and `pystr` engines we previously required the user to pass `--model-name <x>` so we would have a name for the model. If the input is HTTP we do need this to match on the users' JSON request.

If the input is Text we don't need a name. So if the input is Text and we don't already have a name for the model, give it one.
