### PR TITLE
feat: Make verbose flag work with in and out flags and anywhere in the command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,6 +1681,7 @@ dependencies = [
  "hf-hub",
  "humantime",
  "netlink-packet-route",
+ "regex",
  "rtnetlink",
  "serde",
  "serde_json",

--- a/launch/dynamo-run/Cargo.toml
+++ b/launch/dynamo-run/Cargo.toml
@@ -66,6 +66,7 @@ async-openai = { version = "0.27.2" }
 clap = { version = "4.5", features = ["derive", "env"] }
 dialoguer = { version = "0.11", default-features = false, features = ["editor", "history"] }
 futures-util = { version = "0.3" }
+regex = { version = "1.11.1" }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 netlink-packet-route = { version = "0.19", optional = true }

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use regex::Regex;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
-use regex::Regex;
 
 use clap::ValueEnum;
 use dynamo_runtime::pipeline::RouterMode as RuntimeRouterMode;
@@ -209,7 +209,7 @@ impl Flags {
 
         // Regex to match exactly -v, -vv, -vvv, etc.
         let valid_verbosity_flag = Regex::new(r"^-v+$").map_err(|e| e.to_string())?;
-        
+
         // Regex to detect if an argument consists only of '-' and 'v' characters
         // but doesn't match the valid pattern
         let invalid_verbosity_pattern = Regex::new(r"^[-v]+$").map_err(|e| e.to_string())?;
@@ -223,7 +223,10 @@ impl Flags {
             } else if invalid_verbosity_pattern.is_match(arg) && arg.contains('v') {
                 // Argument consists only of '-' and 'v' characters but doesn't match the valid pattern
                 // Also ensure it contains at least one 'v' to avoid matching just dashes
-                return Err(format!("Invalid verbosity flag format: '{}'. Use -v, -vv, etc.", arg));
+                return Err(format!(
+                    "Invalid verbosity flag format: '{}'. Use -v, -vv, etc.",
+                    arg
+                ));
             }
         }
 


### PR DESCRIPTION
#### Overview:
This change allows the verbosity flag (-v, -vv) to work:
1. Anywhere in the command (not just at specific positions)
2. Alongside in/out flags without interference

