### PR TITLE
feat(dynamo-run): improve available engines list in --help

### DIFF
--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -32,7 +32,7 @@ Example:
 
 const ZMQ_SOCKET_PREFIX: &str = "dyn";
 
-const USAGE: &str = "USAGE: dynamo-run in=[http|text|dyn://<path>|batch:<folder>|none] out=[See available engines below] [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin]";
+const USAGE: &str = "USAGE: dynamo-run in=[http|text|dyn://<path>|batch:<folder>|none] out=ENGINE_LIST [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin]";
 
 fn main() -> anyhow::Result<()> {
     logging::init();
@@ -117,12 +117,10 @@ async fn wrapper(runtime: dynamo_runtime::Runtime) -> anyhow::Result<()> {
     let mut out_opt = None;
     let args: Vec<String> = env::args().skip(1).collect();
     if args.is_empty() || args[0] == "-h" || args[0] == "--help" {
-        println!("{USAGE}");
+        let engine_list = Output::available_engines().join("|");
+        let usage = USAGE.replace("ENGINE_LIST", &engine_list);
+        println!("{usage}");
         println!("{HELP}");
-        println!(
-            "Available engines: {}",
-            Output::available_engines().join(", ")
-        );
 
         return Ok(());
     }


### PR DESCRIPTION
#### Overview:

This PR improves the help information of the `dynamo-run` command line tool, optimizing the display of available engines list to make it clearer and easier to understand. This improvement will help users better understand which engine options are available, enhancing the overall user experience.

#### Details:

- Reformatted the available engines list in the `--help` output

#### Where should the reviewer start?

The main changes are in the `launch/dynamo-run/src/main.rs` file, focusing on the sections that handle command line arguments and generate help information.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes GitHub issue: #580 