### PR TITLE
fix: limit rust build parallel jobs

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -90,6 +90,10 @@ COPY Cargo.lock /workspace/
 COPY rust-toolchain.toml /workspace/
 
 ARG CARGO_BUILD_JOBS
+# Set CARGO_BUILD_JOBS to 16 if not provided
+# This is to prevent cargo from building $(nproc) jobs in parallel,
+# which might exceed the number of opened files limit.
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-16}
 
 ENV CARGO_TARGET_DIR=/workspace/target
 

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -262,6 +262,10 @@ COPY components /workspace/components
 COPY launch /workspace/launch
 
 ARG CARGO_BUILD_JOBS
+# Set CARGO_BUILD_JOBS to 16 if not provided
+# This is to prevent cargo from building $(nproc) jobs in parallel,
+# which might exceed the number of opened files limit.
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-16}
 
 ENV CARGO_TARGET_DIR=/workspace/target
 


### PR DESCRIPTION
By default, cargo build num of cpu core jobs in parallel. Limiting the max parallel job build fix the random error of exceeding ulimit on opened files.