### PR TITLE
docs: update pythonpath for starting planner

### DIFF
--- a/components/planner/README.md
+++ b/components/planner/README.md
@@ -24,7 +24,7 @@ The planner is a component that monitors the state of the system and makes adjus
 After you've deployed a dynamo graph, you can start the planner with the following command:
 
 ```bash
-python components/planner.py --namespace <namespace>
+PYTHONPATH=/workspace/examples/llm python components/planner.py --namespace <namespace>
 ```
 
 ## Backends

--- a/docs/guides/planner_benchmark/benchmark_planner.md
+++ b/docs/guides/planner_benchmark/benchmark_planner.md
@@ -51,7 +51,7 @@ cd examples/llm
 dynamo serve graphs.disagg:Frontend -f <path to disagg_1p1d.yml in this folder> --enable-local-planner
 
 # in terminal 2
-python components/planner.py \
+PYTHONPATH=/workspace/examples/llm python components/planner.py \
     --metric-pulling-interval 1 \
     --adjustment-interval 10 \
     --prefill-queue-scale-down-threshold 0.2 \
@@ -95,7 +95,7 @@ In this example, we use a fixed 2p2d engine as baseline. Planner provides a `--n
 dynamo serve --enable-local-planner graphs.disagg:Frontend -f disagg_2p2d.yml
 
 # in terminal 2 (optional)
-python components/planner.py --no-operation --log-dir log/2p2d
+PYTHONPATH=/workspace/examples/llm python components/planner.py --no-operation --log-dir log/2p2d
 
 # in terminal 3
 genai-perf profile --tokenizer deepseek-ai/DeepSeek-R1-Distill-Llama-8B -m deepseek-ai/DeepSeek-R1-Distill-Llama-8B --service-kind openai --endpoint-type chat --url http://localhost:8000 --streaming --input-file payload:sin_b512_t600_rr5.0-20.0-150.0_io3000150-3000150-0.2-0.8-10.jsonl

--- a/docs/planner.md
+++ b/docs/planner.md
@@ -51,7 +51,7 @@ There are two additional rules set by planner to prevent over-compensation:
 ## Usage
 After you've deployed a dynamo graph - you can start the planner with the following command:
 ```bash
-python components/planner.py <arguments>
+PYTHONPATH=/workspace/examples/llm python components/planner.py <arguments>
 ```
 
 Planner takes the following arguments:


### PR DESCRIPTION
need to specify the correct `PYTHONPATH` when starting planner