### PR TITLE
fix: use primary lease for NixlMetadataStore

### DIFF
--- a/examples/llm/utils/nixl.py
+++ b/examples/llm/utils/nixl.py
@@ -79,7 +79,7 @@ class NixlMetadataStore:
                 key, serialized_metadata, self._client.primary_lease_id()
             )
         except Exception as e:
-            logger.warning(f"Error saving metadata for engine {engine_id}: {e}")
+            logger.warning(f"A different metadata exists for engine {engine_id}: {e}")
         self._stored.add(engine_id)
 
     async def get(self, engine_id) -> NixlMetadata:

--- a/examples/llm/utils/nixl.py
+++ b/examples/llm/utils/nixl.py
@@ -75,7 +75,7 @@ class NixlMetadataStore:
         key = "/".join([self._key_prefix, engine_id])
         # create with primary lease so that the kv entry will be deleted when the worker shutdowns
         try:
-            await self._client.kv_create(
+            await self._client.kv_create_or_validate(
                 key, serialized_metadata, self._client.primary_lease_id()
             )
         except Exception as e:

--- a/examples/llm/utils/nixl.py
+++ b/examples/llm/utils/nixl.py
@@ -74,9 +74,12 @@ class NixlMetadataStore:
         serialized_metadata = msgspec.msgpack.encode(metadata)
         key = "/".join([self._key_prefix, engine_id])
         # put with primary lease so that the kv entry will be deleted when the worker shutdowns
-        await self._client.kv_put(
-            key, serialized_metadata, self._client.primary_lease_id()
-        )
+        try:
+            await self._client.kv_create(
+                key, serialized_metadata, self._client.primary_lease_id()
+            )
+        except Exception as e:
+            logger.warning(f"Error saving metadata for engine {engine_id}: {e}")
         self._stored.add(engine_id)
 
     async def get(self, engine_id) -> NixlMetadata:

--- a/examples/llm/utils/nixl.py
+++ b/examples/llm/utils/nixl.py
@@ -75,6 +75,7 @@ class NixlMetadataStore:
         key = "/".join([self._key_prefix, engine_id])
         # create with primary lease so that the kv entry will be deleted when the worker shutdowns
         try:
+            # TODO: should we create a series of function in etcd client to use primary lease?
             await self._client.kv_create_or_validate(
                 key, serialized_metadata, self._client.primary_lease_id()
             )

--- a/examples/llm/utils/nixl.py
+++ b/examples/llm/utils/nixl.py
@@ -73,7 +73,7 @@ class NixlMetadataStore:
     async def put(self, engine_id, metadata: NixlMetadata):
         serialized_metadata = msgspec.msgpack.encode(metadata)
         key = "/".join([self._key_prefix, engine_id])
-        # put with primary lease so that the kv entry will be deleted when the worker shutdowns
+        # create with primary lease so that the kv entry will be deleted when the worker shutdowns
         try:
             await self._client.kv_create(
                 key, serialized_metadata, self._client.primary_lease_id()

--- a/lib/bindings/python/examples/hello_world/server.py
+++ b/lib/bindings/python/examples/hello_world/server.py
@@ -34,6 +34,9 @@ class RequestHandler:
 
 @dynamo_worker(static=False)
 async def worker(runtime: DistributedRuntime):
+    print(
+        f"Primary lease ID: {runtime.etcd_client().primary_lease_id()}/{runtime.etcd_client().primary_lease_id():#x}"
+    )
     await init(runtime, "dynamo")
 
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -482,6 +482,24 @@ impl Namespace {
 #[pymethods]
 impl EtcdClient {
     #[pyo3(signature = (key, value, lease_id=None))]
+    fn kv_create<'p>(
+        &self,
+        py: Python<'p>,
+        key: String,
+        value: Vec<u8>,
+        lease_id: Option<i64>,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let client = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client
+                .kv_create(key, value, lease_id)
+                .await
+                .map_err(to_pyerr)?;
+            Ok(())
+        })
+    }
+
+    #[pyo3(signature = (key, value, lease_id=None))]
     fn kv_create_or_validate<'p>(
         &self,
         py: Python<'p>,

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -499,6 +499,10 @@ impl EtcdClient {
         })
     }
 
+    fn primary_lease_id(&self) -> i64 {
+        self.inner.lease_id()
+    }
+
     #[pyo3(signature = (key, value, lease_id=None))]
     fn kv_put<'p>(
         &self,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -79,9 +79,17 @@ class EtcdClient:
     Etcd is used for discovery in the DistributedRuntime
     """
 
-    async def primary_lease_id(self) -> int:
+    def primary_lease_id(self) -> int:
         """
         return the primary lease id.
+        """
+        ...
+
+    async def kv_create(
+        self, key: str, value: bytes, lease_id: Optional[int] = None
+    ) -> None:
+        """
+        Atomically create a key in etcd, fail if the key already exists.
         """
         ...
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -79,6 +79,12 @@ class EtcdClient:
     Etcd is used for discovery in the DistributedRuntime
     """
 
+    async def primary_lease_id(self) -> int:
+        """
+        return the primary lease id.
+        """
+        ...
+
     async def kv_create_or_validate(
         self, key: str, value: bytes, lease_id: Optional[int] = None
     ) -> None:


### PR DESCRIPTION
fix 
> NixlMetadataStorage: use primary lease of DRT since it's lifecycle is the same as the worker process.

in
https://github.com/ai-dynamo/dynamo/issues/918