### PR TITLE
fix: Add block-size parameter to Router in the example

### DIFF
--- a/examples/llm/configs/agg_router.yaml
+++ b/examples/llm/configs/agg_router.yaml
@@ -29,7 +29,7 @@ Processor:
 
 Router:
   min-workers: 1
-  common-configs: [model, router]
+  common-configs: [model, block-size, router]
 
 VllmWorker:
   enforce-eager: true

--- a/examples/llm/configs/disagg_router.yaml
+++ b/examples/llm/configs/disagg_router.yaml
@@ -29,7 +29,7 @@ Processor:
 
 Router:
   min-workers: 1
-  common-configs: [model, router]
+  common-configs: [model, block-size, router]
 
 VllmWorker:
   max-num-batched-tokens: 16384


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
Currently, the example does not set `block_size` for `Router`, causing `args.block_size` to default to `64` in the LLM example's `Router`. This PR adds the missing parameter to ensure proper configuration.
If we change `block-size` to `32` in `examples/llm/configs/agg_router.yaml`, the log output changes as follows:
Before the PR
```
INFO config.as_args: [Processor:1] Running Processor with args=['--model', 'deepseek-ai/DeepSeek-R1-Distill-Llama-8B', '--block-size', '32', '--max-model-len', '16384', '--router', 'kv']
...
INFO config.as_args: [Router:1] Running Router with args=['--model', 'deepseek-ai/DeepSeek-R1-Distill-Llama-8B', '--router', 'kv', '--min-workers', '1']
```
After the PR
```
INFO config.as_args: [Processor:1] Running Processor with args=['--model', 'deepseek-ai/DeepSeek-R1-Distill-Llama-8B', '--block-size', '32', '--max-model-len', '16384', '--router', 'kv']
...
INFO config.as_args: [Router:1] Running Router with args=['--model', 'deepseek-ai/DeepSeek-R1-Distill-Llama-8B', '--block-size', '32', '--router', 'kv', '--min-workers', '1']
```

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)


