### PR TITLE
feat: add `must_remote_prefill_length` to disagg_router in llm example

### DIFF
--- a/examples/llm/components/disagg_router.py
+++ b/examples/llm/components/disagg_router.py
@@ -28,7 +28,7 @@ class PyDisaggregatedRouter:
         served_model_name,
         max_local_prefill_length=1000,
         max_prefill_queue_size=2,
-        must_remote_prefill_length=0
+        must_remote_prefill_length=0,
     ):
         self.runtime = runtime
         self.served_model_name = served_model_name
@@ -61,7 +61,10 @@ class PyDisaggregatedRouter:
             await self.etcd_kv_cache.get("must_remote_prefill_length")
         )
         absolute_prefill_length = int(prompt_length * (1 - prefix_hit_rate))
-        must_remote_prefill = must_remote_prefill_length > 0 and absolute_prefill_length > must_remote_prefill_length
+        must_remote_prefill = (
+            must_remote_prefill_length > 0
+            and absolute_prefill_length > must_remote_prefill_length
+        )
         # TODO: consider size of each request in the queue when making the decision
         decision = must_remote_prefill or (
             absolute_prefill_length > max_local_prefill_length


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
In disagg combinations such as H20 decoders and H100 prefillers, the compute ability of H100 is much stronger than H20. Therefore, even if the queue is full, user might still want long context requests to enqueue and pass to H100. A new option can give users more flexable control over this.


#### Details:

<!-- Describe the changes made in this PR. -->
added a new config  `must_remote_prefill_length` in examples/llm/components/disagg_router.py, by default it's `0`, which means disabled.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
examples/llm/components/disagg_router.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new setting to control remote prefill behavior based on a specified length threshold.
- **Improvements**
  - Enhanced logging to display the new remote prefill length setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->