### PR TITLE
chore: bump nixl commit to 0.2.0 rc1

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -62,7 +62,7 @@ VLLM_BASE_IMAGE_TAG="25.03-cuda12.8-devel-ubuntu24.04"
 NONE_BASE_IMAGE="ubuntu"
 NONE_BASE_IMAGE_TAG="24.04"
 
-NIXL_COMMIT=3810b36b1ad0b647488e163f0f4e8dfc22ffabdf
+NIXL_COMMIT=d247e88c72db75dc00e4e37aa21ed8d99e60c27d
 NIXL_REPO=ai-dynamo/nixl.git
 
 get_options() {


### PR DESCRIPTION
#### Overview:

Bump the NIXL version to the latest release candidate

