### PR TITLE
chore(code-rabbit): Disable suggested labels and reviewers

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,6 +16,8 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+  suggested_labels: false
+  suggested_reviewers: false
   finishing_touches:
     docstrings:
       enabled: false


### PR DESCRIPTION
Make it a bit less noisy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added two new configuration options for auto review: `suggested_labels` and `suggested_reviewers`, both defaulting to `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->