### PR TITLE
feat: Add AWS EFA support

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -134,6 +134,8 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 # Install NIXL Python module
 # TODO: Move gds_path selection based on arch into NIXL build
 RUN if [ "$ARCH" = "arm64" ]; then \
+        ls -ltR /opt/hpcx/ucx && \
+        ls -ltR /usr/local/cuda/ && \
         cd /opt/nixl && uv pip install . --config-settings=setup-args="-Ducx_path=/opt/hpcx/ucx -Dgds_path=/usr/local/cuda/targets/sbsa-linux/"; \
     else \
         cd /opt/nixl && uv pip install . --config-settings=setup-args="-Ducx_path=/opt/hpcx/ucx"; \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -65,7 +65,40 @@ RUN apt-get update -y && \
     # Install utilities
     nvtop \
     tmux \
-    vim
+    vim \
+    autoconf \
+    libtool
+
+WORKDIR /workspace
+
+### UCX EFA Setup ###
+RUN rm -rf /opt/hpcx/ucx
+RUN cd /usr/local/src && \
+    git clone https://github.com/openucx/ucx.git && \
+    cd ucx && \
+    ./autogen.sh && ./configure \
+    --prefix=/opt/hpcx/ucx      \
+    --enable-shared             \
+    --disable-static            \
+    --disable-doxygen-doc       \
+    --enable-optimizations      \
+    --enable-cma                \
+    --enable-devel-headers      \
+    --with-cuda=/usr/local/cuda \
+    --with-verbs                \
+    --with-efa			\
+    --with-dm                   \
+    --with-gdrcopy=/usr/local   \
+    --enable-mt &&           	\
+    make -j &&                  \
+    make -j install-strip &&    \
+    ldconfig
+
+ENV LD_LIBRARY_PATH=/usr/lib:/opt/hpcx/ucx:/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
+ENV CPATH=/usr/include:$CPATH
+ENV PATH=/usr/bin:$PATH
+ENV PKG_CONFIG_PATH=/usr/lib/pkgconfig:$PKG_CONFIG_PATH
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /workspace
 
@@ -101,9 +134,9 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 # Install NIXL Python module
 # TODO: Move gds_path selection based on arch into NIXL build
 RUN if [ "$ARCH" = "arm64" ]; then \
-        cd /opt/nixl && uv pip install . --config-settings=setup-args="-Dgds_path=/usr/local/cuda/targets/sbsa-linux/"; \
+        cd /opt/nixl && uv pip install . --config-settings=setup-args="-Ducx_path=/opt/hpcx/ucx -Dgds_path=/usr/local/cuda/targets/sbsa-linux/"; \
     else \
-        cd /opt/nixl && uv pip install . ; \
+        cd /opt/nixl && uv pip install . --config-settings=setup-args="-Ducx_path=/opt/hpcx/ucx"; \
     fi
 
 # Install patched vllm - keep this early in Dockerfile to avoid

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -136,7 +136,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 RUN if [ "$ARCH" = "arm64" ]; then \
         ls -ltR /opt/hpcx/ucx && \
         ls -ltR /usr/local/cuda/ && \
-        cd /opt/nixl && uv pip install . --config-settings=setup-args="-Ducx_path=/opt/hpcx/ucx -Dgds_path=/usr/local/cuda/targets/sbsa-linux/"; \
+        cd /opt/nixl && uv pip install . --config-settings=setup-args="-Ducx_path=/opt/hpcx/ucx -Dgds_path=/usr/local/cuda/targets/sbsa-linux"; \
     else \
         cd /opt/nixl && uv pip install . --config-settings=setup-args="-Ducx_path=/opt/hpcx/ucx"; \
     fi

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -73,11 +73,12 @@ WORKDIR /workspace
 
 ### UCX EFA Setup ###
 RUN rm -rf /opt/hpcx/ucx
+RUN rm -rf /usr/local/ucx
 RUN cd /usr/local/src && \
     git clone https://github.com/openucx/ucx.git && \
     cd ucx && \
     ./autogen.sh && ./configure \
-    --prefix=/opt/hpcx/ucx      \
+    --prefix=/usr/local/ucx     \
     --enable-shared             \
     --disable-static            \
     --disable-doxygen-doc       \
@@ -86,7 +87,7 @@ RUN cd /usr/local/src && \
     --enable-devel-headers      \
     --with-cuda=/usr/local/cuda \
     --with-verbs                \
-    --with-efa			\
+    --with-efa			        \
     --with-dm                   \
     --with-gdrcopy=/usr/local   \
     --enable-mt &&           	\
@@ -94,7 +95,7 @@ RUN cd /usr/local/src && \
     make -j install-strip &&    \
     ldconfig
 
-ENV LD_LIBRARY_PATH=/usr/lib:/opt/hpcx/ucx:/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/lib:/usr/local/ucx/lib:/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
 ENV CPATH=/usr/include:$CPATH
 ENV PATH=/usr/bin:$PATH
 ENV PKG_CONFIG_PATH=/usr/lib/pkgconfig:$PKG_CONFIG_PATH
@@ -134,11 +135,9 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 # Install NIXL Python module
 # TODO: Move gds_path selection based on arch into NIXL build
 RUN if [ "$ARCH" = "arm64" ]; then \
-        ls -ltR /opt/hpcx/ucx && \
-        ls -ltR /usr/local/cuda/ && \
-        cd /opt/nixl && uv pip install . --config-settings=setup-args="-Ducx_path=/opt/hpcx/ucx -Dgds_path=/usr/local/cuda/targets/sbsa-linux"; \
+        cd /opt/nixl && uv pip install . --config-settings=setup-args="-Dgds_path=/usr/local/cuda/targets/sbsa-linux"; \
     else \
-        cd /opt/nixl && uv pip install . --config-settings=setup-args="-Ducx_path=/opt/hpcx/ucx"; \
+        cd /opt/nixl && uv pip install . --config-settings=setup-args='-Dgds_path=/usr/local/cuda/targets/x86_64-linux'; \
     fi
 
 # Install patched vllm - keep this early in Dockerfile to avoid

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -76,7 +76,8 @@ RUN rm -rf /opt/hpcx/ucx
 RUN rm -rf /usr/local/ucx
 RUN cd /usr/local/src && \
     git clone https://github.com/openucx/ucx.git && \
-    cd ucx && \
+    cd ucx &&                   \
+    git checkout v1.19.x &&     \
     ./autogen.sh && ./configure \
     --prefix=/usr/local/ucx     \
     --enable-shared             \
@@ -87,10 +88,10 @@ RUN cd /usr/local/src && \
     --enable-devel-headers      \
     --with-cuda=/usr/local/cuda \
     --with-verbs                \
-    --with-efa			        \
+    --with-efa                  \
     --with-dm                   \
     --with-gdrcopy=/usr/local   \
-    --enable-mt &&           	\
+    --enable-mt &&              \
     make -j &&                  \
     make -j install-strip &&    \
     ldconfig
@@ -137,7 +138,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 RUN if [ "$ARCH" = "arm64" ]; then \
         cd /opt/nixl && uv pip install . --config-settings=setup-args="-Dgds_path=/usr/local/cuda/targets/sbsa-linux"; \
     else \
-        cd /opt/nixl && uv pip install . --config-settings=setup-args='-Dgds_path=/usr/local/cuda/targets/x86_64-linux'; \
+        cd /opt/nixl && uv pip install . ; \
     fi
 
 # Install patched vllm - keep this early in Dockerfile to avoid


### PR DESCRIPTION
#### Overview:

NIXL can use the UCX with EFA support from upstream.

#### Details:

Add UCX upstream library into dynamo container. This enables EFA support for NIXL.

#### Where should the reviewer start?

container/Dockerfile.vllm

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to #762 
