### PR TITLE
fix: add fastapi depenedncy in pyproject.toml cherry-pick of #888

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "types-psutil==7.0.0.20250218",
     "kubernetes==32.0.1",
     "ai-dynamo-runtime==0.2.0",
+    "fastapi==0.115.6",
     "distro",
     "typer",
     "circus>=0.17.0",


### PR DESCRIPTION
#### Overview:

When `uv pip install ai-dynamo` without the explicit `[all]` we get 
```
dynamo --help
Traceback (most recent call last):
  File "/py312/bin/dynamo", line 4, in <module>
    from dynamo.sdk.cli.cli import cli
  File "/py312/lib/python3.12/site-packages/dynamo/sdk/__init__.py", line 22, in <module>
    from dynamo.sdk.lib.dependency import depends
  File "/py312/lib/python3.12/site-packages/dynamo/sdk/lib/dependency.py", line 25, in <module>
    from dynamo.sdk.lib.service import DynamoService
  File "/py312/lib/python3.12/site-packages/dynamo/sdk/lib/service.py", line 28, in <module>
    from fastapi import FastAPI
ModuleNotFoundError: No module named 'fastapi'
```

This adds the `fastapi` dependency explicitly.