### PR TITLE
fix: Revert "chore: Bump bentoml version to 1.4.6"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "pytest>=8.3.4",
-    "bentoml==1.4.6",
+    "bentoml==1.4.1",
     "types-psutil==7.0.0.20250218",
     "kubernetes==32.0.1",
     "ai-dynamo-runtime==0.1.0",


### PR DESCRIPTION
Reverts ai-dynamo/dynamo#404

With the bentoml bump we are getting the following error, we will need to test with 1.4.6 before re-introducting this bump.
ImportError: cannot import name 'normalize_identifier' from '_bentoml_impl.loader' (/opt/dynamo/venv/lib/python3.12/site-packages/_bentoml_impl/loader.py)