### PR TITLE
fix(runtime): Shutdown message from eprintln to tracing debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,29 +314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbe221bbf523b625a4dd8585c7f38166e31167ec2ca98051dbcb4c3b6e825d2"
-dependencies = [
- "bindgen 0.69.5",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,7 +760,6 @@ dependencies = [
  "num_cpus",
  "rand 0.8.5",
  "reqwest 0.12.14",
- "rustls 0.23.23",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1503,12 +1479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,13 +1570,13 @@ dependencies = [
  "async-openai",
  "async-stream",
  "async-trait",
- "candle-hf-hub",
  "clap",
  "dialoguer",
  "dynamo-llm",
  "dynamo-runtime",
  "futures",
  "futures-util",
+ "hf-hub",
  "humantime",
  "netlink-packet-route",
  "rtnetlink",
@@ -2046,12 +2016,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -5403,7 +5367,6 @@ version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5481,7 +5444,6 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/launch/dynamo-run/Cargo.toml
+++ b/launch/dynamo-run/Cargo.toml
@@ -51,7 +51,7 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 async-openai = { version = "0.27.2" }
-candle-hf-hub = { version = "0.3.3", default-features = false, features = ["tokio", "rustls-tls"] }
+hf-hub = { version = "0.4.2", default-features = false, features = ["tokio", "rustls-tls"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 dialoguer = { version = "0.11", default-features = false, features = ["editor", "history"] }
 futures-util = { version = "0.3" }

--- a/launch/dynamo-run/src/hub.rs
+++ b/launch/dynamo-run/src/hub.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use candle_hf_hub::api::tokio::ApiBuilder;
+use hf_hub::api::tokio::ApiBuilder;
 use std::path::{Path, PathBuf};
 
 const IGNORED: [&str; 3] = [".gitattributes", "LICENSE", "README.md"];

--- a/lib/runtime/src/worker.rs
+++ b/lib/runtime/src/worker.rs
@@ -132,8 +132,8 @@ impl Worker {
 
             tokio::select! {
                 _ = cancel_token.cancelled() => {
-                    eprintln!("{}", SHUTDOWN_MESSAGE);
-                    eprintln!("{} {} seconds", SHUTDOWN_TIMEOUT_MESSAGE, timeout);
+                    tracing::debug!("{}", SHUTDOWN_MESSAGE);
+                    tracing::debug!("{} {} seconds", SHUTDOWN_TIMEOUT_MESSAGE, timeout);
                 }
 
                 _ = app_tx.closed() => {
@@ -146,7 +146,7 @@ impl Worker {
                 }
 
                 _ = tokio::time::sleep(tokio::time::Duration::from_secs(timeout)) => {
-                    eprintln!("Application did not shutdown in time; terminating");
+                    tracing::debug!("Application did not shutdown in time; terminating");
                     std::process::exit(911);
                 }
             }?;


### PR DESCRIPTION
Switch library `candle-hf-hub` to `hf-hub`. That's the correct one, and they are also identical. Thanks for catching this @ryanolson .

And testing signed commits
