### PR TITLE
chore: Remove unused RouterType and ModelMetaData

### DIFF
--- a/lib/runtime/src/protocols.rs
+++ b/lib/runtime/src/protocols.rs
@@ -183,58 +183,11 @@ impl Endpoint {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum RouterType {
-    PushRoundRobin,
-    PushRandom,
-}
-
-impl Default for RouterType {
-    fn default() -> Self {
-        Self::PushRandom
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
-pub struct ModelMetaData {
-    pub name: String,
-    pub component: Component,
-    pub router_type: RouterType,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::convert::TryFrom;
     use std::str::FromStr;
-
-    #[test]
-    fn test_router_type_default() {
-        let default_router = RouterType::default();
-        assert_eq!(default_router, RouterType::PushRandom);
-    }
-
-    #[test]
-    fn test_router_type_serialization() {
-        let router_round_robin = RouterType::PushRoundRobin;
-        let router_random = RouterType::PushRandom;
-
-        let serialized_round_robin = serde_json::to_string(&router_round_robin).unwrap();
-        let serialized_random = serde_json::to_string(&router_random).unwrap();
-
-        assert_eq!(serialized_round_robin, "\"push_round_robin\"");
-        assert_eq!(serialized_random, "\"push_random\"");
-    }
-
-    #[test]
-    fn test_router_type_deserialization() {
-        let round_robin: RouterType = serde_json::from_str("\"push_round_robin\"").unwrap();
-        let random: RouterType = serde_json::from_str("\"push_random\"").unwrap();
-
-        assert_eq!(round_robin, RouterType::PushRoundRobin);
-        assert_eq!(random, RouterType::PushRandom);
-    }
 
     #[test]
     fn test_valid_endpoint_from() {


### PR DESCRIPTION
#### Overview:

Remove RouterType and ModelMetaData in `lib/runtime/src/protocols.rs`, which are unused (no outside reference). It is because that the routing has been moved to its own module, `pipeline/network/egress/push_router.rs`. Therefore, the legacy definition of RouterType in `protocals.rs` is no longer used.

#### Details:

Investigation: 
- Previously, it seems that runtime had only one “push” network path, so a tiny enum that listed the two algorithms it supported—PushRoundRobin and PushRandom. At that time model‐metadata travelled together with the protocol messages.
- Now, it seems routing grew more complex and KV-aware routing (the “Smart Router” described in docs/architecture.md) was introduced. So the whole feature moved from a protocol helper into its own module, pipeline/network/egress/push_router.rs, because it needs etcd look-ups, NATS subjects, etc.

```
     #[derive(Default, Debug, Clone, Copy, PartialEq)]
     pub enum RouterMode {
         RoundRobin,
         Random,
         Direct(i64),   // pin to a concrete instance
         KV,            // KV-aware router (Smart Router)
     }
```

- RouterMode is now re-exported by pipeline.rs and consumed by CLI flags (launch/dynamo-run)
• It seems that the enum/struct in protocols.rs were simply forgotten, thus safe to remove. 

#### Where should the reviewer start?

Just `the lib/runtime/src/protocols.rs` file.

Run unit test
```
cargo test -p dynamo-runtime
```

All passed

<img width="915" alt="image" src="https://github.com/user-attachments/assets/106fe067-bedb-4d4f-9453-a030a5fa05cb" />


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes GitHub issue: #1098 
