### PR TITLE
fix: potential out-of-bound

### DIFF
--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -245,8 +245,7 @@ pub fn select_worker(
         let kv_load_ratio = w.data.kv_active_blocks as f64 / w.data.kv_total_blocks as f64;
         let load_deviation = kv_load_ratio - workers.load_avg;
 
-        // [FIXME] multiple endpoints of the same worker cause out of bound error
-        let worker_id = workers.worker_ids[i];
+        let worker_id = w.worker_id();
         let overlap_score = request.overlap.scores.get(&worker_id).map_or(0, |x| *x);
         let overlap_score = overlap_score as usize * kv_block_size;
 

--- a/lib/llm/src/kv_router/scoring.rs
+++ b/lib/llm/src/kv_router/scoring.rs
@@ -16,14 +16,12 @@
 //! Scoring functions for the KV router.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 use crate::kv_router::scheduler::Endpoint;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct ProcessedEndpoints {
     pub endpoints: Vec<Endpoint>,
-    pub worker_ids: Vec<i64>,
     pub load_avg: f64,
     pub load_std: f64,
 }
@@ -43,12 +41,8 @@ impl ProcessedEndpoints {
             / load_values.len() as f64;
         let load_std = variance.sqrt();
 
-        let worker_ids: HashSet<i64> = endpoints.iter().map(|x| x.worker_id()).collect();
-        let worker_ids: Vec<i64> = worker_ids.into_iter().collect();
-
         ProcessedEndpoints {
             endpoints,
-            worker_ids,
             load_avg,
             load_std,
         }


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->
Saw this TODO in `scheduler.rs`, and it seems like the workId vector is redundant. It's not costly to extract workerId dynamically from EndPoint, and it simplifies the vector access

I noticed that test `test_frequency` failed in `indexer.rs` on the latest codebase, without my change

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
