### PR TITLE
feat: Add vllm build from source for aarch64

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -124,10 +124,6 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         cd /tmp/vllm/vllm-${VLLM_REF}/ && \
         # Patch vLLM source with dynamo additions
         patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
-        # WAR: Set package version check to 'vllm' instead of 'ai_dynamo_vllm'
-        # to avoid platform detection issues. There is probably a better solution to
-        # make the installed package name 'ai_dynamo_vllm' instead.
-        sed -i 's/version("ai_dynamo_vllm")/version("vllm")/g' vllm/platforms/__init__.py
         # Remove pytorch from vllm install dependencies
         python use_existing_torch.py && \
         # Build/install vllm from source
@@ -155,6 +151,14 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         mkdir -p /workspace/dist && \
         wheel pack . --dest-dir /workspace/dist && \
         uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; \
+    fi
+
+# WAR: Set package version check to 'vllm' instead of 'ai_dynamo_vllm' to avoid
+# platform detection issues on ARM install. There is probably a better solution
+# to make the installed package name for ARM build 'ai_dynamo_vllm' instead.
+RUN if [ "$ARCH" = "arm64" ]; then \
+        cd /tmp/vllm/vllm-${VLLM_REF}/ && \
+        sed -i 's/version("ai_dynamo_vllm")/version("vllm")/g' vllm/platforms/__init__.py ; \
     fi
 
 # Common dependencies

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -128,7 +128,7 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         python use_existing_torch.py && \
         # Build/install vllm from source
         uv pip install -r requirements/build.txt && \
-        # MAX_JOBS set to avoid running OOM on vllm-flash-attn build, this can 
+        # MAX_JOBS set to avoid running OOM on vllm-flash-attn build, this can
         # significantly impact the overall build time. Each job can take up
         # to -16GB RAM each, so tune according to available system memory.
         MAX_JOBS=${VLLM_MAX_JOBS} uv pip install -e . --no-build-isolation ; \
@@ -151,7 +151,7 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         mkdir -p /workspace/dist && \
         wheel pack . --dest-dir /workspace/dist && \
         uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; \
-    fi 
+    fi
 
 # Common dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -111,14 +111,11 @@ ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
 ARG VLLM_PATCHED_PACKAGE_NAME="ai_dynamo_vllm"
 ARG VLLM_PATCHED_PACKAGE_VERSION="0.8.4"
 ARG VLLM_MAX_JOBS=4
-# NOTE: vLLM build from source can be a very long step, so split it out
-#       from patching step to cache the build. However, use of uv cache mount
-#       may make splitting the steps redundant.
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     --mount=type=cache,target=/root/.cache/uv \
     mkdir /tmp/vllm && \
     uv pip install pip wheel && \
-    # TODO: Handle arm64: Build wheel from source
+    # NOTE: vLLM build from source on ARM can take several hours, see VLLM_MAX_JOBS details.
     if [ "$ARCH" = "arm64" ]; then \
         # PyTorch 2.7 supports CUDA 12.8 and aarch64 installs
         uv pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128 && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -6,6 +6,8 @@ ARG BASE_IMAGE_TAG="25.03-cuda12.8-devel-ubuntu24.04"
 ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
+# TODO: Move to published pypi tags
+ARG GENAI_PERF_TAG="e67e853413a07a778dd78a55e299be7fba9c9c24"
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
 #   ARCH: Used for package suffixes (e.g., amd64, arm64)
@@ -108,7 +110,7 @@ ARG VLLM_REF="0.8.4"
 ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
 ARG VLLM_PATCHED_PACKAGE_NAME="ai_dynamo_vllm"
 ARG VLLM_PATCHED_PACKAGE_VERSION="0.8.4"
-ARG VLLM_MAX_JOBS=16
+ARG VLLM_MAX_JOBS=4
 # NOTE: vLLM build from source can be a very long step, so split it out
 #       from patching step to cache the build. However, use of uv cache mount
 #       may make splitting the steps redundant.
@@ -129,16 +131,17 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         python use_existing_torch.py && \
         # Build/install vllm from source
         uv pip install -r requirements/build.txt && \
-        # MAX_JOBS set to avoid running OOM on vllm-flash-attn build
-        # Each job can take between 2-8GB each, so tune according to available system memory.
+        # MAX_JOBS set to avoid running OOM on vllm-flash-attn build, this can 
+        # significantly impact the overall build time. Each job can take up
+        # to -16GB RAM each, so tune according to available system memory.
         MAX_JOBS=${VLLM_MAX_JOBS} uv pip install -e . --no-build-isolation ; \
     # Handle x86_64: Download wheel, unpack, setup for later steps
     else \
         python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \
         # Patch vLLM pre-built download with dynamo additions
         cd /tmp/vllm && \
-        wheel unpack *.whl ; \
-        cd /tmp/vllm/vllm-${VLLM_REF}/ && \
+        wheel unpack *.whl && \
+        cd vllm-${VLLM_REF}/ && \
         patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
         # Rename the package from vllm to ai_dynamo_vllm
         mv vllm-${VLLM_REF}.dist-info ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info && \
@@ -155,12 +158,10 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
 
 # Common dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
-    --mount=type=cache,target=/root/.cache/uv \
     uv pip install --requirement /tmp/requirements.txt
 
 # Install test dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
-    --mount=type=cache,target=/root/.cache/uv \
     uv pip install --requirement /tmp/requirements.txt
 
 # ### MISC UTILITY SETUP ###
@@ -367,15 +368,39 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
 # Tell vllm to use the Dynamo LLM C API for KV Cache Routing
 ENV VLLM_KV_CAPI_PATH=$CARGO_TARGET_DIR/release/libdynamo_llm_capi.so
 
+##########################################
+########## Perf Analyzer Image ###########
+##########################################
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS perf_analyzer
+
+ARG GENAI_PERF_TAG
+
+WORKDIR /workspace
+
+# Build and install Perf Analyzer for benchmarking
+RUN apt-get update -y && apt-get -y install cmake g++ libssl-dev python3 rapidjson-dev zlib1g-dev
+RUN git clone https://github.com/triton-inference-server/perf_analyzer.git
+RUN git -C perf_analyzer checkout ${GENAI_PERF_TAG}
+RUN mkdir perf_analyzer/build
+RUN cmake -B perf_analyzer/build -S perf_analyzer -D TRITON_ENABLE_PERF_ANALYZER_OPENAI=ON
+RUN cmake --build perf_analyzer/build -- -j8
+RUN mkdir bin &&  \
+    cp -r perf_analyzer/build/perf_analyzer/src/perf-analyzer-build /workspace/bin/
+
 ########################################
 ########## Development Image ###########
 ########################################
 FROM ci_minimum AS dev
 
+ARG GENAI_PERF_TAG
+
+COPY --from=perf_analyzer /workspace/bin/perf-analyzer-build/ /perf/bin
+COPY --from=perf_analyzer /workspace/perf_analyzer /perf_analyzer
+ENV PATH="/perf/bin:${PATH}"
+
 # Install genai-perf for benchmarking
-ARG GENAI_PERF_TAG="0.0.11"
-#RUN uv pip install "git+https://github.com/triton-inference-server/perf_analyzer.git@${GENAI_PERF_TAG}#subdirectory=genai-perf"
-RUN uv pip install "genai-perf==${GENAI_PERF_TAG}"
+RUN uv pip install "git+https://github.com/triton-inference-server/perf_analyzer.git@${GENAI_PERF_TAG}#subdirectory=genai-perf"
+RUN uv pip uninstall tritonclient
 
 COPY . /workspace
 

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -124,6 +124,10 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         cd /tmp/vllm/vllm-${VLLM_REF}/ && \
         # Patch vLLM source with dynamo additions
         patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
+        # WAR: Set package version check to 'vllm' instead of 'ai_dynamo_vllm' to avoid
+        # platform detection issues on ARM install.
+        # TODO: Rename package from vllm to ai_dynamo_vllm like x86 path below to remove this WAR.
+        sed -i 's/version("ai_dynamo_vllm")/version("vllm")/g' vllm/platforms/__init__.py && \
         # Remove pytorch from vllm install dependencies
         python use_existing_torch.py && \
         # Build/install vllm from source
@@ -151,14 +155,6 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         mkdir -p /workspace/dist && \
         wheel pack . --dest-dir /workspace/dist && \
         uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; \
-    fi
-
-# WAR: Set package version check to 'vllm' instead of 'ai_dynamo_vllm' to avoid
-# platform detection issues on ARM install. There is probably a better solution
-# to make the installed package name for ARM build 'ai_dynamo_vllm' instead.
-RUN if [ "$ARCH" = "arm64" ]; then \
-        cd /tmp/vllm/vllm-${VLLM_REF}/ && \
-        sed -i 's/version("ai_dynamo_vllm")/version("vllm")/g' vllm/platforms/__init__.py ; \
     fi
 
 # Common dependencies

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -108,9 +108,10 @@ ARG VLLM_REF="0.8.4"
 ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
 ARG VLLM_PATCHED_PACKAGE_NAME="ai_dynamo_vllm"
 ARG VLLM_PATCHED_PACKAGE_VERSION="0.8.4"
-ARG VLLM_MAX_JOBS=48
+ARG VLLM_MAX_JOBS=16
 # NOTE: vLLM build from source can be a very long step, so split it out
-#       from patching step to cache the build.
+#       from patching step to cache the build. However, use of uv cache mount
+#       may make splitting the steps redundant.
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     --mount=type=cache,target=/root/.cache/uv \
     mkdir /tmp/vllm && \
@@ -119,37 +120,38 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     if [ "$ARCH" = "arm64" ]; then \
         # PyTorch 2.7 supports CUDA 12.8 and aarch64 installs
         uv pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128 && \
-        # Build vLLM from source with custom pytorch install 
+        # Download vLLM source with version matching patch
         git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
         cd /tmp/vllm/vllm-${VLLM_REF}/ && \
+        # Patch vLLM source with dynamo additions
+        patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
         # Remove pytorch from vllm install dependencies
         python use_existing_torch.py && \
+        # Build/install vllm from source
         uv pip install -r requirements/build.txt && \
         # MAX_JOBS set to avoid running OOM on vllm-flash-attn build
-        # Each job can take between 2-4GB each, so tune according to available system memory.
+        # Each job can take between 2-8GB each, so tune according to available system memory.
         MAX_JOBS=${VLLM_MAX_JOBS} uv pip install -e . --no-build-isolation ; \
     # Handle x86_64: Download wheel, unpack, setup for later steps
     else \
         python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \
+        # Patch vLLM pre-built download with dynamo additions
         cd /tmp/vllm && \
         wheel unpack *.whl ; \
+        cd /tmp/vllm/vllm-${VLLM_REF}/ && \
+        patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
+        # Rename the package from vllm to ai_dynamo_vllm
+        mv vllm-${VLLM_REF}.dist-info ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info && \
+        sed -i "s/^Name: vllm/Name: ${VLLM_PATCHED_PACKAGE_NAME}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
+        sed -i "s/^Version: ${VLLM_REF}/Version: ${VLLM_PATCHED_PACKAGE_VERSION}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
+        # Update wheel tag from linux_${ARCH_ALT} to manylinux1_${ARCH_ALT} in WHEEL file
+        sed -i 's/Tag: cp38-abi3-linux_${ARCH_ALT}/Tag: cp38-abi3-manylinux1_${ARCH_ALT}/g' ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/WHEEL && \
+        # Also update the tag in RECORD file to match
+        sed -i "s/-cp38-abi3-linux_${ARCH_ALT}.whl/-cp38-abi3-manylinux1_${ARCH_ALT}.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/RECORD && \
+        mkdir -p /workspace/dist && \
+        wheel pack . --dest-dir /workspace/dist && \
+        uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; 
     fi 
-
-# Patch vLLM install with dynamo additions
-RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
-    cd /tmp/vllm/vllm-${VLLM_REF}/ && \
-    patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
-    # Rename the package from vllm to ai_dynamo_vllm
-    mv vllm-${VLLM_REF}.dist-info ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info && \
-    sed -i "s/^Name: vllm/Name: ${VLLM_PATCHED_PACKAGE_NAME}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
-    sed -i "s/^Version: ${VLLM_REF}/Version: ${VLLM_PATCHED_PACKAGE_VERSION}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
-    # Update wheel tag from linux_${ARCH_ALT} to manylinux1_${ARCH_ALT} in WHEEL file
-    sed -i 's/Tag: cp38-abi3-linux_${ARCH_ALT}/Tag: cp38-abi3-manylinux1_${ARCH_ALT}/g' ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/WHEEL && \
-    # Also update the tag in RECORD file to match
-    sed -i "s/-cp38-abi3-linux_${ARCH_ALT}.whl/-cp38-abi3-manylinux1_${ARCH_ALT}.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/RECORD && \
-    mkdir -p /workspace/dist && \
-    wheel pack . --dest-dir /workspace/dist && \
-    uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; 
 
 # Common dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -150,7 +150,7 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         sed -i "s/-cp38-abi3-linux_${ARCH_ALT}.whl/-cp38-abi3-manylinux1_${ARCH_ALT}.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/RECORD && \
         mkdir -p /workspace/dist && \
         wheel pack . --dest-dir /workspace/dist && \
-        uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; 
+        uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; \
     fi 
 
 # Common dependencies
@@ -374,7 +374,8 @@ FROM ci_minimum AS dev
 
 # Install genai-perf for benchmarking
 ARG GENAI_PERF_TAG="0.0.11"
-RUN uv pip install "git+https://github.com/triton-inference-server/perf_analyzer.git@${GENAI_PERF_TAG}#subdirectory=genai-perf"
+#RUN uv pip install "git+https://github.com/triton-inference-server/perf_analyzer.git@${GENAI_PERF_TAG}#subdirectory=genai-perf"
+RUN uv pip install "genai-perf==${GENAI_PERF_TAG}"
 
 COPY . /workspace
 

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -124,6 +124,10 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         cd /tmp/vllm/vllm-${VLLM_REF}/ && \
         # Patch vLLM source with dynamo additions
         patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
+        # WAR: Set package version check to 'vllm' instead of 'ai_dynamo_vllm'
+        # to avoid platform detection issues. There is probably a better solution to
+        # make the installed package name 'ai_dynamo_vllm' instead.
+        sed -i 's/version("ai_dynamo_vllm")/version("vllm")/g' vllm/platforms/__init__.py
         # Remove pytorch from vllm install dependencies
         python use_existing_torch.py && \
         # Build/install vllm from source
@@ -131,7 +135,7 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         # MAX_JOBS set to avoid running OOM on vllm-flash-attn build, this can
         # significantly impact the overall build time. Each job can take up
         # to -16GB RAM each, so tune according to available system memory.
-        MAX_JOBS=${VLLM_MAX_JOBS} uv pip install -e . --no-build-isolation ; \
+        MAX_JOBS=${VLLM_MAX_JOBS} uv pip install . --no-build-isolation ; \
     # Handle x86_64: Download wheel, unpack, setup for later steps
     else \
         python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -99,9 +99,9 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 # Install NIXL Python module
 # TODO: Move gds_path selection based on arch into NIXL build
 RUN if [ "$ARCH" = "arm64" ]; then \
-    cd /opt/nixl && uv pip install . --config-settings=setup-args="-Dgds_path=/usr/local/cuda/targets/sbsa-linux/"; \
+        cd /opt/nixl && uv pip install . --config-settings=setup-args="-Dgds_path=/usr/local/cuda/targets/sbsa-linux/"; \
     else \
-    cd /opt/nixl && uv pip install . ; \
+        cd /opt/nixl && uv pip install . ; \
     fi
 
 # Install patched vllm - keep this early in Dockerfile to avoid
@@ -116,26 +116,35 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     # TODO: Handle arm64: Build wheel from source
     if [ "$ARCH" = "arm64" ]; then \
         git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
-        echo "WARNING: VLLM installation is not supported on arm64 yet, skipping it." ; \
+        # PyTorch 2.7 supports CUDA 12.8 and aarch64 installs
+        uv pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128 && \
+        # Build vLLM from source with custom pytorch install 
+        git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
+        cd /tmp/vllm/vllm-${VLLM_REF}/ && \
+        # Remove pytorch from vllm install dependencies
+        python use_existing_torch.py && \
+        uv pip install -r requirements/build.txt && \
+        uv pip install -e . --no-build-isolation ; \
     # Handle x86_64: Download wheel, unpack, setup for later steps
     else \
         python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \
         cd /tmp/vllm && \
-        wheel unpack *.whl && \
-        cd vllm-${VLLM_REF}/ && \
-        patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
-        # Rename the package from vllm to ai_dynamo_vllm
-        mv vllm-${VLLM_REF}.dist-info ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info && \
-        sed -i "s/^Name: vllm/Name: ${VLLM_PATCHED_PACKAGE_NAME}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
-        sed -i "s/^Version: ${VLLM_REF}/Version: ${VLLM_PATCHED_PACKAGE_VERSION}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
-        # Update wheel tag from linux_x86_64 to manylinux1_x86_64 in WHEEL file
-        sed -i 's/Tag: cp38-abi3-linux_x86_64/Tag: cp38-abi3-manylinux1_x86_64/g' ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/WHEEL && \
-        # Also update the tag in RECORD file to match
-        sed -i "s/-cp38-abi3-linux_x86_64.whl/-cp38-abi3-manylinux1_x86_64.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/RECORD && \
-        mkdir -p /workspace/dist && \
-        wheel pack . --dest-dir /workspace/dist && \
-        uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; \
-    fi
+        wheel unpack *.whl ; \
+    fi \
+    # Patch vLLM install with dynamo additions
+    cd /tmp/vllm/vllm-${VLLM_REF}/ && \
+    patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
+    # Rename the package from vllm to ai_dynamo_vllm
+    mv vllm-${VLLM_REF}.dist-info ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info && \
+    sed -i "s/^Name: vllm/Name: ${VLLM_PATCHED_PACKAGE_NAME}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
+    sed -i "s/^Version: ${VLLM_REF}/Version: ${VLLM_PATCHED_PACKAGE_VERSION}/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/METADATA && \
+    # Update wheel tag from linux_${ARCH_ALT} to manylinux1_${ARCH_ALT} in WHEEL file
+    sed -i 's/Tag: cp38-abi3-linux_${ARCH_ALT}/Tag: cp38-abi3-manylinux1_${ARCH_ALT}/g' ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/WHEEL && \
+    # Also update the tag in RECORD file to match
+    sed -i "s/-cp38-abi3-linux_${ARCH_ALT}.whl/-cp38-abi3-manylinux1_${ARCH_ALT}.whl/g" ${VLLM_PATCHED_PACKAGE_NAME}-${VLLM_PATCHED_PACKAGE_VERSION}.dist-info/RECORD && \
+    mkdir -p /workspace/dist && \
+    wheel pack . --dest-dir /workspace/dist && \
+    uv pip install /workspace/dist/${VLLM_PATCHED_PACKAGE_NAME}-*.whl ; 
 
 # Common dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -6,8 +6,6 @@ ARG BASE_IMAGE_TAG="25.03-cuda12.8-devel-ubuntu24.04"
 ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
-# TODO: Move to published pypi tags
-ARG GENAI_PERF_TAG="e67e853413a07a778dd78a55e299be7fba9c9c24"
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
 #   ARCH: Used for package suffixes (e.g., amd64, arm64)
@@ -110,12 +108,15 @@ ARG VLLM_REF="0.8.4"
 ARG VLLM_PATCH="vllm_v${VLLM_REF}-dynamo-kv-disagg-patch.patch"
 ARG VLLM_PATCHED_PACKAGE_NAME="ai_dynamo_vllm"
 ARG VLLM_PATCHED_PACKAGE_VERSION="0.8.4"
+ARG VLLM_MAX_JOBS=48
+# NOTE: vLLM build from source can be a very long step, so split it out
+#       from patching step to cache the build.
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
+    --mount=type=cache,target=/root/.cache/uv \
     mkdir /tmp/vllm && \
     uv pip install pip wheel && \
     # TODO: Handle arm64: Build wheel from source
     if [ "$ARCH" = "arm64" ]; then \
-        git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
         # PyTorch 2.7 supports CUDA 12.8 and aarch64 installs
         uv pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128 && \
         # Build vLLM from source with custom pytorch install 
@@ -124,14 +125,18 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         # Remove pytorch from vllm install dependencies
         python use_existing_torch.py && \
         uv pip install -r requirements/build.txt && \
-        uv pip install -e . --no-build-isolation ; \
+        # MAX_JOBS set to avoid running OOM on vllm-flash-attn build
+        # Each job can take between 2-4GB each, so tune according to available system memory.
+        MAX_JOBS=${VLLM_MAX_JOBS} uv pip install -e . --no-build-isolation ; \
     # Handle x86_64: Download wheel, unpack, setup for later steps
     else \
         python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \
         cd /tmp/vllm && \
         wheel unpack *.whl ; \
-    fi \
-    # Patch vLLM install with dynamo additions
+    fi 
+
+# Patch vLLM install with dynamo additions
+RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     cd /tmp/vllm/vllm-${VLLM_REF}/ && \
     patch -p1 < /tmp/deps/vllm/${VLLM_PATCH} && \
     # Rename the package from vllm to ai_dynamo_vllm
@@ -148,10 +153,12 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
 
 # Common dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
+    --mount=type=cache,target=/root/.cache/uv \
     uv pip install --requirement /tmp/requirements.txt
 
 # Install test dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
+    --mount=type=cache,target=/root/.cache/uv \
     uv pip install --requirement /tmp/requirements.txt
 
 # ### MISC UTILITY SETUP ###
@@ -358,39 +365,14 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
 # Tell vllm to use the Dynamo LLM C API for KV Cache Routing
 ENV VLLM_KV_CAPI_PATH=$CARGO_TARGET_DIR/release/libdynamo_llm_capi.so
 
-##########################################
-########## Perf Analyzer Image ###########
-##########################################
-FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS perf_analyzer
-
-ARG GENAI_PERF_TAG
-
-WORKDIR /workspace
-
-# Build and install Perf Analyzer for benchmarking
-RUN apt-get update -y && apt-get -y install cmake g++ libssl-dev python3 rapidjson-dev zlib1g-dev
-RUN git clone https://github.com/triton-inference-server/perf_analyzer.git
-RUN git -C perf_analyzer checkout ${GENAI_PERF_TAG}
-RUN mkdir perf_analyzer/build
-RUN cmake -B perf_analyzer/build -S perf_analyzer -D TRITON_ENABLE_PERF_ANALYZER_OPENAI=ON
-RUN cmake --build perf_analyzer/build -- -j8
-RUN mkdir bin &&  \
-    cp -r perf_analyzer/build/perf_analyzer/src/perf-analyzer-build /workspace/bin/
-
 ########################################
 ########## Development Image ###########
 ########################################
 FROM ci_minimum AS dev
 
-ARG GENAI_PERF_TAG
-
-COPY --from=perf_analyzer /workspace/bin/perf-analyzer-build/ /perf/bin
-COPY --from=perf_analyzer /workspace/perf_analyzer /perf_analyzer
-ENV PATH="/perf/bin:${PATH}"
-
 # Install genai-perf for benchmarking
+ARG GENAI_PERF_TAG="0.0.11"
 RUN uv pip install "git+https://github.com/triton-inference-server/perf_analyzer.git@${GENAI_PERF_TAG}#subdirectory=genai-perf"
-RUN uv pip uninstall tritonclient
 
 COPY . /workspace
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Adds vllm patch + install from source for aarch64 via pytorch 2.7 + cuda 12.8 to #839 

```bash
root@gb-nvl-081-compute06:/workspace# python3
Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import vllm
WARNING 04-28 06:03:01 [__init__.py:23] Using ai_dynamo_vllm
WARNING 04-28 06:03:01 [__init__.py:23] Using ai_dynamo_vllm
WARNING 04-28 06:03:01 [__init__.py:23] Using ai_dynamo_vllm
WARNING 04-28 06:03:01 [__init__.py:23] Using ai_dynamo_vllm
WARNING 04-28 06:03:01 [__init__.py:23] Using ai_dynamo_vllm
INFO 04-28 06:03:01 [__init__.py:240] Automatically detected platform cuda.
INFO 04-28 06:03:01 [nixl.py:31] NIXL is available
>>> import torch
>>> torch.cuda.is_available()
True
```

NOTE: Building vLLM (flash attention) from source is quite slow and system memory intensive. Hopefully with the release of prebuilt wheels for pytorch2.7 supporting ARM, vLLM may be able to start publishing ARM wheels as well so we can just download+patch like we do for x86 too.