### PR TITLE
fix: dockerhub registry issues in dynamo operator

### DIFF
--- a/deploy/cloud/helm/deploy.sh
+++ b/deploy/cloud/helm/deploy.sh
@@ -87,7 +87,7 @@ if [[ -n "${DOCKER_USERNAME:-}" && -n "${DOCKER_PASSWORD:-}" ]]; then
 
   # Transform docker.io URLs to index.docker.io/v1/
   DOCKER_SERVER_FOR_SECRET="$DOCKER_SERVER"
-  if [[ "$DOCKER_SERVER" == "docker.io" || "$DOCKER_SERVER" == docker.io/* ]]; then
+  if [[ "$DOCKER_SERVER" == "docker.io" || "$DOCKER_SERVER" == "docker.io/"* ]]; then
     DOCKER_SERVER_FOR_SECRET="https://index.docker.io/v1/"
   fi
 

--- a/deploy/cloud/helm/deploy.sh
+++ b/deploy/cloud/helm/deploy.sh
@@ -85,10 +85,16 @@ fi
 if [[ -n "${DOCKER_USERNAME:-}" && -n "${DOCKER_PASSWORD:-}" ]]; then
   echo "Creating/updating Docker registry secret '$DOCKER_SECRET_NAME' in namespace '$NAMESPACE'..."
 
+  # Transform docker.io URLs to index.docker.io/v1/
+  DOCKER_SERVER_FOR_SECRET="$DOCKER_SERVER"
+  if [[ "$DOCKER_SERVER" == "docker.io" || "$DOCKER_SERVER" == docker.io/* ]]; then
+    DOCKER_SERVER_FOR_SECRET="https://index.docker.io/v1/"
+  fi
+
   kubectl create secret docker-registry "$DOCKER_SECRET_NAME" \
     --docker-username="$DOCKER_USERNAME" \
     --docker-password="$DOCKER_PASSWORD" \
-    --docker-server="$DOCKER_SERVER" \
+    --docker-server="$DOCKER_SERVER_FOR_SECRET" \
     --namespace "$NAMESPACE" \
     --dry-run=client -o yaml | kubectl apply -f -
 else

--- a/deploy/cloud/helm/platform/components/operator/templates/_helpers.tpl
+++ b/deploy/cloud/helm/platform/components/operator/templates/_helpers.tpl
@@ -85,6 +85,9 @@ Generate docker config json for registry credentials
 */}}
 {{- define "dynamo-operator.dockerconfig" -}}
 {{- $server := .Values.dynamo.dockerRegistry.server -}}
+{{- if or (eq $server "docker.io") (hasPrefix "docker.io/" $server) -}}
+  {{- $server = "https://index.docker.io/v1/" -}}
+{{- end -}}
 {{- $username := .Values.dynamo.dockerRegistry.username -}}
 {{- $password := .Values.dynamo.dockerRegistry.password -}}
 {{- if .Values.dynamo.dockerRegistry.passwordExistingSecretName -}}

--- a/deploy/cloud/operator/internal/controller/dynamocomponent_controller.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponent_controller.go
@@ -663,9 +663,6 @@ func (r *DynamoComponentReconciler) getDockerRegistry(ctx context.Context, Dynam
 		dynamoRepositoryName = dockerRegistryConfig.DynamoComponentsRepositoryName
 	}
 	dynamoRepositoryURI := fmt.Sprintf("%s/%s", strings.TrimRight(dockerRegistryConfig.Server, "/"), dynamoRepositoryName)
-	if strings.Contains(dockerRegistryConfig.Server, "docker.io") {
-		dynamoRepositoryURI = fmt.Sprintf("docker.io/%s", dynamoRepositoryName)
-	}
 
 	if DynamoComponent != nil && DynamoComponent.Spec.DockerConfigJSONSecretName != "" {
 		dockerRegistryConfig.SecretName = DynamoComponent.Spec.DockerConfigJSONSecretName


### PR DESCRIPTION
#### Overview:

Dynamo operator mishandles image paths for images from dockerhub. Fixes mishandling

closes https://linear.app/nvidia-dynamo/issue/DEP-126/issues-with-using-dockerhub-as-a-registry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Docker registry URL handling for Docker Hub to ensure compatibility with Kubernetes secret creation and authentication.
- **Refactor**
  - Standardized construction of Docker registry URIs by removing special cases, enhancing consistency without affecting user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->