### PR TITLE
docs: Remove outdated python-wheels directory reference

### DIFF
--- a/lib/bindings/python/README.md
+++ b/lib/bindings/python/README.md
@@ -56,7 +56,6 @@ See [README.md](../../runtime/README.md#️-prerequisites).
 
 1. Start 3 separate shells, and activate the virtual environment in each
 ```
-cd python-wheels/dynamo
 source .venv/bin/activate
 ```
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

It's possible these python bindings docs are outdated and the `maturin` based steps don't work anymore (in favor of `uv build` and other `cargo` workspace changes) - I haven't walked through them to verify, but this reference of `python-wheels` directory is _definitely_ outdated (in favor of `lib/bindings/python`, so this PR removes it to avoid unnecessary confusion.