### PR TITLE
feat: Enable disagg support in trtllm standalone script 

### DIFF
--- a/launch/dynamo-run/src/subprocess/trtllm_config/sample.yaml
+++ b/launch/dynamo-run/src/subprocess/trtllm_config/sample.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a sample config for TensorRT-LLM engine.
+# The config provides smaller free_gpu_memory_fraction to ensure that the engine
+# does not use all the GPU memory and both prefill and decode workers can fit in
+# the GPU memory when running in disaggregated mode.
+# You might have to tweak this config based on your model size and GPU memory.
+
+backend: pytorch
+kv_cache_config:
+  free_gpu_memory_fraction: 0.40

--- a/launch/dynamo-run/src/subprocess/trtllm_inc.py
+++ b/launch/dynamo-run/src/subprocess/trtllm_inc.py
@@ -7,18 +7,28 @@
 #
 # `dynamo-run out=trtllm` runs this script
 # Can be used standalone: `python3 trtllm_inc.py` - lots of optional cmd line params
+#
+# Disaggregated serving:
+# - Ingress: dynamo run in=http out=dyn
+# - Decode Worker: python3 trtllm_inc.py --disagg-mode=decode --extra-engine-args=trtllm_config/sample.yaml
+# - Prefill Worker: python3 trtllm_inc.py --disagg-mode=prefill --extra-engine-args=trtllm_config/sample.yaml
+
 
 import argparse
 import asyncio
+import base64
+import copy
 import logging
 import sys
 import warnings
+from dataclasses import asdict
 from typing import Optional
 
 import uvloop
 
 # Import TRTLLM and related modules
 from tensorrt_llm import SamplingParams
+from tensorrt_llm.llmapi import DisaggregatedParams
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.llmapi.tokenizer import tokenizer_factory
 
@@ -34,11 +44,61 @@ from dynamo.runtime import DistributedRuntime, dynamo_worker
 DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
 # Qwen/Qwen3-0.6B is not supported by TRTLLM yet.
 DEFAULT_MODEL = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+# Default endpoint for the remote prefill service.
+DEFAULT_PREFILL_ENDPOINT = "dyn://dynamo.backend.prefill"
 
 # Default buffer size for kv cache events.
 DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
 
 logging.basicConfig(level=logging.DEBUG)
+
+
+def parse_endpoint(endpoint: str) -> tuple[str, str, str]:
+    endpoint_str = endpoint.replace("dyn://", "", 1)
+    endpoint_parts = endpoint_str.split(".")
+    if len(endpoint_parts) != 3:
+        logging.error(
+            f"Invalid endpoint format: '{endpoint}'. Expected 'dyn://namespace.component.endpoint' or 'namespace.component.endpoint'."
+        )
+        sys.exit(1)
+
+    return tuple(endpoint_parts)
+
+
+class DisaggregatedParamsCodec:
+    """
+    Codec for encoding and decoding disaggregated params for network transfer.
+    """
+
+    @staticmethod
+    def decode(
+        disaggregated_params: DisaggregatedParams,
+    ) -> DisaggregatedParams:
+        if disaggregated_params is None:
+            return None
+        else:
+            opaque_state = (
+                base64.b64decode(disaggregated_params.opaque_state)
+                if disaggregated_params.opaque_state is not None
+                else None
+            )
+            disaggregated_params.opaque_state = opaque_state
+            return disaggregated_params
+
+    @staticmethod
+    def encode(
+        disaggregated_params: DisaggregatedParams,
+    ) -> DisaggregatedParams:
+        if disaggregated_params is None:
+            return None
+        else:
+            encoded_opaque_state = (
+                base64.b64encode(disaggregated_params.opaque_state).decode("utf-8")
+                if disaggregated_params.opaque_state is not None
+                else None
+            )
+            disaggregated_params.opaque_state = encoded_opaque_state
+            return disaggregated_params
 
 
 class Config:
@@ -53,6 +113,8 @@ class Config:
     kv_block_size: int
     extra_engine_args: str
     publish_events_and_metrics: bool
+    disaggregation_mode: str
+    remote_prefill_endpoint: str
 
 
 class RequestHandler:
@@ -60,12 +122,50 @@ class RequestHandler:
     Request handler for the generate endpoint
     """
 
-    def __init__(self, component, engine, default_sampling_params, publishers):
+    def __init__(
+        self,
+        component,
+        engine,
+        default_sampling_params,
+        publishers,
+        disaggregation_mode,
+        remote_prefill_client,
+    ):
         self.engine = engine
         self.component = component
         self.default_sampling_params = default_sampling_params
         self.publishers = publishers
+        self.disaggregation_mode = disaggregation_mode
+        self.remote_prefill_client = remote_prefill_client
         self.first_generation = True
+
+    async def remote_prefill(self, request):
+        prefill_request = copy.deepcopy(request)
+        prefill_request["stop_conditions"]["max_tokens"] = 1
+
+        # Set the disaggregated params to context_only for remote prefill
+        prefill_request["disaggregated_params"] = asdict(
+            DisaggregatedParamsCodec.encode(
+                DisaggregatedParams(request_type="context_only")
+            )
+        )
+
+        if self.remote_prefill_client is None:
+            raise ValueError("Prefill client not initialized")
+
+        # TODO: Use smart KV router to determine which prefill worker to use. This would also require supporting publishing events for prefill workers.
+        remote_prefill_responses = [
+            remote_prefill_response
+            async for remote_prefill_response in await self.remote_prefill_client.round_robin(
+                prefill_request
+            )
+        ]
+        if len(remote_prefill_responses) > 1:
+            raise ValueError(
+                "Prefill worker returned more than one response. This is currently not supported in remote prefill mode."
+            )
+        remote_prefill_response = remote_prefill_responses[0]
+        return remote_prefill_response
 
     async def generate(self, request):
         # Check if there is an error in the publishers error queue
@@ -76,6 +176,41 @@ class RequestHandler:
             raise publishers_error
 
         inputs = request["token_ids"]
+
+        # Decode the disaggregated params from the request
+        if "disaggregated_params" in request:
+            disaggregated_params = DisaggregatedParamsCodec.decode(
+                DisaggregatedParams(**request["disaggregated_params"])
+            )
+        else:
+            disaggregated_params = None
+
+        num_output_tokens_so_far = 0
+
+        if self.disaggregation_mode == "decode":
+            # Run prefill/context phase remotely if disaggregation mode is decode.
+            prefill_result = await self.remote_prefill(request)
+            remote_prefill_response = prefill_result.data()
+            if (
+                remote_prefill_response["finish_reason"] == "stop"
+                or remote_prefill_response["finish_reason"] == "error"
+            ):
+                yield remote_prefill_response
+                return
+            num_output_tokens_so_far = len(remote_prefill_response["token_ids"])
+
+            # Decode the disaggregated params from the remote prefill response
+            disaggregated_params = DisaggregatedParamsCodec.decode(
+                DisaggregatedParams(**remote_prefill_response["disaggregated_params"])
+            )
+
+            # Send the first token response to the client
+            first_token_response = remote_prefill_response
+            first_token_response.pop("disaggregated_params")
+            yield first_token_response
+
+            # Set the disaggregated params to generation_only for the rest of the generation
+            disaggregated_params.request_type = "generation_only"
 
         sampling_params = self.default_sampling_params
         for key, value in request["sampling_options"].items():
@@ -88,10 +223,12 @@ class RequestHandler:
         if max_tokens:
             sampling_params.max_tokens = max_tokens
 
-        num_output_tokens_so_far = 0
         # TODO: Disable streaming for context only requests when adding disagg support
         async for res in self.engine.llm.generate_async(
-            inputs=inputs, sampling_params=sampling_params, streaming=True
+            inputs=inputs,
+            sampling_params=sampling_params,
+            disaggregated_params=disaggregated_params,
+            streaming=(self.disaggregation_mode != "prefill"),
         ):
             # TRTLLM engine needs to start generating tokens first before stats
             # can be retrieved.
@@ -99,7 +236,7 @@ class RequestHandler:
                 self.publishers.start()
                 self.first_generation = False
 
-            if res.finished:
+            if res.finished and self.disaggregation_mode != "prefill":
                 yield {"finish_reason": "stop", "token_ids": []}
                 break
 
@@ -114,6 +251,11 @@ class RequestHandler:
                 out["finish_reason"] = output.finish_reason
             if output.stop_reason:
                 out["stop_reason"] = output.stop_reason
+            if self.disaggregation_mode == "prefill":
+                # Return the disaggregated params only when operating in prefill mode.
+                out["disaggregated_params"] = asdict(
+                    DisaggregatedParamsCodec.encode(output.disaggregated_params)
+                )
             yield out
             num_output_tokens_so_far = next_total_toks
 
@@ -127,6 +269,22 @@ async def init(runtime: DistributedRuntime, config: Config):
     """
     Instantiate and serve
     """
+
+    remote_prefill_client = None
+    if config.disaggregation_mode == "decode":
+        logging.info(
+            f"Initializing remote prefill client for endpoint: {config.remote_prefill_endpoint}"
+        )
+        parsed_namespace, parsed_component_name, parsed_endpoint_name = parse_endpoint(
+            config.remote_prefill_endpoint
+        )
+        remote_prefill_client = (
+            await runtime.namespace(parsed_namespace)
+            .component(parsed_component_name)
+            .endpoint(parsed_endpoint_name)
+            .client()
+        )
+
     component = runtime.namespace(config.namespace).component(config.component)
     await component.create_service()
 
@@ -177,15 +335,25 @@ async def init(runtime: DistributedRuntime, config: Config):
 
     async with get_tensorrtllm_engine(engine_args) as engine:
         endpoint = component.endpoint(config.endpoint)
-        await register_llm(
-            ModelType.Backend,
-            endpoint,
-            config.model_path,
-            config.model_name,
-            kv_cache_block_size=config.kv_block_size,
-        )
 
-        if config.publish_events_and_metrics:
+        if config.disaggregation_mode != "prefill":
+            # Register the model with the endpoint if disaggregation mode is not prefill.
+            # Prefill worker will get the request directly from the Decode worker and not
+            # through the ingress.
+            # FIXME: Enable publishing events and metrics for disaggregated prefill.
+            # Currently prefill workers are chosen in round-robin fashion.
+            await register_llm(
+                ModelType.Backend,
+                endpoint,
+                config.model_path,
+                config.model_name,
+                kv_cache_block_size=config.kv_block_size,
+            )
+
+        if (
+            config.publish_events_and_metrics
+            and config.disaggregation_mode != "prefill"
+        ):
             # Initialize and pass in the publishers to the request handler to
             # publish events and metrics.
             kv_listener = runtime.namespace(config.namespace).component(
@@ -199,12 +367,24 @@ async def init(runtime: DistributedRuntime, config: Config):
                 config.kv_block_size,
             ) as publisher:
                 handler = RequestHandler(
-                    component, engine, default_sampling_params, publisher
+                    component,
+                    engine,
+                    default_sampling_params,
+                    publisher,
+                    config.disaggregation_mode,
+                    remote_prefill_client,
                 )
                 await endpoint.serve_endpoint(handler.generate)
         else:
             # No publishers, so just pass in None to the request handler.
-            handler = RequestHandler(component, engine, default_sampling_params, None)
+            handler = RequestHandler(
+                component,
+                engine,
+                default_sampling_params,
+                None,
+                config.disaggregation_mode,
+                remote_prefill_client,
+            )
             await endpoint.serve_endpoint(handler.generate)
 
 
@@ -253,15 +433,45 @@ def cmd_line_args():
     parser.add_argument(
         "--publish-events-and-metrics",
         action="store_true",
-        help="Publish events and metrics to the dynamo components.",
+        help="Publish events and metrics to the dynamo components. Note: This is not supported when running in prefill disaggregation mode.",
+    )
+    parser.add_argument(
+        "--disagg-mode",
+        type=str,
+        choices=["none", "prefill", "decode"],
+        default="none",
+        help="Specifies the disaggregation mode for the engine. none: aggregated serving, prefill: disaggregated prefill, decode: disaggregated decode",
+    )
+    parser.add_argument(
+        "--remote-prefill-endpoint",
+        type=str,
+        default=DEFAULT_PREFILL_ENDPOINT,
+        help=f"Endpoint(in 'dyn://namespace.component.endpoint' format) to send prefill requests to when running in decode disaggregation mode. Default: {DEFAULT_PREFILL_ENDPOINT}",
     )
     args = parser.parse_args()
 
+    # Validate arguments
     if args.context_length is not None:
         warnings.warn(
             "--context-length is accepted for compatibility but will be ignored for TensorRT-LLM. Please provide max_input_len, max_seq_len and max_output_len in yaml file and point --extra-engine-args to the yaml file.",
             UserWarning,
         )
+
+    endpoint = args.endpoint
+    if args.disagg_mode == "prefill":
+        if args.remote_prefill_endpoint != DEFAULT_PREFILL_ENDPOINT:
+            logging.error(
+                "--remote-prefill-endpoint is not supported when running in prefill disaggregation mode."
+            )
+            sys.exit(1)
+        else:
+            endpoint = DEFAULT_PREFILL_ENDPOINT
+
+        if args.publish_events_and_metrics:
+            warnings.warn(
+                "--publish-events-and-metrics is not supported when running in prefill disaggregation mode.",
+                UserWarning,
+            )
 
     config = Config()
     config.model_path = args.model_path
@@ -271,15 +481,9 @@ def cmd_line_args():
         # This becomes an `Option` on the Rust side
         config.model_name = None
 
-    endpoint_str = args.endpoint.replace("dyn://", "", 1)
-    endpoint_parts = endpoint_str.split(".")
-    if len(endpoint_parts) != 3:
-        logging.error(
-            f"Invalid endpoint format: '{args.endpoint}'. Expected 'dyn://namespace.component.endpoint' or 'namespace.component.endpoint'."
-        )
-        sys.exit(1)
-
-    parsed_namespace, parsed_component_name, parsed_endpoint_name = endpoint_parts
+    parsed_namespace, parsed_component_name, parsed_endpoint_name = parse_endpoint(
+        endpoint
+    )
 
     config.namespace = parsed_namespace
     config.component = parsed_component_name
@@ -288,6 +492,8 @@ def cmd_line_args():
     config.kv_block_size = args.kv_block_size
     config.extra_engine_args = args.extra_engine_args
     config.publish_events_and_metrics = args.publish_events_and_metrics
+    config.disaggregation_mode = args.disagg_mode
+    config.remote_prefill_endpoint = args.remote_prefill_endpoint
 
     return config
 


### PR DESCRIPTION
#### Overview:

Adds support for launching workers in disaggregated mode via dynamo run for TRTLLM. This is a short-term support. We will add more updates in dynamo ingress to support pipelining stages.

#### Details:

There are three disagg modes for the engine: none, prefill and decode. decode worker listens to the ingress and publishes the model card. decode worker directly talks to prefill worker via client interface.

The user can start these services directly and send oai requests to the ingress:
1. Ingress: dynamo run in=http out=dyn
2. Decode Worker: python3 trtllm_inc.py --task=decode --extra-engine-args=trtllm_config/sample.yaml
3. Prefill Worker: python3 trtllm_inc.py --task=prefill --extra-engine-args=trtllm_config/sample.yaml

They can launch multiple such workers on different nodes.

Status:

- [x]  Add event and metrics publishers
- [x]  Support default dynamo-run out=trtllm launch
- [x]  Update dynamo run documentation
- [x]  Support disaggregated serving via standalone script

Pending:
 - [ ] Support disaggregated serving via dynamo run 
 - [ ] Update examples/tensorrt-llm to use these workers instead.


#### Where should the reviewer start?

trtllm_inc.py is the file that is updated. 

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for disaggregated serving modes, enabling separate prefill and decode workers for more flexible deployment.
  - Added command-line options to configure disaggregation mode and specify a remote prefill endpoint.
  - Provided a sample configuration file for managing GPU memory usage in TensorRT-LLM deployments.

- **Bug Fixes**
  - Improved handling of incompatible options in different serving modes with appropriate warnings.

- **Documentation**
  - Included a sample YAML configuration file with usage notes and licensing information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->