### PR TITLE
fix: Fix cancellation flow in python component graph

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -697,6 +697,7 @@ async fn process_stream(
         // Send the PyObject through the channel or log an error
         if let Err(e) = tx.send(annotated).await {
             tracing::error!("Failed to send response: {:?}", e);
+            break;
         }
 
         if is_error {


### PR DESCRIPTION
#### Overview:

My understanding is that cancellation flow works in a daisy chain way. When downstream service can't send response to upstream service it realizes the request is stopped. This was broken for python component flow though it seems. Say the Processor is reading response from Worker with an async iterator. If Processor observes cancellation from frontend via context being `stopped` it can exist out of for loop reading Worker responses. But Worker doesn't know about it right now, it keeps continuing and sending responses. There result in a lot of `Failed to send response:` messages in logs but no cancellation on Worker. By existing out of the `process_stream` loop on this error downstream gets to know of the cancellation and it then works properly.

#### Details:

Added the break out of `process_stream` on encountering an error. 

#### Where should the reviewer start?

It's a one line change.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
