### PR TITLE
feat: Add ignore_eos/nvext support for legacy completions

### DIFF
--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
     resources={"cpu": "10", "memory": "20Gi"},
     workers=1,
 )
+
 class Processor(ChatProcessorMixin):
     worker = depends(TensorRTLLMWorker)
     router = depends(Router)

--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -40,7 +40,6 @@ logger = logging.getLogger(__name__)
     resources={"cpu": "10", "memory": "20Gi"},
     workers=1,
 )
-
 class Processor(ChatProcessorMixin):
     worker = depends(TensorRTLLMWorker)
     router = depends(Router)


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Same as https://github.com/ai-dynamo/dynamo/pull/988 but for `/completions` endpoint

**Before:** 

`min` column of OSL is ~80 when it should be ~256

<img width="541" alt="image" src="https://github.com/user-attachments/assets/2a02a11a-e886-4504-b39f-b2d844a39abc" />

**After:**

`min_column` of OSL is ~256 when including `ignore_eos` via `nvext`:
```
    --extra-inputs "{\"nvext\":{\"ignore_eos\":true}}" \
```

<img width="541" alt="image" src="https://github.com/user-attachments/assets/4912cd4b-dd85-45b2-afc2-10c134bd8c95" />



Example genai-perf command:
```bash
model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
isl=50
osl=256
concurrency=32
request_count=64

genai-perf profile \
    --model ${model} \
    --tokenizer ${model} \
    --endpoint-type completions \
    --streaming \
    --url http://localhost:8000 \
    --synthetic-input-tokens-mean ${isl} \
    --synthetic-input-tokens-stddev 0 \
    --output-tokens-mean ${osl} \
    --output-tokens-stddev 0 \
    --concurrency ${concurrency} \
    --request-count ${request_count} \
    --extra-inputs max_tokens:${osl} \
    --extra-inputs "{\"nvext\":{\"ignore_eos\":true}}" \
    --random-seed 4 \
    --verbose \
    -- \
    --max-threads 256

# NOTE: The `ignore_eos`/`min_tokens` fields here are not currently respected by dynamo
# openai http frontend since they're not in official spec. Only those within the `nvext` extension
# field are respected.
#    --extra-inputs ignore_eos:true \
#    --extra-inputs min_tokens:${osl} \
```

**NOTE**: I also had to patch `genai-perf` to send prompts for completions as a string "hello" instead of a list of strings `["hello"]`, because the current dynamo-trtllm worker doesn't support list of strings: https://github.com/ai-dynamo/dynamo/blob/b813befa67341f086864cb8a2451407eb706823e/examples/tensorrt_llm/common/chat_processor.py#L422. The patch was to send `prompt[0]` instead of `prompt` in genai-perf here: https://github.com/triton-inference-server/perf_analyzer/blob/cc91967d6afaa2d4a5f325e1e8c086f7ef3475bb/genai-perf/genai_perf/inputs/converters/openai_completions_converter.py#L49.

If we move the dynamo-trtllm example preprocessing into `dynamo-run` instead, this restriction should be fixed/lifted.