### PR TITLE
feat: label component CR for planner

### DIFF
--- a/deploy/dynamo/operator/internal/consts/consts.go
+++ b/deploy/dynamo/operator/internal/consts/consts.go
@@ -45,6 +45,7 @@ const (
 	KubeLabelDynamoSelector = "nvidia.com/selector"
 
 	KubeLabelDynamoComponent            = "nvidia.com/dynamo-component"
+	KubeLabelDynamoNamespace            = "nvidia.com/dynamo-namespace"
 	KubeLabelDynamoDeploymentTargetType = "nvidia.com/dynamo-deployment-target-type"
 
 	KubeLabelDynamoComponentType = "nvidia.com/dynamo-component-type"

--- a/deploy/dynamo/operator/internal/dynamo/graph.go
+++ b/deploy/dynamo/operator/internal/dynamo/graph.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/dynamo/operator/api/dynamo/schemas"
 	"github.com/ai-dynamo/dynamo/deploy/dynamo/operator/api/v1alpha1"
 	commonconfig "github.com/ai-dynamo/dynamo/deploy/dynamo/operator/internal/config"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/dynamo/operator/internal/consts"
 	"github.com/huandu/xstrings"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -234,6 +235,10 @@ func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphD
 		deployment.Spec.DynamoTag = config.DynamoTag
 		deployment.Spec.DynamoComponent = parentDynamoGraphDeployment.Spec.DynamoGraph
 		deployment.Spec.ServiceName = service.Name
+		labels := make(map[string]string)
+		deployment.Spec.Labels = labels
+		deployment.Labels = labels
+		labels[commonconsts.KubeLabelDynamoComponent] = service.Name
 		if service.Config.Dynamo != nil && service.Config.Dynamo.Enabled {
 			dynamoNamespace := service.Config.Dynamo.Namespace
 			if dynamoNamespace == "" {
@@ -242,6 +247,7 @@ func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphD
 			}
 			deployment.Spec.DynamoNamespace = &dynamoNamespace
 			dynamoServices[service.Name] = fmt.Sprintf("%s/%s", service.Config.Dynamo.Name, dynamoNamespace)
+			labels[commonconsts.KubeLabelDynamoNamespace] = dynamoNamespace
 		} else {
 			// dynamo is not enabled
 			if config.EntryService == service.Name {

--- a/deploy/dynamo/operator/internal/dynamo/graph.go
+++ b/deploy/dynamo/operator/internal/dynamo/graph.go
@@ -236,7 +236,9 @@ func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphD
 		deployment.Spec.DynamoComponent = parentDynamoGraphDeployment.Spec.DynamoGraph
 		deployment.Spec.ServiceName = service.Name
 		labels := make(map[string]string)
+		// add the labels in the spec in order to label all sub-resources
 		deployment.Spec.Labels = labels
+		// and add the labels to the deployment itself
 		deployment.Labels = labels
 		labels[commonconsts.KubeLabelDynamoComponent] = service.Name
 		if service.Config.Dynamo != nil && service.Config.Dynamo.Enabled {

--- a/deploy/dynamo/operator/internal/dynamo/graph_test.go
+++ b/deploy/dynamo/operator/internal/dynamo/graph_test.go
@@ -23,6 +23,7 @@ import (
 
 	compounaiCommon "github.com/ai-dynamo/dynamo/deploy/dynamo/operator/api/dynamo/common"
 	"github.com/ai-dynamo/dynamo/deploy/dynamo/operator/api/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/dynamo/operator/internal/consts"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -93,6 +94,10 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-dynamographdeployment-service1",
 						Namespace: "default",
+						Labels: map[string]string{
+							commonconsts.KubeLabelDynamoComponent: "service1",
+							commonconsts.KubeLabelDynamoNamespace: "default",
+						},
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
 						DynamoComponent: "dynamocomponent:ac4e234",
@@ -125,6 +130,10 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 									DeploymentSelectorValue: "service2",
 								},
 							},
+							Labels: map[string]string{
+								commonconsts.KubeLabelDynamoComponent: "service1",
+								commonconsts.KubeLabelDynamoNamespace: "default",
+							},
 						},
 					},
 				},
@@ -132,6 +141,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-dynamographdeployment-service2",
 						Namespace: "default",
+						Labels: map[string]string{
+							commonconsts.KubeLabelDynamoComponent: "service2",
+						},
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
 						DynamoComponent: "dynamocomponent:ac4e234",
@@ -140,6 +152,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 							ServiceName: "service2",
 							Autoscaling: &v1alpha1.Autoscaling{
 								Enabled: false,
+							},
+							Labels: map[string]string{
+								commonconsts.KubeLabelDynamoComponent: "service2",
 							},
 						},
 					},
@@ -202,6 +217,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-dynamographdeployment-service1",
 						Namespace: "default",
+						Labels: map[string]string{
+							commonconsts.KubeLabelDynamoComponent: "service1",
+						},
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
 						DynamoComponent: "dynamocomponent:ac4e234",
@@ -237,6 +255,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 								Enabled: true,
 								Host:    "test-dynamographdeployment",
 							},
+							Labels: map[string]string{
+								commonconsts.KubeLabelDynamoComponent: "service1",
+							},
 						},
 					},
 				},
@@ -244,6 +265,10 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-dynamographdeployment-service2",
 						Namespace: "default",
+						Labels: map[string]string{
+							commonconsts.KubeLabelDynamoComponent: "service2",
+							commonconsts.KubeLabelDynamoNamespace: "default",
+						},
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
 						DynamoComponent: "dynamocomponent:ac4e234",
@@ -253,6 +278,10 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 							DynamoNamespace: &[]string{"default"}[0],
 							Autoscaling: &v1alpha1.Autoscaling{
 								Enabled: false,
+							},
+							Labels: map[string]string{
+								commonconsts.KubeLabelDynamoComponent: "service2",
+								commonconsts.KubeLabelDynamoNamespace: "default",
 							},
 						},
 					},
@@ -311,6 +340,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-dynamographdeployment-service1",
 						Namespace: "default",
+						Labels: map[string]string{
+							commonconsts.KubeLabelDynamoComponent: "service1",
+						},
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
 						DynamoComponent: "dynamocomponent:ac4e234",
@@ -343,6 +375,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 								},
 							},
 							Ingress: v1alpha1.IngressSpec{},
+							Labels: map[string]string{
+								commonconsts.KubeLabelDynamoComponent: "service1",
+							},
 						},
 					},
 				},
@@ -350,6 +385,10 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-dynamographdeployment-service2",
 						Namespace: "default",
+						Labels: map[string]string{
+							commonconsts.KubeLabelDynamoComponent: "service2",
+							commonconsts.KubeLabelDynamoNamespace: "dynamo-test-dynamographdeployment",
+						},
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
 						DynamoComponent: "dynamocomponent:ac4e234",
@@ -360,6 +399,10 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 								Enabled: false,
 							},
 							DynamoNamespace: &[]string{"dynamo-test-dynamographdeployment"}[0],
+							Labels: map[string]string{
+								commonconsts.KubeLabelDynamoComponent: "service2",
+								commonconsts.KubeLabelDynamoNamespace: "dynamo-test-dynamographdeployment",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
#### Overview:

 label component CR for planner

#### Details:

for planner to be able to retrieve Custom Resources associated with a dynamo graph, these resources need to be labelled

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #900 
