### PR TITLE
fix: pin click dependency to old releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "distro",
     "typer",
     "circus>=0.17.0",
+    "click<8.2.0",
 ]
 
 classifiers = [


### PR DESCRIPTION
#### Overview:

new click release breaks CI and also results in a dynamo cli error 

Fixes -
 1. https://github.com/ai-dynamo/dynamo/actions/runs/14975506264/job/42066668263?pr=1007
 2. #1039 
