### PR TITLE
fix: Update vLLM examples routing policy

### DIFF
--- a/examples/llm/configs/agg.yaml
+++ b/examples/llm/configs/agg.yaml
@@ -30,7 +30,7 @@ VllmWorker:
   enforce-eager: true
   max-num-batched-tokens: 16384
   enable-prefix-caching: true
-  router: random
+  router: round-robin
   tensor-parallel-size: 1
   ServiceArgs:
     workers: 1

--- a/examples/llm/configs/disagg_router.yaml
+++ b/examples/llm/configs/disagg_router.yaml
@@ -16,7 +16,7 @@ Common:
   model: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
   block-size: 64
   max-model-len: 16384
-  router: kv
+  router: round-robin
   kv-transfer-config: '{"kv_connector":"DynamoNixlConnector"}'
 
 Frontend:
@@ -38,7 +38,6 @@ VllmWorker:
   max-local-prefill-length: 10
   max-prefill-queue-size: 2
   tensor-parallel-size: 1
-  enable-prefix-caching: true
   ServiceArgs:
     workers: 1
     resources:


### PR DESCRIPTION
#### Overview:

Update vLLM examples routing policy for better UX and perf

#### Details:

* For finding prefill workers, round-robin is used.
* Turn off APC for disagg decode workers.
    * Although conditional-disagg is enabled, the max-local-prefill-length is very short, so remote prefill should be used for most requests.

Related PR: https://github.com/ai-dynamo/dynamo/pull/597

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated routing strategy in configuration files to use "round-robin" instead of previous methods.
  - Removed prefix caching option from worker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->