### PR TITLE
docs: Update support matrix

### DIFF
--- a/support_matrix.md
+++ b/support_matrix.md
@@ -32,7 +32,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Ubuntu**           | 22.04       | x86_64           | Supported    |
 | **Ubuntu**           | 24.04       | x86_64           | Supported    |
 | **Ubuntu**           | 24.04       | ARM64            | Experimental |
-| **CentOS Stream**    | 9           | x86_64           | Supported    |
+| **CentOS Stream**    | 9           | x86_64           | Experimental |
 
 > **Note**: For **Linux**, the **ARM64** support is experimental and may have limitations.
 

--- a/support_matrix.md
+++ b/support_matrix.md
@@ -32,7 +32,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Ubuntu**           | 22.04       | x86_64           | Supported    |
 | **Ubuntu**           | 24.04       | x86_64           | Supported    |
 | **Ubuntu**           | 24.04       | ARM64            | Experimental |
-| **CentOS**           | 9           | x86_64           | Supported    |
+| **CentOS Stream**           | 9           | x86_64           | Supported    |
 
 > **Note**: For **Linux**, the **ARM64** support is experimental and may have limitations.
 

--- a/support_matrix.md
+++ b/support_matrix.md
@@ -32,6 +32,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Ubuntu**           | 22.04       | x86_64           | Supported    |
 | **Ubuntu**           | 24.04       | x86_64           | Supported    |
 | **Ubuntu**           | 24.04       | ARM64            | Experimental |
+| **CentOS**           | 9           | x86_64           | Supported    |
 
 > **Note**: For **Linux**, the **ARM64** support is experimental and may have limitations.
 

--- a/support_matrix.md
+++ b/support_matrix.md
@@ -32,7 +32,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Ubuntu**           | 22.04       | x86_64           | Supported    |
 | **Ubuntu**           | 24.04       | x86_64           | Supported    |
 | **Ubuntu**           | 24.04       | ARM64            | Experimental |
-| **CentOS Stream**           | 9           | x86_64           | Supported    |
+| **CentOS Stream**    | 9           | x86_64           | Supported    |
 
 > **Note**: For **Linux**, the **ARM64** support is experimental and may have limitations.
 


### PR DESCRIPTION
#### Overview:

Update support matrix to include the CentOS Stream 9 support starting release v0.1.1. 
