### PR TITLE
refactor: Update default log level to INFO and promote/demote a few log messages

### DIFF
--- a/components/metrics/src/main.rs
+++ b/components/metrics/src/main.rs
@@ -115,7 +115,7 @@ fn get_config(args: &Args) -> Result<LLMWorkerLoadCapacityConfig> {
 async fn app(runtime: Runtime) -> Result<()> {
     let args = Args::parse();
     let config = get_config(&args)?;
-    tracing::info!("Config: {config:?}");
+    tracing::debug!("Config: {config:?}");
 
     let drt = DistributedRuntime::from_settings(runtime.clone()).await?;
 
@@ -124,7 +124,7 @@ async fn app(runtime: Runtime) -> Result<()> {
 
     // Create unique instance of Count
     let key = format!("{}/instance", component.etcd_path());
-    tracing::info!("Creating unique instance of Count at {key}");
+    tracing::debug!("Creating unique instance of Count at {key}");
     drt.etcd_client()
         .kv_create(
             key,
@@ -178,7 +178,7 @@ async fn app(runtime: Runtime) -> Result<()> {
     tokio::spawn(async move {
         match namespace_clone.subscribe(kv_hit_rate_subject).await {
             Ok(mut subscriber) => {
-                tracing::info!("Successfully subscribed to KV hit rate events");
+                tracing::debug!("Successfully subscribed to KV hit rate events");
 
                 while let Some(msg) = subscriber.next().await {
                     match serde_json::from_slice::<KVHitRateEvent>(&msg.payload) {

--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -164,7 +164,9 @@ async fn wrapper(runtime: dynamo_runtime::Runtime) -> anyhow::Result<()> {
         }
         None => {
             let default_engine = Output::default(); // smart default based on feature flags
-            tracing::debug!("Using engine: {default_engine}");
+            tracing::info!(
+                "Using default engine: {default_engine}. Use out=<engine> to specify an engine."
+            );
             default_engine
         }
     };

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -25,7 +25,7 @@
 //!
 //! Filters can be configured using the `DYN_LOG` environment variable or by setting the `filters`
 //! key in the TOML configuration file. Filters are comma-separated key-value pairs where the key
-//! is the crate or module name and the value is the log level. The default log level is `error`.
+//! is the crate or module name and the value is the log level. The default log level is `info`.
 //!
 //! Example:
 //! ```toml
@@ -56,7 +56,7 @@ use tracing_subscriber::{filter::Directive, fmt};
 const FILTER_ENV: &str = "DYN_LOG";
 
 /// Default log level
-const DEFAULT_FILTER_LEVEL: &str = "error";
+const DEFAULT_FILTER_LEVEL: &str = "info";
 
 /// ENV used to set the path to the logging configuration file
 const CONFIG_PATH_ENV: &str = "DYN_LOGGING_CONFIG_PATH";


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Currently some components like `http` and `metrics` output nothing with the default log level of ERROR - this makes it look like the application hanging and leaves users confused until they discover `DYN_LOG=info`. Instead, I think we should default to INFO and prioritize making our logging not too noisy, and using debug/trace instead where appropriate.