### PR TITLE
fix: ignore setuptools warning in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "pytest>=8.3.4",
-    "bentoml==1.4.15",
+    "bentoml==1.4.8",
     "types-psutil==7.0.0.20250218",
     "kubernetes==32.0.1",
     "ai-dynamo-runtime==0.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "pytest>=8.3.4",
-    "bentoml==1.4.8",
+    "bentoml==1.4.15",
     "types-psutil==7.0.0.20250218",
     "kubernetes==32.0.1",
     "ai-dynamo-runtime==0.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "typer",
     "circus>=0.17.0",
     "click<8.2.0",
+    "setuptools<81",
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "typer",
     "circus>=0.17.0",
     "click<8.2.0",
-    "setuptools<81",
 ]
 
 classifiers = [
@@ -143,7 +142,8 @@ filterwarnings = [
     "error",
     "ignore:.*cuda*:DeprecationWarning", # Need this to avoid deprecation warnings from CUDA in tensorrt_llm.
     "ignore:.*pkg_resources.*:DeprecationWarning",
-    "ignore:.*multipart.*:PendingDeprecationWarning"
+    "ignore:.*pkg_resources.*:UserWarning",
+    "ignore:.*multipart.*:PendingDeprecationWarning",
 ]
 
 


### PR DESCRIPTION
#### Overview:
- ignore setuptools warning in pytest 

```
E   UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```