### PR TITLE
feat: Restructure the KVBM WriteTo trait

### DIFF
--- a/lib/llm/src/block_manager/block.rs
+++ b/lib/llm/src/block_manager/block.rs
@@ -24,6 +24,7 @@ use nixl_sys::NixlDescriptor;
 
 pub use registry::{GlobalRegistry, RegistrationHandle};
 pub use state::{BlockState, BlockStateInvalid};
+pub use transfer::TransferContext;
 
 use crate::block_manager::{
     state::KvBlockManagerState as BlockManager,

--- a/lib/llm/src/block_manager/block/transfer.rs
+++ b/lib/llm/src/block_manager/block/transfer.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod context;
 mod cuda;
 mod memcpy;
 mod nixl;
@@ -32,9 +33,9 @@ use nixl_sys::XferOp::{Read, Write};
 use std::ops::Range;
 use tokio::sync::oneshot;
 
-pub use crate::block_manager::state::TransferContext;
 pub use crate::block_manager::storage::{CudaAccessible, Local, Remote};
 pub use async_trait::async_trait;
+pub use context::TransferContext;
 
 /// A block that can be the target of a write
 pub trait Writable {}

--- a/lib/llm/src/block_manager/block/transfer.rs
+++ b/lib/llm/src/block_manager/block/transfer.rs
@@ -29,8 +29,8 @@ use crate::block_manager::storage::{
 use cudarc::driver::CudaStream;
 
 use nixl_sys::XferOp::{Read, Write};
-use std::future::Future;
 use std::ops::Range;
+use tokio::sync::oneshot;
 
 pub use crate::block_manager::state::TransferContext;
 pub use crate::block_manager::storage::{CudaAccessible, Local, Remote};
@@ -149,19 +149,9 @@ pub trait WriteTo<Target> {
     fn write_to(
         &self,
         dst: &mut Vec<Target>,
-        notify: Option<String>,
+        notify: bool,
         ctx: Arc<TransferContext>,
-    ) -> Result<(), TransferError>;
-
-    /// A write_to implementation that expects a NIXL transfer.
-    /// If the transfer strategy is not NIXL, this method will return an error.
-    /// Returns a future that will complete when the transfer is complete.
-    fn nixl_write_to(
-        &self,
-        dst: &mut Vec<Target>,
-        notify: Option<String>,
-        ctx: Arc<TransferContext>,
-    ) -> Result<Box<dyn Future<Output = ()> + Send + Sync + Unpin>, TransferError>;
+    ) -> Result<Option<oneshot::Receiver<()>>, TransferError>;
 }
 
 impl<RB: ReadableBlock, WB: WritableBlock> WriteTo<WB> for Vec<Arc<RB>>
@@ -171,15 +161,25 @@ where
     fn write_to(
         &self,
         dst: &mut Vec<WB>,
-        notify: Option<String>,
+        notify: bool,
         ctx: Arc<TransferContext>,
-    ) -> Result<(), TransferError> {
+    ) -> Result<Option<oneshot::Receiver<()>>, TransferError> {
+        let (tx, rx) = oneshot::channel();
+
         match RB::write_to_strategy() {
             TransferStrategy::Memcpy => {
                 for (src, dst) in self.iter().zip(dst.iter_mut()) {
+                    // TODO: Unlike all other transfer strategies, this is fully blocking.
+                    // We probably want some sort of thread pool to handle these.
                     memcpy::copy_block(src.as_ref(), dst)?;
                 }
-                Ok(())
+
+                if notify {
+                    tx.send(()).unwrap();
+                    Ok(Some(rx))
+                } else {
+                    Ok(None)
+                }
             }
             TransferStrategy::CudaAsyncH2D
             | TransferStrategy::CudaAsyncD2H
@@ -192,44 +192,32 @@ where
                         RB::write_to_strategy(),
                     )?;
                 }
-                Ok(())
+
+                if notify {
+                    let (tx, rx) = oneshot::channel();
+                    ctx.cuda_event(tx)?;
+                    Ok(Some(rx))
+                } else {
+                    Ok(None)
+                }
             }
             TransferStrategy::Nixl(transfer_type) => {
-                std::mem::drop(nixl::write_blocks_to(
-                    self,
-                    dst,
-                    ctx,
-                    notify,
-                    transfer_type,
-                )?);
-                Ok(())
+                let transfer_fut = nixl::write_blocks_to(self, dst, &ctx, transfer_type)?;
+
+                if notify {
+                    ctx.async_rt_handle().spawn(async move {
+                        transfer_fut.await;
+                        tx.send(()).unwrap();
+                    });
+                    Ok(Some(rx))
+                } else {
+                    Ok(None)
+                }
             }
             _ => Err(TransferError::IncompatibleTypes(format!(
                 "Unsupported copy strategy: {:?}",
                 RB::write_to_strategy()
             ))),
-        }
-    }
-
-    fn nixl_write_to(
-        &self,
-        dst: &mut Vec<WB>,
-        notify: Option<String>,
-        ctx: Arc<TransferContext>,
-    ) -> Result<Box<dyn Future<Output = ()> + Send + Sync + Unpin>, TransferError> {
-        if let TransferStrategy::Nixl(transfer_type) = RB::write_to_strategy() {
-            Ok(nixl::write_blocks_to(
-                self,
-                dst,
-                ctx,
-                notify,
-                transfer_type,
-            )?)
-        } else {
-            Err(TransferError::IncompatibleTypes(format!(
-                "Expected NIXL transfer strategy, got: {:?}",
-                RB::write_to_strategy()
-            )))?
         }
     }
 }

--- a/lib/llm/src/block_manager/block/transfer/context.rs
+++ b/lib/llm/src/block_manager/block/transfer/context.rs
@@ -108,7 +108,9 @@ impl Drop for TransferContext {
     fn drop(&mut self) {
         self.cancel_token.cancel();
         if let Some(handle) = self.cuda_event_worker.take() {
-            handle.join().unwrap();
+            if let Err(e) = handle.join() {
+                tracing::error!("Error joining CUDA event worker: {:?}", e);
+            }
         }
     }
 }

--- a/lib/llm/src/block_manager/block/transfer/context.rs
+++ b/lib/llm/src/block_manager/block/transfer/context.rs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+use cudarc::driver::{sys::CUevent_flags, CudaEvent, CudaStream};
+use nixl_sys::Agent as NixlAgent;
+
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use tokio::runtime::Handle;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+
+pub struct TransferContext {
+    nixl_agent: Arc<Option<NixlAgent>>,
+    stream: Arc<CudaStream>,
+    async_rt_handle: Handle,
+
+    cuda_event_tx: mpsc::UnboundedSender<(CudaEvent, oneshot::Sender<()>)>,
+    cuda_event_worker: Option<JoinHandle<()>>,
+    cancel_token: CancellationToken,
+}
+
+impl TransferContext {
+    pub fn new(
+        nixl_agent: Arc<Option<NixlAgent>>,
+        stream: Arc<CudaStream>,
+        async_rt_handle: Handle,
+    ) -> Self {
+        let (cuda_event_tx, mut cuda_event_rx) =
+            mpsc::unbounded_channel::<(CudaEvent, oneshot::Sender<()>)>();
+
+        let cancel_token = CancellationToken::new();
+
+        let cancel_token_clone = cancel_token.clone();
+        let cuda_event_worker = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to build Tokio runtime for CUDA event worker.");
+
+            runtime.block_on(async move {
+                loop {
+                    tokio::select! {
+                        Some((event, tx)) = cuda_event_rx.recv() => {
+                            if let Err(e) = event.synchronize() {
+                                tracing::error!("Error synchronizing CUDA event: {}", e);
+                            }
+                            let _ = tx.send(());
+                        }
+                        _ = cancel_token_clone.cancelled() => {
+                            break;
+                        }
+                    }
+                }
+            });
+        });
+
+        Self {
+            nixl_agent,
+            stream,
+            async_rt_handle,
+            cuda_event_tx,
+            cuda_event_worker: Some(cuda_event_worker),
+            cancel_token,
+        }
+    }
+
+    pub fn nixl_agent(&self) -> Arc<Option<NixlAgent>> {
+        self.nixl_agent.clone()
+    }
+
+    pub fn stream(&self) -> &Arc<CudaStream> {
+        &self.stream
+    }
+
+    pub fn async_rt_handle(&self) -> &Handle {
+        &self.async_rt_handle
+    }
+
+    pub fn cuda_event(&self, tx: oneshot::Sender<()>) -> Result<(), TransferError> {
+        let event = self
+            .stream
+            .record_event(Some(CUevent_flags::CU_EVENT_BLOCKING_SYNC))
+            .map_err(|e| TransferError::ExecutionError(e.to_string()))?;
+
+        self.cuda_event_tx
+            .send((event, tx))
+            .map_err(|_| TransferError::ExecutionError("CUDA event worker exited.".into()))?;
+        Ok(())
+    }
+}
+
+impl Drop for TransferContext {
+    fn drop(&mut self) {
+        self.cancel_token.cancel();
+        if let Some(handle) = self.cuda_event_worker.take() {
+            handle.join().unwrap();
+        }
+    }
+}

--- a/lib/llm/src/block_manager/offload.rs
+++ b/lib/llm/src/block_manager/offload.rs
@@ -44,9 +44,8 @@
 //! The kind of offloads/onboards they perform is dictated by the source and target arguments
 //! of the [`OffloadManager::offload`] and [`OffloadManager::onboard`] methods.
 
-use super::block::{BlockError, BlockMetadata, BlockState, ImmutableBlock};
+use super::block::{BlockError, BlockMetadata, BlockState, ImmutableBlock, TransferContext};
 use super::pool::BlockPoolError;
-use super::state::TransferContext;
 use super::storage::{Cuda, Storage};
 use super::{BlockPool, DeviceStorage, DiskStorage, PinnedStorage};
 use nixl_sys::Agent as NixlAgent;
@@ -141,8 +140,9 @@ impl<Metadata: BlockMetadata> OffloadManager<Metadata> {
                 CudaTransferManager::new(
                     device_offload_transfer_ctx,
                     MAX_CONCURRENT_TRANSFERS,
+                    &async_rt_handle,
                     cancellation_token.clone(),
-                ),
+                )?,
                 MAX_TRANSFER_BATCH_SIZE,
                 &async_rt_handle,
                 cancellation_token.clone(),
@@ -174,7 +174,7 @@ impl<Metadata: BlockMetadata> OffloadManager<Metadata> {
                     MAX_CONCURRENT_TRANSFERS,
                     &async_rt_handle,
                     cancellation_token.clone(),
-                ),
+                )?,
                 MAX_TRANSFER_BATCH_SIZE,
                 &async_rt_handle,
                 cancellation_token.clone(),
@@ -198,8 +198,9 @@ impl<Metadata: BlockMetadata> OffloadManager<Metadata> {
                 CudaTransferManager::new(
                     transfer_ctx.clone(),
                     MAX_CONCURRENT_TRANSFERS,
+                    &async_rt_handle,
                     cancellation_token.clone(),
-                ),
+                )?,
                 MAX_TRANSFER_BATCH_SIZE,
                 &async_rt_handle,
                 cancellation_token.clone(),
@@ -225,7 +226,7 @@ impl<Metadata: BlockMetadata> OffloadManager<Metadata> {
                     MAX_CONCURRENT_TRANSFERS,
                     &async_rt_handle,
                     cancellation_token.clone(),
-                ),
+                )?,
                 MAX_TRANSFER_BATCH_SIZE,
                 &async_rt_handle,
                 cancellation_token.clone(),

--- a/lib/llm/src/block_manager/offload.rs
+++ b/lib/llm/src/block_manager/offload.rs
@@ -129,6 +129,7 @@ impl<Metadata: BlockMetadata> OffloadManager<Metadata> {
         let device_offload_transfer_ctx = Arc::new(TransferContext::new(
             nixl_agent.clone(),
             cuda_ctx.new_stream()?,
+            async_rt_handle.clone(),
         ));
 
         // Device -> Host offload
@@ -159,6 +160,7 @@ impl<Metadata: BlockMetadata> OffloadManager<Metadata> {
         let transfer_ctx = Arc::new(TransferContext::new(
             nixl_agent.clone(),
             cuda_ctx.new_stream()?,
+            async_rt_handle.clone(),
         ));
 
         // Host -> Disk offload
@@ -549,8 +551,10 @@ mod tests {
             let agent = NixlAgent::new("offload-manager").unwrap();
             let (_, ucx_params) = agent.get_plugin_params("UCX").unwrap();
             let (_, gds_params) = agent.get_plugin_params("GDS").unwrap();
+            let (_, posix_params) = agent.get_plugin_params("POSIX").unwrap();
             agent.create_backend("UCX", &ucx_params).unwrap();
             agent.create_backend("GDS", &gds_params).unwrap();
+            agent.create_backend("POSIX", &posix_params).unwrap();
             Arc::new(Some(agent))
         };
     }

--- a/lib/llm/src/block_manager/offload/pending.rs
+++ b/lib/llm/src/block_manager/offload/pending.rs
@@ -225,7 +225,7 @@ where
                 true,
                 self.transfer_ctx.clone(),
             )?
-            .unwrap();
+            .ok_or_else(|| anyhow::anyhow!("write_to returned None when notify was true. This should never happen!"))?;
 
         // Send the pending transfer and event to the worker thread.
         // If the queue is full, we block the worker until space becomes available.
@@ -311,7 +311,7 @@ where
                 true,
                 self.transfer_ctx.clone(),
             )?
-            .unwrap();
+            .ok_or_else(|| anyhow::anyhow!("write_to returned None when notify was true. This should never happen!"))?;
 
         let completion_future = async move {
             let _ = notify.await;

--- a/lib/llm/src/block_manager/offload/pending.rs
+++ b/lib/llm/src/block_manager/offload/pending.rs
@@ -225,7 +225,11 @@ where
                 true,
                 self.transfer_ctx.clone(),
             )?
-            .ok_or_else(|| anyhow::anyhow!("write_to returned None when notify was true. This should never happen!"))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "write_to returned None when notify was true. This should never happen!"
+                )
+            })?;
 
         // Send the pending transfer and event to the worker thread.
         // If the queue is full, we block the worker until space becomes available.
@@ -311,7 +315,11 @@ where
                 true,
                 self.transfer_ctx.clone(),
             )?
-            .ok_or_else(|| anyhow::anyhow!("write_to returned None when notify was true. This should never happen!"))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "write_to returned None when notify was true. This should never happen!"
+                )
+            })?;
 
         let completion_future = async move {
             let _ = notify.await;

--- a/lib/llm/src/block_manager/state.rs
+++ b/lib/llm/src/block_manager/state.rs
@@ -98,7 +98,9 @@ impl TransferContext {
             .record_event(Some(CUevent_flags::CU_EVENT_BLOCKING_SYNC))
             .map_err(|e| TransferError::ExecutionError(e.to_string()))?;
 
-        self.cuda_event_tx.send((event, tx)).map_err(|_| TransferError::ExecutionError("CUDA event worker exited.".into()))?;
+        self.cuda_event_tx
+            .send((event, tx))
+            .map_err(|_| TransferError::ExecutionError("CUDA event worker exited.".into()))?;
         Ok(())
     }
 }

--- a/lib/llm/src/block_manager/state.rs
+++ b/lib/llm/src/block_manager/state.rs
@@ -17,102 +17,11 @@ use super::*;
 
 use super::offload::OffloadManager;
 use super::{
-    block::{transfer::TransferError, Block, GlobalRegistry, ImmutableBlock},
+    block::{Block, GlobalRegistry, ImmutableBlock},
     config::NixlOptions,
 };
-use cudarc::driver::{sys::CUevent_flags, CudaEvent, CudaStream};
-use std::{sync::Arc, thread::JoinHandle};
+use std::sync::Arc;
 use tokio::runtime::Handle;
-use tokio::sync::{mpsc, oneshot};
-
-pub struct TransferContext {
-    nixl_agent: Arc<Option<NixlAgent>>,
-    stream: Arc<CudaStream>,
-    async_rt_handle: Handle,
-
-    cuda_event_tx: mpsc::UnboundedSender<(CudaEvent, oneshot::Sender<()>)>,
-    cuda_event_worker: Option<JoinHandle<()>>,
-    cancel_token: CancellationToken,
-}
-
-impl TransferContext {
-    pub fn new(
-        nixl_agent: Arc<Option<NixlAgent>>,
-        stream: Arc<CudaStream>,
-        async_rt_handle: Handle,
-    ) -> Self {
-        let (cuda_event_tx, mut cuda_event_rx) =
-            mpsc::unbounded_channel::<(CudaEvent, oneshot::Sender<()>)>();
-
-        let cancel_token = CancellationToken::new();
-
-        let cancel_token_clone = cancel_token.clone();
-        let cuda_event_worker = std::thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to build Tokio runtime for CUDA event worker.");
-
-            runtime.block_on(async move {
-                loop {
-                    tokio::select! {
-                        Some((event, tx)) = cuda_event_rx.recv() => {
-                            if let Err(e) = event.synchronize() {
-                                tracing::error!("Error synchronizing CUDA event: {}", e);
-                            }
-                            let _ = tx.send(());
-                        }
-                        _ = cancel_token_clone.cancelled() => {
-                            break;
-                        }
-                    }
-                }
-            });
-        });
-
-        Self {
-            nixl_agent,
-            stream,
-            async_rt_handle,
-            cuda_event_tx,
-            cuda_event_worker: Some(cuda_event_worker),
-            cancel_token,
-        }
-    }
-
-    pub fn nixl_agent(&self) -> Arc<Option<NixlAgent>> {
-        self.nixl_agent.clone()
-    }
-
-    pub fn stream(&self) -> &Arc<CudaStream> {
-        &self.stream
-    }
-
-    pub fn async_rt_handle(&self) -> &Handle {
-        &self.async_rt_handle
-    }
-
-    pub fn cuda_event(&self, tx: oneshot::Sender<()>) -> Result<(), TransferError> {
-        let event = self
-            .stream
-            .record_event(Some(CUevent_flags::CU_EVENT_BLOCKING_SYNC))
-            .map_err(|e| TransferError::ExecutionError(e.to_string()))?;
-
-        self.cuda_event_tx
-            .send((event, tx))
-            .map_err(|_| TransferError::ExecutionError("CUDA event worker exited.".into()))?;
-        Ok(())
-    }
-}
-
-impl Drop for TransferContext {
-    fn drop(&mut self) {
-        self.cancel_token.cancel();
-        if let Some(handle) = self.cuda_event_worker.take() {
-            handle.join().unwrap();
-        }
-    }
-}
 
 #[allow(dead_code)]
 pub struct KvBlockManagerState<Metadata: BlockMetadata> {


### PR DESCRIPTION
This does a couple things:
1. Fixes some perf issues with host -> disk transfers. Perf issues still exist with disk -> device transfers. The NIXL team has been made aware of this.
2. Removes the `nixl_write_to` function in favor of a single `write_to` function which returns a oneshot receiver indicating transfer completion.
3. Fixes some bugs with the existing NIXL polling logic. Poor perf was hiding issues where transfers may never be acknowledged as completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified and improved asynchronous notification for data transfers, providing consistent completion signals across all transfer strategies.
  - Added asynchronous CUDA event handling with a dedicated runtime thread for better integration with async workflows.

- **Bug Fixes**
  - Enhanced reliability of transfer completion notifications, reducing the risk of missed or delayed signals during transfers.

- **Refactor**
  - Simplified and standardized notification mechanisms, replacing custom events with a unified oneshot channel approach.
  - Streamlined transfer context creation and improved test environment setup for broader backend compatibility.
  - Replaced synchronous polling with asynchronous waiting in transfer status checks for improved efficiency.
  - Updated transfer managers to use async notification channels, removing reliance on CUDA events and synchronous blocking.
  - Removed deprecated methods and consolidated transfer logic for cleaner async integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->