### PR TITLE
fix: wait until probing on vllm examples to prevent timeouts (#1293)

### DIFF
--- a/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -38,7 +38,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -962,20 +961,6 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 												"nvidia.com/gpu":      resource.MustParse("1"),
 											},
 										},
-										LivenessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/healthz", Port: intstr.FromString(commonconsts.DynamoHealthPortName),
-												},
-											},
-										},
-										ReadinessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/readyz", Port: intstr.FromString(commonconsts.DynamoHealthPortName),
-												},
-											},
-										},
 									},
 								},
 								Volumes:            []corev1.Volume{{Name: "shared-memory", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory, SizeLimit: limit}}}},
@@ -1013,20 +998,6 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 										Resources: corev1.ResourceRequirements{
 											Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m"), corev1.ResourceMemory: resource.MustParse("500Mi")},
 											Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourceMemory: resource.MustParse("1Gi"), "nvidia.com/gpu": resource.MustParse("1")},
-										},
-										LivenessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/healthz", Port: intstr.FromString(commonconsts.DynamoHealthPortName),
-												},
-											},
-										},
-										ReadinessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/readyz", Port: intstr.FromString(commonconsts.DynamoHealthPortName),
-												},
-											},
 										},
 									},
 								},

--- a/deploy/sdk/src/dynamo/sdk/cli/serve_dynamo.py
+++ b/deploy/sdk/src/dynamo/sdk/cli/serve_dynamo.py
@@ -87,7 +87,7 @@ def add_fastapi_routes(app, service, class_instance):
     return added_routes
 
 
-app = typer.Typer()
+app = typer.Typer(pretty_exceptions_enable=False)
 
 
 @app.command()
@@ -207,6 +207,8 @@ def main(
             dynamo_context["component"] = component
             dynamo_context["endpoints"] = endpoints
             class_instance = service.inner()
+            # signal that class_instance (and its setup) is done
+            instanceReady.set()
             dynamo_handlers = []
             for name, endpoint in dynamo_endpoints.items():
                 if DynamoTransport.DEFAULT in endpoint.transports:
@@ -234,8 +236,6 @@ def main(
             logger.info(
                 f"Starting {service.name} instance with all registered endpoints"
             )
-            # signal that class_instance (and its setup) is done
-            instanceReady.set()
             # Launch serve_endpoint for all endpoints concurrently
             tasks = [
                 endpoint.serve_endpoint(handler)

--- a/examples/llm/configs/disagg.yaml
+++ b/examples/llm/configs/disagg.yaml
@@ -35,7 +35,7 @@ VllmWorker:
   ServiceArgs:
     workers: 1
     resources:
-      gpu: 1
+      gpu: '1'
   common-configs: [model, block-size, max-model-len, kv-transfer-config]
 
 PrefillWorker:
@@ -43,7 +43,7 @@ PrefillWorker:
   ServiceArgs:
     workers: 1
     resources:
-      gpu: 1
+      gpu: '1'
   common-configs: [model, block-size, max-model-len, kv-transfer-config]
 
 Planner:


### PR DESCRIPTION
#### Overview:

fix: wait until probing on vllm examples to prevent timeouts

Cherry-pick https://github.com/ai-dynamo/dynamo/pull/1293


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
