### PR TITLE
chore: use getattr instead of hasattr for checking

### DIFF
--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -129,15 +129,9 @@ class Router:
             for endpoint in metrics.endpoints:
                 worker_id = endpoint.worker_id
                 worker_metrics[worker_id] = {
-                    "gpu_cache_usage_perc": endpoint.gpu_cache_usage_perc
-                    if hasattr(endpoint, "gpu_cache_usage_perc")
-                    else 0.0,
-                    "num_requests_waiting": endpoint.num_requests_waiting
-                    if hasattr(endpoint, "num_requests_waiting")
-                    else 0.0,
-                    "gpu_prefix_cache_hit_rate": endpoint.gpu_prefix_cache_hit_rate
-                    if hasattr(endpoint, "gpu_prefix_cache_hit_rate")
-                    else 0.0,
+                    "gpu_cache_usage_perc": getattr(endpoint, "gpu_cache_usage_perc", 0.0),
+                    "num_requests_waiting": getattr(endpoint, "num_requests_waiting", 0.0),
+                    "gpu_prefix_cache_hit_rate": getattr(endpoint, "gpu_prefix_cache_hit_rate", 0.0),
                 }
                 max_waiting = max(
                     max_waiting, worker_metrics[worker_id]["num_requests_waiting"]


### PR DESCRIPTION
#### Overview:

Use `getattr` instead of using `hasattr` for checking existence of key (worker metrics). Cleaner and avoids a double lookup. Potentially avoids a race condition in multithreaded settings.
