### PR TITLE
chore: Add Richard Huo to CODEOWNERS, and add TRTLLM section

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,13 +11,16 @@ Cargo.toml @ryanolson @grahamking @paulhendricks @biswapanda @tmonty12 @guanluo 
 *.py @nnshah1 @tanmayv25 @piotrm-nvidia @ptarasiewiczNV @ryanolson @grahamking @paulhendricks @biswapanda @tmonty12 @guanluo @rmccorm4 @tedzhouhk @alec-flowers @kkranen @ai-dynamo/Devops @jthomson04 @ishandhanani @PeaBrane
 
 # Container/Environments
-/container/ @rmccorm4 @tanmayv25 @ptarasiewiczNV @ishandhanani @alec-flowers @nnshah1 @ai-dynamo/Devops
+/container/ @rmccorm4 @tanmayv25 @richardhuo-nv @ptarasiewiczNV @ishandhanani @alec-flowers @nnshah1 @ai-dynamo/Devops
 
 # Dynamo deploy
 /deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @nnshah1 @mohammedabdulwahhab
 
-# Dynamo deploy
+# All examples
 /examples/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @nnshah1 @tanmayv25 @piotrm-nvidia @ptarasiewiczNV @ryanolson @grahamking @paulhendricks @biswapanda @tmonty12 @guanluo @rmccorm4 @tedzhouhk @alec-flowers @kkranen @sshchoi @PeaBrane @mohammedabdulwahhab @ai-dynamo/Devops
+
+# TRTLLM
+/examples/tensorrt_llm/ @tanmayv25 @rmccorm4 @guanluo @richardhuo-nv
 
 # Multimodal
 /examples/multimodal/ @indrajit96 @whoisj @krishung5


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

- Adds @richardhuo-nv to CODEOWNERS for trtllm examples and container changes
- Adds `/examples/tensorrt_llm/` section to hopefully keep review pings more focused. 
- In future, may be able to generally make a few areas of work have more specific codeowners to keep the reviewer lists more focused. Currently most changes ping ~20 people for reviews everytime, and this makes some reviewers ignore the notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated code ownership for the `/container/` directory and improved comments for the `/examples/` directory.
  - Added dedicated owners for the new `/examples/tensorrt_llm/` subdirectory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->