### PR TITLE
fix: Account for Metrics.decode() changes

### DIFF
--- a/components/metrics/src/main.rs
+++ b/components/metrics/src/main.rs
@@ -227,10 +227,15 @@ async fn app(runtime: Runtime) -> Result<()> {
         let scrape_timeout = Duration::from_secs(1);
         let endpoints =
             collect_endpoints(&target_component, &service_subject, scrape_timeout).await?;
+        if endpoints.is_empty() {
+            tracing::warn!("No endpoints found matching {service_path}");
+            continue;
+        }
+
         let metrics = extract_metrics(&endpoints);
         let processed = postprocess_metrics(&metrics, &endpoints);
         if processed.endpoints.is_empty() {
-            tracing::warn!("No endpoints found matching {service_path}");
+            tracing::warn!("No metrics found matching {service_path}");
         } else {
             tracing::info!("Aggregated metrics: {processed:?}");
         }


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

The structure of the `Metrics` object and the behavior of `Metrics.decode()` were changed with this PR: https://github.com/ai-dynamo/dynamo/pull/169

This caused the resulting `metrics` binary to fail to decode metrics.

This PR replaces the temporary `StatsWithData` object in the `metrics` binary with the now identical `Metrics` object defined in the library code. Additionally, it updates the decode behavior in the `metrics` binary to match the newly expected behavior and fix the issue.

This also improves some error logging on failure cases.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #482
- closes #538