### PR TITLE
chore: update version for patched vLLM wheel

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -193,7 +193,7 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 # rebuilds from unrelated source code changes
 ARG VLLM_REF="0.7.2"
 ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
-ARG VERSION_PATCH_SUFFIX="dynamo"
+ARG VLLM_VERSION_PATCH_SUFFIX="dynamo"
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     mkdir /tmp/vllm && \
     uv pip install pip wheel && \
@@ -202,10 +202,10 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     wheel unpack *.whl && \
     cd vllm-${VLLM_REF}/ && \
     patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
-    sed -i "s/__version__ = version = '\(.*\)'/__version__ = version = '\1+${VERSION_PATCH_SUFFIX}'/g; s/__version_tuple__ = version_tuple = (\(.*\))/__version_tuple__ = version_tuple = (\1, '${VERSION_PATCH_SUFFIX}')/g" vllm/_version.py && \
-    mv vllm-${VLLM_REF}.dist-info vllm-${VLLM_REF}+${VERSION_PATCH_SUFFIX}.dist-info && \
-    sed -i "s/${VLLM_REF}/${VLLM_REF}+${VERSION_PATCH_SUFFIX}/g" vllm-${VLLM_REF}+${VERSION_PATCH_SUFFIX}.dist-info/METADATA && \
-    sed -i "s/vllm-${VLLM_REF}/vllm-${VLLM_REF}+${VERSION_PATCH_SUFFIX}/g" vllm-${VLLM_REF}+${VERSION_PATCH_SUFFIX}.dist-info/RECORD && \
+    sed -i "s/__version__ = version = '\(.*\)'/__version__ = version = '\1+${VLLM_VERSION_PATCH_SUFFIX}'/g; s/__version_tuple__ = version_tuple = (\(.*\))/__version_tuple__ = version_tuple = (\1, '${VLLM_VERSION_PATCH_SUFFIX}')/g" vllm/_version.py && \
+    mv vllm-${VLLM_REF}.dist-info vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info && \
+    sed -i "s/${VLLM_REF}/${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}/g" vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/METADATA && \
+    sed -i "s/vllm-${VLLM_REF}/vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}/g" vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/RECORD && \
     mkdir -p /workspace/dist && \
     wheel pack . --dest-dir /workspace/dist && \
     uv pip install /workspace/dist/vllm-*.whl

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -191,17 +191,21 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 
 # Install patched vllm - keep this early in Dockerfile to avoid
 # rebuilds from unrelated source code changes
-ARG VLLM_REF="v0.7.2"
-ARG VLLM_PATCH="vllm_${VLLM_REF}-dynamo-kv-disagg-patch.patch"
+ARG VLLM_REF="0.7.2"
+ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
+ARG VERSION_PATCH_SUFFIX="dynamo"
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     mkdir /tmp/vllm && \
     uv pip install pip wheel && \
-    python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==${VLLM_REF} && \
+    python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \
     cd /tmp/vllm && \
     wheel unpack *.whl && \
-    cd vllm-*/ && \
+    cd vllm-${VLLM_REF}/ && \
     patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
-    sed -i "s/__version__ = version = '\(.*\)'/__version__ = version = '\1.dynamo_patch'/g; s/__version_tuple__ = version_tuple = (\(.*\))/__version_tuple__ = version_tuple = (\1, 'dynamo_patch')/g" vllm/_version.py && \
+    sed -i "s/__version__ = version = '\(.*\)'/__version__ = version = '\1+${VERSION_PATCH_SUFFIX}'/g; s/__version_tuple__ = version_tuple = (\(.*\))/__version_tuple__ = version_tuple = (\1, '${VERSION_PATCH_SUFFIX}')/g" vllm/_version.py && \
+    mv vllm-${VLLM_REF}.dist-info vllm-${VLLM_REF}+${VERSION_PATCH_SUFFIX}.dist-info && \
+    sed -i "s/${VLLM_REF}/${VLLM_REF}+${VERSION_PATCH_SUFFIX}/g" vllm-${VLLM_REF}+${VERSION_PATCH_SUFFIX}.dist-info/METADATA && \
+    sed -i "s/vllm-${VLLM_REF}/vllm-${VLLM_REF}+${VERSION_PATCH_SUFFIX}/g" vllm-${VLLM_REF}+${VERSION_PATCH_SUFFIX}.dist-info/RECORD && \
     mkdir -p /workspace/dist && \
     wheel pack . --dest-dir /workspace/dist && \
     uv pip install /workspace/dist/vllm-*.whl

--- a/container/deps/vllm/tests/test_patch_install.py
+++ b/container/deps/vllm/tests/test_patch_install.py
@@ -27,4 +27,4 @@ pytestmark = pytest.mark.pre_merge
 @pytest.mark.skipif(vllm is None, reason="Skipping vllm tests, vllm not installed")
 def test_version():
     # Verify that the image has the patched version of vllm
-    assert vllm.__version__.endswith("dynamo_patch")  # type: ignore
+    assert vllm.__version__.endswith("+dynamo")  # type: ignore


### PR DESCRIPTION
Add version to patched vLLM wheel, `x.y.z.dynamo` is not a valid semantic version, so use `x.y.z+dynamo`

New wheel name - `vllm-0.7.2+dynamo-cp38-abi3-linux_x86_64.whl`

Import -
```
vllm.__version__
'0.7.2+dynamo'
```
