### PR TITLE
fix: add checkout action for path filters

### DIFF
--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: self-hosted
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4      
+      uses: actions/checkout@v4
     - name: Detect source code changes
       id: src_changes
       uses: dorny/paths-filter@v3

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -38,6 +38,8 @@ jobs:
     needs: mirror_repo
     runs-on: self-hosted
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4      
     - name: Detect source code changes
       id: src_changes
       uses: dorny/paths-filter@v3


### PR DESCRIPTION
#### Overview:

Without actions/checkout, path filters fail to clone repo and detect changes