### PR TITLE
docs: Fix broken link to `support_matrix.md` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Built in Rust for performance and in Python for extensibility, Dynamo is fully o
 ### Installation
 
 The following examples require a few system level packages.
-Recommended to use Ubuntu 24.04 with a x86_64 CPU. See [docs/support_matrix.md](support_matrix.md)
+Recommended to use Ubuntu 24.04 with a x86_64 CPU. See [docs/support_matrix.md](docs/support_matrix.md)
 
 ```
 apt-get update


### PR DESCRIPTION
#### Overview:

Fixed the broken relative link to `support_matrix.md` in the `README.md` file.

