### PR TITLE
fix: ignore setuptools warning

### DIFF
--- a/deploy/sdk/src/dynamo/sdk/__init__.py
+++ b/deploy/sdk/src/dynamo/sdk/__init__.py
@@ -13,10 +13,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import warnings
 from typing import Any
 
-from bentoml import on_shutdown as async_on_shutdown
+# Suppress warning from setuptools caused by bentoml
+# TODO: Remove this line after the bentoml import is removed from this file
+warnings.filterwarnings("ignore", category=UserWarning, message=".*pkg_resources.*")
 
+# flake8: noqa: E402
+from bentoml import on_shutdown as async_on_shutdown
 from dynamo.sdk.core.decorators.endpoint import api, endpoint
 from dynamo.sdk.core.lib import DYNAMO_IMAGE, depends, liveness, readiness, service
 from dynamo.sdk.lib.decorators import async_on_start

--- a/deploy/sdk/src/dynamo/sdk/__init__.py
+++ b/deploy/sdk/src/dynamo/sdk/__init__.py
@@ -22,6 +22,8 @@ warnings.filterwarnings("ignore", category=UserWarning, message=".*pkg_resources
 
 # flake8: noqa: E402
 from bentoml import on_shutdown as async_on_shutdown
+
+# flake8: noqa: E402
 from dynamo.sdk.core.decorators.endpoint import api, endpoint
 from dynamo.sdk.core.lib import DYNAMO_IMAGE, depends, liveness, readiness, service
 from dynamo.sdk.lib.decorators import async_on_start


### PR DESCRIPTION
#### Overview:

Bentoml's use of setuptools is causing the following warning to be displayed. 

E   UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.

Suppresses the warning in our logs

closes dep-125
