### PR TITLE
feat: Remove vllm and sglang from cargo build command

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -49,7 +49,7 @@ mkdir -p $HOME/dynamo/.build/target
 export CARGO_TARGET_DIR=$HOME/dynamo/.build/target
 
 # build project, it will be saved at $HOME/dynamo/.build/target
-cargo build --locked --profile dev --features mistralrs,sglang,vllm,python
+cargo build --locked --profile dev --features mistralrs,python
 cargo doc --no-deps
 
 # create symlinks for the binaries in the deploy directory


### PR DESCRIPTION
#### Overview:

Remove vllm and sglang from cargo build command

#### Details:

Since vllm and sglang are built in, cargo build fails if you try to specify it:

```
error: none of the selected packages contains these features: sglang, vllm
selected packages: http, dynamo-llm, dynamo-runtime, metrics, router, dynamo-run, dynamo-engine-llamacpp, dynamo-engine-mistralrs, dynamo-engine-python, llmctl, dynamo-tokens, libdynamo_llm
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
