### PR TITLE
fix: remove sglang hash for pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,10 +66,6 @@ vllm = [
     "ai-dynamo-vllm~=0.8.4"
 ]
 
-sglang = [
-    "sglang[all]@git+https://github.com/sgl-project/sglang@e806f708c954020bda7d1cc98035a44fd6a4eb96#subdirectory=python"
-]
-
 [project.scripts]
 dynamo = "dynamo.sdk.cli.cli:cli"
 dynamo-run = "dynamo.sdk.cli.run_executable:dynamo_run"


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Remove url dependency for sglang per @nv-anants request:
> Pypi will reject our wheel I think, if we put direct urls in dependency

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the optional dependency group for `sglang` from the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->