### PR TITLE
ci: Add External Contribution label

### DIFF
--- a/.github/workflows/pr_full_ci_reminder.yaml
+++ b/.github/workflows/pr_full_ci_reminder.yaml
@@ -45,3 +45,19 @@ jobs:
                 'Your PR reviewers may elect to test the changes comprehensively before approving your changes.\n\n' +
                 '🚀'
             })
+      - name: Adding Label to PR
+        uses: actions/github-script@v7
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CONTRIBUTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const { REPOSITORY, CONTRIBUTOR } = process.env
+
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["external-contribution"]
+            });


### PR DESCRIPTION
Recognize PRs created by external contributors by a new label "external-contribution" and help speed-up code reviews by sending reminders to close these PRs within a defined SLA