### PR TITLE
fix: Fix cargo doc warnings for lib/runtime

### DIFF
--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -148,12 +148,12 @@ where
         })
     }
 
-    /// String identifying <namespace>/<component>/<endpoint>
+    /// String identifying `<namespace>/<component>/<endpoint>`
     pub fn path(&self) -> String {
         self.endpoint.path()
     }
 
-    /// String identifying <namespace>/component/<component>/<endpoint>
+    /// String identifying `<namespace>/component/<component>/<endpoint>`
     pub fn etcd_path(&self) -> String {
         self.endpoint.etcd_path()
     }

--- a/lib/runtime/src/traits/events.rs
+++ b/lib/runtime/src/traits/events.rs
@@ -24,12 +24,12 @@ use crate::Result;
 //     async fn publish(&self, event: &(impl Serialize + Send + Sync)) -> Result<()>;
 // }
 
-/// A [EventPlane] is a component that can publish and/or subscribe to events.
+/// An [EventPublisher] is an object that can publish events.
 ///
-/// Each implementation of [EventPlane] will define the root subject.
+/// Each implementation of [EventPublisher] will define the root subject.
 #[async_trait]
 pub trait EventPublisher {
-    /// The base subject used for this implementation of the [EventPlane].
+    /// The base subject used for this implementation of the [EventPublisher].
     fn subject(&self) -> String;
 
     /// Publish a single event to the event plane. The `event_name` will be `.` concatenated with the
@@ -57,7 +57,7 @@ pub trait EventPublisher {
     // fn publisher_bytes(&self, event_name: impl AsRef<str>) -> &PublisherBytes;
 }
 
-/// A trait for subscribing to events in the event plane.
+/// An [EventSubscriber] is an object that can subscribe to events.
 ///
 /// This trait provides methods to subscribe to events published on specific subjects.
 #[async_trait]

--- a/lib/runtime/src/transports/zmq.rs
+++ b/lib/runtime/src/transports/zmq.rs
@@ -307,7 +307,7 @@ impl ServerExecutionHandle {
 }
 
 // Client implementation
-struct Client {
+pub struct Client {
     dealer: Dealer<IntoIter<Vec<u8>>, Vec<u8>>,
 }
 

--- a/lib/runtime/src/utils/pool.rs
+++ b/lib/runtime/src/utils/pool.rs
@@ -29,7 +29,7 @@ pub trait ReturnHandle<T: Returnable>: Send + Sync + 'static {
     fn return_to_pool(&self, value: PoolValue<T>);
 }
 
-/// Enum to hold either a Box<T> or T directly
+/// Enum to hold either a `Box<T>` or `T` directly
 pub enum PoolValue<T: Returnable> {
     Boxed(Box<T>),
     Direct(T),


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Fix the warnings generated from `cargo doc` on `lib/runtime`, such as these: https://github.com/ai-dynamo/dynamo/actions/runs/13850868992/job/38757812686?pr=147
