### PR TITLE
feat: set model specific prompt templates in the multimodal config files, add documentation for multimodal example deployment

### DIFF
--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -225,7 +225,8 @@ dynamo deployment create $DYNAMO_TAG -n $DEPLOYMENT_NAME -f ./configs/agg.yaml
 
 ### Testing the Deployment
 
-Once the deployment is complete, you can test it using:
+Once the deployment is complete, you can test it. If you have ingress available for your deployment, you can directly call the url returned
+in `dynamo deployment get ${DEPLOYMENT_NAME}` and skip the steps to find and forward the frontend pod.
 
 ```bash
 # Find your frontend pod

--- a/examples/llm/configs/disagg.yaml
+++ b/examples/llm/configs/disagg.yaml
@@ -26,6 +26,7 @@ Frontend:
 Processor:
   router: round-robin
   common-configs: [model, block-size]
+  prompt-template: "USER: <image>\n<prompt> ASSISTANT:"
 
 VllmWorker:
   remote-prefill: true

--- a/examples/multimodal/README.md
+++ b/examples/multimodal/README.md
@@ -28,16 +28,16 @@ The examples are based on the [llava-1.5-7b-hf](https://huggingface.co/llava-hf/
 - processor: Tokenizes the prompt and passes it to the decode worker.
 - frontend: HTTP endpoint to handle incoming requests.
 
-### Deployment
+### Graph
 
-In this deployment, we have two workers, [encode_worker](components/encode_worker.py) and [decode_worker](components/decode_worker.py).
+In this graph, we have two workers, [encode_worker](components/encode_worker.py) and [decode_worker](components/decode_worker.py).
 The encode worker is responsible for encoding the image and passing the embeddings to the decode worker via a combination of NATS and RDMA.
 The work complete event is sent via NATS, while the embeddings tensor is transferred via RDMA through the NIXL interface.
 Its decode worker then prefills and decodes the prompt, just like the [LLM aggregated serving](../llm/README.md) example.
 By separating the encode from the prefill and decode stages, we can have a more flexible deployment and scale the
 encode worker independently from the prefill and decode workers if needed.
 
-This figure shows the flow of the deployment:
+This figure shows the flow of the graph:
 ```mermaid
 flowchart LR
   HTTP --> processor
@@ -89,7 +89,7 @@ You should see a response similar to this:
 {"id": "c37b946e-9e58-4d54-88c8-2dbd92c47b0c", "object": "chat.completion", "created": 1747725277, "model": "llava-hf/llava-1.5-7b-hf", "choices": [{"index": 0, "message": {"role": "assistant", "content": " In the image, there is a city bus parked on a street, with a street sign nearby on the right side. The bus appears to be stopped out of service. The setting is in a foggy city, giving it a slightly moody atmosphere."}, "finish_reason": "stop"}]}
 ```
 
-## Multimodal Disaggregated serving
+## Multimodal Disaggregated Serving
 
 ### Components
 
@@ -97,16 +97,16 @@ You should see a response similar to this:
 - processor: Tokenizes the prompt and passes it to the decode worker.
 - frontend: HTTP endpoint to handle incoming requests.
 
-### Local Serving
+### Graph
 
-In this deployment, we have three workers, [encode_worker](components/encode_worker.py), [decode_worker](components/decode_worker.py), and [prefill_worker](components/prefill_worker.py).
+In this graph, we have three workers, [encode_worker](components/encode_worker.py), [decode_worker](components/decode_worker.py), and [prefill_worker](components/prefill_worker.py).
 For the Llava model, embeddings are only required during the prefill stage. As such, the encode worker is connected directly to the prefill worker.
 The encode worker is responsible for encoding the image and passing the embeddings to the prefill worker via a combination of NATS and RDMA.
 Its work complete event is sent via NATS, while the embeddings tensor is transferred via RDMA through the NIXL interface.
 The prefill worker performs the prefilling step and forwards the KV cache to the decode worker for decoding.
 For more details on the roles of the prefill and decode workers, refer to the [LLM disaggregated serving](../llm/README.md) example.
 
-This figure shows the flow of the deployment:
+This figure shows the flow of the graph:
 ```mermaid
 flowchart LR
   HTTP --> processor

--- a/examples/multimodal/README.md
+++ b/examples/multimodal/README.md
@@ -207,7 +207,8 @@ dynamo deploy $DYNAMO_TAG -n $DEPLOYMENT_NAME -f ./configs/agg.yaml
 
 ### Testing the Deployment
 
-Once the deployment is complete, you can test it using:
+Once the deployment is complete, you can test it. If you have ingress available for your deployment, you can directly call the url returned
+in `dynamo deployment get ${DEPLOYMENT_NAME}` and skip the steps to find and forward the frontend pod.
 
 ```bash
 # Find your frontend pod

--- a/examples/multimodal/README.md
+++ b/examples/multimodal/README.md
@@ -188,17 +188,17 @@ export DYNAMO_IMAGE=<your-registry>/<your-image-name>:<your-tag>
 
 # Build the service
 cd $PROJECT_ROOT/examples/multimodal
-DYNAMO_TAG=$(dynamo build graphs.disagg:Frontend | grep "Successfully built" |  awk '{ print $NF }' | sed 's/\.$//')
-# For aggregated serving:
-# DYNAMO_TAG=$(dynamo build graphs.agg:Frontend | grep "Successfully built" |  awk '{ print $NF }' | sed 's/\.$//')
+DYNAMO_TAG=$(dynamo build graphs.agg:Frontend | grep "Successfully built" |  awk '{ print $NF }' | sed 's/\.$//')
+# For disaggregated serving:
+# DYNAMO_TAG=$(dynamo build graphs.disagg:Frontend | grep "Successfully built" |  awk '{ print $NF }' | sed 's/\.$//')
 
 # Deploy to Kubernetes
-export DEPLOYMENT_NAME=multimodal-disagg
-# For disaggregated serving:
-dynamo deployment create $DYNAMO_TAG -n $DEPLOYMENT_NAME -f ./configs/disagg.yaml
+export DEPLOYMENT_NAME=multimodal-agg
 # For aggregated serving:
-# export DEPLOYMENT_NAME=multimodal-agg
-# dynamo deployment create $DYNAMO_TAG -n $DEPLOYMENT_NAME -f ./configs/agg.yaml
+dynamo deployment create $DYNAMO_TAG -n $DEPLOYMENT_NAME -f ./configs/agg.yaml
+# For disaggregated serving:
+# export DEPLOYMENT_NAME=multimodal-disagg
+# dynamo deployment create $DYNAMO_TAG -n $DEPLOYMENT_NAME -f ./configs/disagg.yaml
 ```
 
 **Note**: To avoid rate limiting from unauthenticated requests to HuggingFace (HF), you can provide your `HF_TOKEN` as a secret in your deployment. See the [operator deployment guide](../../docs/guides/dynamo_deploy/operator_deployment.md#referencing-secrets-in-your-deployment) for instructions on referencing secrets like `HF_TOKEN` in your deployment configuration.

--- a/examples/multimodal/README.md
+++ b/examples/multimodal/README.md
@@ -195,10 +195,10 @@ DYNAMO_TAG=$(dynamo build graphs.agg:Frontend | grep "Successfully built" |  awk
 # Deploy to Kubernetes
 export DEPLOYMENT_NAME=multimodal-agg
 # For aggregated serving:
-dynamo deployment create $DYNAMO_TAG -n $DEPLOYMENT_NAME -f ./configs/agg.yaml
+dynamo deploy $DYNAMO_TAG -n $DEPLOYMENT_NAME -f ./configs/agg.yaml
 # For disaggregated serving:
 # export DEPLOYMENT_NAME=multimodal-disagg
-# dynamo deployment create $DYNAMO_TAG -n $DEPLOYMENT_NAME -f ./configs/disagg.yaml
+# dynamo deploy $DYNAMO_TAG -n $DEPLOYMENT_NAME -f ./configs/disagg.yaml
 ```
 
 **Note**: To avoid rate limiting from unauthenticated requests to HuggingFace (HF), you can provide your `HF_TOKEN` as a secret in your deployment. See the [operator deployment guide](../../docs/guides/dynamo_deploy/operator_deployment.md#referencing-secrets-in-your-deployment) for instructions on referencing secrets like `HF_TOKEN` in your deployment configuration.

--- a/examples/multimodal/components/decode_worker.py
+++ b/examples/multimodal/components/decode_worker.py
@@ -135,8 +135,10 @@ class VllmDecodeWorker:
                 self.disaggregated_router = None
 
             model = LlavaForConditionalGeneration.from_pretrained(
-                self.engine_args.model
-            )
+                self.engine_args.model,
+                device_map="auto",
+                torch_dtype=torch.bfloat16,
+            ).eval()
             vision_tower = model.vision_tower
             self.embedding_size = (
                 vision_tower.vision_model.embeddings.position_embedding.num_embeddings

--- a/examples/multimodal/components/decode_worker.py
+++ b/examples/multimodal/components/decode_worker.py
@@ -241,8 +241,8 @@ class VllmDecodeWorker:
             # The decode worker will pre-allocate the memory based on the prompt token length for the prefill worker to transfer the kv cache.
             # As a workaround, here we manually insert some placeholder dummy tokens based on the embedding size
             # so that decode worker can pre-allocate the memory with the correct size.
-            # The structure of the prompt will be like: "\nUSER: <image> <dummy_tokens>\n<user_prompt>\nASSISTANT:".
             # Since the "<image>" token is included in the prompt, only need to insert (embedding_size - 1) dummy tokens after the image token.
+            # TODO: make this more flexible/model-dependent
             IMAGE_TOKEN_ID = 32000
             DUMMY_TOKEN_ID = 0
             # Find the index of the image token in the prompt token ids

--- a/examples/multimodal/components/prefill_worker.py
+++ b/examples/multimodal/components/prefill_worker.py
@@ -246,8 +246,8 @@ class VllmPrefillWorker:
                 self._loaded_metadata.add(engine_id)
 
             # To make sure the decode worker can pre-allocate the memory with the correct size for the prefill worker to transfer the kv cache,
-            # some placeholder dummy tokens were inserted based on the embedding size in the worker.py.
-            # The structure of the prompt is "\nUSER: <image> <dummy_tokens>\n<user_prompt>\nASSISTANT:", need to remove the dummy tokens after the image token.
+            # some placeholder dummy tokens are inserted based on the embedding size in the worker.py.
+            # TODO: make this more flexible/model-dependent
             IMAGE_TOKEN_ID = 32000
             embedding_size = embeddings.shape[1]
             padding_size = embedding_size - 1

--- a/examples/multimodal/components/processor.py
+++ b/examples/multimodal/components/processor.py
@@ -187,11 +187,12 @@ class Processor(ProcessMixIn):
     # The generate endpoint will be used by the frontend to handle incoming requests.
     @endpoint()
     async def generate(self, raw_request: MultiModalRequest):
+        prompt = str(self.engine_args.prompt_template).replace(
+            "<prompt>", raw_request.messages[0].content[0].text
+        )
         msg = {
             "role": "user",
-            "content": "USER: <image>\nQuestion:"
-            + raw_request.messages[0].content[0].text
-            + " Answer:",
+            "content": prompt,
         }
 
         chat_request = ChatCompletionRequest(

--- a/examples/multimodal/configs/agg.yaml
+++ b/examples/multimodal/configs/agg.yaml
@@ -20,6 +20,7 @@ Common:
 Processor:
   router: round-robin
   common-configs: [model, block-size, max-model-len]
+  prompt-template: "USER: <image>\n<prompt> ASSISTANT:"
 
 VllmDecodeWorker:
   enforce-eager: true

--- a/examples/multimodal/configs/agg.yaml
+++ b/examples/multimodal/configs/agg.yaml
@@ -19,8 +19,8 @@ Common:
 
 Processor:
   router: round-robin
-  common-configs: [model, block-size, max-model-len]
   prompt-template: "USER: <image>\n<prompt> ASSISTANT:"
+  common-configs: [model, block-size, max-model-len]
 
 VllmDecodeWorker:
   enforce-eager: true
@@ -31,7 +31,7 @@ VllmDecodeWorker:
   ServiceArgs:
     workers: 1
     resources:
-      gpu: 1
+      gpu: '1'
   common-configs: [model, block-size, max-model-len]
 
 VllmEncodeWorker:
@@ -40,5 +40,5 @@ VllmEncodeWorker:
   ServiceArgs:
     workers: 1
     resources:
-      gpu: 1
+      gpu: '1'
   common-configs: [model]

--- a/examples/multimodal/configs/disagg.yaml
+++ b/examples/multimodal/configs/disagg.yaml
@@ -20,6 +20,7 @@ Common:
 
 Processor:
   router: round-robin
+  prompt-template: "USER: <image>\n<prompt> ASSISTANT:"
   common-configs: [model, block-size]
 
 VllmDecodeWorker:
@@ -30,7 +31,7 @@ VllmDecodeWorker:
   ServiceArgs:
     workers: 1
     resources:
-      gpu: 1
+      gpu: '1'
   common-configs: [model, block-size, max-model-len, kv-transfer-config]
 
 VllmPrefillWorker:
@@ -38,7 +39,7 @@ VllmPrefillWorker:
   ServiceArgs:
     workers: 1
     resources:
-      gpu: 1
+      gpu: '1'
   common-configs: [model, block-size, max-model-len, kv-transfer-config]
 
 VllmEncodeWorker:
@@ -47,5 +48,5 @@ VllmEncodeWorker:
   ServiceArgs:
     workers: 1
     resources:
-      gpu: 1
+      gpu: '1'
   common-configs: [model]

--- a/examples/multimodal/utils/vllm.py
+++ b/examples/multimodal/utils/vllm.py
@@ -51,6 +51,12 @@ def parse_vllm_args(service_name, prefix) -> AsyncEngineArgs:
         default=3,
         help="Maximum queue size for remote prefill. If the prefill queue size is greater than this value, prefill phase of the incoming request will be executed locally.",
     )
+    parser.add_argument(
+        "--prompt-template",
+        type=str,
+        default="<prompt>",
+        help="Prompt template to use for the model",
+    )
     parser = AsyncEngineArgs.add_cli_args(parser)
     args = parser.parse_args(vllm_args)
     engine_args = AsyncEngineArgs.from_cli_args(args)
@@ -59,4 +65,5 @@ def parse_vllm_args(service_name, prefix) -> AsyncEngineArgs:
     engine_args.conditional_disagg = args.conditional_disagg
     engine_args.max_local_prefill_length = args.max_local_prefill_length
     engine_args.max_prefill_queue_size = args.max_prefill_queue_size
+    engine_args.prompt_template = args.prompt_template
     return engine_args


### PR DESCRIPTION
#### Overview:

- Prompt templates are set in the config YAML files
- Added instructions for deploying the multimodal example to Kubernetes.

#### Details:

- Tested deployment for both agg and disagg in Kubernetes, verified they worked

Curl request output for agg:

> There is a white, black, and yellow city bus in the image, parked on the side of a wet rural road. It is located near a street light, and it is not currently in service. The city bus appears to be on the outskirts of the city and is likely waiting to return to service.

Curl request output for disagg:

> In the image, there is a bus driving down the street, where a house can be seen nearby, and there is an outdoor stop sign by the street. Additionally, there appears to be a building with a traffic light, an electric pole, and a street sign.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizable prompt templates in multimodal and LLM examples via configuration and command-line options.

- **Documentation**
  - Updated deployment and testing instructions for LLM and multimodal examples, including guidance for Kubernetes deployments and ingress usage.
  - Clarified and expanded sections in example READMEs for improved usability.

- **Style**
  - Improved comments in multimodal components for clarity and future flexibility.

- **Refactor**
  - Enhanced model loading in multimodal decode worker for better device and precision handling.

- **Chores**
  - Updated configuration files to support new prompt template options and standardized GPU resource specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->