### PR TITLE
build: cargo build --jobs=4

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -74,20 +74,20 @@ COPY LICENSE /workspace/
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
-    cargo build --release --locked && cargo doc --no-deps
+    cargo build --jobs=4 --release --locked && cargo doc --no-deps
 
 # Build OpenAI HTTP Service binaries
 COPY lib/llm /workspace/lib/llm
 COPY components /workspace/components
 RUN cd components && \
-    cargo build --release && \
+    cargo build --jobs=4 --release && \
     cp target/release/http /usr/local/bin/
 
 # Build Dynamo Run binaries
 COPY launch /workspace/launch
 # TODO: Tanmay Add LLMAPI-based feature flag once the engine is ready.
 RUN cd launch && \
-    cargo build --release --features python && \
+    cargo build --jobs=4 --release --features python && \
     cp target/release/dynamo-run /usr/local/bin/ && \
     cp target/release/llmctl /usr/local/bin/
 COPY deploy/dynamo/sdk /workspace/deploy/dynamo/sdk
@@ -96,7 +96,7 @@ COPY deploy/dynamo/sdk /workspace/deploy/dynamo/sdk
 # Generate C bindings for kv cache routing.
 COPY lib/bindings /workspace/lib/bindings
 RUN cd lib/bindings/c && \
-    cargo build --release --locked && cargo doc --no-deps
+    cargo build --jobs=4 --release --locked && cargo doc --no-deps
 
 # Install uv, create virtualenv for general use, and build dynamo wheel
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -214,26 +214,26 @@ COPY LICENSE /workspace/
 # Build Rust runtime
 COPY lib/runtime /workspace/lib/runtime
 RUN cd lib/runtime && \
-    cargo build --jobs 2 --release --locked && cargo doc --no-deps
+    cargo build --jobs=4 --release --locked && cargo doc --no-deps
 
 # Build OpenAI HTTP Service binaries
 COPY lib/llm /workspace/lib/llm
 COPY components /workspace/components
 RUN cd components && \
-    cargo build --jobs 2 --release && \
+    cargo build --jobs=4 --release && \
     cp target/release/http /usr/local/bin/
 
 # Build Dynamo Run binaries
 COPY launch /workspace/launch
 RUN cd launch && \
-    cargo build --jobs 2 --release --features mistralrs,sglang,vllm,python && \
+    cargo build --jobs=4 --release --features mistralrs,sglang,vllm,python && \
     cp target/release/dynamo-run /usr/local/bin/ && \
     cp target/release/llmctl /usr/local/bin/
 
 # Generate C bindings for kv cache routing in vLLM
 COPY lib/bindings /workspace/lib/bindings
 RUN cd lib/bindings/c && \
-    cargo build --jobs 2 --release --locked && cargo doc --no-deps
+    cargo build --jobs=4 --release --locked && cargo doc --no-deps
 
 COPY deploy/dynamo/sdk /workspace/deploy/dynamo/sdk
 # Build dynamo wheel


### PR DESCRIPTION
#### Overview:

Cargo builds fail with "too many files open" on CI when --jobs are not set. with --jobs=2 builds are too slow. Trying --jobs=4
#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
