### PR TITLE
feat: Support multiple models on single ingress node

### DIFF
--- a/components/metrics/src/main.rs
+++ b/components/metrics/src/main.rs
@@ -123,7 +123,7 @@ async fn app(runtime: Runtime) -> Result<()> {
     let component = namespace.component("count")?;
 
     // Create unique instance of Count
-    let key = format!("{}/instance", component.etcd_path());
+    let key = format!("{}/instance", component.etcd_root());
     tracing::debug!("Creating unique instance of Count at {key}");
     drt.etcd_client()
         .expect("Unreachable because of DistributedRuntime::from_settings above")

--- a/components/planner/src/dynamo/planner/local_connector.py
+++ b/components/planner/src/dynamo/planner/local_connector.py
@@ -158,7 +158,7 @@ class LocalConnector(PlannerConnector):
         # We add a custom component name to ensure that the lease is attatched to this specific watcher
         full_cmd = f"{base_cmd} --worker-env '{worker_env_arg}' --custom-component-name '{watcher_name}'"
 
-        pre_add_endpoint_ids = await self._get_endpoint_ids(component_name)
+        pre_add_endpoint_ids = await self._count_instance_ids(component_name)
         logger.info(f"Pre-add endpoint IDs: {pre_add_endpoint_ids}")
 
         logger.info(f"Adding watcher {watcher_name}")
@@ -184,7 +184,7 @@ class LocalConnector(PlannerConnector):
         if blocking:
             required_endpoint_ids = pre_add_endpoint_ids + 1
             while True:
-                current_endpoint_ids = await self._get_endpoint_ids(component_name)
+                current_endpoint_ids = await self._count_instance_ids(component_name)
                 if current_endpoint_ids == required_endpoint_ids:
                     break
                 logger.info(
@@ -248,9 +248,9 @@ class LocalConnector(PlannerConnector):
 
         return success
 
-    async def _get_endpoint_ids(self, component_name: str) -> int:
+    async def _count_instance_ids(self, component_name: str) -> int:
         """
-        Get the endpoint IDs for a component.
+        Count the instance IDs for the 'generate' endpoint of given component.
 
         Args:
             component_name: Name of the component
@@ -266,7 +266,7 @@ class LocalConnector(PlannerConnector):
                     .endpoint("generate")
                     .client()
                 )
-            worker_ids = self.worker_client.endpoint_ids()
+            worker_ids = self.worker_client.instance_ids()
             return len(worker_ids)
         elif component_name == "PrefillWorker":
             if self.prefill_client is None:
@@ -276,7 +276,7 @@ class LocalConnector(PlannerConnector):
                     .endpoint("mock")
                     .client()
                 )
-            prefill_ids = self.prefill_client.endpoint_ids()
+            prefill_ids = self.prefill_client.instance_ids()
             return len(prefill_ids)
         else:
             raise ValueError(f"Component {component_name} not supported")

--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -4,6 +4,7 @@
     * [Automatically download a model from Hugging Face](#use-model-from-hugging-face)
     * [Run a model from local file](#run-a-model-from-local-file)
     * [Distributed system](#distributed-system)
+    * [Network names](#network-names)
     * [KV-aware routing](#kv-aware-routing)
 * [Full usage details](#full-usage-details)
     * [Setup](#setup)
@@ -24,7 +25,7 @@ It supports the following engines: mistralrs, llamacpp, sglang, vllm and tensorr
 
 Usage:
 ```
-dynamo-run in=[http|text|dyn://<path>|batch:<folder>] out=echo_core|echo_full|mistralrs|llamacpp|sglang|vllm|dyn://<path> [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin|kv]
+dynamo-run in=[http|text|dyn://<path>|batch:<folder>] out=echo_core|echo_full|mistralrs|llamacpp|sglang|vllm|dyn [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin|kv]
 ```
 
 Example: `dynamo run Qwen/Qwen3-0.6B`
@@ -95,7 +96,7 @@ You will need [etcd](https://etcd.io/) and [nats](https://nats.io) with jetstrea
 OpenAI compliant HTTP server, optional pre-processing, worker discovery.
 
 ```
-dynamo-run in=http out=dyn://llama3B_pool
+dynamo-run in=http out=dyn
 ```
 
 **Node 2:**
@@ -103,16 +104,49 @@ dynamo-run in=http out=dyn://llama3B_pool
 Vllm engine. Receives and returns requests over the network.
 
 ```
-dynamo-run in=dyn://llama3B_pool out=vllm ~/llms/Llama-3.2-3B-Instruct
+dynamo-run in=dyn://llama3B.backend.generate out=vllm ~/llms/Llama-3.2-3B-Instruct
 ```
 
 This will use etcd to auto-discover the model and NATS to talk to it. You can
-run multiple workers on the same endpoint and it will pick one based on the
+run multiple instances on the same endpoint and it will pick one based on the
 `--router-mode` (round-robin by default if left unspecified).
 
-The `llama3B_pool` name is purely symbolic, pick anything as long as it matches the other node.
-
 Run `dynamo-run --help` for more options.
+
+### Network names
+
+The `in=dyn://` URLs have the format `dyn://namespace.component.endpoint`. For quickstart just use any string `dyn://test`, `dynamo-run` will default any missing parts for you. The pieces matter for a larger system.
+
+* *Namespace*: A pipeline. Usually a model. e.g "llama_8b". Just a name.
+* *Component*: A load balanced service needed to run that pipeline. "backend", "prefill", "decode", "preprocessor", "draft", etc. This typically has some configuration (which model to use, for example).
+* *Endpoint*: Like a URL. "generate", "load_metrics".
+* *Instance*: A process. Unique. Dynamo assigns each one a unique instance_id. The thing that is running is always an instance. Namespace/component/endpoint can refer to multiple instances.
+
+If you run two models, that is two pipelines. An exception would be if doing speculative decoding. The draft model is part of the pipeline of a bigger model.
+
+If you run two instances of the same model ("data parallel") they are the same namespace+component+endpoint but different instances. The router will spread traffic over all the instances of a namespace+component+endpoint. If you have four prefill workers in a pipeline, they all have the same namespace+component+endpoint and are automatically assigned unique instance_ids.
+
+Example 1: Data parallel load balanced, one model one pipeline two instances.
+```
+Node 1: dynamo-run in=dyn://qwen3-32b.backend.generate out=sglang /data/Qwen3-32B --tensor-parallel-size 2 --base-gpu-id 0
+Node 2: dynamo-run in=dyn://qwen3-32b.backend.generate out=sglang /data/Qwen3-32B --tensor-parallel-size 2 --base-gpu-id 2
+```
+
+Example 2: Two models, two pipelines.
+```
+Node 1: dynamo-run in=dyn://qwen3-32b.backend.generate out=vllm /data/Qwen3-32B
+Node 2: dynamo-run in=dyn://llama3-1-8b.backend.generate out=vllm /data/Llama-3.1-8B-Instruct/
+```
+
+Example 3: Different endpoints.
+
+The KV metrics publisher in VLLM adds a `load_metrics` endpoint to the current component. If the `llama3-1-8b.backend` component above is using patched vllm it will also expose `llama3-1-8b.backend.load_metrics`.
+
+Example 4: Multiple component in a pipeline
+
+In the P/D disaggregated setup you would have `deepseek-distill-llama8b.prefill.generate` (possibly multiple instance of this) and `deepseek-distill-llama8b.decode.generate`.
+
+For output it is always only `out=dyn`. This tells Dynamo to auto-discover the instances, group them by model, and load balance appropriately (depending on `--router-mode` flag). The old syntax of `dyn://...` is still accepted for backwards compatibility.
 
 ### KV-aware routing
 
@@ -144,7 +178,7 @@ dynamo-run in=dyn://dynamo.endpoint.generate out=vllm /data/llms/Qwen/Qwen3-4B
 **Start the ingress node**
 
 ```
-dynamo-run in=http out=dyn://dynamo.endpoint.generate --router-mode kv
+dynamo-run in=http out=dyn --router-mode kv
 ```
 
 The only difference from the distributed system above is `--router-mode kv`. The patched vllm will announce when a KV block is created or removed. The Dynamo router run will find the worker with the best match for those KV blocks and direct the traffic to that node.

--- a/examples/hello_world/disagg_skeleton/components/kv_router.py
+++ b/examples/hello_world/disagg_skeleton/components/kv_router.py
@@ -63,7 +63,7 @@ class Router:
         print("KV Router initialized")
 
     def _cost_function(self, request_prompt):
-        worker_ids = self.workers_client.endpoint_ids()
+        worker_ids = self.workers_client.instance_ids()
         num_workers = len(worker_ids)
         max_hit_rate = -1.0
         for curr_id in self.kv_cache.keys():

--- a/examples/hello_world/disagg_skeleton/components/utils.py
+++ b/examples/hello_world/disagg_skeleton/components/utils.py
@@ -275,7 +275,7 @@ async def check_required_workers(
     tag="",
 ):
     """Wait until the minimum number of workers are ready."""
-    worker_ids = workers_client.endpoint_ids()
+    worker_ids = workers_client.instance_ids()
     num_workers = len(worker_ids)
     new_count = -1  # Force to print "waiting for worker" once
     while num_workers < required_workers:
@@ -287,7 +287,7 @@ async def check_required_workers(
                 f" Required: {required_workers}"
             )
         await asyncio.sleep(poll_interval)
-        worker_ids = workers_client.endpoint_ids()
+        worker_ids = workers_client.instance_ids()
         new_count = len(worker_ids)
 
     print(f"Workers ready: {worker_ids}")

--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -170,7 +170,7 @@ class Router:
 
         # Get all worker IDs from the client. This is needed because scores / metrics may not have values for all workers
         # and we want all workers to be considered in the logit calculation
-        worker_ids = self.workers_client.endpoint_ids()
+        worker_ids = self.workers_client.instance_ids()
 
         worker_logits = {}
         for worker_id in worker_ids:

--- a/examples/llm/components/planner.py
+++ b/examples/llm/components/planner.py
@@ -99,8 +99,8 @@ class Planner:
                 )
                 # TODO: remove this sleep after rust client() is blocking until watching state
                 await asyncio.sleep(0.1)
-            # TODO: use etcd events instead of pulling endpoints_ids
-            p_endpoints = self.prefill_client.endpoint_ids()
+            # TODO: use etcd events instead of pulling instance_ids
+            p_endpoints = self.prefill_client.instance_ids()
         except Exception:
             p_endpoints = []
             self._repeating_log_func(
@@ -116,8 +116,8 @@ class Planner:
                 )
                 # TODO: remove this sleep after rust client() is blocking until watching state
                 await asyncio.sleep(0.1)
-            # TODO: use etcd events instead of pulling endpoints_ids
-            d_endpoints = self.workers_client.endpoint_ids()
+            # TODO: use etcd events instead of pulling instance_ids
+            d_endpoints = self.workers_client.instance_ids()
         except Exception as e:
             raise RuntimeError(f"Failed to get decode worker endpoints: {e}")
         return p_endpoints, d_endpoints

--- a/examples/llm/utils/check_worker.py
+++ b/examples/llm/utils/check_worker.py
@@ -25,12 +25,12 @@ async def check_required_workers(
     workers_client: Client, required_workers: int, on_change=True, poll_interval=0.5
 ):
     """Wait until the minimum number of workers are ready."""
-    worker_ids = workers_client.endpoint_ids()
+    worker_ids = workers_client.instance_ids()
     num_workers = len(worker_ids)
 
     while num_workers < required_workers:
         await asyncio.sleep(poll_interval)
-        worker_ids = workers_client.endpoint_ids()
+        worker_ids = workers_client.instance_ids()
         new_count = len(worker_ids)
 
         if (not on_change) or new_count != num_workers:

--- a/examples/multimodal/utils/logging.py
+++ b/examples/multimodal/utils/logging.py
@@ -25,12 +25,12 @@ async def check_required_workers(
     workers_client: Client, required_workers: int, on_change=True, poll_interval=0.5
 ):
     """Wait until the minimum number of workers are ready."""
-    worker_ids = workers_client.endpoint_ids()
+    worker_ids = workers_client.instance_ids()
     num_workers = len(worker_ids)
 
     while num_workers < required_workers:
         await asyncio.sleep(poll_interval)
-        worker_ids = workers_client.endpoint_ids()
+        worker_ids = workers_client.instance_ids()
         new_count = len(worker_ids)
 
         if (not on_change) or new_count != num_workers:

--- a/examples/tensorrt_llm/components/kv_router.py
+++ b/examples/tensorrt_llm/components/kv_router.py
@@ -90,10 +90,10 @@ class Router:
             .endpoint("generate")
             .client()
         )
-        while len(self.workers_client.endpoint_ids()) < self.args.min_workers:
+        while len(self.workers_client.instance_ids()) < self.args.min_workers:
             logger.info(
                 f"Waiting for more workers to be ready.\n"
-                f" Current: {len(self.workers_client.endpoint_ids())},"
+                f" Current: {len(self.workers_client.instance_ids())},"
                 f" Required: {self.args.min_workers}"
             )
             await asyncio.sleep(30)
@@ -144,7 +144,7 @@ class Router:
 
         # Get all worker IDs from the client. This is needed because scores / metrics may not have values for all workers
         # and we want all workers to be considered in the logit calculation
-        worker_ids = self.workers_client.endpoint_ids()
+        worker_ids = self.workers_client.instance_ids()
 
         worker_logits = {}
         for worker_id in worker_ids:

--- a/examples/tensorrt_llm/components/processor.py
+++ b/examples/tensorrt_llm/components/processor.py
@@ -78,10 +78,10 @@ class Processor(ChatProcessorMixin):
                 .client()
             )
 
-        while len(self.worker_client.endpoint_ids()) < self.min_workers:
+        while len(self.worker_client.instance_ids()) < self.min_workers:
             logger.info(
                 f"Waiting for workers to be ready.\n"
-                f" Current: {len(self.worker_client.endpoint_ids())},"
+                f" Current: {len(self.worker_client.instance_ids())},"
                 f" Required: {self.min_workers}"
             )
             await asyncio.sleep(30)

--- a/examples/tensorrt_llm/components/worker.py
+++ b/examples/tensorrt_llm/components/worker.py
@@ -71,10 +71,10 @@ class TensorRTLLMWorker(BaseTensorrtLLMEngine):
                 .endpoint("generate")
                 .client()
             )
-            while len(self._prefill_client.endpoint_ids()) < self._min_prefill_workers:
+            while len(self._prefill_client.instance_ids()) < self._min_prefill_workers:
                 logger.info(
                     f"Waiting for prefill workers to be ready.\n"
-                    f" Current: {len(self._prefill_client.endpoint_ids())},"
+                    f" Current: {len(self._prefill_client.instance_ids())},"
                     f" Required: {self._min_prefill_workers}"
                 )
                 await asyncio.sleep(30)

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -98,7 +98,7 @@ pub struct Flags {
     #[arg(long)]
     pub leader_addr: Option<String>,
 
-    /// If using `out=dyn://..` with multiple backends, this says how to route the requests.
+    /// If using `out=dyn` with multiple instances, this says how to route the requests.
     ///
     /// Mostly interesting for KV-aware routing.
     /// Defaults to RouterMode::RoundRobin

--- a/launch/dynamo-run/src/input/batch.rs
+++ b/launch/dynamo-run/src/input/batch.rs
@@ -1,17 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use anyhow::Context as _;
 use async_openai::types::FinishReason;
@@ -65,7 +53,7 @@ struct Entry {
 
 pub async fn run(
     runtime: Runtime,
-    flags: Flags,
+    _flags: Flags,
     card: ModelDeploymentCard,
     input_jsonl: PathBuf,
     engine_config: EngineConfig,
@@ -80,7 +68,7 @@ pub async fn run(
         );
     }
 
-    let prepared_engine = common::prepare_engine(runtime, flags, engine_config).await?;
+    let prepared_engine = common::prepare_engine(runtime, engine_config).await?;
     let service_name_ref = Arc::new(prepared_engine.service_name);
 
     let pre_processor = if card.has_tokenizer() {

--- a/launch/dynamo-run/src/input/common.rs
+++ b/launch/dynamo-run/src/input/common.rs
@@ -1,29 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use std::pin::Pin;
 
 use dynamo_llm::{
     backend::{Backend, ExecutionContext},
     engines::StreamingEngineAdapter,
-    http::service::discovery::ModelNetworkName,
-    kv_router::{scheduler::DefaultWorkerSelector, KvPushRouter, KvRouter},
+    http::service::{discovery::ModelWatcher, ModelManager},
     model_card::ModelDeploymentCard,
-    model_type::ModelType,
     preprocessor::OpenAIPreprocessor,
-    protocols::common::llm_backend::{BackendInput, BackendOutput, LLMEngineOutput},
+    protocols::common::llm_backend::{BackendInput, BackendOutput},
     types::{
         openai::chat_completions::{
             NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
@@ -33,139 +19,63 @@ use dynamo_llm::{
     },
 };
 use dynamo_runtime::{
+    component,
     engine::{AsyncEngineStream, Data},
-    pipeline::{
-        Context, ManyOut, Operator, PushRouter, SegmentSource, ServiceBackend, ServiceFrontend,
-        SingleIn, Source,
-    },
+    pipeline::{Context, ManyOut, Operator, ServiceBackend, ServiceFrontend, SingleIn, Source},
     DistributedRuntime, Runtime,
 };
 use std::sync::Arc;
 
-use crate::{flags::RouterMode, EngineConfig, Flags};
+use crate::EngineConfig;
 
 pub struct PreparedEngine {
     pub service_name: String,
     pub engine: OpenAIChatCompletionsStreamingEngine,
     pub inspect_template: bool,
-    pub _cache_dir: Option<tempfile::TempDir>,
 }
 
 /// Turns an EngineConfig into an OpenAI chat-completions and completions supported StreamingEngine.
 pub async fn prepare_engine(
     runtime: Runtime,
-    flags: Flags,
     engine_config: EngineConfig,
 ) -> anyhow::Result<PreparedEngine> {
     match engine_config {
-        EngineConfig::Dynamic(endpoint_id) => {
+        EngineConfig::Dynamic => {
             let distributed_runtime = DistributedRuntime::from_settings(runtime.clone()).await?;
 
-            let endpoint = distributed_runtime
-                .namespace(endpoint_id.namespace.clone())?
-                .component(endpoint_id.component.clone())?
-                .endpoint(endpoint_id.name.clone());
+            let Some(etcd_client) = distributed_runtime.etcd_client() else {
+                anyhow::bail!("Cannot be both static mode and run with dynamic discovery.");
+            };
+            let model_manager = ModelManager::new();
+            let watch_obj = Arc::new(
+                ModelWatcher::new(
+                    distributed_runtime,
+                    model_manager.clone(),
+                    dynamo_runtime::pipeline::RouterMode::RoundRobin,
+                )
+                .await?,
+            );
+            let models_watcher = etcd_client
+                .kv_get_and_watch_prefix(component::MODEL_ROOT_PATH)
+                .await?;
+            let (_prefix, _watcher, receiver) = models_watcher.dissolve();
 
-            let client = endpoint.client().await?;
-            let mut cache_dir = None;
-
+            let inner_watch_obj = watch_obj.clone();
+            let _watcher_task = tokio::spawn(inner_watch_obj.watch(receiver));
             tracing::info!("Waiting for remote model..");
 
-            let remote_endpoints = client.wait_for_endpoints().await?;
-            debug_assert!(!remote_endpoints.is_empty());
-            tracing::info!(count = remote_endpoints.len(), "Model(s) discovered");
+            // TODO: We use the first model to appear, usually we have only one
+            // We should add slash commands to text input `/model <name>` to choose,
+            // '/models` to list, and notifications when models are added / removed.
 
-            let network_name: ModelNetworkName = (&remote_endpoints[0]).into();
-            let Some(etcd_client) = distributed_runtime.etcd_client() else {
-                anyhow::bail!("Cannot run distributed components without etcd");
-            };
-            let network_entry = network_name.load_entry(&etcd_client).await?;
-            let mut card = network_entry.load_mdc(endpoint_id, &etcd_client).await?;
-
-            let engine: OpenAIChatCompletionsStreamingEngine = match network_entry.model_type {
-                ModelType::Backend => {
-                    // Download tokenizer.json etc to local disk
-                    cache_dir = Some(
-                        card.move_from_nats(distributed_runtime.nats_client())
-                            .await?,
-                    );
-
-                    // The backend doesn't mind what we expose to the user (chat or
-                    // completions), and this function is only used by text and batch input so
-                    // the user doesn't see the HTTP request. So use Chat.
-                    let frontend = SegmentSource::<
-                        SingleIn<NvCreateChatCompletionRequest>,
-                        ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
-                    >::new();
-                    let preprocessor = OpenAIPreprocessor::new(card.clone()).await?.into_operator();
-                    let backend = Backend::from_mdc(card.clone()).await?.into_operator();
-                    let router =
-                        PushRouter::<BackendInput, Annotated<LLMEngineOutput>>::from_client(
-                            client,
-                            flags.router_mode.into(),
-                        )
-                        .await?;
-                    let service_backend = match &flags.router_mode {
-                        RouterMode::Random | RouterMode::RoundRobin => {
-                            ServiceBackend::from_engine(Arc::new(router))
-                        }
-                        RouterMode::KV => {
-                            let selector = Box::new(DefaultWorkerSelector {});
-                            let chooser = KvRouter::new(
-                                endpoint.component().clone(),
-                                dynamo_llm::DEFAULT_KV_BLOCK_SIZE,
-                                Some(selector),
-                            )
-                            .await?;
-                            let kv_push_router = KvPushRouter::new(router, Arc::new(chooser));
-                            ServiceBackend::from_engine(Arc::new(kv_push_router))
-                        }
-                    };
-                    frontend
-                        .link(preprocessor.forward_edge())?
-                        .link(backend.forward_edge())?
-                        .link(service_backend)?
-                        .link(backend.backward_edge())?
-                        .link(preprocessor.backward_edge())?
-                        .link(frontend)?
-                }
-                ModelType::Chat => Arc::new(
-                    PushRouter::<
-                        NvCreateChatCompletionRequest,
-                        Annotated<NvCreateChatCompletionStreamResponse>,
-                    >::from_client(client, flags.router_mode.into())
-                    .await?,
-                ),
-                ModelType::Completion => {
-                    anyhow::bail!(
-                        "text and batch input only accept remote Chat models, not Completion"
-                    );
-                    /*
-                    Arc::new(
-                        PushRouter::<
-                            CompletionRequest,
-                            Annotated<CompletionResponse>,
-                        >::from_client(
-                            client, flags.router_mode.into()
-                            )
-                            .await?,
-                            )
-                            */
-                }
-                ModelType::Embedding => {
-                    anyhow::bail!(
-                        "text and batch input only accept remote Chat models, not Embedding"
-                    );
-                }
-            };
-            // The service_name isn't used for text chat outside of logs,
-            // so use the path. That avoids having to listen on etcd for model registration.
-            let service_name = endpoint.subject();
+            let model_service_name = watch_obj.wait_for_chat_model().await;
+            let engine = model_manager
+                .state()
+                .get_chat_completions_engine(&model_service_name)?;
             Ok(PreparedEngine {
-                service_name,
+                service_name: model_service_name,
                 engine,
                 inspect_template: false,
-                _cache_dir: cache_dir,
             })
         }
         EngineConfig::StaticFull { engine, model } => {
@@ -176,7 +86,6 @@ pub async fn prepare_engine(
                 service_name,
                 engine,
                 inspect_template: false,
-                _cache_dir: None,
             })
         }
         EngineConfig::StaticCore {
@@ -195,7 +104,6 @@ pub async fn prepare_engine(
                 service_name,
                 engine: pipeline,
                 inspect_template: true,
-                _cache_dir: None,
             })
         }
     }

--- a/launch/dynamo-run/src/input/endpoint.rs
+++ b/launch/dynamo-run/src/input/endpoint.rs
@@ -89,7 +89,7 @@ pub async fn run(
 
             (Box::pin(fut), Some(model.card().clone()))
         }
-        EngineConfig::Dynamic(_) => {
+        EngineConfig::Dynamic => {
             // We can only get here for in=dyn out=vllm|sglang`, because vllm and sglang are a
             // subprocess that we talk to like a remote endpoint.
             // That means the vllm/sglang subprocess is doing all the work, we are idle.

--- a/launch/dynamo-run/src/input/text.rs
+++ b/launch/dynamo-run/src/input/text.rs
@@ -1,17 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use dynamo_llm::protocols::openai::nvext::NvExt;
 use dynamo_llm::types::openai::chat_completions::{
@@ -30,13 +18,13 @@ const MAX_TOKENS: u32 = 8192;
 
 pub async fn run(
     runtime: Runtime,
-    flags: Flags,
+    _flags: Flags,
     single_prompt: Option<String>,
     engine_config: EngineConfig,
     template: Option<RequestTemplate>,
 ) -> anyhow::Result<()> {
     let cancel_token = runtime.primary_token();
-    let prepared_engine = common::prepare_engine(runtime, flags, engine_config).await?;
+    let prepared_engine = common::prepare_engine(runtime, engine_config).await?;
     main_loop(
         cancel_token,
         &prepared_engine.service_name,

--- a/launch/dynamo-run/src/opt.rs
+++ b/launch/dynamo-run/src/opt.rs
@@ -87,8 +87,8 @@ pub enum Output {
     /// Accept preprocessed requests, echo the tokens back as the response
     EchoCore,
 
-    /// Publish requests to a namespace/component/endpoint path.
-    Endpoint(String),
+    /// Listen for models on nats/etcd, add/remove dynamically
+    Dynamic,
 
     #[cfg(feature = "mistralrs")]
     /// Run inference on a model in a GGUF file using mistralrs w/ candle
@@ -130,9 +130,15 @@ impl TryFrom<&str> for Output {
             "echo_full" => Ok(Output::EchoFull),
             "echo_core" => Ok(Output::EchoCore),
 
+            "dyn" => Ok(Output::Dynamic),
+
+            // Deprecated, should only use `out=dyn`
             endpoint_path if endpoint_path.starts_with(ENDPOINT_SCHEME) => {
-                let path = endpoint_path.strip_prefix(ENDPOINT_SCHEME).unwrap();
-                Ok(Output::Endpoint(path.to_string()))
+                tracing::warn!(
+                    "out=dyn://<path> is deprecated, the path is not used. Please use 'out=dyn'"
+                );
+                //let path = endpoint_path.strip_prefix(ENDPOINT_SCHEME).unwrap();
+                Ok(Output::Dynamic)
             }
 
             #[cfg(feature = "python")]
@@ -163,7 +169,7 @@ impl fmt::Display for Output {
             Output::EchoFull => "echo_full",
             Output::EchoCore => "echo_core",
 
-            Output::Endpoint(path) => path,
+            Output::Dynamic => "dyn",
 
             #[cfg(feature = "python")]
             Output::PythonStr(_) => "pystr",

--- a/launch/llmctl/src/main.rs
+++ b/launch/llmctl/src/main.rs
@@ -271,7 +271,7 @@ async fn add_model(
     let component = distributed.namespace(&namespace)?.component("http")?;
     let path = format!(
         "{}/models/{}/{}",
-        component.etcd_path(),
+        component.etcd_root(),
         model_type.as_str(),
         model_name
     );
@@ -323,7 +323,7 @@ async fn list_single_model(
     let component = distributed.namespace(&namespace)?.component("http")?;
     let path = format!(
         "{}/models/{}/{}",
-        component.etcd_path(),
+        component.etcd_root(),
         model_type.as_str(),
         model_name
     );
@@ -374,7 +374,7 @@ async fn list_models(
     // TODO: Do we need the model_type in etcd key?
 
     for mt in model_types {
-        let prefix = format!("{}/models/{}/", component.etcd_path(), mt.as_str(),);
+        let prefix = format!("{}/models/{}/", component.etcd_root(), mt.as_str(),);
 
         let etcd_client = distributed
             .etcd_client()
@@ -430,7 +430,7 @@ async fn remove_model(
     let component = distributed.namespace(&namespace)?.component("http")?;
     let prefix = format!(
         "{}/models/{}/{}",
-        component.etcd_path(),
+        component.etcd_root(),
         model_type.as_str(),
         name
     );

--- a/lib/bindings/python/examples/error_handling/client.py
+++ b/lib/bindings/python/examples/error_handling/client.py
@@ -36,7 +36,7 @@ async def init(runtime: DistributedRuntime, ns: str):
     client = await endpoint.client()
 
     # wait for an endpoint to be ready
-    await client.wait_for_endpoints()
+    await client.wait_for_instances()
 
     # issue request
     stream = await client.generate("hello world")

--- a/lib/bindings/python/examples/hello_world/client.py
+++ b/lib/bindings/python/examples/hello_world/client.py
@@ -36,7 +36,7 @@ async def init(runtime: DistributedRuntime, ns: str):
     client = await endpoint.client()
 
     # wait for an endpoint to be ready
-    await client.wait_for_endpoints()
+    await client.wait_for_instances()
 
     # issue request
     stream = await client.generate("hello world")

--- a/lib/bindings/python/examples/hello_world/client_static.py
+++ b/lib/bindings/python/examples/hello_world/client_static.py
@@ -36,7 +36,7 @@ async def init(runtime: DistributedRuntime, ns: str):
     client = await endpoint.client()
 
     # wait for an endpoint to be ready
-    await client.wait_for_endpoints()
+    await client.wait_for_instances()
 
     # issue request
     stream = await client.generate("hello world")

--- a/lib/bindings/python/examples/hello_world/server_sglang.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang.py
@@ -17,7 +17,7 @@
 #  - nats-server -js
 #
 # Window 1: `python server_sglang.py`. Wait for log "Starting endpoint".
-# Window 2: `dynamo-run out=dyn://dynamo.backend.generate`
+# Window 2: `dynamo-run out=dyn
 
 import argparse
 import asyncio

--- a/lib/bindings/python/examples/hello_world/server_sglang_tok.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang_tok.py
@@ -18,7 +18,7 @@
 #  - nats-server -js
 #
 # Window 1: `python server_sglang.py`. Wait for log "Starting endpoint".
-# Window 2: `dynamo-run out=dyn://dynamo.backend.generate`
+# Window 2: `dynamo-run out=dyn
 
 import argparse
 import asyncio

--- a/lib/bindings/python/examples/hello_world/server_vllm.py
+++ b/lib/bindings/python/examples/hello_world/server_vllm.py
@@ -25,7 +25,7 @@
 #  - nats-server -js
 #
 # Window 1: `python server_vllm.py`. Wait for log "Starting endpoint".
-# Window 2: `dynamo-run out=dyn://dynamo.backend.generate`
+# Window 2: `dynamo-run out=dyn
 
 import argparse
 import asyncio

--- a/lib/bindings/python/examples/typed/client.py
+++ b/lib/bindings/python/examples/typed/client.py
@@ -31,8 +31,8 @@ async def worker(runtime: DistributedRuntime):
     # create client
     client = await endpoint.client()
 
-    # list the endpoints
-    print(client.endpoint_ids())
+    # list the endpoint instances
+    print(client.instance_ids())
 
     # issue request
     stream = await client.generate(Request(data="hello world").model_dump_json())

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -1,17 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use futures::StreamExt;
 use once_cell::sync::OnceCell;
@@ -589,16 +577,19 @@ impl EtcdClient {
 
 #[pymethods]
 impl Client {
-    /// Get list of current endpoints
-    fn endpoint_ids(&self) -> Vec<i64> {
-        self.router.client.endpoint_ids()
+    /// Get list of current instances.
+    /// Replaces endpoint_ids.
+    fn instance_ids(&self) -> Vec<i64> {
+        self.router.client.instance_ids()
     }
 
-    fn wait_for_endpoints<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
+    /// Wait for an instance to be available for work.
+    /// Replaces wait_for_endpoints.
+    fn wait_for_instances<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
         let inner = self.router.client.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             inner
-                .wait_for_endpoints()
+                .wait_for_instances()
                 .await
                 .map(|v| v.into_iter().map(|cei| cei.id()).collect::<Vec<i64>>())
                 .map_err(to_pyerr)
@@ -669,12 +660,12 @@ impl Client {
     }
 
     /// Directly send a request to a specific endpoint.
-    #[pyo3(signature = (request, endpoint_id, annotated=DEFAULT_ANNOTATED_SETTING))]
+    #[pyo3(signature = (request, instance_id, annotated=DEFAULT_ANNOTATED_SETTING))]
     fn direct<'p>(
         &self,
         py: Python<'p>,
         request: PyObject,
-        endpoint_id: i64,
+        instance_id: i64,
         annotated: Option<bool>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let request: serde_json::Value = pythonize::depythonize(&request.into_bound(py))?;
@@ -685,7 +676,7 @@ impl Client {
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let stream = client
-                .direct(request.into(), endpoint_id)
+                .direct(request.into(), instance_id)
                 .await
                 .map_err(to_pyerr)?;
 

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use dynamo_runtime::{
-    component::{Component, EndpointSource},
+    component::{Component, InstanceSource},
     pipeline::{
         async_trait, AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, PushRouter,
         ResponseStream, SingleIn,
@@ -199,11 +199,11 @@ impl AsyncEngine<SingleIn<BackendInput>, ManyOut<Annotated<LLMEngineOutput>>, Er
         &self,
         request: SingleIn<BackendInput>,
     ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
-        match &self.inner.client.endpoints {
-            EndpointSource::Static => self.inner.r#static(request).await,
-            EndpointSource::Dynamic(_) => {
-                let worker_id = self.chooser.find_best_match(&request.token_ids).await?;
-                self.inner.direct(request, worker_id).await
+        match &self.inner.client.instances {
+            InstanceSource::Static => self.inner.r#static(request).await,
+            InstanceSource::Dynamic(_) => {
+                let instance_id = self.chooser.find_best_match(&request.token_ids).await?;
+                self.inner.direct(request, instance_id).await
             }
         }
     }

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -23,7 +23,7 @@ pub use model::ModelDeploymentCard;
 // network module?
 
 /// Identify model deployment cards in the key-value store
-pub const BUCKET_NAME: &str = "mdc";
+pub const ROOT_PATH: &str = "mdc";
 
 /// Delete model deployment cards that haven't been re-published after this long.
 /// Cleans up if the worker stopped.

--- a/lib/llm/src/model_card/model.rs
+++ b/lib/llm/src/model_card/model.rs
@@ -44,8 +44,6 @@ use crate::gguf::{Content, ContentConfig, ModelConfigLike};
 use crate::key_value_store::Versioned;
 use crate::protocols::TokenIdType;
 
-pub const BUCKET_NAME: &str = "mdc";
-
 /// Delete model deployment cards that haven't been re-published after this long.
 /// Cleans up if the worker stopped.
 pub const BUCKET_TTL: Duration = Duration::from_secs(5 * 60);

--- a/lib/runtime/examples/hello_world/src/bin/client.rs
+++ b/lib/runtime/examples/hello_world/src/bin/client.rs
@@ -34,7 +34,7 @@ async fn app(runtime: Runtime) -> Result<()> {
         .endpoint("generate")
         .client()
         .await?;
-    client.wait_for_endpoints().await?;
+    client.wait_for_instances().await?;
     let router =
         PushRouter::<String, Annotated<String>>::from_client(client, Default::default()).await?;
 

--- a/lib/runtime/examples/service_metrics/src/bin/service_client.rs
+++ b/lib/runtime/examples/service_metrics/src/bin/service_client.rs
@@ -35,7 +35,7 @@ async fn app(runtime: Runtime) -> Result<()> {
 
     let client = component.endpoint("generate").client().await?;
 
-    client.wait_for_endpoints().await?;
+    client.wait_for_instances().await?;
     let router =
         PushRouter::<String, Annotated<String>>::from_client(client, Default::default()).await?;
 

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -1,17 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 //! The [Component] module defines the top-level API for building distributed applications.
 //!
@@ -69,7 +57,14 @@ mod namespace;
 mod registry;
 pub mod service;
 
-pub use client::{Client, EndpointSource};
+pub use client::{Client, InstanceSource};
+
+/// The root etcd path where each instance registers itself in etcd.
+/// An instance is namespace+component+endpoint+lease_id and must be unique.
+pub const INSTANCE_ROOT_PATH: &str = "instances";
+
+/// The root etcd path for ModelEntry
+pub const MODEL_ROOT_PATH: &str = "models";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -89,17 +84,17 @@ pub struct Registry {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ComponentEndpointInfo {
+pub struct Instance {
     pub component: String,
     pub endpoint: String,
     pub namespace: String,
-    pub lease_id: i64,
+    pub instance_id: i64,
     pub transport: TransportType,
 }
 
-impl ComponentEndpointInfo {
+impl Instance {
     pub fn id(&self) -> i64 {
-        self.lease_id
+        self.instance_id
     }
 }
 
@@ -150,8 +145,11 @@ impl RuntimeProvider for Component {
 }
 
 impl Component {
-    pub fn etcd_path(&self) -> String {
-        format!("{}/components/{}", self.namespace.name(), self.name)
+    /// The component part of an instance path in etcd.
+    pub fn etcd_root(&self) -> String {
+        let ns = self.namespace.name();
+        let cp = &self.name;
+        format!("{INSTANCE_ROOT_PATH}/{ns}/{cp}")
     }
 
     pub fn service_name(&self) -> String {
@@ -179,21 +177,21 @@ impl Component {
         }
     }
 
-    pub async fn list_endpoints(&self) -> anyhow::Result<Vec<ComponentEndpointInfo>> {
+    pub async fn list_instances(&self) -> anyhow::Result<Vec<Instance>> {
         let Some(etcd_client) = self.drt.etcd_client() else {
             return Ok(vec![]);
         };
         let mut out = vec![];
         // The extra slash is important to only list exact component matches, not substrings.
         for kv in etcd_client
-            .kv_get_prefix(format!("{}/", self.etcd_path()))
+            .kv_get_prefix(format!("{}/", self.etcd_root()))
             .await?
         {
-            let val = match serde_json::from_slice::<ComponentEndpointInfo>(kv.value()) {
+            let val = match serde_json::from_slice::<Instance>(kv.value()) {
                 Ok(val) => val,
                 Err(err) => {
                     anyhow::bail!(
-                        "Error converting etcd response to ComponentEndpointInfo: {err}. {}",
+                        "Error converting etcd response to Instance: {err}. {}",
                         kv.value_str()?
                     );
                 }
@@ -276,15 +274,20 @@ impl Endpoint {
         format!("{}/{}", self.component.path(), self.name)
     }
 
-    pub fn etcd_path(&self) -> String {
-        format!("{}/{}", self.component.etcd_path(), self.name)
+    /// The endpoint part of an instance path in etcd
+    pub fn etcd_root(&self) -> String {
+        let component_path = self.component.etcd_root();
+        let endpoint_name = &self.name;
+        format!("{component_path}/{endpoint_name}")
     }
 
-    pub fn etcd_path_with_id(&self, lease_id: i64) -> String {
+    /// The fully path of an instance in etcd
+    pub fn etcd_path(&self, lease_id: i64) -> String {
+        let endpoint_root = self.etcd_root();
         if self.is_static {
-            self.etcd_path()
+            endpoint_root
         } else {
-            format!("{}:{:x}", self.etcd_path(), lease_id)
+            format!("{endpoint_root}:{lease_id:x}")
         }
     }
 

--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -59,10 +59,7 @@ impl EndpointConfigBuilder {
         let lease = lease.or(endpoint.drt().primary_lease());
         let lease_id = lease.as_ref().map(|l| l.id()).unwrap_or(0);
 
-        tracing::debug!(
-            "Starting endpoint: {}",
-            endpoint.etcd_path_with_id(lease_id)
-        );
+        tracing::debug!("Starting endpoint: {}", endpoint.etcd_path(lease_id));
 
         let service_name = endpoint.component.service_name();
 
@@ -115,11 +112,11 @@ impl EndpointConfigBuilder {
         // make the components service endpoint discovery in etcd
 
         // client.register_service()
-        let info = ComponentEndpointInfo {
+        let info = Instance {
             component: endpoint.component.name.clone(),
             endpoint: endpoint.name.clone(),
             namespace: endpoint.component.namespace.name.clone(),
-            lease_id,
+            instance_id: lease_id,
             transport: TransportType::NatsTcp(endpoint.subject_to(lease_id)),
         };
 
@@ -127,7 +124,7 @@ impl EndpointConfigBuilder {
 
         if let Some(etcd_client) = &endpoint.component.drt.etcd_client {
             if let Err(e) = etcd_client
-                .kv_create(endpoint.etcd_path_with_id(lease_id), info, Some(lease_id))
+                .kv_create(endpoint.etcd_path(lease_id), info, Some(lease_id))
                 .await
             {
                 tracing::error!("Failed to register discoverable service: {:?}", e);

--- a/lib/runtime/src/component/service.rs
+++ b/lib/runtime/src/component/service.rs
@@ -85,8 +85,6 @@ impl ServiceConfigBuilder {
             .await
             .map_err(|e| anyhow::anyhow!("Failed to start service: {e}"))?;
 
-        tracing::debug!("Service started TEMP");
-
         // new copy of service_name as the previous one is moved into the task above
         let service_name = component.service_name();
 
@@ -101,7 +99,6 @@ impl ServiceConfigBuilder {
         // drop the guard to unlock the mutex
         drop(guard);
 
-        tracing::debug!("create done");
         Ok(component)
     }
 }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 use crate::{
-    component::{Client, Endpoint, EndpointSource},
+    component::{Client, Endpoint, InstanceSource},
     engine::{AsyncEngine, Data},
     pipeline::{AddressedPushRouter, AddressedRequest, Error, ManyOut, SingleIn},
     traits::DistributedRuntimeProvider,
@@ -41,7 +41,7 @@ where
     /// The Client is how we gather remote endpoint information from etcd.
     pub client: Client,
 
-    /// How we choose which endpoint to send traffic to.
+    /// How we choose which instance to send traffic to.
     ///
     /// Setting this to KV means we never intend to call `generate` on this PushRouter. We are
     /// not using it as an AsyncEngine.
@@ -52,7 +52,7 @@ where
     /// Number of round robin requests handled. Used to decide which server is next.
     round_robin_counter: Arc<AtomicU64>,
 
-    /// The next step in the chain. PushRouter (this object) picks an endpoint,
+    /// The next step in the chain. PushRouter (this object) picks an instances,
     /// addresses it, then passes it to AddressedPushRouter which does the network traffic.
     addressed: Arc<AddressedPushRouter>,
 
@@ -101,25 +101,25 @@ where
         })
     }
 
-    /// Issue a request to the next available endpoint in a round-robin fashion
+    /// Issue a request to the next available instance in a round-robin fashion
     pub async fn round_robin(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed);
 
-        let endpoint_id = {
-            let endpoints = self.client.endpoints();
-            let count = endpoints.len();
+        let instance_id = {
+            let instances = self.client.instances();
+            let count = instances.len();
             if count == 0 {
                 return Err(anyhow::anyhow!(
-                    "no endpoints found for endpoint {:?}",
-                    self.client.endpoint.etcd_path()
+                    "no instances found for endpoint {:?}",
+                    self.client.endpoint.etcd_root()
                 ));
             }
             let offset = counter % count as u64;
-            endpoints[offset as usize].id()
+            instances[offset as usize].id()
         };
-        tracing::trace!("round robin router selected {endpoint_id}");
+        tracing::trace!("round robin router selected {instance_id}");
 
-        let subject = self.client.endpoint.subject_to(endpoint_id);
+        let subject = self.client.endpoint.subject_to(instance_id);
         let request = request.map(|req| AddressedRequest::new(req, subject));
 
         self.addressed.generate(request).await
@@ -127,22 +127,22 @@ where
 
     /// Issue a request to a random endpoint
     pub async fn random(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
-        let endpoint_id = {
-            let endpoints = self.client.endpoints();
-            let count = endpoints.len();
+        let instance_id = {
+            let instances = self.client.instances();
+            let count = instances.len();
             if count == 0 {
                 return Err(anyhow::anyhow!(
-                    "no endpoints found for endpoint {:?}",
-                    self.client.endpoint.etcd_path()
+                    "no instances found for endpoint {:?}",
+                    self.client.endpoint.etcd_root()
                 ));
             }
             let counter = rand::rng().random::<u64>();
             let offset = counter % count as u64;
-            endpoints[offset as usize].id()
+            instances[offset as usize].id()
         };
-        tracing::trace!("random router selected {endpoint_id}");
+        tracing::trace!("random router selected {instance_id}");
 
-        let subject = self.client.endpoint.subject_to(endpoint_id);
+        let subject = self.client.endpoint.subject_to(instance_id);
         let request = request.map(|req| AddressedRequest::new(req, subject));
 
         self.addressed.generate(request).await
@@ -152,22 +152,21 @@ where
     pub async fn direct(
         &self,
         request: SingleIn<T>,
-        endpoint_id: i64,
+        instance_id: i64,
     ) -> anyhow::Result<ManyOut<U>> {
         let found = {
-            let endpoints = self.client.endpoints();
-            endpoints.iter().any(|ep| ep.id() == endpoint_id)
+            let instances = self.client.instances();
+            instances.iter().any(|ep| ep.id() == instance_id)
         };
 
         if !found {
             return Err(anyhow::anyhow!(
-                "endpoint_id={} not found for endpoint {:?}",
-                endpoint_id,
-                self.client.endpoint.etcd_path()
+                "instance_id={instance_id} not found for endpoint {:?}",
+                self.client.endpoint.etcd_root()
             ));
         }
 
-        let subject = self.client.endpoint.subject_to(endpoint_id);
+        let subject = self.client.endpoint.subject_to(instance_id);
         let request = request.map(|req| AddressedRequest::new(req, subject));
 
         self.addressed.generate(request).await
@@ -189,12 +188,12 @@ where
     U: Data + for<'de> Deserialize<'de>,
 {
     async fn generate(&self, request: SingleIn<T>) -> Result<ManyOut<U>, Error> {
-        match &self.client.endpoints {
-            EndpointSource::Static => self.r#static(request).await,
-            EndpointSource::Dynamic(_) => match self.router_mode {
+        match &self.client.instances {
+            InstanceSource::Static => self.r#static(request).await,
+            InstanceSource::Dynamic(_) => match self.router_mode {
                 RouterMode::Random => self.random(request).await,
                 RouterMode::RoundRobin => self.round_robin(request).await,
-                RouterMode::Direct(endpoint_id) => self.direct(request, endpoint_id).await,
+                RouterMode::Direct(instance_id) => self.direct(request, instance_id).await,
                 RouterMode::KV => {
                     anyhow::bail!("KV routing should not call generate on PushRouter");
                 }

--- a/lib/runtime/tests/soak.rs
+++ b/lib/runtime/tests/soak.rs
@@ -114,7 +114,7 @@ mod integration {
             .client::<String, Annotated<String>>()
             .await?;
 
-        client.wait_for_endpoints().await?;
+        client.wait_for_instances().await?;
         let client = Arc::new(client);
 
         let start = Instant::now();


### PR DESCRIPTION
We can now do this:

- Node 1:

```
dynamo-run in=http out=dyn
```

- Node 2 and 3, two instances of component 'backend' in the nemotron_ultra pipeline:

```
dynamo-run in=dyn://nemotron_ultra.backend.generate out=vllm /data/models/NemotronUltra
```

- Node 4 and 5, two instances of the 'backend' component in nemotron_super pipeline:

```
dynamo-run in=dyn://nemotron_super.backend.generate out=vllm /data/models/NemotronSuper
```

The ingress node will discover all four instances and route correctly. We have been planning for this for a long time now.

As part of this auto-discovery is now always `out=dyn`, with no extra URL parts. Previously it could only route to a single pipeline.

Also:
- Refactor endpoint / instance naming now that I understand them
- Fix removing models when their instance stops.
