### PR TITLE
fix: update nixl setup for arm builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,9 +4081,8 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.2.1-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4698155ec791ae888482b0c1c5d19792a1b457167fa8ec0ffa487ffef8c8e5a"
+version = "0.2.1"
+source = "git+https://github.com/ai-dynamo/nixl.git?rev=39ea8fe8190d0b0e7304e0293d84bb3e4b740c90#39ea8fe8190d0b0e7304e0293d84bb3e4b740c90"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,8 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.2.1"
-source = "git+https://github.com/ai-dynamo/nixl.git?rev=39ea8fe8190d0b0e7304e0293d84bb3e4b740c90#39ea8fe8190d0b0e7304e0293d84bb3e4b740c90"
+version = "0.2.1-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfeec33e0229249e8688309a70c677f522446f9ac92105a85aad4a5ceef2dd2f"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -171,7 +171,8 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     # NOTE: vLLM build from source on ARM can take several hours, see VLLM_MAX_JOBS details.
     if [ "$ARCH" = "arm64" ]; then \
         # PyTorch 2.7 supports CUDA 12.8 and aarch64 installs
-        uv pip install torch==2.7.0 torchvision torchaudio triton==3.3.0 --verbose --force-reinstall --index-url https://download.pytorch.org/whl/cu128 && \
+        # NIXL has a torch dependency, so need to force-reinstall to install the correct version
+        uv pip install torch==2.7.0 torchvision torchaudio --force-reinstall --index-url https://download.pytorch.org/whl/cu128 && \
         # Download vLLM source with version matching patch
         git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
         cd /tmp/vllm/vllm-${VLLM_REF}/ && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -165,6 +165,7 @@ ARG VLLM_PATCHED_PACKAGE_VERSION="0.8.4.post1"
 ARG VLLM_MAX_JOBS=4
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     --mount=type=cache,target=/root/.cache/uv \
+    set -x && \
     mkdir /tmp/vllm && \
     uv pip install pip wheel && \
     # NOTE: vLLM build from source on ARM can take several hours, see VLLM_MAX_JOBS details.

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -165,7 +165,6 @@ ARG VLLM_PATCHED_PACKAGE_VERSION="0.8.4.post1"
 ARG VLLM_MAX_JOBS=4
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     --mount=type=cache,target=/root/.cache/uv \
-    set -x && \
     mkdir /tmp/vllm && \
     uv pip install pip wheel && \
     # NOTE: vLLM build from source on ARM can take several hours, see VLLM_MAX_JOBS details.

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -171,7 +171,7 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     # NOTE: vLLM build from source on ARM can take several hours, see VLLM_MAX_JOBS details.
     if [ "$ARCH" = "arm64" ]; then \
         # PyTorch 2.7 supports CUDA 12.8 and aarch64 installs
-        uv pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128 && \
+        uv pip install torch==2.7.0 torchvision torchaudio triton==3.2.0 --verbose --index-url https://download.pytorch.org/whl/cu128 && \
         # Download vLLM source with version matching patch
         git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
         cd /tmp/vllm/vllm-${VLLM_REF}/ && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -171,7 +171,7 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     # NOTE: vLLM build from source on ARM can take several hours, see VLLM_MAX_JOBS details.
     if [ "$ARCH" = "arm64" ]; then \
         # PyTorch 2.7 supports CUDA 12.8 and aarch64 installs
-        uv pip install torch==2.7.0 torchvision torchaudio triton==3.2.0 --verbose --index-url https://download.pytorch.org/whl/cu128 && \
+        uv pip install torch==2.7.0 torchvision torchaudio triton==3.3.0 --verbose --index-url https://download.pytorch.org/whl/cu128 && \
         # Download vLLM source with version matching patch
         git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
         cd /tmp/vllm/vllm-${VLLM_REF}/ && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -108,12 +108,21 @@ WORKDIR /workspace
 # Copy nixl source, and use commit hash as cache hint
 COPY --from=nixl_base /opt/nixl /opt/nixl
 COPY --from=nixl_base /opt/nixl/commit.txt /opt/nixl/commit.txt
-RUN cd /opt/nixl && \
-    mkdir build && \
-    meson setup build/ --prefix=/usr/local/nixl && \
-    cd build/ && \
-    ninja && \
-    ninja install
+RUN if [ "$ARCH" = "arm64" ]; then \
+        cd /opt/nixl && \
+        mkdir build && \
+        meson setup build/ --prefix=/usr/local/nixl -Dgds_path=/usr/local/cuda/targets/sbsa-linux && \
+        cd build/ && \
+        ninja && \
+        ninja install; \
+    else \
+        cd /opt/nixl && \
+        mkdir build && \
+        meson setup build/ --prefix=/usr/local/nixl && \
+        cd build/ && \
+        ninja && \
+        ninja install; \
+    fi
 
 ### NATS & ETCD SETUP ###
 # nats

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -171,7 +171,7 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     # NOTE: vLLM build from source on ARM can take several hours, see VLLM_MAX_JOBS details.
     if [ "$ARCH" = "arm64" ]; then \
         # PyTorch 2.7 supports CUDA 12.8 and aarch64 installs
-        uv pip install torch==2.7.0 torchvision torchaudio triton==3.3.0 --verbose --index-url https://download.pytorch.org/whl/cu128 && \
+        uv pip install torch==2.7.0 torchvision torchaudio triton==3.3.0 --verbose --force-reinstall --index-url https://download.pytorch.org/whl/cu128 && \
         # Download vLLM source with version matching patch
         git clone --branch v${VLLM_REF} --depth 1 https://github.com/vllm-project/vllm.git /tmp/vllm/vllm-${VLLM_REF} && \
         cd /tmp/vllm/vllm-${VLLM_REF}/ && \

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -77,7 +77,7 @@ regex = "1"
 rayon = "1"
 
 # block_manager
-nixl-sys = { git = "https://github.com/ai-dynamo/nixl.git",  rev = "39ea8fe8190d0b0e7304e0293d84bb3e4b740c90", optional = true }
+nixl-sys = { version = "0.2.1-rc.3", optional = true }
 cudarc = { version = "0.16.2", features = ["cuda-12020"], optional = true }
 ndarray = { version = "0.16", optional = true }
 

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -77,7 +77,7 @@ regex = "1"
 rayon = "1"
 
 # block_manager
-nixl-sys = { version = "0.2.1-rc.1", optional = true }
+nixl-sys = { git = "https://github.com/ai-dynamo/nixl.git",  rev = "39ea8fe8190d0b0e7304e0293d84bb3e4b740c90", optional = true }
 cudarc = { version = "0.16.2", features = ["cuda-12020"], optional = true }
 ndarray = { version = "0.16", optional = true }
 


### PR DESCRIPTION
#### Overview:
Update nixl install to fix arm builds. 
1. Use latest nixl crate version --- includes fix from https://github.com/ai-dynamo/nixl/issues/298
2. Update nixl ninja install to support arm 
3. Add force-reinstall to torch install, installed previously as a dependency of nixl

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes: OPS-61
