### PR TITLE
fix: more closely mimic perf analyzer location to previous behavior

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -320,10 +320,11 @@ FROM build AS dev
 
 ARG GENAI_PERF_TAG
 
-COPY --from=perf_analyzer /workspace/bin/perf-analyzer-build /workspace/benchmarking
+COPY --from=perf_analyzer /workspace/bin/perf-analyzer-build/ /perf/bin
+COPY --from=perf_analyzer /workspace/perf_analyzer /perf_analyzer
+ENV PATH="/perf/bin:${PATH}"
 
 # Install genai-perf for benchmarking
-ENV PATH="/workspace/benchmarking:${PATH}"
 RUN uv pip install "git+https://github.com/triton-inference-server/perf_analyzer.git@${GENAI_PERF_TAG}#subdirectory=genai-perf"
 RUN uv pip uninstall tritonclient
 


### PR DESCRIPTION
#### Overview:

GitLab test pipeline has been broken due to dependency pytests also running due to location of perf-analyzer was placed. This moves it out of the scope of where those tests execute.

![tests_passing](https://github.com/user-attachments/assets/812580f9-ea43-4630-8e4c-57f5ded5c71a)

