### PR TITLE
feat: KVBM Cache Hit events

### DIFF
--- a/lib/llm/src/block_manager/block.rs
+++ b/lib/llm/src/block_manager/block.rs
@@ -72,15 +72,9 @@ pub enum BlockError {
     Other(#[from] anyhow::Error),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct CacheStats {
     pub(crate) hits: u64,
-}
-
-impl Default for CacheStats {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl CacheStats {
@@ -579,8 +573,6 @@ impl BlockMetadata for BasicMetadata {
         self.returned_tick = tick;
         if let Some(stats) = stats {
             self.cache_hits += stats.hits;
-        } else {
-            self.cache_hits = 0;
         }
     }
 

--- a/lib/llm/src/block_manager/block/transfer.rs
+++ b/lib/llm/src/block_manager/block/transfer.rs
@@ -195,7 +195,7 @@ where
                 Ok(())
             }
             TransferStrategy::Nixl(transfer_type) => {
-                std::mem::drop(nixl::write_blocks_to(
+                drop(nixl::write_blocks_to(
                     self,
                     dst,
                     ctx,

--- a/lib/llm/src/block_manager/events/offload.rs
+++ b/lib/llm/src/block_manager/events/offload.rs
@@ -1,0 +1,33 @@
+use std::sync::{Arc, Weak};
+use tokio::sync::mpsc;
+
+use crate::block_manager::events::{
+    EventManager, EventPublisher, EventReleaseManager, EventType, RegistrationHandle,
+};
+
+pub struct OffloadEventManager {
+    tx: mpsc::UnboundedSender<Vec<Weak<RegistrationHandle>>>,
+}
+
+impl OffloadEventManager {
+    pub fn new(tx: mpsc::UnboundedSender<Vec<Weak<RegistrationHandle>>>) -> Self {
+        Self { tx }
+    }
+}
+
+impl EventPublisher for OffloadEventManager {
+    fn publish(&self, handles: Vec<Arc<RegistrationHandle>>, event_type: EventType) {
+        if event_type != EventType::CacheHit {
+            return;
+        }
+        self.tx
+            .send(handles.iter().map(Arc::downgrade).collect())
+            .unwrap();
+    }
+}
+
+impl EventReleaseManager for OffloadEventManager {
+    fn block_release(&self, _registration_handle: &RegistrationHandle) {}
+}
+
+impl EventManager for OffloadEventManager {}

--- a/lib/llm/src/block_manager/events/offload.rs
+++ b/lib/llm/src/block_manager/events/offload.rs
@@ -21,6 +21,7 @@ use crate::block_manager::events::{
 };
 use crate::tokens::SequenceHash;
 
+/// An event manager that propagates cache hits to the offload manager.
 pub struct OffloadEventManager {
     tx: broadcast::Sender<Vec<SequenceHash>>,
 }

--- a/lib/llm/src/block_manager/events/offload.rs
+++ b/lib/llm/src/block_manager/events/offload.rs
@@ -1,3 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::Arc;
 use tokio::sync::broadcast;
 

--- a/lib/llm/src/block_manager/offload.rs
+++ b/lib/llm/src/block_manager/offload.rs
@@ -258,7 +258,8 @@ impl<Metadata: BlockMetadata> OffloadManager<Metadata> {
                 if let Some(block) = block {
                     // If the block is already in the target, don't offload it.
                     if let Ok(blocks) = target_pool
-                        .match_sequence_hashes_blocking(vec![request.sequence_hash].as_slice())
+                        .match_sequence_hashes(vec![request.sequence_hash].as_slice())
+                        .await
                     {
                         if !blocks.is_empty() {
                             continue;

--- a/lib/llm/src/block_manager/offload/queue.rs
+++ b/lib/llm/src/block_manager/offload/queue.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::request::OffloadRequest;
+use crate::block_manager::{BlockMetadata, Storage};
+use crate::tokens::SequenceHash;
+use std::collections::{BTreeSet, HashMap};
+use tokio::sync::broadcast;
+
+/// A simple priority queue for offloading requests.
+pub struct OffloadQueue<Source: Storage, Metadata: BlockMetadata> {
+    queue: BTreeSet<OffloadRequest<Source, Metadata>>,
+    lookup: HashMap<SequenceHash, OffloadRequest<Source, Metadata>>,
+    cache_hit_receiver: broadcast::Receiver<Vec<SequenceHash>>,
+}
+
+impl<Source: Storage, Metadata: BlockMetadata> OffloadQueue<Source, Metadata> {
+    pub fn new(cache_hit_receiver: broadcast::Receiver<Vec<SequenceHash>>) -> Self {
+        Self {
+            queue: BTreeSet::new(),
+            lookup: HashMap::new(),
+            cache_hit_receiver,
+        }
+    }
+
+    pub fn push(&mut self, request: OffloadRequest<Source, Metadata>) {
+        self.lookup.insert(request.sequence_hash, request.clone());
+        self.queue.insert(request);
+    }
+
+    pub fn pop(&mut self) -> Option<OffloadRequest<Source, Metadata>> {
+        if let Some(request) = self.queue.pop_first() {
+            self.lookup.remove(&request.sequence_hash);
+            Some(request)
+        } else {
+            None
+        }
+    }
+
+    pub async fn cache_hit_worker(&mut self) {
+        while let Ok(cache_hits) = self.cache_hit_receiver.recv().await {
+            for sequence_hash in cache_hits {
+                if let Some(mut request) = self.lookup.remove(&sequence_hash) {
+                    self.queue.remove(&request);
+                    if request.block.upgrade().is_some() {
+                        // We'd probably want something more fancy than this.
+                        // But this works for now. Just increment priority by 1.
+                        request.key.priority += 1;
+                        self.queue.insert(request.clone());
+                        self.lookup.insert(sequence_hash, request);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/llm/src/block_manager/offload/request.rs
+++ b/lib/llm/src/block_manager/offload/request.rs
@@ -22,7 +22,7 @@ use crate::block_manager::storage::Storage;
 
 /// Higher priority offloads are done first.
 /// If two offloads have the same priority, the one that was requested first is done first.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct OffloadRequestKey {
     pub priority: u64,
     pub timestamp: u64,
@@ -50,6 +50,16 @@ pub struct OffloadRequest<S: Storage, M: BlockMetadata> {
     pub key: OffloadRequestKey,
     pub block: Weak<MutableBlock<S, M>>,
     pub sequence_hash: u64,
+}
+
+impl<S: Storage, M: BlockMetadata> Clone for OffloadRequest<S, M> {
+    fn clone(&self) -> Self {
+        Self {
+            key: self.key.clone(),
+            block: self.block.clone(),
+            sequence_hash: self.sequence_hash,
+        }
+    }
 }
 
 impl<S: Storage, M: BlockMetadata> PartialOrd for OffloadRequest<S, M> {

--- a/lib/llm/src/block_manager/offload/request.rs
+++ b/lib/llm/src/block_manager/offload/request.rs
@@ -22,7 +22,7 @@ use crate::block_manager::storage::Storage;
 
 /// Higher priority offloads are done first.
 /// If two offloads have the same priority, the one that was requested first is done first.
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq)]
 pub struct OffloadRequestKey {
     pub priority: u64,
     pub timestamp: u64,
@@ -50,16 +50,6 @@ pub struct OffloadRequest<S: Storage, M: BlockMetadata> {
     pub key: OffloadRequestKey,
     pub block: Weak<MutableBlock<S, M>>,
     pub sequence_hash: u64,
-}
-
-impl<S: Storage, M: BlockMetadata> Clone for OffloadRequest<S, M> {
-    fn clone(&self) -> Self {
-        Self {
-            key: self.key.clone(),
-            block: self.block.clone(),
-            sequence_hash: self.sequence_hash,
-        }
-    }
 }
 
 impl<S: Storage, M: BlockMetadata> PartialOrd for OffloadRequest<S, M> {

--- a/lib/llm/src/block_manager/pool.rs
+++ b/lib/llm/src/block_manager/pool.rs
@@ -71,7 +71,7 @@ pub use super::block::{ImmutableBlock, MutableBlock};
 use super::block::{
     nixl::short_type_name, registry::BlockRegistry, Block, BlockError, BlockMetadata,
 };
-use super::events::EventManager;
+use super::events::{EventManager, EventPublisher};
 use super::storage::Storage;
 
 use crate::tokens::{SequenceHash, TokenBlock};
@@ -443,7 +443,7 @@ struct State<S: Storage, M: BlockMetadata> {
     inactive: InactiveBlockPool<S, M>,
     registry: BlockRegistry,
     return_tx: tokio::sync::mpsc::UnboundedSender<Block<S, M>>,
-    event_managers: Vec<Arc<dyn EventManager>>,
+    event_publishers: Vec<Arc<dyn EventPublisher>>,
 }
 
 struct ProgressEngine<S: Storage, M: BlockMetadata> {

--- a/lib/llm/src/block_manager/pool.rs
+++ b/lib/llm/src/block_manager/pool.rs
@@ -121,10 +121,10 @@ pub struct BlockPoolArgs<S: Storage, M: BlockMetadata> {
 impl<S: Storage, M: BlockMetadata> BlockPoolArgsBuilder<S, M> {
     pub fn build(self) -> anyhow::Result<BlockPool<S, M>> {
         let args = self.build_internal()?;
-        let (event_manager, cancel_token, blocks) = args.dissolve();
+        let (event_managers, cancel_token, blocks) = args.dissolve();
 
         tracing::info!("building block pool");
-        let pool = BlockPool::new(event_manager, cancel_token, blocks);
+        let pool = BlockPool::new(event_managers, cancel_token, blocks);
 
         Ok(pool)
     }

--- a/lib/llm/src/block_manager/pool/active.rs
+++ b/lib/llm/src/block_manager/pool/active.rs
@@ -79,7 +79,7 @@ impl<S: Storage, M: BlockMetadata> ActiveBlockPool<S, M> {
                     self.map.remove(&sequence_hash);
                 }
             }
-            self.cache_hits.remove(&sequence_hash)
+            Some(self.cache_hits.remove(&sequence_hash).unwrap_or_default())
         } else {
             None
         }
@@ -93,7 +93,7 @@ impl<S: Storage, M: BlockMetadata> ActiveBlockPool<S, M> {
             if let Some(arc) = weak.upgrade() {
                 match arc.state() {
                     BlockState::Registered(reg_handle) => {
-                        std::mem::drop(PublishHandle::new(
+                        drop(PublishHandle::new(
                             reg_handle.clone(),
                             self.event_managers
                                 .iter()
@@ -105,10 +105,7 @@ impl<S: Storage, M: BlockMetadata> ActiveBlockPool<S, M> {
                     _ => panic!("Block must be registered. This should never happen."),
                 }
 
-                self.cache_hits
-                    .entry(sequence_hash)
-                    .or_default()
-                    .hits += 1;
+                self.cache_hits.entry(sequence_hash).or_default().hits += 1;
 
                 Some(ImmutableBlock::new(arc))
             } else {

--- a/lib/llm/src/block_manager/pool/inactive.rs
+++ b/lib/llm/src/block_manager/pool/inactive.rs
@@ -490,7 +490,6 @@ pub(crate) mod tests {
     use crate::{
         block_manager::{
             block::{registry::BlockRegistry, state::CompleteState, Blocks, PrivateBlockExt},
-            events::NullEventManager,
             layout::{BlockLayout, FullyContiguous, LayoutConfigBuilder},
             storage::tests::{NullDeviceAllocator, NullDeviceStorage},
         },
@@ -614,8 +613,7 @@ pub(crate) mod tests {
 
         let mut blocks = create_block_collection(num_blocks).into_blocks().unwrap();
 
-        let event_manager = NullEventManager::new();
-        let mut registry = BlockRegistry::new(event_manager);
+        let mut registry = BlockRegistry::new(vec![]);
 
         // Iterate through the generated TokenBlocks and the template Blocks,
         // setting the state and registering each one.
@@ -656,8 +654,7 @@ pub(crate) mod tests {
         let mut matched_blocks = pool.match_token_blocks(&token_blocks);
         let matched_block_count = matched_blocks.len();
 
-        let event_manager = NullEventManager::new();
-        let mut registry = BlockRegistry::new(event_manager);
+        let mut registry = BlockRegistry::new(vec![]);
 
         // all matched blocks should be in the complete or registered state
         for block in &mut matched_blocks {


### PR DESCRIPTION
- Adds KV Cache hit events
- Restructures events to include an enum of event type.
- Refactors event management logic to accept a list of event managers, instead of a single one 
- Also includes a PoC of cache-hit-aware block management, where blocks with more cache hits are prioritized for retention and offloading
