### PR TITLE
chore: Upgrade llamacpp dependency

### DIFF
--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -104,7 +104,7 @@ libc = "0.2"
 serde-pickle = "1.2.0"
 
 # llamacpp
-llama-cpp-2 = { version = "0.1.86", optional = true }
+llama-cpp-2 = { version = "0.1.102", optional = true }
 
 # tokenizers
 tokenizers = { version = "0.21.1", default-features = false, features = [


### PR DESCRIPTION
Aiming to fix this:

> Unknown GGUF architecture `deci`"

on nvidia_Llama-3_3-Nemotron-Super-49B
