### PR TITLE
fix: correct framework validation logic

### DIFF
--- a/container/run.sh
+++ b/container/run.sh
@@ -174,7 +174,7 @@ get_options() {
 
     if [ -n "$FRAMEWORK" ]; then
 	FRAMEWORK=${FRAMEWORK^^}
-	if [[ -n "${FRAMEWORKS[$FRAMEWORK]}" ]]; then
+	if [[ -z "${FRAMEWORKS[$FRAMEWORK]}" ]]; then
 	    error 'ERROR: Unknown framework: ' "$FRAMEWORK"
 	fi
     fi


### PR DESCRIPTION
#### Overview:

Fixes an issue in the Docker run script where valid frameworks (e.g., `VLLM`, `TENSORRTLLM`) were incorrectly rejected as unknown due to a logic error in the validation check.

---

#### Details:

- Corrected the framework validation logic:
  - Previously: frameworks that existed in the list were mistakenly treated as unknown
  - Now: only truly unrecognized frameworks will trigger an error
- This affects all invocations using the `--framework` flag
- Minor style cleanup in that logic block for clarity

---

#### Where should the reviewer start?

- Review logic around `FRAMEWORKS` lookup in the `get_options()` function