### PR TITLE
fix: standardize selector labels for api-store service and ingress

### DIFF
--- a/deploy/dynamo/helm/platform/components/api-store/templates/service.yaml
+++ b/deploy/dynamo/helm/platform/components/api-store/templates/service.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "dynamo-store"
+  name: {{ include "helm.fullname" . }}
   labels:
     {{- include "helm.labels" . | nindent 4 }}
 spec:
@@ -26,4 +26,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: dynamo-api-store
+    {{ include "helm.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
#### Overview:

Adopt Helm `fullname` template to replace hard-coded service names and selector labels.

#### Details:

In api-store templates:
1. Ingress correctly references backend service via `{{ include "helm.fullname" . }}`
2. Service resource contains inconsistencies:
   - Service name: hard-coded `dynamo-store`
   - Selector labels: hard-coded `app: dynamo-api-store`

This mismatch prevents proper service discovery. All references should use consistent templated values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved flexibility of service naming and labeling in deployment configurations to better align with Helm chart context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->