### PR TITLE
fix: fix unrecognized arguments: `--model-name`

### DIFF
--- a/examples/llm/configs/multinode-405b.yaml
+++ b/examples/llm/configs/multinode-405b.yaml
@@ -28,7 +28,7 @@ Processor:
   router: kv
 
 Router:
-  model-name: nvidia/Llama-3.1-405B-Instruct-FP8
+  model: nvidia/Llama-3.1-405B-Instruct-FP8
   min-workers: 1
 
 VllmWorker:


### PR DESCRIPTION
Replace `model-name` with `model` in multinode-405b.yaml

#### Overview:

`model-name` is not recognized as a valid argument.more details:

```
2025-04-23T07:40:53.461Z  INFO config.as_args: [Router:1] Running Router with args=['--model-name', 'nvidia/Llama-3.1-405B-Instruct-FP8', '--min-workers', '1']
usage: serve_dynamo.py [-h] [--min-workers MIN_WORKERS] [--model MODEL] [--block-size BLOCK_SIZE]
                       [--custom-router CUSTOM_ROUTER]
serve_dynamo.py: error: unrecognized arguments: --model-name nvidia/Llama-3.1-405B-Instruct-FP8
```