### PR TITLE
fix: Add __init__.py for compoments folder in llm example

### DIFF
--- a/examples/llm/components/__init__.py
+++ b/examples/llm/components/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
#### Overview:

The __init__ is necessary to used components folder in examples as Python packages.


#### Details:

The components folder in examples can be used as source of services to be served in dynamo:
```
dynamo serve components.prefill_worker:PrefillWorker -f configs/disagg.yaml
```

#### Where should the reviewer start?

Please check other __init__.py files and try to used dynamo server with files from components folder.

