### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,17 +16,20 @@ Cargo.toml @ryanolson @grahamking @paulhendricks @biswapanda @tmonty12 @guanluo 
 # Dynamo deploy
 /deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @nnshah1 @mohammedabdulwahhab
 
-# All examples
-/examples/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @nnshah1 @tanmayv25 @piotrm-nvidia @ptarasiewiczNV @ryanolson @grahamking @paulhendricks @biswapanda @tmonty12 @guanluo @rmccorm4 @tedzhouhk @alec-flowers @kkranen @sshchoi @PeaBrane @mohammedabdulwahhab @ai-dynamo/Devops
-
-# TRTLLM
-/examples/tensorrt_llm/ @tanmayv25 @rmccorm4 @guanluo @richardhuo-nv
-
-# Multimodal
-/examples/multimodal/ @indrajit96 @whoisj @krishung5
+# Examples
+/examples/ @ai-dynamo/Devops @nnshah1 @rmccorm4 @whoisj
+/examples/common/ @tedzhouhk
+/examples/hello_world/ @alec-flowers @biswapanda @grahamking @hhzhang16 @ishandhanani @julienmancuso @kkranen @mohammedabdulwahhab @nnshah1 @tedzhouhk
+/examples/llm/ @alec-flowers @biswapanda @grahamking @guanluo @hhzhang16 @ishandhanani @julienmancuso @kkranen @mohammedabdulwahhab @nnshah1 @piotrm-nvidia @ptarasiewiczNV @rmccorm4 @tanmayv25 @tedzhouhk
+/examples/multimodal/ @indrajit96 @krishung5 @whoisj
+/examples/sglang/ @biswapanda @ishandhanani @tedzhouhk
+/examples/tensorrt_llm/ @guanluo @richardhuo-nv @rmccorm4 @tanmayv25
+/examples/vllm_v0/ @alec-flowers @tedzhouhk
+/examples/vllm_v1/ @biswapanda @ptarasiewiczNV @tedzhouhk
 
 # CI/CD
 /.github/ @ai-dynamo/Devops @nnshah1
+/.github/workflows/*.ps1 @whoisj
 CODEOWNERS @ai-dynamo/Devops @nnshah1
 
 # Legal


### PR DESCRIPTION
This PR breaks the massive list of owners for the /examples/ folder into smaller groups for individual subfolders.

The selection of owners is based on `git blame` and identifying individuals based on the emails they attached to their commits.

The impetus for this PR is based on recent work I did in the /examples/ folder that added over 20 individuals, none of whom were interested in the PR.

Change also slips in adding myself (original author) of the /.github/workflows/ copyright checking tool.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated ownership assignments for multiple subdirectories under the examples directory to improve clarity.
  - Assigned ownership of the general examples directory to a specific team.
  - Added a new owner for certain GitHub workflow files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->