### PR TITLE
fix: Add missing deps for '--framework none' build

### DIFF
--- a/container/Dockerfile.none
+++ b/container/Dockerfile.none
@@ -1,7 +1,8 @@
 FROM ubuntu:24.04 AS dev
 
+# libclang-dev && git needed for llamacpp engine deps in dynamo-run build
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -yq python3-dev python3-pip python3-venv libucx0
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq python3-dev python3-pip python3-venv libucx0 libclang-dev git
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN mkdir /opt/dynamo && \


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Not sure when the last time `./container/build.sh --framework none` used to work, but it seems the `cargo build` of `dynamo-run` in its current form ends up requiring `libclang-dev` and `git` so `cargo build` fails when building this container on top-of-tree right now. From the build logs, this seems to come from `llamacpp` dependencies.

The strange thing is, this still happens without `--features llamacpp` included. Assuming it worked beforehand, it seemed like the build behavior may be a bit different with the separated out engine crates `dynamo-engine-llamacpp`. It's also possible that the standalone llamacpp engine crate bits are getting compiled regardless due to the workspace configuration or something. Despite some efforts to make sure the `llamacpp` feature for dynamo-run was disabled at build time, they still seemed to be included in the larger build. 

I didn't have time to dive deeper into this atm unfortunately, but it would probably be pretty quick to rule a couple things out. @grahamking If any of that rings any bells for you immediately, feel free to chime in, but this PR was an easier WAR to unblock fixing the build for myself in the meantime, rather than fixing a possible issue of llamacpp bits being built when maybe they shouldn't be.

#### Example build error

Without `libclang-dev` installed:

![image](https://github.com/user-attachments/assets/4890871a-4dbd-4802-a9a0-b0453627e64e)

Similarly, without `git` installed you'd then get an error about `no GIT_EXE found ...` from `cmake` related to `llamacpp`.