### PR TITLE
feat: Publish events and metrics when using kv routing

### DIFF
--- a/launch/dynamo-run/src/subprocess.rs
+++ b/launch/dynamo-run/src/subprocess.rs
@@ -55,7 +55,6 @@ pub async fn start(
     // TRTLLM only
     // The worker node will only publish events and metrics if the router mode is KV
     if flags.router_mode == RouterMode::KV {
-        println!("Setting publishers");
         args.push("--publish-events-and-metrics".to_string());
     }
 

--- a/launch/dynamo-run/src/subprocess.rs
+++ b/launch/dynamo-run/src/subprocess.rs
@@ -13,6 +13,8 @@ use tokio::io::AsyncBufReadExt;
 use dynamo_llm::engines::MultiNodeConfig;
 use dynamo_llm::local_model::LocalModel;
 use dynamo_runtime::protocols::Endpoint as EndpointId;
+use crate::flags::RouterMode;
+
 
 pub mod sglang;
 pub mod trtllm;
@@ -51,6 +53,13 @@ pub async fn start(
         "--context-length".to_string(),
         card.context_length.to_string(),
     ];
+    // TRTLLM only
+    // The worker node will only publish events and metrics if the router mode is KV
+    if flags.router_mode == RouterMode::KV {
+        println!("Setting publishers");
+        args.push("--publish-events-and-metrics".to_string());
+    }
+
     // sglang only
     // vllm uses CUDA_VISIBLE_DEVICES
     if flags.base_gpu_id != 0 {

--- a/launch/dynamo-run/src/subprocess.rs
+++ b/launch/dynamo-run/src/subprocess.rs
@@ -10,11 +10,10 @@ use anyhow::Context;
 use regex::Regex;
 use tokio::io::AsyncBufReadExt;
 
+use crate::flags::RouterMode;
 use dynamo_llm::engines::MultiNodeConfig;
 use dynamo_llm::local_model::LocalModel;
 use dynamo_runtime::protocols::Endpoint as EndpointId;
-use crate::flags::RouterMode;
-
 
 pub mod sglang;
 pub mod trtllm;

--- a/launch/dynamo-run/src/subprocess/trtllm_inc.py
+++ b/launch/dynamo-run/src/subprocess/trtllm_inc.py
@@ -178,7 +178,11 @@ async def init(runtime: DistributedRuntime, config: Config):
     async with get_tensorrtllm_engine(engine_args) as engine:
         endpoint = component.endpoint(config.endpoint)
         await register_llm(
-            ModelType.Backend, endpoint, config.model_path, config.model_name
+            ModelType.Backend,
+            endpoint,
+            config.model_path,
+            config.model_name,
+            kv_cache_block_size=config.kv_block_size,
         )
 
         if config.publish_events_and_metrics:


### PR DESCRIPTION
#### Overview:

Enable event and metric publishing in the trtllm worker if using kv routing.

Follow-up from https://github.com/ai-dynamo/dynamo/pull/1223#discussion_r2111725461


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for publishing events and metrics when launching TRTLLM models in specific router modes.
  - Enhanced model registration by including KV cache block size configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->