### PR TITLE
fix: ensure `VLLM_LOGGING_LEVEL=xyz` follows`DYN_LOG=xyz` 

### DIFF
--- a/deploy/dynamo/sdk/src/dynamo/sdk/lib/logging.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/lib/logging.py
@@ -74,3 +74,5 @@ def log_level_mapping(level: str) -> int:
     # python does not have a TRACE level, so we map it to INFO
     elif level == "trace":
         return logging.INFO
+    else:
+        return logging.INFO

--- a/deploy/dynamo/sdk/src/dynamo/sdk/lib/logging.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/lib/logging.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import logging.config
 import os
+import tempfile
 
 from dynamo.runtime.logging import configure_logger as configure_dynamo_logger
 
@@ -36,15 +38,7 @@ def configure_server_logging():
     dyn_var = os.environ.get("DYN_LOG", "info")
     dyn_level = log_level_mapping(dyn_var)
 
-    # Disable VLLM's default configuration
-    os.environ["VLLM_CONFIGURE_LOGGING"] = "0"
-
-    env_controlled_loggers = ["vllm", "nixl", "__init__"]
-    for logger_name in env_controlled_loggers:
-        logger = logging.getLogger(logger_name)
-        logger.handlers = []
-        logger.setLevel(dyn_level)
-        logger.propagate = True
+    configure_vllm_logging(dyn_level)
 
     # loggers that should be configured to ERROR
     error_loggers = ["bentoml", "tag"]
@@ -65,14 +59,45 @@ def log_level_mapping(level: str) -> int:
         return logging.DEBUG
     elif level == "info":
         return logging.INFO
-    elif level == "warning":
+    elif level == "warn" or level == "warning":
         return logging.WARNING
     elif level == "error":
         return logging.ERROR
     elif level == "critical":
         return logging.CRITICAL
-    # python does not have a TRACE level, so we map it to INFO
     elif level == "trace":
         return logging.INFO
     else:
         return logging.INFO
+
+
+def configure_vllm_logging(dyn_level: int):
+    """
+    vLLM requires a logging config file to be set in the environment.
+    This function creates a temporary file with the VLLM logging config and sets the
+    VLLM_LOGGING_CONFIG_PATH environment variable to the path of the file.
+    """
+
+    os.environ["VLLM_CONFIGURE_LOGGING"] = "1"
+    vllm_level = logging.getLevelName(dyn_level)
+
+    # Create a temporary config file for VLLM
+    vllm_config = {
+        "formatters": {"simple": {"format": "%(message)s"}},
+        "handlers": {
+            "dynamo": {
+                "class": "dynamo.runtime.logging.LogHandler",
+                "formatter": "simple",
+                "level": vllm_level,
+            }
+        },
+        "loggers": {
+            "vllm": {"handlers": ["dynamo"], "level": vllm_level, "propagate": False}
+        },
+        "version": 1,
+        "disable_existing_loggers": False,
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(vllm_config, f)
+        os.environ["VLLM_LOGGING_CONFIG_PATH"] = f.name


### PR DESCRIPTION
This PR fixes a bug where setting `VLLM_LOGGING_LEVEL={DEBUG, WARNING, etc}` was not being respected. Diving into vLLM land - I found that to override their logging - you must set `VLLM_CONFIGURE_LOGGING=1` and also provide a path to a logging configuration. This PR creates a tempfile logging config which is applied to vLLM. 

Note that `DYN_LOG` is the way to control logging. Setting `DYN_LOG=debug ...` is equivalent to setting `VLLM_LOGGING_LEVEL=DEBUG`

Examples

```
DYN_LOG=debug dynamo serve graphs.disagg:Frontend -f ./configs/disagg.yaml 
```
![Screenshot 2025-04-15 at 11 48 51 AM](https://github.com/user-attachments/assets/fb6b86f3-c4bd-49b4-8923-4f23ad30d918)