### PR TITLE
feat: Allow passing any arguments to vllm and sglang engines

### DIFF
--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -165,13 +165,15 @@ Any example above using `out=sglang` will work, but our sglang backend is also m
 
 Node 1:
 ```
-dynamo-run in=http out=sglang --model-path ~/llm_models/DeepSeek-R1-Distill-Llama-70B/ --tensor-parallel-size 8 --num-nodes 2 --node-rank 0 --dist-init-addr 10.217.98.122:9876
+dynamo-run in=http out=sglang --model-path ~/llm_models/DeepSeek-R1-Distill-Llama-70B/ --tensor-parallel-size 8 --num-nodes 2 --node-rank 0 --leader-addr 10.217.98.122:9876
 ```
 
 Node 2:
 ```
-dynamo-run in=none out=sglang --model-path ~/llm_models/DeepSeek-R1-Distill-Llama-70B/ --tensor-parallel-size 8 --num-nodes 2 --node-rank 1 --dist-init-addr 10.217.98.122:9876
+dynamo-run in=none out=sglang --model-path ~/llm_models/DeepSeek-R1-Distill-Llama-70B/ --tensor-parallel-size 8 --num-nodes 2 --node-rank 1 --leader-addr 10.217.98.122:9876
 ```
+
+To pass extra arguments to the sglang engine see *Extra engine arguments* below.
 
 ## llama_cpp
 
@@ -224,6 +226,8 @@ Node 2:
 ```
 dynamo-run in=none out=vllm ~/llm_models/Llama-3.2-3B-Instruct/ --num-nodes 2 --leader-addr 10.217.98.122:6539 --node-rank 1
 ```
+
+To pass extra arguments to the vllm engine see *Extra engine arguments* below.
 
 ## Python bring-your-own-engine
 
@@ -433,4 +437,21 @@ The output looks like this:
 ## Defaults
 
 The input defaults to `in=text`. The output will default to `mistralrs` engine. If not available whatever engine you have compiled in (so depending on `--features`).
+
+## Extra engine arguments
+
+The vllm and sglang backends support passing any argument the engine accepts.
+
+Put the arguments in a JSON file:
+```
+{
+    "dtype": "half",
+    "trust_remote_code": true
+}
+```
+
+Pass it like this:
+```
+dynamo-run out=sglang ~/llm_models/Llama-3.2-3B-Instruct --extra-engine-args sglang_extra.json
+```
 

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -257,6 +257,7 @@ pub async fn run(
                 node_conf,
                 flags.tensor_parallel_size,
                 flags.base_gpu_id,
+                flags.extra_engine_args,
             )
             .await?;
             extra = Some(Box::pin(async move {
@@ -310,6 +311,7 @@ pub async fn run(
                     &sock_prefix,
                     node_conf,
                     flags.tensor_parallel_size,
+                    flags.extra_engine_args,
                 )
                 .await?;
                 extra = Some(Box::pin(async move {

--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -32,7 +32,7 @@ Example:
 
 const ZMQ_SOCKET_PREFIX: &str = "dyn";
 
-const USAGE: &str = "USAGE: dynamo-run in=[http|text|dyn://<path>|batch:<folder>|none] out=[mistralrs|sglang|llamacpp|vllm|trtllm|echo_full|echo_core|pystr:<engine.py>|pytok:<engine.py>] [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0]";
+const USAGE: &str = "USAGE: dynamo-run in=[http|text|dyn://<path>|batch:<folder>|none] out=[mistralrs|sglang|llamacpp|vllm|trtllm|echo_full|echo_core|pystr:<engine.py>|pytok:<engine.py>] [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0] [--extra-engine-args=args.json]";
 
 fn main() -> anyhow::Result<()> {
     logging::init();
@@ -68,6 +68,7 @@ fn main() -> anyhow::Result<()> {
                         sglang_flags.pipe_fd as std::os::fd::RawFd,
                         node_config,
                         gpu_config,
+                        flags.extra_engine_args,
                     );
                 }
             } else {
@@ -94,6 +95,7 @@ fn main() -> anyhow::Result<()> {
                         &model_path,
                         node_config,
                         flags.tensor_parallel_size,
+                        flags.extra_engine_args,
                     );
                 }
             } else {

--- a/lib/llm/src/engines/sglang.rs
+++ b/lib/llm/src/engines/sglang.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::backend::ExecutionContext;
@@ -40,6 +40,8 @@ pub async fn make_engine(
     tensor_parallel_size: u32,
     // The base GPU ID to start allocating GPUs from
     base_gpu_id: u32,
+    // Extra arguments to pass directly as sglang ServerArgs
+    extra_engine_args: Option<PathBuf>,
 ) -> pipeline_error::Result<(ExecutionContext, tokio::task::JoinHandle<()>)> {
     let mut engine = SgLangEngine::new(
         cancel_token,
@@ -48,6 +50,7 @@ pub async fn make_engine(
         node_conf,
         tensor_parallel_size,
         base_gpu_id,
+        extra_engine_args,
     )
     .await?;
     let sglang_process = engine.take_sglang_worker_handle();

--- a/lib/llm/src/engines/sglang/engine.rs
+++ b/lib/llm/src/engines/sglang/engine.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use async_stream::stream;
 use async_trait::async_trait;
@@ -39,6 +39,7 @@ impl SgLangEngine {
         node_conf: MultiNodeConfig,
         tensor_parallel_size: u32,
         base_gpu_id: u32,
+        extra_engine_args: Option<PathBuf>,
     ) -> anyhow::Result<Self> {
         let w = super::worker::start(
             cancel_token.clone(),
@@ -47,6 +48,7 @@ impl SgLangEngine {
             node_conf,
             tensor_parallel_size,
             base_gpu_id,
+            extra_engine_args,
         )
         .await?;
         let engine = SgLangEngine {

--- a/lib/llm/src/engines/sglang/sglang_inc.py
+++ b/lib/llm/src/engines/sglang/sglang_inc.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This file is included as a string in subprocess.rs. Most work should be done in the Rust caller.
+#
+
+import json
+import logging
+import tempfile
+from multiprocessing.connection import Connection
+
+from sglang.srt.entrypoints.engine import _set_envs_and_config
+from sglang.srt.managers.scheduler import run_scheduler_process
+from sglang.srt.server_args import PortArgs, ServerArgs
+
+logging.basicConfig(
+    level="DEBUG",
+    force=True,
+    datefmt="%Y-%m-%d %H:%M:%S",
+    format="[%(asctime)s] %(message)s",
+)
+
+# These can all be overridden by --extra-engine-args json file
+arg_map = {
+    "model_path": f"{model_path}",
+    "enable_metrics": False,
+    "log_level": "debug",
+    "log_requests": True,
+    "tp_size": int(tp_size_str),
+    # Multi-node
+    "dist_init_addr": dist_init_addr if dist_init_addr != "" else None,
+    "nnodes": int(nnodes_str),
+    "node_rank": int(node_rank_str),
+}
+json_map = {}
+if extra_engine_args != "":
+    # extra_engine_args is a filename
+    try:
+        with open(extra_engine_args) as f:
+            json_map = json.load(f)
+    except FileNotFoundError:
+        logging.debug(f"File {extra_engine_args} not found.")
+    except json.JSONDecodeError as e:
+        logging.debug(f"Invalid JSON in {extra_engine_args}: {e}")
+    logging.debug(f"Adding extra engine arguments: {json_map}")
+    arg_map = {**arg_map, **json_map}  # json_map gets precedence
+
+server_args = ServerArgs(**arg_map)
+_set_envs_and_config(server_args)
+logging.debug(server_args)
+
+ipc_path = f"ipc:///tmp/{socket_id}"
+# These must match worker.rs zmq_sockets, which is the other side
+port_args = PortArgs(
+    # we don't use this one so use anything
+    tokenizer_ipc_name=f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}",
+    # Us -> sglang
+    scheduler_input_ipc_name=f"{ipc_path}_input_socket",
+    # sglang -> us
+    detokenizer_ipc_name=f"{ipc_path}_output_socket",
+    # The port for nccl initialization (torch.dist), which we don't use
+    nccl_port=9876,
+)
+
+# Rank must be globally unique across nodes
+tp_rank = int(tp_rank_str)
+
+# See nvidia-smi for GPU IDs, they run 0,1,2,etc.
+# In a single-node setup this is the same as rank
+gpu_id = int(gpu_id_str)
+
+pipe_fd_int = int(pipe_fd)
+writer = Connection(handle=pipe_fd_int, readable=False, writable=True)
+
+run_scheduler_process(server_args, port_args, gpu_id, tp_rank, None, writer)

--- a/lib/llm/src/engines/vllm.rs
+++ b/lib/llm/src/engines/vllm.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use std::future::Future;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -46,6 +46,8 @@ pub async fn make_leader_engine(
     node_conf: MultiNodeConfig,
     // How many GPUs to use
     tensor_parallel_size: u32,
+    // Path to extra engine args file
+    extra_engine_args: Option<PathBuf>,
 ) -> pipeline_error::Result<(ExecutionContext, impl Future<Output = ()>)> {
     let ray_obj = if node_conf.num_nodes > 1 {
         let r = ray::start_leader(node_conf.leader_addr.parse()?)?;
@@ -64,6 +66,7 @@ pub async fn make_leader_engine(
         model_path,
         node_conf,
         tensor_parallel_size,
+        extra_engine_args,
     )
     .await?;
     let vllm_process = engine.take_vllm_worker_handle();

--- a/lib/llm/src/engines/vllm/engine.rs
+++ b/lib/llm/src/engines/vllm/engine.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use async_stream::stream;
 use async_trait::async_trait;
@@ -38,6 +38,7 @@ impl VllmEngine {
         model_path: &Path,
         node_conf: MultiNodeConfig,
         tensor_parallel_size: u32,
+        extra_engine_args: Option<PathBuf>,
     ) -> anyhow::Result<Self> {
         let w = worker::start(
             cancel_token.clone(),
@@ -45,6 +46,7 @@ impl VllmEngine {
             model_path,
             node_conf,
             tensor_parallel_size,
+            extra_engine_args,
         )
         .await?;
         let engine = VllmEngine {

--- a/lib/llm/src/engines/vllm/vllm_inc.py
+++ b/lib/llm/src/engines/vllm/vllm_inc.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This file is included as a string in subprocess.rs. Most work should be done in the Rust caller.
+#
+
+import json
+import logging
+import multiprocessing
+
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.engine.multiprocessing.engine import run_mp_engine
+from vllm.usage.usage_lib import UsageContext
+
+arg_map = {
+    "model": f"{model_path}",
+    "served_model_name": None,
+    "task": "generate",
+    "skip_tokenizer_init": True,
+    "seed": 0,
+    "max_model_len": 8192,
+    "max_seq_len_to_capture": 8192,
+    "tensor_parallel_size": int(tp_size_str),
+    "pipeline_parallel_size": int(nnodes_str),
+}
+json_map = {}
+if extra_engine_args != "":
+    # extra_engine_args is a filename
+    try:
+        with open(extra_engine_args) as f:
+            json_map = json.load(f)
+    except FileNotFoundError:
+        logging.debug(f"File {extra_engine_args} not found.")
+    except json.JSONDecodeError as e:
+        logging.debug(f"Invalid JSON in {extra_engine_args}: {e}")
+    logging.debug(f"Adding extra engine arguments: {json_map}")
+    arg_map = {**arg_map, **json_map}  # json_map gets precedence
+
+engine_args = AsyncEngineArgs(**arg_map)
+ipc_path = f"ipc:///tmp/{socket_id}"
+
+engine_alive = multiprocessing.Value("b", True, lock=False)
+
+# 0.7.3
+run_mp_engine(engine_args, UsageContext.OPENAI_API_SERVER, ipc_path, engine_alive)
+
+# 0.8.1
+# TODO: In 0.8+ first argument is VllmConfig, not AsyncEngineArgs
+# disable_log_stats = False
+# disable_log_requests = True
+# run_mp_engine(engine_args, UsageContext.OPENAI_API_SERVER, ipc_path, disable_log_stats, disable_log_requests, engine_alive)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ indent-width = 4
 
 [tool.ruff.lint.extend-per-file-ignores]
 "icp/tests/**/test_*.py" = ["F811", "F401"]
+"*_inc.py" = ["F821"]
 
 [tool.mypy]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ addopts = [
     "--strict-config",
     "--mypy",
     "--ignore-glob=*model.py",
+    "--ignore-glob=*_inc.py",
     # FIXME: Get relative/generic blob paths to work here
 ]
 xfail_strict = true


### PR DESCRIPTION
Put the arguments in a JSON file:
```
{
    "dtype": "half",
    "trust_remote_code": true
}
```

Pass it like this:
```
dynamo-run out=sglang ~/llm_models/Llama-3.2-3B-Instruct --extra-engine-args sglang_extra.json
```

Requested here https://github.com/ai-dynamo/dynamo/issues/290 (`dtype`) and here https://github.com/ai-dynamo/dynamo/issues/360 (`trust_remote_code`).
