### PR TITLE
chore: rename duration to timeout

### DIFF
--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -168,11 +168,11 @@ impl Component {
         unimplemented!("endpoints")
     }
 
-    pub async fn scrape_stats(&self, duration: Duration) -> Result<ServiceSet> {
+    pub async fn scrape_stats(&self, timeout: Duration) -> Result<ServiceSet> {
         let service_name = self.service_name();
         let service_client = self.drt().service_client();
         service_client
-            .collect_services(&service_name, duration)
+            .collect_services(&service_name, timeout)
             .await
     }
 

--- a/lib/runtime/src/service.rs
+++ b/lib/runtime/src/service.rs
@@ -115,16 +115,16 @@ impl ServiceClient {
     pub async fn collect_services(
         &self,
         service_name: &str,
-        duration: Duration,
+        timeout: Duration,
     ) -> Result<ServiceSet> {
         let sub = self.nats_client.scrape_service(service_name).await?;
-        if duration.is_zero() {
-            tracing::warn!("collect_services: duration is zero");
+        if timeout.is_zero() {
+            tracing::warn!("collect_services: timeout is zero");
         }
-        if duration > Duration::from_secs(10) {
-            tracing::warn!("collect_services: duration is greater than 10 seconds");
+        if timeout > Duration::from_secs(10) {
+            tracing::warn!("collect_services: timeout is greater than 10 seconds");
         }
-        let deadline = tokio::time::Instant::now() + duration;
+        let deadline = tokio::time::Instant::now() + timeout;
 
         let services: Vec<ServiceInfo> = stream::until_deadline(sub, deadline)
             .map(|message| serde_json::from_slice::<ServiceInfo>(&message.payload))


### PR DESCRIPTION
#### Overview:

Rename the parameter from `duration` to `timeout`, as the current name is ambiguous in this context.

