### PR TITLE
feat: kv router cost function in rust [DRAFT]

### DIFF
--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -215,7 +215,7 @@ class Router:
     async def generate(self, request: Tokens) -> AsyncIterator[WorkerId]:
         worker_id = await self.metrics_aggregator.find_best_worker(request.tokens)
         yield f"{worker_id}_{0.5}"  # TODO: 0.5 is dummy
-    
+
     # @dynamo_endpoint()
     # async def generate(self, request: Tokens) -> AsyncIterator[WorkerId]:
     #     lora_id = 0
@@ -226,13 +226,13 @@ class Router:
     #     except Exception as e:
     #         scores = {}
     #         vllm_logger.exception(f"Error finding matches: {e}")
-        
-        # metrics = await self.metrics_aggregator.get_metrics()
-        # worker_id, prefix_hit_rate = self._cost_function(
-        #     scores, metrics, len(request.tokens)
-        # )
 
-        # vllm_logger.info(
-        #     f"Scheduling to worker_id: {worker_id} with estimated prefix hit rate: {prefix_hit_rate}"
-        # )
-        # yield f"{worker_id}_{prefix_hit_rate}"
+    # metrics = await self.metrics_aggregator.get_metrics()
+    # worker_id, prefix_hit_rate = self._cost_function(
+    #     scores, metrics, len(request.tokens)
+    # )
+
+    # vllm_logger.info(
+    #     f"Scheduling to worker_id: {worker_id} with estimated prefix hit rate: {prefix_hit_rate}"
+    # )
+    # yield f"{worker_id}_{prefix_hit_rate}"

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -347,6 +347,11 @@ class KvMetricsAggregator:
         """
         Return the aggregated metrics of the endpoints.
         """
+
+    def find_best_worker(self, token_ids: List[int]) -> int:
+        """
+        Find the best worker to route to based on the input tokens
+        """
         ...
 
 class KvEventPublisher:


### PR DESCRIPTION
#### Overview:

Ported the cost function computation for the KV router from Python to Rust. This is for experimental benchmarking and review only at this stage, so please do not merge. 

Hijacked the `KvMetricsAggregator` to use forward metrics from `KvIndexer` to perform worker selection. The right way to do this would probably be to include the cost function under `scheduler.rs` instead.
