### PR TITLE
fix: Update breaking change to enable_overlap_scheduler field from TRTLLM commit b4e5df0e

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -88,7 +88,7 @@ TENSORRTLLM_PIP_WHEEL_DIR="/tmp/trtllm_wheel/"
 # TensorRT-LLM commit to use for building the trtllm wheel if not provided.
 # Important Note: This commit is not used in our CI pipeline. See the CI
 # variables to learn how to run a pipeline with a specific commit.
-TRTLLM_COMMIT=290649b6aaed5f233b0a0adf50edc1347f8d2b14
+TRTLLM_COMMIT="8cb6163a57226e69d8a85788eff542a440ed9c89"
 
 # TensorRT-LLM PyPI index URL
 TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"

--- a/examples/tensorrt_llm/configs/deepseek_r1/agg_llm_api_config.yaml
+++ b/examples/tensorrt_llm/configs/deepseek_r1/agg_llm_api_config.yaml
@@ -39,6 +39,9 @@ kv_cache_config:
   # free_gpu_memory_fraction: 0.30
 
 pytorch_backend_config:
+  # NOTE: overlap_scheduler enabled by default since this commit and changed
+  # config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+  # https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
   use_cuda_graph: true
   cuda_graph_padding_enabled: true
   # NOTE: For larger max batch size, you may want to add larger cuda graph
@@ -54,5 +57,4 @@ pytorch_backend_config:
   - 128
   - 256
   print_iter_log: true
-  enable_overlap_scheduler: true
   kv_cache_dtype: fp8

--- a/examples/tensorrt_llm/configs/deepseek_r1/disagg_llm_api_config.yaml
+++ b/examples/tensorrt_llm/configs/deepseek_r1/disagg_llm_api_config.yaml
@@ -34,7 +34,9 @@ context_servers:
   pipeline_parallel_size: 1
   enable_attention_dp: true
 
-  free_gpu_memory_fraction: 0.75
+  kv_cache_config:
+    free_gpu_memory_fraction: 0.75
+
   pytorch_backend_config:
     # NOTE: This field is called 'enable_overlap_scheduler' in older TRTLLM versions
     # Overlap scheduler not currently supported in context-only
@@ -57,11 +59,12 @@ generation_servers:
   pipeline_parallel_size: 1
   enable_attention_dp: false
 
-  # With dp attention disabled: high free_gpu_memory_fraction is fine.
-  free_gpu_memory_fraction: 0.85
-  # With dp attention enabled: large ISL at high concurrency may need
-  # free_gpu_memory_fraction low to have enough available memory.
-  # free_gpu_memory_fraction: 0.30
+  kv_cache_config:
+    # With dp attention disabled: high free_gpu_memory_fraction is fine.
+    free_gpu_memory_fraction: 0.85
+    # With dp attention enabled: large ISL at high concurrency may need
+    # free_gpu_memory_fraction low to have enough available memory.
+    # free_gpu_memory_fraction: 0.30
 
   pytorch_backend_config:
     # NOTE: This field is called 'enable_overlap_scheduler' in older TRTLLM versions

--- a/examples/tensorrt_llm/configs/deepseek_r1/disagg_llm_api_config.yaml
+++ b/examples/tensorrt_llm/configs/deepseek_r1/disagg_llm_api_config.yaml
@@ -36,6 +36,9 @@ context_servers:
 
   free_gpu_memory_fraction: 0.75
   pytorch_backend_config:
+    # NOTE: This field is called 'enable_overlap_scheduler' in older TRTLLM versions
+    # Overlap scheduler not currently supported in context-only
+    disable_overlap_scheduler: true
     print_iter_log: true
     # NOTE: This dtype must match in both context/generation configs
     kv_cache_dtype: fp8
@@ -61,6 +64,8 @@ generation_servers:
   # free_gpu_memory_fraction: 0.30
 
   pytorch_backend_config:
+    # NOTE: This field is called 'enable_overlap_scheduler' in older TRTLLM versions
+    disable_overlap_scheduler: false
     use_cuda_graph: true
     cuda_graph_padding_enabled: true
     # NOTE: For larger max batch size, you may want to add larger cuda graph
@@ -76,6 +81,5 @@ generation_servers:
     - 128
     - 256
     print_iter_log: true
-    enable_overlap_scheduler: true
     # NOTE: This dtype must match in both context/generation configs
     kv_cache_dtype: fp8

--- a/examples/tensorrt_llm/configs/llm_api_config.yaml
+++ b/examples/tensorrt_llm/configs/llm_api_config.yaml
@@ -34,5 +34,7 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.95
 
 pytorch_backend_config:
-  enable_overlap_scheduler: true
+  # NOTE: overlap_scheduler enabled by default since this commit and changed
+  # config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+  # https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
   use_cuda_graph: true

--- a/examples/tensorrt_llm/configs/llm_api_config_disagg_router.yaml
+++ b/examples/tensorrt_llm/configs/llm_api_config_disagg_router.yaml
@@ -39,5 +39,5 @@ pytorch_backend_config:
   # NOTE: overlap_scheduler enabled by default since this commit and changed
   # config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
   # https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
-  use_cuda_graph: false
+  use_cuda_graph: true
   enable_iter_perf_stats: true

--- a/examples/tensorrt_llm/configs/llm_api_config_disagg_router.yaml
+++ b/examples/tensorrt_llm/configs/llm_api_config_disagg_router.yaml
@@ -36,6 +36,8 @@ kv_cache_config:
   enable_block_reuse: true
 
 pytorch_backend_config:
-  enable_overlap_scheduler: false
+  # NOTE: overlap_scheduler enabled by default since this commit and changed
+  # config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+  # https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
   use_cuda_graph: false
   enable_iter_perf_stats: true

--- a/examples/tensorrt_llm/configs/llm_api_config_router.yaml
+++ b/examples/tensorrt_llm/configs/llm_api_config_router.yaml
@@ -36,6 +36,8 @@ kv_cache_config:
   enable_block_reuse: true
 
 pytorch_backend_config:
-  enable_overlap_scheduler: true
+  # NOTE: overlap_scheduler enabled by default since this commit and changed
+  # config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+  # https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
   use_cuda_graph: true
   enable_iter_perf_stats: true

--- a/examples/tensorrt_llm/configs/llmapi_disagg_configs/single_node_config.yaml
+++ b/examples/tensorrt_llm/configs/llmapi_disagg_configs/single_node_config.yaml
@@ -34,7 +34,9 @@ context_servers:
   cache_transceiver_config:
     max_num_tokens: 10240
   pytorch_backend_config:
-    enable_overlap_scheduler: false
+    # NOTE: This field is called 'enable_overlap_scheduler' in older TRTLLM versions
+    # Overlap scheduler not currently supported in context-only
+    disable_overlap_scheduler: true
     use_cuda_graph: false
   urls:
       - "localhost:8001"
@@ -49,7 +51,8 @@ generation_servers:
   cache_transceiver_config:
     max_num_tokens: 256
   pytorch_backend_config:
-    enable_overlap_scheduler: true
+    # NOTE: This field is called 'enable_overlap_scheduler' in older TRTLLM versions
+    disable_overlap_scheduler: false
     use_cuda_graph: false
   urls:
       - "localhost:8002"

--- a/examples/tensorrt_llm/configs/llmapi_disagg_router_configs/single_node_config.yaml
+++ b/examples/tensorrt_llm/configs/llmapi_disagg_router_configs/single_node_config.yaml
@@ -36,7 +36,9 @@ context_servers:
   cache_transceiver_config:
     max_num_tokens: 10240
   pytorch_backend_config:
-    enable_overlap_scheduler: false
+    # NOTE: This field is called 'enable_overlap_scheduler' in older TRTLLM versions
+    # Overlap scheduler not currently supported in context-only
+    disable_overlap_scheduler: true
     use_cuda_graph: false
     enable_iter_perf_stats: true
   urls:
@@ -54,7 +56,8 @@ generation_servers:
   cache_transceiver_config:
     max_num_tokens: 256
   pytorch_backend_config:
-    enable_overlap_scheduler: true
+    # NOTE: This field is called 'enable_overlap_scheduler' in older TRTLLM versions
+    disable_overlap_scheduler: false
     use_cuda_graph: false
     enable_iter_perf_stats: true
   urls:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

- This [PR](https://github.com/NVIDIA/TensorRT-LLM/pull/4174) in TRTLLM made a breaking change renaming config field `enable_overlap_scheduler` to `disable_overlap_scheduler` and enabling overlap scheduler by default
  - Since our TRTLLM build process for external users is to build wheel from source - update the TRTLLM_COMMIT in build.sh to one that includes this disable_overlap_scheduler (and matches current CI commit)
  - For users installing pip wheel from pypi, they'll need to make sure the version they install includes this change trtllm change, which it should naturally include over the next few weeks of trtllm pip wheel releases. 
  - For users with an existing older trtllm pip install, they can refer to an older stable release branch of dynamo before this change, ex: 0.3.0 or 0.2.1
- Move free_gpu_mem_fraction under kv_cache_config section in all configs as it's strictly enforced now


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Related TRTLLM change: https://github.com/NVIDIA/TensorRT-LLM/pull/4174


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated configuration files to replace the deprecated overlap scheduler setting with the new field, reflecting recent changes in the underlying backend.
	- Added explanatory comments to clarify the new default behavior and field name changes.
	- Updated internal build script to use the latest commit for dependency builds.
- **Style**
	- Added missing trailing newlines to scripts for improved formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->