### PR TITLE
fix: avoid InvalidImageName

### DIFF
--- a/deploy/dynamo/helm/dynamo-platform-values.yaml
+++ b/deploy/dynamo/helm/dynamo-platform-values.yaml
@@ -28,7 +28,7 @@ dynamo-operator:
     manager:
       image:
         repository: ${DOCKER_SERVER}/dynamo-operator
-        tag: ${IMAGE_TAG}
+        tag: "${IMAGE_TAG}"
 
   dynamo:
     dynamoIngressSuffix: ${DYNAMO_INGRESS_SUFFIX}
@@ -45,7 +45,7 @@ dynamo-api-store:
     host: ${NAMESPACE}.${DYNAMO_INGRESS_SUFFIX}
   image:
     repository: ${DOCKER_SERVER}/dynamo-api-store
-    tag: ${IMAGE_TAG}
+    tag: "${IMAGE_TAG}"
     pullPolicy: IfNotPresent
   imagePullSecrets:
   ingress:


### PR DESCRIPTION
#### Overview:

When the IMAGE_TAG environment variable is set to a numeric value like '20250421', it generates an invalid image tag format (e.g. dynamo-api-store:2.0250421e+07).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated YAML configuration to enclose image tag variables in double quotes.
  - Added a newline at the end of the configuration file for improved formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->