### PR TITLE
fix: pin click dependency to old releases (#1042)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "distro",
     "typer",
     "circus>=0.17.0",
+    "click<8.2.0",
 ]
 
 classifiers = [


### PR DESCRIPTION
#### Overview:

add #1042 to release
