### PR TITLE
fix: Fix the dependency specification of block-manager feature

### DIFF
--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -28,9 +28,9 @@ description = "Dynamo LLM Library"
 default = []
 
 testing-full  = ["testing-cuda", "testing-nixl"]
-testing-cuda  = ["dep:cudarc"]
-testing-nixl  = ["dep:nixl-sys"]
-block-manager = ["dep:nixl-sys", "dep:cudarc", "dep:ndarray"]
+testing-cuda  = ["cudarc"]
+testing-nixl  = ["nixl-sys"]
+block-manager = ["nixl-sys", "cudarc", "ndarray"]
 sentencepiece = ["dep:sentencepiece"]
 
 [dependencies]


### PR DESCRIPTION
### Before 

```
45 22.40 warning: build failed, waiting for other jobs to finish...
#45 33.75 💥 maturin failed
#45 33.75   Caused by: Failed to build a native library through cargo
#45 33.75   Caused by: Cargo build finished with "exit status: 101": `env -u CARGO PYO3_ENVIRONMENT_SIGNATURE="cpython-3.12-64bit" PYO3_PYTHON="/root/.cache/uv/builds-v0/.tmpavBlUB/bin/python" PYTHON_SYS_EXECUTABLE="/root/.cache/uv/builds-v0/.tmpavBlUB/bin/python" "cargo" "rustc" "--features" "dynamo-llm/block-manager" "--message-format" "json-render-diagnostics" "--manifest-path" "/workspace/lib/bindings/python/Cargo.toml" "--release" "--lib"`
#45 33.75 Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/root/.cache/uv/builds-v0/.tmpavBlUB/bin/python', '--auditwheel', 'repair', '--manylinux'] returned non-zero exit status 1
#45 33.77   × Failed to build `/workspace/lib/bindings/python`
#45 33.77   ├─▶ The build backend returned an error
#45 33.77   ╰─▶ Call to `maturin.build_wheel` failed (exit status: 1)
#45 33.77       hint: This usually indicates a problem with the package or the build
#45 33.77       environment.
#45 ERROR: process "/bin/sh -c uv build --wheel --out-dir /workspace/dist &&     cd /workspace/lib/bindings/python &&     uv build --wheel --out-dir /workspace/dist --python 3.12 &&     if [ \"$RELEASE_BUILD\" = \"true\" ]; then         uv build --wheel --out-dir /workspace/dist --python 3.11 &&         uv build --wheel --out-dir /workspace/dist --python 3.10;     fi" did not complete successfully: exit code: 2
```

### After

Builds successfully. 
The dependency is already specified  under [dependency], should not need extra prefix deps:.
