### PR TITLE
feat: Add request template support for default inference parameters

### DIFF
--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -126,6 +126,17 @@ pub struct Flags {
     #[arg(long)]
     pub extra_engine_args: Option<PathBuf>,
 
+    /// Path to a JSON file containing default request fields.
+    /// These fields will be merged with each request, but can be overridden by the request.
+    /// Example file contents:
+    /// {
+    ///     "model": "Qwen2.5-3B-Instruct",
+    ///     "temperature": 0.7,
+    ///     "max_completion_tokens": 4096
+    /// }
+    #[arg(long)]
+    pub request_template: Option<PathBuf>,
+
     /// Everything after a `--`.
     /// These are the command line arguments to the python engine when using `pystr` or `pytok`.
     #[arg(index = 2, last = true, hide = true, allow_hyphen_values = true)]

--- a/launch/dynamo-run/src/input/batch.rs
+++ b/launch/dynamo-run/src/input/batch.rs
@@ -225,9 +225,17 @@ async fn evaluate(
     );
     let inner = async_openai::types::CreateChatCompletionRequestArgs::default()
         .messages(vec![user_message])
-        .model(template.as_ref().map_or_else(|| service_name.to_string(), |t| t.model.clone()))
+        .model(
+            template
+                .as_ref()
+                .map_or_else(|| service_name.to_string(), |t| t.model.clone()),
+        )
         .stream(true)
-        .max_completion_tokens(template.as_ref().map_or(MAX_TOKENS, |t| t.max_completion_tokens))
+        .max_completion_tokens(
+            template
+                .as_ref()
+                .map_or(MAX_TOKENS, |t| t.max_completion_tokens),
+        )
         .temperature(template.as_ref().map_or(0.7, |t| t.temperature))
         .build()?;
     let req = NvCreateChatCompletionRequest { inner, nvext: None };

--- a/launch/dynamo-run/src/input/batch.rs
+++ b/launch/dynamo-run/src/input/batch.rs
@@ -141,14 +141,21 @@ pub async fn run(
         let service_name_ref = service_name_ref.clone();
         let handle = tokio::spawn(async move {
             let local_start = Instant::now();
-            let response =
-                match evaluate(request_id, service_name_ref.as_str(), engine, &mut entry, template).await {
-                    Ok(r) => r,
-                    Err(err) => {
-                        tracing::error!(%err, entry.text, "Failed evaluating prompt");
-                        return;
-                    }
-                };
+            let response = match evaluate(
+                request_id,
+                service_name_ref.as_str(),
+                engine,
+                &mut entry,
+                template,
+            )
+            .await
+            {
+                Ok(r) => r,
+                Err(err) => {
+                    tracing::error!(%err, entry.text, "Failed evaluating prompt");
+                    return;
+                }
+            };
             let local_elapsed = Instant::now() - local_start;
             entry.elapsed_ms = local_elapsed.as_millis() as usize;
 

--- a/launch/dynamo-run/src/input/http.rs
+++ b/launch/dynamo-run/src/input/http.rs
@@ -35,11 +35,13 @@ pub async fn run(
     runtime: Runtime,
     flags: Flags,
     engine_config: EngineConfig,
+    template: Option<RequestTemplate>,
 ) -> anyhow::Result<()> {
     let http_service = service_v2::HttpService::builder()
         .port(flags.http_port)
         .enable_chat_endpoints(true)
         .enable_cmpl_endpoints(true)
+        .with_request_template(template)
         .build()?;
     match engine_config {
         EngineConfig::Dynamic(endpoint) => {

--- a/launch/dynamo-run/src/input/http.rs
+++ b/launch/dynamo-run/src/input/http.rs
@@ -27,6 +27,7 @@ use dynamo_llm::{
         },
         openai::completions::{CompletionRequest, CompletionResponse},
     },
+    request_template::RequestTemplate,
 };
 use dynamo_runtime::{DistributedRuntime, Runtime};
 

--- a/launch/dynamo-run/src/input/http.rs
+++ b/launch/dynamo-run/src/input/http.rs
@@ -21,13 +21,13 @@ use dynamo_llm::{
     engines::StreamingEngineAdapter,
     http::service::{discovery, service_v2},
     model_type::ModelType,
+    request_template::RequestTemplate,
     types::{
         openai::chat_completions::{
             NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
         },
         openai::completions::{CompletionRequest, CompletionResponse},
     },
-    request_template::RequestTemplate,
 };
 use dynamo_runtime::{DistributedRuntime, Runtime};
 

--- a/launch/dynamo-run/src/input/text.rs
+++ b/launch/dynamo-run/src/input/text.rs
@@ -107,9 +107,17 @@ async fn main_loop(
         // Request
         let inner = async_openai::types::CreateChatCompletionRequestArgs::default()
             .messages(messages.clone())
-            .model(template.as_ref().map_or_else(|| service_name.to_string(), |t| t.model.clone()))
+            .model(
+                template
+                    .as_ref()
+                    .map_or_else(|| service_name.to_string(), |t| t.model.clone()),
+            )
             .stream(true)
-            .max_completion_tokens(template.as_ref().map_or(MAX_TOKENS, |t| t.max_completion_tokens))
+            .max_completion_tokens(
+                template
+                    .as_ref()
+                    .map_or(MAX_TOKENS, |t| t.max_completion_tokens),
+            )
             .temperature(template.as_ref().map_or(0.7, |t| t.temperature))
             .n(1) // only generate one response
             .build()?;

--- a/launch/dynamo-run/src/input/text.rs
+++ b/launch/dynamo-run/src/input/text.rs
@@ -22,7 +22,7 @@ use futures::StreamExt;
 use std::io::{ErrorKind, Write};
 
 use crate::input::common;
-use crate::{EngineConfig, Flags};
+use crate::{EngineConfig, Flags, RequestTemplate};
 
 /// Max response tokens for each single query. Must be less than model context size.
 /// TODO: Cmd line flag to overwrite this
@@ -33,6 +33,7 @@ pub async fn run(
     flags: Flags,
     single_prompt: Option<String>,
     engine_config: EngineConfig,
+    template: Option<RequestTemplate>,
 ) -> anyhow::Result<()> {
     let cancel_token = runtime.primary_token();
     let (service_name, engine, inspect_template): (
@@ -46,6 +47,7 @@ pub async fn run(
         engine,
         single_prompt,
         inspect_template,
+        template,
     )
     .await
 }
@@ -56,6 +58,7 @@ async fn main_loop(
     engine: OpenAIChatCompletionsStreamingEngine,
     mut initial_prompt: Option<String>,
     _inspect_template: bool,
+    template: Option<RequestTemplate>,
 ) -> anyhow::Result<()> {
     if initial_prompt.is_none() {
         tracing::info!("Ctrl-c to exit");
@@ -101,14 +104,13 @@ async fn main_loop(
             },
         );
         messages.push(user_message);
-
         // Request
         let inner = async_openai::types::CreateChatCompletionRequestArgs::default()
             .messages(messages.clone())
-            .model(service_name)
+            .model(template.as_ref().map_or_else(|| service_name.to_string(), |t| t.model.clone()))
             .stream(true)
-            .max_completion_tokens(MAX_TOKENS)
-            .temperature(0.7)
+            .max_completion_tokens(template.as_ref().map_or(MAX_TOKENS, |t| t.max_completion_tokens))
+            .temperature(template.as_ref().map_or(0.7, |t| t.temperature))
             .n(1) // only generate one response
             .build()?;
         let nvext = NvExt {

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -198,13 +198,12 @@ pub async fn run(
     let mut extra: Option<Pin<Box<dyn Future<Output = ()> + Send>>> = None; // vllm and sglang sub-process
 
     let template = if let Some(path) = flags.request_template.as_ref() {
-        Some(RequestTemplate::load(path)?)
+        let template = RequestTemplate::load(path)?;
+        tracing::debug!("Using request template: {template:?}");
+        Some(template)
     } else {
         None
     };
-    if let Some(template) = template.as_ref() {
-        tracing::info!("Using request template: {template:?}");
-    }
 
     // Create the engine matching `out`
     let engine_config = match out_opt {

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -31,6 +31,7 @@ mod input;
 mod net;
 mod opt;
 pub use opt::{Input, Output};
+pub use dynamo_llm::request_template::RequestTemplate;
 
 /// How we identify a namespace/component/endpoint URL.
 /// Technically the '://' is not part of the scheme but it eliminates several string
@@ -195,6 +196,15 @@ pub async fn run(
 
     #[cfg(any(feature = "vllm", feature = "sglang"))]
     let mut extra: Option<Pin<Box<dyn Future<Output = ()> + Send>>> = None; // vllm and sglang sub-process
+
+    let template = if let Some(path) = flags.request_template.as_ref() {
+        Some(RequestTemplate::load(path)?)
+    } else {
+        None
+    };
+    if let Some(template) = template.as_ref() {
+        tracing::info!("Using request template: {template:?}");
+    }
 
     // Create the engine matching `out`
     let engine_config = match out_opt {
@@ -461,15 +471,15 @@ pub async fn run(
 
     match in_opt {
         Input::Http => {
-            crate::input::http::run(runtime.clone(), flags, engine_config).await?;
+            crate::input::http::run(runtime.clone(), flags, engine_config, template).await?;
         }
         Input::Text => {
-            crate::input::text::run(runtime.clone(), flags, None, engine_config).await?;
+            crate::input::text::run(runtime.clone(), flags, None, engine_config, template).await?;
         }
         Input::Stdin => {
             let mut prompt = String::new();
             std::io::stdin().read_to_string(&mut prompt).unwrap();
-            crate::input::text::run(runtime.clone(), flags, Some(prompt), engine_config).await?;
+            crate::input::text::run(runtime.clone(), flags, Some(prompt), engine_config, template).await?;
         }
         Input::Batch(path) => {
             crate::input::batch::run(runtime.clone(), flags, maybe_card, path, engine_config)

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -482,7 +482,7 @@ pub async fn run(
             crate::input::text::run(runtime.clone(), flags, Some(prompt), engine_config, template).await?;
         }
         Input::Batch(path) => {
-            crate::input::batch::run(runtime.clone(), flags, maybe_card, path, engine_config)
+            crate::input::batch::run(runtime.clone(), flags, maybe_card, path, engine_config, template)
                 .await?;
         }
         Input::Endpoint(path) => {

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -30,8 +30,8 @@ mod input;
 #[cfg(any(feature = "vllm", feature = "sglang"))]
 mod net;
 mod opt;
-pub use opt::{Input, Output};
 pub use dynamo_llm::request_template::RequestTemplate;
+pub use opt::{Input, Output};
 
 /// How we identify a namespace/component/endpoint URL.
 /// Technically the '://' is not part of the scheme but it eliminates several string
@@ -479,11 +479,25 @@ pub async fn run(
         Input::Stdin => {
             let mut prompt = String::new();
             std::io::stdin().read_to_string(&mut prompt).unwrap();
-            crate::input::text::run(runtime.clone(), flags, Some(prompt), engine_config, template).await?;
+            crate::input::text::run(
+                runtime.clone(),
+                flags,
+                Some(prompt),
+                engine_config,
+                template,
+            )
+            .await?;
         }
         Input::Batch(path) => {
-            crate::input::batch::run(runtime.clone(), flags, maybe_card, path, engine_config, template)
-                .await?;
+            crate::input::batch::run(
+                runtime.clone(),
+                flags,
+                maybe_card,
+                path,
+                engine_config,
+                template,
+            )
+            .await?;
         }
         Input::Endpoint(path) => {
             let Some(dyn_input) = dyn_input else {

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -234,8 +234,8 @@ async fn chat_completions(
         if request.inner.temperature.unwrap_or(0.0) == 0.0 {
             request.inner.temperature = Some(template.temperature);
         }
-        if request.inner.max_tokens.unwrap_or(0) == 0 {
-            request.inner.max_tokens = Some(template.max_completion_tokens);
+        if request.inner.max_completion_tokens.unwrap_or(0) == 0 {
+            request.inner.max_completion_tokens = Some(template.max_completion_tokens);
         }
     }
     tracing::trace!("Received chat completions request: {:?}", request.inner);

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -43,6 +43,7 @@ use super::{
 use crate::protocols::openai::{
     chat_completions::NvCreateChatCompletionResponse, completions::CompletionResponse,
 };
+use crate::request_template::RequestTemplate;
 use crate::types::{
     openai::{chat_completions::NvCreateChatCompletionRequest, completions::CompletionRequest},
     Annotated,
@@ -219,11 +220,25 @@ async fn completions(
 /// non-streaming requests, we will fold the stream into a single response as part of this handler.
 #[tracing::instrument(skip_all)]
 async fn chat_completions(
-    State(state): State<Arc<DeploymentState>>,
-    Json(request): Json<NvCreateChatCompletionRequest>,
+    State((state, template)): State<(Arc<DeploymentState>, Option<RequestTemplate>)>,
+    Json(mut request): Json<NvCreateChatCompletionRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     // return a 503 if the service is not ready
     check_ready(&state)?;
+
+    // Apply template values if present
+    if let Some(template) = template {
+        if request.inner.model.is_empty() {
+            request.inner.model = template.model.clone();
+        }
+        if request.inner.temperature.unwrap_or(0.0) == 0.0 {
+            request.inner.temperature = Some(template.temperature);
+        }
+        if request.inner.max_tokens.unwrap_or(0) == 0 {
+            request.inner.max_tokens = Some(template.max_completion_tokens);
+        }
+    }
+    tracing::trace!("Received chat completions request: {:?}", request.inner);
 
     // todo - extract distributed tracing id and context id from headers
     let request_id = uuid::Uuid::new_v4().to_string();
@@ -512,13 +527,14 @@ pub fn completions_router(
 /// If not path is provided, the default path is `/v1/chat/completions`
 pub fn chat_completions_router(
     state: Arc<DeploymentState>,
+    template: Option<RequestTemplate>,
     path: Option<String>,
 ) -> (Vec<RouteDoc>, Router) {
     let path = path.unwrap_or("/v1/chat/completions".to_string());
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let router = Router::new()
         .route(&path, post(chat_completions))
-        .with_state(state);
+        .with_state((state, template));
     (vec![doc], router)
 }
 

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -15,11 +15,11 @@
 
 use super::metrics;
 use super::ModelManager;
+use crate::request_template::RequestTemplate;
 use anyhow::Result;
 use derive_builder::Builder;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use crate::request_template::RequestTemplate;
 
 #[derive(Clone)]
 pub struct HttpService {

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -19,6 +19,7 @@ use anyhow::Result;
 use derive_builder::Builder;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use crate::request_template::RequestTemplate;
 
 #[derive(Clone)]
 pub struct HttpService {
@@ -44,6 +45,9 @@ pub struct HttpServiceConfig {
 
     #[builder(default = "true")]
     enable_cmpl_endpoints: bool,
+
+    #[builder(default = "None")]
+    request_template: Option<RequestTemplate>,
 }
 
 impl HttpService {
@@ -91,6 +95,7 @@ impl HttpServiceConfigBuilder {
         model_manager.metrics().register(&registry)?;
 
         let mut router = axum::Router::new();
+
         let mut all_docs = Vec::new();
 
         let mut routes = vec![
@@ -101,6 +106,7 @@ impl HttpServiceConfigBuilder {
         if config.enable_chat_endpoints {
             routes.push(super::openai::chat_completions_router(
                 model_manager.state(),
+                config.request_template,
                 None,
             ));
         }
@@ -128,5 +134,10 @@ impl HttpServiceConfigBuilder {
             port: config.port,
             host: config.host,
         })
+    }
+
+    pub fn with_request_template(mut self, request_template: Option<RequestTemplate>) -> Self {
+        self.request_template = Some(request_template);
+        self
     }
 }

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -34,6 +34,7 @@ pub mod recorder;
 pub mod tokenizers;
 pub mod tokens;
 pub mod types;
+pub mod request_template;
 
 #[cfg(feature = "cuda_kv")]
 pub mod kv;

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -31,10 +31,10 @@ pub mod model_type;
 pub mod preprocessor;
 pub mod protocols;
 pub mod recorder;
+pub mod request_template;
 pub mod tokenizers;
 pub mod tokens;
 pub mod types;
-pub mod request_template;
 
 #[cfg(feature = "cuda_kv")]
 pub mod kv;

--- a/lib/llm/src/request_template.rs
+++ b/lib/llm/src/request_template.rs
@@ -15,5 +15,4 @@ impl RequestTemplate {
         let template: Self = serde_json::from_str(&template)?;
         Ok(template)
     }
-
 }

--- a/lib/llm/src/request_template.rs
+++ b/lib/llm/src/request_template.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RequestTemplate {
+    pub model: String,
+    pub temperature: f32,
+    pub max_completion_tokens: u32,
+}
+
+impl RequestTemplate {
+    pub fn load(path: &Path) -> Result<Self> {
+        let template = std::fs::read_to_string(path)?;
+        let template: Self = serde_json::from_str(&template)?;
+        Ok(template)
+    }
+
+}

--- a/lib/llm/src/request_template.rs
+++ b/lib/llm/src/request_template.rs
@@ -1,6 +1,19 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RequestTemplate {

--- a/lib/llm/src/request_template.rs
+++ b/lib/llm/src/request_template.rs
@@ -14,7 +14,6 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RequestTemplate {
     pub model: String,


### PR DESCRIPTION
#### Overview:

Adds support for specifying default request parameters through a json template file that can be applied across all inference requests. This enables consistent parameter settings while still allowing per-request overrides.

Changes:
Add --request-template CLI flag to specify template file path
Integrate template support in HTTP, batch and text input modes
Template values can be overridden by individual request parameters
Example template.json:
{
    "model": "Qwen2.5-3B-Instruct",
    "temperature": 0.7,
    "max_completion_tokens": 4096
}

#### Details:

<!-- Describe the changes made in this PR. -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: https://github.com/ai-dynamo/dynamo/issues/570
