### PR TITLE
fix: Install efa for ucx

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -77,6 +77,9 @@ WORKDIR /workspace
 ### UCX EFA Setup ###
 RUN rm -rf /opt/hpcx/ucx
 RUN rm -rf /usr/local/ucx
+RUN curl -O https://efa-installer.amazonaws.com/aws-efa-installer-1.41.0.tar.gz && \
+    tar -xf aws-efa-installer-1.41.0.tar.gz && cd aws-efa-installer && \
+    ./efa_installer.sh -y --skip-kmod -g --no-verify
 RUN cd /usr/local/src && \
     git clone https://github.com/openucx/ucx.git && \
     cd ucx &&                   \


### PR DESCRIPTION
#### Overview:
UCX's EFA support is not properly detected in Docker container builds due to missing or incomplete RDMA/EFA dependencies. This causes UCX to fall back to TCP transport even when the device can support RDMA.

#### Details:

Before this change, UCX configuration showed:
- No IB modules detected (IB modules: < >)
- Only basic transports available (UCT modules: < cma >)
- Missing libibverbs support (libibverbs not found)

```
configure: Compiling with verbs support from /usr
checking for infiniband/verbs.h... yes
checking for ibv_get_device_list in -libverbs... no
configure: WARNING: libibverbs not found
...
configure:           ASAN check:   no
configure:         Multi-thread:   disabled
configure:            MPI tests:   disabled
configure:          VFS support:   no
configure:        Devel headers:   no
configure: io_demo CUDA support:   no
configure:             Bindings:   < >
configure:          UCS modules:   < >
configure:          UCT modules:   < cma >
configure:         CUDA modules:   < gdrcopy >
configure:         ROCM modules:   < >
configure:           IB modules:   < >
configure:          UCM modules:   < >
configure:         Perf modules:   < >
```

The root cause is that UCX requires EFA installer and its dependencies to be installed before UCX configuration. Without proper EFA support, UCX falls back to TCP transport only


With EFA installation, SRD transport becomes available for EFA
```
#      Transport: srd
#         Device: rdmap164s0:1
#           Type: network
#  System device: rdmap164s0 (44)
#
#      capabilities:
#            bandwidth: 11785.69/ppn + 0.00 MB/sec
#              latency: 630 nsec
#             overhead: 105 nsec
#             am_bcopy: <= 4085
#             am_zcopy: <= 4085, up to 1 iov
#   am_opt_zcopy_align: <= 512
#         am_align_mtu: <= 4K
#            am header: <= 4085
#           connection: to iface
#      device priority: 0
#     device num paths: 1
#              max eps: inf
#       device address: 11 bytes
#        iface address: 3 bytes
#       error handling: peer failure, ep_check
```

```
+ docker build -f /home/ubuntu/dynamo/container/Dockerfile.vllm --target dev --platform linux/amd64 --build-arg NIXL_COMMIT=78695c2900cd7fff506764377386592dfc98e87e --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base --build-arg BASE_IMAGE_TAG=25.01-cuda12.8-devel-ubuntu24.04 --build-arg FRAMEWORK=VLLM --build-arg VLLM_FRAMEWORK=1 --build-arg VERSION=v0.1.0.dev.7e452a2e --build-arg PYTHON_PACKAGE_VERSION=0.1.0.dev+7e452a2e --tag dynamo:v0.1.0.dev.7e452a2e-vllm --tag dynamo:latest-vllm --build-context nixl=/tmp/nixl/nixl_src /home/ubuntu/dynamo --no-cache
docker:default
 => [base 18/24] RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt     uv pip install --requirement /tmp/requirements.txt                                                                                                                                                                                                                           4.4s
 => [base 19/24] RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt     uv pip install --requirement /tmp/requirements.txt                                                                                                                                                                                                                      0.6s
 => [base 20/24] RUN pyright --help > /dev/null 2>&1                                                                                                                                                                                                                                                                                                                                          6.3s
 => [base 21/24] RUN printf "[safe]\n      directory=/workspace\n" > /root/.gitconfig                                                                                                                                                                                                                                                                                                         0.2s
 => [base 22/24] RUN ln -sf /bin/bash /bin/sh                                                                                                                                                                                                                                                                                                                                                 0.3s
 => [base 23/24] RUN apt update -y &&     apt install --no-install-recommends -y     build-essential     protobuf-compiler     cmake     libssl-dev     pkg-config                                                                                                                                                                                                                            5.4s
 => [base 24/24] RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/x86_64-unknown-linux-gnu/rustup-init" &&     chmod +x rustup-init &&     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain 1.86.0 --default-host x86_64-unknown-linux-gnu &&     rm rustup-init &&     chmod -R a+w /usr/local/rustup /usr/local/cargo
...
 ```
#### Where should the reviewer start?
Dockerfile.vllm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the environment setup to use the AWS EFA installer version 1.41.0 during container build. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->