### PR TITLE
feat: make the model name to be the same as the HF repo name for dynamo-run

### DIFF
--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -124,10 +124,7 @@ pub async fn run(
     // If it's an HF repo download it
     if let Some(inner_model_path) = model_path.as_ref() {
         if !inner_model_path.exists() {
-            model_name = inner_model_path
-                .iter()
-                .next_back()
-                .map(|s| s.to_string_lossy().to_string());
+            model_name = Some(inner_model_path.display().to_string());
             model_path = Some(hub::from_hf(inner_model_path).await?);
         }
     }


### PR DESCRIPTION
#### Overview: 

Make the model name to be the same as the HF repo name for dynamo-run.

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #635
