### PR TITLE
feat: updated to override command line and support non equals and space in …

### DIFF
--- a/deploy/dynamo/sdk/src/dynamo/sdk/cli/serve.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/cli/serve.py
@@ -63,7 +63,7 @@ def deprecated_option(*param_decls: str, **attrs: t.Any):
     return decorator
 
 
-def _parse_service_arg(arg_name: str, arg_value: str) -> tuple[str, str, t.Any] | None:
+def _parse_service_arg(arg_name: str, arg_value: str) -> tuple[str, str, t.Any]:
     """Parse a single CLI argument into service name, key, and value."""
 
     service, key = arg_name.split(".", 1)
@@ -86,7 +86,7 @@ def _parse_service_arg(arg_name: str, arg_value: str) -> tuple[str, str, t.Any] 
     return service, key, value
 
 
-def _parse_service_args(args: list[str]) -> t.Dict[str, t.Any] | None:
+def _parse_service_args(args: list[str]) -> t.Dict[str, t.Any]:
     service_configs: t.DefaultDict[str, t.Dict[str, t.Any]] = collections.defaultdict(
         dict
     )
@@ -346,7 +346,7 @@ def build_serve_command() -> click.Group:
 
         from dynamo.sdk.lib.service import LinkedServices
 
-        service_configs = {}
+        service_configs: dict[str, dict[str, t.Any]] = {}
 
         # Load file if provided
         if file:
@@ -363,9 +363,7 @@ def build_serve_command() -> click.Group:
         # Process Overrides
 
         # Process service-specific options
-        cmdline_overrides: t.Optional[t.Dict[str, t.Any]] = _parse_service_args(
-            ctx.args
-        )
+        cmdline_overrides: t.Dict[str, t.Any] = _parse_service_args(ctx.args)
         for service, configs in cmdline_overrides.items():
             for key, value in configs.items():
                 if service not in service_configs:

--- a/deploy/dynamo/sdk/src/dynamo/sdk/cli/serve.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/cli/serve.py
@@ -63,34 +63,25 @@ def deprecated_option(*param_decls: str, **attrs: t.Any):
     return decorator
 
 
-def _parse_service_arg(arg: str) -> tuple[str, str, t.Any] | None:
+def _parse_service_arg(arg_name: str, arg_value: str) -> tuple[str, str, t.Any] | None:
     """Parse a single CLI argument into service name, key, and value."""
-    if not (arg.startswith("--") and "=" in arg):
-        return None
 
-    # Remove leading dashes
-    param = arg[2:]
-    key_path, value_str = param.split("=", 1)
-
-    if "." not in key_path:
-        return None
-
-    service, key = key_path.split(".", 1)
+    service, key = arg_name.split(".", 1)
 
     # Parse value based on type
     try:
         # Try as JSON for complex types
-        value = json.loads(value_str)
+        value = json.loads(arg_value)
     except json.JSONDecodeError:
         # Handle basic types
-        if value_str.isdigit():
-            value = int(value_str)
-        elif value_str.replace(".", "", 1).isdigit() and value_str.count(".") <= 1:
-            value = float(value_str)
-        elif value_str.lower() in ("true", "false"):
-            value = value_str.lower() == "true"
+        if arg_value.isdigit():
+            value = int(arg_value)
+        elif arg_value.replace(".", "", 1).isdigit() and arg_value.count(".") <= 1:
+            value = float(arg_value)
+        elif arg_value.lower() in ("true", "false"):
+            value = arg_value.lower() == "true"
         else:
-            value = value_str
+            value = arg_value
 
     return service, key, value
 
@@ -100,11 +91,35 @@ def _parse_service_args(args: list[str]) -> t.Dict[str, t.Any] | None:
         dict
     )
 
-    for arg in args:
-        parsed = _parse_service_arg(arg)
-        if parsed:
+    index = 0
+    while index < len(args):
+        next_arg = args[index]
+
+        arg_name = ""
+        arg_value = ""
+
+        if not (next_arg.startswith("--") or "." not in next_arg):
+            continue
+        try:
+            if "=" in next_arg:
+                arg_name, arg_value = next_arg.split("=", 1)
+                index += 1
+            elif args[index + 1] == "=":
+                arg_name = next_arg
+                arg_value = args[index + 2]
+                index += 3
+            else:
+                arg_name = next_arg
+                arg_value = args[index + 1]
+                index += 2
+            if arg_value.startswith("-"):
+                raise ValueError("Service arg value can not start with -")
+            arg_name = arg_name[2:]
+            parsed = _parse_service_arg(arg_name, arg_value)
             service, key, value = parsed
             service_configs[service][key] = value
+        except Exception:
+            raise ValueError(f"Error parsing service arg: {args[index]}")
 
     return service_configs
 
@@ -331,15 +346,13 @@ def build_serve_command() -> click.Group:
 
         from dynamo.sdk.lib.service import LinkedServices
 
-        # Process service-specific options
-        service_configs: t.Optional[t.Dict[str, t.Any]] = _parse_service_args(ctx.args)
+        service_configs = {}
 
-        # Load and merge config file if provided
+        # Load file if provided
         if file:
             with open(file) as f:
                 yaml_configs = yaml.safe_load(f)
                 # Initialize service_configs as empty dict if it's None
-                service_configs = dict(service_configs or {})
                 # Convert nested YAML structure to flat dict with dot notation
                 for service, configs in yaml_configs.items():
                     for key, value in configs.items():
@@ -347,7 +360,17 @@ def build_serve_command() -> click.Group:
                             service_configs[service] = {}
                         service_configs[service][key] = value
 
-        # print("service_configs", service_configs)
+        # Process Overrides
+
+        # Process service-specific options
+        cmdline_overrides: t.Optional[t.Dict[str, t.Any]] = _parse_service_args(
+            ctx.args
+        )
+        for service, configs in cmdline_overrides.items():
+            for key, value in configs.items():
+                if service not in service_configs:
+                    service_configs[service] = {}
+                service_configs[service][key] = value
 
         # Set environment variable with service configuration
         if service_configs:


### PR DESCRIPTION


#### Overview:

1. Make command line service args override config
2. Support for 

```
--VllmWorker.model foo
--VllmWorker.model=foo
--VllmWorker.model = foo
```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
