### PR TITLE
chore: Upgrade Rust to 1.86

### DIFF
--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -66,7 +66,7 @@ jobs:
       if: ${{ env.ACT }}
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu
+        rustup toolchain install 1.86.0-x86_64-unknown-linux-gnu
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
     - name: Set up Rust Toolchain Components
       run: rustup component add rustfmt clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
     "lib/bindings/c",
     "lib/engines/*",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "0.1.0"

--- a/Earthfile
+++ b/Earthfile
@@ -73,13 +73,13 @@ rust-base:
     ENV RUSTUP_HOME=/usr/local/rustup
     ENV CARGO_HOME=/usr/local/cargo
     ENV PATH=/usr/local/cargo/bin:$PATH
-    ENV RUST_VERSION=1.85.0
+    ENV RUST_VERSION=1.86.0
     ENV RUSTARCH=x86_64-unknown-linux-gnu
 
     RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/x86_64-unknown-linux-gnu/rustup-init" && \
         echo "a3339fb004c3d0bb9862ba0bce001861fe5cbde9c10d16591eb3f39ee6cd3e7f *rustup-init" | sha256sum -c - && \
         chmod +x rustup-init && \
-        ./rustup-init -y --no-modify-path --profile minimal --default-toolchain 1.85.0 --default-host x86_64-unknown-linux-gnu && \
+        ./rustup-init -y --no-modify-path --profile minimal --default-toolchain 1.86.0 --default-host x86_64-unknown-linux-gnu && \
         rm rustup-init && \
         chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 

--- a/container/Dockerfile.none
+++ b/container/Dockerfile.none
@@ -25,7 +25,7 @@ RUN apt update -y && \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.85.0 \
+    RUST_VERSION=1.86.0 \
     RUSTARCH=x86_64-unknown-linux-gnu
 
 RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" && \

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -68,7 +68,7 @@ RUN apt-get update && \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.85.0 \
+    RUST_VERSION=1.86.0 \
     RUSTARCH=x86_64-unknown-linux-gnu
 
 RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -237,7 +237,7 @@ RUN apt update -y && \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.85.0 \
+    RUST_VERSION=1.86.0 \
     RUSTARCH=x86_64-unknown-linux-gnu
 
 RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" && \

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -100,7 +100,7 @@ pub async fn run(
         .or_else(|| {
             model_path
                 .as_ref()
-                .and_then(|p| p.iter().last())
+                .and_then(|p| p.iter().next_back())
                 .map(|n| n.to_string_lossy().into_owned())
         })
         .or_else(|| {
@@ -116,7 +116,7 @@ pub async fn run(
         if !inner_model_path.exists() {
             model_name = inner_model_path
                 .iter()
-                .last()
+                .next_back()
                 .map(|s| s.to_string_lossy().to_string());
             model_path = Some(hub::from_hf(inner_model_path).await?);
         }

--- a/lib/llm/src/engines.rs
+++ b/lib/llm/src/engines.rs
@@ -139,7 +139,7 @@ impl
         let (request, context) = incoming_request.transfer(());
         let deltas = request.response_generator();
         let ctx = context.context();
-        let req = request.inner.messages.into_iter().last().unwrap();
+        let req = request.inner.messages.into_iter().next_back().unwrap();
 
         let prompt = match req {
             async_openai::types::ChatCompletionRequestMessage::User(user_msg) => {

--- a/lib/llm/src/kv_router/indexer.rs
+++ b/lib/llm/src/kv_router/indexer.rs
@@ -822,9 +822,7 @@ impl KvIndexerInterface for KvIndexerSharded {
                                 - (scores.frequencies.len() as i64);
 
                             if diff > 0 {
-                                scores
-                                    .frequencies
-                                    .extend(iter::repeat(0).take(diff as usize));
+                                scores.frequencies.extend(iter::repeat_n(0, diff as usize));
                             }
 
                             for i in 0..response.frequencies.len() {

--- a/lib/llm/src/model_card/create.rs
+++ b/lib/llm/src/model_card/create.rs
@@ -62,7 +62,7 @@ impl ModelDeploymentCard {
         let model_name = model_name.map(|s| s.to_string()).or_else(|| {
             gguf_file
                 .iter()
-                .last()
+                .next_back()
                 .map(|n| n.to_string_lossy().to_string())
         });
         let Some(model_name) = model_name else {

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -16,7 +16,7 @@
 //! The Preprocessor consists of the following modules
 //!
 //! - `translation`: This module converts the allowed Ingress message types to the corresponding
-//!    internal representation.
+//!   internal representation.
 //! - `apply`: This module applies ModelConfig defaults to any empty optional fields specified
 //! - `prompt`: This module applies any prompt template logic to the internal Request object.
 //! - `tokenize`: This module tokenizes the formatted prompt string and returns the token ids.

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -18,7 +18,7 @@ members = [
     "hello_world",
     "service_metrics",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "0.1.0"

--- a/lib/runtime/examples/rust-toolchain.toml
+++ b/lib/runtime/examples/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"

--- a/lib/runtime/src/config.rs
+++ b/lib/runtime/src/config.rs
@@ -96,7 +96,7 @@ impl RuntimeConfig {
     /// Load the runtime configuration from the environment and configuration files
     /// Configuration is priorities in the following order, where the last has the lowest priority:
     /// 1. Environment variables (top priority)
-    ///     TO DO: Add documentation for configuration files. Paths should be configurable.
+    ///    TO DO: Add documentation for configuration files. Paths should be configurable.
     /// 2. /opt/dynamo/etc/runtime.toml
     /// 3. /opt/dynamo/defaults/runtime.toml (lowest priority)
     ///

--- a/lib/runtime/src/pipeline/context.rs
+++ b/lib/runtime/src/pipeline/context.rs
@@ -17,7 +17,7 @@
 //! There are two context object defined in this module:
 //!
 //! - [`Context`] is an input context which is propagated through the processing pipeline,
-//!    up to the point where the input is pass to an [`crate::engine::AsyncEngine`] for processing.
+//!   up to the point where the input is pass to an [`crate::engine::AsyncEngine`] for processing.
 //! - [`StreamContext`] is the input context transformed into to a type erased context that maintains the inputs
 //!   registry and visitors. `StreamAdaptors` will amend themselves to the [`StreamContext`] to allow for the
 

--- a/lib/runtime/src/service.rs
+++ b/lib/runtime/src/service.rs
@@ -67,7 +67,7 @@ impl EndpointInfo {
         let id = self
             .subject
             .split('-')
-            .last()
+            .next_back()
             .ok_or_else(|| error!("No id found in subject"))?;
 
         i64::from_str_radix(id, 16).map_err(|e| error!("Invalid id format: {}", e))

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"


### PR DESCRIPTION
Also upgrade the cargo resolver to v3, the default.

New clippy lints:
- `next_back()` instead of `last()` for a double-ended iterator. That avoids walking the whole list.
- ` repeat_n` instead of `repeat.take`. That avoids cloning.
- Doc indenting

