### PR TITLE
chore: Prevent duplicate components with different models.

### DIFF
--- a/launch/dynamo-run/src/input/common.rs
+++ b/launch/dynamo-run/src/input/common.rs
@@ -79,8 +79,8 @@ pub async fn prepare_engine(
             let Some(etcd_client) = distributed_runtime.etcd_client() else {
                 anyhow::bail!("Cannot run distributed components without etcd");
             };
-            let network_entry = network_name.load_entry(etcd_client.clone()).await?;
-            let mut card = network_entry.load_mdc(endpoint_id, etcd_client).await?;
+            let network_entry = network_name.load_entry(&etcd_client).await?;
+            let mut card = network_entry.load_mdc(endpoint_id, &etcd_client).await?;
 
             let engine: OpenAIChatCompletionsStreamingEngine = match network_entry.model_type {
                 ModelType::Backend => {


### PR DESCRIPTION
Each namespace is for a single pipeline, so a component must be model-unique. The means we can have several components with the same name running the same model (data parallel), their traffic will be routed according to `--router-mode`, but we cannot have several components with the same name running different models.

Add an `ensure_unique` check to prevent that happening.
