### PR TITLE
fix: prefillqueue stream name in load-planner

### DIFF
--- a/components/planner/src/dynamo/planner/defaults.py
+++ b/components/planner/src/dynamo/planner/defaults.py
@@ -17,7 +17,6 @@
 # Source of truth for planner defaults
 class PlannerDefaults:
     namespace = "dynamo"
-    served_model_name = "vllm"
     environment = "local"
     no_operation = False
     log_dir = None

--- a/docs/architecture/planner.md
+++ b/docs/architecture/planner.md
@@ -110,7 +110,6 @@ dynamo serve graphs.disagg:Frontend -f disagg.yaml --Planner.environment=local -
 Configuration options:
 * `namespace` (str, default: "dynamo"): Target namespace for planner operations
 * `environment` (str, default: "local"): Target environment (local, kubernetes)
-* `served-model-name` (str, default: "vllm"): Target model name
 * `no-operation` (bool, default: false): Run in observation mode only
 * `log-dir` (str, default: None): Tensorboard log directory
 * `adjustment-interval` (int, default: 30): Seconds between adjustments

--- a/docs/guides/planner_benchmark/benchmark_planner.md
+++ b/docs/guides/planner_benchmark/benchmark_planner.md
@@ -54,7 +54,6 @@ dynamo serve graphs.disagg_router:Frontend -f disagg_1p1d.yml
 genai-perf profile \
     --tokenizer deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
     -m deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
-    --service-kind openai \
     --endpoint-type chat \
     --url http://localhost:8000 \
     --streaming \

--- a/examples/llm/components/planner.py
+++ b/examples/llm/components/planner.py
@@ -64,7 +64,7 @@ class Planner:
         self._prefill_queue_nats_server = os.getenv(
             "NATS_SERVER", "nats://localhost:4222"
         )
-        self._prefill_queue_stream_name = self.args.served_model_name
+        self._prefill_queue_stream_name = f"{self.namespace}_prefill_queue"
 
         self.prefill_client: Any | None = None
         self.workers_client: Any | None = None

--- a/examples/llm/components/planner.py
+++ b/examples/llm/components/planner.py
@@ -412,12 +412,6 @@ if __name__ == "__main__":
         help="Namespace planner will look at",
     )
     parser.add_argument(
-        "--served-model-name",
-        type=str,
-        default=PlannerDefaults.served_model_name,
-        help="Model name that is being served (used for prefill queue name)",
-    )
-    parser.add_argument(
         "--no-operation",
         action="store_true",
         default=PlannerDefaults.no_operation,


### PR DESCRIPTION
Use correct prefillqueue stream name in load-planner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the ability to specify a served model name in the planner configuration and command-line options.
- **Documentation**
	- Updated planner documentation to remove references to the served model name configuration.
	- Revised benchmark guide to eliminate the `--service-kind openai` option from example commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->