### PR TITLE
feat: add additional packages to log filters

### DIFF
--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -85,6 +85,12 @@ impl Default for LoggingConfig {
                 ("hyper_util".to_string(), "error".to_string()),
                 ("neli".to_string(), "error".to_string()),
                 ("async_nats".to_string(), "error".to_string()),
+                ("rustls".to_string(), "error".to_string()),
+                ("tokenizers".to_string(), "error".to_string()),
+                ("axum".to_string(), "error".to_string()),
+                ("tonic".to_string(), "error".to_string()),
+                ("mistralrs_core".to_string(), "error".to_string()),
+                ("hf_hub".to_string(), "error".to_string()),
             ]),
         }
     }


### PR DESCRIPTION
#### Overview:

This PR silences logs from additional packages by setting their log level to 'error'.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: https://github.com/ai-dynamo/dynamo/issues/566
