### PR TITLE
build: Suffix dev version to trtllm wheel

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -89,9 +89,6 @@ TENSORRTLLM_PIP_WHEEL_DIR="/tmp/trtllm_wheel/"
 # Important Note: This commit is not used in our CI pipeline. See the CI
 # variables to learn how to run a pipeline with a specific commit.
 TRTLLM_COMMIT=83f37614ef735d251281136c3c05b1fecf8ef68b
-# Version suffix for the wheel. Use this to uniquely identify the wheel for a given commit.
-# Increment this value when the commit changes.
-TRTLLM_COMMIT_VERSION=1
 
 # TensorRT-LLM PyPI index URL
 TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"
@@ -467,7 +464,7 @@ if [[ $FRAMEWORK == "TENSORRTLLM" ]]; then
         echo "Checking for TensorRT-LLM wheel in ${TENSORRTLLM_PIP_WHEEL_DIR}"
         if ! check_wheel_file "${TENSORRTLLM_PIP_WHEEL_DIR}" "${ARCH}_${TRTLLM_COMMIT}"; then
             echo "WARN: Valid trtllm wheel file not found in ${TENSORRTLLM_PIP_WHEEL_DIR}, attempting to build from source"
-            if ! env -i ${SOURCE_DIR}/build_trtllm_wheel.sh -o ${TENSORRTLLM_PIP_WHEEL_DIR} -c ${TRTLLM_COMMIT} -a ${ARCH} -v ${TRTLLM_COMMIT_VERSION}; then
+            if ! env -i ${SOURCE_DIR}/build_trtllm_wheel.sh -o ${TENSORRTLLM_PIP_WHEEL_DIR} -c ${TRTLLM_COMMIT} -a ${ARCH}; then
                 error "ERROR: Failed to build TensorRT-LLM wheel"
             fi
         fi

--- a/container/build.sh
+++ b/container/build.sh
@@ -89,6 +89,10 @@ TENSORRTLLM_PIP_WHEEL_DIR="/tmp/trtllm_wheel/"
 # Important Note: This commit is not used in our CI pipeline. See the CI
 # variables to learn how to run a pipeline with a specific commit.
 TRTLLM_COMMIT=83f37614ef735d251281136c3c05b1fecf8ef68b
+# Version suffix for the wheel. Use this to uniquely identify the wheel for a given commit.
+# Increment this value when the commit changes.
+TRTLLM_COMMIT_VERSION=1
+
 # TensorRT-LLM PyPI index URL
 TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"
 TENSORRTLLM_PIP_WHEEL=""
@@ -465,7 +469,7 @@ if [[ $FRAMEWORK == "TENSORRTLLM" ]]; then
         echo "Checking for TensorRT-LLM wheel in ${TENSORRTLLM_PIP_WHEEL_DIR}"
         if ! check_wheel_file "${TENSORRTLLM_PIP_WHEEL_DIR}" "${ARCH}_${TRTLLM_COMMIT}"; then
             echo "WARN: Valid trtllm wheel file not found in ${TENSORRTLLM_PIP_WHEEL_DIR}, attempting to build from source"
-            if ! env -i ${SOURCE_DIR}/build_trtllm_wheel.sh -o ${TENSORRTLLM_PIP_WHEEL_DIR} -c ${TRTLLM_COMMIT} -a ${ARCH}; then
+            if ! env -i ${SOURCE_DIR}/build_trtllm_wheel.sh -o ${TENSORRTLLM_PIP_WHEEL_DIR} -c ${TRTLLM_COMMIT} -a ${ARCH} -v ${TRTLLM_COMMIT_VERSION}; then
                 error "ERROR: Failed to build TensorRT-LLM wheel"
             fi
         fi

--- a/container/build_trtllm_wheel.sh
+++ b/container/build_trtllm_wheel.sh
@@ -18,12 +18,12 @@
 
 # This script builds the TRT-LLM base image for Dynamo with TensorRT-LLM.
 
-while getopts "c:v:o:a:" opt; do
+while getopts "c:o:a:" opt; do
   case ${opt} in
     c) TRTLLM_COMMIT=$OPTARG ;;
     o) OUTPUT_DIR=$OPTARG ;;
     a) ARCH=$OPTARG ;;
-    *) echo "Usage: $(basename $0) [-c commit] [-v version] [-o output_dir] [-a arch]"
+    *) echo "Usage: $(basename $0) [-c commit] [-o output_dir] [-a arch]"
        echo "  -c: TensorRT-LLM commit to build"
        echo "  -o: Output directory for wheel files"
        echo "  -a: Architecture (amd64 or arm64)"

--- a/container/build_trtllm_wheel.sh
+++ b/container/build_trtllm_wheel.sh
@@ -18,13 +18,15 @@
 
 # This script builds the TRT-LLM base image for Dynamo with TensorRT-LLM.
 
-while getopts "c:o:a:" opt; do
+while getopts "c:v:o:a:" opt; do
   case ${opt} in
     c) TRTLLM_COMMIT=$OPTARG ;;
+    v) COMMIT_VERSION=$OPTARG ;;
     o) OUTPUT_DIR=$OPTARG ;;
     a) ARCH=$OPTARG ;;
-    *) echo "Usage: $(basename $0) [-c commit] [-o output_dir] [-a arch]"
+    *) echo "Usage: $(basename $0) [-c commit] [-v version] [-o output_dir] [-a arch]"
        echo "  -c: TensorRT-LLM commit to build"
+       echo "  -v: Version suffix for the wheel. Use this to uniquely identify the wheel for a given commit."
        echo "  -o: Output directory for wheel files"
        echo "  -a: Architecture (amd64 or arm64)"
        exit 1 ;;
@@ -55,7 +57,30 @@ git checkout $TRTLLM_COMMIT
 git submodule update --init --recursive
 git lfs pull
 
-# Build the TRT-LLM base image.
+VERSION_FILE="tensorrt_llm/version.py"
+
+# Check if file exists
+if [ ! -f "$VERSION_FILE" ]; then
+    echo "Error: $VERSION_FILE not found"
+    exit 1
+fi
+
+# Create a backup of the original version file
+cp $VERSION_FILE ${VERSION_FILE}.bak
+
+# Check if version line exists
+if ! grep -q "^__version__" "$VERSION_FILE"; then
+    echo "Error: __version__ not found in $VERSION_FILE"
+    exit 1
+fi
+
+# Append suffix to version
+sed -i "s/__version__ = \"\(.*\)\"/__version__ = \"\1.dev${COMMIT_VERSION}\"/" "$VERSION_FILE"
+
+echo "Updated version:"
+grep "__version__" "$VERSION_FILE"
+
+
 make -C docker wheel_build
 
 # Copy the wheel to the host
@@ -65,6 +90,10 @@ docker create --name trtllm_wheel_container docker.io/tensorrt_llm/wheel:latest
 docker cp trtllm_wheel_container:/src/tensorrt_llm/build $OUTPUT_DIR/
 cp $OUTPUT_DIR/build/*.whl $OUTPUT_DIR/
 docker rm trtllm_wheel_container || true
+
+# Restore the original version file
+mv ${VERSION_FILE}.bak $VERSION_FILE
+
 )
 
 # Store the commit hash in the output directory to ensure the wheel is built from the correct commit.

--- a/container/build_trtllm_wheel.sh
+++ b/container/build_trtllm_wheel.sh
@@ -74,7 +74,7 @@ fi
 
 # Append suffix to version
 COMMIT_VERSION=$(git rev-parse --short HEAD)
-sed -i "s/__version__ = \"\(.*\)\"/__version__ = \"\1.dev${COMMIT_VERSION}\"/" "$VERSION_FILE"
+sed -i "s/__version__ = \"\(.*\)\"/__version__ = \"\1+dev${COMMIT_VERSION}\"/" "$VERSION_FILE"
 
 echo "Updated version:"
 grep "__version__" "$VERSION_FILE"

--- a/container/build_trtllm_wheel.sh
+++ b/container/build_trtllm_wheel.sh
@@ -21,12 +21,10 @@
 while getopts "c:v:o:a:" opt; do
   case ${opt} in
     c) TRTLLM_COMMIT=$OPTARG ;;
-    v) COMMIT_VERSION=$OPTARG ;;
     o) OUTPUT_DIR=$OPTARG ;;
     a) ARCH=$OPTARG ;;
     *) echo "Usage: $(basename $0) [-c commit] [-v version] [-o output_dir] [-a arch]"
        echo "  -c: TensorRT-LLM commit to build"
-       echo "  -v: Version suffix for the wheel. Use this to uniquely identify the wheel for a given commit."
        echo "  -o: Output directory for wheel files"
        echo "  -a: Architecture (amd64 or arm64)"
        exit 1 ;;
@@ -75,6 +73,7 @@ if ! grep -q "^__version__" "$VERSION_FILE"; then
 fi
 
 # Append suffix to version
+COMMIT_VERSION=$(git rev-parse --short HEAD)
 sed -i "s/__version__ = \"\(.*\)\"/__version__ = \"\1.dev${COMMIT_VERSION}\"/" "$VERSION_FILE"
 
 echo "Updated version:"


### PR DESCRIPTION
#### Overview:

The pip wheels were being cached by the build system as the version remained the same. With this change we are adding a identifier index for the wheel generated for a specific commit on the artifactory. We would need to increment the version of the wheel everytime the commit id is updated on the artifactory.
