### PR TITLE
chore: reduce code repetition in processor

### DIFF
--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -114,7 +114,8 @@ class Router:
 
         kv_listener = self.runtime.namespace("dynamo").component("VllmWorker")
         await kv_listener.create_service()
-        self.indexer = KvIndexer(kv_listener, self.args.block_size)
+        if self.router_type == RouterType.KV:
+            self.indexer = KvIndexer(kv_listener, self.args.block_size)
         self.metrics_aggregator = KvMetricsAggregator(kv_listener)
         logger.info("KV Router initialized")
 

--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -233,7 +233,15 @@ class Router:
             logger.warning(f"All KV loads are zero. {fallback_msg}")
             return "", 0.0
 
-        best_worker_id = min(kv_load.keys(), key=lambda k: kv_load[k])
+        min_load = min(kv_load.values())
+        min_load_workers = [
+            worker_id for worker_id, load in kv_load.items() if load == min_load
+        ]
+        best_worker_id = random.choice(min_load_workers)
+
+        logger.info(
+            f"Selected worker: {best_worker_id}, KV load: {kv_load[best_worker_id]:.3f}"
+        )
         return best_worker_id, kv_load[best_worker_id]
 
     @dynamo_endpoint()

--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -224,6 +224,10 @@ class Router:
         return best_worker_id, worker_scores.get(best_worker_id, 0.0)
 
     def _get_underloaded_worker(self, metrics: AggregatedMetrics | None):
+        if not metrics:
+            logger.warning(f"Cannot get metrics. {fallback_msg}")
+            return "", 0.0  
+
         kv_load = {
             endpoint.worker_id: getattr(endpoint, "gpu_cache_usage_perc", 0.0)
             for endpoint in metrics.endpoints
@@ -253,7 +257,7 @@ class Router:
             try:
                 yield self._get_underloaded_worker(metrics)
             except Exception as e:
-                logger.exception(f"Error getting metrics: {e}. {fallback_msg}")
+                logger.exception(f"Error finding underloaded worker: {e}. {fallback_msg}")
                 yield "", 0.0
             return
 

--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -226,7 +226,7 @@ class Router:
     def _get_underloaded_worker(self, metrics: AggregatedMetrics | None):
         if not metrics:
             logger.warning(f"Cannot get metrics. {fallback_msg}")
-            return "", 0.0  
+            return "", 0.0
 
         kv_load = {
             endpoint.worker_id: getattr(endpoint, "gpu_cache_usage_perc", 0.0)
@@ -257,7 +257,9 @@ class Router:
             try:
                 yield self._get_underloaded_worker(metrics)
             except Exception as e:
-                logger.exception(f"Error finding underloaded worker: {e}. {fallback_msg}")
+                logger.exception(
+                    f"Error finding underloaded worker: {e}. {fallback_msg}"
+                )
                 yield "", 0.0
             return
 

--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -232,13 +232,15 @@ class Router:
                     for endpoint in metrics.endpoints
                 }
 
-                if kv_load:
-                    best_worker_id = min(kv_load, key=kv_load.get)
-                    logger.info(
-                        f"KV_LOAD routing to worker {best_worker_id} (kv load: {kv_load})"
-                    )
-                    yield f"{best_worker_id}_0.0"
-                    return
+                if not kv_load:
+                    raise ValueError("No workers found for KV_LOAD routing")
+                
+                best_worker_id = min(kv_load.keys(), key=lambda k: kv_load[k])
+                logger.info(
+                    f"KV_LOAD routing to worker {best_worker_id} (kv load: {kv_load})"
+                )
+                yield f"{best_worker_id}_0.0"
+                return
             except Exception as e:
                 logger.info(
                     f"Error finding worker with least kv load: {e}, fallback to KV routing"

--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -242,7 +242,7 @@ class Router:
                 yield f"{best_worker_id}_0.0"
                 return
             except Exception as e:
-                logger.info(
+                logger.exception(
                     f"Error finding worker with least kv load: {e}, fallback to KV routing"
                 )
 

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -142,9 +142,6 @@ class Processor(ProcessMixIn):
             decision = await router_generator.__anext__()
             worker_id, prefix_hit_rate = decision.data()
             prefix_hit_rate = float(prefix_hit_rate)
-            logger.info(
-                f"Worker ID: {worker_id} with estimated prefix hit rate: {prefix_hit_rate}"
-            )
 
         # Create request object once with default prefix_hit_rate
         request_obj = vLLMGenerateRequest(

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -140,8 +140,7 @@ class Processor(ProcessMixIn):
                 Tokens(tokens=engine_prompt["prompt_token_ids"]).model_dump_json()
             )
             decision = await router_generator.__anext__()
-            decision = decision.data()
-            worker_id, prefix_hit_rate = decision.split("_")
+            worker_id, prefix_hit_rate = decision.data()
             prefix_hit_rate = float(prefix_hit_rate)
             logger.info(
                 f"Worker ID: {worker_id} with estimated prefix hit rate: {prefix_hit_rate}"

--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -95,7 +95,8 @@ class Processor(ProcessMixIn):
             .client()
         )
 
-        if self.engine_args.router == RouterType.KV:
+        self.use_router = self.engine_args.router in (RouterType.KV, RouterType.KV_LOAD)
+        if self.use_router:
             router_ns, router_name = Router.dynamo_address()  # type: ignore
             self.router_client = (
                 await runtime.namespace(router_ns)
@@ -116,22 +117,6 @@ class Processor(ProcessMixIn):
             {"router": self.engine_args.router},
         )
 
-    async def _get_kv_load(self):
-        metrics = await self.metrics_aggregator.get_metrics()
-        kv_load = {}
-        for endpoint in metrics.endpoints:
-            worker_id = endpoint.worker_id
-            kv_load[worker_id] = getattr(endpoint, "gpu_cache_usage_perc", 0.0)
-        return kv_load
-
-    async def _get_pending_requests(self):
-        metrics = await self.metrics_aggregator.get_metrics()
-        pending_requests = {}
-        for endpoint in metrics.endpoints:
-            worker_id = endpoint.worker_id
-            pending_requests[worker_id] = getattr(endpoint, "num_requests_waiting", 0)
-        return pending_requests
-
     async def _generate(
         self,
         raw_request: Union[CompletionRequest, ChatCompletionRequest],
@@ -146,9 +131,11 @@ class Processor(ProcessMixIn):
             engine_prompt,
             sampling_params,
         ) = await self._parse_raw_request(raw_request)
-        # TODO: queue request at processor when engines are full
+
         router_mode = (await self.etcd_kv_cache.get("router")).decode()
-        if router_mode == RouterType.KV:
+        prefix_hit_rate = 0.0
+
+        if self.use_router:
             router_generator = await self.router_client.generate(
                 Tokens(tokens=engine_prompt["prompt_token_ids"]).model_dump_json()
             )
@@ -160,67 +147,26 @@ class Processor(ProcessMixIn):
                 f"Worker ID: {worker_id} with estimated prefix hit rate: {prefix_hit_rate}"
             )
 
+        # Create request object once with default prefix_hit_rate
+        request_obj = vLLMGenerateRequest(
+            engine_prompt=engine_prompt,
+            sampling_params=sampling_params,
+            request_id=request_id,
+            prefix_hit_rate=prefix_hit_rate,
+        ).model_dump_json()
+
+        if self.use_router:
             if worker_id == "":
-                engine_generator = await self.worker_client.generate(
-                    vLLMGenerateRequest(
-                        engine_prompt=engine_prompt,
-                        sampling_params=sampling_params,
-                        request_id=request_id,
-                        prefix_hit_rate=prefix_hit_rate,
-                    ).model_dump_json()
-                )
+                engine_generator = await self.worker_client.generate(request_obj)
             else:
                 engine_generator = await self.worker_client.direct(
-                    vLLMGenerateRequest(
-                        engine_prompt=engine_prompt,
-                        sampling_params=sampling_params,
-                        request_id=request_id,
-                        prefix_hit_rate=prefix_hit_rate,
-                    ).model_dump_json(),
-                    int(worker_id),
+                    request_obj, int(worker_id)
                 )
         elif router_mode == RouterType.RANDOM:
-            engine_generator = await self.worker_client.generate(
-                vLLMGenerateRequest(
-                    engine_prompt=engine_prompt,
-                    sampling_params=sampling_params,
-                    request_id=request_id,
-                ).model_dump_json()
-            )
+            engine_generator = await self.worker_client.generate(request_obj)
         elif router_mode == RouterType.ROUND_ROBIN:
-            engine_generator = await self.worker_client.round_robin(
-                vLLMGenerateRequest(
-                    engine_prompt=engine_prompt,
-                    sampling_params=sampling_params,
-                    request_id=request_id,
-                ).model_dump_json()
-            )
-        elif router_mode == RouterType.KV_LOAD:
-            # route to worker with least kv load
-            # TODO: move the router to a separate file and clean up processor.py
-            try:
-                kv_load = await self._get_kv_load()
-                best_worker_id = min(kv_load, key=kv_load.get)
-                logger.info(f"Routing to worker {best_worker_id} (kv load: {kv_load})")
-                engine_generator = await self.worker_client.direct(
-                    vLLMGenerateRequest(
-                        engine_prompt=engine_prompt,
-                        sampling_params=sampling_params,
-                        request_id=request_id,
-                    ).model_dump_json(),
-                    int(best_worker_id),
-                )
-            except Exception as e:
-                logger.info(
-                    f"Error finding worker with least kv load: {e}, fallback to random"
-                )
-                engine_generator = await self.worker_client.generate(
-                    vLLMGenerateRequest(
-                        engine_prompt=engine_prompt,
-                        sampling_params=sampling_params,
-                        request_id=request_id,
-                    ).model_dump_json()
-                )
+            engine_generator = await self.worker_client.round_robin(request_obj)
+
         output = self._generate_responses(engine_generator, request_type)
 
         async for response in await self._stream_response(

--- a/examples/llm/configs/agg_router.yaml
+++ b/examples/llm/configs/agg_router.yaml
@@ -29,7 +29,7 @@ Processor:
 
 Router:
   min-workers: 1
-  common-configs: [model]
+  common-configs: [model, router]
 
 VllmWorker:
   enforce-eager: true

--- a/examples/llm/configs/disagg_router.yaml
+++ b/examples/llm/configs/disagg_router.yaml
@@ -29,7 +29,7 @@ Processor:
 
 Router:
   min-workers: 1
-  common-configs: [model]
+  common-configs: [model, router]
 
 VllmWorker:
   max-num-batched-tokens: 16384


### PR DESCRIPTION
#### Overview:

1. Move KV_LOAD router logic into kv_router.py (routing based only on kv load)
2. reduce code repetition in processor.py, by generating the vllm request object once, and shared by all routing modes