### PR TITLE
fix: direct clients vs dependancies

### DIFF
--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -124,7 +124,7 @@ class Processor(ProcessMixIn):
             sampling_params,
         ) = await self._parse_raw_request(raw_request)
         router_mode = (await self.etcd_kv_cache.get("router")).decode()
-        if router_mode == "kv":
+        if router_mode == "kv"
             router_generator = await self.router_client.generate(
                 Tokens(tokens=engine_prompt["prompt_token_ids"]).model_dump_json()
             )

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -124,7 +124,7 @@ class Processor(ProcessMixIn):
             sampling_params,
         ) = await self._parse_raw_request(raw_request)
         router_mode = (await self.etcd_kv_cache.get("router")).decode()
-        if router_mode == "kv"
+        if router_mode == "kv":
             router_generator = await self.router_client.generate(
                 Tokens(tokens=engine_prompt["prompt_token_ids"]).model_dump_json()
             )

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -67,6 +67,7 @@ class Processor(ProcessMixIn):
             self.tokenizer, self.model_config
         )
         self.min_workers = 1
+        print(f"Processor init: {self.engine_args.router}")
 
     def _create_tokenizer(self, engine_args: AsyncEngineArgs) -> AnyTokenizer:
         """Create a TokenizerGroup using engine arguments similar to VLLM's approach"""
@@ -93,13 +94,14 @@ class Processor(ProcessMixIn):
             .client()
         )
 
-        router_ns, router_name = Router.dynamo_address()  # type: ignore
-        self.router_client = (
-            await runtime.namespace(router_ns)
-            .component(router_name)
-            .endpoint("generate")
-            .client()
-        )
+        if self.engine_args.router == "kv":
+            router_ns, router_name = Router.dynamo_address()  # type: ignore
+            self.router_client = (
+                await runtime.namespace(router_ns)
+                .component(router_name)
+                .endpoint("generate")
+                .client()
+            )
 
         await check_required_workers(self.worker_client, self.min_workers)
 

--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -65,6 +65,14 @@ class Processor(ChatProcessorMixin):
             .endpoint("generate")
             .client()
         )
+
+        router_ns, router_name = Router.dynamo_address()  # type: ignore
+        self.router_client = (
+            await runtime.namespace(router_ns)
+            .component(router_name)
+            .endpoint("generate")
+            .client()
+        )
         while len(self.worker_client.endpoint_ids()) < self.min_workers:
             logger.info(
                 f"Waiting for workers to be ready.\n"
@@ -88,7 +96,7 @@ class Processor(ChatProcessorMixin):
 
         worker_id = ""
         if self.router_mode == "kv":
-            async for route_response in self.router.generate(
+            async for route_response in self.router_client.generate(
                 preprocessed_request.tokens.model_dump_json()
             ):
                 worker_id, prefix_hit_rate = route_response.split("_")

--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -96,15 +96,16 @@ class Processor(ChatProcessorMixin):
 
         worker_id = ""
         if self.router_mode == "kv":
-            async for route_response in self.router_client.generate(
+            router_generator = await self.router_client.generate(
                 preprocessed_request.tokens.model_dump_json()
-            ):
-                worker_id, prefix_hit_rate = route_response.split("_")
-                prefix_hit_rate = float(prefix_hit_rate)
-                logger.info(
-                    f"Worker ID: {worker_id} with estimated prefix hit rate: {prefix_hit_rate}"
-                )
-                break
+            )
+            decision = await router_generator.__anext__()
+            decision = decision.data()
+            worker_id, prefix_hit_rate = decision.split("_")
+            prefix_hit_rate = float(prefix_hit_rate)
+            logger.info(
+                f"Worker ID: {worker_id} with estimated prefix hit rate: {prefix_hit_rate}"
+            )
 
         if worker_id == "":
             if self.router_mode == "round-robin":

--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -52,6 +52,7 @@ class Processor(ChatProcessorMixin):
         self.remote_prefill = args.remote_prefill
         self.router_mode = args.router
         self.min_workers = 1
+        self.args = args
 
         super().__init__(engine_config)
 
@@ -66,7 +67,7 @@ class Processor(ChatProcessorMixin):
             .client()
         )
 
-        if self.engine_args.router == "kv":
+        if self.args.router == "kv":
             router_ns, router_name = Router.dynamo_address()  # type: ignore
             self.router_client = (
                 await runtime.namespace(router_ns)

--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -66,13 +66,15 @@ class Processor(ChatProcessorMixin):
             .client()
         )
 
-        router_ns, router_name = Router.dynamo_address()  # type: ignore
-        self.router_client = (
-            await runtime.namespace(router_ns)
-            .component(router_name)
-            .endpoint("generate")
-            .client()
-        )
+        if self.engine_args.router == "kv":
+            router_ns, router_name = Router.dynamo_address()  # type: ignore
+            self.router_client = (
+                await runtime.namespace(router_ns)
+                .component(router_name)
+                .endpoint("generate")
+                .client()
+            )
+
         while len(self.worker_client.endpoint_ids()) < self.min_workers:
             logger.info(
                 f"Waiting for workers to be ready.\n"


### PR DESCRIPTION
#### Overview:

We've been hitting some issues with the router endpoint dying when in `kv` mode then coming back up at high ISL and concurrencies. This does not happen during `round-robin` or `random`. The only difference is how we are creating the client to the dynamo endpoint.

#### Details:

When we create a `DynamoDependancy` using the `depends()` statement, we do some asyncio queue work. This bypasses that, creates the client directly and leverages only python bindings

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
