### PR TITLE
fix: fix UCX installation for RDMA

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -77,6 +77,11 @@ WORKDIR /workspace
 ### UCX EFA Setup ###
 RUN rm -rf /opt/hpcx/ucx
 RUN rm -rf /usr/local/ucx
+# These headers are missing with the hpcx installer, required
+# by UCX to find RDMA devices
+RUN apt-get update -y && \
+    apt-get install -y   \
+    --reinstall libibverbs-dev rdma-core ibverbs-utils libibumad-dev
 RUN cd /usr/local/src && \
     git clone https://github.com/openucx/ucx.git && \
     cd ucx &&                   \
@@ -91,7 +96,6 @@ RUN cd /usr/local/src && \
     --enable-devel-headers      \
     --with-cuda=/usr/local/cuda \
     --with-verbs                \
-    --with-efa                  \
     --with-dm                   \
     --with-gdrcopy=/usr/local   \
     --enable-mt &&              \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -96,6 +96,7 @@ RUN cd /usr/local/src && \
     --enable-devel-headers      \
     --with-cuda=/usr/local/cuda \
     --with-verbs                \
+    --with-efa                  \
     --with-dm                   \
     --with-gdrcopy=/usr/local   \
     --enable-mt &&              \


### PR DESCRIPTION
#### Overview:

Before this change, UCX installation doesn't have RDMA properly setup and `ucx_info -d` will not show RDMA devices, results in TCP being selected and cause extra overhead on init transfer for vLLM KV cache transfer

llama 8B, ISL 5000/OSL 1

Before:
```
2025-05-28T21:32:44.357Z  INFO nixl.write_blocks: Creating xfer handles   
2025-05-28T21:32:44.357Z  INFO nixl.write_blocks: Time to get block descs ids: 0.7594999624416232 ms   
2025-05-28T21:32:44.358Z  INFO nixl.write_blocks: Time to prepped xfer: 0.5069919861853123 ms   
2025-05-28T21:32:46.158Z  INFO nixl.write_blocks: Time to init xfer: 1800.3110489808023 ms   
2025-05-28T21:32:46.158Z  INFO nixl.write_blocks: Total time for write: 1803.4315309487283 ms 
```
After
```
2025-05-30T23:21:52.363Z  INFO nixl.write_blocks: Creating xfer handles   
2025-05-30T23:21:52.364Z  INFO nixl.write_blocks: Time to get block descs ids: 0.7347879000008106 ms   
2025-05-30T23:21:52.364Z  INFO nixl.write_blocks: Time to prepped xfer: 0.4207589663565159 ms   
2025-05-30T23:21:52.364Z  INFO nixl.write_blocks: Time to init xfer: 0.16039889305830002 ms   
2025-05-30T23:21:52.364Z  INFO nixl.write_blocks: Total time for write: 3.083118237555027 ms 
```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated system packages to ensure required RDMA development libraries are installed for improved compatibility.
  - Adjusted UCX installation steps for enhanced environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->