### PR TITLE
build: remove block-manager feature flag for runtime wheel

### DIFF
--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -51,7 +51,6 @@ module-name = "dynamo._core"
 manifest-path = "Cargo.toml"
 python-packages = ["dynamo"]
 python-source = "src"
-features = ["dynamo-llm/block-manager"]
 
 [build-system]
 requires = ["maturin>=1.0,<2.0", "patchelf"]


### PR DESCRIPTION
#### Overview:
Enabling block-manager feature packages some nixl so libraries in the ai-dynamo-runtime wheel. Since these nixl libraries are not built in manylinux container, the glibc version requirement is higher. Error log 
```
import dynamo.runtime
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/py310/lib/python3.10/site-packages/dynamo/runtime/__init__.py", line 25, in <module>
    from dynamo._core import Backend as Backend
ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /py310/lib/python3.10/site-packages/dynamo/../dynamo.libs/libnixl-1279b4e0.so)
```

Python bindings do not use the block-manager feature today, so safe to remove for now

closes: OPS-58
