### PR TITLE
docs: fix grammar in architecture support note

### DIFF
--- a/support_matrix.md
+++ b/support_matrix.md
@@ -10,7 +10,7 @@ This document provides the support matrix for Dynamo, including hardware, softwa
 | **x86_64**            | Supported     |
 | **ARM64**             | Experimental  |
 
-> **Note**: While **x86_64** architecture is supported on systems with a minimum of 32 GB RAM and at least 4 CPU cores. The **ARM64** support is experimental and may have limitations.
+> **Note**: While **x86_64** architecture is supported on systems with a minimum of 32 GB RAM and at least 4 CPU cores, The **ARM64** support is experimental and may have limitations.
 
 ### GPU Compatibility
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Hi team! 😊

First of all, congratulations on the release of Dynamo — really exciting to see it out! We’re currently running some benchmarks comparing TTFT and QPS — impressive work so far.

While reading the documentation, we noticed a small grammar issue that we wanted to point out:

Original:

`Note: While x86_64 architecture is supported on systems with a minimum of 32 GB RAM and at least 4 CPU cores. The ARM64 support is experimental and may have limitations.`

The issue is that the “while” clause is incomplete — “while” introduces a dependent clause, so it should be followed by a main clause instead of ending with a period.
Hope this helps polish the documentation a bit!
Wishing you all a great day and looking forward to following Dynamo’s progress! 🚀

#### Details:

<!-- Describe the changes made in this PR. -->

	•	Updated the architecture support note to fix grammar:
	•	Replaced the period with a comma after the “while” clause.
	•	Improved the sentence flow for clarity and correctness.
from 

> **Note**: While **x86_64** architecture is supported on systems with a minimum of 32 GB RAM and at least 4 CPU cores. The **ARM64** support is experimental and may have limitations.

to

> **Note**: While **x86_64** architecture is supported on systems with a minimum of 32 GB RAM and at least 4 CPU cores, The **ARM64** support is experimental and may have limitations.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
support_matrix.md line 13

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
