### PR TITLE
fix: metrics missing field decode error

### DIFF
--- a/components/metrics/src/lib.rs
+++ b/components/metrics/src/lib.rs
@@ -589,7 +589,11 @@ pub fn extract_metrics(endpoints: &[EndpointInfo]) -> Vec<ForwardPassMetrics> {
         .iter()
         .filter_map(|e| {
             let metrics_data = e.as_ref()?;
-            metrics_data.clone().decode::<StatsWithData>().ok()
+            metrics_data.clone()
+            .decode::<StatsWithData>()
+            .map_err(|err| {
+                tracing::warn!("Error decoding stats: {err}");
+            }).ok()
         })
         .collect();
     tracing::debug!("Stats: {stats:?}");

--- a/components/metrics/src/main.rs
+++ b/components/metrics/src/main.rs
@@ -225,10 +225,20 @@ async fn app(runtime: Runtime) -> Result<()> {
         let scrape_timeout = Duration::from_secs(1);
         let endpoints =
             collect_endpoints(&target_component, &service_subject, scrape_timeout).await?;
+        if endpoints.is_empty() {
+            tracing::warn!("No endpoints found matching {service_path}");
+        } else {
+            tracing::debug!("Found {} endpoints matching {}", endpoints.len(), service_path);
+        }
         let metrics = extract_metrics(&endpoints);
+        if metrics.is_empty() {
+            tracing::warn!("Extract metrics from endpoints got empty");
+        } else {
+            tracing::debug!("Extracted {} metrics from {} endpoints", metrics.len(), endpoints.len());
+        }
         let processed = postprocess_metrics(&metrics, &endpoints);
         if processed.endpoints.is_empty() {
-            tracing::warn!("No endpoints found matching {service_path}");
+            tracing::warn!("No endpoints to aggregated metrics");
         } else {
             tracing::info!("Aggregated metrics: {processed:?}");
         }

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -138,6 +138,8 @@ export NATS_SERVER = '<your-nats-server-address>'
 export ETCD_ENDPOINTS = '<your-etcd-endpoints-address>'
 
 cd /workspace/examples/llm
+sed -i '/worker = depends(VllmWorker)/d' ./components/frontend.py
+sed -i '/worker = depends(VllmWorker)/d' ./components/Processor.py
 dynamo serve graphs.frontend_router:Fronend -f /configs/disagg_router.yaml
 ```
 

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -130,6 +130,36 @@ cd /workspace/examples/llm
 dynamo serve graphs.disagg_router:Frontend -f ./configs/disagg_router.yaml
 ```
 
+#### Disaggregated serving in multi nodes with KV Routing
+
+##### frontend node
+```bash
+export NATS_SERVER = '<your-nats-server-address>'
+export ETCD_ENDPOINTS = '<your-etcd-endpoints-address>'
+
+cd /workspace/examples/llm
+dynamo serve graphs.frontend_router:Fronend -f /configs/disagg_router.yaml
+```
+
+##### worker node
+```bash
+export NATS_SERVER = '<your-nats-server-address>'
+export ETCD_ENDPOINTS = '<your-etcd-endpoints-address>'
+
+cd /workspace/examples/llm
+sed -i '/prefill_worker = depends(PrefillWorker)/d' ./components/worker.py
+dynamo serve components.worker:VllmWorker -f ./configs/disagg_router.yaml
+```
+
+##### prefill worker node
+```bash
+export NATS_SERVER = '<your-nats-server-address>'
+export ETCD_ENDPOINTS = '<your-etcd-endpoints-address>'
+
+cd /workspace/examples/llm
+dynamo serve components.prefill_worker:PrefillWorker -f ./configs/disagg_router.yaml
+```
+
 ### Client
 
 In another terminal:

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -140,7 +140,7 @@ export ETCD_ENDPOINTS = '<your-etcd-endpoints-address>'
 cd /workspace/examples/llm
 sed -i '/worker = depends(VllmWorker)/d' ./components/frontend.py
 sed -i '/worker = depends(VllmWorker)/d' ./components/processor.py
-dynamo serve graphs.frontend_router:Fronend -f ./configs/disagg_router.yaml
+dynamo serve graphs.frontend_router:Frontend -f ./configs/disagg_router.yaml
 ```
 
 ##### worker node

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -139,8 +139,8 @@ export ETCD_ENDPOINTS = '<your-etcd-endpoints-address>'
 
 cd /workspace/examples/llm
 sed -i '/worker = depends(VllmWorker)/d' ./components/frontend.py
-sed -i '/worker = depends(VllmWorker)/d' ./components/Processor.py
-dynamo serve graphs.frontend_router:Fronend -f /configs/disagg_router.yaml
+sed -i '/worker = depends(VllmWorker)/d' ./components/processor.py
+dynamo serve graphs.frontend_router:Fronend -f ./configs/disagg_router.yaml
 ```
 
 ##### worker node

--- a/examples/llm/graphs/frontend_router.py
+++ b/examples/llm/graphs/frontend_router.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from components.frontend import Frontend
+from components.kv_router import Router
+from components.processor import Processor
+
+Frontend.link(Processor).link(Router)

--- a/lib/runtime/src/service.rs
+++ b/lib/runtime/src/service.rs
@@ -94,7 +94,8 @@ pub struct Metrics {
 
 impl Metrics {
     pub fn decode<T: for<'de> Deserialize<'de>>(self) -> Result<T> {
-        serde_json::from_value(self.data).map_err(Into::into)
+        let v = serde_json::to_value(&self)?;
+        serde_json::from_value(v).map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
#### Overview:

The components' metrics now consistently display 'No endpoints found matching {service_path}' because the `Metrics` struct cannot be deserialized into the `StatsWithData` type.

#### Details:

As a Rust beginner, I'm not sure if this fix follows best practices. I think adding logging with detailed information would be helpful.

#### Where should the reviewer start?

In the file `components/src/main.rs`, the code collects endpoints and extracts metrics from them. The extract function encountered a deserialization error while attempting to convert `Metrics` to the `StatsWithData` type defined in `components/src/lib.rs`.