### PR TITLE
fix: add DYNAMO_HOME env var to vLLM docker image

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -349,6 +349,8 @@ RUN source /opt/dynamo/venv/bin/activate && \
 #######################################
 FROM build AS ci_minimum
 
+ENV DYNAMO_HOME=/workspace
+
 COPY . /workspace
 COPY --from=wheel_builder /workspace/dist/ /workspace/dist/
 


### PR DESCRIPTION
#### Overview:

Set $DYNAMO_HOME env var to /workspace

DYNAMO_HOME is used as part of examples - https://github.com/ai-dynamo/dynamo/blob/main/examples/llm/README.md
