### PR TITLE
fix: add VLLM_KV_CAPI_PATH to vllm dockerfile to make kv routing working

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -414,6 +414,8 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
     sed '/^#\s/d' /workspace/launch_message.txt > ~/.launch_screen && \
     echo "cat ~/.launch_screen" >> ~/.bashrc
 
+# Tell vllm to use the Dynamo LLM C API for KV Cache Routing
+ENV VLLM_KV_CAPI_PATH=$CARGO_TARGET_DIR/release/libdynamo_llm_capi.so
 
 ##########################################
 ########## Perf Analyzer Image ###########


### PR DESCRIPTION
#### Overview:

We did not set env var VLLM_KV_CAPI_PATH in dockerfile such that vllm cannot find dynamo LLM C API for kv routing

Tested manually:
```
root@a87eb6e-lcedt:/workspace/examples/llm# echo $VLLM_KV_CAPI_PATH
/workspace/target/release/libdynamo_llm_capi.so

# dynamo log:
2025-04-25T18:44:26.601Z  INFO event_manager.__init__: KVCacheEventManager initialized successfully. Ready to publish KV Cache Events
```
