### PR TITLE
feat: easier configurable namespace for llm example

### DIFF
--- a/examples/llm/components/disagg_router.py
+++ b/examples/llm/components/disagg_router.py
@@ -15,9 +15,10 @@
 
 import logging
 
+from utils.ns import get_namespace
+
 from dynamo.runtime import EtcdKvCache
 from dynamo.sdk import dynamo_context
-from utils.ns import get_namespace
 
 logger = logging.getLogger(__name__)
 

--- a/examples/llm/components/disagg_router.py
+++ b/examples/llm/components/disagg_router.py
@@ -17,6 +17,7 @@ import logging
 
 from dynamo.runtime import EtcdKvCache
 from dynamo.sdk import dynamo_context
+from utils.ns import get_namespace
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ class PyDisaggregatedRouter:
         runtime = dynamo_context["runtime"]
         self.etcd_kv_cache = await EtcdKvCache.create(
             runtime.etcd_client(),
-            "/dynamo/disagg_router/",
+            f"/{get_namespace()}/disagg_router/",
             {
                 "max_local_prefill_length": str(self.max_local_prefill_length),
                 "max_prefill_queue_size": str(self.max_prefill_queue_size),

--- a/examples/llm/components/frontend.py
+++ b/examples/llm/components/frontend.py
@@ -52,7 +52,7 @@ class FrontendConfig(BaseModel):
 @service(
     dynamo={
         "enabled": True,
-        "namespace": "dynamo",
+        "namespace": get_namespace(),
     },
     resources={"cpu": "10", "memory": "20Gi"},
     workers=1,
@@ -78,6 +78,8 @@ class Frontend:
         subprocess.run(
             [
                 "llmctl",
+                "-n",
+                get_namespace(),
                 "http",
                 "remove",
                 "chat-models",
@@ -88,6 +90,8 @@ class Frontend:
         subprocess.run(
             [
                 "llmctl",
+                "-n",
+                get_namespace(),
                 "http",
                 "add",
                 "chat-models",
@@ -103,7 +107,13 @@ class Frontend:
         http_binary = get_http_binary_path()
 
         self.process = subprocess.Popen(
-            [http_binary, "-p", str(self.frontend_config.port)],
+            [
+                http_binary,
+                "-p",
+                str(self.frontend_config.port),
+                "--namespace",
+                get_namespace(),
+            ],
             stdout=None,
             stderr=None,
         )
@@ -116,6 +126,8 @@ class Frontend:
         subprocess.run(
             [
                 "llmctl",
+                "-n",
+                get_namespace(),
                 "http",
                 "remove",
                 "chat-models",

--- a/examples/llm/components/frontend.py
+++ b/examples/llm/components/frontend.py
@@ -26,6 +26,7 @@ from dynamo import sdk
 from dynamo.sdk import async_on_shutdown, depends, service
 from dynamo.sdk.lib.config import ServiceConfig
 from dynamo.sdk.lib.image import DYNAMO_IMAGE
+from utils.ns import get_namespace
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,6 @@ class FrontendConfig(BaseModel):
     """Configuration for the Frontend service including model and HTTP server settings."""
 
     served_model_name: str
-    endpoint: str
     port: int = 8080
 
 
@@ -92,7 +92,7 @@ class Frontend:
                 "add",
                 "chat-models",
                 self.frontend_config.served_model_name,
-                self.frontend_config.endpoint,
+                f"{get_namespace()}.Processor.chat/completions",
             ],
             check=False,
         )

--- a/examples/llm/components/frontend.py
+++ b/examples/llm/components/frontend.py
@@ -21,12 +21,12 @@ from components.processor import Processor
 from components.worker import VllmWorker
 from fastapi import FastAPI
 from pydantic import BaseModel
+from utils.ns import get_namespace
 
 from dynamo import sdk
 from dynamo.sdk import async_on_shutdown, depends, service
 from dynamo.sdk.lib.config import ServiceConfig
 from dynamo.sdk.lib.image import DYNAMO_IMAGE
-from utils.ns import get_namespace
 
 logger = logging.getLogger(__name__)
 

--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -22,9 +22,9 @@ from typing import AsyncIterator
 
 from components.worker import VllmWorker
 from utils.logging import check_required_workers
+from utils.ns import get_namespace
 from utils.protocol import Tokens
 from vllm.logger import logger as vllm_logger
-from utils.ns import get_namespace
 
 from dynamo.llm import AggregatedMetrics, KvIndexer, KvMetricsAggregator, OverlapScores
 from dynamo.sdk import async_on_start, depends, dynamo_context, dynamo_endpoint, service

--- a/examples/llm/components/prefill_worker.py
+++ b/examples/llm/components/prefill_worker.py
@@ -21,6 +21,7 @@ import sys
 
 from pydantic import BaseModel
 from utils.nixl import NixlMetadataStore
+from utils.ns import get_namespace
 from utils.prefill_queue import PrefillQueue
 from utils.vllm import parse_vllm_args
 from vllm.entrypoints.openai.api_server import (
@@ -31,7 +32,6 @@ from vllm.remote_prefill import RemotePrefillParams, RemotePrefillRequest
 
 from dynamo.sdk import async_on_start, dynamo_context, dynamo_endpoint, service
 from dynamo.sdk.lib.service import LeaseConfig
-from utils.ns import get_namespace
 
 logger = logging.getLogger(__name__)
 
@@ -119,10 +119,14 @@ class PrefillWorker:
     async def prefill_queue_handler(self):
         logger.info("Prefill queue handler entered")
         prefill_queue_nats_server = os.getenv("NATS_SERVER", "nats://localhost:4222")
-        prefill_queue_stream_name = get_namespace() + '_' + (
-            self.engine_args.served_model_name
-            if self.engine_args.served_model_name is not None
-            else "vllm"
+        prefill_queue_stream_name = (
+            get_namespace()
+            + "_"
+            + (
+                self.engine_args.served_model_name
+                if self.engine_args.served_model_name is not None
+                else "vllm"
+            )
         )
         logger.info(
             f"Prefill queue: {prefill_queue_nats_server}:{prefill_queue_stream_name}"

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -29,6 +29,7 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.openai.protocol import ChatCompletionRequest, CompletionRequest
 from vllm.outputs import RequestOutput
 from vllm.transformers_utils.tokenizer import AnyTokenizer
+from utils.ns import get_namespace
 
 from dynamo.llm import KvMetricsAggregator
 from dynamo.runtime import EtcdKvCache
@@ -45,7 +46,7 @@ class RequestType(Enum):
 @service(
     dynamo={
         "enabled": True,
-        "namespace": "dynamo",
+        "namespace": get_namespace(),
     },
     resources={"cpu": "10", "memory": "20Gi"},
     workers=1,
@@ -112,7 +113,7 @@ class Processor(ProcessMixIn):
 
         self.etcd_kv_cache = await EtcdKvCache.create(
             runtime.etcd_client(),
-            "/dynamo/processor/",
+            f"/{get_namespace()}/processor/",
             {"router": self.engine_args.router},
         )
 

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -23,13 +23,13 @@ from components.worker import VllmWorker
 from transformers import AutoTokenizer
 from utils.chat_processor import ChatProcessor, CompletionsProcessor, ProcessMixIn
 from utils.logging import check_required_workers
+from utils.ns import get_namespace
 from utils.protocol import MyRequestOutput, Tokens, vLLMGenerateRequest
 from utils.vllm import RouterType, parse_vllm_args
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.openai.protocol import ChatCompletionRequest, CompletionRequest
 from vllm.outputs import RequestOutput
 from vllm.transformers_utils.tokenizer import AnyTokenizer
-from utils.ns import get_namespace
 
 from dynamo.llm import KvMetricsAggregator
 from dynamo.runtime import EtcdKvCache

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -107,7 +107,7 @@ class Processor(ProcessMixIn):
 
         await check_required_workers(self.worker_client, self.min_workers)
 
-        kv_listener = runtime.namespace("dynamo").component("VllmWorker")
+        kv_listener = runtime.namespace(get_namespace()).component("VllmWorker")
         await kv_listener.create_service()
         self.metrics_aggregator = KvMetricsAggregator(kv_listener)
 

--- a/examples/llm/components/worker.py
+++ b/examples/llm/components/worker.py
@@ -22,6 +22,7 @@ import signal
 from components.disagg_router import PyDisaggregatedRouter
 from components.prefill_worker import PrefillWorker
 from utils.nixl import NixlMetadataStore
+from utils.ns import get_namespace
 from utils.prefill_queue import PrefillQueue
 from utils.protocol import MyRequestOutput, vLLMGenerateRequest
 from utils.vllm import RouterType, parse_vllm_args
@@ -34,7 +35,6 @@ from vllm.sampling_params import RequestOutputKind
 from dynamo.llm import KvMetricsPublisher
 from dynamo.sdk import async_on_start, depends, dynamo_context, dynamo_endpoint, service
 from dynamo.sdk.lib.service import LeaseConfig
-from utils.ns import get_namespace
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ class VllmWorker:
         self._prefill_queue_nats_server = os.getenv(
             "NATS_SERVER", "nats://localhost:4222"
         )
-        self._prefill_queue_stream_name = get_namespace() + '_' + self.model_name
+        self._prefill_queue_stream_name = get_namespace() + "_" + self.model_name
         logger.info(
             f"Prefill queue: {self._prefill_queue_nats_server}:{self._prefill_queue_stream_name}"
         )

--- a/examples/llm/configs/agg.yaml
+++ b/examples/llm/configs/agg.yaml
@@ -19,7 +19,6 @@ Common:
 
 Frontend:
   served_model_name: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
-  endpoint: dynamo.Processor.chat/completions
   port: 8000
 
 Processor:

--- a/examples/llm/configs/agg_router.yaml
+++ b/examples/llm/configs/agg_router.yaml
@@ -21,7 +21,6 @@ Common:
 
 Frontend:
   served_model_name: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
-  endpoint: dynamo.Processor.chat/completions
   port: 8000
 
 Processor:

--- a/examples/llm/configs/disagg.yaml
+++ b/examples/llm/configs/disagg.yaml
@@ -20,7 +20,6 @@ Common:
 
 Frontend:
   served_model_name: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
-  endpoint: dynamo.Processor.chat/completions
   port: 8000
 
 Processor:

--- a/examples/llm/configs/disagg_router.yaml
+++ b/examples/llm/configs/disagg_router.yaml
@@ -21,7 +21,6 @@ Common:
 
 Frontend:
   served_model_name: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
-  endpoint: dynamo.Processor.chat/completions
   port: 8000
 
 Processor:

--- a/examples/llm/configs/multinode-405b.yaml
+++ b/examples/llm/configs/multinode-405b.yaml
@@ -18,7 +18,6 @@
 
 Frontend:
   served_model_name: nvidia/Llama-3.1-405B-Instruct-FP8
-  endpoint: dynamo.Processor.chat/completions
   port: 8000
 
 Processor:

--- a/examples/llm/configs/multinode_agg_r1.yaml
+++ b/examples/llm/configs/multinode_agg_r1.yaml
@@ -19,7 +19,6 @@ Common:
 
 Frontend:
   served_model_name: deepseek-ai/DeepSeek-R1
-  endpoint: dynamo.Processor.chat/completions
   port: 8000
 
 Processor:

--- a/examples/llm/configs/mutinode_disagg_r1.yaml
+++ b/examples/llm/configs/mutinode_disagg_r1.yaml
@@ -21,7 +21,6 @@ Common:
 
 Frontend:
   served_model_name: deepseek-ai/DeepSeek-R1
-  endpoint: dynamo.Processor.chat/completions
   port: 8000
 
 Processor:

--- a/examples/llm/utils/ns.py
+++ b/examples/llm/utils/ns.py
@@ -1,4 +1,5 @@
 import os
 
+
 def get_namespace():
     return os.getenv("DYN_NAMESPACE", "dynamo")

--- a/examples/llm/utils/ns.py
+++ b/examples/llm/utils/ns.py
@@ -1,3 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import os
 
 

--- a/examples/llm/utils/ns.py
+++ b/examples/llm/utils/ns.py
@@ -1,0 +1,4 @@
+import os
+
+def get_namespace():
+    return os.getenv("DYN_NAMESPACE", "dynamo")

--- a/lib/llm/src/disagg_router.rs
+++ b/lib/llm/src/disagg_router.rs
@@ -39,8 +39,7 @@ impl DisaggRouterConf {
         drt: Arc<DistributedRuntime>,
         model_name: &str,
     ) -> anyhow::Result<(Self, watch::Receiver<Self>)> {
-        let namespace = std::env::var("DYN_NAMESPACE").unwrap_or_else(|_| "dynamo".to_string());
-        let etcd_key = format!("{}/public/components/disagg_router/models/chat/{}", namespace, model_name);
+        let etcd_key = format!("public/components/disagg_router/models/chat/{}", model_name);
 
         // Get the initial value if it exists
         let Some(etcd_client) = drt.etcd_client() else {

--- a/lib/llm/src/disagg_router.rs
+++ b/lib/llm/src/disagg_router.rs
@@ -39,7 +39,8 @@ impl DisaggRouterConf {
         drt: Arc<DistributedRuntime>,
         model_name: &str,
     ) -> anyhow::Result<(Self, watch::Receiver<Self>)> {
-        let etcd_key = format!("public/components/disagg_router/models/chat/{}", model_name);
+        let namespace = std::env::var("DYN_NAMESPACE").unwrap_or_else(|_| "dynamo".to_string());
+        let etcd_key = format!("{}/public/components/disagg_router/models/chat/{}", namespace, model_name);
 
         // Get the initial value if it exists
         let Some(etcd_client) = drt.etcd_client() else {


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
As for #656 , we can add namespace to dynamo to allow multiple instances to share etcd/nats. However, currently  in llm example:
1. namespace are hardcoded in lots of place, it's not easy to use and change. 
2. nats streams has no respect to namespace

I sugguest we use a single env var to customize it. And if you guys have any better idea, please let me know. Thanks!

#### Details:

1. change all hardcoded namespace to use a env var
2. add namespace to nat stream between decode and prefill
3. remove configurable `endpoint` in frontend (since this is related to namespace, we can only read it in python)

#### Where should the reviewer start?

components/configs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic namespace support throughout the application, allowing the namespace to be set via an environment variable.
- **Improvements**
  - Replaced all hardcoded namespace strings with dynamic retrieval, ensuring consistent and flexible namespace usage.
- **Configuration**
  - Removed the need to manually specify the `endpoint` field in configuration files; endpoints are now constructed internally.
- **Bug Fixes**
  - Ensured all components consistently use the correct runtime namespace, reducing potential misconfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->