### PR TITLE
[WIP] fix: enable clean shutdown of all workers and processes

### DIFF
--- a/deploy/dynamo/sdk/src/dynamo/sdk/lib/decorators.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/lib/decorators.py
@@ -99,3 +99,9 @@ def async_on_start(func: t.Callable) -> t.Callable:
     # Mark the function as a startup hook
     setattr(func, "__bentoml_startup_hook__", True)
     return bentoml.on_startup(func)
+
+def async_on_shutdown(func: t.Callable) -> t.Callable:
+    """Decorator for async onshutdown functions."""
+    # Mark the function as a shutdown hook
+    setattr(func, "__bentoml_shutdown_hook__", True)
+    return bentoml.on_shutdown(func)

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -64,7 +64,6 @@ class Processor(ProcessMixIn):
             self.tokenizer, self.model_config
         )
         self.router_mode = self.engine_args.router
-        self.min_workers = 1
 
     def _create_tokenizer(self, engine_args: AsyncEngineArgs) -> AnyTokenizer:
         """Create a TokenizerGroup using engine arguments similar to VLLM's approach"""
@@ -90,12 +89,8 @@ class Processor(ProcessMixIn):
             .endpoint("generate")
             .client()
         )
-        while len(self.worker_client.endpoint_ids()) < self.min_workers:
-            print(
-                f"Waiting for workers to be ready.\n"
-                f" Current: {len(self.worker_client.endpoint_ids())},"
-                f" Required: {self.min_workers}"
-            )
+        while len(self.worker_client.endpoint_ids()) < 1:
+            print("Waiting for a worker to be ready...")
             await asyncio.sleep(2)
 
     async def _generate(

--- a/examples/llm/components/worker.py
+++ b/examples/llm/components/worker.py
@@ -31,7 +31,7 @@ from vllm.remote_prefill import RemotePrefillParams, RemotePrefillRequest
 from vllm.sampling_params import RequestOutputKind
 
 from dynamo.llm import KvMetricsPublisher
-from dynamo.sdk import async_on_start, depends, dynamo_context, dynamo_endpoint, service
+from dynamo.sdk import async_on_start, depends, dynamo_context, dynamo_endpoint, service, async_on_shutdown
 
 
 @service(
@@ -129,6 +129,13 @@ class VllmWorker:
         else:
             self.disaggregated_router = None
         print("VllmWorker has been initialized")
+
+    @async_on_shutdown
+    async def async_shutdown(self):
+        print("VllmWorker is shutting down")
+        self.engine_client.shutdown_background_loop()
+        await self.engine_client.__aexit__()
+        print("VllmWorker has been shutdown")
 
     async def create_metrics_publisher_endpoint(self):
         component = dynamo_context["component"]


### PR DESCRIPTION
There's been a couple different [issues](https://github.com/ai-dynamo/dynamo/issues/308) people running into lingering zombie processes even after you run a `ctrl-c`. Many times these are VLLM processes. This PR does 2 things

1. Adds some signal handling to our dynamo worker at the SDK level
2. Wires up the `async_shutdown` hook allowing our reference examples to use things like `shutdown_background_loop()` from the VLLM AsyncLLMEngine code. 
3. Bring back the use of uvloop (@PeaBrane)

As of right now - I have tested on 4 examples and think I have (1) working. 