### PR TITLE
docs: add fix for Zsh globbing error with `pip install .[all]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -yq python3-dev python3-pip pytho
 python3 -m venv venv
 source venv/bin/activate
 
-pip install ai-dynamo[all]
+pip install "ai-dynamo[all]"
 ```
 > [!NOTE]
 > To ensure compatibility, please refer to the examples in the release branch or tag that matches the version you installed.
@@ -177,7 +177,7 @@ cd lib/bindings/python
 pip install .
 
 cd ../../../
-pip install .[all]
+pip install ".[all]"
 
 # To test
 docker compose -f deploy/docker-compose.yml up -d

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -24,7 +24,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -yq python3-dev python3-pip pytho
 python3 -m venv venv
 source venv/bin/activate
 
-pip install ai-dynamo[all]
+pip install "ai-dynamo[all]"
 ```
 
 ## Dynamo workflow


### PR DESCRIPTION
#### Overview:

This PR updates the README.md to address the common error zsh: no matches found: .[all] when running pip install .[all] in Zsh.

#### Details:

Before this pr: `zsh: no matches found: .[all]`.
Added explanations for why Zsh fails (square brackets interpreted as globbing). Recommended ".[all]" as the most portable fix.

#### Where should the reviewer start?

Verified commands work in both Zsh and Bash.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
