### PR TITLE
fix: prefill queue handler async task should not silently error

### DIFF
--- a/examples/llm/components/prefill_worker.py
+++ b/examples/llm/components/prefill_worker.py
@@ -89,9 +89,9 @@ class PrefillWorker:
         def prefill_queue_handler_cb(fut):
             try:
                 fut.result()
-                print("prefill queue handler created successfully")
+                print("prefill queue handler exited successfully")
             except Exception as e:
-                print(f"prefill queue handler failed: {e!r}")
+                print(f"[ERROR] prefill queue handler failed: {e!r}")
                 sys.exit(1)
 
         task.add_done_callback(prefill_queue_handler_cb)

--- a/examples/llm/components/prefill_worker.py
+++ b/examples/llm/components/prefill_worker.py
@@ -16,6 +16,7 @@
 
 import asyncio
 import os
+import sys
 
 from pydantic import BaseModel
 from utils.nixl import NixlMetadataStore
@@ -86,8 +87,12 @@ class PrefillWorker:
         task = asyncio.create_task(self.prefill_queue_handler())
 
         def prefill_queue_handler_cb(fut):
-            fut.result()
-            print("prefill queue handler created successfully")
+            try:
+                fut.result()
+                print("prefill queue handler created successfully")
+            except Exception as e:
+                print(f"prefill queue handler failed: {e!r}")
+                sys.exit(1)
 
         task.add_done_callback(prefill_queue_handler_cb)
         print("PrefillWorker initialized")

--- a/examples/llm/components/prefill_worker.py
+++ b/examples/llm/components/prefill_worker.py
@@ -84,7 +84,12 @@ class PrefillWorker:
         self._metadata_store = NixlMetadataStore("dynamo", runtime)
         await self._metadata_store.put(metadata.engine_id, metadata)
         task = asyncio.create_task(self.prefill_queue_handler())
-        task.add_done_callback(lambda _: print("prefill queue handler created"))
+
+        def prefill_queue_handler_cb(fut):
+            fut.result()
+            print("prefill queue handler created successfully")
+
+        task.add_done_callback(prefill_queue_handler_cb)
         print("PrefillWorker initialized")
 
     async def prefill_queue_handler(self):


### PR DESCRIPTION
#### Overview:
Fix silent error by explicitly unwrapping the future

#### Details:

This managed to catch the following silent error:
```
Dequeued prefill request: c71e24b4-c7c6-434d-bd0b-329a2764012e
prefill queue handler failed: 'RemotePrefillRequest' object has no attribute 'computed_block_ids'
```

Turns out this is due to non-dockerized disagg not working with vllm due to vllm being unpatched