### PR TITLE
fix: Allow building only llamacpp or only mistralrs engine.

### DIFF
--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -116,9 +116,9 @@ pub async fn run(
 
     let out_opt = out_opt.unwrap_or_else(|| {
         let default_engine = if card.is_gguf() {
-            Output::LlamaCpp
+            gguf_default()
         } else {
-            Output::MistralRs
+            safetensors_default()
         };
         tracing::info!(
             "Using default engine: {default_engine}. Use out=<engine> to specify one of {}",
@@ -400,3 +400,22 @@ fn print_cuda(output: &Output) {
 
 #[cfg(not(any(feature = "mistralrs", feature = "llamacpp")))]
 fn print_cuda(_output: &Output) {}
+
+fn gguf_default() -> Output {
+    #[cfg(feature = "llamacpp")]
+    return Output::LlamaCpp;
+
+    #[cfg(all(feature = "mistralrs", not(feature = "llamacpp")))]
+    return Output::MistralRs;
+
+    #[cfg(not(any(feature = "mistralrs", feature = "llamacpp")))]
+    return Output::EchoFull;
+}
+
+fn safetensors_default() -> Output {
+    #[cfg(feature = "mistralrs")]
+    return Output::MistralRs;
+
+    #[cfg(not(feature = "mistralrs"))]
+    return Output::EchoFull;
+}


### PR DESCRIPTION
This allows building:
-  only `mistral.rs` engine: `--no-default-features --features mistralrs`  
- or only `llama.cpp` engine: `--no-default-features --features llamacpp`. 

Since llama.cpp became a default we'd only tested building both at once. The docs already said we supported that but there was some combo of Rust features that didn't build. This is the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for selecting the default output engine, making it adapt based on enabled features rather than using a fixed choice. This change ensures more flexible and accurate default engine selection for different model formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->