### PR TITLE
feat: Add log verbosity level flag to dynamo-run cli

### DIFF
--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -46,6 +46,10 @@ pub struct Flags {
     #[arg(long)]
     pub model_name: Option<String>,
 
+    /// Verbose output (-v for debug, -vv for trace)
+    #[arg(short = 'v', action = clap::ArgAction::Count, default_value_t = 0)]
+    pub verbosity: u8,
+
     /// llamacpp only
     ///
     /// The path to the tokenizer and model config because:
@@ -126,6 +130,8 @@ pub struct Flags {
     /// These are the command line arguments to the python engine when using `pystr` or `pytok`.
     #[arg(index = 2, last = true, hide = true, allow_hyphen_values = true)]
     pub last: Vec<String>,
+
+
 }
 
 impl Flags {

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -130,8 +130,6 @@ pub struct Flags {
     /// These are the command line arguments to the python engine when using `pystr` or `pytok`.
     #[arg(index = 2, last = true, hide = true, allow_hyphen_values = true)]
     pub last: Vec<String>,
-
-
 }
 
 impl Flags {

--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -45,7 +45,11 @@ fn main() -> anyhow::Result<()> {
         },
         Err(_) => "info", 
     };
-    std::env::set_var("DYN_LOG", log_level);
+
+    if log_level != "info" {
+        std::env::set_var("DYN_LOG", log_level);
+    }
+
     logging::init();
 
     // Call sub-processes before starting the Runtime machinery

--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -41,9 +41,13 @@ fn main() -> anyhow::Result<()> {
             0 => "info",
             1 => "debug",
             2 => "trace",
-            _ => return Err(anyhow::anyhow!("Invalid verbosity level. Valid values are v (debug) or vv (trace)")),
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Invalid verbosity level. Valid values are v (debug) or vv (trace)"
+                ))
+            }
         },
-        Err(_) => "info", 
+        Err(_) => "info",
     };
 
     if log_level != "info" {
@@ -131,10 +135,10 @@ async fn wrapper(runtime: dynamo_runtime::Runtime) -> anyhow::Result<()> {
     let mut in_opt = None;
     let mut out_opt = None;
     let args: Vec<String> = env::args().skip(1).collect();
-    if args.is_empty() 
-        || args[0] == "-h" 
+    if args.is_empty()
+        || args[0] == "-h"
         || args[0] == "--help"
-        || (args.iter().all(|arg| arg == "-v" || arg == "-vv")) 
+        || (args.iter().all(|arg| arg == "-v" || arg == "-vv"))
     {
         let engine_list = Output::available_engines().join("|");
         let usage = USAGE.replace("ENGINE_LIST", &engine_list);

--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -35,6 +35,17 @@ const ZMQ_SOCKET_PREFIX: &str = "dyn";
 const USAGE: &str = "USAGE: dynamo-run in=[http|text|dyn://<path>|batch:<folder>|none] out=ENGINE_LIST [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin]";
 
 fn main() -> anyhow::Result<()> {
+    // Set log level based on verbosity flag
+    let log_level = match dynamo_run::Flags::try_parse() {
+        Ok(flags) => match flags.verbosity {
+            0 => "info",
+            1 => "debug",
+            2 => "trace",
+            _ => return Err(anyhow::anyhow!("Invalid verbosity level. Valid values are v (debug) or vv (trace)")),
+        },
+        Err(_) => "info", 
+    };
+    std::env::set_var("DYN_LOG", log_level);
     logging::init();
 
     // Call sub-processes before starting the Runtime machinery
@@ -116,12 +127,15 @@ async fn wrapper(runtime: dynamo_runtime::Runtime) -> anyhow::Result<()> {
     let mut in_opt = None;
     let mut out_opt = None;
     let args: Vec<String> = env::args().skip(1).collect();
-    if args.is_empty() || args[0] == "-h" || args[0] == "--help" {
+    if args.is_empty() 
+        || args[0] == "-h" 
+        || args[0] == "--help"
+        || (args.iter().all(|arg| arg == "-v" || arg == "-vv")) 
+    {
         let engine_list = Output::available_engines().join("|");
         let usage = USAGE.replace("ENGINE_LIST", &engine_list);
         println!("{usage}");
         println!("{HELP}");
-
         return Ok(());
     }
     for arg in env::args().skip(1).take(2) {


### PR DESCRIPTION
#### Overview:

This PR adds a command-line verbosity flag (-v, -vv) to dynamo-run to control log levels.
- Added new verbosity flag to Flags struct:
  - -v: Sets log level to debug
  - -vv: Sets log level to trace
  - No flag (default): Keeps log level at info

#### Details:
- closes GitHub issue: https://github.com/ai-dynamo/dynamo/issues/567
