### PR TITLE
chore: Update TensorRT-LLM version to latest

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ARG BASE_IMAGE="nvcr.io/nvidia/pytorch"
-ARG BASE_IMAGE_TAG="25.03-py3"
+ARG BASE_IMAGE_TAG="25.04-py3"
 ARG RELEASE_BUILD
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
@@ -141,7 +141,11 @@ COPY --from=trtllm_wheel . /trtllm_wheel/
 # TODO: Currently, ABI compatibility issues with TRTLLM wheel and NGC PyTorch prevent us
 # from using the TRTLLM wheel in a uv venv. Once the issues are resolved, we can
 # use uv to install TensorRT-LLM wheel within the uv venv.
+# Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel
+# because there might be mismatched versions of TensorRT between the NGC PyTorch
+# and the TRTLLM wheel.
 RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
+    pip uninstall -y tensorrt && \
     if [ "$HAS_TRTLLM_CONTEXT" = "1" ]; then \
         # Install from local wheel directory in build context
         WHEEL_FILE=$(find /trtllm_wheel -name "*.whl" | head -n 1); \

--- a/container/build.sh
+++ b/container/build.sh
@@ -58,7 +58,7 @@ BUILD_CONTEXT=$(dirname "$(readlink -f "$SOURCE_DIR")")
 
 # Base Images
 TENSORRTLLM_BASE_IMAGE=nvcr.io/nvidia/pytorch
-TENSORRTLLM_BASE_IMAGE_TAG=25.03-py3
+TENSORRTLLM_BASE_IMAGE_TAG=25.04-py3
 
 # Important Note: Because of ABI compatibility issues between TensorRT-LLM and NGC PyTorch,
 # we need to build the TensorRT-LLM wheel from source.
@@ -88,7 +88,7 @@ TENSORRTLLM_PIP_WHEEL_DIR="/tmp/trtllm_wheel/"
 # TensorRT-LLM commit to use for building the trtllm wheel if not provided.
 # Important Note: This commit is not used in our CI pipeline. See the CI
 # variables to learn how to run a pipeline with a specific commit.
-TRTLLM_COMMIT=83f37614ef735d251281136c3c05b1fecf8ef68b
+TRTLLM_COMMIT=290649b6aaed5f233b0a0adf50edc1347f8d2b14
 
 # TensorRT-LLM PyPI index URL
 TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"


### PR DESCRIPTION
#### Overview:

Updating to pytorch NGC 25.04 and latest TensorRT-LLM.

#### Details:

This helps me with cuda/driver mismatch errors in the container.


