### PR TITLE
chore: added clang and cmake to the dev-container Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,6 +34,8 @@ RUN apt-get update && apt-get install -y \
     sudo \
     protobuf-compiler \
     bash \
+    clang \
+    cmake \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This PR adds the `clang` and `cmake` dependencies in the `.devcontainer/Dockerfile` to allow for compiling dynamo out of the box. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development environment to include `clang` and `cmake` for improved tool support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->