### PR TITLE
fix: comment out line in deploy.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,6 @@ __pycache__/
 Chart.lock
 generated-values.yaml
 
+.build/
+
 TensorRT-LLM

--- a/deploy/dynamo/helm/deploy.sh
+++ b/deploy/dynamo/helm/deploy.sh
@@ -89,7 +89,7 @@ envsubst '${NAMESPACE} ${NGC_TOKEN} ${CI_COMMIT_SHA} ${RELEASE_NAME} ${DYNAMO_IN
 echo ""
 echo "Generated values file saved as generated-values.yaml"
 
-Build dependencies before installation
+# Build dependencies before installation
 echo "Building helm dependencies..."
 cd platform
 retry_command "$HELM_CMD dep build" 5 5


### PR DESCRIPTION
#### Overview:

Commenting out comment in deploy.sh

#### Details:

A line in deploy.sh should be commented out but wasn't (or was uncommented somehow). Fixing that here. Also added .build/ folder to gitignore for others like me who have generated them.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
