### PR TITLE
fix: Add mpirun WAR for running TRTLLM workers in slurm environment

### DIFF
--- a/deploy/dynamo/sdk/src/dynamo/sdk/cli/serving.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/cli/serving.py
@@ -26,6 +26,7 @@ import pathlib
 import platform
 import shutil
 import socket
+import sys
 import tempfile
 import typing as t
 from typing import Any, Dict, Optional, Protocol, TypeVar
@@ -131,8 +132,6 @@ def maybe_get_slurm_mpirun_command(service_name, args):
     # HACK: WAR issues with running MPI_Spawn in TRTLLM internals
     #       while in a Slurm environment.
     # FIXME: Find a better solution for running TRTLLM workers with `dynamo serve`
-    import sys
-
     is_slurm = os.environ.get("SLURM_NODELIST") is not None
     if is_slurm and "TensorRTLLM" in service_name:
         logger.info(
@@ -250,8 +249,6 @@ def create_dynamo_watcher(
     # use namespace from the service
     namespace, _ = svc.dynamo_address()
 
-    # HACK: WAR issues with running MPI_Spawn in TRTLLM internals
-    #       while in a Slurm environment.
     # FIXME: Find a better solution for running TRTLLM workers with `dynamo serve`
     cmd, args = maybe_get_slurm_mpirun_command(svc.name, args)
 
@@ -442,8 +439,6 @@ def serve_http(
                 except json.JSONDecodeError as e:
                     logger.warning(f"Failed to parse DYNAMO_SERVICE_ENVS: {e}")
 
-            # HACK: WAR issues with running MPI_Spawn in TRTLLM internals
-            #       while in a Slurm environment.
             # FIXME: Find a better solution for running TRTLLM workers with `dynamo serve`
             cmd, dynamo_args = maybe_get_slurm_mpirun_command(svc.name, dynamo_args)
 

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -27,6 +27,14 @@ Note that this TensorRT-LLM version does not support all the options yet.
 
 Note: TensorRT-LLM disaggregation does not support conditional disaggregation yet. You can only configure the deployment to always use aggregate or disaggregated serving.
 
+> [!IMPORTANT]
+> Deploying TRTLLM workers involves the use of [MPI_Comm_spawn](https://www.mpich.org/static/docs/v3.3/www3/MPI_Comm_spawn.html),
+> which requires that internally these workers are deployed via [mpirun](https://www.open-mpi.org/doc/v4.1/man1/mpirun.1.php).
+>
+> To support running `mpirun` in container environments that often default to a root user, we supply the
+> `mpirun --allow-run-as-root` argument. Removing the need for this, or making it more transparent
+> to the user at deployment time is a work in progress.
+
 ## Getting Started
 
 1. Choose a deployment architecture based on your requirements


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Without this change when running in a slurm based environment:
```
$ srun --container-image <dynamo_trtllm_image> ...
$ cd /workspace/examples/tensorrt_llm
$ dynamo serve graphs.agg:Frontend -f ./configs/agg.yaml
...
2025-04-24T03:28:42.886Z  INFO serve_dynamo.worker: [TensorRTLLMWorker:1] Created TensorRTLLMWorker component   
2025-04-24T03:28:42.886Z  INFO worker.__init__: [TensorRTLLMWorker:1] Initializing TensorRT-LLM Worker   
2025-04-24T03:28:42.887Z  INFO config.as_args: [TensorRTLLMWorker:1] Running TensorRTLLMWorker with args=['--engine_args', 'configs/llm_api_config.yaml', '--router', 'round-robin']   
2025-04-24T03:28:42.889Z  INFO base_engine._init_engine: [TensorRTLLMWorker:1] Initializing engine   
...
rank 0 using MpiPoolSession to spawn MPI processes
...
Exception in thread Thread-4 (_manager_spawn):
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.12/dist-packages/mpi4py/futures/_lib.py", line 324, in _manager_spawn
    comm = serialized(client_spawn)(pyexe, pyargs, nprocs, info)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/mpi4py/futures/_lib.py", line 935, in client_spawn
    comm = MPI.COMM_SELF.Spawn(python_exe, args, max_workers, info)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "mpi4py/MPI/Comm.pyx", line 1931, in mpi4py.MPI.Intracomm.Spawn
mpi4py.MPI.Exception: MPI_ERR_SPAWN: could not spawn processes
```

After this change:
```
# runs successfully
```
