### PR TITLE
chore: Update default router mode from random to round-robin

### DIFF
--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -106,7 +106,9 @@ Vllm engine. Receives and returns requests over the network.
 dynamo-run in=dyn://llama3B_pool out=vllm ~/llms/Llama-3.2-3B-Instruct
 ```
 
-This will use etcd to auto-discover the model and NATS to talk to it. You can run multiple workers on the same endpoint and it will pick one at random each time.
+This will use etcd to auto-discover the model and NATS to talk to it. You can
+run multiple workers on the same endpoint and it will pick one based on the
+`--router-mode` (round-robin by default if left unspecified).
 
 The `llama3B_pool` name is purely symbolic, pick anything as long as it matches the other node.
 

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -187,9 +187,9 @@ impl Flags {
 #[derive(Default, PartialEq, Eq, ValueEnum, Clone, Debug, Copy)]
 pub enum RouterMode {
     #[default]
-    Random,
     #[value(name = "round-robin")]
     RoundRobin,
+    Random,
     #[value(name = "kv")]
     KV,
 }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -65,8 +65,8 @@ where
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub enum RouterMode {
     #[default]
-    Random,
     RoundRobin,
+    Random,
     Direct(i64),
     // Marker value, KV routing itself is in dynamo-llm
     KV,

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -65,8 +65,8 @@ where
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub enum RouterMode {
     #[default]
-    RoundRobin,
     Random,
+    RoundRobin,
     Direct(i64),
     // Marker value, KV routing itself is in dynamo-llm
     KV,

--- a/lib/runtime/src/protocols.rs
+++ b/lib/runtime/src/protocols.rs
@@ -192,7 +192,7 @@ pub enum RouterType {
 
 impl Default for RouterType {
     fn default() -> Self {
-        Self::PushRandom
+        Self::PushRoundRobin
     }
 }
 
@@ -212,7 +212,7 @@ mod tests {
     #[test]
     fn test_router_type_default() {
         let default_router = RouterType::default();
-        assert_eq!(default_router, RouterType::PushRandom);
+        assert_eq!(default_router, RouterType::PushRoundRobin);
     }
 
     #[test]

--- a/lib/runtime/src/protocols.rs
+++ b/lib/runtime/src/protocols.rs
@@ -192,7 +192,7 @@ pub enum RouterType {
 
 impl Default for RouterType {
     fn default() -> Self {
-        Self::PushRoundRobin
+        Self::PushRandom
     }
 }
 
@@ -212,7 +212,7 @@ mod tests {
     #[test]
     fn test_router_type_default() {
         let default_router = RouterType::default();
-        assert_eq!(default_router, RouterType::PushRoundRobin);
+        assert_eq!(default_router, RouterType::PushRandom);
     }
 
     #[test]


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Based on https://github.com/ai-dynamo/dynamo/pull/1092#discussion_r2091715104

RoundRobin is an intuitive default behavior that is easy to explain and easy to test. Random may be preferred in some scenarios, but is less predictable and can be configured when needed.

#### Details

Seems like the dynamo-run `--router-mode` CLI flag already defaulted to round-robin, so left unchanged here: https://github.com/ai-dynamo/dynamo/blob/889ab67e0c9a732b2be76619ea4b6f72684c95f8/launch/dynamo-run/src/flags.rs#L105
