### PR TITLE
fix(dynamo-run): Network interface detection is Linux only

### DIFF
--- a/launch/Cargo.lock
+++ b/launch/Cargo.lock
@@ -1507,7 +1507,6 @@ dependencies = [
  "dynamo-runtime",
  "futures",
  "futures-util",
- "libc",
  "netlink-packet-route",
  "rtnetlink",
  "serde",

--- a/launch/dynamo-run/Cargo.toml
+++ b/launch/dynamo-run/Cargo.toml
@@ -41,9 +41,6 @@ clap = { version = "4.5", features = ["derive", "env"] }
 dialoguer = { version = "0.11", default-features = false, features = ["editor", "history"] }
 futures = { version = "0.3" }
 futures-util = "0.3"
-libc = { version = "0.2" }
-netlink-packet-route = { version = "0.19", optional = true }
-rtnetlink = { version = "0.14", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
@@ -52,3 +49,7 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "local-time", "json"] }
 dynamo-runtime = { path = "../../lib/runtime" }
 dynamo-llm = { path = "../../lib/llm" }
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+netlink-packet-route = { version = "0.19", optional = true }
+rtnetlink = { version = "0.14", optional = true }

--- a/lib/llm/src/engines/vllm/worker.rs
+++ b/lib/llm/src/engines/vllm/worker.rs
@@ -339,7 +339,7 @@ async fn start_vllm(
             let mut log_level = line_parts.next().unwrap_or_default();
             // Skip date (0) and time (1). Print last (2) which is everything else.
             let line = line_parts.nth(2).unwrap_or_default();
-            if line.starts_with("custom_op.py:68") {
+            if line.starts_with("custom_op.py:68") || line.trim().len() == 0 {
                 // Skip a noisy line
                 // custom_op.py:68] custom op <the op> enabled
                 continue;
@@ -349,7 +349,7 @@ async fn start_vllm(
             }
             match log_level {
                 "DEBUG" => tracing::debug!("VLLM: {line}"),
-                "INFO" => tracing::debug!("VLLM: {line}"), // VLLM is noisy
+                "INFO" => tracing::debug!("VLLM: {line}"), // VLLM is noisy in debug mode
                 "WARNING" => tracing::warn!("VLLM: {line}"),
                 "ERROR" => tracing::error!("VLLM: {line}"),
                 level => tracing::info!("VLLM: {level} {line}"),
@@ -359,6 +359,9 @@ async fn start_vllm(
     tokio::spawn(async move {
         let mut lines = stderr.lines();
         while let Ok(Some(line)) = lines.next_line().await {
+            if line.trim().len() == 0 {
+                continue;
+            }
             tracing::warn!("VLLM: {line}");
         }
     });
@@ -399,7 +402,7 @@ async fn start_vllm(
             .extract(py)
             .unwrap()
     });
-    tracing::info!("vllm zmq backend is ready: {resp:?}");
+    tracing::debug!("vllm zmq backend is ready: {resp:?}");
 
     Ok(proc)
 }


### PR DESCRIPTION
"netlink" doesn't exist on Mac. We print the primary network interface to help multi-node setup, which is also unlikely on Mac.
