### PR TITLE
fix: Only check model name on etcd-registered endpoints

### DIFF
--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -184,8 +184,8 @@ impl LocalModel {
         };
         for endpoint_info in component.list_instances().await? {
             let network_name: ModelNetworkName = (&endpoint_info).into();
-            if endpoint_info.endpoint == "generate" {
-                let entry = network_name.load_entry(&etcd_client).await?;
+
+            if let Ok(entry) = network_name.load_entry(&etcd_client).await {
                 if entry.name != model_name {
                     anyhow::bail!("Duplicate component. Attempt to register model {model_name} at {component}, which is already used by {network_name} running model {}.", entry.name);
                 }

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -184,9 +184,11 @@ impl LocalModel {
         };
         for endpoint_info in component.list_instances().await? {
             let network_name: ModelNetworkName = (&endpoint_info).into();
-            let entry = network_name.load_entry(&etcd_client).await?;
-            if entry.name != model_name {
-                anyhow::bail!("Duplicate component. Attempt to register model {model_name} at {component}, which is already used by {network_name} running model {}.", entry.name);
+            if endpoint_info.endpoint == "generate" {
+                let entry = network_name.load_entry(&etcd_client).await?;
+                if entry.name != model_name {
+                    anyhow::bail!("Duplicate component. Attempt to register model {model_name} at {component}, which is already used by {network_name} running model {}.", entry.name);
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Fixes kv routing to multiple python workers. After creating one worker, creating another worker would cause etcd errors. This was because we were checking model names of every endpoint for the component. Some of the endpoints (such as load_metrics) aren't published to etcd, so this would fail. Instead, we can just check the model name for endpoints registered to etcd.

Closes: #1234 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved uniqueness checks to only apply to component instances with a "generate" endpoint, reducing unnecessary duplicate detection for other endpoints.
  - Enhanced error handling during model name uniqueness verification to avoid interruptions from network entry loading issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->