### PR TITLE
fix: adding conversion to string for notif id comparison

### DIFF
--- a/container/deps/vllm/vllm_v0.7.2-dynamo-kv-disagg-patch.patch
+++ b/container/deps/vllm/vllm_v0.7.2-dynamo-kv-disagg-patch.patch
@@ -4214,7 +4214,7 @@ index 819b81fb..2891854b 100644
 +            for notifs in all_new_notifs:
 +                for req_ids in notifs.values():
 +                    for req_id in req_ids:
-+                        request_notif_counter[req_id] += 1
++                        request_notif_counter[req_id.decode("utf-8")] += 1
 +
 +            if request_notif_counter:
 +                logger.debug("Request notif counter: %s", request_notif_counter)


### PR DESCRIPTION
#### Overview:

This patch ensures that notification / request ids given to NIXL as strings are matched correctly with those returned by ```
`get_new_notifs`

get_new_notifs changed in 0.1.1 to bring the python bindings and the c++ api in line to both use bytes for ids to avoid any potential issues.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
