### PR TITLE
fix: typo in devcontainer ulimit nofile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
         "--shm-size=10G",
         "--ulimit=memlock=-1",
         "--ulimit=stack=67108864",
-        "--ulimit nofile=65536:65536"
+        "--ulimit=nofile=65536:65536"
     ],
     "service": "dynamo",
     "customizations": {


### PR DESCRIPTION
Unlike the command line option in container/run.sh, the devcontainer does not like the space after --ulimit

#### Overview:

Fixes a bug introduced from #969 

