### PR TITLE
fix: add planner path in devcontainer

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -66,3 +66,4 @@ cd $HOME/dynamo && retry env DYNAMO_BIN_PATH=$HOME/dynamo/.build/target/debug uv
 echo "source /opt/dynamo/venv/bin/activate" >> ~/.bashrc
 echo "export VLLM_KV_CAPI_PATH=$HOME/dynamo/.build/target/debug/libdynamo_llm_capi.so" >> ~/.bashrc
 echo "export GPG_TTY=$(tty)" >> ~/.bashrc
+echo "export PYTHONPATH=$HOME/dynamo/components/planner/src:$PYTHONPATH" >> ~/.bashrc

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -67,3 +67,4 @@ echo "source /opt/dynamo/venv/bin/activate" >> ~/.bashrc
 echo "export VLLM_KV_CAPI_PATH=$HOME/dynamo/.build/target/debug/libdynamo_llm_capi.so" >> ~/.bashrc
 echo "export GPG_TTY=$(tty)" >> ~/.bashrc
 echo "export PYTHONPATH=$HOME/dynamo/components/planner/src:$PYTHONPATH" >> ~/.bashrc
+echo "export PYTHONPATH=$HOME/dynamo/deploy/sdk/src:$PYTHONPATH" >> ~/.bashrc

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -66,5 +66,3 @@ cd $HOME/dynamo && retry env DYNAMO_BIN_PATH=$HOME/dynamo/.build/target/debug uv
 echo "source /opt/dynamo/venv/bin/activate" >> ~/.bashrc
 echo "export VLLM_KV_CAPI_PATH=$HOME/dynamo/.build/target/debug/libdynamo_llm_capi.so" >> ~/.bashrc
 echo "export GPG_TTY=$(tty)" >> ~/.bashrc
-echo "export PYTHONPATH=$HOME/dynamo/components/planner/src:$PYTHONPATH" >> ~/.bashrc
-echo "export PYTHONPATH=$HOME/dynamo/deploy/sdk/src:$PYTHONPATH" >> ~/.bashrc

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -296,6 +296,7 @@ COPY --from=base --chown=$USERNAME:$USERNAME /usr/local/bin /usr/local/bin
 
 USER $USERNAME
 ENV HOME=/home/$USERNAME
+ENV PYTHONPATH=$HOME/dynamo/deploy/sdk/src:$PYTHONPATH:$HOME/dynamo/components/planner/src:$PYTHONPATH
 WORKDIR $HOME
 
 # https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history


### PR DESCRIPTION
#### Details:

Add planner path in devcontainer based on [README](https://github.com/ai-dynamo/dynamo?tab=readme-ov-file#local-development)

it's causing error during `dynamo` cli invocation in devcontainer

```
(venv) ubuntu@hostname$ dynamo --help
Traceback (most recent call last):
  File "/opt/dynamo/venv/bin/dynamo", line 4, in <module>
    from dynamo.sdk.cli.cli import cli
  File "/home/ubuntu/dynamo/deploy/sdk/src/dynamo/sdk/cli/cli.py", line 25, in <module>
    from dynamo.sdk.cli.deployment import app as deployment_app
  File "/home/ubuntu/dynamo/deploy/sdk/src/dynamo/sdk/cli/deployment.py", line 40, in <module>
    from .utils import resolve_service_config
  File "/home/ubuntu/dynamo/deploy/sdk/src/dynamo/sdk/cli/utils.py", line 36, in <module>
    from dynamo.planner.defaults import PlannerDefaults  # type: ignore[attr-defined]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'dynamo.planner'
``` 

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
