### PR TITLE
fix: Disable block manager by default in Python bindings

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -375,10 +375,11 @@ RUN cargo build --release --locked --features mistralrs,python,dynamo-llm/block-
 # Build dynamo wheel
 RUN uv build --wheel --out-dir /workspace/dist && \
     cd /workspace/lib/bindings/python && \
-    uv build --wheel --out-dir /workspace/dist --python 3.12 && \
+    uv pip install maturin[patchelf] && \
+    maturin build --release --features block-manager --out /workspace/dist && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
-        uv build --wheel --out-dir /workspace/dist --python 3.11 && \
-        uv build --wheel --out-dir /workspace/dist --python 3.10; \
+        uv run --python 3.11 maturin build --release --features block-manager --out /workspace/dist && \
+        uv run --python 3.10 maturin build --release --features block-manager --out /workspace/dist; \
     fi
 
 #######################################

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -375,6 +375,7 @@ RUN cargo build --release --locked --features mistralrs,python,dynamo-llm/block-
 # Build dynamo wheel
 RUN uv build --wheel --out-dir /workspace/dist && \
     cd /workspace/lib/bindings/python && \
+    sed -i 's/features = \[""\]/features = \["block-manager"\]/' pyproject.toml && \
     uv build --wheel --out-dir /workspace/dist --python 3.12 && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
         uv build --wheel --out-dir /workspace/dist --python 3.11 && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -375,7 +375,6 @@ RUN cargo build --release --locked --features mistralrs,python,dynamo-llm/block-
 # Build dynamo wheel
 RUN uv build --wheel --out-dir /workspace/dist && \
     cd /workspace/lib/bindings/python && \
-    sed -i 's/features = \[""\]/features = \["block-manager"\]/' pyproject.toml && \
     uv build --wheel --out-dir /workspace/dist --python 3.12 && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
         uv build --wheel --out-dir /workspace/dist --python 3.11 && \

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -51,7 +51,6 @@ module-name = "dynamo._core"
 manifest-path = "Cargo.toml"
 python-packages = ["dynamo"]
 python-source = "src"
-features = ["block-manager"]
 
 [build-system]
 requires = ["maturin>=1.0,<2.0", "patchelf"]

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -51,7 +51,7 @@ module-name = "dynamo._core"
 manifest-path = "Cargo.toml"
 python-packages = ["dynamo"]
 python-source = "src"
-features = [""]
+features = ["block-manager"]
 
 [build-system]
 requires = ["maturin>=1.0,<2.0", "patchelf"]

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -51,7 +51,7 @@ module-name = "dynamo._core"
 manifest-path = "Cargo.toml"
 python-packages = ["dynamo"]
 python-source = "src"
-features = ["block-manager"]
+features = [""]
 
 [build-system]
 requires = ["maturin>=1.0,<2.0", "patchelf"]

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 
 from dynamo._core import AggregatedMetrics as AggregatedMetrics
-from dynamo._core import BlockManager as BlockManager
+
+try:
+    from dynamo._core import BlockManager as BlockManager
+except ImportError:
+    pass  # BlockManager is not enabled by default
+
 from dynamo._core import DisaggregatedRouter as DisaggregatedRouter
 from dynamo._core import HttpAsyncEngine as HttpAsyncEngine
 from dynamo._core import HttpError as HttpError


### PR DESCRIPTION
#### Overview:

Disable block manager by default in Python bindings. Only enable it during Dockerfile.vllm build.

#### Details:

N/A

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A
