### PR TITLE
fix: bump GAP to r25.03

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -45,8 +45,8 @@ COPY ${TENSORRTLLM_PIP_WHEEL_PATH}/*.whl /tmp/
 RUN find /tmp -name "*.whl" -exec pip install {} +
 
 # Install genai-perf for benchmarking
-# TODO: Move to tag when fix for genai-perf will be released
-ARG GENAI_PERF_TAG="25d0188713adc47868d6b3f22426375237a90529"
+# TODO: Move to tag when fix for genai-perf will be released and has proper CI testing
+ARG GENAI_PERF_TAG="e67e853413a07a778dd78a55e299be7fba9c9c24"
 RUN pip install "git+https://github.com/triton-inference-server/perf_analyzer.git@${GENAI_PERF_TAG}#subdirectory=genai-perf"
 
 # Install test dependencies

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -45,7 +45,7 @@ COPY ${TENSORRTLLM_PIP_WHEEL_PATH}/*.whl /tmp/
 RUN find /tmp -name "*.whl" -exec pip install {} +
 
 # Install genai-perf for benchmarking
-# TODO: Move to tag when fix for genai-perf will be released and has proper CI testing
+# TODO: Move to published pypi tags
 ARG GENAI_PERF_TAG="e67e853413a07a778dd78a55e299be7fba9c9c24"
 RUN pip install "git+https://github.com/triton-inference-server/perf_analyzer.git@${GENAI_PERF_TAG}#subdirectory=genai-perf"
 

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -7,7 +7,7 @@ ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
 ARG MANYLINUX_IMAGE="quay.io/pypa/manylinux_2_28_x86_64"
-# TODO: Move to tag when fix for genai-perf will be released and has proper CI testing
+# TODO: Move to published pypi tags
 ARG GENAI_PERF_TAG="e67e853413a07a778dd78a55e299be7fba9c9c24"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS nixl_base

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -7,7 +7,8 @@ ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
 ARG MANYLINUX_IMAGE="quay.io/pypa/manylinux_2_28_x86_64"
-ARG GENAI_PERF_TAG="25d0188713adc47868d6b3f22426375237a90529"
+# TODO: Move to tag when fix for genai-perf will be released and has proper CI testing
+ARG GENAI_PERF_TAG="e67e853413a07a778dd78a55e299be7fba9c9c24"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS nixl_base
 WORKDIR /opt/nixl


### PR DESCRIPTION
Current version doesn't work for trace (static file). This PR fix this. 