### PR TITLE
fix: add explicit http_exposed flag to expose http service  as ingress

### DIFF
--- a/deploy/sdk/src/dynamo/sdk/cli/build.py
+++ b/deploy/sdk/src/dynamo/sdk/cli/build.py
@@ -128,6 +128,7 @@ class ServiceInfo(BaseModel):
         for ep_name, endpoint in service.get_dynamo_endpoints().items():
             if DynamoTransport.HTTP in endpoint.transports:
                 api_endpoints.append(f"/{ep_name}")
+        http_exposed = service.config.http_exposed or len(api_endpoints) > 0
 
         image = service.config.image or DYNAMO_IMAGE
         assert (
@@ -142,7 +143,7 @@ class ServiceInfo(BaseModel):
             workers=service.config.workers,
             image=image,
             dynamo=service.config.dynamo.model_dump(),
-            http_exposed=len(api_endpoints) > 0,
+            http_exposed=http_exposed,
             api_endpoints=api_endpoints,
         )
 

--- a/deploy/sdk/src/dynamo/sdk/cli/build.py
+++ b/deploy/sdk/src/dynamo/sdk/cli/build.py
@@ -128,16 +128,13 @@ class ServiceInfo(BaseModel):
         for ep_name, endpoint in service.get_dynamo_endpoints().items():
             if DynamoTransport.HTTP in endpoint.transports:
                 api_endpoints.append(f"/{ep_name}")
-        http_exposed = service.config.http_exposed
-        if len(api_endpoints) > 0:
-            assert (
-                http_exposed
-            ), "HTTP exposed must be True if API endpoints are defined"
-
         image = service.config.image or DYNAMO_IMAGE
         assert (
             image is not None
         ), "Please set DYNAMO_IMAGE environment variable or image field in service config"
+
+        if service.config.http_exposed:
+            logger.info(f"exposing HTTP service for {name}")
 
         # Create config
         config = ServiceConfig(
@@ -147,7 +144,7 @@ class ServiceInfo(BaseModel):
             workers=service.config.workers,
             image=image,
             dynamo=service.config.dynamo.model_dump(),
-            http_exposed=http_exposed,
+            http_exposed=service.config.http_exposed,
             api_endpoints=api_endpoints,
         )
 

--- a/deploy/sdk/src/dynamo/sdk/cli/build.py
+++ b/deploy/sdk/src/dynamo/sdk/cli/build.py
@@ -128,7 +128,11 @@ class ServiceInfo(BaseModel):
         for ep_name, endpoint in service.get_dynamo_endpoints().items():
             if DynamoTransport.HTTP in endpoint.transports:
                 api_endpoints.append(f"/{ep_name}")
-        http_exposed = service.config.http_exposed or len(api_endpoints) > 0
+        http_exposed = service.config.http_exposed
+        if len(api_endpoints) > 0:
+            assert (
+                http_exposed
+            ), "HTTP exposed must be True if API endpoints are defined"
 
         image = service.config.image or DYNAMO_IMAGE
         assert (

--- a/deploy/sdk/src/dynamo/sdk/cli/serve_dynamo.py
+++ b/deploy/sdk/src/dynamo/sdk/cli/serve_dynamo.py
@@ -166,6 +166,9 @@ def main(
     # will be set once dyn_worker has created class_instance
     instanceReady = asyncio.Event()
 
+    if service.config.http_exposed:
+        logger.info(f"exposing HTTP service for {service.name}")
+
     @dynamo_worker()
     async def dyn_worker(runtime: DistributedRuntime):
         nonlocal class_instance

--- a/deploy/sdk/src/dynamo/sdk/core/protocol/interface.py
+++ b/deploy/sdk/src/dynamo/sdk/core/protocol/interface.py
@@ -76,6 +76,7 @@ class ServiceConfig(BaseModel):
     image: str | None = None
     envs: List[Env] | None = None
     labels: Dict[str, str] | None = None
+    http_exposed: bool = False
 
 
 class DynamoEndpointInterface(ABC):

--- a/examples/hello_world/disagg_skeleton/components/frontend.py
+++ b/examples/hello_world/disagg_skeleton/components/frontend.py
@@ -33,6 +33,7 @@ app = FastAPI(title="Hello World LLM")
     dynamo={"namespace": "dynamo-demo"},
     image=DYNAMO_IMAGE,
     app=app,
+    http_exposed=True,
 )
 class Frontend:
     processor = depends(Processor)

--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -116,6 +116,7 @@ class Middle:
 @service(
     dynamo={"namespace": "inference"},
     image=DYNAMO_IMAGE,
+    http_exposed=True,
 )
 class Frontend:
     """A simple frontend HTTP API that forwards requests to the dynamo graph."""

--- a/examples/hello_world/multinode_example/components/frontend.py
+++ b/examples/hello_world/multinode_example/components/frontend.py
@@ -34,6 +34,7 @@ app = FastAPI(title="Hello World!")
     },
     image=DYNAMO_IMAGE,
     app=app,
+    http_exposed=True,
 )
 class Frontend:
     processor = depends(Processor)

--- a/examples/llm/components/frontend.py
+++ b/examples/llm/components/frontend.py
@@ -56,6 +56,7 @@ class FrontendConfig(BaseModel):
     resources={"cpu": "10", "memory": "20Gi"},
     workers=1,
     image=DYNAMO_IMAGE,
+    http_exposed=True,
 )
 class Frontend:
     planner = depends(Planner)

--- a/examples/multimodal/components/frontend.py
+++ b/examples/multimodal/components/frontend.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
     workers=1,
     image=DYNAMO_IMAGE,
     app=FastAPI(title="Multimodal Example"),
+    http_exposed=True,
 )
 class Frontend:
     processor = depends(Processor)

--- a/examples/sglang/components/frontend.py
+++ b/examples/sglang/components/frontend.py
@@ -54,6 +54,7 @@ class FrontendConfig(BaseModel):
     workers=1,
     image=DYNAMO_IMAGE,
     app=FastAPI(title="LLM Example"),
+    http_exposed=True,
 )
 class Frontend:
     worker = depends(SGLangWorker)

--- a/examples/tensorrt_llm/components/frontend.py
+++ b/examples/tensorrt_llm/components/frontend.py
@@ -54,6 +54,7 @@ class FrontendConfig(BaseModel):
     workers=1,
     image=DYNAMO_IMAGE,
     app=FastAPI(title="TensorRT LLM Example"),
+    http_exposed=True,
 )
 # todo this should be called ApiServer
 class Frontend:

--- a/examples/vllm_v0/components/frontend.py
+++ b/examples/vllm_v0/components/frontend.py
@@ -57,6 +57,7 @@ class FrontendConfig(BaseModel):
     workers=1,
     image=DYNAMO_IMAGE,
     app=FastAPI(title="LLM Example"),
+    http_exposed=True,
 )
 class Frontend:
     worker = depends(VllmWorker)

--- a/examples/vllm_v1/components/frontend.py
+++ b/examples/vllm_v1/components/frontend.py
@@ -56,6 +56,7 @@ class FrontendConfig(BaseModel):
     workers=1,
     image=DYNAMO_IMAGE,
     app=FastAPI(title="LLM Example"),
+    http_exposed=True,
 )
 class Frontend:
     worker = depends(SimpleLoadBalancer)


### PR DESCRIPTION
#### Overview:

This PR adds `http_exposed` boolean flag in the service configuration to expose a http service over k8s ingress. 

before: logic handles FastAPI based endpoints only and doesn't expose endpoint for http services when there it is launched using a sub-process.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?
- Added http_exposed: bool = False field to ServiceConfigclass
-  Added http_exposed=True parameter to the @service decorator on examples/*/Frontend classes.




#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added an explicit option to mark services as exposed over HTTP for several example frontend components.
	- Introduced a new configuration field to indicate HTTP exposure status for services.
	- Added informational logging when HTTP services are exposed.

- **Bug Fixes**
	- Improved consistency in how HTTP exposure is determined and reflected in service configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->