### PR TITLE
fix: wrong lease_id

### DIFF
--- a/examples/llm/components/worker.py
+++ b/examples/llm/components/worker.py
@@ -89,11 +89,10 @@ class VllmWorker:
                 )
                 self.engine_args.enable_prefix_caching = True
 
-            VLLM_WORKER_ID = dynamo_context["endpoints"][0].lease_id()
-            os.environ["VLLM_WORKER_ID"] = str(VLLM_WORKER_ID)
+            os.environ["VLLM_WORKER_ID"] = str(dynamo_context.get("lease").id())
             os.environ["VLLM_KV_NAMESPACE"] = "dynamo"
             os.environ["VLLM_KV_COMPONENT"] = class_name
-            logger.info(f"Generate endpoint ID: {VLLM_WORKER_ID}")
+
         self.metrics_publisher = KvMetricsPublisher()
 
         signal.signal(signal.SIGTERM, self.shutdown_vllm_engine)


### PR DESCRIPTION
#### Overview:

Bug: We were getting no block matches in vLLM.

Fix: Turns out the endpoint_ids() were different than the worker_id we were setting on the vLLM worker. From changes to use custom leases for endpoints. We just switch to use the new custom lease for now.
