### PR TITLE
chore: Fix typos in docs/guides

### DIFF
--- a/docs/guides/backend.md
+++ b/docs/guides/backend.md
@@ -73,7 +73,7 @@ see the [Dynamo SDK Docs](../API/sdk.md).
 
 ### Request/Response Types
 
-Request/Response types of endpoints can be defined arbitraily for your use case's needs, as long as
+Request/Response types of endpoints can be defined arbitrarily for your use case's needs, as long as
 the client calling your worker matches the expectations.
 
 Define your request and response types using Pydantic models:

--- a/docs/guides/cli_overview.md
+++ b/docs/guides/cli_overview.md
@@ -67,7 +67,7 @@ dynamo serve  --service-name Middle hello_world:Frontend
 
 ### `build`
 
-The `build` commmand allows you to package up your inference graph and its dependancies and create an archive of it. This is commonly paired with the `--containerize` flag to create a single docker container that runs your inference graph. As with `serve`, you point toward the first service in your dependency graph. For details about `dynamo build`, see [Serving Inference Graphs](dynamo_serve.md).
+The `build` command allows you to package up your inference graph and its dependencies and create an archive of it. This is commonly paired with the `--containerize` flag to create a single docker container that runs your inference graph. As with `serve`, you point toward the first service in your dependency graph. For details about `dynamo build`, see [Serving Inference Graphs](dynamo_serve.md).
 
 **Usage**
 ```bash
@@ -89,7 +89,7 @@ dynamo build hello_world:Frontend
 
 ### `deploy`
 
-The `deploy` commmand creates a pipeline on Dynamo Cloud using parameters at the prompt or using a YAML configuration file. For details, see [Deploying Inference Graphs to Kubernetes](dynamo_deploy/README.md).
+The `deploy` command creates a pipeline on Dynamo Cloud using parameters at the prompt or using a YAML configuration file. For details, see [Deploying Inference Graphs to Kubernetes](dynamo_deploy/README.md).
 
 **Usage**
 ```bash

--- a/docs/guides/dynamo_serve.md
+++ b/docs/guides/dynamo_serve.md
@@ -77,7 +77,7 @@ The `.link()` method is useful for:
 
 ## Deploying the inference graph
 
-Once you've defined your inference graph and its configuration, deploy it locally using the `dynamo serve` command. We recommend running the `--dry-run` command to see what arguments will be pasesd into your final graph.
+Once you've defined your inference graph and its configuration, deploy it locally using the `dynamo serve` command. We recommend running the `--dry-run` command to see what arguments will be passed into your final graph.
 
 Consider the following example.
 
@@ -129,7 +129,7 @@ class VllmWorker:
     ...
 ```
 
-Note that our prebuilt components have the maximal set of dependancies needed to run the component, which allows you to plug different components into the same graph to create different architectures. When writing your own components, you can be as flexible as you like.
+Note that our prebuilt components have the maximal set of dependencies needed to run the component, which allows you to plug different components into the same graph to create different architectures. When writing your own components, you can be as flexible as you like.
 
 #### Define your graph
 

--- a/docs/guides/planner.md
+++ b/docs/guides/planner.md
@@ -86,7 +86,7 @@ The following information will be printed out in the terminal:
 2025-05-16 15:20:24 - __main__ - INFO - Suggested planner upper/lower bound for decode kv cache utilization: 0.20/0.10
 ```
 
-After finding the best TP size for prefill and decode, the script will then interpolate the TTFT with ISL and ITL with active KV cache and decode context length. This is to provide a more accurate estimation of the performance when ISL and OSL changes. The results will be saved to `<output_dir>/<decode/prefill>_tp<best_tp>_interploation`.
+After finding the best TP size for prefill and decode, the script will then interpolate the TTFT with ISL and ITL with active KV cache and decode context length. This is to provide a more accurate estimation of the performance when ISL and OSL changes. The results will be saved to `<output_dir>/<decode/prefill>_tp<best_tp>_interpolation`.
 
 ## Usage
 The planner is started automatically as part of Dynamo pipelines when running `dynamo serve`. You can configure the planner just as you would any other component in your pipeline either via YAML configuration or through CLI arguments.


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

(Testing signed commits triggering gitlab pipelines)

Fix typos in docs/guides

This CLI is quite fast and nice for smoke checking typos: https://github.com/crate-ci/typos

```bash
# show typos
typos

# auto fix when possible
typos -w
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected multiple typographical errors across various user guides to improve clarity and accuracy. No changes to functionality or instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->