### PR TITLE
fix: check for resource in pipeline helm chart

### DIFF
--- a/deploy/Kubernetes/pipeline/chart/templates/deployment.yaml
+++ b/deploy/Kubernetes/pipeline/chart/templates/deployment.yaml
@@ -48,9 +48,12 @@ spec:
         command:
         - sh
         - -c
+        {{ if .config.resources }}
         resources:
           requests:
+            {{ if .config.resources.cpu }}
             cpu: "{{ .config.resources.cpu }}"
+            {{ end }}
             {{ if .config.resources.memory }}
             memory: "{{ .config.resources.memory }}"
             {{ end }}
@@ -58,13 +61,16 @@ spec:
             nvidia.com/gpu: "{{ .config.resources.gpu }}"
             {{ end }}
           limits:
+            {{ if .config.resources.cpu }}
             cpu: "{{ .config.resources.cpu }}"
+            {{ end }}
             {{ if .config.resources.memory }}
             memory: "{{ .config.resources.memory }}"
             {{ end }}
             {{ if .config.resources.gpu }}
             nvidia.com/gpu: "{{ .config.resources.gpu }}"
             {{ end }}
+        {{ end }}
         env:
         - name: TRAFFIC_TIMEOUT
           value: "{{ .config.traffic.timeout }}"


### PR DESCRIPTION
#### Overview:

Avoid NPE in helm chart when no resource is specified for service in pipeline

#### Details:

Avoid NPE in helm chart when no resource is specified for service in pipeline

#### Where should the reviewer start?

deployment.yaml

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #686
