### PR TITLE
fix: Add missing arg to echo_full example and source cargo env in setup steps

### DIFF
--- a/launch/dynamo-run/README.md
+++ b/launch/dynamo-run/README.md
@@ -303,7 +303,7 @@ dynamo-run in=http out=echo_core --model-path <hf-repo-checkout>
 The `echo_full` engine accepts un-processed requests and echoes the prompt back as the response.
 
 ```
-dynamo-run in=http out=echo_full
+dynamo-run in=http out=echo_full --model-name my_model
 ```
 
 ### Configuration

--- a/launch/dynamo-run/README.md
+++ b/launch/dynamo-run/README.md
@@ -12,6 +12,7 @@ apt install -y build-essential libhwloc-dev libudev-dev pkg-config libssl-dev pr
 Install Rust:
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
 ```
 
 ## Build


### PR DESCRIPTION
Avoid copy/pasting into this error:
```
$ dynamo-run in=http out=echo_full
2025-03-11T22:20:58.314062Z ERROR dynamo_runtime::worker: Application shutdown with error: Pass --model-name or --model-path so we know which model to imitate
Error: Pass --model-name or --model-path so we know which model to imitate
```