### PR TITLE
fix(metrics): decode error missing field

### DIFF
--- a/components/metrics/src/lib.rs
+++ b/components/metrics/src/lib.rs
@@ -589,7 +589,11 @@ pub fn extract_metrics(endpoints: &[EndpointInfo]) -> Vec<ForwardPassMetrics> {
         .iter()
         .filter_map(|e| {
             let metrics_data = e.as_ref()?;
-            metrics_data.clone().decode::<StatsWithData>().ok()
+            metrics_data.clone()
+            .decode::<StatsWithData>()
+            .map_err(|err| {
+                tracing::warn!("Error decoding stats: {err}");
+            }).ok()
         })
         .collect();
     tracing::debug!("Stats: {stats:?}");

--- a/components/metrics/src/lib.rs
+++ b/components/metrics/src/lib.rs
@@ -589,11 +589,13 @@ pub fn extract_metrics(endpoints: &[EndpointInfo]) -> Vec<ForwardPassMetrics> {
         .iter()
         .filter_map(|e| {
             let metrics_data = e.as_ref()?;
-            metrics_data.clone()
-            .decode::<StatsWithData>()
-            .map_err(|err| {
-                tracing::warn!("Error decoding stats: {err}");
-            }).ok()
+            metrics_data
+                .clone()
+                .decode::<StatsWithData>()
+                .map_err(|err| {
+                    tracing::warn!("Error decoding stats: {err}");
+                })
+                .ok()
         })
         .collect();
     tracing::debug!("Stats: {stats:?}");

--- a/components/metrics/src/lib.rs
+++ b/components/metrics/src/lib.rs
@@ -592,7 +592,7 @@ pub fn extract_metrics(endpoints: &[EndpointInfo]) -> Vec<ForwardPassMetrics> {
             metrics_data
                 .clone()
                 .decode::<StatsWithData>()
-                .map_err(|err| {
+                .inspect_err(|err| {
                     tracing::warn!("Error decoding stats: {err}");
                 })
                 .ok()

--- a/components/metrics/src/main.rs
+++ b/components/metrics/src/main.rs
@@ -225,10 +225,20 @@ async fn app(runtime: Runtime) -> Result<()> {
         let scrape_timeout = Duration::from_secs(1);
         let endpoints =
             collect_endpoints(&target_component, &service_subject, scrape_timeout).await?;
+        if endpoints.is_empty() {
+            tracing::warn!("No endpoints found matching {service_path}");
+        } else {
+            tracing::debug!("Found {} endpoints matching {}", endpoints.len(), service_path);
+        }
         let metrics = extract_metrics(&endpoints);
+        if metrics.is_empty() {
+            tracing::warn!("Extract metrics from endpoints got empty");
+        } else {
+            tracing::debug!("Extracted {} metrics from {} endpoints", metrics.len(), endpoints.len());
+        }
         let processed = postprocess_metrics(&metrics, &endpoints);
         if processed.endpoints.is_empty() {
-            tracing::warn!("No endpoints found matching {service_path}");
+            tracing::warn!("No endpoints to aggregated metrics");
         } else {
             tracing::info!("Aggregated metrics: {processed:?}");
         }

--- a/components/metrics/src/main.rs
+++ b/components/metrics/src/main.rs
@@ -227,6 +227,7 @@ async fn app(runtime: Runtime) -> Result<()> {
             collect_endpoints(&target_component, &service_subject, scrape_timeout).await?;
         if endpoints.is_empty() {
             tracing::warn!("No endpoints found matching {service_path}");
+            continue;
         } else {
             tracing::debug!(
                 "Found {} endpoints matching {}",
@@ -237,6 +238,7 @@ async fn app(runtime: Runtime) -> Result<()> {
         let metrics = extract_metrics(&endpoints);
         if metrics.is_empty() {
             tracing::warn!("Extract metrics from endpoints got empty");
+            continue;
         } else {
             tracing::debug!(
                 "Extracted {} metrics from {} endpoints",
@@ -247,6 +249,7 @@ async fn app(runtime: Runtime) -> Result<()> {
         let processed = postprocess_metrics(&metrics, &endpoints);
         if processed.endpoints.is_empty() {
             tracing::warn!("No endpoints to aggregated metrics");
+            continue;
         } else {
             tracing::info!("Aggregated metrics: {processed:?}");
         }

--- a/components/metrics/src/main.rs
+++ b/components/metrics/src/main.rs
@@ -228,31 +228,28 @@ async fn app(runtime: Runtime) -> Result<()> {
         if endpoints.is_empty() {
             tracing::warn!("No endpoints found matching {service_path}");
             continue;
-        } else {
-            tracing::debug!(
-                "Found {} endpoints matching {}",
-                endpoints.len(),
-                service_path
-            );
         }
+        tracing::debug!(
+            "Found {} endpoints matching {}",
+            endpoints.len(),
+            service_path
+        );
         let metrics = extract_metrics(&endpoints);
         if metrics.is_empty() {
             tracing::warn!("Extract metrics from endpoints got empty");
             continue;
-        } else {
-            tracing::debug!(
-                "Extracted {} metrics from {} endpoints",
-                metrics.len(),
-                endpoints.len()
-            );
         }
+        tracing::debug!(
+            "Extracted {} metrics from {} endpoints",
+            metrics.len(),
+            endpoints.len()
+        );
         let processed = postprocess_metrics(&metrics, &endpoints);
         if processed.endpoints.is_empty() {
             tracing::warn!("No endpoints to aggregated metrics");
             continue;
-        } else {
-            tracing::info!("Aggregated metrics: {processed:?}");
         }
+        tracing::info!("Aggregated metrics: {processed:?}");
 
         // Update Prometheus metrics
         metrics_collector.lock().await.update(&config, &processed);

--- a/components/metrics/src/main.rs
+++ b/components/metrics/src/main.rs
@@ -228,13 +228,21 @@ async fn app(runtime: Runtime) -> Result<()> {
         if endpoints.is_empty() {
             tracing::warn!("No endpoints found matching {service_path}");
         } else {
-            tracing::debug!("Found {} endpoints matching {}", endpoints.len(), service_path);
+            tracing::debug!(
+                "Found {} endpoints matching {}",
+                endpoints.len(),
+                service_path
+            );
         }
         let metrics = extract_metrics(&endpoints);
         if metrics.is_empty() {
             tracing::warn!("Extract metrics from endpoints got empty");
         } else {
-            tracing::debug!("Extracted {} metrics from {} endpoints", metrics.len(), endpoints.len());
+            tracing::debug!(
+                "Extracted {} metrics from {} endpoints",
+                metrics.len(),
+                endpoints.len()
+            );
         }
         let processed = postprocess_metrics(&metrics, &endpoints);
         if processed.endpoints.is_empty() {

--- a/lib/llm/src/kv_router/metrics_aggregator.rs
+++ b/lib/llm/src/kv_router/metrics_aggregator.rs
@@ -139,7 +139,7 @@ pub async fn collect_endpoints_task(
                     .into_iter()
                     .filter(|s| s.data.is_some())
                     .filter_map(|s|
-                        match s.data.unwrap().decode::<ForwardPassMetrics>() {
+                        match s.data.unwrap().decode_data::<ForwardPassMetrics>() {
                             Ok(data) => Some(Endpoint {
                                 name: s.name,
                                 subject: s.subject,

--- a/lib/runtime/src/service.rs
+++ b/lib/runtime/src/service.rs
@@ -94,7 +94,8 @@ pub struct Metrics {
 
 impl Metrics {
     pub fn decode<T: for<'de> Deserialize<'de>>(self) -> Result<T> {
-        serde_json::from_value(self.data).map_err(Into::into)
+        let v = serde_json::to_value(&self)?;
+        serde_json::from_value(v).map_err(Into::into)
     }
 }
 

--- a/lib/runtime/src/service.rs
+++ b/lib/runtime/src/service.rs
@@ -97,6 +97,10 @@ impl Metrics {
         let v = serde_json::to_value(&self)?;
         serde_json::from_value(v).map_err(Into::into)
     }
+
+    pub fn decode_data<T: for<'de> Deserialize<'de>>(self) -> Result<T> {
+        serde_json::from_value(self.data).map_err(Into::into)
+    }
 }
 
 impl ServiceClient {


### PR DESCRIPTION
Overview:
The components' metrics now consistently display 'No endpoints found matching {service_path}' because the Metrics struct cannot be deserialized into the StatsWithData type.

Details:
As a Rust beginner, I'm not sure if this fix follows best practices. I think adding logging with detailed information would be helpful.

Where should the reviewer start?
In the file components/src/main.rs, the code collects endpoints and extracts metrics from them. The extract function encountered a deserialization error while attempting to convert Metrics to the StatsWithData type defined in components/src/lib.rs.
