### PR TITLE
fix: use rustup-init for rust install

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -58,11 +58,24 @@ RUN ln -sf /bin/bash /bin/sh
 
 # Rust build/dev dependencies
 RUN apt-get update && \
-    apt-get install --no-install-recommends --yes  gdb protobuf-compiler cmake libssl-dev pkg-config
+    apt-get install --no-install-recommends -y \
+    gdb \
+    protobuf-compiler \
+    cmake \
+    libssl-dev \
+    pkg-config
 
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.85.0 \
+    RUSTARCH=x86_64-unknown-linux-gnu
+
+RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.27.1/${RUSTARCH}/rustup-init" && \
+    chmod +x rustup-init && \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${RUSTARCH} && \
+    rm rustup-init && \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
 # Working directory
 WORKDIR /workspace

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -71,7 +71,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     RUST_VERSION=1.85.0 \
     RUSTARCH=x86_64-unknown-linux-gnu
 
-RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.27.1/${RUSTARCH}/rustup-init" && \
+RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" && \
     chmod +x rustup-init && \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${RUSTARCH} && \
     rm rustup-init && \

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -72,6 +72,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     RUSTARCH=x86_64-unknown-linux-gnu
 
 RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" && \
+    echo "a3339fb004c3d0bb9862ba0bce001861fe5cbde9c10d16591eb3f39ee6cd3e7f *rustup-init" | sha256sum -c - && \
     chmod +x rustup-init && \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${RUSTARCH} && \
     rm rustup-init && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -239,7 +239,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     RUST_VERSION=1.85.0 \
     RUSTARCH=x86_64-unknown-linux-gnu
 
-RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.27.1/${RUSTARCH}/rustup-init" && \
+RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" && \
     chmod +x rustup-init && \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${RUSTARCH} && \
     rm rustup-init && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -226,15 +226,24 @@ RUN ln -sf /bin/bash /bin/sh
 
 # Rust build/dev dependencies
 RUN apt update -y && \
-    apt install -y \
+    apt install --no-install-recommends -y \
     build-essential \
     protobuf-compiler \
     cmake \
     libssl-dev \
-    pkg-config && \
-    curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
+    pkg-config
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.85.0 \
+    RUSTARCH=x86_64-unknown-linux-gnu
+
+RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.27.1/${RUSTARCH}/rustup-init" && \
+    chmod +x rustup-init && \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${RUSTARCH} && \
+    rm rustup-init && \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
 # Working directory
 WORKDIR /workspace

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -240,6 +240,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     RUSTARCH=x86_64-unknown-linux-gnu
 
 RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" && \
+    echo "a3339fb004c3d0bb9862ba0bce001861fe5cbde9c10d16591eb3f39ee6cd3e7f *rustup-init" | sha256sum -c - && \
     chmod +x rustup-init && \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${RUSTARCH} && \
     rm rustup-init && \


### PR DESCRIPTION
#### Overview:

curl + pipe (`|`) install leads to silent failures. Use rustup-init to install the desired rust version.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #315
