### PR TITLE
fix: change trtllm kv_router default block_size to 32

### DIFF
--- a/examples/tensorrt_llm/components/kv_router.py
+++ b/examples/tensorrt_llm/components/kv_router.py
@@ -51,7 +51,7 @@ def parse_args(service_name, prefix) -> Namespace:
     parser.add_argument(
         "--block-size",
         type=int,
-        default=64,
+        default=32,
         help="KV block size",
     )
     parser.add_argument(


### PR DESCRIPTION
#### Overview:

Set 32 as default block_size to kv_router, which will be used by indexer. This will make it the same default value as TRTLLM worker pytorch backend. If not the same, cache/hash will not work
