### PR TITLE
fix: Create default sampling params only once during initialization

### DIFF
--- a/examples/llm/components/processor.py
+++ b/examples/llm/components/processor.py
@@ -63,6 +63,7 @@ class Processor(ProcessMixIn):
         class_name = self.__class__.__name__
         self.engine_args = parse_vllm_args(class_name, "")
         self.model_config = self.engine_args.create_model_config()
+        self.default_sampling_params = self.model_config.get_diff_sampling_param()
         self.tokenizer = self._create_tokenizer(self.engine_args)
         self.chat_processor = ChatProcessor(self.tokenizer, self.model_config)
         self.completions_processor = CompletionsProcessor(

--- a/examples/llm/utils/chat_processor.py
+++ b/examples/llm/utils/chat_processor.py
@@ -39,6 +39,7 @@ class ProcessMixInRequired(Protocol):
     chat_processor: "ChatProcessor | None"
     completions_processor: "CompletionsProcessor | None"
     model_config: ModelConfig
+    default_sampling_params: SamplingParams
 
 
 class ProcessMixIn(ProcessMixInRequired):

--- a/examples/llm/utils/chat_processor.py
+++ b/examples/llm/utils/chat_processor.py
@@ -29,8 +29,9 @@ from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
 from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
 from vllm.entrypoints.openai.serving_engine import RequestPrompt
 from vllm.inputs.data import TokensPrompt
-from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.sampling_params import SamplingParams
+from vllm.transformers_utils.tokenizer import AnyTokenizer
+
 
 @runtime_checkable
 class ProcessMixInRequired(Protocol):

--- a/examples/llm/utils/chat_processor.py
+++ b/examples/llm/utils/chat_processor.py
@@ -30,7 +30,7 @@ from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
 from vllm.entrypoints.openai.serving_engine import RequestPrompt
 from vllm.inputs.data import TokensPrompt
 from vllm.transformers_utils.tokenizer import AnyTokenizer
-
+from vllm.sampling_params import SamplingParams
 
 @runtime_checkable
 class ProcessMixInRequired(Protocol):
@@ -50,6 +50,7 @@ class ProcessMixIn(ProcessMixInRequired):
     chat_processor: "ChatProcessor | None"
     completions_processor: "CompletionsProcessor | None"
     model_config: ModelConfig
+    default_sampling_params: SamplingParams
 
     def __init__(self):
         pass
@@ -76,11 +77,10 @@ class ProcessMixIn(ProcessMixInRequired):
         default_max_tokens = self.model_config.max_model_len - len(
             preprocess_result.engine_prompt["prompt_token_ids"]
         )
-        default_sampling_params = self.model_config.get_diff_sampling_param()
         sampling_params = request.to_sampling_params(
             default_max_tokens,
             self.model_config.logits_processor_pattern,
-            default_sampling_params,
+            self.default_sampling_params,
         )
         return (
             request,


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

`self.model_config.get_diff_sampling_param()` takes around 80ms which significantly reduced the performance:

![image](https://github.com/user-attachments/assets/0eb6791f-94ae-4e1b-bef0-7d4903b17af1)

`dynamo_agg` is current main, `dynamo_agg_fix` is this PR, `dynamo_simple` is a very basic vllm worker without processor, `vllm_serve` is vllm serve.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
