### PR TITLE
fix: make imagePullSecrets optional when installing dynamo cloud

### DIFF
--- a/deploy/cloud/helm/platform/components/api-store/templates/deployment.yaml
+++ b/deploy/cloud/helm/platform/components/api-store/templates/deployment.yaml
@@ -112,4 +112,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}

--- a/deploy/cloud/helm/platform/components/api-store/values.yaml
+++ b/deploy/cloud/helm/platform/components/api-store/values.yaml
@@ -23,10 +23,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-imagePullSecrets:
-  - name: nvcrimagepullsecret
-  - name: docker-imagepullsecret
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+#imagePullSecrets: []
 # This is to override the chart name.
 nameOverride: ""
 fullnameOverride: ""

--- a/deploy/cloud/helm/platform/components/operator/templates/deployment.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args: {{- toYaml .Values.controllerManager.kubeRbacProxy.args | nindent
           8 }}
@@ -120,9 +124,6 @@ spec:
           10 }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
-      {{ with .Values.imagePullSecrets }}
-        imagePullSecrets: {{ . | toJson }}
-      {{ end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "dynamo-operator.fullname" . }}-controller-manager

--- a/deploy/cloud/helm/platform/components/operator/templates/deployment.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/deployment.yaml
@@ -120,7 +120,9 @@ spec:
           10 }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
-      imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
+      {{ with .Values.imagePullSecrets }}
+        imagePullSecrets: {{ . | toJson }}
+      {{ end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "dynamo-operator.fullname" . }}-controller-manager

--- a/deploy/cloud/helm/platform/components/operator/values.yaml
+++ b/deploy/cloud/helm/platform/components/operator/values.yaml
@@ -107,7 +107,7 @@ dynamo:
     cacheRepo: ''
     snapshotMode: '' # options: full, redo, time
 
-imagePullSecrets: []
+#imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
 metricsService:
   ports:

--- a/deploy/cloud/helm/platform/values.yaml
+++ b/deploy/cloud/helm/platform/values.yaml
@@ -14,15 +14,9 @@
 # limitations under the License.
 # Used to generate top-level secrets (overridden by custom-values.yaml)
 
-imagePullSecrets:
-
 # Subcharts
 dynamo-operator:
   enabled: true
-  imagePullSecrets:
-    - name: gitlab-imagepull
-    - name: nvcrimagepullsecret
-    - name: docker-imagepullsecret
   natsAddr: ""
   etcdAddr: ""
   namespaceRestriction:
@@ -79,7 +73,6 @@ dynamo-api-store:
     repository: ""
     tag: "latest"
     pullPolicy: IfNotPresent
-  imagePullSecrets:
   ingress:
     enabled: false
     className: nginx


### PR DESCRIPTION
#### Overview:

make imagePullSecrets optional when installing dynamo cloud

#### Details:

make imagePullSecrets optional when installing dynamo cloud

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #1225


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Helm chart configuration to remove default image pull secrets and related settings.
	- Improved handling of image pull secrets by only including them when explicitly defined.
	- Corrected a typo in configuration comments for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->