### PR TITLE
refactor: bump bento to 1.4.8

### DIFF
--- a/deploy/dynamo/sdk/src/dynamo/sdk/lib/image.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/lib/image.py
@@ -22,4 +22,4 @@ import bentoml
 # TODO: "dynamo:latest-vllm-dev" image will not be available to image builder in k8s
 # so We'd consider publishing the base image for releases to public nvcr.io registry.
 image_name = os.getenv("DYNAMO_IMAGE", "dynamo:latest-vllm-dev")
-DYNAMO_IMAGE = bentoml.images.PythonImage(base_image=image_name)
+DYNAMO_IMAGE = bentoml.images.Image(base_image=image_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "pytest>=8.3.4",
-    "bentoml==1.4.7",
+    "bentoml==1.4.8",
     "types-psutil==7.0.0.20250218",
     "kubernetes==32.0.1",
     "ai-dynamo-runtime==0.1.1",


### PR DESCRIPTION
1. Bump bento to 1.4.8
2. `PythonImage` to `Image` as it is now deprecated