### PR TITLE
fix: add maxage to nats stream

### DIFF
--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -390,6 +390,7 @@ impl NatsQueue {
                 let stream_config = jetstream::stream::Config {
                     name: self.stream_name.clone(),
                     subjects: vec![self.subject.clone()],
+                    max_age: time::Duration::from_secs(60 * 10), // 10 min
                     ..Default::default()
                 };
                 client.jetstream().create_stream(stream_config).await?;


### PR DESCRIPTION
#### Overview:

add max_age to nats stream when create, 10 min should be very enough for prefill workers to consume. this prevent system crash while nats jetstream hits disk limit by endless growing messages.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #1052 
