### PR TITLE
fix: Fix default RouterMode value

### DIFF
--- a/components/http/src/main.rs
+++ b/components/http/src/main.rs
@@ -1,30 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use clap::Parser;
 use std::sync::Arc;
 
 use dynamo_llm::{
-    http::service::{
-        discovery::{LLMRouterMode, ModelWatcher},
-        service_v2::HttpService,
-    },
+    http::service::{discovery::ModelWatcher, service_v2::HttpService},
     model_type::ModelType,
 };
 use dynamo_runtime::{
-    logging, transports::etcd::PrefixWatcher, DistributedRuntime, Result, Runtime, Worker,
+    logging, pipeline::RouterMode, transports::etcd::PrefixWatcher, DistributedRuntime, Result,
+    Runtime, Worker,
 };
 
 #[derive(Parser)]
@@ -89,7 +75,7 @@ async fn app(runtime: Runtime) -> Result<()> {
                 component.clone(),
                 manager.clone(),
                 &etcd_path,
-                LLMRouterMode::Random,
+                RouterMode::Random,
             )
             .await?,
         );

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -17,7 +17,6 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use clap::ValueEnum;
-use dynamo_llm::http::service::discovery::LLMRouterMode;
 use dynamo_runtime::pipeline::RouterMode as RuntimeRouterMode;
 
 /// Required options depend on the in and out choices
@@ -195,25 +194,12 @@ pub enum RouterMode {
     KV,
 }
 
-impl RouterMode {
-    pub fn is_kv_routing(&self) -> bool {
-        *self == RouterMode::KV
-    }
-
-    pub fn as_runtime(&self) -> Option<RuntimeRouterMode> {
-        match self {
-            RouterMode::RoundRobin => Some(RuntimeRouterMode::RoundRobin),
-            RouterMode::Random => Some(RuntimeRouterMode::Random),
-            // Runtime router does not have KV, it's a dynamo-llm thing, not dynamo-runtime
-            RouterMode::KV => None,
-        }
-    }
-
-    pub fn as_llm(&self) -> LLMRouterMode {
-        match self {
-            RouterMode::RoundRobin => LLMRouterMode::RoundRobin,
-            RouterMode::Random => LLMRouterMode::Random,
-            RouterMode::KV => LLMRouterMode::KV,
+impl From<RouterMode> for RuntimeRouterMode {
+    fn from(r: RouterMode) -> RuntimeRouterMode {
+        match r {
+            RouterMode::RoundRobin => RuntimeRouterMode::RoundRobin,
+            RouterMode::Random => RuntimeRouterMode::Random,
+            RouterMode::KV => RuntimeRouterMode::KV,
         }
     }
 }

--- a/launch/dynamo-run/src/input/common.rs
+++ b/launch/dynamo-run/src/input/common.rs
@@ -102,7 +102,7 @@ pub async fn prepare_engine(
                     let router =
                         PushRouter::<BackendInput, Annotated<LLMEngineOutput>>::from_client(
                             client,
-                            flags.router_mode.as_runtime(),
+                            flags.router_mode.into(),
                         )
                         .await?;
                     let service_backend = match &flags.router_mode {
@@ -133,7 +133,7 @@ pub async fn prepare_engine(
                     PushRouter::<
                         NvCreateChatCompletionRequest,
                         Annotated<NvCreateChatCompletionStreamResponse>,
-                    >::from_client(client, flags.router_mode.as_runtime())
+                    >::from_client(client, flags.router_mode.into())
                     .await?,
                 ),
                 ModelType::Completion => {

--- a/launch/dynamo-run/src/input/http.rs
+++ b/launch/dynamo-run/src/input/http.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 
 use crate::input::common;
 use crate::{EngineConfig, Flags};
-use dynamo_llm::http::service::discovery::LLMRouterMode;
 use dynamo_llm::http::service::ModelManager;
 use dynamo_llm::{
     engines::StreamingEngineAdapter,
@@ -31,6 +30,7 @@ use dynamo_llm::{
     },
 };
 use dynamo_runtime::component::Component;
+use dynamo_runtime::pipeline::RouterMode;
 use dynamo_runtime::transports::etcd;
 use dynamo_runtime::{DistributedRuntime, Runtime};
 
@@ -65,7 +65,7 @@ pub async fn run(
                         http_service.model_manager().clone(),
                         etcd_client.clone(),
                         &network_prefix,
-                        flags.router_mode.as_llm(),
+                        flags.router_mode.into(),
                     )
                     .await?;
                 }
@@ -121,7 +121,7 @@ async fn run_watcher(
     model_manager: ModelManager,
     etcd_client: etcd::Client,
     network_prefix: &str,
-    router_mode: LLMRouterMode,
+    router_mode: RouterMode,
 ) -> anyhow::Result<()> {
     let watch_obj = Arc::new(
         discovery::ModelWatcher::new(component, model_manager, network_prefix, router_mode).await?,

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -76,7 +76,10 @@ pub async fn run(
                 }
                 None => {
                     // echo_full engine doesn't need a path
-                    Default::default()
+                    match &flags.model_name {
+                        Some(name) => LocalModel::with_name_only(name),
+                        None => Default::default(),
+                    }
                 }
             }
         }

--- a/lib/llm/src/http/service/discovery.rs
+++ b/lib/llm/src/http/service/discovery.rs
@@ -1,17 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use std::sync::Arc;
 
@@ -22,8 +10,8 @@ use tokio::sync::mpsc::Receiver;
 use dynamo_runtime::{
     component::{self, Component, ComponentEndpointInfo},
     pipeline::{
-        network::egress::push_router::PushRouter, ManyOut, Operator,
-        RouterMode as RuntimeRouterMode, SegmentSource, ServiceBackend, SingleIn, Source,
+        network::egress::push_router::PushRouter, ManyOut, Operator, RouterMode, SegmentSource,
+        ServiceBackend, SingleIn, Source,
     },
     protocols::{self, annotated::Annotated},
     slug::Slug,
@@ -165,33 +153,11 @@ impl std::fmt::Display for ModelNetworkName {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum LLMRouterMode {
-    Random,
-    RoundRobin,
-    KV,
-}
-
-impl LLMRouterMode {
-    pub fn is_kv_routing(&self) -> bool {
-        *self == LLMRouterMode::KV
-    }
-
-    pub fn as_runtime(&self) -> Option<RuntimeRouterMode> {
-        match self {
-            LLMRouterMode::RoundRobin => Some(RuntimeRouterMode::RoundRobin),
-            LLMRouterMode::Random => Some(RuntimeRouterMode::Random),
-            // Runtime router does not have KV, it's a dynamo-llm thing, not dynamo-runtime
-            LLMRouterMode::KV => None,
-        }
-    }
-}
-
 pub struct ModelWatcher {
     prefix: String,
     manager: ModelManager,
     drt: DistributedRuntime,
-    router_mode: LLMRouterMode,
+    router_mode: RouterMode,
     kv_chooser: Option<Arc<KvRouter>>,
 }
 
@@ -200,7 +166,7 @@ impl ModelWatcher {
         component: Component,
         model_manager: ModelManager,
         network_prefix: &str,
-        router_mode: LLMRouterMode,
+        router_mode: RouterMode,
     ) -> anyhow::Result<ModelWatcher> {
         let kv_chooser = if router_mode.is_kv_routing() {
             let selector = Box::new(DefaultWorkerSelector {});
@@ -329,14 +295,14 @@ impl ModelWatcher {
                 let backend = Backend::from_mdc(card.clone()).await?.into_operator();
                 let router = PushRouter::<BackendInput, Annotated<LLMEngineOutput>>::from_client(
                     client.clone(),
-                    self.router_mode.as_runtime(),
+                    self.router_mode,
                 )
                 .await?;
                 let service_backend = match self.router_mode {
-                    LLMRouterMode::Random | LLMRouterMode::RoundRobin => {
+                    RouterMode::Random | RouterMode::RoundRobin | RouterMode::Direct(_) => {
                         ServiceBackend::from_engine(Arc::new(router))
                     }
-                    LLMRouterMode::KV => {
+                    RouterMode::KV => {
                         let Some(kv_chooser) = self.kv_chooser.clone() else {
                             anyhow::bail!("KV routing mode with no chooser, should be unreachable");
                         };
@@ -363,14 +329,14 @@ impl ModelWatcher {
                 let backend = Backend::from_mdc(card.clone()).await?.into_operator();
                 let router = PushRouter::<BackendInput, Annotated<LLMEngineOutput>>::from_client(
                     client,
-                    self.router_mode.as_runtime(),
+                    self.router_mode,
                 )
                 .await?;
                 let service_backend = match self.router_mode {
-                    LLMRouterMode::Random | LLMRouterMode::RoundRobin => {
+                    RouterMode::Random | RouterMode::RoundRobin | RouterMode::Direct(_) => {
                         ServiceBackend::from_engine(Arc::new(router))
                     }
-                    LLMRouterMode::KV => {
+                    RouterMode::KV => {
                         let Some(kv_chooser) = self.kv_chooser.clone() else {
                             anyhow::bail!("KV routing mode with no chooser, should be unreachable");
                         };

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -36,6 +36,13 @@ impl Default for LocalModel {
 }
 
 impl LocalModel {
+    pub fn with_name_only(name: &str) -> Self {
+        LocalModel {
+            card: ModelDeploymentCard::with_name_only(name),
+            ..Default::default()
+        }
+    }
+
     pub fn card(&self) -> &ModelDeploymentCard {
         &self.card
     }


### PR DESCRIPTION
The Python bindings use the default value for RouterMode. Previously that was Random (good), but now it became None (bad).

Remove the option and clean up the duplicate RouterMode. I was trying to avoid putting the `KV` enum in dynamo-runtime. Turns out adding those two characters gives us a healthy simplification, and restores the old default router value.

Also clean up two noisy log messages when waiting for KV routing metrics to start in worker.
