### PR TITLE
feat: add more metrics to rust frontend

### DIFF
--- a/lib/engines/mistralrs/src/lib.rs
+++ b/lib/engines/mistralrs/src/lib.rs
@@ -407,6 +407,9 @@ impl
                             id: None,
                             data: Some(delta),
                             event: None,
+                            chunk_tokens: None,
+                            input_tokens: None,
+                            output_tokens: None,
                             comment: None,
                         };
                         yield ann;
@@ -566,6 +569,9 @@ impl AsyncEngine<SingleIn<CompletionRequest>, ManyOut<Annotated<CompletionRespon
                             id: None,
                             data: Some(inner),
                             event: None,
+                            chunk_tokens: None,
+                            input_tokens: None,
+                            output_tokens: None,
                             comment: None,
                         };
                         yield ann;

--- a/lib/llm/src/engines.rs
+++ b/lib/llm/src/engines.rs
@@ -202,7 +202,7 @@ impl
                 let response = NvCreateChatCompletionStreamResponse {
                     inner,
                 };
-                yield Annotated{ id: Some(id.to_string()), data: Some(response), event: None, comment: None };
+                yield Annotated{ id: Some(id.to_string()), data: Some(response), event: None, chunk_tokens: None, input_tokens: None, output_tokens: None, comment: None };
                 id += 1;
             }
 
@@ -210,7 +210,7 @@ impl
             let response = NvCreateChatCompletionStreamResponse {
                 inner,
             };
-            yield Annotated { id: Some(id.to_string()), data: Some(response), event: None, comment: None };
+            yield Annotated { id: Some(id.to_string()), data: Some(response), event: None, chunk_tokens: None, input_tokens: None, output_tokens: None, comment: None };
         };
 
         Ok(ResponseStream::new(Box::pin(output), ctx))
@@ -234,11 +234,11 @@ impl AsyncEngine<SingleIn<CompletionRequest>, ManyOut<Annotated<CompletionRespon
             for c in chars_string.chars() {
                 tokio::time::sleep(*TOKEN_ECHO_DELAY).await;
                 let response = deltas.create_choice(0, Some(c.to_string()), None);
-                yield Annotated{ id: Some(id.to_string()), data: Some(response), event: None, comment: None };
+                yield Annotated{ id: Some(id.to_string()), data: Some(response), event: None, chunk_tokens: None, input_tokens: None, output_tokens: None, comment: None };
                 id += 1;
             }
             let response = deltas.create_choice(0, None, Some("stop".to_string()));
-            yield Annotated { id: Some(id.to_string()), data: Some(response), event: None, comment: None };
+            yield Annotated { id: Some(id.to_string()), data: Some(response), event: None, chunk_tokens: None, input_tokens: None, output_tokens: None, comment: None };
 
         };
 

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -131,7 +131,7 @@ impl Metrics {
                 "Input sequence length in tokens",
             )
             .buckets(vec![
-                50.0, 100.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0, 32000.0, 64000.0,
+                0.0, 50.0, 100.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0, 32000.0, 64000.0,
                 128000.0,
             ]),
             &["model"],
@@ -144,7 +144,7 @@ impl Metrics {
                 "Output sequence length in tokens",
             )
             .buckets(vec![
-                50.0, 100.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0, 32000.0,
+                0.0, 50.0, 100.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0, 16000.0, 32000.0,
             ]),
             &["model"],
         )
@@ -156,8 +156,8 @@ impl Metrics {
                 "Time to first token in seconds",
             )
             .buckets(vec![
-                0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0,
-                120.0, 240.0, 480.0,
+                0.0, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0,
+                60.0, 120.0, 240.0, 480.0,
             ]),
             &["model"],
         )
@@ -169,7 +169,7 @@ impl Metrics {
                 "Inter-token latency in seconds",
             )
             .buckets(vec![
-                0.001, 0.005, 0.01, 0.015, 0.02, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0,
+                0.0, 0.001, 0.005, 0.01, 0.015, 0.02, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0,
             ]),
             &["model"],
         )
@@ -316,7 +316,7 @@ impl InflightGuard {
 
     pub(crate) fn observe_response(&mut self, isl: usize, num_tokens: usize) {
         if self.first_token {
-            // NOTE: when there are multiple tokens in the first response, 
+            // NOTE: when there are multiple tokens in the first response,
             // we use the full response time as TTFT and ignore the ITL
             self.first_token = false;
 

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -316,7 +316,8 @@ impl InflightGuard {
 
     pub(crate) fn observe_response(&mut self, isl: usize, num_tokens: usize) {
         if self.first_token {
-            // NOTE: We don't consider the case with multiple tokens in the first response.
+            // NOTE: when there are multiple tokens in the first response, 
+            // we use the full response time as TTFT and ignore the ITL
             self.first_token = false;
 
             // Publish TTFT
@@ -327,6 +328,7 @@ impl InflightGuard {
                 .observe(ttft);
 
             // Publish ISL
+            // TODO: publish ITL as soon as the tokenization process completes
             self.metrics
                 .input_sequence_length
                 .with_label_values(&[&self.model])

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -90,8 +90,8 @@ impl Metrics {
     /// - `{prefix}_http_service_requests_total` - IntCounterVec for the total number of requests processed
     /// - `{prefix}_http_service_inflight_requests` - IntGaugeVec for the number of inflight requests
     /// - `{prefix}_http_service_request_duration_seconds` - HistogramVec for the duration of requests
-    /// - `{prefix}_http_service_input_sequence_length` - HistogramVec for input sequence length in tokens
-    /// - `{prefix}_http_service_output_sequence_length` - HistogramVec for output sequence length in tokens
+    /// - `{prefix}_http_service_input_sequence_tokens` - HistogramVec for input sequence length in tokens
+    /// - `{prefix}_http_service_output_sequence_tokens` - HistogramVec for output sequence length in tokens
     /// - `{prefix}_http_service_time_to_first_token_seconds` - HistogramVec for time to first token in seconds
     /// - `{prefix}_http_service_inter_token_latency_seconds` - HistogramVec for inter-token latency in seconds
     pub fn new(prefix: &str) -> Self {
@@ -127,7 +127,7 @@ impl Metrics {
 
         let input_sequence_length = HistogramVec::new(
             HistogramOpts::new(
-                format!("{}_http_service_input_sequence_length", prefix),
+                format!("{}_http_service_input_sequence_tokens", prefix),
                 "Input sequence length in tokens",
             )
             .buckets(vec![
@@ -140,7 +140,7 @@ impl Metrics {
 
         let output_sequence_length = HistogramVec::new(
             HistogramOpts::new(
-                format!("{}_http_service_output_sequence_length", prefix),
+                format!("{}_http_service_output_sequence_tokens", prefix),
                 "Output sequence length in tokens",
             )
             .buckets(vec![

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -45,8 +45,8 @@ pub struct InflightGuard {
     request_type: RequestType,
     status: Status,
     timer: Instant,
-    // we use is_first_token to distinguish TTFT from ITL. It is false by default and
-    // flip to true when the first token is returned and TTFT is published.
+    // we use is_first_token to distinguish TTFT from ITL. It is true by default and
+    // flipped to false when the first token is returned and TTFT is published.
     is_first_token: bool,
     // we track the last response time so that ITL for the newly returned tokens can
     // be computed.

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -319,6 +319,10 @@ impl InflightGuard {
     }
 
     pub(crate) fn observe_response(&mut self, isl: usize, num_tokens: usize) {
+        if num_tokens == 0 {
+            return;
+        }
+
         if self.is_first_token {
             // NOTE: when there are multiple tokens in the first response,
             // we use the full response time as TTFT and ignore the ITL

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -291,10 +291,7 @@ impl Metrics {
     }
 
     /// Create a new [`ResponseMetricCollector`] for collecting per-response metrics (i.e., TTFT, ITL)
-    pub fn create_response_collector(
-        self: Arc<Self>,
-        model: &str,
-    ) -> ResponseMetricCollector {
+    pub fn create_response_collector(self: Arc<Self>, model: &str) -> ResponseMetricCollector {
         ResponseMetricCollector::new(self, model.to_string().to_lowercase())
     }
 }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -48,8 +48,8 @@ pub struct InflightGuard {
     // we use is_first_token to distinguish TTFT from ITL. It is false by default and
     // flip to true when the first token is returned and TTFT is published.
     is_first_token: bool,
-    // we track the last response time so that ITL for the newly returned tokens can 
-    // be computed. 
+    // we track the last response time so that ITL for the newly returned tokens can
+    // be computed.
     last_response_time: Option<Duration>,
     osl: usize,
 }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -328,7 +328,7 @@ impl InflightGuard {
                 .observe(ttft);
 
             // Publish ISL
-            // TODO: publish ITL as soon as the tokenization process completes
+            // TODO: publish ISL as soon as the tokenization process completes
             self.metrics
                 .input_sequence_length
                 .with_label_values(&[&self.model])

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -275,7 +275,12 @@ impl Metrics {
             RequestType::Unary
         };
 
-        InflightGuard::new(self.clone(), model.to_string().to_lowercase(), endpoint, request_type)
+        InflightGuard::new(
+            self.clone(),
+            model.to_string().to_lowercase(),
+            endpoint,
+            request_type,
+        )
     }
 }
 

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -275,7 +275,7 @@ impl Metrics {
             RequestType::Unary
         };
 
-        InflightGuard::new(self.clone(), model.to_string(), endpoint, request_type)
+        InflightGuard::new(self.clone(), model.to_string().to_lowercase(), endpoint, request_type)
     }
 }
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::{SystemTime, UNIX_EPOCH},
 };
 use tokio_stream::wrappers::ReceiverStream;
@@ -153,10 +153,11 @@ async fn completions(
         .map_err(|_| ErrorResponse::model_not_found())?;
 
     // this will increment the inflight gauge for the model
-    let mut inflight =
-        state
-            .metrics_clone()
-            .create_inflight_guard(model, Endpoint::Completions, streaming);
+    let inflight = Arc::new(Mutex::new(state.metrics_clone().create_inflight_guard(
+        model,
+        Endpoint::Completions,
+        streaming,
+    )));
 
     // setup context
     // todo - inherit request_id from distributed trace details
@@ -175,7 +176,10 @@ async fn completions(
     // note - we might do this as part of the post processing set to make it more generic
 
     if streaming {
-        let stream = stream.map(|response| Event::try_from(EventConverter::from(response)));
+        let inflight_clone = inflight.clone();
+        let stream = stream.map(move |response| {
+            process_event_converter(EventConverter::from(response), &inflight_clone)
+        });
         let stream = monitor_for_disconnects(stream.boxed(), ctx, inflight).await;
 
         let mut sse_stream = Sse::new(stream);
@@ -197,7 +201,7 @@ async fn completions(
                 ErrorResponse::internal_server_error("Failed to fold completions stream")
             })?;
 
-        inflight.mark_ok();
+        inflight.lock().unwrap().mark_ok();
         Ok(Json(response).into_response())
     }
 }
@@ -270,10 +274,11 @@ async fn chat_completions(
         .map_err(|_| ErrorResponse::model_not_found())?;
 
     // this will increment the inflight gauge for the model
-    let mut inflight =
-        state
-            .metrics_clone()
-            .create_inflight_guard(model, Endpoint::ChatCompletions, streaming);
+    let inflight = Arc::new(Mutex::new(state.metrics_clone().create_inflight_guard(
+        model,
+        Endpoint::ChatCompletions,
+        streaming,
+    )));
 
     // setup context
     // todo - inherit request_id from distributed trace details
@@ -294,7 +299,10 @@ async fn chat_completions(
     // note - we might do this as part of the post processing set to make it more generic
 
     if streaming {
-        let stream = stream.map(|response| Event::try_from(EventConverter::from(response)));
+        let inflight_clone = inflight.clone();
+        let stream = stream.map(move |response| {
+            process_event_converter(EventConverter::from(response), &inflight_clone)
+        });
         let stream = monitor_for_disconnects(stream.boxed(), ctx, inflight).await;
 
         let mut sse_stream = Sse::new(stream);
@@ -319,7 +327,7 @@ async fn chat_completions(
                 ))
             })?;
 
-        inflight.mark_ok();
+        inflight.lock().unwrap().mark_ok();
         Ok(Json(response).into_response())
     }
 }
@@ -399,12 +407,11 @@ async fn monitor_for_disconnects(
         Box<dyn Stream<Item = Result<axum::response::sse::Event, axum::Error>> + std::marker::Send>,
     >,
     context: Arc<dyn AsyncEngineContext>,
-    inflight: InflightGuard,
+    inflight: Arc<Mutex<InflightGuard>>,
 ) -> ReceiverStream<Result<Event, axum::Error>> {
     let (tx, rx) = tokio::sync::mpsc::channel(8);
 
     tokio::spawn(async move {
-        let mut inflight = inflight;
         let mut stream = stream;
         while let Some(event) = stream.next().await {
             let event = match event {
@@ -422,7 +429,7 @@ async fn monitor_for_disconnects(
         // the stream completed successfully - mark as ok
         // this will increment the request counter with an "success" status
         if tx.send(Ok(Event::default().data("[DONE]"))).await.is_ok() {
-            inflight.mark_ok();
+            inflight.lock().unwrap().mark_ok();
         }
     });
 
@@ -437,41 +444,85 @@ impl<T> From<Annotated<T>> for EventConverter<T> {
     }
 }
 
-/// Convert an Annotated into an Event
-/// If the Event represents an Error, then return an axum::Error
-/// The [`monitor_for_disconnects`] method will handle the error, emit to the sse stream
-/// then stop the generation of completions.
-impl<T: Serialize> TryFrom<EventConverter<T>> for Event {
-    type Error = axum::Error;
+fn process_event_converter<T: Serialize>(
+    annotated: EventConverter<T>,
+    inflight_guard: &Arc<Mutex<InflightGuard>>,
+) -> Result<Event, axum::Error> {
+    let annotated = annotated.0;
 
-    fn try_from(annotated: EventConverter<T>) -> Result<Self, Self::Error> {
-        let annotated = annotated.0;
+    let mut event = Event::default();
 
-        let mut event = Event::default();
-
-        if let Some(data) = annotated.data {
-            event = event.json_data(data)?;
-        }
-
-        if let Some(msg) = annotated.event {
-            if msg == "error" {
-                let msgs = annotated
-                    .comment
-                    .unwrap_or_else(|| vec!["unspecified error".to_string()]);
-                return Err(axum::Error::new(msgs.join(" -- ")));
-            }
-            event = event.event(msg);
-        }
-
-        if let Some(comments) = annotated.comment {
-            for comment in comments {
-                event = event.comment(comment);
-            }
-        }
-
-        Ok(event)
+    if let Some(data) = annotated.data {
+        event = event.json_data(data)?;
     }
+
+    if let Some(msg) = annotated.event {
+        if msg == "error" {
+            let msgs = annotated
+                .comment
+                .unwrap_or_else(|| vec!["unspecified error".to_string()]);
+            return Err(axum::Error::new(msgs.join(" -- ")));
+        }
+        event = event.event(msg);
+    }
+
+    {
+        let mut inflight_guard = inflight_guard.lock().unwrap();
+        if let Some(osl) = annotated.output_tokens {
+            inflight_guard.observe_current_osl(osl);
+        }
+
+        if let Some(isl) = annotated.input_tokens {
+            if let Some(chunk_tokens) = annotated.chunk_tokens {
+                inflight_guard.observe_response(isl, chunk_tokens);
+            }
+        }
+    }
+
+    if let Some(comments) = annotated.comment {
+        for comment in comments {
+            event = event.comment(comment);
+        }
+    }
+
+    Ok(event)
 }
+
+// /// Convert an Annotated into an Event
+// /// If the Event represents an Error, then return an axum::Error
+// /// The [`monitor_for_disconnects`] method will handle the error, emit to the sse stream
+// /// then stop the generation of completions.
+// impl<T: Serialize> TryFrom<EventConverter<T>> for Event {
+//     type Error = axum::Error;
+
+//     fn try_from(annotated: EventConverter<T>) -> Result<Self, Self::Error> {
+//         let annotated = annotated.0;
+
+//         let mut event = Event::default();
+
+//         if let Some(data) = annotated.data {
+//             event = event.json_data(data)?;
+//         }
+
+//         if let Some(msg) = annotated.event {
+//             if msg == "error" {
+//                 let msgs = annotated
+//                     .comment
+//                     .unwrap_or_else(|| vec!["unspecified error".to_string()]);
+//                 return Err(axum::Error::new(msgs.join(" -- ")));
+//             }
+//             event = event.event(msg);
+//         }
+
+//         if let Some(comments) = annotated.comment {
+//             for comment in comments {
+//                 event = event.comment(comment);
+//             }
+//         }
+
+//         Ok(event)
+//     }
+// }
 
 /// Create an Axum [`Router`] for the OpenAI API Completions endpoint
 /// If not path is provided, the default path is `/v1/completions`

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -488,42 +488,6 @@ fn process_event_converter<T: Serialize>(
     Ok(event)
 }
 
-// /// Convert an Annotated into an Event
-// /// If the Event represents an Error, then return an axum::Error
-// /// The [`monitor_for_disconnects`] method will handle the error, emit to the sse stream
-// /// then stop the generation of completions.
-// impl<T: Serialize> TryFrom<EventConverter<T>> for Event {
-//     type Error = axum::Error;
-
-//     fn try_from(annotated: EventConverter<T>) -> Result<Self, Self::Error> {
-//         let annotated = annotated.0;
-
-//         let mut event = Event::default();
-
-//         if let Some(data) = annotated.data {
-//             event = event.json_data(data)?;
-//         }
-
-//         if let Some(msg) = annotated.event {
-//             if msg == "error" {
-//                 let msgs = annotated
-//                     .comment
-//                     .unwrap_or_else(|| vec!["unspecified error".to_string()]);
-//                 return Err(axum::Error::new(msgs.join(" -- ")));
-//             }
-//             event = event.event(msg);
-//         }
-
-//         if let Some(comments) = annotated.comment {
-//             for comment in comments {
-//                 event = event.comment(comment);
-//             }
-//         }
-
-//         Ok(event)
-//     }
-// }
-
 /// Create an Axum [`Router`] for the OpenAI API Completions endpoint
 /// If not path is provided, the default path is `/v1/completions`
 pub fn completions_router(

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -157,7 +157,7 @@ async fn completions(
             .metrics_clone()
             .create_inflight_guard(model, Endpoint::Completions, streaming);
 
-    let response_collector = state.metrics_clone().create_response_collector(model);
+    let mut response_collector = state.metrics_clone().create_response_collector(model);
 
     // setup context
     // todo - inherit request_id from distributed trace details
@@ -176,7 +176,6 @@ async fn completions(
     // note - we might do this as part of the post processing set to make it more generic
 
     if streaming {
-        let mut response_collector = response_collector; // Make it mutable
         let stream = stream.map(move |response| {
             process_event_converter(EventConverter::from(response), &mut response_collector)
         });
@@ -279,7 +278,7 @@ async fn chat_completions(
             .metrics_clone()
             .create_inflight_guard(model, Endpoint::ChatCompletions, streaming);
 
-    let response_collector = state.metrics_clone().create_response_collector(model);
+    let mut response_collector = state.metrics_clone().create_response_collector(model);
 
     // setup context
     // todo - inherit request_id from distributed trace details
@@ -300,7 +299,6 @@ async fn chat_completions(
     // note - we might do this as part of the post processing set to make it more generic
 
     if streaming {
-        let mut response_collector = response_collector; // Make it mutable
         let stream = stream.map(move |response| {
             process_event_converter(EventConverter::from(response), &mut response_collector)
         });

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -190,6 +190,7 @@ async fn completions(
 
         Ok(sse_stream.into_response())
     } else {
+        // TODO: report ISL/OSL for non-streaming requests
         let response = CompletionResponse::from_annotated_stream(stream.into())
             .await
             .map_err(|e| {
@@ -313,6 +314,7 @@ async fn chat_completions(
 
         Ok(sse_stream.into_response())
     } else {
+        // TODO: report ISL/OSL for non-streaming requests
         let response = NvCreateChatCompletionResponse::from_annotated_stream(stream.into())
             .await
             .map_err(|e| {

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -152,11 +152,10 @@ async fn completions(
         .get_completions_engine(model)
         .map_err(|_| ErrorResponse::model_not_found())?;
 
-    let mut inflight_guard = state.metrics_clone().create_inflight_guard(
-        model,
-        Endpoint::Completions,
-        streaming,
-    );
+    let mut inflight_guard =
+        state
+            .metrics_clone()
+            .create_inflight_guard(model, Endpoint::Completions, streaming);
 
     let response_collector = state.metrics_clone().create_response_collector(model);
 
@@ -275,11 +274,10 @@ async fn chat_completions(
         .map_err(|_| ErrorResponse::model_not_found())?;
 
     // Create separate guards - no Arc/Mutex needed
-    let mut inflight_guard = state.metrics_clone().create_inflight_guard(
-        model,
-        Endpoint::ChatCompletions,
-        streaming,
-    );
+    let mut inflight_guard =
+        state
+            .metrics_clone()
+            .create_inflight_guard(model, Endpoint::ChatCompletions, streaming);
 
     let response_collector = state.metrics_clone().create_response_collector(model);
 
@@ -410,7 +408,7 @@ async fn monitor_for_disconnects(
         Box<dyn Stream<Item = Result<axum::response::sse::Event, axum::Error>> + std::marker::Send>,
     >,
     context: Arc<dyn AsyncEngineContext>,
-    mut inflight_guard: InflightGuard, 
+    mut inflight_guard: InflightGuard,
 ) -> ReceiverStream<Result<Event, axum::Error>> {
     let (tx, rx) = tokio::sync::mpsc::channel(8);
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -273,7 +273,6 @@ async fn chat_completions(
         .get_chat_completions_engine(model)
         .map_err(|_| ErrorResponse::model_not_found())?;
 
-    // Create separate guards - no Arc/Mutex needed
     let mut inflight_guard =
         state
             .metrics_clone()
@@ -429,7 +428,7 @@ async fn monitor_for_disconnects(
 
         // Stream completed successfully - mark as ok
         if tx.send(Ok(Event::default().data("[DONE]"))).await.is_ok() {
-            inflight_guard.mark_ok(); // Direct call, no mutex
+            inflight_guard.mark_ok();
         }
     });
 
@@ -446,7 +445,7 @@ impl<T> From<Annotated<T>> for EventConverter<T> {
 
 fn process_event_converter<T: Serialize>(
     annotated: EventConverter<T>,
-    response_collector: &mut ResponseMetricCollector, // Direct reference, no Arc/Mutex
+    response_collector: &mut ResponseMetricCollector,
 ) -> Result<Event, axum::Error> {
     let annotated = annotated.0;
 
@@ -466,7 +465,6 @@ fn process_event_converter<T: Serialize>(
         event = event.event(msg);
     }
 
-    // Use response_collector directly - no mutex needed
     if let Some(osl) = annotated.output_tokens {
         response_collector.observe_current_osl(osl);
     }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -225,9 +225,9 @@ impl OpenAIPreprocessor {
                     let (chunk_tokens, isl) = if let Some(ref backend_output) = response.data {
                         let chunk_tokens = backend_output.token_ids.len();
                         inner.cumulative_output_tokens += chunk_tokens;
-                        
+
                         let isl = inner.response_generator.get_isl().unwrap_or(0) as usize;
-                        
+
                         (chunk_tokens, isl)
                     } else {
                         (0, 0)
@@ -235,7 +235,7 @@ impl OpenAIPreprocessor {
 
                     let current_osl = inner.cumulative_output_tokens;
 
-                    let response = response.map_data(|data| {
+                    let mut response = response.map_data(|data| {
                         inner
                             .response_generator
                             .choice_from_postprocessor(data)
@@ -251,17 +251,9 @@ impl OpenAIPreprocessor {
                             .map_err(|e| e.to_string())
                     });
 
-                    let response = match response {
-                        Ok(mut annotated_resp) => {
-                            let mut comments = annotated_resp.comment.unwrap_or_default();
-                            comments.push(format!("chunk_tokens: {}", chunk_tokens));
-                            comments.push(format!("input_tokens: {}", isl));
-                            comments.push(format!("output_tokens: {}", current_osl));
-                            annotated_resp.comment = Some(comments);
-                            Ok(annotated_resp)
-                        }
-                        Err(e) => Err(e),
-                    };
+                    response.chunk_tokens = Some(chunk_tokens);
+                    response.input_tokens = Some(isl);
+                    response.output_tokens = Some(current_osl);
 
                     tracing::trace!(
                         request_id = inner.context.id(),

--- a/lib/llm/src/protocols/codec.rs
+++ b/lib/llm/src/protocols/codec.rs
@@ -118,6 +118,9 @@ where
             data,
             id: value.id,
             event: value.event,
+            chunk_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
             comment: value.comments,
         })
     }

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -307,6 +307,9 @@ pub trait DeltaGeneratorExt<ResponseType: Send + Sync + 'static + std::fmt::Debu
         &mut self,
         response: common::llm_backend::BackendOutput,
     ) -> Result<ResponseType>;
+
+    /// Gets the current prompt token count (Input Sequence Length).
+    fn get_isl(&self) -> Option<u32>;
 }
 
 #[cfg(test)]

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -284,6 +284,9 @@ mod tests {
             data: Some(data),
             id: Some("test_id".to_string()),
             event: None,
+            chunk_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
             comment: None,
         }
     }
@@ -427,6 +430,9 @@ mod tests {
             data: Some(data),
             id: Some("test_id".to_string()),
             event: None,
+            chunk_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
             comment: None,
         };
         let stream = Box::pin(stream::iter(vec![annotated_delta]));

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -110,6 +110,10 @@ impl DeltaGenerator {
         self.usage.prompt_tokens = isl;
     }
 
+    pub fn get_isl(&self) -> Option<u32> {
+        Some(self.usage.prompt_tokens)
+    }
+
     /// Creates a choice within a chat completion response.
     ///
     /// # Arguments

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -110,10 +110,6 @@ impl DeltaGenerator {
         self.usage.prompt_tokens = isl;
     }
 
-    pub fn get_isl(&self) -> Option<u32> {
-        Some(self.usage.prompt_tokens)
-    }
-
     /// Creates a choice within a chat completion response.
     ///
     /// # Arguments
@@ -215,5 +211,9 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
         Ok(NvCreateChatCompletionStreamResponse {
             inner: stream_response,
         })
+    }
+
+    fn get_isl(&self) -> Option<u32> {
+        Some(self.usage.prompt_tokens)
     }
 }

--- a/lib/llm/src/protocols/openai/completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/completions/aggregator.rs
@@ -205,6 +205,9 @@ mod tests {
             }),
             id: Some("test_id".to_string()),
             event: None,
+            chunk_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
             comment: None,
         }
     }
@@ -314,6 +317,9 @@ mod tests {
             }),
             id: Some("test_id".to_string()),
             event: None,
+            chunk_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
             comment: None,
         };
 

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -126,4 +126,9 @@ impl crate::protocols::openai::DeltaGeneratorExt<CompletionResponse> for DeltaGe
         let index = 0;
         Ok(self.create_choice(index, delta.text, finish_reason))
     }
+
+    // TODO: This is a hack. Change `prompt_tokens` to u32
+    fn get_isl(&self) -> Option<u32> {
+        Some(self.usage.prompt_tokens as u32)
+    }
 }

--- a/lib/runtime/src/protocols/annotated.rs
+++ b/lib/runtime/src/protocols/annotated.rs
@@ -37,6 +37,12 @@ pub struct Annotated<R> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk_tokens: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<Vec<String>>,
 }
 
@@ -47,6 +53,9 @@ impl<R> Annotated<R> {
             data: None,
             id: None,
             event: Some("error".to_string()),
+            chunk_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
             comment: Some(vec![error]),
         }
     }
@@ -57,6 +66,9 @@ impl<R> Annotated<R> {
             data: Some(data),
             id: None,
             event: None,
+            chunk_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
             comment: None,
         }
     }
@@ -72,6 +84,9 @@ impl<R> Annotated<R> {
             data: None,
             id: None,
             event: Some(name.into()),
+            chunk_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
             comment: Some(vec![serde_json::to_string(value)?]),
         })
     }
@@ -107,6 +122,9 @@ impl<R> Annotated<R> {
             data,
             id: self.id,
             event: self.event,
+            chunk_tokens: self.chunk_tokens,
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
             comment: self.comment,
         }
     }
@@ -122,6 +140,9 @@ impl<R> Annotated<R> {
                 data,
                 id: self.id,
                 event: self.event,
+                chunk_tokens: self.chunk_tokens,
+                input_tokens: self.input_tokens,
+                output_tokens: self.output_tokens,
                 comment: self.comment,
             },
             Err(e) => Annotated::from_error(e),


### PR DESCRIPTION
Add these metrics to rust frontend (stream mode only):
- ISL
- OSL
- TTFT
- ITL

Special thanks to @jthomson04 for the help in rust implementation!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detailed token usage metrics to streaming responses, including per-chunk tokens, input tokens, and cumulative output tokens.
  - Enhanced API responses to include richer metadata about token counts for better usage insights.
  - Introduced new metrics for input/output sequence length, time to first token, and inter-token latency, improving observability and monitoring.
  - Added input sequence length retrieval method to token generators for improved token count tracking.
  - Extended annotated response structures with new optional token count fields.
  - Improved event processing in streaming endpoints to update response metrics in real time.
- **Bug Fixes**
  - Improved thread safety and reliability in metrics tracking during streaming responses.
- **Documentation**
  - Updated API to reflect new optional token-related fields in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->