### PR TITLE
fix: broken link to dynamo run

### DIFF
--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -90,7 +90,7 @@ dynamo run out=pystr:./engines/agg_engine.py -- --engine_args ./configs/llm_api_
 ```
 The above command should load the model specified in `llm_api_config.yaml` and start accepting
 text input from the client. For more details on the `dynamo run` command, please refer to the
-[dynamo run](/launch/README.md#python-bring-your-own-engine) documentation.
+[dynamo run](/docs/guides/dynamo_run.md#python-bring-your-own-engine) documentation.
 
 Currently only aggregated deployment option is supported by `dynamo run` for TensorRT-LLM.
 Adding support for disaggregated deployment is under development. This does *not* require


### PR DESCRIPTION
The file `/launch/README.md` exists on the `dynamo/trtllm_llmapi_v1` branch.
Update the link to point to `/docs/guids/dynamo_run.md` on the main branch instead.