### PR TITLE
fix: give the user ownership permissions of /opt/dynamo/venv

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -276,6 +276,7 @@ RUN apt-get update && apt-get install -y sudo gnupg2 gnupg1 \
 # This is a slow operation (~40s on my cpu)
 # Much better than chown -R $USERNAME:$USERNAME /opt/dynamo/venv (~10min on my cpu)
 COPY --from=base --chown=$USER_UID:$USER_GID /opt/dynamo/venv/ /opt/dynamo/venv/
+RUN chown $USERNAME:$USERNAME /opt/dynamo/venv
 COPY --from=base --chown=$USERNAME:$USERNAME /usr/local/bin /usr/local/bin
 
 USER $USERNAME


### PR DESCRIPTION
#### Overview:

When using the devcontainer, for the post-create script, the user needs to have ownership permissions of `/opt/dynamo/venv` when installing the python bindings. 

#### Details:

Currently the user (ubuntu/1000) has ownership permissions of files within `/opt/dynamo/venv` but not the folder itself. That causes the post-create.sh script to fail when making the devcontainer since the user doesn't have permissions to edit `/opt/dynamo/venv`.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
