### PR TITLE
chore: Clarified docs, added more informative error prints

### DIFF
--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -86,15 +86,20 @@ apt install -y build-essential libhwloc-dev libudev-dev pkg-config libssl-dev li
 ```
 
 Libraries macOS:
+- [Homebrew](https://brew.sh/)
+```
+# if brew is not installed on your system, install it
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+- [Xcode](https://developer.apple.com/xcode/)
+
 ```
 brew install cmake protobuf
 
-# install Xcode from App Store and check that Metal is accessible
+# Check that Metal is accessible
 xcrun -sdk macosx metal
-
-# may have to install Xcode Command Line Tools:
-xcode-select --install
 ```
+If Metal is accessible, you should see an error like `metal: error: no input files`, which confirms it is installed correctly.
 
 Install Rust:
 ```

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -129,21 +129,34 @@ pub async fn run(
     let (maybe_card_path, maybe_card) = match (&model_path, &flags.model_config) {
         // --model-config takes precedence
         (_, Some(model_config)) => {
-            let card = match ModelDeploymentCard::from_local_path(model_config, model_name.as_deref()).await {
-                Ok(card) => Some(card),
-                Err(e) => {
-                    tracing::error!("Failed to load model card from config path {:?}: {}", model_config, e);
-                    None
-                }
-            };
+            let card =
+                match ModelDeploymentCard::from_local_path(model_config, model_name.as_deref())
+                    .await
+                {
+                    Ok(card) => Some(card),
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to load model card from config path {}: {}",
+                            model_config.display(),
+                            e
+                        );
+                        None
+                    }
+                };
             (Some(model_config.clone()), card)
         }
         // If --model-path is an HF repo use that
         (Some(model_path), _) if model_path.is_dir() => {
-            let card = match ModelDeploymentCard::from_local_path(model_path, model_name.as_deref()).await {
+            let card = match ModelDeploymentCard::from_local_path(model_path, model_name.as_deref())
+                .await
+            {
                 Ok(card) => Some(card),
                 Err(e) => {
-                    tracing::error!("Failed to load model card from model path {:?}: {}", model_path, e);
+                    tracing::error!(
+                        "Failed to load model card from model path {}: {}",
+                        model_path.display(),
+                        e
+                    );
                     None
                 }
             };

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -272,7 +272,8 @@ pub async fn run(
             };
             let Some(card) = maybe_card.clone() else {
                 anyhow::bail!(
-                    "out=vllm requires --model-path to be an HF repo, or for GGUF add flag --model-config <hf-repo>"
+                    "Failed to load model card: either unsupported HuggingFace repo format \
+                    or for GGUF files --model-config is missing."
                 );
             };
             let Some(sock_prefix) = zmq_socket_prefix else {


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

- Added some clarifications to `dynamo-run` guides, related to MacOS
- Added error prints, to improve UX. Currently, dynamo seems to support only fast tokenizers, so HF repos which use slow tokenizers were failing with:

```
2025-03-20T18:16:21.338594Z DEBUG reqwest::connect: starting new connection: https://huggingface.co/    
2025-03-20T18:16:21.345275Z DEBUG rustls::client::hs: No cached session for DnsName("huggingface.co")    
2025-03-20T18:16:21.345373Z DEBUG rustls::client::hs: Not resuming any session    
2025-03-20T18:16:21.352069Z DEBUG rustls::client::hs: Using ciphersuite TLS13_AES_128_GCM_SHA256    
2025-03-20T18:16:21.352113Z DEBUG rustls::client::tls13: Not resuming    
2025-03-20T18:16:21.352202Z DEBUG rustls::client::tls13: TLS1.3 encrypted extensions: [ServerNameAck, Protocols([ProtocolName(6832)])]    
2025-03-20T18:16:21.352224Z DEBUG rustls::client::hs: ALPN protocol is Some(b"h2")    
2025-03-20T18:16:21.432481Z DEBUG rustls::common_state: Sending warning alert CloseNotify    
2025-03-20T18:16:21.432748Z ERROR dynamo_runtime::worker: Application shutdown with error: out=vllm requires --model-path to be an HF repo, or for GGUF add flag --model-config <hf-repo>
Error: out=vllm requires --model-path to be an HF repo, or for GGUF add flag --model-config <hf-repo>
```

Wasn't clear why exactly, so I've added more verbosity in this PR, so now the actual cause is printed:
```
2025-03-21T19:18:01.227466Z DEBUG reqwest::connect: starting new connection: https://huggingface.co/    
2025-03-21T19:18:01.258130Z DEBUG rustls::client::hs: No cached session for DnsName("huggingface.co")    
2025-03-21T19:18:01.258243Z DEBUG rustls::client::hs: Not resuming any session    
2025-03-21T19:18:01.283263Z DEBUG rustls::client::hs: Using ciphersuite TLS13_AES_128_GCM_SHA256    
2025-03-21T19:18:01.283305Z DEBUG rustls::client::tls13: Not resuming    
2025-03-21T19:18:01.283409Z DEBUG rustls::client::tls13: TLS1.3 encrypted extensions: [ServerNameAck, Protocols([ProtocolName(6832)])]    
2025-03-21T19:18:01.283436Z DEBUG rustls::client::hs: ALPN protocol is Some(b"h2")    
2025-03-21T19:18:01.404529Z DEBUG rustls::common_state: Sending warning alert CloseNotify    
2025-03-21T19:18:01.405659Z ERROR dynamo_run: Failed to load model card from model path "/Users/oandreeva/.cache/huggingface/hub/models--facebook--opt-125m/snapshots/27dcfa74d334bc871f3234de431e71c6eeba5dd6": unable to extract tokenizer kind from repo /Users/oandreeva/.cache/huggingface/hub/models--facebook--opt-125m/snapshots/27dcfa74d334bc871f3234de431e71c6eeba5dd6
2025-03-21T19:18:01.405800Z ERROR dynamo_runtime::worker: Application shutdown with error: Failed to load model card: either unsupported HuggingFace repo format or for GGUF files --model-config is missing.
Error: Failed to load model card: either unsupported HuggingFace repo format or for GGUF files --model-config is missing.
```

#### Details:

ditto

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: N/A
