### PR TITLE
feat(dynamo-run): Print HTTP routes on startup

### DIFF
--- a/launch/dynamo-run/src/input/http.rs
+++ b/launch/dynamo-run/src/input/http.rs
@@ -98,6 +98,14 @@ pub async fn run(
             manager.add_completions_model(model.service_name(), cmpl_pipeline)?;
         }
     }
+    tracing::debug!(
+        "Supported routes: {:?}",
+        http_service
+            .route_docs()
+            .iter()
+            .map(|rd| rd.to_string())
+            .collect::<Vec<String>>()
+    );
     http_service.run(runtime.primary_token()).await?;
     runtime.shutdown(); // Cancel primary token
     Ok(())

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -231,7 +231,7 @@ impl DeploymentState {
 }
 
 /// Documentation for a route
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RouteDoc {
     method: axum::http::Method,
     path: String,

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -15,6 +15,7 @@
 
 use super::metrics;
 use super::ModelManager;
+use super::RouteDoc;
 use crate::request_template::RequestTemplate;
 use anyhow::Result;
 use derive_builder::Builder;
@@ -27,6 +28,7 @@ pub struct HttpService {
     router: axum::Router,
     port: u16,
     host: String,
+    route_docs: Vec<RouteDoc>,
 }
 
 #[derive(Clone, Builder)]
@@ -82,6 +84,11 @@ impl HttpService {
 
         Ok(())
     }
+
+    /// Documentation of exposed HTTP endpoints
+    pub fn route_docs(&self) -> &[RouteDoc] {
+        &self.route_docs
+    }
 }
 
 impl HttpServiceConfigBuilder {
@@ -133,6 +140,7 @@ impl HttpServiceConfigBuilder {
             router,
             port: config.port,
             host: config.host,
+            route_docs: all_docs,
         })
     }
 


### PR DESCRIPTION
For #1006

Prints this on startup:
```
2025-05-09T13:06:34.529Z DEBUG dynamo_run::input::http: Supported routes: ["GET /metrics", "GET /dynamo/alpha/list-models", "GET /v1/models", "POST /v1/chat/completions", "POST /v1/completions"]
```

closes DYN-262