### PR TITLE
revert: "build: use wheel for vllm install (#163)"

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -181,13 +181,7 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 ARG VLLM_REF="v0.7.2"
 ARG VLLM_PATCH="vllm_${VLLM_REF}-dynamo-kv-disagg-patch.patch"
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
-    git clone https://github.com/vllm-project/vllm.git vllm && \
-    cd vllm && \
-    git checkout ${VLLM_REF} && \
-    git apply /tmp/deps/vllm/${VLLM_PATCH} && \
-    VLLM_USE_PRECOMPILED=1 uv build --wheel --out-dir /workspace/dist && \
-    uv pip install /workspace/dist/vllm*cp312*.whl && \
-    cd .. && rm -rf vllm
+    bash /tmp/deps/vllm/install.sh --patch /tmp/deps/vllm/${VLLM_PATCH} --ref ${VLLM_REF} --install-cmd "uv pip install --editable" --use-precompiled --installation-dir /opt/vllm
 
 # Install genai-perf for benchmarking
 ARG GENAI_PERF_TAG="25d0188713adc47868d6b3f22426375237a90529"


### PR DESCRIPTION
This reverts commit dc1caff1f194218163febd2aa3fadd9c890b6eb9.

Causes failures in virtual env
```
INFO 03-14 15:32:58 __init__.py:190] Automatically detected platform cuda.
0: Traceback (most recent call last):
0:   File "/workspace/examples/python_rs/llm/vllm/processor.py", line 23, in <module>
0:     from utils.chat_processor import ChatProcessor, CompletionsProcessor, ProcessMixIn
0:   File "/workspace/examples/python_rs/llm/vllm/utils/chat_processor.py", line 20, in <module>
0:     from vllm.config import ModelConfig
0:   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/__init__.py", line 7, in <module>
0:     from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
0:   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 20, in <module>
0:     from vllm.executor.executor_base import ExecutorBase
0:   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/executor/executor_base.py", line 15, in <module>
0:     from vllm.platforms import current_platform
0:   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/platforms/__init__.py", line 222, in __getattr__
0:     _current_platform = resolve_obj_by_qualname(
0:                         ^^^^^^^^^^^^^^^^^^^^^^^^
0:   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/utils.py", line 1906, in resolve_obj_by_qualname
0:     module = importlib.import_module(module_name)
0:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0:   File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
0:     return _bootstrap._gcd_import(name[level:], package, level)
0:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0:   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/platforms/cuda.py", line 15, in <module>
0:     import vllm._C  # noqa
0:     ^^^^^^^^^^^^^^
0: ModuleNotFoundError: No module named 'vllm._C'
```