### PR TITLE
ci: lock cuda at 12.8

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -75,18 +75,18 @@ rust-base:
     RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb && \
         apt install -y ./cuda-keyring_1.1-1_all.deb && \
         apt update && \
-        apt install -y cuda-toolkit nvidia-utils-535 nvidia-driver-535 && \
+        apt install -y cuda-toolkit-12-8 nvidia-utils-535 nvidia-driver-535 && \
         rm cuda-keyring_1.1-1_all.deb
 
     # Set CUDA compute capability explicitly
     ENV CUDA_COMPUTE_CAP=80
 
-    ENV CUDA_HOME=/usr/local/cuda
-    ENV CUDA_ROOT=/usr/local/cuda
-    ENV CUDA_PATH=/usr/local/cuda
-    ENV CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda
-    ENV PATH=$CUDA_HOME/bin:$PATH
-    ENV LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
+    ENV CUDA_HOME=/usr/local/cuda-12.8
+    ENV CUDA_ROOT=/usr/local/cuda-12.8
+    ENV CUDA_PATH=/usr/local/cuda-12.8
+    ENV CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-12.8
+    ENV PATH=/usr/local/cuda-12.8/bin:$PATH
+    ENV LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:$LD_LIBRARY_PATH
 
     ENV RUSTUP_HOME=/usr/local/rustup
     ENV CARGO_HOME=/usr/local/cargo


### PR DESCRIPTION
#### Overview:

To fix CI: lock cuda version for dynamo base docker to be cuda 12.8

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
