### PR TITLE
chore: check prefix caching while using kv router

### DIFF
--- a/examples/llm/components/worker.py
+++ b/examples/llm/components/worker.py
@@ -81,7 +81,9 @@ class VllmWorker:
 
         if self.engine_args.router == "kv":
             if self.engine_args.enable_prefix_caching is not True:
-                logger.info("When using KV router, prefix caching must be enabled, setting to True")
+                logger.info(
+                    "When using KV router, prefix caching must be enabled, setting to True"
+                )
                 self.engine_args.enable_prefix_caching = True
 
             VLLM_WORKER_ID = dynamo_context["endpoints"][0].lease_id()

--- a/examples/llm/components/worker.py
+++ b/examples/llm/components/worker.py
@@ -80,6 +80,10 @@ class VllmWorker:
                 self.engine_args.pipeline_parallel_size = 1
 
         if self.engine_args.router == "kv":
+            if self.engine_args.enable_prefix_caching is not True:
+                logger.info("When using KV router, prefix caching must be enabled, setting to True")
+                self.engine_args.enable_prefix_caching = True
+
             VLLM_WORKER_ID = dynamo_context["endpoints"][0].lease_id()
             os.environ["VLLM_WORKER_ID"] = str(VLLM_WORKER_ID)
             os.environ["VLLM_KV_NAMESPACE"] = "dynamo"

--- a/examples/llm/components/worker.py
+++ b/examples/llm/components/worker.py
@@ -80,7 +80,7 @@ class VllmWorker:
                 self.engine_args.pipeline_parallel_size = 1
 
         if self.engine_args.router == "kv":
-            if self.engine_args.enable_prefix_caching is not True:
+            if not self.engine_args.enable_prefix_caching:
                 logger.info(
                     "When using KV router, prefix caching must be enabled, setting to True"
                 )


### PR DESCRIPTION
#### Overview:

When using the KV router without enabling prefix caching, it will throw the error: 'Event API not supported with naive allocator'.