### PR TITLE
feat: make ingress configurable in operator

### DIFF
--- a/deploy/dynamo/helm/dynamo-platform-values.yaml
+++ b/deploy/dynamo/helm/dynamo-platform-values.yaml
@@ -22,6 +22,8 @@ dynamo-operator:
   enabled: true
   natsAddr: "nats://${RELEASE_NAME}-nats:4222"
   etcdAddr: "${RELEASE_NAME}-etcd:2379"
+  istioVirtualServiceEnabled: false
+  ingressControllerClassName: ""
   namespaceRestriction:
     enabled: true
     targetNamespace: ${NAMESPACE}

--- a/deploy/dynamo/helm/platform/Chart.yaml
+++ b/deploy/dynamo/helm/platform/Chart.yaml
@@ -23,7 +23,7 @@ version: 25.2.0-rc3
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator
-    version: 0.1.2
+    version: 0.1.3
     repository: file://components/operator
     condition: dynamo-operator.enabled
   - name: dynamo-api-store

--- a/deploy/dynamo/helm/platform/components/operator/Chart.yaml
+++ b/deploy/dynamo/helm/platform/components/operator/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/deploy/dynamo/helm/platform/components/operator/templates/deployment.yaml
+++ b/deploy/dynamo/helm/platform/components/operator/templates/deployment.yaml
@@ -72,6 +72,12 @@ spec:
         {{- if .Values.etcdAddr }}
           - --etcdAddr={{ .Values.etcdAddr }}
         {{- end }}
+        {{- if .Values.istioVirtualServiceEnabled }}
+          - --istio-virtual-service-enabled
+        {{- end }}
+        {{- if .Values.ingressControllerClassName }}
+          - --ingress-controller-class-name={{ .Values.ingressControllerClassName }}
+        {{- end }}
         command:
         - /manager
         env:

--- a/deploy/dynamo/helm/platform/components/operator/templates/manager-rbac.yaml
+++ b/deploy/dynamo/helm/platform/components/operator/templates/manager-rbac.yaml
@@ -277,6 +277,7 @@ rules:
   - patch
   - update
   - watch
+{{- if .Values.istioVirtualServiceEnabled }}
 - apiGroups:
   - networking.istio.io
   resources:
@@ -289,6 +290,7 @@ rules:
   - patch
   - update
   - watch
+{{- end }}
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/deploy/dynamo/operator/go.mod
+++ b/deploy/dynamo/operator/go.mod
@@ -8,6 +8,7 @@ require (
 	dario.cat/mergo v1.0.1
 	emperror.dev/errors v0.8.1
 	github.com/apparentlymart/go-shquot v0.0.1
+	github.com/bsm/gomega v1.27.10
 	github.com/cisco-open/k8s-objectmatcher v1.9.0
 	github.com/ettle/strcase v0.2.0
 	github.com/huandu/xstrings v1.4.0

--- a/deploy/dynamo/operator/go.sum
+++ b/deploy/dynamo/operator/go.sum
@@ -6,6 +6,8 @@ github.com/apparentlymart/go-shquot v0.0.1 h1:MGV8lwxF4zw75lN7e0MGs7o6AFYn7L6AZa
 github.com/apparentlymart/go-shquot v0.0.1/go.mod h1:lw58XsE5IgUXZ9h0cxnypdx31p9mPFIVEQ9P3c7MlrU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cisco-open/k8s-objectmatcher v1.9.0 h1:/sfuO0BD09fpynZjXsqeZrh28Juc4VEwc2P6Ov/Q6fM=

--- a/deploy/dynamo/operator/internal/nim/nim.go
+++ b/deploy/dynamo/operator/internal/nim/nim.go
@@ -256,7 +256,6 @@ func GenerateDynamoNIMDeployments(ctx context.Context, parentDynamoDeployment *v
 			if config.EntryService == service.Name {
 				// enable virtual service for the entry service
 				deployment.Spec.Ingress.Enabled = true
-				deployment.Spec.Ingress.UseVirtualService = &deployment.Spec.Ingress.Enabled
 			}
 		}
 		if service.Config.Resources != nil {

--- a/deploy/dynamo/operator/internal/nim/nim_test.go
+++ b/deploy/dynamo/operator/internal/nim/nim_test.go
@@ -228,8 +228,7 @@ func TestGenerateDynamoNIMDeployments(t *testing.T) {
 								},
 							},
 							Ingress: v1alpha1.IngressSpec{
-								Enabled:           true,
-								UseVirtualService: &[]bool{true}[0],
+								Enabled: true,
 							},
 						},
 					},
@@ -336,8 +335,7 @@ func TestGenerateDynamoNIMDeployments(t *testing.T) {
 								},
 							},
 							Ingress: v1alpha1.IngressSpec{
-								Enabled:           true,
-								UseVirtualService: &[]bool{true}[0],
+								Enabled: true,
 							},
 						},
 					},


### PR DESCRIPTION
#### Overview:

make ingress configurable in operator

#### Details:

This change allow to configure ingress as part of the operator configuration.

#### Where should the reviewer start?

helm chart then the controller code

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #706
