### PR TITLE
chore: Move block manager checks to pre-merge-rust

### DIFF
--- a/.github/workflows/pre-merge-python.yml
+++ b/.github/workflows/pre-merge-python.yml
@@ -47,9 +47,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
         run: |
           ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target ci_minimum --framework ${{ matrix.framework }}
-      - name: Run Rust checks (llm/block-manager)
-        run: |
-          docker run -w /workspace/lib/llm --name ${{ env.CONTAINER_ID }}_rust_checks ${{ steps.define_image_tag.outputs.image_tag }} bash -ec 'rustup component add rustfmt clippy && cargo fmt -- --check && cargo clippy --features block-manager --no-deps --all-targets -- -D warnings && cargo test --locked --all-targets --features=block-manager'
       - name: Run pytest
         env:
           PYTEST_MARKS: "pre_merge or mypy"

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -92,9 +92,8 @@ jobs:
       run: cargo test --locked --all-targets
 
   block-manager-rust:
-    runs-on: ubuntu-latest
-    # runs-on:
-    #   group: Fastchecker
+    runs-on:
+      group: Fastchecker
     name: Docker Rust Checks (llm/block-manager)
     env:
       CONTAINER_ID: rust_check_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -90,3 +90,29 @@ jobs:
       working-directory: ${{ matrix.dir }}
       # NOTE: --all-targets doesn't run doc tests
       run: cargo test --locked --all-targets
+
+  block-manager-rust:
+    runs-on: ubuntu-latest
+    # runs-on:
+    #   group: Fastchecker
+    name: Docker Rust Checks (llm/block-manager)
+    env:
+      CONTAINER_ID: rust_check_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Define Image Tag
+        id: define_image_tag
+        run: |
+          echo "image_tag=dynamo:block-manager-rust" >> $GITHUB_OUTPUT
+      - name: Build image
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: |
+          ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target ci_minimum --framework vllm
+      - name: Run Rust checks (llm/block-manager)
+        run: |
+          docker run -w /workspace/lib/llm --name ${{ env.CONTAINER_ID }}_rust_checks ${{ steps.define_image_tag.outputs.image_tag }} bash -ec 'rustup component add rustfmt clippy && cargo fmt -- --check && cargo clippy --features block-manager --no-deps --all-targets -- -D warnings && cargo test --locked --all-targets --features=block-manager'
+

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -91,6 +91,7 @@ jobs:
       # NOTE: --all-targets doesn't run doc tests
       run: cargo test --locked --all-targets
 
+  # The block manager requires NIXL to be installed, so we run this part in docker in a separate job.
   block-manager-rust:
     runs-on:
       group: Fastchecker


### PR DESCRIPTION
Move the llm block manager rust tests from `pre-merge-python` to `pre-merge-rust`

Closes  #1149 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated pre-merge workflows to separate Rust checks for the block-manager feature into a dedicated job, improving workflow organization and clarity.
	- Removed Rust checks from the Python pre-merge workflow; these checks now run exclusively in the Rust workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->