### PR TITLE
fix: serviceArgs in config was not getting set for workers

### DIFF
--- a/deploy/dynamo/sdk/src/dynamo/sdk/lib/config.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/lib/config.py
@@ -89,7 +89,7 @@ class ServiceConfig(dict):
         service_config = self[service_name].copy()
         if "ServiceArgs" in service_config:
             del service_config["ServiceArgs"]
-        
+
         if (common := self.get(COMMON_CONFIG_SERVICE)) is not None and (
             common_config_keys := service_config.get(COMMON_CONFIG_KEY)
         ) is not None:

--- a/deploy/dynamo/sdk/src/dynamo/sdk/lib/config.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/lib/config.py
@@ -84,14 +84,20 @@ class ServiceConfig(dict):
             else:
                 args.extend([f"--{arg_key}", str(value)])
 
+        # Get service config excluding ServiceArgs if it exists
+        # We never want args to be generated from the ServiceArgs
+        service_config = self[service_name].copy()
+        if "ServiceArgs" in service_config:
+            del service_config["ServiceArgs"]
+        
         if (common := self.get(COMMON_CONFIG_SERVICE)) is not None and (
-            common_config_keys := self[service_name].get(COMMON_CONFIG_KEY)
+            common_config_keys := service_config.get(COMMON_CONFIG_KEY)
         ) is not None:
             for key in common_config_keys:
-                if key in common and key not in self[service_name]:
+                if key in common and key not in service_config:
                     add_to_args(args, key, common[key])
 
-        for key, value in self[service_name].items():
+        for key, value in service_config.items():
             add_to_args(args, key, value)
 
         logger.info(f"Running {service_name} with {args=}")

--- a/deploy/dynamo/sdk/src/dynamo/sdk/lib/service.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/lib/service.py
@@ -90,14 +90,27 @@ class DynamoService(Service[T]):
 
         super().__init__(config=config, inner=inner, image=image, envs=envs or [])
 
-        # Initialize Dynamo configuration
-        self._dynamo_config = (
-            dynamo_config
-            if dynamo_config
-            else DynamoConfig(name=inner.__name__, namespace="default")
-        )
+        # Get any dynamo overrides from service_args
+        dynamo_overrides = {}
+        if service_args and "dynamo" in service_args:
+            dynamo_overrides = service_args["dynamo"]
+            logger.debug(f"Found dynamo overrides in service_args: {dynamo_overrides}")
+
+        # Initialize Dynamo configuration with overrides
+        base_config = dynamo_config if dynamo_config else DynamoConfig(name=inner.__name__, namespace="default")
+        logger.debug(f"Initial base DynamoConfig: {asdict(base_config)}")
+        
+        # Apply overrides from service_args to base config
+        for key, value in dynamo_overrides.items():
+            if hasattr(base_config, key):
+                logger.debug(f"Applying override: {key}={value}")
+                setattr(base_config, key, value)
+        
+        self._dynamo_config = base_config
         if self._dynamo_config.name is None:
             self._dynamo_config.name = inner.__name__
+
+        logger.debug(f"Final DynamoConfig: {asdict(self._dynamo_config)}")
 
         # Add dynamo configuration to the service config
         # this allows for the config to be part of the service in bento.yaml
@@ -182,6 +195,7 @@ class DynamoService(Service[T]):
 
     def _remove_service_args(self, service_name: str):
         """Remove ServiceArgs from the environment config after using them, preserving envs"""
+        logger.debug(f"Removing service args for {service_name}")
         config_str = os.environ.get("DYNAMO_SERVICE_CONFIG")
         if config_str:
             config = json.loads(config_str)
@@ -197,11 +211,6 @@ class DynamoService(Service[T]):
                         "envs": service_args["envs"]
                     }
                     os.environ["DYNAMO_SERVICE_ENVS"] = json.dumps(envs_config)
-
-                # Remove ServiceArgs from main config
-                del config[service_name]["ServiceArgs"]
-                os.environ["DYNAMO_SERVICE_CONFIG"] = json.dumps(config)
-
 
 def service(
     inner: Optional[type[T]] = None,

--- a/deploy/dynamo/sdk/src/dynamo/sdk/lib/service.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/lib/service.py
@@ -97,15 +97,19 @@ class DynamoService(Service[T]):
             logger.debug(f"Found dynamo overrides in service_args: {dynamo_overrides}")
 
         # Initialize Dynamo configuration with overrides
-        base_config = dynamo_config if dynamo_config else DynamoConfig(name=inner.__name__, namespace="default")
+        base_config = (
+            dynamo_config
+            if dynamo_config
+            else DynamoConfig(name=inner.__name__, namespace="default")
+        )
         logger.debug(f"Initial base DynamoConfig: {asdict(base_config)}")
-        
+
         # Apply overrides from service_args to base config
         for key, value in dynamo_overrides.items():
             if hasattr(base_config, key):
                 logger.debug(f"Applying override: {key}={value}")
                 setattr(base_config, key, value)
-        
+
         self._dynamo_config = base_config
         if self._dynamo_config.name is None:
             self._dynamo_config.name = inner.__name__
@@ -211,6 +215,7 @@ class DynamoService(Service[T]):
                         "envs": service_args["envs"]
                     }
                     os.environ["DYNAMO_SERVICE_ENVS"] = json.dumps(envs_config)
+
 
 def service(
     inner: Optional[type[T]] = None,


### PR DESCRIPTION
#### Overview:

ServiceArgs portion of `DYNAMO_SERVICE_CONFIG` will always be empty from the POV of workers due to this [line](https://github.com/ai-dynamo/dynamo/pull/640/files#diff-2b6527ac4f121f67e6689fe95dff6049075c037192389ee96575159e3cd10335L202). This MR fixes this issue.

Then why does setting `gpus` or `workers` in the config file currently work (e.g [here](https://github.com/ai-dynamo/dynamo/blob/main/examples/llm/configs/agg.yaml#L35))? Workers and gpus are attributes consumed and processed by the top level program. They aren't consumed at all in the subprocesses. At the top level program these attributes are available and okay. However, any attributes that need to be consumed at the subprocess level will simply not be present.

### Testing

Tested:
- hello world
- Aggregated Serving
- Disaggregated Serving
