### PR TITLE
fix: Check nvext for ignore_eos and set min_tokens for benchmark consistency

### DIFF
--- a/examples/llm/benchmarks/perf.sh
+++ b/examples/llm/benchmarks/perf.sh
@@ -25,7 +25,7 @@ osl=150
 # Concurrency levels to test
 for concurrency in 1 2 4 8 16 32 64 128 256; do
 
-  # NOTE: For Dynamo HTTP OpenAI frontned, use `nvext` for fields like
+  # NOTE: For Dynamo HTTP OpenAI frontend, use `nvext` for fields like
   # `ignore_eos` since they are not in the official OpenAI spec.
   genai-perf profile \
     --model ${model} \

--- a/examples/llm/benchmarks/perf.sh
+++ b/examples/llm/benchmarks/perf.sh
@@ -25,6 +25,8 @@ osl=150
 # Concurrency levels to test
 for concurrency in 1 2 4 8 16 32 64 128 256; do
 
+  # NOTE: For Dynamo HTTP OpenAI frontned, use `nvext` for fields like
+  # `ignore_eos` since they are not in the official OpenAI spec.
   genai-perf profile \
     --model ${model} \
     --tokenizer ${model} \
@@ -40,6 +42,7 @@ for concurrency in 1 2 4 8 16 32 64 128 256; do
     --extra-inputs max_tokens:${osl} \
     --extra-inputs min_tokens:${osl} \
     --extra-inputs ignore_eos:true \
+    --extra-inputs "{\"nvext\":{\"ignore_eos\":true}}" \
     --concurrency ${concurrency} \
     --request-count $(($concurrency*10)) \
     --warmup-request-count $(($concurrency*2)) \

--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -165,6 +165,9 @@ class Processor(ChatProcessorMixin):
             # If ignore_eos is True, set min_tokens to max_tokens to guarantee
             # the full expected OSL for consistent benchmarking purposes.
             if ignore_eos:
+                logger.debug(
+                    f"[preprocessor] `ignore_eos` detected, setting `min_tokens` to `max_completion_tokens`: {raw_request.max_completion_tokens}"
+                )
                 raw_request.min_tokens = raw_request.max_completion_tokens
 
         async for response in self._generate(raw_request, RequestType.CHAT):

--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -156,6 +156,17 @@ class Processor(ChatProcessorMixin):
                     raise ValueError(
                         "max_tokens and max_completion_tokens must be the same"
                     )
+
+        # min_tokens isn't currently propagated through the Rust OpenAI HTTP frontend,
+        # and ignore_eos is passed through the 'nvext' field, so set both when found.
+        if raw_request.nvext:
+            ignore_eos = raw_request.nvext.get("ignore_eos")
+            raw_request.ignore_eos = ignore_eos
+            # If ignore_eos is True, set min_tokens to max_tokens to guarantee
+            # the full expected OSL for consistent benchmarking purposes.
+            if ignore_eos:
+                raw_request.min_tokens = raw_request.max_completion_tokens
+
         async for response in self._generate(raw_request, RequestType.CHAT):
             yield response
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Before:
- Rust OpenAI HTTP frontend follows OpenAI spec, and extends it with an additional `nvext` field
- min_tokens is not in OpenAI spec, nor in `nvext` (currently)
- ignore_eos is not in OpenAI spec, but _is_ in `nvext`
- TRTLLM worker does not check `nvext` field passed to backend from frontend

After:
- TRTLLM worker checks `nvext` for `ignore_eos`, and updates the sampling parameter accordingly
- If `ignore_eos` is True, we will also update `min_tokens=max_tokens` as a WAR until `min_tokens` is added back to `nvext` to unblock benchmarking work and get consistent results.

refs:
- https://github.com/ai-dynamo/dynamo/blob/3c3cec975da28c856db2c611ed798762e2ba698e/lib/llm/src/http/service/openai.rs#L255-L258
- https://github.com/ai-dynamo/dynamo/blob/3c3cec975da28c856db2c611ed798762e2ba698e/lib/llm/src/protocols/openai/nvext.rs#L28-L32
- https://github.com/ai-dynamo/dynamo/blob/3c3cec975da28c856db2c611ed798762e2ba698e/lib/llm/src/protocols/openai/chat_completions.rs#L151-L155

Future improvements:
- Add `min_tokens` to `nvext` in Rust side and check for it in Python side