### PR TITLE
chore: cleaner required workers check (don't spam print)

### DIFF
--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -21,6 +21,7 @@ from argparse import Namespace
 from typing import AsyncIterator
 
 from components.worker import VllmWorker
+from utils.logging import check_required_workers
 from utils.protocol import Tokens
 from vllm.logger import logger as vllm_logger
 
@@ -98,14 +99,8 @@ class Router:
             .endpoint("generate")
             .client()
         )
-        while len(self.workers_client.endpoint_ids()) < self.args.min_workers:
-            # TODO: replace print w/ vllm_logger.info
-            print(
-                f"Waiting for more workers to be ready.\n"
-                f" Current: {len(self.workers_client.endpoint_ids())},"
-                f" Required: {self.args.min_workers}"
-            )
-            await asyncio.sleep(2)
+
+        await check_required_workers(self.workers_client, self.args.min_workers)
 
         kv_listener = self.runtime.namespace("dynamo").component("VllmWorker")
         await kv_listener.create_service()

--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -15,7 +15,6 @@
 
 
 import argparse
-import asyncio
 import random
 from argparse import Namespace
 from typing import AsyncIterator

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import uuid
 from enum import Enum
 from typing import AsyncIterator, Tuple, Union

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -22,6 +22,7 @@ from components.kv_router import Router
 from components.worker import VllmWorker
 from transformers import AutoTokenizer
 from utils.chat_processor import ChatProcessor, CompletionsProcessor, ProcessMixIn
+from utils.logging import check_required_workers
 from utils.protocol import MyRequestOutput, Tokens, vLLMGenerateRequest
 from utils.vllm import parse_vllm_args
 from vllm.engine.arg_utils import AsyncEngineArgs
@@ -90,13 +91,8 @@ class Processor(ProcessMixIn):
             .endpoint("generate")
             .client()
         )
-        while len(self.worker_client.endpoint_ids()) < self.min_workers:
-            print(
-                f"Waiting for workers to be ready.\n"
-                f" Current: {len(self.worker_client.endpoint_ids())},"
-                f" Required: {self.min_workers}"
-            )
-            await asyncio.sleep(2)
+
+        await check_required_workers(self.worker_client, self.min_workers)
 
     async def _generate(
         self,

--- a/examples/llm/utils/logging.py
+++ b/examples/llm/utils/logging.py
@@ -38,4 +38,5 @@ async def check_required_workers(
             )
         num_workers = new_count
 
+    print(f"Workers ready: {worker_ids}")
     return worker_ids

--- a/examples/llm/utils/logging.py
+++ b/examples/llm/utils/logging.py
@@ -1,8 +1,9 @@
 import asyncio
+from dynamo._core import Client
 
 
 async def check_required_workers(
-    workers_client, required_workers, on_change=True, poll_interval=0.5
+    workers_client: Client, required_workers: int, on_change=True, poll_interval=0.5
 ):
     """Wait until the minimum number of workers are ready."""
     worker_ids = workers_client.endpoint_ids()

--- a/examples/llm/utils/logging.py
+++ b/examples/llm/utils/logging.py
@@ -1,0 +1,24 @@
+import asyncio
+
+
+async def check_required_workers(
+    workers_client, required_workers, on_change=True, poll_interval=0.5
+):
+    """Wait until the minimum number of workers are ready."""
+    worker_ids = workers_client.endpoint_ids()
+    num_workers = len(worker_ids)
+
+    while num_workers < required_workers:
+        await asyncio.sleep(poll_interval)
+        worker_ids = workers_client.endpoint_ids()
+        new_count = len(worker_ids)
+
+        if (not on_change) or new_count != num_workers:
+            print(
+                f"Waiting for more workers to be ready.\n"
+                f" Current: {new_count},"
+                f" Required: {required_workers}"
+            )
+        num_workers = new_count
+
+    return worker_ids

--- a/examples/llm/utils/logging.py
+++ b/examples/llm/utils/logging.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import asyncio
+
 from dynamo._core import Client
 
 

--- a/examples/llm/utils/logging.py
+++ b/examples/llm/utils/logging.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 from dynamo._core import Client
 


### PR DESCRIPTION
#### Overview:

Print out the current launched workers only upon a change, so the prints do not overload the terminal. Refactor this into a separate util function and called in both `kv_router.py` and `processor.py`.
