### PR TITLE
fix: enable updates for router parameters in etcd (#647)

### DIFF
--- a/examples/llm/components/disagg_router.py
+++ b/examples/llm/components/disagg_router.py
@@ -39,10 +39,17 @@ class PyDisaggregatedRouter:
         self.etcd_kv_cache = await EtcdKvCache.create(
             runtime.etcd_client(),
             "/dynamo/disagg_router/",
-            {
-                "max_local_prefill_length": str(self.max_local_prefill_length),
-                "max_prefill_queue_size": str(self.max_prefill_queue_size),
-            },
+            {} 
+        )
+        
+        # Use the put method to update the value
+        await self.etcd_kv_cache.put(
+            "max_local_prefill_length",
+            str(self.max_local_prefill_length).encode()
+        )
+        await self.etcd_kv_cache.put(
+            "max_prefill_queue_size",
+            str(self.max_prefill_queue_size).encode()
         )
 
     async def prefill_remote(

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -104,7 +104,7 @@ class Processor(ProcessMixIn):
         # Use the put method to update the value
         await self.etcd_kv_cache.put(
             "router",
-            str(self.engine_args.router).encode()
+            (self.engine_args.router).encode()
         )
 
     async def _generate(

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -98,13 +98,7 @@ class Processor(ProcessMixIn):
         self.etcd_kv_cache = await EtcdKvCache.create(
             runtime.etcd_client(),
             "/dynamo/processor/",
-            {},
-        )
-
-        # Use the put method to update the value
-        await self.etcd_kv_cache.put(
-            "router",
-            (self.engine_args.router).encode()
+            {"router": self.engine_args.router},
         )
 
     async def _generate(

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -104,7 +104,7 @@ class Processor(ProcessMixIn):
         # Use the put method to update the value
         await self.etcd_kv_cache.put(
             "router",
-            self.engine_args.router.encode()
+            str(self.engine_args.router).encode()
         )
 
     async def _generate(

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -98,7 +98,13 @@ class Processor(ProcessMixIn):
         self.etcd_kv_cache = await EtcdKvCache.create(
             runtime.etcd_client(),
             "/dynamo/processor/",
-            {"router": self.engine_args.router},
+            {},
+        )
+
+        # Use the put method to update the value
+        await self.etcd_kv_cache.put(
+            "router",
+            self.engine_args.router.encode()
         )
 
     async def _generate(


### PR DESCRIPTION
Signed-off-by: Yue Zhang <zhangy2259@gmail.com>

#### Overview:
This PR improves the parameter update mechanism in the Router by implementing proper etcd value updates. Currently, when updating args like `max_local_prefill_length` or `max_prefill_queue_size`, the changes are not reflected in etcd if the keys already exist. This PR fixes this limitation by modifying the initialization process and adding explicit update functionality.

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details: 

Changed from using `EtcdKvCache.create()` with initial values to using `put()` for explicit updates.

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: #647 
