### PR TITLE
feat: improve serve commands and expose `DYNAMO_HOME` env var

### DIFF
--- a/container/Dockerfile.none
+++ b/container/Dockerfile.none
@@ -37,6 +37,7 @@ RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.
 
 
 WORKDIR /workspace
+ENV DYNAMO_HOME=/workspace
 
 COPY . /workspace/
 

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -140,6 +140,7 @@ RUN pip install dist/ai_dynamo_runtime*cp312*.whl  && \
 
 # Tell TRTLLM worker to use the Dynamo LLM C API for KV Cache Routing
 ENV DYNAMO_KV_CAPI_PATH="/opt/dynamo/bindings/lib/libdynamo_llm_capi.so"
+ENV DYNAMO_HOME=/workspace
 
 # FIXME: Copy more specific folders in for dev/debug after directory restructure
 COPY . /workspace

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -362,6 +362,7 @@ CMD []
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
 
 WORKDIR /workspace
+ENV DYNAMO_HOME=/workspace
 ENV VIRTUAL_ENV=/opt/dynamo/venv
 
 # Copy NIXL

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -131,9 +131,6 @@ cd $DYNAMO_HOME/examples/llm
 dynamo serve graphs.disagg_router:Frontend -f ./configs/disagg_router.yaml
 ```
 
-
-
-
 ### Client
 
 In another terminal:

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -105,30 +105,34 @@ This figure shows an overview of the major components to deploy:
 ```
 
 ### Example architectures
+_Note_: For a non-dockerized deployment, first export `DYNAMO_HOME` to point to the dynamo repository root, e.g. `export DYNAMO_HOME=$(pwd)`
 
 #### Aggregated serving
 ```bash
-cd examples/llm
+cd $DYNAMO_HOME/examples/llm
 dynamo serve graphs.agg:Frontend -f ./configs/agg.yaml
 ```
 
 #### Aggregated serving with KV Routing
 ```bash
-cd examples/llm
+cd $DYNAMO_HOME/examples/llm
 dynamo serve graphs.agg_router:Frontend -f ./configs/agg_router.yaml
 ```
 
 #### Disaggregated serving
 ```bash
-cd examples/llm
+cd $DYNAMO_HOME/examples/llm
 dynamo serve graphs.disagg:Frontend -f ./configs/disagg.yaml
 ```
 
 #### Disaggregated serving with KV Routing
 ```bash
-cd examples/llm
+cd $DYNAMO_HOME/examples/llm
 dynamo serve graphs.disagg_router:Frontend -f ./configs/disagg_router.yaml
 ```
+
+
+
 
 ### Client
 

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -108,25 +108,25 @@ This figure shows an overview of the major components to deploy:
 
 #### Aggregated serving
 ```bash
-cd /workspace/examples/llm
+cd examples/llm
 dynamo serve graphs.agg:Frontend -f ./configs/agg.yaml
 ```
 
 #### Aggregated serving with KV Routing
 ```bash
-cd /workspace/examples/llm
+cd examples/llm
 dynamo serve graphs.agg_router:Frontend -f ./configs/agg_router.yaml
 ```
 
 #### Disaggregated serving
 ```bash
-cd /workspace/examples/llm
+cd examples/llm
 dynamo serve graphs.disagg:Frontend -f ./configs/disagg.yaml
 ```
 
 #### Disaggregated serving with KV Routing
 ```bash
-cd /workspace/examples/llm
+cd examples/llm
 dynamo serve graphs.disagg_router:Frontend -f ./configs/disagg_router.yaml
 ```
 


### PR DESCRIPTION
#### Overview:
/workspace only exists on dockerized deployment.

#### Details:
Expose `DYNAMO_HOME` which is configured to `/workspace` within provided containers, and user-configurable for non-docker deployments

One may prefer a non-dockerized dev setup since even changing one line of python code results in 2 minutes of build time

![image](https://github.com/user-attachments/assets/c896b298-74e1-4085-b1d3-2a2fd36ec08d)

