### PR TITLE
chore: Two-line copyright check

### DIFF
--- a/.github/workflows/copyright-check.ps1
+++ b/.github/workflows/copyright-check.ps1
@@ -31,15 +31,6 @@ $global:copyright_matchers = @(
     matches = @(
       '# SPDX-FileCopyrightText: Copyright (c) ' + $date_key + ' NVIDIA CORPORATION & AFFILIATES. All rights reserved.'
       '# SPDX-License-Identifier: Apache-2.0'
-      '# Licensed under the Apache License, Version 2.0 (the "License");'
-      '# you may not use this file except in compliance with the License.'
-      '# You may obtain a copy of the License at'
-      '# http://www.apache.org/licenses/LICENSE-2.0'
-      '# Unless required by applicable law or agreed to in writing, software'
-      '# distributed under the License is distributed on an "AS IS" BASIS,'
-      '# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.'
-      '# See the License for the specific language governing permissions and'
-      '# limitations under the License.'
     )
     name = 'basic'
     regex = $null
@@ -52,16 +43,6 @@ $global:copyright_matchers = @(
       '"copyright": ['
       '  "SPDX-FileCopyrightText: Copyright (c) ' + $date_key + ' NVIDIA CORPORATION & AFFILIATES. All rights reserved.",'
       '  "SPDX-License-Identifier: Apache-2.0",'
-      '  "Licensed under the Apache License, Version 2.0 (the \"License\");",'
-      '  "you may not use this file except in compliance with the License.",'
-      '  "You may obtain a copy of the License at",'
-      '  "http://www.apache.org/licenses/LICENSE-2.0",'
-      '  "Unless required by applicable law or agreed to in writing, software",'
-      '  "distributed under the License is distributed on an \"AS IS\" BASIS,",'
-      '  "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",'
-      '  "See the License for the specific language governing permissions and",'
-      '  "limitations under the License."'
-      '],'
     )
     name = 'json'
     regex = $null
@@ -74,16 +55,6 @@ $global:copyright_matchers = @(
       '<!--'
       'SPDX-FileCopyrightText: Copyright (c) ' + $date_key + ' NVIDIA CORPORATION & AFFILIATES. All rights reserved.'
       'SPDX-License-Identifier: Apache-2.0'
-      'Licensed under the Apache License, Version 2.0 (the "License");'
-      'you may not use this file except in compliance with the License.'
-      'You may obtain a copy of the License at'
-      'http://www.apache.org/licenses/LICENSE-2.0'
-      'Unless required by applicable law or agreed to in writing, software'
-      'distributed under the License is distributed on an "AS IS" BASIS,'
-      'WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.'
-      'See the License for the specific language governing permissions and'
-      'limitations under the License.'
-      '-->'
     )
     name = 'markdown'
     regex = $null
@@ -95,15 +66,6 @@ $global:copyright_matchers = @(
     matches = @(
       '// SPDX-FileCopyrightText: Copyright (c) ' + $date_key + ' NVIDIA CORPORATION & AFFILIATES. All rights reserved.'
       '// SPDX-License-Identifier: Apache-2.0'
-      '// Licensed under the Apache License, Version 2.0 (the "License");'
-      '// you may not use this file except in compliance with the License.'
-      '// You may obtain a copy of the License at'
-      '// http://www.apache.org/licenses/LICENSE-2.0'
-      '// Unless required by applicable law or agreed to in writing, software'
-      '// distributed under the License is distributed on an "AS IS" BASIS,'
-      '// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.'
-      '// See the License for the specific language governing permissions and'
-      '// limitations under the License.'
     )
     name = 'c-like'
     regex = $null


### PR DESCRIPTION
Approved by OSRB in Slack.

Note we don't check for the closing delimiter to allow the longer copyright format.

Motivation is that it reduces the context usage by 12 lines for every file in the project. That helps things like Cursor and Claude Code fit more, go faster, and cost less.

