### PR TITLE
fix: dynamo-run add warning if block-size different

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -185,6 +185,16 @@ impl ModelManager {
         kv_cache_block_size: usize,
     ) -> anyhow::Result<Arc<KvRouter>> {
         if let Some(kv_chooser) = self.get_kv_chooser(model_name) {
+            // Check if the existing router has a different block size
+            if kv_chooser.block_size() != kv_cache_block_size {
+                tracing::warn!(
+                    model_name = %model_name,
+                    existing_block_size = %kv_chooser.block_size(),
+                    requested_block_size = %kv_cache_block_size,
+                    "KV Router block size mismatch! Model is requesting a different kv_cache_block_size than the existing router. \
+                     This will cause routing to fail silently. Consider using the same block size or restarting the router."
+                );
+            }
             return Ok(kv_chooser);
         }
         self.create_kv_chooser(model_name, component, kv_cache_block_size)

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -144,6 +144,11 @@ impl KvRouter {
         let worker_id = self.scheduler.schedule(overlap_scores, isl_tokens).await?;
         Ok(worker_id)
     }
+
+    /// Get the block size this router was configured with
+    pub fn block_size(&self) -> usize {
+        self.block_size
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
#### Overview:

https://github.com/ai-dynamo/dynamo/issues/1232

#### Details:

- add a warning to let user know what is happening

```
2025-05-28T04:49:50.256Z  WARN dynamo_llm::discovery::model_manager: KV Router block size mismatch! Model is requesting a different kv_cache_block_size than the existing router. This will cause routing to fail silently. Consider using the same block size or restarting the router. model_name=Qwen/Qwen3-0.6B existing_block_size=16 requested_block_size=64
```