### PR TITLE
feat(dynamo-run): KV-aware routing

### DIFF
--- a/components/router/src/main.rs
+++ b/components/router/src/main.rs
@@ -20,6 +20,8 @@
 // 2. Update the backend component to produce a config in a standard location.
 // 3. Update the KvRouter to read the config from the backend component.
 
+use std::sync::Arc;
+
 use clap::Parser;
 
 use dynamo_llm::kv_router::{
@@ -65,7 +67,7 @@ async fn app(runtime: Runtime) -> Result<()> {
     let selector = Box::new(CustomWorkerSelector::default());
 
     let router = KvRouter::new(component.clone(), args.block_size, Some(selector)).await?;
-    let router = Ingress::for_engine(router)?;
+    let router = Ingress::for_engine(Arc::new(router))?;
 
     component
         .service_builder()

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use clap::ValueEnum;
+use dynamo_llm::http::service::discovery::LLMRouterMode;
 use dynamo_runtime::pipeline::RouterMode as RuntimeRouterMode;
 
 /// Required options depend on the in and out choices
@@ -184,7 +185,7 @@ impl Flags {
     }
 }
 
-#[derive(Default, PartialEq, Eq, ValueEnum, Clone, Debug)]
+#[derive(Default, PartialEq, Eq, ValueEnum, Clone, Debug, Copy)]
 pub enum RouterMode {
     #[default]
     Random,
@@ -198,14 +199,21 @@ impl RouterMode {
     pub fn is_kv_routing(&self) -> bool {
         *self == RouterMode::KV
     }
-}
 
-impl From<RouterMode> for RuntimeRouterMode {
-    fn from(r: RouterMode) -> RuntimeRouterMode {
-        match r {
-            RouterMode::RoundRobin => RuntimeRouterMode::RoundRobin,
-            RouterMode::KV => todo!("KV not implemented yet"),
-            _ => RuntimeRouterMode::Random,
+    pub fn as_runtime(&self) -> Option<RuntimeRouterMode> {
+        match self {
+            RouterMode::RoundRobin => Some(RuntimeRouterMode::RoundRobin),
+            RouterMode::Random => Some(RuntimeRouterMode::Random),
+            // Runtime router does not have KV, it's a dynamo-llm thing, not dynamo-runtime
+            RouterMode::KV => None,
+        }
+    }
+
+    pub fn as_llm(&self) -> LLMRouterMode {
+        match self {
+            RouterMode::RoundRobin => LLMRouterMode::RoundRobin,
+            RouterMode::Random => LLMRouterMode::Random,
+            RouterMode::KV => LLMRouterMode::KV,
         }
     }
 }

--- a/launch/dynamo-run/src/input/common.rs
+++ b/launch/dynamo-run/src/input/common.rs
@@ -19,6 +19,7 @@ use dynamo_llm::{
     backend::{Backend, ExecutionContext},
     engines::StreamingEngineAdapter,
     http::service::discovery::ModelNetworkName,
+    kv_router::{scheduler::DefaultWorkerSelector, KvPushRouter, KvRouter},
     model_card::ModelDeploymentCard,
     model_type::ModelType,
     preprocessor::OpenAIPreprocessor,
@@ -67,82 +68,91 @@ pub async fn prepare_engine(
 
             let client = endpoint.client().await?;
             let mut cache_dir = None;
-            let engine: OpenAIChatCompletionsStreamingEngine = match &flags.router_mode {
-                RouterMode::Random | RouterMode::RoundRobin => {
-                    tracing::info!("Waiting for remote model..");
 
-                    let remote_endpoints = client.wait_for_endpoints().await?;
-                    debug_assert!(!remote_endpoints.is_empty());
-                    tracing::info!(count = remote_endpoints.len(), "Model(s) discovered");
+            tracing::info!("Waiting for remote model..");
 
-                    let network_name: ModelNetworkName = (&remote_endpoints[0]).into();
-                    let Some(etcd_client) = distributed_runtime.etcd_client() else {
-                        anyhow::bail!("Cannot run distributed components without etcd");
-                    };
-                    let network_entry = network_name.load_entry(etcd_client.clone()).await?;
-                    let mut card = network_entry.load_mdc(endpoint_id, etcd_client).await?;
+            let remote_endpoints = client.wait_for_endpoints().await?;
+            debug_assert!(!remote_endpoints.is_empty());
+            tracing::info!(count = remote_endpoints.len(), "Model(s) discovered");
 
-                    match network_entry.model_type {
-                        ModelType::Backend => {
-                            // Download tokenizer.json etc to local disk
-                            cache_dir = Some(
-                                card.move_from_nats(distributed_runtime.nats_client())
-                                    .await?,
-                            );
-
-                            // The backend doesn't mind what we expose to the user (chat or
-                            // completions), and this function is only used by text and batch input so
-                            // the user doesn't see the HTTP request. So use Chat.
-                            let frontend = SegmentSource::<
-                                SingleIn<NvCreateChatCompletionRequest>,
-                                ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
-                            >::new();
-                            let preprocessor =
-                                OpenAIPreprocessor::new(card.clone()).await?.into_operator();
-                            let backend = Backend::from_mdc(card.clone()).await?.into_operator();
-                            let router =
-                                PushRouter::<BackendInput, Annotated<LLMEngineOutput>>::from_client(
-                                    client,
-                                    flags.router_mode.into(),
-                                )
-                                .await?;
-
-                            frontend
-                                .link(preprocessor.forward_edge())?
-                                .link(backend.forward_edge())?
-                                .link(ServiceBackend::from_engine(Arc::new(router)))?
-                                .link(backend.backward_edge())?
-                                .link(preprocessor.backward_edge())?
-                                .link(frontend)?
-                        }
-                        ModelType::Chat => Arc::new(
-                            PushRouter::<
-                                NvCreateChatCompletionRequest,
-                                Annotated<NvCreateChatCompletionStreamResponse>,
-                            >::from_client(
-                                client, flags.router_mode.into()
-                            )
-                            .await?,
-                        ),
-                        ModelType::Completion => {
-                            anyhow::bail!("text and batch input only accept remote Chat models, not Completion");
-                            /*
-                            Arc::new(
-                                PushRouter::<
-                                    CompletionRequest,
-                                    Annotated<CompletionResponse>,
-                                >::from_client(
-                                    client, flags.router_mode.into()
-                                )
-                                .await?,
-                            )
-                            */
-                        }
-                    }
-                }
-                RouterMode::KV => todo!(),
+            let network_name: ModelNetworkName = (&remote_endpoints[0]).into();
+            let Some(etcd_client) = distributed_runtime.etcd_client() else {
+                anyhow::bail!("Cannot run distributed components without etcd");
             };
+            let network_entry = network_name.load_entry(etcd_client.clone()).await?;
+            let mut card = network_entry.load_mdc(endpoint_id, etcd_client).await?;
 
+            let engine: OpenAIChatCompletionsStreamingEngine = match network_entry.model_type {
+                ModelType::Backend => {
+                    // Download tokenizer.json etc to local disk
+                    cache_dir = Some(
+                        card.move_from_nats(distributed_runtime.nats_client())
+                            .await?,
+                    );
+
+                    // The backend doesn't mind what we expose to the user (chat or
+                    // completions), and this function is only used by text and batch input so
+                    // the user doesn't see the HTTP request. So use Chat.
+                    let frontend = SegmentSource::<
+                        SingleIn<NvCreateChatCompletionRequest>,
+                        ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
+                    >::new();
+                    let preprocessor = OpenAIPreprocessor::new(card.clone()).await?.into_operator();
+                    let backend = Backend::from_mdc(card.clone()).await?.into_operator();
+                    let router =
+                        PushRouter::<BackendInput, Annotated<LLMEngineOutput>>::from_client(
+                            client,
+                            flags.router_mode.as_runtime(),
+                        )
+                        .await?;
+                    let service_backend = match &flags.router_mode {
+                        RouterMode::Random | RouterMode::RoundRobin => {
+                            ServiceBackend::from_engine(Arc::new(router))
+                        }
+                        RouterMode::KV => {
+                            let selector = Box::new(DefaultWorkerSelector {});
+                            let chooser = KvRouter::new(
+                                endpoint.component().clone(),
+                                dynamo_llm::DEFAULT_KV_BLOCK_SIZE,
+                                Some(selector),
+                            )
+                            .await?;
+                            let kv_push_router = KvPushRouter::new(router, Arc::new(chooser));
+                            ServiceBackend::from_engine(Arc::new(kv_push_router))
+                        }
+                    };
+                    frontend
+                        .link(preprocessor.forward_edge())?
+                        .link(backend.forward_edge())?
+                        .link(service_backend)?
+                        .link(backend.backward_edge())?
+                        .link(preprocessor.backward_edge())?
+                        .link(frontend)?
+                }
+                ModelType::Chat => Arc::new(
+                    PushRouter::<
+                        NvCreateChatCompletionRequest,
+                        Annotated<NvCreateChatCompletionStreamResponse>,
+                    >::from_client(client, flags.router_mode.as_runtime())
+                    .await?,
+                ),
+                ModelType::Completion => {
+                    anyhow::bail!(
+                        "text and batch input only accept remote Chat models, not Completion"
+                    );
+                    /*
+                    Arc::new(
+                        PushRouter::<
+                            CompletionRequest,
+                            Annotated<CompletionResponse>,
+                        >::from_client(
+                            client, flags.router_mode.into()
+                        )
+                        .await?,
+                    )
+                    */
+                }
+            };
             // The service_name isn't used for text chat outside of logs,
             // so use the path. That avoids having to listen on etcd for model registration.
             let service_name = endpoint.subject();

--- a/launch/dynamo-run/src/input/http.rs
+++ b/launch/dynamo-run/src/input/http.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use crate::input::common;
 use crate::{EngineConfig, Flags};
+use dynamo_llm::http::service::discovery::LLMRouterMode;
 use dynamo_llm::http::service::ModelManager;
 use dynamo_llm::{
     engines::StreamingEngineAdapter,
@@ -29,6 +30,7 @@ use dynamo_llm::{
         openai::completions::{CompletionRequest, CompletionResponse},
     },
 };
+use dynamo_runtime::component::Component;
 use dynamo_runtime::transports::etcd;
 use dynamo_runtime::{DistributedRuntime, Runtime};
 
@@ -59,10 +61,11 @@ pub async fn run(
 
                     // Listen for models registering themselves in etcd, add them to HTTP service
                     run_watcher(
-                        distributed_runtime.clone(),
+                        component.clone(),
                         http_service.model_manager().clone(),
                         etcd_client.clone(),
                         &network_prefix,
+                        flags.router_mode.as_llm(),
                     )
                     .await?;
                 }
@@ -106,19 +109,18 @@ pub async fn run(
 /// Spawns a task that watches for new models in etcd at network_prefix,
 /// and registers them with the ModelManager so that the HTTP service can use them.
 async fn run_watcher(
-    distributed_runtime: DistributedRuntime,
+    component: Component,
     model_manager: ModelManager,
     etcd_client: etcd::Client,
     network_prefix: &str,
+    router_mode: LLMRouterMode,
 ) -> anyhow::Result<()> {
-    let state = Arc::new(discovery::ModelWatchState {
-        prefix: network_prefix.to_string(),
-        manager: model_manager,
-        drt: distributed_runtime.clone(),
-    });
+    let watch_obj = Arc::new(
+        discovery::ModelWatcher::new(component, model_manager, network_prefix, router_mode).await?,
+    );
     tracing::info!("Watching for remote model at {network_prefix}");
     let models_watcher = etcd_client.kv_get_and_watch_prefix(network_prefix).await?;
     let (_prefix, _watcher, receiver) = models_watcher.dissolve();
-    let _watcher_task = tokio::spawn(discovery::model_watcher(state, receiver));
+    let _watcher_task = tokio::spawn(watch_obj.watch(receiver));
     Ok(())
 }

--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -30,7 +30,7 @@ Example:
 - OR: ./dynamo-run /data/models/Llama-3.2-1B-Instruct-Q4_K_M.gguf
 "#;
 
-const USAGE: &str = "USAGE: dynamo-run in=[http|text|dyn://<path>|batch:<folder>] out=ENGINE_LIST|dyn://<path> [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin]";
+const USAGE: &str = "USAGE: dynamo-run in=[http|text|dyn://<path>|batch:<folder>] out=ENGINE_LIST|dyn://<path> [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin|kv]";
 
 fn main() -> anyhow::Result<()> {
     // Set log level based on verbosity flag

--- a/launch/dynamo-run/src/subprocess.rs
+++ b/launch/dynamo-run/src/subprocess.rs
@@ -13,18 +13,18 @@ use tokio::io::AsyncBufReadExt;
 
 use dynamo_llm::engines::MultiNodeConfig;
 use dynamo_llm::LocalModel;
+use dynamo_runtime::protocols::Endpoint as EndpointId;
 
 pub mod sglang;
 pub mod vllm;
-
-/// Internal endpoint to connect the subprocess over etcd/nats
-pub const ENDPOINT: &str = "dyn://dynamo.internal.worker";
 
 pub async fn start(
     // The Python code to run
     py_script: &'static str,
     // Model info
     local_model: &LocalModel,
+    // Endpoint to connect the subprocess over etcd/nats
+    endpoint: &EndpointId,
     // How many GPUs to use
     tensor_parallel_size: u32,
     // sglang which GPU to start from, on a multi-GPU system
@@ -43,13 +43,15 @@ pub async fn start(
     let mut args = vec![
         script_path.to_string_lossy().to_string(),
         "--endpoint".to_string(),
-        ENDPOINT.to_string(),
+        endpoint.as_url(),
         "--model-path".to_string(),
         local_model.path().to_string_lossy().to_string(),
         "--model-name".to_string(),
         local_model.display_name().to_string(),
         "--tensor-parallel-size".to_string(),
         tensor_parallel_size.to_string(),
+        "--kv-block-size".to_string(),
+        dynamo_llm::DEFAULT_KV_BLOCK_SIZE.to_string(),
     ];
     // sglang only
     if let Some(base_gpu_id) = base_gpu_id {

--- a/lib/bindings/python/examples/hello_world/server_sglang.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang.py
@@ -31,7 +31,7 @@ from dynamo.llm import ModelType, register_llm
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
-DEFAULT_MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
 
 
 class Config:

--- a/lib/bindings/python/examples/hello_world/server_vllm.py
+++ b/lib/bindings/python/examples/hello_world/server_vllm.py
@@ -43,7 +43,7 @@ from dynamo.llm import ModelType, register_llm
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
-DEFAULT_MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
 
 
 class Config:

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -51,7 +51,6 @@ module-name = "dynamo._core"
 manifest-path = "Cargo.toml"
 python-packages = ["dynamo"]
 python-source = "src"
-features = ["dynamo-llm/block-manager"]
 
 [build-system]
 requires = ["maturin>=1.0,<2.0", "patchelf"]

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -37,7 +37,9 @@ impl KvRouter {
                 llm_rs::kv_router::KvRouter::new(component.inner.clone(), kv_block_size, None)
                     .await
                     .map_err(to_pyerr)?;
-            Ok(Self { inner })
+            Ok(Self {
+                inner: Arc::new(inner),
+            })
         })
     }
 

--- a/lib/llm/src/kv_router/metrics_aggregator.rs
+++ b/lib/llm/src/kv_router/metrics_aggregator.rs
@@ -70,10 +70,8 @@ pub async fn collect_endpoints(
         .into_endpoints()
         .filter(|e| e.subject.starts_with(subject))
         .collect::<Vec<_>>();
-    tracing::debug!("Endpoints: {endpoints:?}");
-
     if endpoints.is_empty() {
-        tracing::warn!("No endpoints found matching subject {subject}");
+        tracing::debug!("Metrics endpoint not visible yet");
     }
 
     Ok(endpoints)
@@ -92,7 +90,6 @@ pub async fn collect_endpoints_task(
     loop {
         tokio::select! {
             _ = cancel.cancelled() => {
-                tracing::debug!("cancellation token triggered");
                 break;
             }
             _ = tokio::time::sleep(backoff_delay) => {
@@ -106,8 +103,6 @@ pub async fn collect_endpoints_task(
                             continue;
                         }
                     };
-                tracing::debug!("unfiltered endpoints: {:?}", unfiltered_endpoints);
-
                 let endpoints: Vec<Endpoint> = unfiltered_endpoints
                     .into_iter()
                     .filter(|s| s.data.is_some())
@@ -125,13 +120,7 @@ pub async fn collect_endpoints_task(
                         }
                     )
                     .collect();
-                tracing::debug!("endpoints: {:?}", endpoints);
-
-                tracing::trace!(
-                    "found {} endpoints for service: {}",
-                    endpoints.len(),
-                    service_subject
-                );
+                tracing::trace!("Found {} endpoints for service: {service_subject}", endpoints.len());
 
                 let processed = ProcessedEndpoints::new(endpoints);
 

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -28,7 +28,6 @@ use dynamo_runtime::{
 use futures::stream;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing as log;
 
 pub struct KvEventPublisher {
     tx: mpsc::UnboundedSender<KvCacheEvent>,
@@ -45,7 +44,7 @@ impl KvEventPublisher {
     }
 
     pub fn publish(&self, event: KvCacheEvent) -> Result<(), mpsc::error::SendError<KvCacheEvent>> {
-        log::debug!("Publish event: {:?}", event);
+        tracing::debug!("Publish event: {:?}", event);
         self.tx.send(event)
     }
 
@@ -60,7 +59,7 @@ fn start_publish_task(
     mut rx: mpsc::UnboundedReceiver<KvCacheEvent>,
 ) {
     let component_clone = component.clone();
-    log::info!("Publishing KV Events to subject: {}", KV_EVENT_SUBJECT);
+    tracing::info!("Publishing KV Events to subject: {}", KV_EVENT_SUBJECT);
 
     _ = component.drt().runtime().secondary().spawn(async move {
         while let Some(event) = rx.recv().await {
@@ -88,7 +87,7 @@ impl KvMetricsPublisher {
         &self,
         metrics: Arc<ForwardPassMetrics>,
     ) -> Result<(), tokio::sync::watch::error::SendError<Arc<ForwardPassMetrics>>> {
-        log::debug!("Publish metrics: {:?}", metrics);
+        tracing::trace!("Publish metrics: {metrics:?}");
         self.tx.send(metrics)
     }
 

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -27,6 +27,7 @@ pub mod http;
 pub mod hub;
 pub mod key_value_store;
 pub mod kv_router;
+pub use kv_router::DEFAULT_KV_BLOCK_SIZE;
 pub mod model_card;
 pub mod model_type;
 pub mod preprocessor;

--- a/lib/llm/src/protocols/common/llm_backend.rs
+++ b/lib/llm/src/protocols/common/llm_backend.rs
@@ -20,7 +20,8 @@ use crate::protocols::TokenIdType;
 pub type TokenType = Option<String>;
 pub type LogProbs = Vec<f64>;
 
-pub use super::preprocessor::PreprocessedRequest as BackendInput;
+pub use super::preprocessor::PreprocessedRequest as BackendInput; // TODO stop renaming this
+pub use super::preprocessor::PreprocessedRequest;
 pub use super::FinishReason;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/lib/runtime/src/protocols.rs
+++ b/lib/runtime/src/protocols.rs
@@ -173,6 +173,16 @@ impl FromStr for Endpoint {
     }
 }
 
+impl Endpoint {
+    /// As a String like dyn://dynamo.internal.worker
+    pub fn as_url(&self) -> String {
+        format!(
+            "{ENDPOINT_SCHEME}{}.{}.{}",
+            self.namespace, self.component, self.name
+        )
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RouterType {


### PR DESCRIPTION
Router:
```
dynamo-run in=http out=dyn://dynamo.endpoint.generate --router-mode kv
```

Worker (* N):
```
dynamo-run in=dyn://dynamo.endpoint.generate out=vllm /data/llms/Qwen/Qwen3-4B
```

You need patched vllm and the C bindings `.so`. Full docs in the updated guide: `docs/guides/dynamo_run.md`.

This gives us a pure-Rust ingress node: OpenAI compliant HTTP server + Pre-processor + KV-aware router.
