### PR TITLE
build: add vllm optional dependency

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -324,10 +324,7 @@ RUN uv venv $VIRTUAL_ENV --python 3.12 && \
 
 # Install the wheels
 COPY --from=dev /workspace/dist/*.whl whls/
-RUN uv pip install $(find whls -name ai_dynamo_runtime-*.whl) && \
-    uv pip install $(find whls -name ai_dynamo-*.whl) && \
-    uv pip install $(find whls -name vllm-*.whl) && \
-    rm -r whls
+RUN uv pip install ai-dynamo[vllm] --find-links whls
 
 # Tell vllm to use the Dynamo LLM C API for KV Cache Routing
 ENV VLLM_KV_CAPI_PATH="/opt/dynamo/bindings/lib/libdynamo_llm_capi.so"

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -323,8 +323,9 @@ RUN uv venv $VIRTUAL_ENV --python 3.12 && \
     echo "source $VIRTUAL_ENV/bin/activate" >> ~/.bashrc
 
 # Install the wheels
-COPY --from=dev /workspace/dist/*.whl whls/
-RUN uv pip install ai-dynamo[vllm] --find-links whls
+COPY --from=dev /workspace/dist/*.whl wheelhouse/
+RUN uv pip install ai-dynamo[vllm] --find-links wheelhouse && \
+    rm -r wheelhouse
 
 # Tell vllm to use the Dynamo LLM C API for KV Cache Routing
 ENV VLLM_KV_CAPI_PATH="/opt/dynamo/bindings/lib/libdynamo_llm_capi.so"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "types-psutil==7.0.0.20250218",
     "ai-dynamo-runtime==0.1.0",
 ]
+
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -45,6 +46,11 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 keywords = ["llm", "genai", "inference", "nvidia", "distributed", "dynamo"]
+
+[project.optional-dependencies]
+vllm = [
+    "vllm==0.7.2+dynamo"
+]
 
 [project.scripts]
 dynamo = "dynamo.sdk.cli.cli:cli"


### PR DESCRIPTION
#### Overview:

* add optional vllm dependency
* update runtime container to use vllm dependency

Testing
```
 => [runtime  7/10] COPY --from=dev /workspace/dist/*.whl wheelhouse/                                                                                                            0.5s
 => [runtime  8/10] RUN uv pip install ai-dynamo[vllm] --find-links wheelhouse &&     rm -r wheelhouse                                                                          28.5s
 => [runtime  9/10] RUN --mount=type=bind,source=./container/launch_mess.....
 ```