### PR TITLE
chore: Send llama.cpp logs to tracing crate

### DIFF
--- a/lib/engines/llamacpp/src/lib.rs
+++ b/lib/engines/llamacpp/src/lib.rs
@@ -4,7 +4,7 @@
 use std::{
     num::NonZeroU32,
     path::Path,
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Arc, Mutex, Once, OnceLock},
 };
 
 use async_stream::stream;
@@ -37,6 +37,8 @@ const NUM_CONTEXTS: usize = 3;
 static LLAMA_CONTEXTS: [OnceLock<Mutex<ContextWrapper>>; NUM_CONTEXTS] =
     [OnceLock::new(), OnceLock::new(), OnceLock::new()];
 
+static LLAMA_CPP_LOG_REDIRECT: Once = Once::new();
+
 // Newtype to simplify LlamaContext lifetime
 #[derive(Debug)]
 struct ContextWrapper(LlamaContext<'static>);
@@ -67,7 +69,9 @@ impl LlamacppEngine {
         cancel_token: CancellationToken,
         model_config: &LocalModel,
     ) -> pipeline_error::Result<Self> {
-        llama_cpp_2::send_logs_to_tracing(LogOptions::default().with_logs_enabled(true));
+        LLAMA_CPP_LOG_REDIRECT.call_once(|| {
+            llama_cpp_2::send_logs_to_tracing(LogOptions::default().with_logs_enabled(true));
+        });
         let backend = LlamaBackend::init()?;
         let model = load_model(&backend, model_config.path())?;
         LLAMA_MODEL.set(model)?;

--- a/lib/engines/llamacpp/src/lib.rs
+++ b/lib/engines/llamacpp/src/lib.rs
@@ -20,6 +20,7 @@ use llama_cpp_2::{
     model::{params::LlamaModelParams, LlamaModel},
     sampling::LlamaSampler,
     token::LlamaToken,
+    LogOptions,
 };
 
 use dynamo_llm::protocols::common::llm_backend::{BackendInput, LLMEngineOutput};
@@ -66,6 +67,7 @@ impl LlamacppEngine {
         cancel_token: CancellationToken,
         model_config: &LocalModel,
     ) -> pipeline_error::Result<Self> {
+        llama_cpp_2::send_logs_to_tracing(LogOptions::default().with_logs_enabled(true));
         let backend = LlamaBackend::init()?;
         let model = load_model(&backend, model_config.path())?;
         LLAMA_MODEL.set(model)?;


### PR DESCRIPTION
Unify them with all our other logs, so we can filter with `DYN_LOG`, they will eventually go to the log aggregation, etc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved logging by enabling forwarding of logs to the tracing infrastructure for better observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->