### PR TITLE
refactor: Refactor kv event publishers

### DIFF
--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -148,7 +148,7 @@ fn dynamo_create_kv_publisher(
     {
         Ok(drt) => {
             let backend = drt.namespace(namespace)?.component(component)?;
-            KvEventPublisher::new(backend, worker_id, kv_block_size)
+            KvEventPublisher::new(backend, worker_id, kv_block_size, None)
         }
         Err(e) => Err(e),
     }

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -22,9 +22,7 @@ use rs::traits::events::EventSubscriber;
 use tracing;
 
 use llm_rs::kv_router::protocols::*;
-use llm_rs::kv_router::publisher::{
-    create_stored_blocks, KvEventInternalSourceConfig, KvEventSourceConfig,
-};
+use llm_rs::kv_router::publisher::{create_stored_blocks, KvEventSourceConfig};
 
 #[pyclass]
 pub(crate) struct KvRouter {
@@ -178,7 +176,7 @@ impl ZmqKvEventPublisher {
             component.inner,
             config.worker_id,
             config.kv_block_size,
-            KvEventSourceConfig::Internal(KvEventInternalSourceConfig::Zmq {
+            Some(KvEventSourceConfig::Zmq {
                 endpoint: config.zmq_endpoint,
                 topic: config.zmq_topic,
             }),
@@ -207,7 +205,7 @@ impl KvEventPublisher {
             component.inner,
             worker_id,
             kv_block_size,
-            KvEventSourceConfig::External,
+            None,
         )
         .map_err(to_pyerr)?;
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -22,7 +22,9 @@ use rs::traits::events::EventSubscriber;
 use tracing;
 
 use llm_rs::kv_router::protocols::*;
-use llm_rs::kv_router::publisher::create_stored_blocks;
+use llm_rs::kv_router::publisher::{
+    create_stored_blocks, KvEventInternalSourceConfig, KvEventSourceConfig,
+};
 
 #[pyclass]
 pub(crate) struct KvRouter {
@@ -165,21 +167,23 @@ impl ZmqKvEventPublisherConfig {
 
 #[pyclass]
 pub(crate) struct ZmqKvEventPublisher {
-    inner: llm_rs::kv_router::publisher::ZmqKvEventPublisher,
+    inner: llm_rs::kv_router::publisher::KvEventPublisher,
 }
 
 #[pymethods]
 impl ZmqKvEventPublisher {
     #[new]
     fn new(component: Component, config: ZmqKvEventPublisherConfig) -> PyResult<Self> {
-        let mut inner =
-            llm_rs::kv_router::publisher::ZmqKvEventPublisher::new(config.kv_block_size);
-        inner.start_background_task(
+        let inner = llm_rs::kv_router::publisher::KvEventPublisher::new(
             component.inner,
             config.worker_id,
-            config.zmq_endpoint,
-            config.zmq_topic,
-        );
+            config.kv_block_size,
+            KvEventSourceConfig::Internal(KvEventInternalSourceConfig::Zmq {
+                endpoint: config.zmq_endpoint,
+                topic: config.zmq_topic,
+            }),
+        )
+        .map_err(to_pyerr)?;
         Ok(Self { inner })
     }
 
@@ -203,8 +207,10 @@ impl KvEventPublisher {
             component.inner,
             worker_id,
             kv_block_size,
+            KvEventSourceConfig::External,
         )
         .map_err(to_pyerr)?;
+
         Ok(Self {
             inner: inner.into(),
             kv_block_size,

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -19,7 +19,7 @@ use crate::kv_router::{
     KV_EVENT_SUBJECT, KV_METRICS_ENDPOINT,
 };
 use async_trait::async_trait;
-use dynamo_runtime::traits::{events::EventPublisher, DistributedRuntimeProvider, RuntimeProvider};
+use dynamo_runtime::traits::{events::EventPublisher, DistributedRuntimeProvider};
 use dynamo_runtime::{
     component::Component,
     pipeline::{
@@ -127,6 +127,7 @@ impl KvEventSource {
         kv_block_size: usize,
         source_config: KvEventSourceConfig,
     ) -> Result<Self> {
+        tracing::info!("Publishing KV Events to subject: {}", KV_EVENT_SUBJECT);
         match source_config {
             KvEventSourceConfig::Internal(internal_source_config) => {
                 let source = KvEventInternalSource::start(
@@ -140,8 +141,6 @@ impl KvEventSource {
             }
             KvEventSourceConfig::External => {
                 let (tx, mut rx) = mpsc::unbounded_channel::<KvCacheEvent>();
-                tracing::info!("Publishing KV Events to subject: {}", KV_EVENT_SUBJECT);
-
                 _ = component.drt().runtime().secondary().spawn(async move {
                     loop {
                         tokio::select! {

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -45,30 +45,30 @@ use zeromq::{Socket, SocketRecv, SubSocket};
 // KV Event Publishers -----------------------------------------------------
 // -------------------------------------------------------------------------
 
-pub enum KvEventInternalSourceConfig {
+/// Configure the source of KV events.
+/// Currently, only ZMQ is supported.
+pub enum KvEventSourceConfig {
     Zmq { endpoint: String, topic: String },
 }
 
-enum KvEventInternalSource {
+/// The source of KV events.
+enum KvEventSource {
     Zmq {
         zmq_handle: tokio::task::JoinHandle<()>,
-        processor_handle: tokio::task::JoinHandle<()>,
     },
 }
 
-impl KvEventInternalSource {
+impl KvEventSource {
+    /// Start the event source from a [`KvEventSourceConfig`].
     fn start(
         component: Component,
-        worker_id: i64,
-        cancellation_token: CancellationToken,
         kv_block_size: usize,
-        source_config: KvEventInternalSourceConfig,
+        source_config: KvEventSourceConfig,
+        cancellation_token: CancellationToken,
+        tx: mpsc::UnboundedSender<KvCacheEvent>,
     ) -> Result<Self> {
         match source_config {
-            KvEventInternalSourceConfig::Zmq { endpoint, topic } => {
-                let (raw_tx, raw_rx) = mpsc::unbounded_channel::<(u64, Vec<u8>)>();
-                let warning_count = Arc::new(AtomicU32::new(0));
-
+            KvEventSourceConfig::Zmq { endpoint, topic } => {
                 let zmq_handle = component
                     .drt()
                     .runtime()
@@ -76,123 +76,36 @@ impl KvEventInternalSource {
                     .spawn(start_zmq_listener(
                         endpoint,
                         topic,
-                        raw_tx,
+                        tx,
                         cancellation_token.clone(),
+                        kv_block_size,
                     ));
 
-                let processor_handle = component.drt().runtime().secondary().spawn(start_zmq_event_processor(
-                    raw_rx,
-                    component,
-                    worker_id,
-                    kv_block_size,
-                    warning_count,
-                    cancellation_token,
-                ));
-
-                Ok(KvEventInternalSource::Zmq {
-                    zmq_handle,
-                    processor_handle,
-                })
+                Ok(KvEventSource::Zmq { zmq_handle })
             }
         }
     }
 
     fn shutdown(&self) {
         match self {
-            KvEventInternalSource::Zmq { zmq_handle, processor_handle } => {
+            KvEventSource::Zmq { zmq_handle } => {
                 zmq_handle.abort();
-                processor_handle.abort();
             }
         }
     }
 }
 
-pub enum KvEventSourceConfig {
-    Internal(KvEventInternalSourceConfig),
-    External,
-}
-
-enum KvEventSource {
-    Internal(KvEventInternalSource),
-    External {
-        tx: mpsc::UnboundedSender<KvCacheEvent>,
-    },
-}
-
-impl KvEventSource {
-    fn start(
-        component: Component,
-        worker_id: i64,
-        cancellation_token: CancellationToken,
-        kv_block_size: usize,
-        source_config: KvEventSourceConfig,
-    ) -> Result<Self> {
-        tracing::info!("Publishing KV Events to subject: {}", KV_EVENT_SUBJECT);
-        match source_config {
-            KvEventSourceConfig::Internal(internal_source_config) => {
-                let source = KvEventInternalSource::start(
-                    component,
-                    worker_id,
-                    cancellation_token,
-                    kv_block_size,
-                    internal_source_config,
-                )?;
-                Ok(Self::Internal(source))
-            }
-            KvEventSourceConfig::External => {
-                let (tx, mut rx) = mpsc::unbounded_channel::<KvCacheEvent>();
-                _ = component.drt().runtime().secondary().spawn(async move {
-                    loop {
-                        tokio::select! {
-                            _ = cancellation_token.cancelled() => {
-                                tracing::info!("KV Event source received cancellation signal");
-                                break;
-                            }
-                            Some(event) = rx.recv() => {
-                                let router_event = RouterEvent::new(worker_id, event);
-                                component
-                                    .publish(KV_EVENT_SUBJECT, &router_event)
-                                    .await
-                                    .unwrap();
-                            }
-                        }
-                    }
-                });
-
-                Ok(Self::External { tx })
-            }
-        }
-    }
-}
-
-impl KvEventSource {
-    fn publish(&self, event: KvCacheEvent) -> Result<()> {
-        match self {
-            KvEventSource::Internal(_) => {
-                anyhow::bail!("Internal source does not support manual publishing");
-            }
-
-            KvEventSource::External { tx } => {
-                tx.send(event)?;
-                Ok(())
-            }
-        }
-    }
-
-    fn shutdown(&self) {
-        match self {
-            KvEventSource::Internal(source) => {
-                source.shutdown();
-            }
-            KvEventSource::External { tx: _ } => {}
-        }
-    }
-}
-
+/// A publisher of KV events.
 pub struct KvEventPublisher {
+    /// The size of the KV block.
     kv_block_size: usize,
-    source: KvEventSource,
+    /// The source of KV events.
+    /// Can be `None` if all events provided through [`KvEventPublisher::publish`].
+    source: Option<KvEventSource>,
+    /// The cancellation token.
     cancellation_token: CancellationToken,
+    /// The channel to send events to.
+    tx: mpsc::UnboundedSender<KvCacheEvent>,
 }
 
 impl KvEventPublisher {
@@ -200,39 +113,60 @@ impl KvEventPublisher {
         component: Component,
         worker_id: i64,
         kv_block_size: usize,
-        source_config: KvEventSourceConfig,
+        source_config: Option<KvEventSourceConfig>,
     ) -> Result<Self> {
         let cancellation_token = CancellationToken::new();
 
-        let source = KvEventSource::start(
-            component,
-            worker_id,
-            cancellation_token.clone(),
-            kv_block_size,
-            source_config,
-        )?;
+        let (tx, rx) = mpsc::unbounded_channel::<KvCacheEvent>();
+
+        // Create our event source (if any)
+        let source = source_config.map(|config| {
+            KvEventSource::start(
+                component.clone(),
+                kv_block_size,
+                config,
+                cancellation_token.clone(),
+                tx.clone(),
+            )
+            .unwrap()
+        });
+
+        component
+            .drt()
+            .runtime()
+            .secondary()
+            .spawn(start_event_processor(
+                component,
+                worker_id,
+                cancellation_token.clone(),
+                rx,
+            ));
 
         Ok(Self {
             kv_block_size,
             source,
             cancellation_token,
+            tx,
         })
     }
 
-    pub fn publish(&self, event: KvCacheEvent) -> Result<()> {
+    pub fn publish(&self, event: KvCacheEvent) -> Result<(), mpsc::error::SendError<KvCacheEvent>> {
         tracing::trace!("Publish event: {:?}", event);
-        self.source.publish(event)
+        self.tx.send(event)
     }
 
     pub fn kv_block_size(&self) -> usize {
         self.kv_block_size
     }
 
-    pub fn shutdown(&self) {
+    pub fn shutdown(&mut self) {
         if !self.cancellation_token.is_cancelled() {
             self.cancellation_token.cancel();
         }
-        self.source.shutdown();
+
+        if let Some(source) = self.source.take() {
+            source.shutdown();
+        }
     }
 }
 
@@ -242,53 +176,33 @@ impl Drop for KvEventPublisher {
     }
 }
 
-async fn start_zmq_event_processor<P: EventPublisher>(
-    mut raw_rx: mpsc::UnboundedReceiver<(u64, Vec<u8>)>,
-    component: P,
+async fn start_event_processor<P: EventPublisher + Send + Sync + 'static>(
+    publisher: P,
     worker_id: i64,
-    kv_block_size: usize,
-    warning_count: Arc<AtomicU32>,
-    cancellation_token: dynamo_runtime::CancellationToken,
+    cancellation_token: CancellationToken,
+    mut rx: mpsc::UnboundedReceiver<KvCacheEvent>,
 ) {
     loop {
         tokio::select! {
-            biased;
-
-            // Check for cancellation
             _ = cancellation_token.cancelled() => {
-                tracing::debug!("Event processor received cancellation signal");
+                tracing::info!("KV Event source received cancellation signal");
                 break;
             }
-
-            // Process incoming messages
-            msg = raw_rx.recv() => {
-                let Some((seq, payload)) = msg else {
-                    tracing::debug!("Event processor channel closed");
+            event = rx.recv() => {
+                let Some(event) = event else {
+                    tracing::debug!("Event processor channel closed.");
                     break;
                 };
 
-                let batch_result = rmps::from_slice::<KvEventBatch>(&payload);
-                let Ok(batch) = batch_result else {
-                    let e = batch_result.unwrap_err();
-                    tracing::warn!(error=%e, "Failed to decode KVEventBatch msgpack");
-                    continue;
-                };
-
-                for raw_evt in batch.events.into_iter() {
-                    let Some(event) = convert_event(raw_evt, seq, kv_block_size, &warning_count) else {
-                        // Case where convert_event returns None
-                        continue;
-                    };
-
-                    let router_event = RouterEvent::new(worker_id, event);
-                    if let Err(e) = component.publish(KV_EVENT_SUBJECT, &router_event).await {
-                        tracing::warn!(error=%e, "Failed to publish router event.");
-                    }
-                }
+                // Encapsulate in a router event and publish.
+                let router_event = RouterEvent::new(worker_id, event);
+                publisher
+                    .publish(KV_EVENT_SUBJECT, &router_event)
+                    .await
+                    .unwrap();
             }
         }
     }
-    tracing::debug!("Event processor exiting");
 }
 
 // Error handling configuration for ZMQ operations
@@ -308,14 +222,17 @@ fn calculate_backoff_ms(consecutive_errors: u32) -> u64 {
 async fn start_zmq_listener(
     zmq_endpoint: String,
     zmq_topic: String,
-    raw_tx: mpsc::UnboundedSender<(u64, Vec<u8>)>,
-    zmq_token: dynamo_runtime::CancellationToken,
+    tx: mpsc::UnboundedSender<KvCacheEvent>,
+    cancellation_token: CancellationToken,
+    kv_block_size: usize,
 ) {
     tracing::debug!(
         "KVEventPublisher connecting to ZMQ endpoint {} (topic '{}')",
         zmq_endpoint,
         zmq_topic
     );
+
+    let warning_count = Arc::new(AtomicU32::new(0));
 
     let mut socket = SubSocket::new();
 
@@ -337,7 +254,7 @@ async fn start_zmq_listener(
             biased;
 
             // Check for cancellation
-            _ = zmq_token.cancelled() => {
+            _ = cancellation_token.cancelled() => {
                 tracing::info!("ZMQ listener received cancellation signal");
                 break;
             }
@@ -370,7 +287,6 @@ async fn start_zmq_listener(
                     tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                     continue;
                 };
-
                 // Reset error count on successful message
                 consecutive_errors = 0;
 
@@ -381,8 +297,10 @@ async fn start_zmq_listener(
                     tracing::warn!(expected=3, actual=%frames.len(), "Received unexpected ZMQ frame count");
                     continue;
                 }
-                let payload = frames.remove(2);
-                let seq_bytes = frames.remove(1);
+
+                // Extract the payload and sequence number.
+                let payload = frames.pop().unwrap();
+                let seq_bytes = frames.pop().unwrap();
 
                 if seq_bytes.len() != 8 {
                     tracing::warn!(expected=8, actual=%seq_bytes.len(), "Invalid sequence number byte length");
@@ -390,14 +308,28 @@ async fn start_zmq_listener(
                 }
 
                 let seq = u64::from_be_bytes(seq_bytes.try_into().unwrap());
-                if raw_tx.send((seq, payload)).is_err() {
-                    tracing::warn!("Failed to send message to channel - receiver dropped");
-                    break;
+
+                // Decode our batch of events.
+                let batch_result = rmps::from_slice::<KvEventBatch>(&payload);
+                let Ok(batch) = batch_result else {
+                    let e = batch_result.unwrap_err();
+                    tracing::warn!(error=%e, "Failed to decode KVEventBatch msgpack");
+                    continue;
+                };
+
+                // For each of our events, convert them to [`KvCacheEvent`] and send to the event_processor.
+                for raw_event in batch.events.into_iter() {
+                    if let Some(event) = convert_event(raw_event, seq, kv_block_size, &warning_count) {
+                        if tx.send(event).is_err() {
+                            tracing::warn!("Failed to send message to channel - receiver dropped");
+                            break;
+                        }
+                    }
                 }
             }
         }
+        tracing::debug!("ZMQ listener exiting");
     }
-    tracing::debug!("ZMQ listener exiting");
 }
 
 /// Convert a raw event coming from the ZMQ channel into the internal
@@ -708,6 +640,7 @@ mod test_event_processing {
 #[cfg(test)]
 mod tests_startup_helpers {
     use super::*;
+    use crate::kv_router::protocols::ExternalSequenceBlockHash;
     use async_trait;
     use bytes::Bytes;
     use std::sync::{Arc, Mutex};
@@ -769,53 +702,35 @@ mod tests_startup_helpers {
     }
 
     //--------------------------------------------------------------------
-    // Test start_zmq_event_processor in isolation
+    // Test start_event_processor
     //--------------------------------------------------------------------
     #[tokio::test]
-    async fn test_start_zmq_event_processor_sends_router_event() {
-        let kv_block_size = 4;
-        let worker_id = 99;
+    async fn test_start_event_processor() {
+        let (component, published) = MockComponent::new();
 
-        // 1) build a one-item KvEventBatch and msgpack-encode it
-        let batch = KvEventBatch {
-            ts: 0.0,
-            events: vec![RawKvEvent::BlockRemoved {
-                block_hashes: vec![1, 2],
-            }],
+        let event = KvCacheEvent {
+            event_id: 1,
+            data: KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(1), ExternalSequenceBlockHash(2)],
+            }),
         };
-        let payload = rmps::to_vec(&batch).unwrap();
 
-        let token = dynamo_runtime::CancellationToken::new();
-
-        // 2) channel feeding the processor
-        let (tx, rx) = mpsc::unbounded_channel::<(u64, Vec<u8>)>();
-        tx.send((123, payload.clone())).unwrap(); // seq = 123
+        let token = CancellationToken::new();
+        let (tx, rx) = mpsc::unbounded_channel::<KvCacheEvent>();
+        tx.send(event).unwrap();
         drop(tx);
 
-        // 3) mock component to capture output
-        let (comp, published) = MockComponent::new();
+        let handle = tokio::spawn(start_event_processor(component, 1, token, rx));
 
-        // 4) run the function under test (let it consume exactly one msg)
-        let handle = tokio::spawn(start_zmq_event_processor(
-            rx,
-            comp,
-            worker_id,
-            kv_block_size,
-            Arc::new(AtomicU32::new(0)),
-            token,
-        ));
-
-        tokio::time::timeout(std::time::Duration::from_secs(1), handle)
+        tokio::time::timeout(tokio::time::Duration::from_secs(1), handle)
             .await
             .unwrap()
             .unwrap();
 
-        // 5) assert we have exactly one RouterEvent pushed with right worker_id
         let published = published.lock().unwrap();
-        let (subject, bytes) = &published[0];
-
+        assert_eq!(published.len(), 1);
+        let (subject, _) = &published[0];
         assert_eq!(subject, &KV_EVENT_SUBJECT.to_string());
-        assert_eq!(bytes.first(), payload.first())
     }
 
     //--------------------------------------------------------------------
@@ -825,7 +740,7 @@ mod tests_startup_helpers {
     #[tokio::test]
     async fn test_start_zmq_listener_pushes_to_channel() {
         // Prepare channel that listener should fill
-        let (tx, mut rx) = mpsc::unbounded_channel::<(u64, Vec<u8>)>();
+        let (tx, mut rx) = mpsc::unbounded_channel::<KvCacheEvent>();
 
         // ZMQ TCP endpoint using localhost with fixed port
         let endpoint = "tcp://127.0.0.1:15555";
@@ -841,7 +756,7 @@ mod tests_startup_helpers {
         // Spawn async listener
         let listener_handle = tokio::spawn({
             let token = token.clone();
-            start_zmq_listener(endpoint.to_string(), topic, tx, token)
+            start_zmq_listener(endpoint.to_string(), topic, tx, token, 4)
         });
 
         // Give time for the connection to establish
@@ -849,7 +764,18 @@ mod tests_startup_helpers {
 
         // Send synthetic 3-frame message: [topic, seq(8B), payload]
         let seq: u64 = 77;
-        let payload = Bytes::from("hello");
+
+        let events = vec![RawKvEvent::BlockStored {
+            block_hashes: vec![42],
+            parent_block_hash: None,
+            token_ids: vec![0, 1, 2, 3],
+            block_size: 4,
+            lora_id: None,
+        }];
+
+        let batch = KvEventBatch { ts: 0.0, events };
+
+        let payload = Bytes::from(rmps::to_vec(&batch).unwrap());
 
         let frames = vec![
             Bytes::from(""),
@@ -867,9 +793,19 @@ mod tests_startup_helpers {
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
         // Check that we received the message
-        let (got_seq, got_payload) = rx.try_recv().expect("no message received");
-        assert_eq!(got_seq, seq);
-        assert_eq!(got_payload, payload);
+        let event = rx.try_recv().expect("no message received");
+
+        let KvCacheEventData::Stored(KvCacheStoreData {
+            parent_hash,
+            blocks,
+        }) = event.data
+        else {
+            panic!("expected KvCacheStoreData");
+        };
+
+        assert!(parent_hash.is_none());
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].block_hash.0, 42);
 
         // Stop the listener
         token.cancel();


### PR DESCRIPTION
We currently have a `KvEventPublisher` and `ZmqKvEventPublisher` which have relatively similar functionalities. This MR unifies these two to create a single configurable `KvEventPublisher`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved event publishing with unified configuration options for event sources.
  - Added support for configuring ZMQ as an event source.

- **Refactor**
  - Streamlined event processing and publishing for better reliability and easier cancellation.
  - Consolidated background tasks into a single, more manageable workflow.

- **Bug Fixes**
  - Enhanced shutdown and cleanup handling for event publishing processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->