### PR TITLE
feat: support liveness decorator in sdk

### DIFF
--- a/deploy/sdk/src/dynamo/sdk/__init__.py
+++ b/deploy/sdk/src/dynamo/sdk/__init__.py
@@ -17,8 +17,8 @@ from typing import Any
 
 from bentoml import on_shutdown as async_on_shutdown
 
-from dynamo.sdk.core.decorators.endpoint import api, endpoint
-from dynamo.sdk.core.lib import DYNAMO_IMAGE, depends, service
+from dynamo.sdk.core.decorators.endpoint import api, dynamo_endpoint
+from dynamo.sdk.core.lib import DYNAMO_IMAGE, depends, liveness, service
 from dynamo.sdk.lib.decorators import async_on_start
 
 dynamo_context: dict[str, Any] = {}
@@ -32,4 +32,5 @@ __all__ = [
     "endpoint",
     "api",
     "service",
+    "liveness",
 ]

--- a/deploy/sdk/src/dynamo/sdk/__init__.py
+++ b/deploy/sdk/src/dynamo/sdk/__init__.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from bentoml import on_shutdown as async_on_shutdown
 
-from dynamo.sdk.core.decorators.endpoint import api, dynamo_endpoint
+from dynamo.sdk.core.decorators.endpoint import api, endpoint
 from dynamo.sdk.core.lib import DYNAMO_IMAGE, depends, liveness, service
 from dynamo.sdk.lib.decorators import async_on_start
 

--- a/deploy/sdk/src/dynamo/sdk/core/lib.py
+++ b/deploy/sdk/src/dynamo/sdk/core/lib.py
@@ -27,6 +27,7 @@ from dynamo.sdk.core.protocol.interface import (
     ServiceInterface,
 )
 
+T = TypeVar("T", bound=object)
 G = TypeVar("G", bound=Callable[..., Any])
 
 #  Note: global service provider.
@@ -51,7 +52,7 @@ def get_target() -> DeploymentTarget:
 
 # TODO: dynamo_component
 def service(
-    inner: Optional[Type[G]] = None,
+    inner: Optional[Type[T]] = None,
     /,
     *,
     dynamo: Optional[Union[Dict[str, Any], DynamoConfig]] = None,
@@ -70,7 +71,7 @@ def service(
 
     assert isinstance(dynamo_config, DynamoConfig)
 
-    def decorator(inner: Type[G]) -> ServiceInterface[G]:
+    def decorator(inner: Type[T]) -> ServiceInterface[T]:
         provider = get_target()
         if inner is not None:
             dynamo_config.name = inner.__name__
@@ -87,8 +88,8 @@ def service(
 
 
 def depends(
-    on: Optional[ServiceInterface[G]] = None, **kwargs: Any
-) -> DependencyInterface[G]:
+    on: Optional[ServiceInterface[T]] = None, **kwargs: Any
+) -> DependencyInterface[T]:
     """Create a dependency using the current service provider"""
     provider = get_target()
     return provider.create_dependency(on=on, **kwargs)

--- a/deploy/sdk/src/dynamo/sdk/core/lib.py
+++ b/deploy/sdk/src/dynamo/sdk/core/lib.py
@@ -15,7 +15,7 @@
 #  Modifications Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
 
 import os
-from typing import Any, Dict, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union
 
 from fastapi import FastAPI
 
@@ -27,7 +27,7 @@ from dynamo.sdk.core.protocol.interface import (
     ServiceInterface,
 )
 
-T = TypeVar("T", bound=object)
+G = TypeVar("G", bound=Callable[..., Any])
 
 #  Note: global service provider.
 # this should be set to a concrete implementation of the DeploymentTarget interface
@@ -51,7 +51,7 @@ def get_target() -> DeploymentTarget:
 
 # TODO: dynamo_component
 def service(
-    inner: Optional[Type[T]] = None,
+    inner: Optional[Type[G]] = None,
     /,
     *,
     dynamo: Optional[Union[Dict[str, Any], DynamoConfig]] = None,
@@ -70,7 +70,7 @@ def service(
 
     assert isinstance(dynamo_config, DynamoConfig)
 
-    def decorator(inner: Type[T]) -> ServiceInterface[T]:
+    def decorator(inner: Type[G]) -> ServiceInterface[G]:
         provider = get_target()
         if inner is not None:
             dynamo_config.name = inner.__name__
@@ -87,8 +87,25 @@ def service(
 
 
 def depends(
-    on: Optional[ServiceInterface[T]] = None, **kwargs: Any
-) -> DependencyInterface[T]:
+    on: Optional[ServiceInterface[G]] = None, **kwargs: Any
+) -> DependencyInterface[G]:
     """Create a dependency using the current service provider"""
     provider = get_target()
     return provider.create_dependency(on=on, **kwargs)
+
+
+def liveness(func: G) -> G:
+    """Decorator for liveness probe."""
+    if not callable(func):
+        raise TypeError("@liveness can only decorate callable methods")
+
+    func.__is_liveness_probe__ = True  # type: ignore
+    return func
+
+
+def get_liveness_handler(obj):
+    for attr in dir(obj):
+        fn = getattr(obj, attr)
+        if callable(fn) and getattr(fn, "__is_liveness_probe__", False):
+            return fn
+    return None

--- a/deploy/sdk/src/dynamo/sdk/core/runner/bentoml.py
+++ b/deploy/sdk/src/dynamo/sdk/core/runner/bentoml.py
@@ -35,6 +35,7 @@ from dynamo.sdk.core.protocol.interface import (
     ServiceInterface,
 )
 from dynamo.sdk.core.runner.common import ServiceMixin
+from dynamo.sdk.core.runner.health import register_liveness_probe
 
 T = TypeVar("T", bound=object)
 
@@ -116,6 +117,7 @@ class BentoServiceAdapter(ServiceMixin, ServiceInterface[T]):
             self.app = FastAPI(title=name)
         else:
             self.app = app
+        register_liveness_probe(self.app, service_cls)
         self._dependencies: Dict[str, "DependencyInterface"] = {}
         self._bentoml_service.config["dynamo"] = asdict(self._dynamo_config)
         self._api_endpoints: list[str] = []

--- a/deploy/sdk/src/dynamo/sdk/core/runner/dynamo.py
+++ b/deploy/sdk/src/dynamo/sdk/core/runner/dynamo.py
@@ -41,6 +41,7 @@ from dynamo.sdk.core.protocol.interface import (
     ServiceInterface,
 )
 from dynamo.sdk.core.runner.common import ServiceMixin
+from dynamo.sdk.core.runner.health import register_liveness_probe
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +98,8 @@ class LocalService(ServiceMixin, ServiceInterface[T]):
                 )
             if isinstance(field, DependencyInterface):
                 self._dependencies[field_name] = field
+        inner_instance = inner_cls()
+        register_liveness_probe(self.app, inner_instance)
 
     def find_dependent_by_name(self, name: str) -> "ServiceInterface":
         return self.all_services()[name]

--- a/deploy/sdk/src/dynamo/sdk/core/runner/health.py
+++ b/deploy/sdk/src/dynamo/sdk/core/runner/health.py
@@ -1,0 +1,57 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2020 Atalaya Tech. Inc
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  Modifications Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+
+
+from typing import Any
+
+from fastapi import FastAPI, Response
+
+
+def register_liveness_probe(
+    app: FastAPI, instance: Any, route: str = "/healthz/liveness"
+) -> None:
+    """Registers /healthz/liveness only if a method decorated with @liveness is found.
+
+    Does nothing otherwise (no fallback, no error).
+
+     Args:
+        app (FastAPI): The FastAPI application to register the liveness route on.
+        instance (Any): The service or component instance to inspect for a @liveness-decorated method.
+        route (str, optional): The URL path to register the liveness endpoint under.
+                               Defaults to "/healthz/liveness".
+    """
+
+    # Find the decorated method.
+    for attr in dir(instance):
+        decorated_method = getattr(instance, attr)
+        if callable(decorated_method) and getattr(
+            decorated_method, "__is_liveness_probe__", False
+        ):
+            break
+    else:
+        # Do nothing if no @liveness() decorator found.
+        return
+
+    @app.get(route)
+    async def liveness_check():
+        try:
+            result = decorated_method()
+            if callable(getattr(result, "__await__", None)):
+                result = await result
+            return Response(status_code=200 if result else 503)
+        except Exception as e:
+            return Response(content=str(e), status_code=500)

--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sdk import DYNAMO_IMAGE, api, depends, endpoint, service
+from dynamo.sdk.core.lib import liveness
 from dynamo.sdk.lib.config import ServiceConfig
 
 logger = logging.getLogger(__name__)
@@ -136,3 +137,8 @@ class Frontend:
                 yield f"Frontend: {response}"
 
         return StreamingResponse(content_generator())
+
+    @liveness
+    def is_alive(self) -> bool:
+        logger.info("Liveness probe")
+        return True


### PR DESCRIPTION
#### Overview:

The service will serve a liveness http endpoint.

#### Details:

see DEP-90
https://linear.app/nvidia-dynamo/issue/DEP-90/add-liveness-and-readiness-decorators-to-dynamo-deploy-sdk

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: DEP-90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a liveness probe mechanism, allowing services to expose a health check endpoint for monitoring availability.
  * Added support for marking specific service methods as liveness probes.
  * Services now automatically register a liveness health check endpoint if a liveness probe is present.
  * Example service updated to include a liveness check method.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->