### PR TITLE
feat: Python decorator dynamo_worker takes optional `static` parameter without etcd

### DIFF
--- a/components/http/src/main.rs
+++ b/components/http/src/main.rs
@@ -89,12 +89,14 @@ async fn app(runtime: Runtime) -> Result<()> {
             drt: distributed.clone(),
         });
 
-        let etcd_client = distributed.etcd_client();
-        let models_watcher: PrefixWatcher = etcd_client.kv_get_and_watch_prefix(etcd_path).await?;
+        if let Some(etcd_client) = distributed.etcd_client() {
+            let models_watcher: PrefixWatcher =
+                etcd_client.kv_get_and_watch_prefix(etcd_path).await?;
 
-        let (_prefix, _watcher, receiver) = models_watcher.dissolve();
-        let watcher_task = tokio::spawn(model_watcher(state, receiver));
-        watcher_tasks.push(watcher_task);
+            let (_prefix, _watcher, receiver) = models_watcher.dissolve();
+            let watcher_task = tokio::spawn(model_watcher(state, receiver));
+            watcher_tasks.push(watcher_task);
+        }
     }
 
     // Run the service

--- a/examples/llm/utils/nixl.py
+++ b/examples/llm/utils/nixl.py
@@ -64,6 +64,8 @@ class NixlMetadataStore:
 
         self._cached: dict[str, NixlMetadata] = {}
         self._client = runtime.etcd_client()
+        if self._client is None:
+            raise Exception("Cannot be used with static workers")
         self._key_prefix = f"{self._namespace}/{NixlMetadataStore.NIXL_METADATA_KEY}"
 
     async def put(self, engine_id, metadata: NixlMetadata):

--- a/launch/dynamo-run/src/input/http.rs
+++ b/launch/dynamo-run/src/input/http.rs
@@ -47,26 +47,33 @@ pub async fn run(
         .build()?;
     match engine_config {
         EngineConfig::Dynamic(endpoint) => {
-            // This will attempt to connect to NATS and etcd
             let distributed_runtime = DistributedRuntime::from_settings(runtime.clone()).await?;
+            match distributed_runtime.etcd_client() {
+                Some(etcd_client) => {
+                    // This will attempt to connect to NATS and etcd
 
-            let component = distributed_runtime
-                .namespace(endpoint.namespace)?
-                .component(endpoint.component)?;
-            let network_prefix = component.service_name();
+                    let component = distributed_runtime
+                        .namespace(endpoint.namespace)?
+                        .component(endpoint.component)?;
+                    let network_prefix = component.service_name();
 
-            // Listen for models registering themselves in etcd, add them to HTTP service
-            let state = Arc::new(discovery::ModelWatchState {
-                prefix: network_prefix.clone(),
-                model_type: ModelType::Chat,
-                manager: http_service.model_manager().clone(),
-                drt: distributed_runtime.clone(),
-            });
-            tracing::info!("Waiting for remote model at {network_prefix}");
-            let etcd_client = distributed_runtime.etcd_client();
-            let models_watcher = etcd_client.kv_get_and_watch_prefix(network_prefix).await?;
-            let (_prefix, _watcher, receiver) = models_watcher.dissolve();
-            let _watcher_task = tokio::spawn(discovery::model_watcher(state, receiver));
+                    // Listen for models registering themselves in etcd, add them to HTTP service
+                    let state = Arc::new(discovery::ModelWatchState {
+                        prefix: network_prefix.clone(),
+                        model_type: ModelType::Chat,
+                        manager: http_service.model_manager().clone(),
+                        drt: distributed_runtime.clone(),
+                    });
+                    tracing::info!("Waiting for remote model at {network_prefix}");
+                    let models_watcher =
+                        etcd_client.kv_get_and_watch_prefix(network_prefix).await?;
+                    let (_prefix, _watcher, receiver) = models_watcher.dissolve();
+                    let _watcher_task = tokio::spawn(discovery::model_watcher(state, receiver));
+                }
+                None => {
+                    // Static endpoints don't need discovery
+                }
+            }
         }
         EngineConfig::StaticFull {
             service_name,

--- a/launch/llmctl/src/main.rs
+++ b/launch/llmctl/src/main.rs
@@ -271,7 +271,7 @@ async fn add_model(
     );
     let etcd_client = distributed
         .etcd_client()
-        .expect("llmctl is only useful with dynamic workers");
+        .expect("unreachable: llmctl is only useful with dynamic workers");
 
     // check if model already exists
     let kvs = etcd_client.kv_get_prefix(&path).await?;

--- a/launch/llmctl/src/main.rs
+++ b/launch/llmctl/src/main.rs
@@ -269,7 +269,9 @@ async fn add_model(
         model_type.as_str(),
         model_name
     );
-    let etcd_client = distributed.etcd_client();
+    let etcd_client = distributed
+        .etcd_client()
+        .expect("llmctl is only useful with dynamic workers");
 
     // check if model already exists
     let kvs = etcd_client.kv_get_prefix(&path).await?;
@@ -321,7 +323,9 @@ async fn list_single_model(
     );
 
     let mut models = Vec::new();
-    let etcd_client = distributed.etcd_client();
+    let etcd_client = distributed
+        .etcd_client()
+        .expect("llmctl is only useful for dynamic workers");
     let kvs = etcd_client.kv_get_prefix(&path).await?;
 
     for kv in kvs {
@@ -364,7 +368,9 @@ async fn list_models(
     for mt in model_types {
         let prefix = format!("{}/models/{}/", component.etcd_path(), mt.as_str(),);
 
-        let etcd_client = distributed.etcd_client();
+        let etcd_client = distributed
+            .etcd_client()
+            .expect("llmctl is only useful with dynamic workers");
         let kvs = etcd_client.kv_get_prefix(&prefix).await?;
 
         for kv in kvs {
@@ -424,7 +430,11 @@ async fn remove_model(
     log::debug!("deleting key: {}", prefix);
 
     // get the kvs from etcd
-    let mut kv_client = distributed.etcd_client().etcd_client().kv_client();
+    let mut kv_client = distributed
+        .etcd_client()
+        .expect("llmctl is only useful with dynamic workers")
+        .etcd_client()
+        .kv_client();
     match kv_client.delete(prefix.as_bytes(), None).await {
         Ok(_response) => {
             println!(

--- a/lib/bindings/python/examples/hello_world/client.py
+++ b/lib/bindings/python/examples/hello_world/client.py
@@ -17,10 +17,10 @@ import asyncio
 
 import uvloop
 
-from dynamo.runtime import DistributedRuntime, dynamo_worker
+from dynamo.runtime import DistributedRuntime, dynamo_static_worker
 
 
-@dynamo_worker()
+@dynamo_static_worker()
 async def worker(runtime: DistributedRuntime):
     await init(runtime, "dynamo")
 

--- a/lib/bindings/python/examples/hello_world/client.py
+++ b/lib/bindings/python/examples/hello_world/client.py
@@ -17,10 +17,10 @@ import asyncio
 
 import uvloop
 
-from dynamo.runtime import DistributedRuntime, dynamo_static_worker
+from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 
-@dynamo_static_worker()
+@dynamo_worker(static=True)
 async def worker(runtime: DistributedRuntime):
     await init(runtime, "dynamo")
 

--- a/lib/bindings/python/examples/hello_world/run.py
+++ b/lib/bindings/python/examples/hello_world/run.py
@@ -21,7 +21,7 @@ import uvloop
 from client import init as client_init
 from server import init as server_init
 
-from dynamo.runtime import DistributedRuntime, dynamo_worker
+from dynamo.runtime import DistributedRuntime, dynamo_static_worker
 
 
 def random_string(length=10):
@@ -29,10 +29,11 @@ def random_string(length=10):
     return "".join(random.choices(chars, k=length))
 
 
-@dynamo_worker()
+@dynamo_static_worker()
 async def worker(runtime: DistributedRuntime):
     ns = random_string()
     task = asyncio.create_task(server_init(runtime, ns))
+    await asyncio.sleep(0.1)  # let the server start
     await client_init(runtime, ns)
     runtime.shutdown()
     await task

--- a/lib/bindings/python/examples/hello_world/run.py
+++ b/lib/bindings/python/examples/hello_world/run.py
@@ -21,7 +21,7 @@ import uvloop
 from client import init as client_init
 from server import init as server_init
 
-from dynamo.runtime import DistributedRuntime, dynamo_static_worker
+from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 
 def random_string(length=10):
@@ -29,7 +29,7 @@ def random_string(length=10):
     return "".join(random.choices(chars, k=length))
 
 
-@dynamo_static_worker()
+@dynamo_worker(static=True)
 async def worker(runtime: DistributedRuntime):
     ns = random_string()
     task = asyncio.create_task(server_init(runtime, ns))

--- a/lib/bindings/python/examples/hello_world/server.py
+++ b/lib/bindings/python/examples/hello_world/server.py
@@ -17,7 +17,7 @@ import asyncio
 
 import uvloop
 
-from dynamo.runtime import DistributedRuntime, dynamo_static_worker
+from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 
 class RequestHandler:
@@ -31,7 +31,7 @@ class RequestHandler:
             yield char
 
 
-@dynamo_static_worker()
+@dynamo_worker(static=True)
 async def worker(runtime: DistributedRuntime):
     await init(runtime, "dynamo")
 

--- a/lib/bindings/python/examples/hello_world/server.py
+++ b/lib/bindings/python/examples/hello_world/server.py
@@ -17,7 +17,7 @@ import asyncio
 
 import uvloop
 
-from dynamo.runtime import DistributedRuntime, dynamo_worker
+from dynamo.runtime import DistributedRuntime, dynamo_static_worker
 
 
 class RequestHandler:
@@ -31,7 +31,7 @@ class RequestHandler:
             yield char
 
 
-@dynamo_worker()
+@dynamo_static_worker()
 async def worker(runtime: DistributedRuntime):
     await init(runtime, "dynamo")
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -144,7 +144,7 @@ struct Client {
 #[pymethods]
 impl DistributedRuntime {
     #[new]
-    fn new(event_loop: PyObject) -> PyResult<Self> {
+    fn new(event_loop: PyObject, is_static: bool) -> PyResult<Self> {
         let worker = rs::Worker::from_settings().map_err(to_pyerr)?;
         INIT.get_or_try_init(|| {
             let primary = worker.tokio_runtime()?;
@@ -156,11 +156,17 @@ impl DistributedRuntime {
 
         let runtime = worker.runtime().clone();
 
-        let inner = worker
-            .runtime()
-            .secondary()
-            .block_on(rs::DistributedRuntime::from_settings(runtime))
-            .map_err(to_pyerr)?;
+        let inner =
+            if is_static {
+                runtime.secondary().block_on(
+                    rs::DistributedRuntime::from_settings_without_discovery(runtime),
+                )
+            } else {
+                runtime
+                    .secondary()
+                    .block_on(rs::DistributedRuntime::from_settings(runtime))
+            };
+        let inner = inner.map_err(to_pyerr)?;
 
         Ok(DistributedRuntime { inner, event_loop })
     }
@@ -172,10 +178,11 @@ impl DistributedRuntime {
         })
     }
 
-    fn etcd_client(&self) -> PyResult<EtcdClient> {
-        Ok(EtcdClient {
-            inner: self.inner.etcd_client().clone(),
-        })
+    fn etcd_client(&self) -> PyResult<Option<EtcdClient>> {
+        match self.inner.etcd_client().clone() {
+            Some(etcd_client) => Ok(Some(EtcdClient { inner: etcd_client })),
+            None => Ok(None),
+        }
     }
 
     fn primary_token(&self) -> CancellationToken {
@@ -262,7 +269,11 @@ impl Endpoint {
     }
 
     fn lease_id(&self) -> i64 {
-        self.inner.drt().primary_lease().id()
+        self.inner
+            .drt()
+            .primary_lease()
+            .map(|l| l.id())
+            .unwrap_or(0)
     }
 }
 
@@ -348,7 +359,7 @@ impl EtcdClient {
 impl Client {
     /// Get list of current endpoints
     fn endpoint_ids(&self) -> Vec<i64> {
-        self.inner.endpoint_ids().borrow().clone()
+        self.inner.endpoint_ids()
     }
 
     fn wait_for_endpoints<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
@@ -366,7 +377,11 @@ impl Client {
         request: PyObject,
         annotated: Option<bool>,
     ) -> PyResult<Bound<'p, PyAny>> {
-        self.random(py, request, annotated)
+        if self.inner.is_static() {
+            self.r#static(py, request, annotated)
+        } else {
+            self.random(py, request, annotated)
+        }
     }
 
     /// Send a request to the next endpoint in a round-robin fashion.
@@ -437,6 +452,32 @@ impl Client {
                 .direct(request.into(), endpoint_id)
                 .await
                 .map_err(to_pyerr)?;
+
+            tokio::spawn(process_stream(stream, tx));
+
+            Ok(AsyncResponseStream {
+                rx: Arc::new(Mutex::new(rx)),
+                annotated,
+            })
+        })
+    }
+
+    /// Directly send a request to a pre-defined static worker
+    #[pyo3(signature = (request, annotated=DEFAULT_ANNOTATED_SETTING))]
+    fn r#static<'p>(
+        &self,
+        py: Python<'p>,
+        request: PyObject,
+        annotated: Option<bool>,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let request: serde_json::Value = pythonize::depythonize(&request.into_bound(py))?;
+        let annotated = annotated.unwrap_or(false);
+
+        let (tx, rx) = tokio::sync::mpsc::channel(32);
+        let client = self.inner.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let stream = client.r#static(request.into()).await.map_err(to_pyerr)?;
 
             tokio::spawn(process_stream(stream, tx));
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -43,9 +43,9 @@ class DistributedRuntime:
         """
         ...
 
-    def etcd_client(self) -> EtcdClient:
+    def etcd_client(self) -> Optional[EtcdClient]:
         """
-        Get the `EtcdClient` object
+        Get the `EtcdClient` object. Not available for static workers.
         """
         ...
 

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -30,12 +30,26 @@ from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
 from dynamo._core import OAIChatPreprocessor as OAIChatPreprocessor
 
 
+def dynamo_static_worker():
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            loop = asyncio.get_running_loop()
+            runtime = DistributedRuntime(loop, True)
+
+            await func(runtime, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 def dynamo_worker():
     def decorator(func):
         @wraps(func)
         async def wrapper(*args, **kwargs):
             loop = asyncio.get_running_loop()
-            runtime = DistributedRuntime(loop)
+            runtime = DistributedRuntime(loop, False)
 
             await func(runtime, *args, **kwargs)
 

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -30,26 +30,12 @@ from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
 from dynamo._core import OAIChatPreprocessor as OAIChatPreprocessor
 
 
-def dynamo_static_worker():
+def dynamo_worker(static=False):
     def decorator(func):
         @wraps(func)
         async def wrapper(*args, **kwargs):
             loop = asyncio.get_running_loop()
-            runtime = DistributedRuntime(loop, True)
-
-            await func(runtime, *args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
-def dynamo_worker():
-    def decorator(func):
-        @wraps(func)
-        async def wrapper(*args, **kwargs):
-            loop = asyncio.get_running_loop()
-            runtime = DistributedRuntime(loop, False)
+            runtime = DistributedRuntime(loop, static)
 
             await func(runtime, *args, **kwargs)
 

--- a/lib/bindings/python/tests/test_etcd_bindings.py
+++ b/lib/bindings/python/tests/test_etcd_bindings.py
@@ -24,7 +24,7 @@ from dynamo._core import DistributedRuntime
 async def test_simple_put_get():
     # Initialize runtime
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop)
+    runtime = DistributedRuntime(loop, False)
 
     # Get etcd client
     etcd = runtime.etcd_client()

--- a/lib/bindings/python/tests/test_kv_bindings.py
+++ b/lib/bindings/python/tests/test_kv_bindings.py
@@ -56,7 +56,7 @@ def setup_and_teardown():
 @pytest.fixture(scope="module")
 async def distributed_runtime():
     loop = asyncio.get_running_loop()
-    return DistributedRuntime(loop)
+    return DistributedRuntime(loop, False)
 
 
 # TODO Figure out how to test with different kv_block_size

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -74,7 +74,11 @@ impl KvRouter {
         block_size: usize,
         selector: Option<Box<dyn WorkerSelector + Send + Sync>>,
     ) -> Result<Arc<Self>> {
-        let cancellation_token = component.drt().primary_lease().primary_token();
+        let cancellation_token = component
+            .drt()
+            .primary_lease()
+            .expect("Cannot KV route static workers")
+            .primary_token();
 
         let metrics_aggregator =
             KvMetricsAggregator::new(component.clone(), cancellation_token.clone()).await;

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -118,6 +118,10 @@ pub struct Component {
     /// Namespace
     #[builder(setter(into))]
     namespace: Namespace,
+
+    // A static component's endpoints cannot be discovered via etcd, they are
+    // fixed at startup time.
+    is_static: bool,
 }
 
 impl std::fmt::Display for Component {
@@ -144,7 +148,12 @@ impl Component {
     }
 
     pub fn service_name(&self) -> String {
-        Slug::from_string(format!("{}|{}", self.namespace.name(), self.name)).to_string()
+        let service_name = format!("{}_{}", self.namespace.name(), self.name);
+        if self.is_static {
+            Slug::slugify(&service_name).to_string()
+        } else {
+            Slug::slugify_unique(&service_name).to_string()
+        }
     }
 
     pub fn path(&self) -> String {
@@ -159,6 +168,7 @@ impl Component {
         Endpoint {
             component: self.clone(),
             name: endpoint.into(),
+            is_static: self.is_static,
         }
     }
 
@@ -204,6 +214,8 @@ pub struct Endpoint {
     // todo - restrict alphabet
     /// Endpoint name
     name: String,
+
+    is_static: bool,
 }
 
 impl DistributedRuntimeProvider for Endpoint {
@@ -236,11 +248,19 @@ impl Endpoint {
     }
 
     pub fn etcd_path_with_id(&self, lease_id: i64) -> String {
-        format!("{}:{:x}", self.etcd_path(), lease_id)
+        if self.is_static {
+            self.etcd_path()
+        } else {
+            format!("{}:{:x}", self.etcd_path(), lease_id)
+        }
     }
 
     pub fn name_with_id(&self, lease_id: i64) -> String {
-        format!("{}-{:x}", self.name, lease_id)
+        if self.is_static {
+            self.name.clone()
+        } else {
+            format!("{}-{:x}", self.name, lease_id)
+        }
     }
 
     pub fn subject(&self) -> String {
@@ -261,7 +281,11 @@ impl Endpoint {
         Req: Serialize + Send + Sync + 'static,
         Resp: for<'de> Deserialize<'de> + Send + Sync + 'static,
     {
-        client::Client::new(self.clone()).await
+        if self.is_static {
+            client::Client::new_static(self.clone()).await
+        } else {
+            client::Client::new_dynamic(self.clone()).await
+        }
     }
 
     pub fn endpoint_builder(&self) -> endpoint::EndpointConfigBuilder {
@@ -279,6 +303,8 @@ pub struct Namespace {
 
     #[validate()]
     name: String,
+
+    is_static: bool,
 }
 
 impl DistributedRuntimeProvider for Namespace {
@@ -300,18 +326,20 @@ impl std::fmt::Display for Namespace {
 }
 
 impl Namespace {
-    pub(crate) fn new(runtime: DistributedRuntime, name: String) -> Result<Self> {
+    pub(crate) fn new(runtime: DistributedRuntime, name: String, is_static: bool) -> Result<Self> {
         Ok(NamespaceBuilder::default()
             .runtime(runtime)
             .name(name)
+            .is_static(is_static)
             .build()?)
     }
 
-    /// Create a [`Component`] in the namespace
+    /// Create a [`Component`] in the namespace who's endpoints can be discovered with etcd
     pub fn component(&self, name: impl Into<String>) -> Result<Component> {
         Ok(ComponentBuilder::from_runtime(self.runtime.clone())
             .name(name)
             .namespace(self.clone())
+            .is_static(self.is_static)
             .build()?)
     }
 

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -149,11 +149,7 @@ impl Component {
 
     pub fn service_name(&self) -> String {
         let service_name = format!("{}_{}", self.namespace.name(), self.name);
-        if self.is_static {
-            Slug::slugify(&service_name).to_string()
-        } else {
-            Slug::slugify_unique(&service_name).to_string()
-        }
+        Slug::slugify_unique(&service_name).to_string()
     }
 
     pub fn path(&self) -> String {

--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -56,11 +56,12 @@ impl EndpointConfigBuilder {
 
     pub async fn start(self) -> Result<()> {
         let (endpoint, lease, handler, stats_handler) = self.build_internal()?.dissolve();
-        let lease = lease.unwrap_or(endpoint.drt().primary_lease());
+        let lease = lease.or(endpoint.drt().primary_lease());
+        let lease_id = lease.as_ref().map(|l| l.id()).unwrap_or(0);
 
         tracing::debug!(
             "Starting endpoint: {}",
-            endpoint.etcd_path_with_id(lease.id())
+            endpoint.etcd_path_with_id(lease_id)
         );
 
         let service_name = endpoint.component.service_name();
@@ -89,16 +90,18 @@ impl EndpointConfigBuilder {
             handler_map
                 .lock()
                 .unwrap()
-                .insert(endpoint.subject_to(lease.id()), stats_handler);
+                .insert(endpoint.subject_to(lease_id), stats_handler);
         }
 
         // creates an endpoint for the service
         let service_endpoint = group
-            .endpoint(&endpoint.name_with_id(lease.id()))
+            .endpoint(&endpoint.name_with_id(lease_id))
             .await
             .map_err(|e| anyhow::anyhow!("Failed to start endpoint: {e}"))?;
 
-        let cancel_token = lease.child_token();
+        let cancel_token = lease
+            .map(|l| l.child_token())
+            .unwrap_or_else(|| endpoint.drt().child_token());
 
         let push_endpoint = PushEndpoint::builder()
             .service_handler(handler)
@@ -116,28 +119,22 @@ impl EndpointConfigBuilder {
             component: endpoint.component.name.clone(),
             endpoint: endpoint.name.clone(),
             namespace: endpoint.component.namespace.name.clone(),
-            lease_id: lease.id(),
-            transport: TransportType::NatsTcp(endpoint.subject_to(lease.id())),
+            lease_id,
+            transport: TransportType::NatsTcp(endpoint.subject_to(lease_id)),
         };
 
         let info = serde_json::to_vec_pretty(&info)?;
 
-        if let Err(e) = endpoint
-            .component
-            .drt
-            .etcd_client
-            .kv_create(
-                endpoint.etcd_path_with_id(lease.id()),
-                info,
-                Some(lease.id()),
-            )
-            .await
-        {
-            tracing::error!("Failed to register discoverable service: {:?}", e);
-            cancel_token.cancel();
-            return Err(error!("Failed to register discoverable service"));
+        if let Some(etcd_client) = &endpoint.component.drt.etcd_client {
+            if let Err(e) = etcd_client
+                .kv_create(endpoint.etcd_path_with_id(lease_id), info, Some(lease_id))
+                .await
+            {
+                tracing::error!("Failed to register discoverable service: {:?}", e);
+                cancel_token.cancel();
+                return Err(error!("Failed to register discoverable service"));
+            }
         }
-
         task.await??;
 
         Ok(())

--- a/lib/runtime/src/component/service.rs
+++ b/lib/runtime/src/component/service.rs
@@ -69,7 +69,7 @@ impl ServiceConfigBuilder {
         let builder = component.drt.nats_client.client().service_builder();
 
         tracing::debug!("Starting service: {}", service_name);
-        let service = builder
+        let service_builder = builder
             .description(description)
             .stats_handler(move |name, stats| {
                 log::trace!("stats_handler: {name}, {stats:?}");
@@ -78,10 +78,14 @@ impl ServiceConfigBuilder {
                     Some(handler) => handler(stats),
                     None => serde_json::Value::Null,
                 }
-            })
+            });
+        tracing::debug!("Got builder");
+        let service = service_builder
             .start(service_name.clone(), version)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to start service: {e}"))?;
+
+        tracing::debug!("Service started TEMP");
 
         // new copy of service_name as the previous one is moved into the task above
         let service_name = component.service_name();
@@ -97,6 +101,7 @@ impl ServiceConfigBuilder {
         // drop the guard to unlock the mutex
         drop(guard);
 
+        tracing::debug!("create done");
         Ok(component)
     }
 }

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -74,7 +74,7 @@ pub struct DistributedRuntime {
     runtime: Runtime,
 
     // we might consider a unifed transport manager here
-    etcd_client: transports::etcd::Client,
+    etcd_client: Option<transports::etcd::Client>,
     nats_client: transports::nats::Client,
     tcp_server: Arc<OnceCell<Arc<transports::tcp::server::TcpStreamServer>>>,
 
@@ -84,4 +84,8 @@ pub struct DistributedRuntime {
     // a single endpoint watcher for both clients, this keeps the number background tasking watching specific
     // paths in etcd to a minimum.
     component_registry: component::Registry,
+
+    // Will only have static components that are not discoverable via etcd, they must be know at
+    // startup. Will not start etcd.
+    is_static: bool,
 }

--- a/lib/runtime/src/slug.rs
+++ b/lib/runtime/src/slug.rs
@@ -36,26 +36,26 @@ impl Slug {
         Slug::slugify_unique(s.as_ref())
     }
 
-    // /// Turn the string into a valid slug, replacing any not-web-or-nats-safe characters with '-'
-    // fn slugify(s: &str) -> Slug {
-    //     let out = s
-    //         .to_lowercase()
-    //         .chars()
-    //         .map(|c| {
-    //             let is_valid = c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_';
-    //             if is_valid {
-    //                 c
-    //             } else {
-    //                 REPLACEMENT_CHAR
-    //             }
-    //         })
-    //         .collect::<String>();
-    //     Slug::new(out)
-    // }
+    /// Turn the string into a valid slug, replacing any not-web-or-nats-safe characters with '-'
+    pub fn slugify(s: &str) -> Slug {
+        let out = s
+            .to_lowercase()
+            .chars()
+            .map(|c| {
+                let is_valid = c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_';
+                if is_valid {
+                    c
+                } else {
+                    REPLACEMENT_CHAR
+                }
+            })
+            .collect::<String>();
+        Slug::new(out)
+    }
 
     /// Like slugify but also add a four byte hash on the end, in case two different strings slug
     /// to the same thing.
-    fn slugify_unique(s: &str) -> Slug {
+    pub fn slugify_unique(s: &str) -> Slug {
         let out = s
             .to_lowercase()
             .chars()

--- a/lib/runtime/src/slug.rs
+++ b/lib/runtime/src/slug.rs
@@ -36,6 +36,8 @@ impl Slug {
         Slug::slugify_unique(s.as_ref())
     }
 
+    /* Not currently used but leave it for now
+     *
     /// Turn the string into a valid slug, replacing any not-web-or-nats-safe characters with '-'
     pub fn slugify(s: &str) -> Slug {
         let out = s
@@ -52,6 +54,7 @@ impl Slug {
             .collect::<String>();
         Slug::new(out)
     }
+    */
 
     /// Like slugify but also add a four byte hash on the end, in case two different strings slug
     /// to the same thing.


### PR DESCRIPTION
Adds `@dynamo_worker(static = True)` to create a static worker which has a predictable name and hence does not require discovery or `etcd` to be running. There can only be a single static worker per namespace / component / endpoint trio.

This contrasts with the default dynamic `dynamo_worker` endpoints we have now, which get a unique random name (based on namespace/component/endpoint), and are discovered by ingress components using etcd.

Also change the hello_world example to use `dynamo_worker(static = True)` so that it is exercised and demonstrated somewhere.

For NIM.
