### PR TITLE
chore: Increase sleep times from 2s -> 30s for startup logs

### DIFF
--- a/examples/tensorrt_llm/components/kv_router.py
+++ b/examples/tensorrt_llm/components/kv_router.py
@@ -97,7 +97,7 @@ class Router:
                 f" Current: {len(self.workers_client.endpoint_ids())},"
                 f" Required: {self.args.min_workers}"
             )
-            await asyncio.sleep(2)
+            await asyncio.sleep(30)
 
         kv_listener = self.runtime.namespace("dynamo").component("TensorRTLLMWorker")
         await kv_listener.create_service()

--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -82,7 +82,7 @@ class Processor(ChatProcessorMixin):
                 f" Current: {len(self.worker_client.endpoint_ids())},"
                 f" Required: {self.min_workers}"
             )
-            await asyncio.sleep(2)
+            await asyncio.sleep(30)
 
     async def _generate(self, raw_request, request_type: RequestType):
         raw_request.skip_special_tokens = False

--- a/examples/tensorrt_llm/components/worker.py
+++ b/examples/tensorrt_llm/components/worker.py
@@ -78,7 +78,7 @@ class TensorRTLLMWorker(BaseTensorrtLLMEngine):
                     f" Current: {len(self._prefill_client.endpoint_ids())},"
                     f" Required: {self._min_prefill_workers}"
                 )
-                await asyncio.sleep(2)
+                await asyncio.sleep(30)
 
         if self._kv_metrics_publisher is not None:
             task = asyncio.create_task(self.create_metrics_publisher_endpoint())


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Large models like Deepseek R1 can take a significant time to startup. Logging from 3 different components every 2 seconds leads to a lot of spam in the shell and obscures some loading/startup messages. Increasing it to 30 seconds seems like a reasonable middle ground of not pausing for too long, but not spamming too much.