### PR TITLE
chore: add fastapi depenedncy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "types-psutil==7.0.0.20250218",
     "kubernetes==32.0.1",
     "ai-dynamo-runtime==0.2.0",
+    "fastapi==0.115.6",
     "distro",
     "typer",
     "circus>=0.17.0",


### PR DESCRIPTION
#### Overview:

add fastapi depenedncy in pyproject.toml

Dynamo depends on fastapi for spinning up python based http service


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
