### PR TITLE
feat: Add linux aarch64 support to dynamo-run build

### DIFF
--- a/launch/dynamo-run/Cargo.toml
+++ b/launch/dynamo-run/Cargo.toml
@@ -74,3 +74,7 @@ rtnetlink = { version = "0.14", optional = true }
 [target.x86_64-unknown-linux-musl.dependencies]
 netlink-packet-route = { version = "0.19", optional = true }
 rtnetlink = { version = "0.14", optional = true }
+
+[target.aarch64-unknown-linux-gnu.dependencies]
+netlink-packet-route = { version = "0.19", optional = true }
+rtnetlink = { version = "0.14", optional = true }


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Adds support for linux arm64 build of dynamo-run

Tested locally. Needed for building on GB200.