### PR TITLE
feat: Support a small runtime container

### DIFF
--- a/.github/workflows/pre-merge-python.yml
+++ b/.github/workflows/pre-merge-python.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
         run: |
-          ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target --framework ${{ matrix.framework }} ${{ steps.which_caches.outputs.cache_from_location }} ${{ steps.which_caches.outputs.cache_to_location }}
+          ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target dev --framework ${{ matrix.framework }} ${{ steps.which_caches.outputs.cache_from_location }} ${{ steps.which_caches.outputs.cache_to_location }}
       - name: Run pytest
         env:
           PYTEST_MARKS: "pre_merge or mypy"

--- a/.github/workflows/pre-merge-python.yml
+++ b/.github/workflows/pre-merge-python.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
         run: |
-          ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --framework ${{ matrix.framework }} ${{ steps.which_caches.outputs.cache_from_location }} ${{ steps.which_caches.outputs.cache_to_location }}
+          ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target --framework ${{ matrix.framework }} ${{ steps.which_caches.outputs.cache_from_location }} ${{ steps.which_caches.outputs.cache_to_location }}
       - name: Run pytest
         env:
           PYTEST_MARKS: "pre_merge or mypy"

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -296,10 +296,14 @@ RUN uv venv $VIRTUAL_ENV --python 3.12 && \
     echo "source $VIRTUAL_ENV/bin/activate" >> ~/.bashrc
 
 # Install the wheels
-COPY --from=dev /workspace/dist/ai_dynamo*.whl whls/
+COPY --from=dev /workspace/dist/*.whl whls/
 RUN uv pip install $(find whls -name ai_dynamo_runtime-*.whl) && \
     uv pip install $(find whls -name ai_dynamo-*.whl) && \
+    uv pip install $(find whls -name vllm*cp312*.whl) && \
     rm -r whls
+
+# Tell vllm to use the Dynamo LLM C API for KV Cache Routing
+ENV VLLM_KV_CAPI_PATH="/opt/dynamo/bindings/lib/libdynamo_llm_capi.so"
 
 # dynamo run in=text out=mistralrs Qwen/Qwen2.5-3B-Instruct
 CMD []

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -4,6 +4,9 @@
 ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 
+ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
+ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
+
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS dev
 
 USER root
@@ -264,5 +267,28 @@ ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 
 CMD []
 
-### TODO Lean Runtime Image Stage ###
+########################################
+########## RUNTIME CONTAINER ###########
+########################################
 
+FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
+
+WORKDIR /workspace
+ENV VIRTUAL_ENV=/opt/dynamo/venv
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# Setup the python environment
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+RUN uv venv $VIRTUAL_ENV --python 3.12 && \
+    ln -s $(find / -name libpython3.12.so*) /usr/lib && \
+    echo "source $VIRTUAL_ENV/bin/activate" >> ~/.bashrc
+
+# Install the wheels
+COPY --from=dev /workspace/dist/ai_dynamo*.whl whls/
+RUN uv pip install $(find whls -name ai_dynamo_runtime-*.whl) && \
+    uv pip install $(find whls -name ai_dynamo-*.whl) && \
+    rm -r whls
+
+# dynamo run in=text out=mistralrs Qwen/Qwen2.5-3B-Instruct
+CMD []

--- a/container/build.sh
+++ b/container/build.sh
@@ -229,6 +229,8 @@ get_options() {
 
     if [ ! -z "$TARGET" ]; then
         TARGET_STR="--target ${TARGET}"
+    else
+        TARGET_STR="--target runtime"
     fi
 }
 


### PR DESCRIPTION
#### Overview:

Our development container is unnecessarily heavy for an end user that wants to demo Dynamo. This bases off of `nvcr.io/nvidia/cuda:12.8.1-runtime-ubuntu24.04` and just installs the necessary python environment and pip wheels.

#### Details:

Adds a new target in the VLLM dockerfile for runtime.

Updates the CI to only build the dev container.

#### Where should the reviewer start?

container/Dockerfile.vllm has the significant changes