### PR TITLE
fix: downgrade CUDA image use to work around PyNccl timeout in vLLM Ray use case

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
+# FIXME: NCCL will hang with 25.03, so use 25.01 for now
+# Please check https://github.com/ai-dynamo/dynamo/pull/1065
+# for details and reproducer to manually test if the image
+# can be updated to later versions.
 ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
-ARG BASE_IMAGE_TAG="25.03-cuda12.8-devel-ubuntu24.04"
+ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"

--- a/container/build.sh
+++ b/container/build.sh
@@ -96,7 +96,7 @@ TENSORRTLLM_PIP_WHEEL=""
 
 
 VLLM_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
-VLLM_BASE_IMAGE_TAG="25.03-cuda12.8-devel-ubuntu24.04"
+VLLM_BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 
 NONE_BASE_IMAGE="ubuntu"
 NONE_BASE_IMAGE_TAG="24.04"

--- a/container/build.sh
+++ b/container/build.sh
@@ -96,6 +96,10 @@ TENSORRTLLM_PIP_WHEEL=""
 
 
 VLLM_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
+# FIXME: NCCL will hang with 25.03, so use 25.01 for now
+# Please check https://github.com/ai-dynamo/dynamo/pull/1065
+# for details and reproducer to manually test if the image
+# can be updated to later versions.
 VLLM_BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 
 NONE_BASE_IMAGE="ubuntu"


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Starting from https://github.com/ai-dynamo/dynamo/commit/566068dc395970c224c6d74d8939997e7a5d40d8 , deploying single model across nodes in vLLM will result in NCCL timeout. Which happens due to updating the CUDA image. This suggests incompatible (versions?) between the driver library and what is used for vLLM, will revert this update for now until the issue is better understood.

```
INFO 05-11 21:27:10 [worker.py:284] model weights take 1.00GiB; non_torch_memory takes 4.39GiB; PyTorch activation peak memory takes 1.30GiB; the rest of the memory reserved for KV Cache is 64.51GiB.
(RayWorkerWrapper pid=144878, ip=10.52.51.35) [rank12]:[E511 21:37:10.112405891 ProcessGroupNCCL.cpp:629] [Rank 12] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=1, OpType=GATHER, NumelIn=2052096, NumelOut=0, Timeout(ms)=600000) ran for 600074 milliseconds before timing out.
(RayWorkerWrapper pid=144878, ip=10.52.51.35) [rank12]:[E511 21:37:10.112440392 ProcessGroupNCCL.cpp:2168] [PG ID 2 PG GUID 3 Rank 12]  failure detected by watchdog at work sequence id: 1 PG status: last enqueued work: 1, last completed work: -1
(RayWorkerWrapper pid=144878, ip=10.52.51.35) [rank12]:[E511 21:37:10.112451424 ProcessGroupNCCL.cpp:667] Stack trace of the failed collective not found, potentially because FlightRecorder is disabled. You can enable it by setting TORCH_NCCL_TRACE_BUFFER_SIZE to a non-zero value.
(RayWorkerWrapper pid=144878, ip=10.52.51.35) [rank12]:[E511 21:37:10.112454356 ProcessGroupNCCL.cpp:681] [Rank 12] Some NCCL operations have failed or timed out. Due to the asynchronous nature of CUDA kernels, subsequent GPU operations might run on corrupted/incomplete data.
(RayWorkerWrapper pid=144878, ip=10.52.51.35) [rank12]:[E511 21:37:10.112457053 ProcessGroupNCCL.cpp:695] [Rank 12] To avoid data inconsistency, we are taking the entire process down.
```

#### Details:

<!-- Describe the changes made in this PR. -->

Reproducer:
As this repro requires multi-node environment, you need to have access to at least two nodes, and make their GPUs visible via `ray start --head --port=6379 --disable-usage-stats` on one node and `ray start --address={cluster_head}:6379` on the rest of the nodes.
Then on one of the nodes, run and make sure --tensor-parallel-size is set to span two nodes (i.e. below is 16 = 2 nodes * 8 GPUs per node), and wait for the error regarding timeout
```
vllm serve deepseek-ai/DeepSeek-R1-Distill-Llama-8B   --block-size 64   --max-model-len 13500   --tensor-parallel-size 16   --gpu-memory-utilization 0.90   --disable-log-requests   --port 8001
```
With this image downgraph, the issue goes away. Note that there can still be intermittent  failure from CUDA graph capturing, but that has passed the stalling point and should be investigate as a separate issue.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
