### PR TITLE
fix: Attach lease to etcd key

### DIFF
--- a/launch/dynamo-run/src/input/endpoint.rs
+++ b/launch/dynamo-run/src/input/endpoint.rs
@@ -101,7 +101,7 @@ pub async fn run(
         .kv_create(
             network_name.clone(),
             serde_json::to_vec_pretty(&model_registration)?,
-            None,
+            Some(etcd_client.lease_id()),
         )
         .await?;
 


### PR DESCRIPTION
That ensures it gets removed when the process stops.
