### PR TITLE
fix:  dynamo deploy helm chart cleanup

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -174,10 +174,10 @@ all-test:
     BUILD ./deploy/dynamo/operator+test
 
 all-docker:
-    ARG CI_REGISTRY_IMAGE=my-registry
-    ARG CI_COMMIT_SHA=latest
-    BUILD ./deploy/dynamo/operator+docker --CI_REGISTRY_IMAGE=$CI_REGISTRY_IMAGE --CI_COMMIT_SHA=$CI_COMMIT_SHA
-    BUILD ./deploy/dynamo/api-store+docker --CI_REGISTRY_IMAGE=$CI_REGISTRY_IMAGE --CI_COMMIT_SHA=$CI_COMMIT_SHA
+    ARG DOCKER_SERVER=my-registry
+    ARG IMAGE_TAG=latest
+    BUILD ./deploy/dynamo/operator+docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
+    BUILD ./deploy/dynamo/api-store+docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
 
 all-lint:
     BUILD ./deploy/dynamo/operator+lint
@@ -189,6 +189,6 @@ all:
 
 # For testing
 custom:
-    ARG CI_REGISTRY_IMAGE=my-registry
-    ARG CI_COMMIT_SHA=latest
+    ARG DOCKER_SERVER=my-registry
+    ARG IMAGE_TAG=latest
     BUILD +all-test

--- a/deploy/dynamo/api-store/Earthfile
+++ b/deploy/dynamo/api-store/Earthfile
@@ -30,12 +30,12 @@ uv-base:
     RUN uv sync --frozen --no-install-project --no-dev --no-install-workspace --no-editable
 
 docker:
-    ARG CI_REGISTRY_IMAGE=my-registry
-    ARG CI_COMMIT_SHA=latest
+    ARG DOCKER_SERVER=my-registry
+    ARG IMAGE_TAG=latest
     ARG IMAGE=dynamo-api-store
     FROM +uv-base
     # Copy project files
     COPY ai_dynamo_store ai_dynamo_store
     RUN uv pip install .
     ENTRYPOINT ["ai-dynamo-store"]
-    SAVE IMAGE --push $CI_REGISTRY_IMAGE/$IMAGE:$CI_COMMIT_SHA
+    SAVE IMAGE --push $DOCKER_SERVER/$IMAGE:$IMAGE_TAG

--- a/deploy/dynamo/helm/README.md
+++ b/deploy/dynamo/helm/README.md
@@ -35,7 +35,7 @@ export IMAGE_TAG=<TAG>
 ```
 
 As a description of the placeholders:
-- `<CONTAINER_REGISTRY>`: Your container registry (e.g., `nvcr.io`, `docker.io`, etc.)
+- `<CONTAINER_REGISTRY>`: Your container registry (e.g., `nvcr.io`, `docker.io/<your-username>`, etc.)
 - `<TAG>`: The tag you want to use for the image (e.g., `latest`, `0.0.1`, etc.)
 
 Note: Make sure you're logged in to your container registry before pushing images. For example:
@@ -45,28 +45,42 @@ docker login <CONTAINER_REGISTRY>
 
 You can build each component individually or build all components at once:
 
-#### Option 1: Build All Components at Once
+#### Build and push platform components
 ```bash
 earthly --push +all-docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
 ```
 
-#### Option 2: Build Components Individually
-
-1. **API Store**
-```bash
-cd deploy/dynamo/api-store
-earthly --push +docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
-```
-
-2. **Operator**
-```bash
-cd deploy/dynamo/operator
-earthly --push +docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
-```
 
 ## Deploy Dynamo Cloud Platform
 
-Pre-requisite: make sure your terminal is set in the `deploy/dynamo/helm/` directory.
+### Prerequisites
+Before deploying Dynamo Cloud, ensure your Kubernetes cluster meets the following requirements:
+
+#### 1. Istio Installation
+Dynamo Cloud requires Istio for service mesh capabilities. Verify Istio is installed and running:
+
+```bash
+# Check if Istio is installed
+kubectl get pods -n istio-system
+
+# Expected output should show running Istio pods
+# istiod-* pods should be in Running state
+```
+
+#### 2. PVC Support with Default Storage Class
+Dynamo Cloud requires Persistent Volume Claim (PVC) support with a default storage class. Verify your cluster configuration:
+
+```bash
+# Check if default storage class exists
+kubectl get storageclass
+
+# Expected output should show at least one storage class marked as (default)
+# Example:
+# NAME                 PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+# standard (default)   kubernetes.io/gce-pd    Delete          Immediate              true                   1d
+```
+
+### Installation
 
 ```bash
 cd deploy/dynamo/helm

--- a/deploy/dynamo/helm/README.md
+++ b/deploy/dynamo/helm/README.md
@@ -30,12 +30,12 @@ You can build and push Docker images for the Dynamo cloud components (API server
 
 First, set the required environment variables:
 ```bash
-export CI_REGISTRY_IMAGE=<CONTAINER_REGISTRY>/<ORGANIZATION>
-export CI_COMMIT_SHA=<TAG>
+export DOCKER_SERVER=<CONTAINER_REGISTRY>
+export IMAGE_TAG=<TAG>
 ```
 
 As a description of the placeholders:
-- `<CONTAINER_REGISTRY>/<ORGANIZATION>`: Your container registry and organization name (e.g., `nvcr.io/myorg`, `docker.io/myorg`, etc.)
+- `<CONTAINER_REGISTRY>`: Your container registry (e.g., `nvcr.io`, `docker.io`, etc.)
 - `<TAG>`: The tag you want to use for the image (e.g., `latest`, `0.0.1`, etc.)
 
 Note: Make sure you're logged in to your container registry before pushing images. For example:
@@ -47,7 +47,7 @@ You can build each component individually or build all components at once:
 
 #### Option 1: Build All Components at Once
 ```bash
-earthly --push +all-docker --CI_REGISTRY_IMAGE=$CI_REGISTRY_IMAGE --CI_COMMIT_SHA=$CI_COMMIT_SHA
+earthly --push +all-docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
 ```
 
 #### Option 2: Build Components Individually
@@ -55,13 +55,13 @@ earthly --push +all-docker --CI_REGISTRY_IMAGE=$CI_REGISTRY_IMAGE --CI_COMMIT_SH
 1. **API Store**
 ```bash
 cd deploy/dynamo/api-store
-earthly --push +docker --CI_REGISTRY_IMAGE=$CI_REGISTRY_IMAGE --CI_COMMIT_SHA=$CI_COMMIT_SHA
+earthly --push +docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
 ```
 
 2. **Operator**
 ```bash
 cd deploy/dynamo/operator
-earthly --push +docker --CI_REGISTRY_IMAGE=$CI_REGISTRY_IMAGE --CI_COMMIT_SHA=$CI_COMMIT_SHA
+earthly --push +docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
 ```
 
 ## Deploy Dynamo Cloud Platform
@@ -70,31 +70,30 @@ Pre-requisite: make sure your terminal is set in the `deploy/dynamo/helm/` direc
 
 ```bash
 cd deploy/dynamo/helm
-export KUBE_NS=hello-world    # change this to whatever you want!
+export NAMESPACE=dynamo-cloud    # change this to whatever you want!
 ```
 
 1. [One-time Action] Create a new kubernetes namespace and set it as your default. Create image pull secrets if needed.
 
 ```bash
-kubectl create namespace $KUBE_NS
-kubectl config set-context --current --namespace=$KUBE_NS
+kubectl create namespace $NAMESPACE
+kubectl config set-context --current --namespace=$NAMESPACE
 
 # [Optional] if needed, create image pull secrets
 kubectl create secret docker-registry docker-imagepullsecret \
   --docker-server=<your-registry> \
   --docker-username=<your-username> \
   --docker-password=<your-password> \
-  --namespace=$KUBE_NS
+  --namespace=$NAMESPACE
 ```
 
 2. Deploy the helm chart using the deploy script:
 
 ```bash
-export NGC_TOKEN=$NGC_API_TOKEN
-export NAMESPACE=$KUBE_NS
-export CI_COMMIT_SHA=<TAG>  # Use the same tag you used when building the images
-export CI_REGISTRY_IMAGE=<CONTAINER_REGISTRY>/<ORGANIZATION>  # Use the same registry/org you used when building the images
-export RELEASE_NAME=$KUBE_NS
+export DOCKER_USERNAME=<your-docker-username>
+export DOCKER_PASSWORD=<your-docker-password>
+export DOCKER_SERVER=<your-docker-server>
+export IMAGE_TAG=<TAG>  # Use the same tag you used when building the images
 
 ./deploy.sh
 ```

--- a/deploy/dynamo/helm/README.md
+++ b/deploy/dynamo/helm/README.md
@@ -50,7 +50,6 @@ You can build each component individually or build all components at once:
 earthly --push +all-docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
 ```
 
-
 ## Deploy Dynamo Cloud Platform
 
 ### Prerequisites
@@ -82,32 +81,32 @@ kubectl get storageclass
 
 ### Installation
 
-```bash
-cd deploy/dynamo/helm
-export NAMESPACE=dynamo-cloud    # change this to whatever you want!
-```
-
-1. [One-time Action] Create a new kubernetes namespace and set it as your default. Create image pull secrets if needed.
-
-```bash
-kubectl create namespace $NAMESPACE
-kubectl config set-context --current --namespace=$NAMESPACE
-
-# [Optional] if needed, create image pull secrets
-kubectl create secret docker-registry docker-imagepullsecret \
-  --docker-server=<your-registry> \
-  --docker-username=<your-username> \
-  --docker-password=<your-password> \
-  --namespace=$NAMESPACE
-```
-
-2. Deploy the helm chart using the deploy script:
-
+1. Set the required environment variables:
 ```bash
 export DOCKER_USERNAME=<your-docker-username>
 export DOCKER_PASSWORD=<your-docker-password>
 export DOCKER_SERVER=<your-docker-server>
 export IMAGE_TAG=<TAG>  # Use the same tag you used when building the images
+export NAMESPACE=dynamo-cloud    # change this to whatever you want!
+```
 
+2. [One-time Action] Create a new kubernetes namespace and set it as your default. Create image pull secrets if needed.
+
+```bash
+cd deploy/dynamo/helm
+kubectl create namespace $NAMESPACE
+kubectl config set-context --current --namespace=$NAMESPACE
+
+# [Optional] if needed, create image pull secrets
+kubectl create secret docker-registry docker-imagepullsecret \
+  --docker-server=$DOCKER_SERVER \
+  --docker-username=$DOCKER_USERNAME \
+  --docker-password=$DOCKER_PASSWORD \
+  --namespace=$NAMESPACE
+```
+
+3. Deploy the helm chart using the deploy script:
+
+```bash
 ./deploy.sh
 ```

--- a/deploy/dynamo/helm/deploy.sh
+++ b/deploy/dynamo/helm/deploy.sh
@@ -21,21 +21,27 @@ set -euo pipefail
 HELM_CMD=$(which helm)
 
 # Set default values only if not already set
-export NAMESPACE="${NAMESPACE:=cai-system}"  # Default namespace
-export NGC_TOKEN="${NGC_TOKEN:=<your-ngc-token>}"  # Default NGC token
-export CI_REGISTRY_IMAGE="${CI_REGISTRY_IMAGE:=<your-registry>/<your-org>}"  # Default registry/org
-export CI_COMMIT_SHA="${CI_COMMIT_SHA:=250e2e0f93f7af3d83a4a0ff992e56956f7651f2}"  # Default commit SHA
-export RELEASE_NAME="${RELEASE_NAME:=dynamo-platform}"  # Default release name
+export NAMESPACE="${NAMESPACE:=dynamo-cloud}"  # Default namespace
+export RELEASE_NAME="${RELEASE_NAME:=${NAMESPACE}}"  # Default release name is same as namespace
+export DOCKER_USERNAME="${DOCKER_USERNAME:=<your-docker-username>}"  # Default docker username
+export DOCKER_PASSWORD="${DOCKER_PASSWORD:=<your-docker-password>}"  # Default docker password
+export DOCKER_SERVER="${DOCKER_SERVER:=<your-docker-server>}"  # Default docker server
+export IMAGE_TAG="${IMAGE_TAG:=250e2e0f93f7af3d83a4a0ff992e56956f7651f2}"  # Default image tag
 export DYNAMO_INGRESS_SUFFIX="${DYNAMO_INGRESS_SUFFIX:=}"
 
 # Check if required variables are set
-if [ "$NGC_TOKEN" = "<your-ngc-token>" ]; then
-    echo "Error: Please set your NGC_TOKEN in the script or via environment variable"
+if [ "$DOCKER_USERNAME" = "<your-docker-username>" ]; then
+    echo "Error: Please set your DOCKER_USERNAME in the script or via environment variable"
     exit 1
 fi
 
-if [ "$CI_REGISTRY_IMAGE" = "<your-registry>/<your-org>" ]; then
-    echo "Error: Please set your CI_REGISTRY_IMAGE in the script or via environment variable"
+if [ "$DOCKER_PASSWORD" = "<your-docker-password>" ]; then
+    echo "Error: Please set your DOCKER_PASSWORD in the script or via environment variable"
+    exit 1
+fi
+
+if [ "$DOCKER_SERVER" = "<your-docker-server>" ]; then
+    echo "Error: Please set your DOCKER_SERVER in the script or via environment variable"
     exit 1
 fi
 
@@ -76,15 +82,16 @@ cd ..
 # Generate the values file
 echo "Generating values file with:"
 echo "NAMESPACE: $NAMESPACE"
-echo "CI_COMMIT_SHA: $CI_COMMIT_SHA"
-echo "CI_REGISTRY_IMAGE: $CI_REGISTRY_IMAGE"
-echo "NGC_TOKEN: [HIDDEN]"
 echo "RELEASE_NAME: $RELEASE_NAME"
+echo "IMAGE_TAG: $IMAGE_TAG"
+echo "DOCKER_USERNAME: $DOCKER_USERNAME"
+echo "DOCKER_SERVER: $DOCKER_SERVER"
+echo "DOCKER_PASSWORD: [HIDDEN]"
 
 echo "generated file contents:"
-envsubst '${NAMESPACE} ${NGC_TOKEN} ${CI_COMMIT_SHA} ${RELEASE_NAME} ${DYNAMO_INGRESS_SUFFIX} ${CI_REGISTRY_IMAGE}' < dynamo-platform-values.yaml
+envsubst '${NAMESPACE} ${RELEASE_NAME} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${DOCKER_SERVER} ${IMAGE_TAG} ${DYNAMO_INGRESS_SUFFIX}' < dynamo-platform-values.yaml
 
-envsubst '${NAMESPACE} ${NGC_TOKEN} ${CI_COMMIT_SHA} ${RELEASE_NAME} ${DYNAMO_INGRESS_SUFFIX} ${CI_REGISTRY_IMAGE}' < dynamo-platform-values.yaml > generated-values.yaml
+envsubst '${NAMESPACE} ${RELEASE_NAME} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${DOCKER_SERVER} ${IMAGE_TAG} ${DYNAMO_INGRESS_SUFFIX}' < dynamo-platform-values.yaml > generated-values.yaml
 
 echo ""
 echo "Generated values file saved as generated-values.yaml"

--- a/deploy/dynamo/helm/deploy.sh
+++ b/deploy/dynamo/helm/deploy.sh
@@ -26,8 +26,8 @@ export RELEASE_NAME="${RELEASE_NAME:=${NAMESPACE}}"  # Default release name is s
 export DOCKER_USERNAME="${DOCKER_USERNAME:=<your-docker-username>}"  # Default docker username
 export DOCKER_PASSWORD="${DOCKER_PASSWORD:=<your-docker-password>}"  # Default docker password
 export DOCKER_SERVER="${DOCKER_SERVER:=<your-docker-server>}"  # Default docker server
-export IMAGE_TAG="${IMAGE_TAG:=250e2e0f93f7af3d83a4a0ff992e56956f7651f2}"  # Default image tag
-export DYNAMO_INGRESS_SUFFIX="${DYNAMO_INGRESS_SUFFIX:=}"
+export IMAGE_TAG="${IMAGE_TAG:=latest}"  # Default image tag
+export DYNAMO_INGRESS_SUFFIX="${DYNAMO_INGRESS_SUFFIX:=dynamo-cloud.com}"
 
 # Check if required variables are set
 if [ "$DOCKER_USERNAME" = "<your-docker-username>" ]; then

--- a/deploy/dynamo/helm/dynamo-platform-values.yaml
+++ b/deploy/dynamo/helm/dynamo-platform-values.yaml
@@ -40,7 +40,7 @@ dynamo-api-store:
     enabled: true
     targetNamespace: ${NAMESPACE}
   istio:
-    host: ${NAMESPACE}.dev.aire.nvidia.com
+    host: ${NAMESPACE}.${DYNAMO_INGRESS_SUFFIX}
   image:
     repository: ${DOCKER_SERVER}/dynamo-api-store
     tag: ${IMAGE_TAG}
@@ -48,7 +48,7 @@ dynamo-api-store:
   imagePullSecrets:
   ingress:
     hosts:
-      - host: ${NAMESPACE}.dev.aire.nvidia.com
+      - host: ${NAMESPACE}.${DYNAMO_INGRESS_SUFFIX}
         paths:
           - path: /
             pathType: Prefix

--- a/deploy/dynamo/helm/dynamo-platform-values.yaml
+++ b/deploy/dynamo/helm/dynamo-platform-values.yaml
@@ -12,115 +12,52 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-existingImagePullSecret: nvcrimagepullsecret
 
 # Global values used across charts
 global:
-  NGC_API_KEY: ${NGC_TOKEN}
+  NGC_API_KEY: ${DOCKER_PASSWORD}
 
 dynamo-operator:
-  enabled: true
   natsAddr: "nats://${RELEASE_NAME}-nats:4222"
   etcdAddr: "${RELEASE_NAME}-etcd:2379"
   namespaceRestriction:
-    enabled: true
     targetNamespace: ${NAMESPACE}
   controllerManager:
     manager:
       image:
-        repository: ${CI_REGISTRY_IMAGE}/dynamo-operator
-        tag: ${CI_COMMIT_SHA}
-      args:
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        repository: ${DOCKER_SERVER}/dynamo-operator
+        tag: ${IMAGE_TAG}
 
   dynamo:
     dynamoIngressSuffix: ${DYNAMO_INGRESS_SUFFIX}
-    yatai:
-      endpoint: http://dynamo-store
-      clusterName: default
-
-    yataiSystem:
-      namespace: ""
-
-    internalImages:
-      bentoDownloader: quay.io/bentoml/bento-downloader:0.0.5
-      kaniko: quay.io/bentoml/kaniko:debug
-      buildkit: quay.io/bentoml/buildkit:master
-      buildkitRootless: quay.io/bentoml/buildkit:master-rootless
-      metricsTransformer: quay.io/bentoml/yatai-bento-metrics-transformer:0.0.4
-      debugger: quay.io/bentoml/bento-debugger:0.0.8
-      monitorExporter: quay.io/bentoml/bentoml-monitor-exporter:0.0.3
-      proxy: quay.io/bentoml/bentoml-proxy:0.0.1
-
-    disableAutomateBentoImageBuilder: false
-    enableRestrictedSecurityContext: false
-    disableYataiComponentRegistration: false
-
     dockerRegistry:
-      server: 'nvcr.io/nvidian/nim-llm-dev'
-      inClusterServer: ''
-      username: '$oauthtoken'
-      passwordExistingSecretName: 'nvcrimagepullsecret'
-      secure: true
-      bentoRepositoryName: yatai-bentos
-
-    bentoImageBuildEngine: buildkit
-    addNamespacePrefixToImageName: false
-
-    estargz:
-      enabled: false
-
-    kaniko:
-      cacheRepo: ''
-      snapshotMode: ''
+      server: ${DOCKER_SERVER}
+      username: ${DOCKER_USERNAME}
+      password: ${DOCKER_PASSWORD}
 
 dynamo-api-store:
-  enabled: true
   namespaceRestriction:
     enabled: true
     targetNamespace: ${NAMESPACE}
   istio:
     host: ${NAMESPACE}.dev.aire.nvidia.com
-  dynamo:
-    env:
-      resource_scope: "user"
   image:
-    repository: ${CI_REGISTRY_IMAGE}/dynamo-api-store
-    tag: ${CI_COMMIT_SHA}
+    repository: ${DOCKER_SERVER}/dynamo-api-store
+    tag: ${IMAGE_TAG}
     pullPolicy: IfNotPresent
   imagePullSecrets:
-    - name: nvcrimagepullsecret
-    - name: docker-imagepullsecret
-    - name: gitlab-imagepull
   ingress:
-    enabled: true
-    className: nginx
     hosts:
       - host: ${NAMESPACE}.dev.aire.nvidia.com
         paths:
           - path: /
             pathType: Prefix
-  postgresql:
-    primary:
-      persistence:
-        enabled: false
-  minio:
-    persistence:
-      enabled: true
-      size: 5Gi
-      storageClass: "local-path"
-    apiIngress:
-      enabled: false
-      ingressClassName: nginx
-      hostname: minio.example.com
-      pathType: Prefix
 
 etcd:
   enabled: true
   persistence:
     enabled: true
-    storageClass: "local-path"
+    storageClass: ""
     size: 1Gi
   preUpgrade:
     enabled: false
@@ -133,4 +70,4 @@ nats:
       fileStore:
         pvc:
           size: 1Gi
-          storageClassName: "local-path"
+          storageClassName: ""

--- a/deploy/dynamo/helm/platform/components/operator/templates/buildkit.yaml
+++ b/deploy/dynamo/helm/platform/components/operator/templates/buildkit.yaml
@@ -101,7 +101,6 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-        storageClassName: ""
         resources:
           requests:
             storage: 1000Gi

--- a/deploy/dynamo/helm/platform/components/operator/templates/buildkit.yaml
+++ b/deploy/dynamo/helm/platform/components/operator/templates/buildkit.yaml
@@ -101,7 +101,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
-        storageClassName: local-path
+        storageClassName: ""
         resources:
           requests:
             storage: 1000Gi

--- a/deploy/dynamo/helm/platform/values.yaml
+++ b/deploy/dynamo/helm/platform/values.yaml
@@ -13,32 +13,100 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Used to generate top-level secrets (overridden by custom-values.yaml)
-existingSecret: ""
-existingImagePullSecret: ""
-ngcAPIKey: YOUR-NGC-API-KEY
+
 imagePullSecrets:
-  - name: nvcrimagepullsecret
-    registry: nvcr.io
-    username: $oauthtoken
-    password: YOUR-NGC-API-KEY
+
 # Subcharts
 dynamo-operator:
-  enabled: false
+  enabled: true
   imagePullSecrets:
     - name: gitlab-imagepull
     - name: nvcrimagepullsecret
     - name: docker-imagepullsecret
+  natsAddr: ""
+  etcdAddr: ""
+  namespaceRestriction:
+    enabled: true
+    targetNamespace: ""
   controllerManager:
     manager:
       image:
-        repository: gitlab-master.nvidia.com:5005/aire/microservices/nmp/dynamo-operator
+        repository: ""
         tag: "latest"
-dynamo-api-server:
-  enabled: false
+      args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+  dynamo:
+    yatai:
+      endpoint: http://dynamo-store
+      clusterName: default
+    yataiSystem:
+      namespace: ""
+    internalImages:
+      bentoDownloader: quay.io/bentoml/bento-downloader:0.0.5
+      kaniko: quay.io/bentoml/kaniko:debug
+      buildkit: quay.io/bentoml/buildkit:master
+      buildkitRootless: quay.io/bentoml/buildkit:master-rootless
+      metricsTransformer: quay.io/bentoml/yatai-bento-metrics-transformer:0.0.4
+      debugger: quay.io/bentoml/bento-debugger:0.0.8
+      monitorExporter: quay.io/bentoml/bentoml-monitor-exporter:0.0.3
+      proxy: quay.io/bentoml/bentoml-proxy:0.0.1
+    disableAutomateBentoImageBuilder: false
+    enableRestrictedSecurityContext: false
+    disableYataiComponentRegistration: false
+    dockerRegistry:
+      server: ""
+      inClusterServer: ""
+      username: ""
+      password: ""
+      secure: true
+      bentoRepositoryName: yatai-bentos
+    bentoImageBuildEngine: buildkit
+    addNamespacePrefixToImageName: false
+    estargz:
+      enabled: false
+    kaniko:
+      cacheRepo: ""
+      snapshotMode: ""
+
+dynamo-api-store:
+  enabled: true
+  namespaceRestriction:
+    enabled: true
+    targetNamespace: ""
+  istio:
+    host: ""
+  dynamo:
+    env:
+      resource_scope: "user"
+  image:
+    repository: ""
+    tag: "latest"
+    pullPolicy: IfNotPresent
   imagePullSecrets:
-    - name: gitlab-imagepull
-    - name: nvcrimagepullsecret
-    - name: docker-imagepullsecret
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+  postgresql:
+    primary:
+      persistence:
+        enabled: false
+  minio:
+    persistence:
+      enabled: true
+      size: 5Gi
+      storageClass: ""
+    apiIngress:
+      enabled: false
+      ingressClassName: nginx
+      hostname: minio.example.com
+      pathType: Prefix
+
 etcd:
   enabled: false
   replicaCount: 1

--- a/deploy/dynamo/operator/Earthfile
+++ b/deploy/dynamo/operator/Earthfile
@@ -37,12 +37,12 @@ test:
     SAVE ARTIFACT cover.out
 
 docker:
-    ARG CI_REGISTRY_IMAGE=my-registry
-    ARG CI_COMMIT_SHA=latest
+    ARG DOCKER_SERVER=my-registry
+    ARG IMAGE_TAG=latest
     ARG IMAGE_SUFFIX=dynamo-operator
     FROM gcr.io/distroless/static-debian11
     WORKDIR /
     COPY +build/manager .
     USER 65532:65532
     CMD ["./manager"]
-    SAVE IMAGE --push $CI_REGISTRY_IMAGE/$IMAGE_SUFFIX:$CI_COMMIT_SHA
+    SAVE IMAGE --push $DOCKER_SERVER/$IMAGE_SUFFIX:$IMAGE_TAG


### PR DESCRIPTION
#### Overview:

- add callouts for deps on istio and default storage class
- remove explicit references to `local-path` from values so that default storage class can be used
- simplify READMEs to remove unnecessary args `CI_COMMIT_SHA`
- push back defaults to values.yaml (there were too many values present in the dynamo-platform-values.yaml file which should be reserved for overrides)
- remove ngc_token other nvidia-internal references from values and readme


### Testing

Minikube deployment from scratch succeeds and hello world works

