### PR TITLE
fix: wrong indent -> only one worker metric

### DIFF
--- a/examples/python_rs/llm/vllm/kv_router.py
+++ b/examples/python_rs/llm/vllm/kv_router.py
@@ -66,20 +66,20 @@ class CustomRouter:
         if metrics:
             for endpoint in metrics.endpoints:
                 worker_id = endpoint.worker_id
-            worker_metrics[worker_id] = {
-                "gpu_cache_usage_perc": endpoint.gpu_cache_usage_perc
-                if hasattr(endpoint, "gpu_cache_usage_perc")
-                else 0.0,
-                "num_requests_waiting": endpoint.num_requests_waiting
-                if hasattr(endpoint, "num_requests_waiting")
-                else 0.0,
-                "gpu_prefix_cache_hit_rate": endpoint.gpu_prefix_cache_hit_rate
-                if hasattr(endpoint, "gpu_prefix_cache_hit_rate")
-                else 0.0,
-            }
-            max_waiting = max(
-                max_waiting, worker_metrics[worker_id]["num_requests_waiting"]
-            )
+                worker_metrics[worker_id] = {
+                    "gpu_cache_usage_perc": endpoint.gpu_cache_usage_perc
+                    if hasattr(endpoint, "gpu_cache_usage_perc")
+                    else 0.0,
+                    "num_requests_waiting": endpoint.num_requests_waiting
+                    if hasattr(endpoint, "num_requests_waiting")
+                    else 0.0,
+                    "gpu_prefix_cache_hit_rate": endpoint.gpu_prefix_cache_hit_rate
+                    if hasattr(endpoint, "gpu_prefix_cache_hit_rate")
+                    else 0.0,
+                }
+                max_waiting = max(
+                    max_waiting, worker_metrics[worker_id]["num_requests_waiting"]
+                )
 
         # Get all worker IDs from the client. This is needed because scores / metrics may not have values for all workers
         # and we want all workers to be considered in the logit calculation


### PR DESCRIPTION
fix wrong indent causing kv metrics to only include one decode worker.