### PR TITLE
chore: fix arg name in example

### DIFF
--- a/examples/llm/configs/multinode-405b.yaml
+++ b/examples/llm/configs/multinode-405b.yaml
@@ -28,7 +28,7 @@ Processor:
   router: kv
 
 Router:
-  model-name: nvidia/Llama-3.1-405B-Instruct-FP8
+  model: nvidia/Llama-3.1-405B-Instruct-FP8
   min-workers: 1
 
 VllmWorker:


### PR DESCRIPTION
#### Overview:

Correct the parameter name: the router does not have a parameter called `model-name`, but rather `model`.
