### PR TITLE
fix: fix pipeline helm chart

### DIFF
--- a/deploy/Kubernetes/pipeline/chart/templates/deployment.yaml
+++ b/deploy/Kubernetes/pipeline/chart/templates/deployment.yaml
@@ -72,18 +72,20 @@ spec:
             {{ end }}
         {{ end }}
         env:
+        {{- if and .config.traffic .config.traffic.timeout }}
         - name: TRAFFIC_TIMEOUT
           value: "{{ .config.traffic.timeout }}"
-      {{- if and .config.dynamo .config.dynamo.enabled }}
+        {{- end }}
+        {{- if and .config.dynamo .config.dynamo.enabled }}
         - name: DYNAMO_NAMESPACE
           value: "{{ .config.dynamo.namespace }}"
         - name: DYNAMO_NAME
           value: "{{ .config.dynamo.name }}"
-      {{- end }}
-      {{- if .config.workers }}
+        {{- end }}
+        {{- if .config.workers }}
         - name: WORKERS
           value: "{{ .config.workers }}"
-      {{- end }}
+        {{- end }}
         - name: PORT
           value: "3000"
         {{- if $.Values.natsAddr }}


### PR DESCRIPTION
#### Overview:

fix pipeline helm chart

#### Details:

if no timeout is set in the python annotation, the helm chart won't install

#### Where should the reviewer start?

only 1 file

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
