### PR TITLE
docs: change dynamo serve trtllm example enable_overlap_scheduler to false

### DIFF
--- a/examples/tensorrt_llm/configs/llm_api_config.yaml
+++ b/examples/tensorrt_llm/configs/llm_api_config.yaml
@@ -32,5 +32,5 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.95
 
 pytorch_backend_config:
-  enable_overlap_scheduler: true
-  use_cuda_graph: true
+  enable_overlap_scheduler: false
+  use_cuda_graph: false

--- a/examples/tensorrt_llm/configs/llm_api_config_router.yaml
+++ b/examples/tensorrt_llm/configs/llm_api_config_router.yaml
@@ -34,6 +34,6 @@ kv_cache_config:
   enable_block_reuse: true
 
 pytorch_backend_config:
-  enable_overlap_scheduler: true
-  use_cuda_graph: true
+  enable_overlap_scheduler: false
+  use_cuda_graph: false
   enable_iter_perf_stats: true


### PR DESCRIPTION
#### Overview:

When set `enable_overlap_scheduler` to true, seeing
```
generator: ValueError: a python exception was caught while processing the async generator: RuntimeError: Failed to generate: Failed during generation: Context only requests are not supported in pytorch backend when overlap is enabled.
````

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
