### PR TITLE
fix(vllm,sglang): Let the engine enforce max tokens

### DIFF
--- a/launch/dynamo-run/src/input/text.rs
+++ b/launch/dynamo-run/src/input/text.rs
@@ -24,6 +24,7 @@ use crate::input::common;
 use crate::EngineConfig;
 
 /// Max response tokens for each single query. Must be less than model context size.
+/// TODO: Cmd line flag to overwrite this
 const MAX_TOKENS: u32 = 8192;
 
 pub async fn run(

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -143,12 +143,6 @@ impl OpenAIPreprocessor {
         }
 
         let mut stop_conditions = request.extract_stop_conditions()?;
-
-        // todo - pull this from the mdc default sampling/stop params
-        if stop_conditions.max_tokens.is_none() {
-            stop_conditions.max_tokens = Some(64);
-        }
-
         if let Some(stop_tokens) = &mut stop_conditions.stop_token_ids_hidden {
             for eos_token in self.model_info.eos_token_ids() {
                 if !stop_tokens.contains(&eos_token) {

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -138,15 +138,11 @@ impl OpenAISamplingOptionsProvider for NvCreateChatCompletionRequest {
 
 /// Implements `OpenAIStopConditionsProvider` for `NvCreateChatCompletionRequest`,
 /// providing access to stop conditions that control chat completion behavior.
-#[allow(deprecated)]
 impl OpenAIStopConditionsProvider for NvCreateChatCompletionRequest {
     /// Retrieves the maximum number of tokens allowed in the response.
-    ///
-    /// # Note
-    /// This field is deprecated in favor of `max_completion_tokens`.
+    #[allow(deprecated)]
     fn get_max_tokens(&self) -> Option<u32> {
-        // ALLOW: max_tokens is deprecated in favor of max_completion_tokens
-        self.inner.max_tokens
+        self.inner.max_completion_tokens.or(self.inner.max_tokens)
     }
 
     /// Retrieves the minimum number of tokens required in the response.


### PR DESCRIPTION
Previously several parts of the stack ensured max tokens (for this single request) was set.

Now only text input sets it (to 8k). Everything else leaves as is, potentially blank. The engines themselves have very small defaults, 16 for vllm and 128 for sglang.

Also fix dynamo-run CUDA startup message to only print if we're using an engine that would benefit from it (mistralrs, llamacpp).
