### PR TITLE
build: update cudarc dependency to crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
  "byteorder",
  "candle-kernels 0.8.0",
  "candle-metal-kernels",
- "cudarc 0.13.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cudarc 0.13.9",
  "float8",
  "gemm 0.17.1",
  "half",
@@ -702,7 +702,7 @@ checksum = "06ccf5ee3532e66868516d9b315f73aec9f34ea1a37ae98514534d458915dbf1"
 dependencies = [
  "byteorder",
  "candle-kernels 0.8.4",
- "cudarc 0.13.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cudarc 0.13.9",
  "gemm 0.17.1",
  "half",
  "memmap2",
@@ -1151,8 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.13.9"
-source = "git+https://github.com/coreylowman/cudarc.git?rev=8c52e735b55bf8e979e1a16bd85e3dfe4f87c9fe#8c52e735b55bf8e979e1a16bd85e3dfe4f87c9fe"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ed411343abcb4dd6fd1fbc32db3533d76c2af0fd40735a9e5e39e778a81254"
 dependencies = [
  "libloading",
 ]
@@ -1611,7 +1612,7 @@ dependencies = [
  "bytes",
  "candle-core 0.8.4",
  "chrono",
- "cudarc 0.13.9 (git+https://github.com/coreylowman/cudarc.git?rev=8c52e735b55bf8e979e1a16bd85e3dfe4f87c9fe)",
+ "cudarc 0.16.2",
  "derive-getters",
  "derive_builder",
  "dynamo-runtime",
@@ -2061,7 +2062,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee36245af1dccf978103fcd393582806db2a1d0bcd2f38c663cdbb4a363a01c"
 dependencies = [
- "cudarc 0.13.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cudarc 0.13.9",
  "half",
  "num-traits",
  "rand 0.9.0",
@@ -6802,7 +6803,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50758486d7941f8b0a636ba7e29455c07071f41590beac1fd307ec893e8db69a"
 dependencies = [
- "cudarc 0.13.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cudarc 0.13.9",
  "half",
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed", "dynamo"]
 
 [workspace.dependencies]
 # Local crates
-dynamo-runtime = { path = "lib/runtime" }
-dynamo-llm = { path = "lib/llm" }
-dynamo-tokens = { path = "lib/tokens" }
+dynamo-runtime = { path = "lib/runtime", version = "0.1.1" }
+dynamo-llm = { path = "lib/llm", version = "0.1.1" }
+dynamo-tokens = { path = "lib/tokens", version = "0.1.1" }
 
 # External dependencies
 anyhow = { version = "1" }

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -68,7 +68,7 @@ regex = "1"
 rayon = "1"
 
 # kv_cuda
-cudarc = { git = "https://github.com/coreylowman/cudarc.git", rev = "8c52e735b55bf8e979e1a16bd85e3dfe4f87c9fe", features = ["cuda-12040"], optional = true }
+cudarc = { version = "0.16.2", features = ["cuda-12040"], optional = true }
 ndarray = { version = "0.16", optional = true }
 
 # protocols

--- a/lib/llm/src/kv/storage.rs
+++ b/lib/llm/src/kv/storage.rs
@@ -205,8 +205,9 @@ impl DeviceStorageOwned {
     }
 
     pub fn device_ptr(&self) -> *const c_void {
-        let ptr = self.cuda_slice.device_ptr();
-        (*ptr) as *const c_void
+        let stream = self.cuda_device.default_stream();
+        let (ptr, _) = self.cuda_slice.device_ptr(&stream);
+        ptr as *const c_void
     }
 
     pub fn context(&self) -> Arc<CudaContext> {


### PR DESCRIPTION
#### Overview:

* Use crates.io latest version for cudarc dependency in dynamo-llm
* Add versions for local crates, required for cargo publish
* Fix compilation errors -
  * device_ptr method now requires a &CudaStream parameter
  * returns a tuple (sys::CUdeviceptr, super::SyncOnDrop<'a>)
```
error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> lib/llm/src/kv/storage.rs:208:35
    |
208 |         let ptr = self.cuda_slice.device_ptr();
    |                                   ^^^^^^^^^^-- argument #1 of type `&CudaStream` is missing
    |
note: method defined here
   --> /home/anants/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cudarc-0.16.2/src/driver/safe/core.rs:838:8
    |
838 |     fn device_ptr<'a>(&'a self, stream: &'a CudaStream) -> (sys::CUdeviceptr, SyncOnDrop<'a>);
    |        ^^^^^^^^^^
help: provide the argument
    |
208 -         let ptr = self.cuda_slice.device_ptr();
208 +         let ptr = self.cuda_slice.device_ptr(/* &CudaStream */);
    |

error[E0614]: type `(u64, SyncOnDrop<'_>)` cannot be dereferenced
   --> lib/llm/src/kv/storage.rs:209:9
    |
209 |         (*ptr) as *const c_void
    |         ^^^^^^
```