### PR TITLE
fix: set env vars before worker spawn

### DIFF
--- a/deploy/dynamo/sdk/src/dynamo/sdk/cli/serve_dynamo.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/cli/serve_dynamo.py
@@ -73,7 +73,7 @@ def main(
     dynamo_context["runner_map"] = runner_map
     dynamo_context["worker_id"] = worker_id
 
-    # Handle worker environment if specified
+    # Ensure environment variables are set before we initialize
     if worker_env:
         env_list: list[dict[str, t.Any]] = json.loads(worker_env)
         if worker_id is not None:
@@ -85,7 +85,6 @@ def main(
                 )
             os.environ.update(env_list[worker_key])
 
-    # Import service first to check configuration
     service = import_service(bento_identifier)
     if service_name and service_name != service.name:
         service = service.find_dependent_by_name(service_name)

--- a/deploy/dynamo/sdk/src/dynamo/sdk/cli/serve_dynamo.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/cli/serve_dynamo.py
@@ -73,11 +73,6 @@ def main(
     dynamo_context["runner_map"] = runner_map
     dynamo_context["worker_id"] = worker_id
 
-    # Import service first to check configuration
-    service = import_service(bento_identifier)
-    if service_name and service_name != service.name:
-        service = service.find_dependent_by_name(service_name)
-
     # Handle worker environment if specified
     if worker_env:
         env_list: list[dict[str, t.Any]] = json.loads(worker_env)
@@ -89,6 +84,11 @@ def main(
                     f"the maximum worker ID is {len(env_list)}"
                 )
             os.environ.update(env_list[worker_key])
+    
+    # Import service first to check configuration
+    service = import_service(bento_identifier)
+    if service_name and service_name != service.name:
+        service = service.find_dependent_by_name(service_name)
 
     configure_server_logging()
     if runner_map:

--- a/deploy/dynamo/sdk/src/dynamo/sdk/cli/serve_dynamo.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/cli/serve_dynamo.py
@@ -84,7 +84,7 @@ def main(
                     f"the maximum worker ID is {len(env_list)}"
                 )
             os.environ.update(env_list[worker_key])
-    
+
     # Import service first to check configuration
     service = import_service(bento_identifier)
     if service_name and service_name != service.name:


### PR DESCRIPTION
Before this PR - we would import a service and then update the environment variables before the worker would spawn. This doesn't work with TRTLLM which needs `CUDA_VISIBLE_DEVICES` set before any of its imports run. 

To solve - we swap the order. Now we make sure all env vars for each worker as set and then import the file 