### PR TITLE
feat: use nats/etcd checks in health decorators

### DIFF
--- a/deploy/sdk/src/dynamo/sdk/cli/serve_dynamo.py
+++ b/deploy/sdk/src/dynamo/sdk/cli/serve_dynamo.py
@@ -172,7 +172,6 @@ def main(
     async def dyn_worker(runtime: DistributedRuntime):
         nonlocal class_instance
         global dynamo_context
-
         dynamo_context["runtime"] = runtime
         if service_name and service_name != service.name:
             server_context.service_type = "service"

--- a/deploy/sdk/src/dynamo/sdk/core/lib.py
+++ b/deploy/sdk/src/dynamo/sdk/core/lib.py
@@ -42,6 +42,17 @@ DYNAMO_IMAGE = os.getenv("DYNAMO_IMAGE", "dynamo:latest-vllm")
 nats_client: NATS = None
 
 
+def set_nats_client(client: NATS) -> None:
+    """Set the global NATS client."""
+    global _nats_client
+    _nats_client = client
+
+
+def get_nats_client() -> Optional[NATS]:
+    """Return the global NATS client."""
+    return _nats_client
+
+
 def set_target(target: DeploymentTarget) -> None:
     """Set the global service provider implementation"""
     global _target
@@ -91,8 +102,6 @@ def depends(
 
 def is_nats_connected() -> bool:
     try:
-        # nats_client = NATS()
-        # await nats_client.connect("nats://localhost:4222")
         return nats_client is not None and nats_client.is_connected
     except Exception as e:
         logger.warning(f"NATS connection check failed: {e}")


### PR DESCRIPTION
Overview:


#### Overview:

DEP-128
liveness and readiness decorators should use nats/etcd entries as a minimum to validate they are being served

#### Related Issues: (Relates to [DEP-90](https://linear.app/nvidia-dynamo/issue/DEP-90))




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Liveness checks now verify NATS connectivity and return a clear HTTP 503 response if the service is unhealthy.
  - Added automatic connection to a local NATS server during system app startup to enhance service monitoring.
- **Bug Fixes**
  - Improved reliability of health checks by ensuring they accurately reflect NATS connection status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->