### PR TITLE
fix: frontend and http server signal handling

### DIFF
--- a/examples/llm/components/frontend.py
+++ b/examples/llm/components/frontend.py
@@ -14,9 +14,7 @@
 # limitations under the License.
 
 import logging
-import signal
 import subprocess
-import sys
 from pathlib import Path
 
 from components.processor import Processor
@@ -24,7 +22,7 @@ from components.worker import VllmWorker
 from pydantic import BaseModel
 
 from dynamo import sdk
-from dynamo.sdk import depends, service
+from dynamo.sdk import async_on_shutdown, depends, service
 from dynamo.sdk.lib.config import ServiceConfig
 from dynamo.sdk.lib.image import DYNAMO_IMAGE
 
@@ -32,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_http_binary_path():
+    """Find the HTTP binary path in SDK or fallback to 'http' command."""
     sdk_path = Path(sdk.__file__)
     binary_path = sdk_path.parent / "cli/bin/http"
     if not binary_path.exists():
@@ -41,6 +40,8 @@ def get_http_binary_path():
 
 
 class FrontendConfig(BaseModel):
+    """Configuration for the Frontend service including model and HTTP server settings."""
+
     served_model_name: str
     endpoint: str
     port: int = 8080
@@ -57,25 +58,17 @@ class Frontend:
     processor = depends(Processor)
 
     def __init__(self):
+        """Initialize Frontend service with HTTP server and model configuration."""
         config = ServiceConfig.get_instance()
         frontend_config = FrontendConfig(**config.get("Frontend", {}))
         self.frontend_config = frontend_config
         self.process = None
 
-        signal.signal(signal.SIGTERM, self.handle_exit)
-        signal.signal(signal.SIGINT, self.handle_exit)
-
-        # Initial setup
         self.setup_model()
         self.start_http_server()
 
-        try:
-            if self.process:
-                self.process.wait()
-        except KeyboardInterrupt:
-            self.cleanup()
-
     def setup_model(self):
+        """Configure the model for HTTP service using llmctl."""
         subprocess.run(
             [
                 "llmctl",
@@ -83,7 +76,8 @@ class Frontend:
                 "remove",
                 "chat-models",
                 self.frontend_config.served_model_name,
-            ]
+            ],
+            check=False,
         )
         # Add the model
         subprocess.run(
@@ -94,20 +88,25 @@ class Frontend:
                 "chat-models",
                 self.frontend_config.served_model_name,
                 self.frontend_config.endpoint,
-            ]
+            ],
+            check=False,
         )
 
     def start_http_server(self):
+        """Start the HTTP server on the configured port."""
         logger.info("Starting HTTP server")
         http_binary = get_http_binary_path()
+
+        # Note: Circusd will manage this subprocess, so we don't need signal handling in this class
         self.process = subprocess.Popen(
             [http_binary, "-p", str(self.frontend_config.port)],
             stdout=None,
             stderr=None,
         )
 
+    @async_on_shutdown
     def cleanup(self):
-        logger.info("Cleaning up before shutdown...")
+        """Clean up resources before shutdown."""
         subprocess.run(
             [
                 "llmctl",
@@ -115,14 +114,6 @@ class Frontend:
                 "remove",
                 "chat-models",
                 self.frontend_config.served_model_name,
-            ]
+            ],
+            check=False,
         )
-        if self.process:
-            logger.info("Terminating HTTP process")
-            self.process.terminate()
-            self.process.wait(timeout=10)
-
-    def handle_exit(self, signum, frame):
-        logger.debug(f"Received signal {signum}, shutting down...")
-        self.cleanup()
-        sys.exit(0)

--- a/examples/llm/components/frontend.py
+++ b/examples/llm/components/frontend.py
@@ -79,7 +79,6 @@ class Frontend:
             ],
             check=False,
         )
-        # Add the model
         subprocess.run(
             [
                 "llmctl",
@@ -97,7 +96,6 @@ class Frontend:
         logger.info("Starting HTTP server")
         http_binary = get_http_binary_path()
 
-        # Note: Circusd will manage this subprocess, so we don't need signal handling in this class
         self.process = subprocess.Popen(
             [http_binary, "-p", str(self.frontend_config.port)],
             stdout=None,
@@ -107,6 +105,8 @@ class Frontend:
     @async_on_shutdown
     def cleanup(self):
         """Clean up resources before shutdown."""
+
+        # circusd manages shutdown of http server process, we just need to remove the model using the on_shutdown hook
         subprocess.run(
             [
                 "llmctl",


### PR DESCRIPTION
#### Overview:

We were using sys.exit() and a range of signal handlers to shutdown the frontend that was working, but would result in a bunch of errors in the terminal.

This simplifies the frontend to make use of circusD and bentoML.


#### Details:

- remove the process.wait() which would block initialization startup
- remove signal handlers from the class which would interfere with circusd
- use the async_on_shutdown hook to remove the model on shutdown
- add docstrings to all classes

