### PR TITLE
fix: allow custom annotations in api-store service

### DIFF
--- a/deploy/cloud/helm/platform/components/api-store/templates/service.yaml
+++ b/deploy/cloud/helm/platform/components/api-store/templates/service.yaml
@@ -16,6 +16,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "dynamo-store"
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "helm.labels" . | nindent 4 }}
 spec:

--- a/deploy/cloud/helm/platform/components/api-store/values.yaml
+++ b/deploy/cloud/helm/platform/components/api-store/values.yaml
@@ -65,6 +65,8 @@ service:
   type: ClusterIP
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 80
+  # This sets the annotations for the service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  annotations: {}
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:


### PR DESCRIPTION
#### Overview:

allow custom annotations in api-store service

#### Details:

allow custom annotations in api-store service

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #1221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying custom annotations on the "dynamo-store" Kubernetes service via Helm chart values. This allows users to add arbitrary service annotations as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->