### PR TITLE
build: Fix 'uv: command not found' in TRTLLM build

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -166,8 +166,7 @@ RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
 ARG GENAI_PERF_VERSION
 
 # Install genai-perf for benchmarking
-
-RUN uv pip install genai-perf==$GENAI_PERF_VERSION
+RUN pip install genai-perf==$GENAI_PERF_VERSION
 
 # Install test dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Quick fix fo build failure introduced here: https://github.com/ai-dynamo/dynamo/pull/1231/files

```
#31 [build 13/21] RUN uv pip install genai-perf==0.0.13
#31 0.642 /bin/bash: line 1: uv: command not found
```

Current TRTLLM container doesn't activate venv by default like the VLLM container does due to various issues around pytorch/trtllm install in the past, so doing a normal `pip install` outside the venv makes `genai-perf` readily available when entering the container.

Long term fix is to polish up the TRTLLM Dockerfile to use `uv pip` everywhere if all issues with PyTorch/TRTLLM dependencies are now resolved with respect to `venv` usage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the package installation command to ensure proper installation of the required Python package during container build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->