### PR TITLE
fix: increase trtllm example event_buffer_max_size to avoid event drop

### DIFF
--- a/examples/tensorrt_llm/configs/llm_api_config_disagg_router.yaml
+++ b/examples/tensorrt_llm/configs/llm_api_config_disagg_router.yaml
@@ -36,6 +36,6 @@ kv_cache_config:
   enable_block_reuse: true
 
 pytorch_backend_config:
-  enable_overlap_scheduler: true
-  use_cuda_graph: true
+  enable_overlap_scheduler: false
+  use_cuda_graph: false
   enable_iter_perf_stats: true

--- a/examples/tensorrt_llm/configs/llm_api_config_disagg_router.yaml
+++ b/examples/tensorrt_llm/configs/llm_api_config_disagg_router.yaml
@@ -32,7 +32,7 @@ enable_chunked_prefill: true
 
 kv_cache_config:
   free_gpu_memory_fraction: 0.95
-  event_buffer_max_size: 1024
+  event_buffer_max_size: 8192
   enable_block_reuse: true
 
 pytorch_backend_config:

--- a/examples/tensorrt_llm/configs/llm_api_config_disagg_router.yaml
+++ b/examples/tensorrt_llm/configs/llm_api_config_disagg_router.yaml
@@ -36,6 +36,6 @@ kv_cache_config:
   enable_block_reuse: true
 
 pytorch_backend_config:
-  enable_overlap_scheduler: false
-  use_cuda_graph: false
+  enable_overlap_scheduler: true
+  use_cuda_graph: true
   enable_iter_perf_stats: true

--- a/examples/tensorrt_llm/configs/llm_api_config_router.yaml
+++ b/examples/tensorrt_llm/configs/llm_api_config_router.yaml
@@ -32,7 +32,7 @@ enable_chunked_prefill: true
 
 kv_cache_config:
   free_gpu_memory_fraction: 0.95
-  event_buffer_max_size: 1024
+  event_buffer_max_size: 8192
   enable_block_reuse: true
 
 pytorch_backend_config:


### PR DESCRIPTION
#### Overview:

By setting `event_buffer_max_size`  from `1024` to `8192`, the warning of `The event queue has reached the max size of 1024. Events have been discarded` is gone, when running `genai-perf` with public mooncake trace. `8192` should be a safer value.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the event buffer maximum size from 1024 to 8192 in relevant configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->