### PR TITLE
fix: Use min of max tokens or context length

### DIFF
--- a/lib/engines/mistralrs/src/lib.rs
+++ b/lib/engines/mistralrs/src/lib.rs
@@ -511,11 +511,7 @@ impl AsyncEngine<SingleIn<CompletionRequest>, ManyOut<Annotated<CompletionRespon
                 .map(to_stop_tokens)
                 .or(det.stop_toks),
             max_len: {
-                let requested_max_tokens = request
-                    .inner
-                    .max_tokens
-                    .or(request.inner.max_tokens)
-                    .map(|m| m as usize);
+                let requested_max_tokens = request.inner.max_tokens.map(|m| m as usize);
 
                 // Ensure max_len doesn't exceed context length
                 match requested_max_tokens {

--- a/lib/engines/mistralrs/src/lib.rs
+++ b/lib/engines/mistralrs/src/lib.rs
@@ -65,6 +65,7 @@ fn best_device() -> pipeline_error::Result<Device> {
 
 struct MistralRsEngine {
     mistralrs: Arc<MistralRs>,
+    context_length: usize,
 }
 
 impl MistralRsEngine {
@@ -203,6 +204,7 @@ impl MistralRsEngine {
         .with_prefix_cache_n(16);
         let engine = MistralRsEngine {
             mistralrs: builder.build(),
+            context_length: max_seq_len,
         };
 
         // skip the id used for dummy run https://github.com/EricLBuehler/mistral.rs/issues/1218
@@ -310,12 +312,19 @@ impl
             frequency_penalty: request.inner.frequency_penalty.or(det.frequency_penalty),
             presence_penalty: request.inner.presence_penalty.or(det.presence_penalty),
             stop_toks: request.inner.stop.map(to_stop_tokens).or(det.stop_toks),
-            max_len: request
-                .inner
-                .max_completion_tokens
-                .or(request.inner.max_tokens)
-                .map(|m| m as usize)
-                .or(det.max_len),
+            max_len: {
+                let requested_max_tokens = request
+                    .inner
+                    .max_completion_tokens
+                    .or(request.inner.max_tokens)
+                    .map(|m| m as usize);
+                
+                // Ensure max_len doesn't exceed context length
+                match requested_max_tokens {
+                    Some(max_tokens) => Some(std::cmp::min(max_tokens, self.context_length)),
+                    None => det.max_len.map(|len| std::cmp::min(len, self.context_length))
+                }
+            },
             logits_bias: request
                 .inner
                 .logit_bias
@@ -499,12 +508,19 @@ impl AsyncEngine<SingleIn<CompletionRequest>, ManyOut<Annotated<CompletionRespon
                 .clone()
                 .map(to_stop_tokens)
                 .or(det.stop_toks),
-            max_len: request
-                .inner
-                .max_tokens
-                .or(request.inner.max_tokens)
-                .map(|m| m as usize)
-                .or(det.max_len),
+            max_len: {
+                let requested_max_tokens = request
+                    .inner
+                    .max_tokens
+                    .or(request.inner.max_tokens)
+                    .map(|m| m as usize);
+                
+                // Ensure max_len doesn't exceed context length
+                match requested_max_tokens {
+                    Some(max_tokens) => Some(std::cmp::min(max_tokens, self.context_length)),
+                    None => det.max_len.map(|len| std::cmp::min(len, self.context_length))
+                }
+            },
             logits_bias: request
                 .inner
                 .logit_bias

--- a/lib/engines/mistralrs/src/lib.rs
+++ b/lib/engines/mistralrs/src/lib.rs
@@ -318,11 +318,13 @@ impl
                     .max_completion_tokens
                     .or(request.inner.max_tokens)
                     .map(|m| m as usize);
-                
+
                 // Ensure max_len doesn't exceed context length
                 match requested_max_tokens {
                     Some(max_tokens) => Some(std::cmp::min(max_tokens, self.context_length)),
-                    None => det.max_len.map(|len| std::cmp::min(len, self.context_length))
+                    None => det
+                        .max_len
+                        .map(|len| std::cmp::min(len, self.context_length)),
                 }
             },
             logits_bias: request
@@ -514,11 +516,13 @@ impl AsyncEngine<SingleIn<CompletionRequest>, ManyOut<Annotated<CompletionRespon
                     .max_tokens
                     .or(request.inner.max_tokens)
                     .map(|m| m as usize);
-                
+
                 // Ensure max_len doesn't exceed context length
                 match requested_max_tokens {
                     Some(max_tokens) => Some(std::cmp::min(max_tokens, self.context_length)),
-                    None => det.max_len.map(|len| std::cmp::min(len, self.context_length))
+                    None => det
+                        .max_len
+                        .map(|len| std::cmp::min(len, self.context_length)),
                 }
             },
             logits_bias: request


### PR DESCRIPTION
#### Overview:

This PR modifies the mistralrs engine to ensure that the maximum output token length never exceeds the context length provided.


###### Details:

Modified the token length calculation logic to use the minimum of:
  - The user-requested maximum tokens
  - The context length

#### Testing
Before this change:
With command `./dynamo-run  out=mistralrs  --context-length 1  hf://Qwen/Qwen2.5-3B-Instruct` and prompt `Generate 100 words` response generated contains 100 words.

After this change:
With command `./dynamo-run  out=mistralrs  --context-length 1  hf://Qwen/Qwen2.5-3B-Instruct` and prompt `Generate 100 words` response generated contains one word.

#### Note: 
Even without any changes to preprocessor, llamacpp would generate one word if context length is set to one word.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: https://github.com/ai-dynamo/dynamo/issues/1173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of maximum token limits for completions and chat responses, ensuring requests do not exceed the model's supported context length. This prevents errors when generating longer outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->