### PR TITLE
docs: update close-deployment in dynamo_serve.md

### DIFF
--- a/docs/guides/dynamo_serve.md
+++ b/docs/guides/dynamo_serve.md
@@ -235,20 +235,10 @@ curl localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   
   }'
 ```
 
-## Close your deployment
+## Close deployment
 
-If you have any lingering processes after running `ctrl-c`, you can kill them by running
+> [!IMPORTANT]
+> We are aware of an issue where vLLM subprocesses might not be killed when `ctrl-c` is pressed.
+> We are working on addressing this. Relevant vLLM issues can be found [here](https://github.com/vllm-project/vllm/pull/8492) and [here](https://github.com/vllm-project/vllm/issues/6219#issuecomment-2439257824).
 
-```bash
-function kill_tree() {
-local parent=$1
-    local children=$(ps -o pid= --ppid $parent)
-for child in $children; do
-kill_tree $child
-done
-echo "Killing process $parent"
-kill -9 $parent
-}
-
-kill_tree $(pgrep circusd)
-```
+To stop the serve, you can press `ctrl-c` which will kill the different components. In order to kill the remaining vLLM subprocesses you can run `nvidia-smi` and `kill -9` the remaining processes or run `pkill python3` from inside of the container.

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -157,8 +157,4 @@ See [multinode-examples.md](multinode-examples.md) for more details.
 
 ### Close deployment
 
-> [!IMPORTANT]
-> We are aware of an issue where vLLM subprocesses might not be killed when `ctrl-c` is pressed.
-> We are working on addressing this. Relevant vLLM issues can be found [here](https://github.com/vllm-project/vllm/pull/8492) and [here](https://github.com/vllm-project/vllm/issues/6219#issuecomment-2439257824).
-
-To stop the serve, you can press `ctrl-c` which will kill the different components. In order to kill the remaining vLLM subprocesses you can run `nvidia-smi` and `kill -9` the remaining processes or run `pkill python3` from inside of the container.
+See [close deployment](../../docs/guides/dynamo_serve.md#close-deployment) section to learn about how to close the deployment.

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -119,7 +119,7 @@ See [client](../llm/README.md#client) section to learn how to send request to th
 
 ### Close deployment
 
-See [close deployment](../llm/README.md#close-deployment) section to learn about how to close the deployment.
+See [close deployment](../../docs/guides/dynamo_serve.md#close-deployment) section to learn about how to close the deployment.
 
 Remaining tasks:
 


### PR DESCRIPTION
#### Overview:

Relocate the `close-deployment` section to `docs/guides/dynamo_serve.md`, then add cross-references to this section in both `examples/llm/README.md` and `examples/tensorrt_llm/README.md`.
