### PR TITLE
fix: Add missing binaries back into container build

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -85,7 +85,7 @@ COPY components /workspace/components
 COPY launch /workspace/launch
 
 # TODO: Tanmay Add LLMAPI-based feature flag once the engine is ready.
-RUN cargo build --release --locked --features python && \
+RUN cargo build --release --locked --features mistralrs,sglang,python && \
     cargo doc --no-deps && \
     cp target/release/dynamo-run /usr/local/bin && \
     cp target/release/http /usr/local/bin && \

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -87,8 +87,10 @@ COPY launch /workspace/launch
 # TODO: Tanmay Add LLMAPI-based feature flag once the engine is ready.
 RUN cargo build --release --locked --features python && \
     cargo doc --no-deps && \
-    cp target/release/dynamo-run /usr/local/bin/ && \
-    cp target/release/llmctl /usr/local/bin/
+    cp target/release/dynamo-run /usr/local/bin && \
+    cp target/release/http /usr/local/bin && \
+    cp target/release/llmctl /usr/local/bin && \
+    cp target/release/metrics /usr/local/bin
 
 COPY deploy/dynamo/sdk /workspace/deploy/dynamo/sdk
 

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -224,7 +224,11 @@ ARG CARGO_BUILD_JOBS
 ENV CARGO_TARGET_DIR=/workspace/target
 
 RUN cargo build --release --locked --features mistralrs,sglang,vllm,python && \
-    cargo doc --no-deps
+    cargo doc --no-deps && \
+    cp target/release/dynamo-run /usr/local/bin && \
+    cp target/release/http /usr/local/bin && \
+    cp target/release/llmctl /usr/local/bin && \
+    cp target/release/metrics /usr/local/bin
 
 COPY deploy/dynamo/sdk /workspace/deploy/dynamo/sdk
 # Build dynamo wheel


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Binaries were removed from the container with recent changes to the Dockerfiles that are required for interactive use of dynamo. This change adds them back.