### PR TITLE
feat(mistralrs): Let the engine enforce max tokens

### DIFF
--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -28,7 +28,6 @@ Example:
 - cd target/release
 - ./dynamo-run hf_checkouts/Llama-3.2-3B-Instruct/
 - OR: ./dynamo-run Llama-3.2-1B-Instruct-Q4_K_M.gguf
-
 "#;
 
 const ZMQ_SOCKET_PREFIX: &str = "dyn";
@@ -126,6 +125,11 @@ async fn wrapper(runtime: dynamo_runtime::Runtime) -> anyhow::Result<()> {
     if args.is_empty() || args[0] == "-h" || args[0] == "--help" {
         println!("{USAGE}");
         println!("{HELP}");
+        println!(
+            "Available engines: {}",
+            Output::available_engines().join(", ")
+        );
+
         return Ok(());
     }
     for arg in env::args().skip(1).take(2) {

--- a/launch/dynamo-run/src/opt.rs
+++ b/launch/dynamo-run/src/opt.rs
@@ -117,6 +117,9 @@ pub enum Output {
     /// tokens. We do the pre-processing.
     #[cfg(feature = "python")]
     PythonTok(String),
+    //
+    // DEVELOPER NOTE
+    // If you add an engine add it to `available_engines` below, and to Default if it makes sense
 }
 
 impl TryFrom<&str> for Output {
@@ -192,10 +195,10 @@ impl fmt::Display for Output {
             Output::Endpoint(path) => path,
 
             #[cfg(feature = "python")]
-            Output::PythonStr(path) => path,
+            Output::PythonStr(_) => "pystr",
 
             #[cfg(feature = "python")]
-            Output::PythonTok(path) => path,
+            Output::PythonTok(_) => "pytok",
         };
         write!(f, "{s}")
     }
@@ -228,6 +231,45 @@ impl Default for Output {
         #[cfg(feature = "vllm")]
         {
             out = Output::Vllm;
+        }
+
+        out
+    }
+}
+
+impl Output {
+    #[allow(unused_mut)]
+    pub fn available_engines() -> Vec<String> {
+        let mut out = vec!["echo_core".to_string(), "echo_full".to_string()];
+        #[cfg(feature = "mistralrs")]
+        {
+            out.push(Output::MistralRs.to_string());
+        }
+
+        #[cfg(feature = "llamacpp")]
+        {
+            out.push(Output::LlamaCpp.to_string());
+        }
+
+        #[cfg(feature = "sglang")]
+        {
+            out.push(Output::SgLang.to_string());
+        }
+
+        #[cfg(feature = "vllm")]
+        {
+            out.push(Output::Vllm.to_string());
+        }
+
+        #[cfg(feature = "python")]
+        {
+            out.push(Output::PythonStr("file.py".to_string()).to_string());
+            out.push(Output::PythonTok("file.py".to_string()).to_string());
+        }
+
+        #[cfg(feature = "trtllm")]
+        {
+            out.push(Output::TrtLLM.to_string());
         }
 
         out


### PR DESCRIPTION
Previously we tokenized and counted tokens to stop when max tokens was reached. Now we let the mistral.rs engine do it which saves the extra tokenization step.

Also dynamo-run prints which engines are compiled in in help message, and some minor lint fixes.
