### PR TITLE
fix: increase ulimit nofile for container/run.sh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,8 @@
         "--cap-add=SYS_PTRACE",
         "--shm-size=10G",
         "--ulimit=memlock=-1",
-        "--ulimit=stack=67108864"
+        "--ulimit=stack=67108864",
+        "--ulimit nofile=65536:65536"
     ],
     "service": "dynamo",
     "customizations": {

--- a/container/run.sh
+++ b/container/run.sh
@@ -288,6 +288,24 @@ if [ -z "$RUN_PREFIX" ]; then
     set -x
 fi
 
-${RUN_PREFIX} docker run ${GPU_STRING} ${INTERACTIVE} ${RM_STRING} --network host --shm-size=10G --ulimit memlock=-1 --ulimit stack=67108864 ${ENVIRONMENT_VARIABLES} ${VOLUME_MOUNTS} -w /workspace --cap-add CAP_SYS_PTRACE --ipc host ${PRIVILEGED_STRING} ${NAME_STRING} ${ENTRYPOINT_STRING} ${IMAGE} "${REMAINING_ARGS[@]}"
+${RUN_PREFIX} docker run \
+    ${GPU_STRING} \
+    ${INTERACTIVE} \
+    ${RM_STRING} \
+    --network host \
+    --shm-size=10G \
+    --ulimit memlock=-1 \
+    --ulimit stack=67108864 \
+    --ulimit nofile=65536:65536 \
+    ${ENVIRONMENT_VARIABLES} \
+    ${VOLUME_MOUNTS} \
+    -w /workspace \
+    --cap-add CAP_SYS_PTRACE \
+    --ipc host \
+    ${PRIVILEGED_STRING} \
+    ${NAME_STRING} \
+    ${ENTRYPOINT_STRING} \
+    ${IMAGE} \
+    "${REMAINING_ARGS[@]}"
 
 { set +x; } 2>/dev/null


### PR DESCRIPTION
#### Overview:

Fixes issue of `Too many open files (os error 24)` when handling lots of simultaneous requests when run from `container/run.sh`.

Also re-formats the docker run command to be more readable and maintainable.

#### Details:

Note that `--ulimit nofile=65536:65536 \` is the only change. everything else is just formatting.

#### Where should the reviewer start?

Inside the container: run Dynamo
```
(workspace) root@nv-dev:/workspace/examples/llm# dynamo serve graphs.agg:Frontend -f ./configs/agg.yaml
```

Flood it with requests:
```
genai-perf profile \
  -m deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
  --endpoint-type chat \
  --synthetic-input-tokens-mean 128 \
  --synthetic-input-tokens-stddev 0 \
  --output-tokens-mean 20 \
  --output-tokens-stddev 0 \
  --streaming \
  --request-count 1000 \
  --warmup-request-count 1000 \
  --concurrency 500
```

optionally increase 500 to 1000.


![image](https://github.com/user-attachments/assets/06259092-57a0-4582-8f2a-4ec14865ce78)

