### PR TITLE
feat: Add unified x86 / aarch64 (ARM) build for VLLM image

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ docker login <your-registry>
 docker push <your-registry>/dynamo-base:latest-vllm
 ```
 
+Notes about builds for specific frameworks:
+- For specific details on the `--framework vllm` build, see [here](examples/llm/README.md).
+- For specific details on the `--framework tensorrtllm` build, see [here](examples/tensorrt_llm/README.md).
+
 After building, you can use this image by setting the `DYNAMO_IMAGE` environment variable to point to your built image:
 ```bash
 export DYNAMO_IMAGE=<your-registry>/dynamo-base:latest-vllm

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -99,9 +99,9 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 # Install NIXL Python module
 # TODO: Move gds_path selection based on arch into NIXL build
 RUN if [ "$ARCH" = "arm64" ]; then \
-    cd /opt/nixl && uv pip install . --config-settings=setup-args="-Dgds_path=/usr/local/cuda/targets/sbsa-linux/"; \
+        cd /opt/nixl && uv pip install . --config-settings=setup-args="-Dgds_path=/usr/local/cuda/targets/sbsa-linux/"; \
     else \
-    cd /opt/nixl && uv pip install . ; \
+        cd /opt/nixl && uv pip install . ; \
     fi
 
 # Install patched vllm - keep this early in Dockerfile to avoid
@@ -110,16 +110,36 @@ ARG VLLM_REF="0.8.4"
 ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
 ARG VLLM_PATCHED_PACKAGE_NAME="ai_dynamo_vllm"
 ARG VLLM_PATCHED_PACKAGE_VERSION="0.8.4"
+ARG VLLM_MAX_JOBS=4
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
+    --mount=type=cache,target=/root/.cache/uv \
     mkdir /tmp/vllm && \
     uv pip install pip wheel && \
-    # TODO: Handle arm64: Build wheel from source
+    # NOTE: vLLM build from source on ARM can take several hours, see VLLM_MAX_JOBS details.
     if [ "$ARCH" = "arm64" ]; then \
+        # PyTorch 2.7 supports CUDA 12.8 and aarch64 installs
+        uv pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128 && \
+        # Download vLLM source with version matching patch
         git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
-        echo "WARNING: VLLM installation is not supported on arm64 yet, skipping it." ; \
+        cd /tmp/vllm/vllm-${VLLM_REF}/ && \
+        # Patch vLLM source with dynamo additions
+        patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
+        # WAR: Set package version check to 'vllm' instead of 'ai_dynamo_vllm' to avoid
+        # platform detection issues on ARM install.
+        # TODO: Rename package from vllm to ai_dynamo_vllm like x86 path below to remove this WAR.
+        sed -i 's/version("ai_dynamo_vllm")/version("vllm")/g' vllm/platforms/__init__.py && \
+        # Remove pytorch from vllm install dependencies
+        python use_existing_torch.py && \
+        # Build/install vllm from source
+        uv pip install -r requirements/build.txt && \
+        # MAX_JOBS set to avoid running OOM on vllm-flash-attn build, this can
+        # significantly impact the overall build time. Each job can take up
+        # to -16GB RAM each, so tune according to available system memory.
+        MAX_JOBS=${VLLM_MAX_JOBS} uv pip install . --no-build-isolation ; \
     # Handle x86_64: Download wheel, unpack, setup for later steps
     else \
         python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \
+        # Patch vLLM pre-built download with dynamo additions
         cd /tmp/vllm && \
         wheel unpack *.whl && \
         cd vllm-${VLLM_REF}/ && \
@@ -128,10 +148,10 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         mv vllm-${VLLM_REF}.dist-info ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info && \
         sed -i "s/^Name: vllm/Name: ${VLLM_PATCHED_PACKAGE_NAME}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
         sed -i "s/^Version: ${VLLM_REF}/Version: ${VLLM_PATCHED_PACKAGE_VERSION}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
-        # Update wheel tag from linux_x86_64 to manylinux1_x86_64 in WHEEL file
-        sed -i 's/Tag: cp38-abi3-linux_x86_64/Tag: cp38-abi3-manylinux1_x86_64/g' ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/WHEEL && \
+        # Update wheel tag from linux_${ARCH_ALT} to manylinux1_${ARCH_ALT} in WHEEL file
+        sed -i 's/Tag: cp38-abi3-linux_${ARCH_ALT}/Tag: cp38-abi3-manylinux1_${ARCH_ALT}/g' ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/WHEEL && \
         # Also update the tag in RECORD file to match
-        sed -i "s/-cp38-abi3-linux_x86_64.whl/-cp38-abi3-manylinux1_x86_64.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/RECORD && \
+        sed -i "s/-cp38-abi3-linux_${ARCH_ALT}.whl/-cp38-abi3-manylinux1_${ARCH_ALT}.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/RECORD && \
         mkdir -p /workspace/dist && \
         wheel pack . --dest-dir /workspace/dist && \
         uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -115,26 +115,26 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     uv pip install pip wheel && \
     # TODO: Handle arm64: Build wheel from source
     if [ "$ARCH" = "arm64" ]; then \
-    git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
-    echo "WARNING: VLLM installation is not supported on arm64 yet, skipping it." ; \
+        git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
+        echo "WARNING: VLLM installation is not supported on arm64 yet, skipping it." ; \
     # Handle x86_64: Download wheel, unpack, setup for later steps
     else \
-    python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \
-    cd /tmp/vllm && \
-    wheel unpack *.whl && \
-    cd vllm-${VLLM_REF}/ && \
-    patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
-    # Rename the package from vllm to ai_dynamo_vllm
-    mv vllm-${VLLM_REF}.dist-info ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info && \
-    sed -i "s/^Name: vllm/Name: ${VLLM_PATCHED_PACKAGE_NAME}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
-    sed -i "s/^Version: ${VLLM_REF}/Version: ${VLLM_PATCHED_PACKAGE_VERSION}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
-    # Update wheel tag from linux_x86_64 to manylinux1_x86_64 in WHEEL file
-    sed -i 's/Tag: cp38-abi3-linux_x86_64/Tag: cp38-abi3-manylinux1_x86_64/g' ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/WHEEL && \
-    # Also update the tag in RECORD file to match
-    sed -i "s/-cp38-abi3-linux_x86_64.whl/-cp38-abi3-manylinux1_x86_64.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/RECORD && \
-    mkdir -p /workspace/dist && \
-    wheel pack . --dest-dir /workspace/dist && \
-    uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; \
+        python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \
+        cd /tmp/vllm && \
+        wheel unpack *.whl && \
+        cd vllm-${VLLM_REF}/ && \
+        patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
+        # Rename the package from vllm to ai_dynamo_vllm
+        mv vllm-${VLLM_REF}.dist-info ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info && \
+        sed -i "s/^Name: vllm/Name: ${VLLM_PATCHED_PACKAGE_NAME}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
+        sed -i "s/^Version: ${VLLM_REF}/Version: ${VLLM_PATCHED_PACKAGE_VERSION}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
+        # Update wheel tag from linux_x86_64 to manylinux1_x86_64 in WHEEL file
+        sed -i 's/Tag: cp38-abi3-linux_x86_64/Tag: cp38-abi3-manylinux1_x86_64/g' ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/WHEEL && \
+        # Also update the tag in RECORD file to match
+        sed -i "s/-cp38-abi3-linux_x86_64.whl/-cp38-abi3-manylinux1_x86_64.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/RECORD && \
+        mkdir -p /workspace/dist && \
+        wheel pack . --dest-dir /workspace/dist && \
+        uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; \
     fi
 
 # Common dependencies
@@ -297,8 +297,8 @@ RUN uv build --wheel --out-dir /workspace/dist && \
     cd /workspace/lib/bindings/python && \
     uv build --wheel --out-dir /workspace/dist --python 3.12 && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
-    uv build --wheel --out-dir /workspace/dist --python 3.11 && \
-    uv build --wheel --out-dir /workspace/dist --python 3.10; \
+        uv build --wheel --out-dir /workspace/dist --python 3.11 && \
+        uv build --wheel --out-dir /workspace/dist --python 3.10; \
     fi
 
 #######################################
@@ -399,14 +399,6 @@ WORKDIR /workspace
 ENV DYNAMO_HOME=/workspace
 ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-<<<<<<< HEAD
-=======
-
-# Copy NIXL
-COPY --from=base /usr/local/nixl /usr/local/nixl
-ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-ENV PYTHONPATH=/usr/local/nixl/lib/python3/dist-packages/:/opt/nixl/test/python/:$PYTHONPATH
->>>>>>> 94702c7930cbc7874f4a211c1198cd611ed02c0f
 
 # Setup the python environment
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -2,15 +2,34 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
-ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
+ARG BASE_IMAGE_TAG="25.03-cuda12.8-devel-ubuntu24.04"
 ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
-ARG MANYLINUX_IMAGE="quay.io/pypa/manylinux_2_28_x86_64"
 # TODO: Move to published pypi tags
 ARG GENAI_PERF_TAG="e67e853413a07a778dd78a55e299be7fba9c9c24"
 
+# Define general architecture ARGs for supporting both x86 and aarch64 builds.
+#   ARCH: Used for package suffixes (e.g., amd64, arm64)
+#   ARCH_ALT: Used for Rust targets, manylinux suffix (e.g., x86_64, aarch64)
+#
+# Default values are for x86/amd64:
+#   --build-arg ARCH=amd64 --build-arg ARCH_ALT=x86_64
+#
+# For arm64/aarch64, build with:
+#   --build-arg ARCH=arm64 --build-arg ARCH_ALT=aarch64
+#
+# NOTE: There isn't an easy way to define one of these values based on the other value
+# without adding if statements everywhere, so just define both as ARGs for now.
+ARG ARCH=amd64
+ARG ARCH_ALT=x86_64
+
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS nixl_base
+
+# Redeclare ARCH and ARCH_ALT so they're available in this stage
+ARG ARCH
+ARG ARCH_ALT
+
 WORKDIR /opt/nixl
 # Add a cache hint that only changes when the nixl commit changes
 ARG NIXL_COMMIT
@@ -25,146 +44,41 @@ COPY --from=nixl . .
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS base
 
+# Redeclare ARCH and ARCH_ALT so they're available in this stage
+ARG ARCH
+ARG ARCH_ALT
+
 USER root
+ARG PYTHON_VERSION=3.12
+
+RUN apt-get update -y && \
+    apt-get install -y \
+    # NIXL build dependencies
+    cmake \
+    meson \
+    ninja-build \
+    pybind11-dev \
+    # Rust build dependencies
+    libclang-dev \
+    # Install utilities
+    nvtop \
+    tmux \
+    vim
+
+WORKDIR /workspace
 
 ### NIXL SETUP ###
-
-ARG MOFED_VERSION=24.10-1.1.4.0
-ARG PYTHON_VERSION=3.12
-ARG NSYS_URL=https://developer.nvidia.com/downloads/assets/tools/secure/nsight-systems/2025_1/
-ARG NSYS_PKG=NsightSystems-linux-cli-public-2025.1.1.131-3554042.deb
-
-RUN apt-get update -y && apt-get -y install curl \
-    git \
-    libnuma-dev \
-    numactl \
-    wget \
-    autotools-dev \
-    automake \
-    libtool \
-    libz-dev \
-    libiberty-dev \
-    flex \
-    build-essential \
-    cmake \
-    libibverbs-dev \
-    libgoogle-glog-dev \
-    libgtest-dev \
-    libjsoncpp-dev \
-    libpython3-dev \
-    libboost-all-dev \
-    libssl-dev \
-    libgrpc-dev \
-    libgrpc++-dev \
-    libprotobuf-dev \
-    libclang-dev \
-    protobuf-compiler-grpc \
-    pybind11-dev \
-    python3-full \
-    python3-pip \
-    python3-numpy \
-    etcd-server \
-    net-tools \
-    pciutils \
-    libpci-dev \
-    vim \
-    tmux \
-    screen \
-    ibverbs-utils \
-    libibmad-dev
-
-RUN apt-get install -y linux-tools-common linux-tools-generic ethtool iproute2
-RUN apt-get install -y dkms linux-headers-generic
-RUN apt-get install -y meson ninja-build uuid-dev gdb
-
-RUN apt install -y libglib2.0-0
-RUN wget ${NSYS_URL}${NSYS_PKG} &&\
-    apt install -y ./${NSYS_PKG} &&\
-    rm ${NSYS_PKG}
-
-RUN cd /usr/local/src && \
-    curl -fSsL "https://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-ubuntu24.04-x86_64.tgz" -o mofed.tgz && \
-    tar -xf /usr/local/src/mofed.tgz && \
-    cd MLNX_OFED_LINUX-* && \
-    apt-get update && apt-get install -y --no-install-recommends \
-    ./DEBS/libibverbs* ./DEBS/ibverbs-providers* ./DEBS/librdmacm* ./DEBS/libibumad* && \
-    rm -rf /var/lib/apt/lists/* /usr/local/src/* mofed.tgz
-
-ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/lib64 \
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64
-
-ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib \
-    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-
-WORKDIR /workspace
-RUN git clone https://github.com/NVIDIA/gdrcopy.git
-RUN PREFIX=/usr/local DESTLIB=/usr/local/lib make -C /workspace/gdrcopy lib_install
-RUN cp gdrcopy/src/libgdrapi.so.2.* /usr/lib/x86_64-linux-gnu/
-RUN ldconfig
-
-ARG UCX_VERSION=v1.18.0
-
-RUN cd /usr/local/src && \
-    curl -fSsL "https://github.com/openucx/ucx/tarball/${UCX_VERSION}" | tar xz && \
-    cd openucx-ucx* && \
-    ./autogen.sh && ./configure     \
-    --enable-shared             \
-    --disable-static            \
-    --disable-doxygen-doc       \
-    --enable-optimizations      \
-    --enable-cma                \
-    --enable-devel-headers      \
-    --with-cuda=/usr/local/cuda \
-    --with-verbs                \
-    --with-dm                   \
-    --with-gdrcopy=/usr/local   \
-    --enable-mt                 \
-    --with-mlx5-dv &&           \
-    make -j &&                      \
-    make -j install-strip &&        \
-    ldconfig
-
-ENV LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
-ENV CPATH=/usr/include:$CPATH
-ENV PATH=/usr/bin:$PATH
-ENV PKG_CONFIG_PATH=/usr/lib/pkgconfig:$PKG_CONFIG_PATH
-SHELL ["/bin/bash", "-c"]
-
-WORKDIR /workspace
-
-ENV LD_LIBRARY_PATH=/usr/local/ompi/lib:$LD_LIBRARY_PATH
-ENV CPATH=/usr/local/ompi/include:$CPATH
-ENV PATH=/usr/local/ompi/bin:$PATH
-ENV PKG_CONFIG_PATH=/usr/local/ompi/lib/pkgconfig:$PKG_CONFIG_PATH
-
 # Copy nixl source, and use commit hash as cache hint
 COPY --from=nixl_base /opt/nixl /opt/nixl
 COPY --from=nixl_base /opt/nixl/commit.txt /opt/nixl/commit.txt
-RUN cd /opt/nixl && \
-    mkdir build && \
-    meson setup build/ --prefix=/usr/local/nixl && \
-    cd build/ && \
-    ninja && \
-    ninja install
 
-ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
-ENV PYTHONPATH=/usr/local/nixl/lib/python3/dist-packages/:/opt/nixl/test/python/:$PYTHONPATH
-ENV UCX_TLS=^cuda_ipc
-ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/x86_64-linux-gnu/plugins
-
-RUN ls -l /usr/local/nixl/
-RUN ls -l /usr/local/nixl/include/
-
-RUN ls /opt/nixl
-
-# Install utilities
-RUN apt update -y && apt install -y git wget curl nvtop tmux vim
+### NATS & ETCD SETUP ###
 # nats
-RUN wget --tries=3 --waitretry=5 https://github.com/nats-io/nats-server/releases/download/v2.10.24/nats-server-v2.10.24-amd64.deb && \
-    dpkg -i nats-server-v2.10.24-amd64.deb && rm nats-server-v2.10.24-amd64.deb
+RUN wget --tries=3 --waitretry=5 https://github.com/nats-io/nats-server/releases/download/v2.10.24/nats-server-v2.10.24-${ARCH}.deb && \
+    dpkg -i nats-server-v2.10.24-${ARCH}.deb && rm nats-server-v2.10.24-${ARCH}.deb
 # etcd
 ENV ETCD_VERSION="v3.5.18"
-RUN wget --tries=3 --waitretry=5 https://github.com/etcd-io/etcd/releases/download/$ETCD_VERSION/etcd-$ETCD_VERSION-linux-amd64.tar.gz -O /tmp/etcd.tar.gz && \
+RUN wget --tries=3 --waitretry=5 https://github.com/etcd-io/etcd/releases/download/$ETCD_VERSION/etcd-$ETCD_VERSION-linux-${ARCH}.tar.gz -O /tmp/etcd.tar.gz && \
     mkdir -p /usr/local/bin/etcd && \
     tar -xvf /tmp/etcd.tar.gz -C /usr/local/bin/etcd --strip-components=1 && \
     rm /tmp/etcd.tar.gz
@@ -182,6 +96,14 @@ RUN mkdir /opt/dynamo && \
 ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
+# Install NIXL Python module
+# TODO: Can NIXL build select gds_path based on arch instead of us?
+RUN if [ "$ARCH" = "arm64" ]; then \
+    cd /opt/nixl && uv pip install . --config-settings=setup-args="-Dgds_path=/usr/local/cuda/targets/sbsa-linux/"; \
+    else \
+    cd /opt/nixl && uv pip install . ; \
+    fi
+
 # Install patched vllm - keep this early in Dockerfile to avoid
 # rebuilds from unrelated source code changes
 ARG VLLM_REF="0.8.4"
@@ -189,8 +111,14 @@ ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
 ARG VLLM_PATCHED_PACKAGE_NAME="ai_dynamo_vllm"
 ARG VLLM_PATCHED_PACKAGE_VERSION="0.8.4"
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
-    mkdir /tmp/vllm && \
+    mkdir -p /tmp/vllm && \
     uv pip install pip wheel && \
+    # TODO: Handle arm64: Build wheel from source
+    if [ "$ARCH" = "arm64" ]; then \
+    git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
+    echo "WARNING: VLLM installation is not supported on arm64 yet, skipping it." ; \
+    # Handle x86_64: Download wheel, unpack, setup for later steps
+    else \
     python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \
     cd /tmp/vllm && \
     wheel unpack *.whl && \
@@ -206,7 +134,8 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     sed -i "s/-cp38-abi3-linux_x86_64.whl/-cp38-abi3-manylinux1_x86_64.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/RECORD && \
     mkdir -p /workspace/dist && \
     wheel pack . --dest-dir /workspace/dist && \
-    uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl
+    uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; \
+    fi
 
 # Common dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
@@ -240,11 +169,14 @@ RUN apt update -y && \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.86.0 \
-    RUSTARCH=x86_64-unknown-linux-gnu
+    RUST_VERSION=1.86.0
 
+# Define Rust target based on ARCH_ALT ARG
+ARG RUSTARCH=${ARCH_ALT}-unknown-linux-gnu
+
+# Install Rust using RUSTARCH derived from ARCH_ALT
 RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" && \
-    echo "a3339fb004c3d0bb9862ba0bce001861fe5cbde9c10d16591eb3f39ee6cd3e7f *rustup-init" | sha256sum -c - && \
+    # TODO: Add SHA check back based on RUSTARCH
     chmod +x rustup-init && \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${RUSTARCH} && \
     rm rustup-init && \
@@ -305,8 +237,10 @@ ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 ##### Wheel Build Image ##########
 ##################################
 
-# Build the wheel in the manylinux environment
-FROM ${MANYLINUX_IMAGE} AS wheel_builder
+# Redeclare ARCH_ALT ARG so it's available for interpolation in the FROM instruction
+ARG ARCH_ALT
+
+FROM quay.io/pypa/manylinux_2_28_${ARCH_ALT} AS wheel_builder
 
 ARG CARGO_BUILD_JOBS
 # Set CARGO_BUILD_JOBS to 16 if not provided
@@ -321,8 +255,6 @@ WORKDIR /workspace
 RUN yum update -y \
     && yum install -y python3.12-devel \
     && yum install -y protobuf-compiler \
-    || yum install -y https://raw.repo.almalinux.org/almalinux/8.10/AppStream/x86_64/os/Packages/protobuf-3.5.0-15.el8.x86_64.rpm \
-    https://raw.repo.almalinux.org/almalinux/8.10/AppStream/x86_64/os/Packages/protobuf-compiler-3.5.0-15.el8.x86_64.rpm \
     && yum clean all \
     && rm -rf /var/cache/yum
 
@@ -365,8 +297,8 @@ RUN uv build --wheel --out-dir /workspace/dist && \
     cd /workspace/lib/bindings/python && \
     uv build --wheel --out-dir /workspace/dist --python 3.12 && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
-        uv build --wheel --out-dir /workspace/dist --python 3.11 && \
-        uv build --wheel --out-dir /workspace/dist --python 3.10; \
+    uv build --wheel --out-dir /workspace/dist --python 3.11 && \
+    uv build --wheel --out-dir /workspace/dist --python 3.10; \
     fi
 
 #######################################
@@ -467,11 +399,14 @@ WORKDIR /workspace
 ENV DYNAMO_HOME=/workspace
 ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+<<<<<<< HEAD
+=======
 
 # Copy NIXL
 COPY --from=base /usr/local/nixl /usr/local/nixl
 ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
 ENV PYTHONPATH=/usr/local/nixl/lib/python3/dist-packages/:/opt/nixl/test/python/:$PYTHONPATH
+>>>>>>> 94702c7930cbc7874f4a211c1198cd611ed02c0f
 
 # Setup the python environment
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -97,7 +97,7 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 # Install NIXL Python module
-# TODO: Can NIXL build select gds_path based on arch instead of us?
+# TODO: Move gds_path selection based on arch into NIXL build
 RUN if [ "$ARCH" = "arm64" ]; then \
     cd /opt/nixl && uv pip install . --config-settings=setup-args="-Dgds_path=/usr/local/cuda/targets/sbsa-linux/"; \
     else \
@@ -111,7 +111,7 @@ ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
 ARG VLLM_PATCHED_PACKAGE_NAME="ai_dynamo_vllm"
 ARG VLLM_PATCHED_PACKAGE_VERSION="0.8.4"
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
-    mkdir -p /tmp/vllm && \
+    mkdir /tmp/vllm && \
     uv pip install pip wheel && \
     # TODO: Handle arm64: Build wheel from source
     if [ "$ARCH" = "arm64" ]; then \

--- a/container/build.sh
+++ b/container/build.sh
@@ -57,7 +57,7 @@ TENSORRTLLM_BASE_IMAGE_TAG=latest_squashed
 TENSORRTLLM_PIP_WHEEL_PATH=""
 
 VLLM_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
-VLLM_BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
+VLLM_BASE_IMAGE_TAG="25.03-cuda12.8-devel-ubuntu24.04"
 
 NONE_BASE_IMAGE="ubuntu"
 NONE_BASE_IMAGE_TAG="24.04"

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -72,8 +72,28 @@ docker compose -f deploy/docker-compose.yml up -d
 ### Build docker
 
 ```
-./container/build.sh
+# On an x86 machine
+./container/build.sh --framework vllm
+
+# On an ARM machine (ex: GB200)
+./container/build.sh --framework vllm --platform linux/arm64
 ```
+
+> [!NOTE]
+> Building a vLLM docker image for ARM machines currently involves building vLLM from source,
+> which has known issues with being slow and requiring a lot of system RAM:
+> https://github.com/vllm-project/vllm/issues/8878
+>
+> You can tune the number of parallel build jobs for building VLLM from source
+> on ARM based on your available cores and system RAM with `VLLM_MAX_JOBS`.
+>
+> For example, on a machine with low resources:
+> `./container/build.sh --framework vllm --platform linux/arm64 --build-arg VLLM_MAX_JOBS=2`
+>
+> For example, on a GB200 which has very high CPU cores and memory resource:
+> `./container/build.sh --framework vllm --platform linux/arm64 --build-arg VLLM_MAX_JOBS=64`
+>
+> When vLLM has pre-built ARM wheels published, this process can be improved.
 
 ### Run container
 

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -71,7 +71,7 @@ docker compose -f deploy/docker-compose.yml up -d
 
 ### Build docker
 
-```
+```bash
 # On an x86 machine
 ./container/build.sh --framework vllm
 
@@ -87,7 +87,7 @@ docker compose -f deploy/docker-compose.yml up -d
 > You can tune the number of parallel build jobs for building VLLM from source
 > on ARM based on your available cores and system RAM with `VLLM_MAX_JOBS`.
 >
-> For example, on a machine with low resources:
+> For example, on an ARM machine with low system resources:
 > `./container/build.sh --framework vllm --platform linux/arm64 --build-arg VLLM_MAX_JOBS=2`
 >
 > For example, on a GB200 which has very high CPU cores and memory resource:
@@ -98,8 +98,9 @@ docker compose -f deploy/docker-compose.yml up -d
 ### Run container
 
 ```
-./container/run.sh -it
+./container/run.sh -it --framework vllm
 ```
+
 ## Run Deployment
 
 This figure shows an overview of the major components to deploy:

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -66,7 +66,11 @@ If you already have a TensorRT-LLM container image, you can skip this step.
 #### Step 2: Build the Dynamo container
 
 ```
+# On an x86 machine:
 ./container/build.sh --framework tensorrtllm
+
+# On an ARM machine:
+./container/build.sh --framework tensorrtllm --platform linux/arm64
 ```
 
 This build script internally points to the base container image built with step 1. If you skipped previous step because you already have the container image available, you can run the build script with that image as a base.


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Parameterizes ARCH for x86/arm installs of etcd, nats, dynamo, and NIXL, similar to https://github.com/ai-dynamo/dynamo/pull/803

Extends NIXL install from https://github.com/ai-dynamo/dynamo/pull/594 with ARM support.

VLLM ARM build/install from source added in separate PR here for easier isolation of changes, but merged into this PR: https://github.com/ai-dynamo/dynamo/pull/845

---

Manually tested with following builds (minimal runtime testing).

x86
```bash
# or default with no args: 
#   ./container/build.sh --framework vllm
./container/build.sh --framework vllm --platform linux/amd64

# example x86 image produced:
#   gitlab-master.nvidia.com:5005/dl/ai-dynamo/dynamo-ci/rmccormick:dynamo_2cee3f_vllm0.8.4_x86
```

ARM
```bash
# NOTE: Building vllm from source can easily take anywhere from 1-4+ hours depending
# on VLLM_MAX_JOBS value and available system memory.
# - With 256GB RAM and VLLM_MAX_JOBS=16 - I believe it took somewhere between 3-4 hours
# - With > 1 TB RAM (GB200 machine) and VLLM_MAX_JOBS=64 - I believe it took about an 1-1.5 hours
./container/build.sh --framework vllm --platform linux/arm64

# Example on system with large memory to speed up build vllm build on ARM
./container/build.sh --framework vllm --platform linux/arm64 --build-args VLLM_MAX_JOBS=16

# example aarch64 image produced: 
#   gitlab-master.nvidia.com:5005/dl/ai-dynamo/dynamo-ci/rmccormick:dynamo_6084b0f_vllm0.8.4_aarch64
```

Minimal runtime validation of vllm/torch installs after: https://github.com/ai-dynamo/dynamo/pull/845

```bash
root@gb-nvl-081-compute06:/workspace# python3
Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import vllm
WARNING 04-28 06:03:01 [__init__.py:23] Using ai_dynamo_vllm
WARNING 04-28 06:03:01 [__init__.py:23] Using ai_dynamo_vllm
WARNING 04-28 06:03:01 [__init__.py:23] Using ai_dynamo_vllm
WARNING 04-28 06:03:01 [__init__.py:23] Using ai_dynamo_vllm
WARNING 04-28 06:03:01 [__init__.py:23] Using ai_dynamo_vllm
INFO 04-28 06:03:01 [__init__.py:240] Automatically detected platform cuda.
INFO 04-28 06:03:01 [nixl.py:31] NIXL is available
>>> import torch
>>> torch.cuda.is_available()
True
```

---

**Needs follow-up:** (@saturley-hall @nv-anants)
- If the wheel needs to be published to pypi, it may need a couple tweaks to package metadata to publish as `ai_dynamo_vllm`, similar to how it's done in the x86 download+patch+publish path: https://github.com/ai-dynamo/dynamo/blob/6084b0f93bf32e5ac1b5c59725f8cabb0df524cc/container/Dockerfile.vllm#L127-L130
- Currently it is installed from source and ends up listed as package name `vllm` instead of `ai_dynamo_vllm` on ARM only:
```bash
$ ./container/run.sh -it --image gitlab-master.nvidia.com:5005/dl/ai-dynamo/dynamo-ci/rmccormick:dynamo_6084b0f_vllm0.8.4_aarch64
$ pip freeze
...
vllm @ file:///tmp/vllm/vllm-0.8.4
```
- Building vLLM (flash attention) from source is quite slow and system memory intensive (see [MAX_JOBS](https://github.com/vllm-project/vllm/issues/8878#issuecomment-2378357324)). Hopefully with the release of prebuilt wheels for [pytorch2.7 supporting ARM](https://pytorch.org/blog/pytorch-2-7/), vLLM may be able to start publishing ARM wheels as well so we can just download+patch like we do for x86 too.