### PR TITLE
chore: Replace TRD->Dynamo in llmctl help output

### DIFF
--- a/launch/llmctl/src/main.rs
+++ b/launch/llmctl/src/main.rs
@@ -98,7 +98,7 @@ define_type_subcommands!(
 #[command(
     author="NVIDIA",
     version="0.2.1",
-    about="LLMCTL - Control and manage TRD Components",
+    about="LLMCTL - Control and manage Dynamo Components",
     long_about = None,
     disable_help_subcommand = true,
 )]


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Fixes missed "TRD" reference in llmctl help output