### PR TITLE
fix: fix dynamoNimDeployment status

### DIFF
--- a/deploy/dynamo/helm/deploy.sh
+++ b/deploy/dynamo/helm/deploy.sh
@@ -89,7 +89,7 @@ envsubst '${NAMESPACE} ${NGC_TOKEN} ${CI_COMMIT_SHA} ${RELEASE_NAME} ${DYNAMO_IN
 echo ""
 echo "Generated values file saved as generated-values.yaml"
 
-Build dependencies before installation
+# Build dependencies before installation
 echo "Building helm dependencies..."
 cd platform
 retry_command "$HELM_CMD dep build" 5 5

--- a/deploy/dynamo/operator/internal/controller/dynamonimdeployment_controller_test.go
+++ b/deploy/dynamo/operator/internal/controller/dynamonimdeployment_controller_test.go
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022 Atalaya Tech. Inc
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * Modifications Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+ */
+
+package controller
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsDeploymentReady(t *testing.T) {
+	type args struct {
+		deployment *appsv1.Deployment
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "deployment is nil",
+			args: args{
+				deployment: nil,
+			},
+			want: false,
+		},
+		{
+			name: "not ready",
+			args: args{
+				deployment: &appsv1.Deployment{
+					Spec: appsv1.DeploymentSpec{},
+					Status: appsv1.DeploymentStatus{
+						Conditions: []appsv1.DeploymentCondition{
+							{
+								Type:   appsv1.DeploymentAvailable,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not ready (paused)",
+			args: args{
+				deployment: &appsv1.Deployment{
+					Spec: appsv1.DeploymentSpec{
+						Paused: true,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ready",
+			args: args{
+				deployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 1,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &[]int32{1}[0],
+					},
+					Status: appsv1.DeploymentStatus{
+						ObservedGeneration: 1,
+						UpdatedReplicas:    1,
+						AvailableReplicas:  1,
+						Conditions: []appsv1.DeploymentCondition{
+							{
+								Type:   appsv1.DeploymentAvailable,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ready (no desired replicas)",
+			args: args{
+				deployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 1,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &[]int32{0}[0],
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "not ready (condition false)",
+			args: args{
+				deployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 1,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &[]int32{1}[0],
+					},
+					Status: appsv1.DeploymentStatus{
+						ObservedGeneration: 1,
+						UpdatedReplicas:    1,
+						AvailableReplicas:  1,
+						Conditions: []appsv1.DeploymentCondition{
+							{
+								Type:   appsv1.DeploymentAvailable,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDeploymentReady(tt.args.deployment); got != tt.want {
+				t.Errorf("IsDeploymentReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/dynamo/operator/internal/controller_common/resource.go
+++ b/deploy/dynamo/operator/internal/controller_common/resource.go
@@ -80,8 +80,8 @@ func SyncResource[T Resource](ctx context.Context, c client.Client, desired T, n
 	// Check if the Spec has changed and update if necessary
 	if IsSpecChanged(current, desired) {
 		// update the spec of the current object with the desired spec
-		current.SetSpec(desired.GetSpec())
-		if err := c.Update(ctx, current); err != nil {
+		desired.SetResourceVersion(current.GetResourceVersion())
+		if err := c.Update(ctx, desired); err != nil {
 			return desired, fmt.Errorf("failed to update resource: %w", err)
 		}
 	}

--- a/deploy/dynamo/operator/internal/nim/nim.go
+++ b/deploy/dynamo/operator/internal/nim/nim.go
@@ -258,11 +258,13 @@ func GenerateDynamoNIMDeployments(parentDynamoDeployment *v1alpha1.DynamoDeploym
 				},
 			}
 		}
+		deployment.Spec.Autoscaling = &v1alpha1.Autoscaling{
+			Enabled: false,
+		}
 		if service.Config.Autoscaling != nil {
-			deployment.Spec.Autoscaling = &v1alpha1.Autoscaling{
-				MinReplicas: service.Config.Autoscaling.MinReplicas,
-				MaxReplicas: service.Config.Autoscaling.MaxReplicas,
-			}
+			deployment.Spec.Autoscaling.Enabled = true
+			deployment.Spec.Autoscaling.MinReplicas = service.Config.Autoscaling.MinReplicas
+			deployment.Spec.Autoscaling.MaxReplicas = service.Config.Autoscaling.MaxReplicas
 		}
 		deployments[service.Name] = deployment
 	}

--- a/deploy/dynamo/operator/internal/nim/nim_test.go
+++ b/deploy/dynamo/operator/internal/nim/nim_test.go
@@ -110,6 +110,7 @@ func TestGenerateDynamoNIMDeployments(t *testing.T) {
 							},
 						},
 						Autoscaling: &v1alpha1.Autoscaling{
+							Enabled:     true,
 							MinReplicas: 1,
 							MaxReplicas: 5,
 						},
@@ -130,6 +131,9 @@ func TestGenerateDynamoNIMDeployments(t *testing.T) {
 						DynamoNim:   "dynamonim--ac4e234",
 						DynamoTag:   "dynamonim:MyService1",
 						ServiceName: "service2",
+						Autoscaling: &v1alpha1.Autoscaling{
+							Enabled: false,
+						},
 					},
 				},
 			},
@@ -206,6 +210,7 @@ func TestGenerateDynamoNIMDeployments(t *testing.T) {
 							},
 						},
 						Autoscaling: &v1alpha1.Autoscaling{
+							Enabled:     true,
 							MinReplicas: 1,
 							MaxReplicas: 5,
 						},
@@ -230,6 +235,9 @@ func TestGenerateDynamoNIMDeployments(t *testing.T) {
 						DynamoNim:   "dynamonim--ac4e234",
 						DynamoTag:   "dynamonim:MyService2",
 						ServiceName: "service2",
+						Autoscaling: &v1alpha1.Autoscaling{
+							Enabled: false,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
#### Overview:

fix dynamoNimDeployment status

#### Details:

the DynamoNimDeployment status which is set by the operator doesn't take into account the actual status of the k8s deployment which is reconciled.
this change set the status of the DynamoNimDeployment correctly by looking at the underlying k8s deployment.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #485
