### PR TITLE
fix: resources naming

### DIFF
--- a/deploy/sdk/src/dynamo/sdk/cli/build.py
+++ b/deploy/sdk/src/dynamo/sdk/cli/build.py
@@ -101,7 +101,7 @@ class ServiceConfig(BaseModel):
     service: str = ""  # Fully qualified service name
     models: t.List[str] = Field(default_factory=list)
     dependencies: t.List[str] = Field(default_factory=list)
-    resource: t.Dict[str, t.Any] = Field(default_factory=dict)
+    resources: t.Dict[str, t.Any] = Field(default_factory=dict)
     workers: t.Optional[int] = None
     image: str = "dynamo:latest"
     dynamo: t.Dict[str, t.Any] = Field(default_factory=dict)
@@ -138,7 +138,7 @@ class ServiceInfo(BaseModel):
         config = ServiceConfig(
             name=name,
             service="",
-            resource=service.config.resources.model_dump(),
+            resources=service.config.resources.model_dump(),
             workers=service.config.workers,
             image=image,
             dynamo=service.config.dynamo.model_dump(),
@@ -212,7 +212,7 @@ class ManifestInfo(BaseModel):
                 "name": service["name"],
                 "service": service["config"]["service"],
                 "config": {
-                    "resource": service["config"]["resource"],
+                    "resources": service["config"]["resources"],
                     "workers": service["config"]["workers"],
                     "image": service["config"]["image"],
                     "dynamo": service["config"]["dynamo"],

--- a/deploy/sdk/src/dynamo/sdk/core/protocol/interface.py
+++ b/deploy/sdk/src/dynamo/sdk/core/protocol/interface.py
@@ -17,10 +17,10 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from enum import Enum, auto
-from typing import Any, Dict, Generic, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, Generic, List, Optional, Set, Tuple, Type, TypeVar
 
 from fastapi import FastAPI
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 from dynamo.sdk.core.protocol.deployment import Env
 
@@ -59,15 +59,12 @@ class DynamoTransport(Enum):
 class ResourceConfig(BaseModel):
     """Configuration for Dynamo resources"""
 
+    # auto convert gpu and cpu values to string from int
+    model_config = ConfigDict(coerce_numbers_to_str=True)
+
     cpu: str = Field(default="1")
     memory: str = Field(default="500Mi")
     gpu: str = Field(default="0")
-
-    @field_validator("gpu", mode="before")
-    @classmethod
-    def convert_gpu_to_string(cls, v: Union[str, int]) -> str:
-        """Convert gpu value to string if it's an integer"""
-        return str(v)
 
 
 class ServiceConfig(BaseModel):

--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -67,7 +67,7 @@ class ResponseType(BaseModel):
     dynamo={
         "namespace": "inference",
     },
-    resource={"cpu": 1, "memory": "500Mi"},
+    resources={"cpu": 1, "memory": "500Mi"},
     workers=2,
     image=DYNAMO_IMAGE,
 )


### PR DESCRIPTION
#### Overview:

- service args should be `resources` (plural) not `resource`

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the field and related references from `resource` to `resources` for consistency across configuration and serialization.
  - Updated decorators and configuration parameters to use the new `resources` naming.
  - Simplified resource type coercion logic by leveraging automatic configuration, removing manual conversion methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->