### PR TITLE
fix(dynamo-run): Don't exit interactive chat on error

### DIFF
--- a/launch/dynamo-run/src/input/text.rs
+++ b/launch/dynamo-run/src/input/text.rs
@@ -122,7 +122,13 @@ async fn main_loop(
         };
 
         // Call the model
-        let mut stream = engine.generate(Context::new(req)).await?;
+        let mut stream = match engine.generate(Context::new(req)).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                tracing::error!(%err, "Request failed.");
+                continue;
+            }
+        };
 
         // Stream the output to stdout
         let mut stdout = std::io::stdout();


### PR DESCRIPTION
Previously any error would cause us to halt. Most of them are recoverable. So now we print the error and return to the prompt.

