### PR TITLE
fix: NixlMetadataStore exception print bug and better check_required_workers message

### DIFF
--- a/examples/llm/utils/logging.py
+++ b/examples/llm/utils/logging.py
@@ -20,6 +20,7 @@ from dynamo._core import Client
 
 logger = logging.getLogger(__name__)
 
+
 async def check_required_workers(
     workers_client: Client,
     required_workers: int,

--- a/examples/llm/utils/logging.py
+++ b/examples/llm/utils/logging.py
@@ -20,26 +20,28 @@ from dynamo._core import Client
 
 logger = logging.getLogger(__name__)
 
-
 async def check_required_workers(
-    workers_client: Client, required_workers: int, on_change=True, poll_interval=0.5
+    workers_client: Client,
+    required_workers: int,
+    on_change=True,
+    poll_interval=5,
+    tag="",
 ):
     """Wait until the minimum number of workers are ready."""
     worker_ids = workers_client.endpoint_ids()
     num_workers = len(worker_ids)
-
+    new_count = -1  # Force to print "waiting for worker" once
     while num_workers < required_workers:
+        if (not on_change) or new_count != num_workers:
+            num_workers = new_count if new_count >= 0 else num_workers
+            print(
+                f" {tag} Waiting for more workers to be ready.\n"
+                f" Current: {num_workers},"
+                f" Required: {required_workers}"
+            )
         await asyncio.sleep(poll_interval)
         worker_ids = workers_client.endpoint_ids()
         new_count = len(worker_ids)
-
-        if (not on_change) or new_count != num_workers:
-            logger.info(
-                f"Waiting for more workers to be ready.\n"
-                f" Current: {new_count},"
-                f" Required: {required_workers}"
-            )
-        num_workers = new_count
 
     print(f"Workers ready: {worker_ids}")
     return worker_ids

--- a/examples/llm/utils/nixl.py
+++ b/examples/llm/utils/nixl.py
@@ -104,6 +104,6 @@ class NixlMetadataStore:
             # )
 
         except Exception as e:
-            raise Exception("Error retrieving metadata for engine {engine_id}") from e
+            raise Exception(f"Error retrieving metadata for engine {engine_id}: {e}") from e
 
         return deserialized_metadata

--- a/examples/llm/utils/nixl.py
+++ b/examples/llm/utils/nixl.py
@@ -104,6 +104,8 @@ class NixlMetadataStore:
             # )
 
         except Exception as e:
-            raise Exception(f"Error retrieving metadata for engine {engine_id}: {e}") from e
+            raise Exception(
+                f"Error retrieving metadata for engine {engine_id}: {e}"
+            ) from e
 
         return deserialized_metadata


### PR DESCRIPTION
#### Overview:

1. Fixed a bug for Exception message in NixlMetadataStore.get
2. Force `check_required_workers` to print out "waiting for worker" message at least once, otherwise it would be like program hanging



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional tag parameter to worker status messages for improved identification.

- **Improvements**
  - Increased the default polling interval for worker checks to reduce message frequency.
  - Status messages now include more detailed error information when metadata retrieval fails.

- **Bug Fixes**
  - Ensured worker status messages are always printed at least once for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->