### PR TITLE
fix: fixed the error 'VllmWorker' object has no attribute 'lease'

### DIFF
--- a/examples/llm/components/worker.py
+++ b/examples/llm/components/worker.py
@@ -101,6 +101,7 @@ class VllmWorker:
 
     @async_on_start
     async def async_init(self):
+        self.lease = dynamo_context.get("lease")
         self._engine_context = build_async_engine_client_from_engine_args(
             self.engine_args
         )
@@ -145,7 +146,6 @@ class VllmWorker:
         else:
             self.disaggregated_router = None
 
-        self.lease = dynamo_context.get("lease")
         logger.info("VllmWorker has been initialized")
 
     def shutdown_vllm_engine(self, signum, frame):


### PR DESCRIPTION
#### Overview:

Fixed the error "'VllmWorker' object has no attribute 'lease'"

#### Details:

The configuration is as follows:
```yaml
Common:
  model: /models/DeepSeek-R1-Distill-Llama-70B-FP8-dynamic
  block-size: 64
  max-model-len: 16384
  router: kv
  kv-transfer-config: '{"kv_connector":"DynamoNixlConnector"}'

Frontend:
  served_model_name: DeepSeek-R1-Distill-Llama-70B-FP8-dynamic
  endpoint: dynamo.Processor.chat/completions
  port: 9197

Processor:
  common-configs: [model, block-size, max-model-len, router]

Router:
  min-workers: 1
  common-configs: [model]

VllmWorker:
  max-num-batched-tokens: 16384
  remote-prefill: true
  conditional-disagg: true
  max-local-prefill-length: 10
  max-prefill-queue-size: 2
  tensor-parallel-size: 4
  enable-prefix-caching: true
  ServiceArgs:
    workers: 1
    resources:
      gpu: 4
  common-configs: [model, block-size, max-model-len, router, kv-transfer-config]

PrefillWorker:
  max-num-batched-tokens: 16384
  ServiceArgs:
    workers: 4
    resources:
      gpu: 1
  common-configs: [model, block-size, max-model-len, kv-transfer-config]
```

start Frontend:
`dynamo serve graphs.disagg_router:Frontend -f ./configs/test.yaml`

log:
```
....
(VllmWorkerProcess pid=3357) Initialized NIXL agent: ae5406c1-7b21-4722-b48d-7d930f159893
(VllmWorkerProcess pid=3358) Initialized NIXL agent: 8fc4d2a0-4119-419c-97c9-7fd567ba5ed1
(VllmWorkerProcess pid=3360) Initialized NIXL agent: 0bc06a90-60d4-4552-b7b7-637033446780
2025-04-22T09:10:12.857Z  INFO worker.<lambda>: [VllmWorker:1] metrics publisher endpoint created   
2025-04-22T09:10:12.860Z  INFO worker.async_init: [VllmWorker:1] VllmWorker has been initialized   
2025-04-22T09:10:12.861Z ERROR serve_dynamo.worker: [VllmWorker:1] Task exception was never retrieved
future: <Task finished name='Task-6' coro=<VllmWorker.create_metrics_publisher_endpoint() done, defined at /workspace/examples/llm/components/worker.py:163> exception=AttributeError("'VllmWorker' object has no attribute 'lease'")>
Traceback (most recent call last):
  File "/workspace/examples/llm/components/worker.py", line 165, in create_metrics_publisher_endpoint
    if self.lease is None:
       ^^^^^^^^^^
AttributeError: 'VllmWorker' object has no attribute 'lease'   
2025-04-22T09:10:12.861Z  INFO serve_dynamo.worker: [VllmWorker:1] Starting VllmWorker instance with all registered endpoints   
2025-04-22T09:10:12.861Z  INFO serve_dynamo.worker: [VllmWorker:1] Serving VllmWorker with lease: 7587886244875460844   
2025-04-22T09:10:13.152Z  INFO logging.check_required_workers: [Router:1] Waiting for more workers to be ready.
 Current: 1, Required: 1   
Workers ready: [7587886244875460844]
...
```

#### Where should the reviewer start?

using the main branch code, commit id is 5aa5d4b2

