### PR TITLE
fix: read 'workers' to set deployments 'replicas'

### DIFF
--- a/deploy/cloud/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/cloud/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -18,10 +18,12 @@
 package controller
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
 
+	"github.com/ai-dynamo/dynamo/deploy/cloud/operator/api/dynamo/common"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/cloud/operator/api/v1alpha1"
 	"github.com/bsm/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -201,6 +203,113 @@ func Test_updateDynDeploymentConfig(t *testing.T) {
 			}
 			g := gomega.NewGomegaWithT(t)
 			g.Expect(tt.args.dynamoDeploymentComponent.Spec.Envs).To(gomega.Equal(tt.want))
+		})
+	}
+}
+
+func Test_overrideWithDynDeploymentConfig(t *testing.T) {
+	type args struct {
+		ctx                       context.Context
+		dynamoDeploymentComponent *nvidiacomv1alpha1.DynamoComponentDeployment
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantErr  bool
+		expected *nvidiacomv1alpha1.DynamoComponentDeployment
+	}{
+		{
+			name: "no env var",
+			args: args{
+				ctx: context.Background(),
+				dynamoDeploymentComponent: &nvidiacomv1alpha1.DynamoComponentDeployment{
+					Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+						DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+							ServiceName: "Frontend",
+							Replicas:    &[]int32{1}[0],
+							Resources: &common.Resources{
+								Requests: &common.ResourceItem{
+									CPU:    "1",
+									Memory: "1Gi",
+									GPU:    "1",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			expected: &nvidiacomv1alpha1.DynamoComponentDeployment{
+				Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+					DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						ServiceName: "Frontend",
+						Replicas:    &[]int32{1}[0],
+						Resources: &common.Resources{
+							Requests: &common.ResourceItem{
+								CPU:    "1",
+								Memory: "1Gi",
+								GPU:    "1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "override workers",
+			args: args{
+				ctx: context.Background(),
+				dynamoDeploymentComponent: &nvidiacomv1alpha1.DynamoComponentDeployment{
+					Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+						DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+							ServiceName: "Frontend",
+							Envs: []corev1.EnvVar{
+								{
+									Name:  "DYN_DEPLOYMENT_CONFIG",
+									Value: `{"Frontend":{"port":8080,"ServiceArgs":{"Workers":3}},"Planner":{"environment":"kubernetes"}}`,
+								},
+							},
+							Replicas: &[]int32{1}[0],
+							Resources: &common.Resources{
+								Requests: &common.ResourceItem{
+									CPU:    "1",
+									Memory: "1Gi",
+									GPU:    "1",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			expected: &nvidiacomv1alpha1.DynamoComponentDeployment{
+				Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+					DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						ServiceName: "Frontend",
+						Envs: []corev1.EnvVar{
+							{
+								Name:  "DYN_DEPLOYMENT_CONFIG",
+								Value: `{"Frontend":{"port":8080,"ServiceArgs":{"Workers":3, "Resources":{"CPU":"2", "Memory":"2Gi", "GPU":"2"}}},"Planner":{"environment":"kubernetes"}}`,
+							},
+						},
+						Replicas: &[]int32{3}[0],
+						Resources: &common.Resources{
+							Requests: &common.ResourceItem{
+								CPU:    "2",
+								Memory: "2Gi",
+								GPU:    "2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := overrideWithDynDeploymentConfig(tt.args.ctx, tt.args.dynamoDeploymentComponent); (err != nil) != tt.wantErr {
+				t.Errorf("overrideWithDynDeploymentConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -78,6 +78,7 @@ type Config struct {
 	Autoscaling  *Autoscaling  `yaml:"autoscaling,omitempty"`
 	HttpExposed  bool          `yaml:"http_exposed,omitempty"`
 	ApiEndpoints []string      `yaml:"api_endpoints,omitempty"`
+	Workers      *int32        `yaml:"workers,omitempty"`
 }
 
 type ServiceConfig struct {
@@ -244,6 +245,7 @@ func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphD
 		deployment.Spec.DynamoTag = config.DynamoTag
 		deployment.Spec.DynamoComponent = parentDynamoGraphDeployment.Spec.DynamoGraph
 		deployment.Spec.ServiceName = service.Name
+		deployment.Spec.Replicas = service.Config.Workers
 		labels := make(map[string]string)
 		// add the labels in the spec in order to label all sub-resources
 		deployment.Spec.Labels = labels

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -20,6 +20,7 @@ package dynamo
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -56,10 +57,10 @@ type DynamoConfig struct {
 }
 
 type Resources struct {
-	CPU    *string           `yaml:"cpu,omitempty"`
-	Memory *string           `yaml:"memory,omitempty"`
-	GPU    *string           `yaml:"gpu,omitempty"`
-	Custom map[string]string `yaml:"custom,omitempty"`
+	CPU    *string           `yaml:"cpu,omitempty" json:"cpu,omitempty"`
+	Memory *string           `yaml:"memory,omitempty" json:"memory,omitempty"`
+	GPU    *string           `yaml:"gpu,omitempty" json:"gpu,omitempty"`
+	Custom map[string]string `yaml:"custom,omitempty" json:"custom,omitempty"`
 }
 
 type Traffic struct {
@@ -87,20 +88,17 @@ type ServiceConfig struct {
 	Config       Config              `yaml:"config"`
 }
 
-type DynDeploymentConfig struct {
-	Port       int                                    `json:"port"`
-	Components map[string]*DynDeploymentServiceConfig `yaml:"-"`
-}
+type DynDeploymentConfig = map[string]*DynDeploymentServiceConfig
 
 // ServiceConfig represents the configuration for a specific service
 type DynDeploymentServiceConfig struct {
-	ServiceArgs *ServiceArgs `yaml:"serviceArgs,omitempty"`
+	ServiceArgs *ServiceArgs `json:"ServiceArgs,omitempty"`
 }
 
 // ServiceArgs represents the arguments that can be passed to any service
 type ServiceArgs struct {
-	Workers   *int32     `yaml:"workers,omitempty"`
-	Resources *Resources `yaml:"resources,omitempty"`
+	Workers   *int32     `json:"workers,omitempty"`
+	Resources *Resources `json:"resources,omitempty"`
 }
 
 func (s ServiceConfig) GetNamespace() *string {
@@ -237,10 +235,10 @@ func ParseDynamoGraphConfig(ctx context.Context, yamlContent *bytes.Buffer) (*Dy
 	return &config, err
 }
 
-func ParseDynDeploymentConfig(ctx context.Context, yamlContent []byte) (*DynDeploymentConfig, error) {
+func ParseDynDeploymentConfig(ctx context.Context, jsonContent []byte) (DynDeploymentConfig, error) {
 	var config DynDeploymentConfig
-	err := yaml.Unmarshal(yamlContent, &config)
-	return &config, err
+	err := json.Unmarshal(jsonContent, &config)
+	return config, err
 }
 
 func GetDynamoGraphConfig(ctx context.Context, dynamoDeployment *v1alpha1.DynamoGraphDeployment, recorder EventRecorder) (*DynamoGraphConfig, error) {

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -65,9 +65,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 									Name:      "service1",
 								},
 								Resources: &Resources{
-									CPU:    "1",
-									Memory: "1Gi",
-									GPU:    "0",
+									CPU:    &[]string{"1"}[0],
+									Memory: &[]string{"1Gi"}[0],
+									GPU:    &[]string{"0"}[0],
 									Custom: map[string]string{},
 								},
 								Autoscaling: &Autoscaling{
@@ -186,9 +186,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 							Config: Config{
 								HttpExposed: true,
 								Resources: &Resources{
-									CPU:    "1",
-									Memory: "1Gi",
-									GPU:    "0",
+									CPU:    &[]string{"1"}[0],
+									Memory: &[]string{"1Gi"}[0],
+									GPU:    &[]string{"0"}[0],
 									Custom: map[string]string{},
 								},
 								Autoscaling: &Autoscaling{
@@ -330,9 +330,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 							Config: Config{
 								HttpExposed: true,
 								Resources: &Resources{
-									CPU:    "1",
-									Memory: "1Gi",
-									GPU:    "0",
+									CPU:    &[]string{"1"}[0],
+									Memory: &[]string{"1Gi"}[0],
+									GPU:    &[]string{"0"}[0],
 									Custom: map[string]string{},
 								},
 								Autoscaling: &Autoscaling{
@@ -481,9 +481,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 									Name:      "service1",
 								},
 								Resources: &Resources{
-									CPU:    "1",
-									Memory: "1Gi",
-									GPU:    "0",
+									CPU:    &[]string{"1"}[0],
+									Memory: &[]string{"1Gi"}[0],
+									GPU:    &[]string{"0"}[0],
 									Custom: map[string]string{},
 								},
 								Autoscaling: &Autoscaling{
@@ -534,9 +534,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 									ComponentType: ComponentTypePlanner,
 								},
 								Resources: &Resources{
-									CPU:    "1",
-									Memory: "1Gi",
-									GPU:    "0",
+									CPU:    &[]string{"1"}[0],
+									Memory: &[]string{"1Gi"}[0],
+									GPU:    &[]string{"0"}[0],
 									Custom: map[string]string{},
 								},
 							},
@@ -615,9 +615,9 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 									Name:      "service1",
 								},
 								Resources: &Resources{
-									CPU:    "1",
-									Memory: "1Gi",
-									GPU:    "0",
+									CPU:    &[]string{"1"}[0],
+									Memory: &[]string{"1Gi"}[0],
+									GPU:    &[]string{"0"}[0],
 									Custom: map[string]string{},
 								},
 								Autoscaling: &Autoscaling{

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -74,6 +74,7 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 									MinReplicas: 1,
 									MaxReplicas: 5,
 								},
+								Workers: &[]int32{3}[0],
 							},
 						},
 						{
@@ -105,6 +106,7 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 						DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
 							ServiceName:     "service1",
 							DynamoNamespace: &[]string{"default"}[0],
+							Replicas:        &[]int32{3}[0],
 							Resources: &compounaiCommon.Resources{
 								Requests: &compounaiCommon.ResourceItem{
 									CPU:    "1",


### PR DESCRIPTION
#### Overview:

read 'workers' to set deployments 'replicas'

#### Details:

Currently operator ignore this property.
This change makes operator read this property and use it to set deployments "replicas"

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
