### PR TITLE
feat: Make llama.cpp Gnu OpenMP dependency optional

### DIFF
--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -324,6 +324,12 @@ If you have multiple GPUs, mistral.rs does automatic tensor parallelism. You do 
 cargo build --features cuda|metal|vulkan -p dynamo-run
 ```
 
+For GNU OpenMP support add the `openmp` feature. On Ubuntu this requires `libgomp1` (part of `build-essential`) at build and runtime.
+
+```
+cargo build --features cuda,openmp -p dynamo-run
+```
+
 ```
 dynamo-run out=llamacpp ~/llms/gemma-3-1b-it-q4_0.gguf
 dynamo-run out=llamacpp ~/llms/Qwen3-0.6B-Q8_0.gguf # From https://huggingface.co/ggml-org

--- a/launch/dynamo-run/Cargo.toml
+++ b/launch/dynamo-run/Cargo.toml
@@ -21,6 +21,7 @@ llamacpp = ["dep:dynamo-engine-llamacpp"]
 cuda = ["dynamo-engine-llamacpp/cuda", "dynamo-engine-mistralrs/cuda"]
 metal = ["dynamo-engine-llamacpp/metal", "dynamo-engine-mistralrs/metal"]
 vulkan = ["dynamo-engine-llamacpp/vulkan"]
+openmp = ["dynamo-engine-llamacpp/openmp"]
 
 [dependencies]
 dynamo-llm = { workspace = true }

--- a/lib/engines/llamacpp/Cargo.toml
+++ b/lib/engines/llamacpp/Cargo.toml
@@ -29,6 +29,7 @@ default = []
 cuda = ["llama-cpp-2/cuda"]
 metal = ["llama-cpp-2/metal"]
 vulkan = ["llama-cpp-2/vulkan"]
+openmp = ["llama-cpp-2/openmp"]
 
 [dependencies]
 dynamo-runtime = { workspace = true }
@@ -38,4 +39,5 @@ async-stream = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
-llama-cpp-2 = { version = "0.1.107" }
+# default-features = false to disable openmp because that needs libgomp1 installed
+llama-cpp-2 = { version = "0.1.107", default-features = false }


### PR DESCRIPTION
Do not include by default as it needs `libgomp1` at runtime. Add a feature to enable it at build time.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for building with OpenMP support, including required system libraries and example build commands.

- **New Features**
  - Added an optional OpenMP feature for improved performance when building with supported engines.

- **Chores**
  - Adjusted package configuration to allow enabling OpenMP support without activating it by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->