### PR TITLE
chore: vLLM arm build has verbose logging turned on to see progress

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -192,7 +192,7 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         # MAX_JOBS set to avoid running OOM on vllm-flash-attn build, this can
         # significantly impact the overall build time. Each job can take up
         # to -16GB RAM each, so tune according to available system memory.
-        MAX_JOBS=${VLLM_MAX_JOBS} uv pip install . --no-build-isolation ; \
+        MAX_JOBS=${VLLM_MAX_JOBS} uv pip install -vv . --no-build-isolation ; \
     # Handle x86_64: Download wheel, unpack, setup for later steps
     else \
         python -m pip download --only-binary=:all: --no-deps --dest /tmp/vllm vllm==v${VLLM_REF} && \


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This adds logging to the vllm arm build.
closes: https://linear.app/nvidia-dynamo/issue/OPS-111/unblock-vllm-arm64-build

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
