### PR TITLE
fix: set default max_tokens for tensorrtllm on dynamo

### DIFF
--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -156,6 +156,13 @@ class Processor(ChatProcessorMixin):
                     raise ValueError(
                         "max_tokens and max_completion_tokens must be the same"
                     )
+
+        # max_tokens is required for TRTLLM sampling params
+        if raw_request.max_completion_tokens is None:
+            if raw_request.max_tokens is None:
+                raw_request.max_tokens = 20
+                raw_request.max_completion_tokens = raw_request.max_tokens
+
         async for response in self._generate(raw_request, RequestType.CHAT):
             yield response
 


### PR DESCRIPTION
#### Overview:

max_tokens is a required param for TRTLLM:
```
[TensorRT-LLM][ERROR] Assertion failed: missing required argument max_tokens 
```
Some tools like llm-benchmarks will send inference requests without max_tokens, it expect the openai frontend to set a default value for max_tokens, which is true for vLLM.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of chat generation parameters to ensure default values are set for maximum tokens when not specified, resulting in more reliable chat completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->