### PR TITLE
feat: replace dynamo server with dynamo cloud

### DIFF
--- a/deploy/dynamo/sdk/src/dynamo/sdk/cli/cli.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/cli/cli.py
@@ -30,13 +30,13 @@ def create_bentoml_cli() -> click.Command:
     from bentoml_cli.utils import get_entry_points
 
     from dynamo.sdk.cli.bentos import bento_command
+    from dynamo.sdk.cli.cloud import cloud_command
     from dynamo.sdk.cli.deployment import deployment_command
     from dynamo.sdk.cli.env import env_command
 
     # from dynamo.sdk.cli.deploy import deploy_command
     from dynamo.sdk.cli.run import run_command
     from dynamo.sdk.cli.serve import serve_command
-    from dynamo.sdk.cli.cloud import cloud_command
     from dynamo.sdk.cli.utils import DynamoCommandGroup
 
     server_context.service_type = "cli"

--- a/deploy/dynamo/sdk/src/dynamo/sdk/cli/cli.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/cli/cli.py
@@ -36,10 +36,8 @@ def create_bentoml_cli() -> click.Command:
     # from dynamo.sdk.cli.deploy import deploy_command
     from dynamo.sdk.cli.run import run_command
     from dynamo.sdk.cli.serve import serve_command
-    from dynamo.sdk.cli.server import cloud_command
+    from dynamo.sdk.cli.cloud import cloud_command
     from dynamo.sdk.cli.utils import DynamoCommandGroup
-
-    # from dynamo.sdk.cli.cloud import cloud_command
 
     server_context.service_type = "cli"
 
@@ -53,8 +51,8 @@ def create_bentoml_cli() -> click.Command:
         It takes inspiration from and leverages core pieces of the BentoML deployment stack.
 
         At a high level, you use `serve` to run a set of dynamo services locally,
-        `build` and `containerize` to package them  up for deployment, and then `server`
-        and `deploy` to deploy them to a K8s cluster running the Dynamo Server
+        `build` and `containerize` to package them up for deployment, and then `cloud`
+        and `deploy` to deploy them to a K8s cluster running the Dynamo Cloud Server
         """
 
     # Add top-level CLI commands

--- a/deploy/dynamo/sdk/src/dynamo/sdk/cli/cloud.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/cli/cloud.py
@@ -34,18 +34,18 @@ from bentoml.exceptions import CLIException, CloudRESTApiClientError
 
 
 def build_cloud_command() -> click.Group:
-    @click.group(name="server")
+    @click.group(name="cloud")
     @add_experimental_docstring
     def cloud_command():
-        """Interact with your Dynamo Server"""
+        """Interact with your Dynamo Cloud Server"""
 
     @cloud_command.command()
     @click.option(
         "--endpoint",
         type=click.STRING,
-        help="Dynamo Server endpoint",
+        help="Dynamo Cloud endpoint",
         default=DEFAULT_ENDPOINT,
-        envvar="DYNAMO_SERVER_API_ENDPOINT",
+        envvar="DYNAMO_CLOUD_API_ENDPOINT",
         show_default=True,
         show_envvar=True,
         required=True,
@@ -53,13 +53,13 @@ def build_cloud_command() -> click.Group:
     @click.option(
         "--api-token",
         type=click.STRING,
-        help="Dynamo Server user API token",
-        envvar="DYNAMO_SERVER_API_KEY",
+        help="Dynamo Cloud user API token",
+        envvar="DYNAMO_CLOUD_API_KEY",
         show_envvar=True,
         required=True,
     )
     def login(endpoint: str, api_token: str) -> None:  # type: ignore
-        """Connect to your Dynamo Server. You can find deployment instructions for this in our docs"""
+        """Connect to your Dynamo Cloud. You can find deployment instructions for this in our docs"""
         try:
             cloud_rest_client = RestApiClient(endpoint, api_token)
             user = cloud_rest_client.v1.get_current_user()

--- a/deploy/dynamo/tests/test_deployment.sh
+++ b/deploy/dynamo/tests/test_deployment.sh
@@ -18,14 +18,14 @@
 
 set -euo pipefail
 
-export DYNAMO_SERVER="${DYNAMO_SERVER:-http://dynamo-server}"
+export DYNAMO_CLOUD="${DYNAMO_CLOUD:-http://dynamo-cloud}"
 export DYNAMO_IMAGE="${DYNAMO_IMAGE:-dynamo-base:latest}"
 export DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-ci-hw}"
 
 cd /workspace/examples/hello_world
 
-# Step.1: Login to  dynamo server
-dynamo server login --api-token TEST-TOKEN --endpoint $DYNAMO_SERVER
+# Step.1: Login to  dynamo cloud
+dynamo cloud login --api-token TEST-TOKEN --endpoint $DYNAMO_CLOUD
 
 # Step.2:  build a dynamo nim with framework-less base
 DYNAMO_TAG=$(dynamo build hello_world:Frontend | grep "Successfully built" | awk -F"\"" '{ print $2 }')

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -34,6 +34,7 @@ Dynamo CLI has the following 4 sub-commands.
 - :palm_up_hand: dynamo serve: compose a graph of workers locally and serve.
 - :hammer: (Experimental) dynamo build: containerize either the entire graph or parts of graph to multiple containers
 - :rocket: (Experimental) dynamo deploy: deploy to K8 with helm charts or custom operators
+- :cloud: (Experimental) dynamo cloud: interact with your dynamo cloud server
 
 For more detailed examples on serving LLMs with disaggregated serving, KV aware routing, etc,  please refer to [LLM deployment examples](https://github.com/ai-dynamo/dynamo/blob/main/examples/llm/README.md)
 

--- a/docs/guides/dynamo_deploy/dynamo_cloud.md
+++ b/docs/guides/dynamo_deploy/dynamo_cloud.md
@@ -150,7 +150,7 @@ Deploy the platform:
 
 3. **Expose Dynamo Cloud Externally**
 
-You must also expose the `dynamo-store` service within the namespace externally. This will be the endpoint the CLI uses to interface with Dynamo Cloud. You might setup an Ingress, use an `ExternalService` with Istio, or simply port-forward. In our docs, we refer to this externally available endpoint as `DYNAMO_SERVER`.
+You must also expose the `dynamo-store` service within the namespace externally. This will be the endpoint the CLI uses to interface with Dynamo Cloud. You might setup an Ingress, use an `ExternalService` with Istio, or simply port-forward. In our docs, we refer to this externally available endpoint as `DYNAMO_CLOUD`.
 
 ## Next Steps
 

--- a/docs/guides/dynamo_deploy/operator_deployment.md
+++ b/docs/guides/dynamo_deploy/operator_deployment.md
@@ -39,9 +39,9 @@ The deployment process involves two main steps:
 
 ## Deployment Steps
 
-### 1. Login to Dynamo Server
+### 1. Login to Dynamo Cloud
 
-First, configure your environment and login to the Dynamo server:
+First, configure your environment and login to the Dynamo cloud:
 
 ```bash
 # Set your project root directory
@@ -51,10 +51,10 @@ export PROJECT_ROOT=$(pwd)
 export KUBE_NS=hello-world
 
 # Externally accessible endpoint to the `dynamo-store` service within your Dynamo Cloud installation
-export DYNAMO_SERVER=https://${KUBE_NS}.dev.aire.nvidia.com
+export DYNAMO_CLOUD=https://${KUBE_NS}.dev.aire.nvidia.com
 
-# Login to the Dynamo server
-dynamo server login --api-token TEST-TOKEN --endpoint $DYNAMO_SERVER
+# Login to the Dynamo cloud
+dynamo cloud login --api-token TEST-TOKEN --endpoint $DYNAMO_CLOUD
 ```
 
 ### 2. Build the Dynamo Base Image

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -136,13 +136,13 @@ The deployment process involves two distinct build steps:
 
 ##### Deployment Steps
 
-1. **Login to Dynamo Server**
+1. **Login to Dynamo Cloud**
 
 ```bash
 export PROJECT_ROOT=$(pwd)
 export KUBE_NS=hello-world  # Must match your Kubernetes namespace
-export DYNAMO_SERVER=https://${KUBE_NS}.dev.aire.nvidia.com
-dynamo server login --api-token TEST-TOKEN --endpoint $DYNAMO_SERVER
+export DYNAMO_CLOUD=https://${KUBE_NS}.dev.aire.nvidia.com
+dynamo cloud login --api-token TEST-TOKEN --endpoint $DYNAMO_CLOUD
 ```
 
 2. **Build the Dynamo Base Image**

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -184,8 +184,8 @@ You must have first followed the instructions in [deploy/dynamo/helm/README.md](
 ```bash
 export PROJECT_ROOT=$(pwd)
 export KUBE_NS=dynamo-cloud  # Note: This must match the Kubernetes namespace where you installed Dynamo Cloud
-export DYNAMO_SERVER=https://${KUBE_NS}.dev.aire.nvidia.com # Externally accessible endpoint to the `dynamo-store` service within your Dynamo Cloud installation
-dynamo server login --api-token TEST-TOKEN --endpoint $DYNAMO_SERVER
+export DYNAMO_CLOUD=https://${KUBE_NS}.dev.aire.nvidia.com # Externally accessible endpoint to the `dynamo-store` service within your Dynamo Cloud installation
+dynamo cloud login --api-token TEST-TOKEN --endpoint $DYNAMO_CLOUD
 ```
 
 2. **Build the Dynamo Base Image**


### PR DESCRIPTION
#### Overview:

Replace mentions of `dynamo server` with `dynamo cloud`

#### Details:

There has been confusion regarding the similarity between "dynamo serve" and "dynamo server", although they represent separate concepts. The Dynamo server is synonymous with the user-managed Dynamo cloud platform, so for now we will rename it to `dynamo cloud` and refer to it as such to avoid confusion.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
