### PR TITLE
build: add CARGO_BUILD_JOBS argument to Dockerfiles

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+jobs = "$(if [ $(nproc) -gt 32 ]; then echo 32; else echo $(nproc); fi)" 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-jobs = "$(if [ $(nproc) -gt 2 ]; then echo 2; else echo $(nproc); fi)" 
+jobs = "$(if [ $(nproc) -gt 32 ]; then echo 32; else echo $(nproc); fi)"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-jobs = "$(if [ $(nproc) -gt 32 ]; then echo 32; else echo $(nproc); fi)"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-jobs = "$(if [ $(nproc) -gt 32 ]; then echo 32; else echo $(nproc); fi)" 
+jobs = "$(if [ $(nproc) -gt 2 ]; then echo 2; else echo $(nproc); fi)" 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -126,7 +126,7 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-RUN nproc && CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN export CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
 RUN echo $CARGO_BUILD_JOBS
 
 # Build Rust runtime

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -126,7 +126,8 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-RUN CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN nproc && CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN env|grep CARGO_BUILD_JOBS
 
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -127,7 +127,7 @@ COPY README.md /workspace/
 COPY LICENSE /workspace/
 
 # Build Rust runtime
-COPY .cargo /workspace/.cargo
+ENV CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
     cargo build --release --locked && cargo doc --no-deps

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -126,7 +126,7 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-ENV CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
 
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -127,6 +127,7 @@ COPY README.md /workspace/
 COPY LICENSE /workspace/
 
 # Build Rust runtime
+COPY .cargo /workspace/.cargo
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
     cargo build --release --locked && cargo doc --no-deps

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -126,8 +126,9 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-# Build Rust runtime
 ENV CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+
+# Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
     cargo build --release --locked && cargo doc --no-deps

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -126,8 +126,7 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-RUN export CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
-RUN echo $CARGO_BUILD_JOBS
+ARG CARGO_BUILD_JOBS
 
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -127,7 +127,7 @@ COPY README.md /workspace/
 COPY LICENSE /workspace/
 
 RUN nproc && CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
-RUN env|grep CARGO_BUILD_JOBS
+RUN echo $CARGO_BUILD_JOBS
 
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -71,7 +71,7 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-RUN CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN nproc && CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
 RUN env|grep CARGO_BUILD_JOBS
 
 # Build Rust runtime

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -71,7 +71,8 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-ENV CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN env|grep CARGO_BUILD_JOBS
 
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -71,8 +71,7 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-RUN export CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
-RUN echo $CARGO_BUILD_JOBS
+ARG CARGO_BUILD_JOBS
 
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -72,7 +72,7 @@ COPY README.md /workspace/
 COPY LICENSE /workspace/
 
 # Build Rust runtime
-COPY .cargo /workspace/.cargo
+ENV CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
     cargo build --release --locked && cargo doc --no-deps

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -72,7 +72,7 @@ COPY README.md /workspace/
 COPY LICENSE /workspace/
 
 RUN nproc && CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
-RUN env|grep CARGO_BUILD_JOBS
+RUN echo $CARGO_BUILD_JOBS
 
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -71,7 +71,7 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-RUN nproc && CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN export CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
 RUN echo $CARGO_BUILD_JOBS
 
 # Build Rust runtime

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -72,6 +72,7 @@ COPY README.md /workspace/
 COPY LICENSE /workspace/
 
 # Build Rust runtime
+COPY .cargo /workspace/.cargo
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
     cargo build --release --locked && cargo doc --no-deps

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -71,8 +71,9 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-# Build Rust runtime
 ENV CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+
+# Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
     cargo build --release --locked && cargo doc --no-deps

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -210,7 +210,7 @@ COPY README.md /workspace/
 COPY LICENSE /workspace/
 
 # Build Rust runtime
-COPY .cargo /workspace/.cargo
+ENV CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
     cargo build --release --locked && cargo doc --no-deps

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -210,6 +210,7 @@ COPY README.md /workspace/
 COPY LICENSE /workspace/
 
 # Build Rust runtime
+COPY .cargo /workspace/.cargo
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
     cargo build --release --locked && cargo doc --no-deps

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -209,8 +209,9 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-# Build Rust runtime
 ENV CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+
+# Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
     cargo build --release --locked && cargo doc --no-deps

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -209,7 +209,7 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-RUN nproc && CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN export CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
 RUN echo $CARGO_BUILD_JOBS
 
 # Build Rust runtime

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -210,7 +210,7 @@ COPY README.md /workspace/
 COPY LICENSE /workspace/
 
 RUN nproc && CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
-RUN env|grep CARGO_BUILD_JOBS
+RUN echo $CARGO_BUILD_JOBS
 
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -209,8 +209,7 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-RUN export CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
-RUN echo $CARGO_BUILD_JOBS
+ARG CARGO_BUILD_JOBS
 
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -209,7 +209,7 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-RUN CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN nproc && CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
 RUN env|grep CARGO_BUILD_JOBS
 
 # Build Rust runtime

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -209,7 +209,8 @@ COPY pyproject.toml /workspace/
 COPY README.md /workspace/
 COPY LICENSE /workspace/
 
-ENV CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN CARGO_BUILD_JOBS=$(( $(nproc) > 32 ? 32 : $(nproc) ))
+RUN env|grep CARGO_BUILD_JOBS
 
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime


### PR DESCRIPTION
#### Overview:

Add CARGO_BUILD_JOBS build argument to all Dockerfiles to allow
controlling the number of parallel jobs when building Rust components.
This enables better resource utilization during container builds.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
