### PR TITLE
fix: remove prefill worker dependency in worker.py

### DIFF
--- a/examples/llm/components/worker.py
+++ b/examples/llm/components/worker.py
@@ -31,7 +31,7 @@ from vllm.remote_prefill import RemotePrefillParams, RemotePrefillRequest
 from vllm.sampling_params import RequestOutputKind
 
 from dynamo.llm import KvMetricsPublisher
-from dynamo.sdk import async_on_start, depends, dynamo_context, dynamo_endpoint, service
+from dynamo.sdk import async_on_start, dynamo_context, dynamo_endpoint, service
 from dynamo.sdk.lib.service import LeaseConfig
 
 logger = logging.getLogger(__name__)

--- a/examples/llm/components/worker.py
+++ b/examples/llm/components/worker.py
@@ -20,7 +20,6 @@ import os
 import signal
 
 from components.disagg_router import PyDisaggregatedRouter
-from components.prefill_worker import PrefillWorker
 from utils.nixl import NixlMetadataStore
 from utils.prefill_queue import PrefillQueue
 from utils.protocol import MyRequestOutput, vLLMGenerateRequest
@@ -48,8 +47,6 @@ logger = logging.getLogger(__name__)
     workers=1,
 )
 class VllmWorker:
-    prefill_worker = depends(PrefillWorker)
-
     def __init__(self):
         self.client = None
         self.disaggregated_router: PyDisaggregatedRouter = None  # type: ignore


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

as the doc stat:

> Note that this can be easily extended to more nodes. You can also run the Frontend, Processor, and Router on a separate CPU only node if you'd like as long as all nodes have access to the NATS/ETCD endpoints!

and:

> Since we only want to start the `PrefillWorker` on node 2, you can simply run just the PrefillWorker component directly with the configuration file from before.
> `dynamo serve components.prefill_worker:PrefillWorker -f ./configs/multinode-405b.yaml`

but I found that after I started a frontend+processor+router service, and I want to start a standalone VllmWorker like this:

```
dynamo serve components.worker:VllmWorker -f ./configs/disagg_router.yaml
```

will result in both decode and prefill worker are started, which is unexpected (I want to start VllmWorker only, and PrefillWorker will be started on another node). I have to remove the `PrefillWorker` dependency to make this work.

#### Details:

<!-- Describe the changes made in this PR. -->
remove the PrefillWorker dependency in worker.py.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
