### PR TITLE
fix: Various for MacOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,6 @@ uuid = { version = "1", features = ["v4", "serde"] }
 xxhash-rust = { version = "0.8", features = ["xxh3", "const_xxh3"] }
 strum = { version = "0.27", features = ["derive"] }
 prometheus = { version = "0.13" }
+
+[profile.dev.package]
+insta.opt-level = 3

--- a/launch/dynamo-run/src/net.rs
+++ b/launch/dynamo-run/src/net.rs
@@ -208,7 +208,7 @@ mod unix {
         })
         .try_collect()
         .await
-        .map_err(super::LinkDataError::communication)
+        .map_err(|err| super::LinkDataError::communication(err.to_string()))
     }
 
     fn extract_interface_name(link_message: &LinkMessage) -> Option<String> {

--- a/launch/dynamo-run/src/net.rs
+++ b/launch/dynamo-run/src/net.rs
@@ -39,7 +39,7 @@ impl LinkDataError {
         Self { kind, interface }
     }
 
-    fn communication(communication_error: rtnetlink::Error) -> Self {
+    fn communication(communication_error: String) -> Self {
         let kind = LinkDataErrorKind::Communication(communication_error);
         let interface = None;
         Self { kind, interface }
@@ -69,7 +69,7 @@ impl std::error::Error for LinkDataError {
 #[derive(Debug)]
 pub enum LinkDataErrorKind {
     Connection(std::io::Error),
-    Communication(rtnetlink::Error),
+    Communication(String),
 }
 
 #[cfg(target_os = "linux")]
@@ -183,7 +183,7 @@ mod unix {
             })
             .try_collect()
             .await
-            .map_err(super::LinkDataError::communication)?;
+            .map_err(|err| super::LinkDataError::communication(err.to_string()))?;
 
         let link_handle = rtnetlink_handle.link().get().execute();
         link_handle

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -160,6 +160,3 @@ insta = { version = "1.41", features = [
 [build-dependencies]
 bindgen = "0.70"
 cmake = "0.1"
-
-[profile.dev.package]
-insta.opt-level = 3

--- a/lib/llm/src/engines/sglang/worker.rs
+++ b/lib/llm/src/engines/sglang/worker.rs
@@ -447,7 +447,8 @@ async fn start_sglang(
     // This pipe is how sglang tells us it's ready
     let mut pipe_fds: [libc::c_int; 2] = [-1, -1];
     unsafe {
-        let err = libc::pipe2(pipe_fds.as_mut_ptr() as *mut c_int, 0); // libc::O_NONBLOCK);
+        // Seems to be OK without libc::O_NONBLOCK
+        let err = libc::pipe(pipe_fds.as_mut_ptr() as *mut c_int);
         if err != 0 {
             anyhow::bail!("libc::pipe error {err}");
         }


### PR DESCRIPTION
- Mac doesn't have `pipe2` syscall so use plain `pipe`.
- rtnetlink isn't a dependency on mac so don't use the type