### PR TITLE
fix(llmctl): Use ModelWatcher instead of direct etcd operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3522,6 +3522,7 @@ dependencies = [
 name = "llmctl"
 version = "0.2.1"
 dependencies = [
+ "anyhow",
  "clap",
  "dynamo-llm",
  "dynamo-runtime",

--- a/components/http/src/main.rs
+++ b/components/http/src/main.rs
@@ -56,7 +56,7 @@ async fn app(runtime: Runtime) -> Result<()> {
     // the cli when operating on an `http` component will validate the namespace.component is
     // registered with HttpServiceComponentDefinition
 
-    let watch_obj = ModelWatcher::new(distributed.clone(), manager, RouterMode::Random).await?;
+    let watch_obj = ModelWatcher::new(distributed.clone(), manager, RouterMode::Random);
 
     if let Some(etcd_client) = distributed.etcd_client() {
         let models_watcher: PrefixWatcher =

--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -14,7 +14,7 @@
     * [Vllm](#vllm)
     * [TensorRT-LLM](#tensorrt-llm-engine)
     * [Echo Engines](#echo-engines)
-    * [Write your own engine in Python](#write-your-own-engine-in-python)
+    * [Writing your own engine in Python](#writing-your-own-engine-in-python)
 * [Batch mode](#batch-mode)
 * [Defaults](#defaults)
 * [Extra engine arguments](#extra-engine-arguments)

--- a/launch/dynamo-run/src/input/common.rs
+++ b/launch/dynamo-run/src/input/common.rs
@@ -46,14 +46,11 @@ pub async fn prepare_engine(
                 anyhow::bail!("Cannot be both static mode and run with dynamic discovery.");
             };
             let model_manager = Arc::new(ModelManager::new());
-            let watch_obj = Arc::new(
-                ModelWatcher::new(
-                    distributed_runtime,
-                    model_manager.clone(),
-                    dynamo_runtime::pipeline::RouterMode::RoundRobin,
-                )
-                .await?,
-            );
+            let watch_obj = Arc::new(ModelWatcher::new(
+                distributed_runtime,
+                model_manager.clone(),
+                dynamo_runtime::pipeline::RouterMode::RoundRobin,
+            ));
             let models_watcher = etcd_client.kv_get_and_watch_prefix(MODEL_ROOT_PATH).await?;
             let (_prefix, _watcher, receiver) = models_watcher.dissolve();
 

--- a/launch/dynamo-run/src/input/http.rs
+++ b/launch/dynamo-run/src/input/http.rs
@@ -103,7 +103,7 @@ async fn run_watcher(
     network_prefix: &str,
     router_mode: RouterMode,
 ) -> anyhow::Result<()> {
-    let watch_obj = ModelWatcher::new(runtime, model_manager, router_mode).await?;
+    let watch_obj = ModelWatcher::new(runtime, model_manager, router_mode);
     tracing::info!("Watching for remote model at {network_prefix}");
     let models_watcher = etcd_client.kv_get_and_watch_prefix(network_prefix).await?;
     let (_prefix, _watcher, receiver) = models_watcher.dissolve();

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -5,7 +5,7 @@ use std::{future::Future, pin::Pin};
 use std::{io::Read, sync::Arc, time::Duration};
 
 use anyhow::Context;
-use dynamo_llm::{backend::ExecutionContext, engines::StreamingEngine, LocalModel};
+use dynamo_llm::{backend::ExecutionContext, engines::StreamingEngine, local_model::LocalModel};
 use dynamo_runtime::{CancellationToken, DistributedRuntime};
 
 mod flags;

--- a/launch/dynamo-run/src/subprocess.rs
+++ b/launch/dynamo-run/src/subprocess.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 use tokio::io::AsyncBufReadExt;
 
 use dynamo_llm::engines::MultiNodeConfig;
-use dynamo_llm::LocalModel;
+use dynamo_llm::local_model::LocalModel;
 use dynamo_runtime::protocols::Endpoint as EndpointId;
 
 pub mod sglang;

--- a/launch/llmctl/Cargo.toml
+++ b/launch/llmctl/Cargo.toml
@@ -23,6 +23,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 dynamo-runtime = { workspace = true }
 dynamo-llm = { workspace = true }
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -111,9 +111,10 @@ fn register_llm<'p>(
     let model_name = model_name.map(|n| n.to_string());
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         // Download from HF, load the ModelDeploymentCard
-        let mut local_model = llm_rs::LocalModel::prepare(&inner_path, None, model_name)
-            .await
-            .map_err(to_pyerr)?;
+        let mut local_model =
+            llm_rs::local_model::LocalModel::prepare(&inner_path, None, model_name)
+                .await
+                .map_err(to_pyerr)?;
 
         // Advertise ourself on etcd so ingress can find us
         local_model

--- a/lib/engines/mistralrs/src/lib.rs
+++ b/lib/engines/mistralrs/src/lib.rs
@@ -42,7 +42,7 @@ use dynamo_llm::protocols::openai::{
 };
 
 use dynamo_llm::engines::{EngineDispatcher, StreamingEngine};
-use dynamo_llm::LocalModel;
+use dynamo_llm::local_model::LocalModel;
 
 /// How many requests mistral will run at once in the paged attention scheduler.
 /// It actually runs 1 fewer than this.

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -13,6 +13,7 @@ use crate::{
         completions::OpenAICompletionsStreamingEngine, embeddings::OpenAIEmbeddingsStreamingEngine,
     },
 };
+use std::collections::HashSet;
 use std::sync::RwLock;
 use std::{
     collections::HashMap,
@@ -60,6 +61,14 @@ impl ModelManager {
     pub fn has_model_any(&self, model: &str) -> bool {
         self.chat_completion_engines.read().unwrap().contains(model)
             || self.completion_engines.read().unwrap().contains(model)
+    }
+
+    pub fn model_display_names(&self) -> HashSet<String> {
+        self.list_chat_completions_models()
+            .into_iter()
+            .chain(self.list_completions_models())
+            .chain(self.list_embeddings_models())
+            .collect()
     }
 
     pub fn list_chat_completions_models(&self) -> Vec<String> {

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -357,17 +357,10 @@ async fn list_models_openai(
         .as_secs();
     let mut data = Vec::new();
 
-    let models: HashSet<String> = state
-        .manager()
-        .list_chat_completions_models()
-        .into_iter()
-        .chain(state.manager().list_completions_models())
-        .chain(state.manager().list_embeddings_models())
-        .collect();
-
-    for model_id in models {
+    let models: HashSet<String> = state.manager().model_display_names();
+    for model_name in models {
         data.push(ModelListing {
-            id: model_id.clone(),
+            id: model_name.clone(),
             object: "object",
             created,                        // Where would this come from? The GGUF?
             owned_by: "nvidia".to_string(), // Get organization from GGUF

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -29,6 +29,7 @@ pub mod hub;
 pub mod key_value_store;
 pub mod kv_router;
 pub use kv_router::DEFAULT_KV_BLOCK_SIZE;
+pub mod local_model;
 pub mod mocker;
 pub mod model_card;
 pub mod model_type;
@@ -39,9 +40,6 @@ pub mod request_template;
 pub mod tokenizers;
 pub mod tokens;
 pub mod types;
-
-mod local_model;
-pub use local_model::LocalModel;
 
 #[cfg(feature = "block-manager")]
 pub mod block_manager;

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -149,7 +149,7 @@ impl LocalModel {
         let network_name = ModelNetworkName::from_local(endpoint, etcd_client.lease_id());
         tracing::debug!("Registering with etcd as {network_name}");
         let model_registration = ModelEntry {
-            name: self.service_name().to_string(),
+            name: self.display_name().to_string(),
             endpoint: endpoint.id(),
             model_type,
         };

--- a/lib/llm/src/local_model/network_name.rs
+++ b/lib/llm/src/local_model/network_name.rs
@@ -32,6 +32,15 @@ impl ModelNetworkName {
         )
     }
 
+    pub fn from_entry(entry: &ModelEntry, lease_id: i64) -> Self {
+        Self::from_parts(
+            &entry.endpoint.namespace,
+            &entry.endpoint.component,
+            &entry.endpoint.name,
+            lease_id,
+        )
+    }
+
     /// Fetch the ModelEntry from etcd.
     pub async fn load_entry(&self, etcd_client: &etcd::Client) -> anyhow::Result<ModelEntry> {
         let mut model_entries = etcd_client.kv_get(self.to_string(), None).await?;

--- a/lib/llm/src/model_card/model.rs
+++ b/lib/llm/src/model_card/model.rs
@@ -143,13 +143,6 @@ impl ModelDeploymentCard {
         }
     }
 
-    /// A URL and NATS friendly and very likely unique ID for this model.
-    /// Mostly human readable. a-z, 0-9, _ and - only.
-    /// Pass the service_name.
-    pub fn service_name_slug(s: &str) -> Slug {
-        Slug::from_string(s)
-    }
-
     /// How often we should check if a model deployment card expired because it's workers are gone
     pub fn expiry_check_period() -> Duration {
         match CARD_MAX_AGE.to_std() {
@@ -186,7 +179,7 @@ impl ModelDeploymentCard {
     }
 
     pub fn slug(&self) -> Slug {
-        ModelDeploymentCard::service_name_slug(&self.service_name)
+        Slug::from_string(&self.display_name)
     }
 
     /// Serialize the model deployment card to a JSON string


### PR DESCRIPTION
Should fix some Python example issues.

Originally broken by https://github.com/ai-dynamo/dynamo/pull/1127 where I changed the internal etcd paths.

