### PR TITLE
fix: change environment variable to support local mount

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -367,7 +367,7 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
     echo "cat ~/.launch_screen" >> ~/.bashrc
 
 # Tell vllm to use the Dynamo LLM C API for KV Cache Routing
-ENV VLLM_KV_CAPI_PATH=$CARGO_TARGET_DIR/release/libdynamo_llm_capi.so
+ENV VLLM_KV_CAPI_PATH=/opt/dynamo/bindings/lib/libdynamo_llm_capi.so
 
 ##########################################
 ########## Perf Analyzer Image ###########


### PR DESCRIPTION
#### Overview:
When using the ```--mount-workspace``` argument to ```container/run.sh``` - the local workspace is mounted and the '/workspace/target' folder may be empty. 

#### Details:

Changed environment variable to point to installed version.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Found during internal release candidate testing.

- closes GitHub issue: #xxx
