### PR TITLE
docs: add copy dynamo-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ cargo build --release
 mkdir -p /workspace/deploy/dynamo/sdk/src/dynamo/sdk/cli/bin
 cp /workspace/target/release/http /workspace/deploy/dynamo/sdk/src/dynamo/sdk/cli/bin
 cp /workspace/target/release/llmctl /workspace/deploy/dynamo/sdk/src/dynamo/sdk/cli/bin
+cp /workspace/target/release/dynamo-run /workspace/deploy/dynamo/sdk/src/dynamo/sdk/cli/bin
 
 uv pip install -e .
 ```


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Improve documentation, resolve executing 'dynamo run out=vllm deepseek-ai/DeepSeek-R1-Distill-Llama-8B' in Local Development reports 'dynamo-run not found'
#### Details:

<!-- Describe the changes made in this PR. -->
After completing the operations guided in Local Development, executing 'dynamo run out=vllm deepseek-ai/DeepSeek-R1-Distill-Llama-8B' results in the following error:
```
root@ecs-28633845:/workspace# dynamo run out=vllm deepseek-ai/DeepSeek-R1-Distill-Llama-8B                                                                                        
Traceback (most recent call last):                                                       
  File "/opt/dynamo/venv/bin/dynamo-run", line 10, in <module>                                                                                                                    
    sys.exit(dynamo_run())                                                               
             ^^^^^^^^^^^^                                                                
  File "/workspace/deploy/dynamo/sdk/src/dynamo/sdk/cli/run_executable.py", line 68, in dynamo_run                                                                                
    result = run_executable("dynamo-run", args=args, capture_output=False)                                                                                                        
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                        
  File "/workspace/deploy/dynamo/sdk/src/dynamo/sdk/cli/run_executable.py", line 42, in run_executable                                                                            
    raise FileNotFoundError(                                                             
FileNotFoundError: Executable 'dynamo-run' not found in /workspace/deploy/dynamo/sdk/src/dynamo/sdk/cli/bin                                                                       
root@ecs-28633845:/workspace# which dynamo                                                                                                                                        
/opt/dynamo/venv/bin/dynamo                                                              
root@ecs-28633845:/workspace# which dynamo-run                                                                                                                                    
/opt/dynamo/venv/bin/dynamo-run                                                          
root@ecs-28633845:/workspace# /opt/dynamo/venv/bin/dynamo-run                                                                                                                     
Traceback (most recent call last):                                                       
  File "/opt/dynamo/venv/bin/dynamo-run", line 10, in <module>                                                                                                                    
    sys.exit(dynamo_run())                                                               
             ^^^^^^^^^^^^                                                                
  File "/workspace/deploy/dynamo/sdk/src/dynamo/sdk/cli/run_executable.py", line 68, in dynamo_run                                                                                
    result = run_executable("dynamo-run", args=args, capture_output=False)                                                                                                        
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                        
  File "/workspace/deploy/dynamo/sdk/src/dynamo/sdk/cli/run_executable.py", line 42, in run_executable                                                                            
    raise FileNotFoundError(                                                             
FileNotFoundError: Executable 'dynamo-run' not found in /workspace/deploy/dynamo/sdk/src/dynamo/sdk/cli/bin     
```
#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

