### PR TITLE
chore: Disable blank issue creation for default issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Dynamo documentation
     url: https://www.nvidia.com/en-us/ai/dynamo/


### PR DESCRIPTION
#### Overview:

Disable blank issue creation to ensure all bugs/features are filed following the template. If these are not applicable, We will add additional templates to help users files bugs/tickets. 

#### Details:

- Set ``blank_issues_enabled`` to false
