### PR TITLE
fix: Change default vLLM router to round-robin

### DIFF
--- a/examples/llm/utils/vllm.py
+++ b/examples/llm/utils/vllm.py
@@ -28,7 +28,7 @@ def parse_vllm_args(service_name, prefix) -> AsyncEngineArgs:
         "--router",
         type=str,
         choices=["random", "round-robin", "kv"],
-        default="random",
+        default="round-robin",
         help="Router type to use for scheduling requests to workers",
     )
     parser.add_argument(

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -98,8 +98,8 @@ pub struct Flags {
     /// If using `out=dyn://..` with multiple backends, this says how to route the requests.
     ///
     /// Mostly interesting for KV-aware routing.
-    /// Defaults to RouterMode::Random
-    #[arg(long, default_value = "random")]
+    /// Defaults to RouterMode::RoundRobin
+    #[arg(long, default_value = "round-robin")]
     pub router_mode: RouterMode,
 
     /// Internal use only.


### PR DESCRIPTION
This change modifies default router parameter for vLLM workers to round-robin.

It should improve performance for default setup with many prefill workers.