### PR TITLE
fix: allow for an empty dynamo config file

### DIFF
--- a/deploy/Kubernetes/pipeline/deploy.sh
+++ b/deploy/Kubernetes/pipeline/deploy.sh
@@ -31,7 +31,7 @@ DOCKER_REGISTRY=$1
 NAMESPACE=$2
 DYNAMO_DIRECTORY=$3
 DYNAMO_IDENTIFIER=$4
-DYNAMO_CONFIG_FILE=$5
+DYNAMO_CONFIG_FILE=${5:-""}  # Set to empty string if not provided
 
 # Check if any of the inputs are empty
 if [[ -z "$DOCKER_REGISTRY" || -z "$NAMESPACE" || -z "$DYNAMO_IDENTIFIER" || -z "$DYNAMO_DIRECTORY" ]]; then


### PR DESCRIPTION
#### Overview:

The Dynamo config file in this script should be optional and we don't want to throw an error if it's not provided

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
