### PR TITLE
fix: correct calculation of block needed in rust kv router

### DIFF
--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -325,7 +325,7 @@ impl WorkerSelector for DefaultWorkerSelector {
         tracing::debug!("Selected worker: {worker_id}, logit: {best_logit:.3}");
 
         // Log selection metrics
-        let total_blocks = std::cmp::min(request.isl_tokens / block_size, 1) as u64;
+        let total_blocks = std::cmp::max(request.isl_tokens / block_size, 1) as u64;
         let overlap_blocks = request.overlap.scores.get(&worker_id).copied().unwrap_or(0) as usize;
 
         Ok(WorkerSelectionResult {


### PR DESCRIPTION
correct calculation of block needed in rust kv router

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved calculation of required blocks for processing requests, ensuring more accurate resource allocation based on request size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->