### PR TITLE
chore: rename patched vllm wheel to ai_dynamo_vllm

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -189,7 +189,7 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 ARG VLLM_REF="0.7.2"
 ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
 ARG VLLM_VERSION_PATCH_SUFFIX="dynamo"
-ARG VLLM_PACKAGE_NAME="ai_dynamo_vllm"
+ARG VLLM_PATCHED_PACKAGE_NAME="ai_dynamo_vllm"
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     mkdir /tmp/vllm && \
     uv pip install pip wheel && \
@@ -199,18 +199,19 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     cd vllm-${VLLM_REF}/ && \
     patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
     sed -i "s/__version__ = version = '\(.*\)'/__version__ = version = '\1+${VLLM_VERSION_PATCH_SUFFIX}'/g; s/__version_tuple__ = version_tuple = (\(.*\))/__version_tuple__ = version_tuple = (\1, '${VLLM_VERSION_PATCH_SUFFIX}')/g" vllm/_version.py && \
-    mv vllm-${VLLM_REF}.dist-info ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info && \
-    sed -i "s/${VLLM_REF}/${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}/g" ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/METADATA && \
-    sed -i "s/vllm-${VLLM_REF}/vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}/g" ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/RECORD && \
     # Rename the package from vllm to ai_dynamo_vllm
-    sed -i "s/^Name: vllm/Name: ${VLLM_PACKAGE_NAME}/g" ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/METADATA && \
+    mv vllm-${VLLM_REF}.dist-info ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info && \
+    sed -i "s/${VLLM_REF}/${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/METADATA && \
+    sed -i "s/vllm-${VLLM_REF}/vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/RECORD && \
+    # Rename the package from vllm to ai_dynamo_vllm
+    sed -i "s/^Name: vllm/Name: ${VLLM_PATCHED_PACKAGE_NAME}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/METADATA && \
     # Update wheel tag from linux_x86_64 to manylinux1_x86_64 in WHEEL file
-    sed -i 's/Tag: cp38-abi3-linux_x86_64/Tag: cp38-abi3-manylinux1_x86_64/g' ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/WHEEL && \
+    sed -i 's/Tag: cp38-abi3-linux_x86_64/Tag: cp38-abi3-manylinux1_x86_64/g' ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/WHEEL && \
     # Also update the tag in RECORD file to match
-    sed -i "s/-cp38-abi3-linux_x86_64.whl/-cp38-abi3-manylinux1_x86_64.whl/g" ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/RECORD && \
+    sed -i "s/-cp38-abi3-linux_x86_64.whl/-cp38-abi3-manylinux1_x86_64.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/RECORD && \
     mkdir -p /workspace/dist && \
     wheel pack . --dest-dir /workspace/dist && \
-    uv pip install /workspace/dist/${VLLM_PACKAGE_NAME}-*.whl
+    uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl
 
 # Install test dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -189,6 +189,7 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 ARG VLLM_REF="0.7.2"
 ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
 ARG VLLM_VERSION_PATCH_SUFFIX="dynamo"
+ARG VLLM_PACKAGE_NAME="ai_dynamo_vllm"
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     mkdir /tmp/vllm && \
     uv pip install pip wheel && \
@@ -198,12 +199,18 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     cd vllm-${VLLM_REF}/ && \
     patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
     sed -i "s/__version__ = version = '\(.*\)'/__version__ = version = '\1+${VLLM_VERSION_PATCH_SUFFIX}'/g; s/__version_tuple__ = version_tuple = (\(.*\))/__version_tuple__ = version_tuple = (\1, '${VLLM_VERSION_PATCH_SUFFIX}')/g" vllm/_version.py && \
-    mv vllm-${VLLM_REF}.dist-info vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info && \
-    sed -i "s/${VLLM_REF}/${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}/g" vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/METADATA && \
-    sed -i "s/vllm-${VLLM_REF}/vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}/g" vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/RECORD && \
+    mv vllm-${VLLM_REF}.dist-info ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info && \
+    sed -i "s/${VLLM_REF}/${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}/g" ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/METADATA && \
+    sed -i "s/vllm-${VLLM_REF}/vllm-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}/g" ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/RECORD && \
+    # Rename the package from vllm to ai_dynamo_vllm
+    sed -i "s/^Name: vllm/Name: ${VLLM_PACKAGE_NAME}/g" ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/METADATA && \
+    # Update wheel tag from linux_x86_64 to manylinux1_x86_64 in WHEEL file
+    sed -i 's/Tag: cp38-abi3-linux_x86_64/Tag: cp38-abi3-manylinux1_x86_64/g' ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/WHEEL && \
+    # Also update the tag in RECORD file to match
+    sed -i "s/-cp38-abi3-linux_x86_64.whl/-cp38-abi3-manylinux1_x86_64.whl/g" ${VLLM_PACKAGE_NAME}-${VLLM_REF}+${VLLM_VERSION_PATCH_SUFFIX}.dist-info/RECORD && \
     mkdir -p /workspace/dist && \
     wheel pack . --dest-dir /workspace/dist && \
-    uv pip install /workspace/dist/vllm-*.whl
+    uv pip install /workspace/dist/${VLLM_PACKAGE_NAME}-*.whl
 
 # Install test dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,12 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 
 [project.optional-dependencies]
 all = [
-    "vllm==0.7.2+dynamo",
+    "ai-dynamo-vllm==0.7.2+dynamo",
     "nixl",
 ]
 
 vllm = [
-    "vllm==0.7.2+dynamo"
+    "ai-dynamo-vllm==0.7.2+dynamo"
 ]
 
 [project.scripts]


### PR DESCRIPTION
#### Overview:

Rename vllm patched wheel for hosting on pypi to ai_dynamo_vllm
Fix tags to be same as original name - https://pypi.org/project/vllm/0.7.2/#files


New wheel name - will copy from CI job