### PR TITLE
docs: Add slurm env var workaround for MPI spawn errors

### DIFF
--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -197,6 +197,12 @@ Notes:
   cd /workspace/examples/tensorrt_llm
   dynamo serve components.worker:TensorRTLLMWorker -f ./configs/disagg.yaml --service-name TensorRTLLMWorker &
   ```
+- If you see an error about MPI Spawn failing during TRTLLM Worker initialziation on a Slurm-based cluster,
+  try unsetting the following environment variables before launching the TRTLLM worker:
+  ```bash
+  # Workaround for error: `mpi4py.MPI.Exception: MPI_ERR_SPAWN: could not spawn processes`
+  unset SLURM_JOBID SLURM_JOB_ID SLURM_NODELIST
+  ```
 
 ### Client
 

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -198,7 +198,9 @@ Notes:
   dynamo serve components.worker:TensorRTLLMWorker -f ./configs/disagg.yaml --service-name TensorRTLLMWorker &
   ```
 - If you see an error about MPI Spawn failing during TRTLLM Worker initialziation on a Slurm-based cluster,
-  try unsetting the following environment variables before launching the TRTLLM worker:
+  try unsetting the following environment variables before launching the TRTLLM worker. If you intend to
+  run other slurm-based commands or processes on the same node after deploying the TRTLLM worker, you may
+  want to save these values into temporary variables and then restore them afterwards.
   ```bash
   # Workaround for error: `mpi4py.MPI.Exception: MPI_ERR_SPAWN: could not spawn processes`
   unset SLURM_JOBID SLURM_JOB_ID SLURM_NODELIST


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Add note about env var based workaround for common MPI Spawn issues in certain slurm/pmix environments.

This is a slightly less overkill version of the trtllm launch script that unsets everything it finds (temporarily): https://github.com/NVIDIA/TensorRT-LLM/blob/dae67814944624953ddcce7932d38dc4536793f9/tensorrt_llm/llmapi/trtllm-llmapi-launch#L49-L75

**NOTE:** There may me more nuance to the solution for a single model multi-node deployment (ex: TP16), where these vars may only need to be set on the head node and not the worker node in that scenario, or in scenarios where you launch the jobs on each node all at once with an `srun -N 2 ... <command>` rather than interactively launching different commands on each node.

However, for the workflow of running indepedent workers connected over nats/etcd on separate nodes, this workaround should be done on each.

#### Details

So all together a simple multi-node 1x decode 1x prefill deployment should look something like this, accounting for slurm cluster environments that raise MPI spawn errors:

head node
```bash
# mpi spawn workaround
unset SLURM_JOBID SLURM_JOB_ID SLURM_NODELIST

# utilities
nats-server -js &
etcd --listen-client-urls http://0.0.0.0:2379/ --advertise-client-urls http://0.0.0.0:2379/ --data-dir /tmp/etcd &

# launch frontend + decode worker
cd /workspace/examples/tensorrt_llm
dynamo serve graphs.agg:Frontend -f ./configs/disagg.yaml &
```

worker node(s)
```bash
# mpi spawn workaround
unset SLURM_JOBID SLURM_JOB_ID SLURM_NODELIST

# utilities
export HEAD_NODE_IP="<head-node-ip>" # example: ptyche0220
export NATS_SERVER="nats://${HEAD_NODE_IP}:4222"
export ETCD_ENDPOINTS="${HEAD_NODE_IP}:2379"

# launch prefill worker
cd /workspace/examples/tensorrt_llm
dynamo serve components.prefill_worker:TensorRTLLMPrefillWorker -f ./configs/disagg.yaml --service-name TensorRTLLMPrefillWorker &
```