### PR TITLE
Provide examples of enabling dynamo to support the openai v1/completions interface

### DIFF
--- a/container/deps/vllm/vllm_v0.8.4-dynamo-kv-disagg-patch.patch
+++ b/container/deps/vllm/vllm_v0.8.4-dynamo-kv-disagg-patch.patch
@@ -1045,7 +1045,7 @@ index 000000000..a2f9ce99e
 \ No newline at end of file
 diff --git a/vllm/distributed/device_communicators/nixl.py b/vllm/distributed/device_communicators/nixl.py
 new file mode 100644
-index 000000000..8f773b8f8
+index 000000000..bd4ac984e
 --- /dev/null
 +++ b/vllm/distributed/device_communicators/nixl.py
 @@ -0,0 +1,445 @@
@@ -1309,24 +1309,21 @@ index 000000000..8f773b8f8
 +            return
 +
 +        start_time = time.perf_counter()
-++
-+        tp_multiplier = self._tp_size[dst_engine_id] // self._tp_size[self.engine_id]
-+        remote_block_descs_ids = self._get_block_descs_ids(dst_engine_id, "all", remote_block_ids)
-+        local_xfer_side_handle = self.src_xfer_side_handles[tp_multiplier]
-+        handles = []
 +
 +        if self._is_mla:
 +            # TODO ptarasiewicz: we skip staging when is_mla is true, we shouldn't assign staging blocks at all
 +            staging_rearranging_ranges = None
 +            staging_block_ids = local_block_ids
-+        elif tp_multiplier == 1:
-+            staging_block_ids = local_block_ids
-+            staging_rearranging_ranges = self._get_ranges(staging_block_ids)
 +        else:
 +            local_ranges = self._get_ranges(local_block_ids)
 +            staging_ranges = self._get_ranges(staging_block_ids)
 +
 +            local_rearranging_ranges, staging_rearranging_ranges = self._get_same_length_ranges(local_ranges, staging_ranges)
++
++        tp_multiplier = self._tp_size[dst_engine_id] // self._tp_size[self.engine_id]
++        remote_block_descs_ids = self._get_block_descs_ids(dst_engine_id, "all", remote_block_ids)
++        local_xfer_side_handle = self.src_xfer_side_handles[tp_multiplier]
++        handles = []
 +
 +        logger.debug("Time to get block descs ids: %s ms", (time.perf_counter() - start_time) * 1000)
 +        create_xfer_start_time = time.perf_counter()
@@ -1357,7 +1354,7 @@ index 000000000..8f773b8f8
 +
 +        rearrange_start_time = time.perf_counter()
 +
-+        if not self._is_mla and tp_multiplier != 1:
++        if not self._is_mla:
 +            for local_range, staging_range in zip(local_rearranging_ranges, staging_rearranging_ranges):
 +                logger.debug("Rearranging tensors for cache: %s, local_range: %s, staging_range: %s", self.kv_caches[0].shape, local_range, staging_range)
 +                for kv_cache in self.kv_caches:
@@ -1391,9 +1388,6 @@ index 000000000..8f773b8f8
 +            # TODO ptarasiewicz: we skip staging when is_mla is true, we shouldn't assign staging blocks at all
 +            staging_rearranging_ranges = None
 +            staging_block_ids = local_block_ids
-+        elif tp_multiplier == 1:
-+            staging_block_ids = local_block_ids
-+            staging_rearranging_ranges = self._get_ranges(staging_block_ids)
 +        else:
 +            local_ranges = self._get_ranges(local_block_ids)
 +            staging_ranges = self._get_ranges(staging_block_ids)
@@ -1494,6 +1488,12 @@ index 000000000..8f773b8f8
 +                if xfer_state == "PROC":
 +                    running_reqs.append(handle)
 +                else:
++                    raise RuntimeError("Transfer failed with state %s", xfer_state)
++            if len(running_reqs) == 0:
++                done_req_ids.append(req_id)
++            else:
++                self._transfers[req_id] = running_reqs
++        return done_req_ids
 diff --git a/vllm/distributed/kv_transfer/kv_connector/dynamo_connector.py b/vllm/distributed/kv_transfer/kv_connector/dynamo_connector.py
 new file mode 100644
 index 000000000..418fc7154

--- a/container/deps/vllm/vllm_v0.8.4-dynamo-kv-disagg-patch.patch
+++ b/container/deps/vllm/vllm_v0.8.4-dynamo-kv-disagg-patch.patch
@@ -1045,7 +1045,7 @@ index 000000000..a2f9ce99e
 \ No newline at end of file
 diff --git a/vllm/distributed/device_communicators/nixl.py b/vllm/distributed/device_communicators/nixl.py
 new file mode 100644
-index 000000000..bd4ac984e
+index 000000000..8f773b8f8
 --- /dev/null
 +++ b/vllm/distributed/device_communicators/nixl.py
 @@ -0,0 +1,445 @@
@@ -1309,21 +1309,24 @@ index 000000000..bd4ac984e
 +            return
 +
 +        start_time = time.perf_counter()
+++
++        tp_multiplier = self._tp_size[dst_engine_id] // self._tp_size[self.engine_id]
++        remote_block_descs_ids = self._get_block_descs_ids(dst_engine_id, "all", remote_block_ids)
++        local_xfer_side_handle = self.src_xfer_side_handles[tp_multiplier]
++        handles = []
 +
 +        if self._is_mla:
 +            # TODO ptarasiewicz: we skip staging when is_mla is true, we shouldn't assign staging blocks at all
 +            staging_rearranging_ranges = None
 +            staging_block_ids = local_block_ids
++        elif tp_multiplier == 1:
++            staging_block_ids = local_block_ids
++            staging_rearranging_ranges = self._get_ranges(staging_block_ids)
 +        else:
 +            local_ranges = self._get_ranges(local_block_ids)
 +            staging_ranges = self._get_ranges(staging_block_ids)
 +
 +            local_rearranging_ranges, staging_rearranging_ranges = self._get_same_length_ranges(local_ranges, staging_ranges)
-+
-+        tp_multiplier = self._tp_size[dst_engine_id] // self._tp_size[self.engine_id]
-+        remote_block_descs_ids = self._get_block_descs_ids(dst_engine_id, "all", remote_block_ids)
-+        local_xfer_side_handle = self.src_xfer_side_handles[tp_multiplier]
-+        handles = []
 +
 +        logger.debug("Time to get block descs ids: %s ms", (time.perf_counter() - start_time) * 1000)
 +        create_xfer_start_time = time.perf_counter()
@@ -1354,7 +1357,7 @@ index 000000000..bd4ac984e
 +
 +        rearrange_start_time = time.perf_counter()
 +
-+        if not self._is_mla:
++        if not self._is_mla and tp_multiplier != 1:
 +            for local_range, staging_range in zip(local_rearranging_ranges, staging_rearranging_ranges):
 +                logger.debug("Rearranging tensors for cache: %s, local_range: %s, staging_range: %s", self.kv_caches[0].shape, local_range, staging_range)
 +                for kv_cache in self.kv_caches:
@@ -1388,6 +1391,9 @@ index 000000000..bd4ac984e
 +            # TODO ptarasiewicz: we skip staging when is_mla is true, we shouldn't assign staging blocks at all
 +            staging_rearranging_ranges = None
 +            staging_block_ids = local_block_ids
++        elif tp_multiplier == 1:
++            staging_block_ids = local_block_ids
++            staging_rearranging_ranges = self._get_ranges(staging_block_ids)
 +        else:
 +            local_ranges = self._get_ranges(local_block_ids)
 +            staging_ranges = self._get_ranges(staging_block_ids)
@@ -1488,12 +1494,6 @@ index 000000000..bd4ac984e
 +                if xfer_state == "PROC":
 +                    running_reqs.append(handle)
 +                else:
-+                    raise RuntimeError("Transfer failed with state %s", xfer_state)
-+            if len(running_reqs) == 0:
-+                done_req_ids.append(req_id)
-+            else:
-+                self._transfers[req_id] = running_reqs
-+        return done_req_ids
 diff --git a/vllm/distributed/kv_transfer/kv_connector/dynamo_connector.py b/vllm/distributed/kv_transfer/kv_connector/dynamo_connector.py
 new file mode 100644
 index 000000000..418fc7154
@@ -4023,6 +4023,34 @@ index dd0b67df4..f436b0752 100644
 @@ -247,6 +262,7 @@ class OpenAIServingChat(OpenAIServing):
                          trace_headers=trace_headers,
                          prompt_adapter_request=prompt_adapter_request,
+                         priority=request.priority,
++                        remote_prefill_params=remote_prefill_params,
+                     )
+ 
+                 generators.append(generator)
+diff --git a/vllm/entrypoints/openai/serving_completion.py b/vllm/entrypoints/openai/serving_completion.py
+index 1067f35ce..cbc131de4 100644
+--- a/vllm/entrypoints/openai/serving_completion.py
++++ b/vllm/entrypoints/openai/serving_completion.py
+@@ -33,6 +33,7 @@ from vllm.sampling_params import BeamSearchParams, SamplingParams
+ from vllm.sequence import Logprob
+ from vllm.transformers_utils.tokenizer import AnyTokenizer
+ from vllm.utils import merge_async_iterators
++from vllm.remote_prefill import RemotePrefillParams
+ 
+ logger = init_logger(__name__)
+ 
+@@ -65,6 +66,7 @@ class OpenAIServingCompletion(OpenAIServing):
+         self,
+         request: CompletionRequest,
+         raw_request: Optional[Request] = None,
++        remote_prefill_params: Optional[RemotePrefillParams] = None,
+     ) -> Union[AsyncGenerator[str, None], CompletionResponse, ErrorResponse]:
+         """Completion API similar to OpenAI's API.
+ 
+@@ -167,6 +169,7 @@ class OpenAIServingCompletion(OpenAIServing):
+                         prompt_adapter_request=prompt_adapter_request,
+                         trace_headers=trace_headers,
                          priority=request.priority,
 +                        remote_prefill_params=remote_prefill_params,
                      )

--- a/examples/llm/openai-completions-example.md
+++ b/examples/llm/openai-completions-example.md
@@ -1,0 +1,80 @@
+# Openai v1/completions interface examples
+
+## Step 1: Modify the parameters of subprocess.run in frontend.py
+
+Change "chat-models" in subprocess.run to "completions"
+```python
+# DYNAMO_DIR/examples/llm/components/frontend.py
+
+# The first modification
+def setup_model(self):
+    """Configure the model for HTTP service using llmctl."""
+    subprocess.run(
+        [
+            "llmctl",
+            "http",
+            "remove",
+            "completions",        # "chat-models" -> "completions"
+            self.frontend_config.served_model_name,
+        ],
+        check=False,
+    )
+    # The second modification
+    subprocess.run(
+        [
+            "llmctl",
+            "http",
+            "add",
+            "completions",        # "chat-models" -> "completions"
+            self.frontend_config.served_model_name,
+            self.frontend_config.endpoint,
+        ],
+        check=False,
+    )
+
+# The third modification
+@async_on_shutdown
+def cleanup(self):
+    """Clean up resources before shutdown."""
+
+    # circusd manages shutdown of http server process, we just need to remove the model using the on_shutdown hook
+    subprocess.run(
+        [
+            "llmctl",
+            "http",
+            "remove",
+            "completions",            # "chat-models" -> "completions"
+            self.frontend_config.served_model_name,
+        ],
+        check=False,
+    )
+
+```
+
+## **Step 2**: Annotation processor.py chat_completions method and enable completions
+
+```python
+# DYNAMO_DIR/examples/LLM/components/processor.py
+
+# @dynamo_endpoint(name="chat/completions")
+# async def chat_completions(self, raw_request: ChatCompletionRequest):
+#     async for response in self._generate(raw_request, RequestType.CHAT):
+#         yield response
+
+@dynamo_endpoint()
+async def completions(self, raw_request: CompletionRequest):
+    async for response in self._generate(raw_request, RequestType.COMPLETION):
+        yield response
+
+```
+
+## **Step 3**: Modify the endpoint in the Frontend of the yaml file
+
+```yaml
+# The yaml files required for dynamo serve
+
+Frontend:
+  served_model_name: Meta-Llama-3.1-8B-Instruct
+  endpoint: dynamo.Processor.completions        # chat/completions -> completions
+  port: 8000
+```


### PR DESCRIPTION
#### Overview:

Provide examples of enabling dynamo to support the openai v1/completions interface

#### Details:

1. Modify the /vllm/entrypoints/openai/serving_completion.py in ai-dynamo-vllm, make it support pd disaggregated.
2. An operation example for enabling dynamo to support the openai v1/completions interface is given.

#### Where should the reviewer start?

After modifying the code in examples/llm/openai-completions-example.md, start a server through dynamo serve and send completions requests to the server to test the availability of v1/completions.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

#312 
