### PR TITLE
refactor: Rename CompletionRequest to NvCreateCompletionRequest

### DIFF
--- a/launch/dynamo-run/src/input/common.rs
+++ b/launch/dynamo-run/src/input/common.rs
@@ -139,7 +139,7 @@ mod tests {
     use super::*;
     use dynamo_llm::types::openai::{
         chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
-        completions::{CompletionRequest, CompletionResponse},
+        completions::{CompletionResponse, NvCreateCompletionRequest},
     };
 
     const HF_PATH: &str = concat!(
@@ -174,7 +174,7 @@ mod tests {
 
         // Build pipeline for completions
         let pipeline =
-            build_pipeline::<CompletionRequest, CompletionResponse>(&card, engine).await?;
+            build_pipeline::<NvCreateCompletionRequest, CompletionResponse>(&card, engine).await?;
 
         // Verify pipeline was created
         assert!(Arc::strong_count(&pipeline) >= 1);

--- a/launch/dynamo-run/src/input/http.rs
+++ b/launch/dynamo-run/src/input/http.rs
@@ -15,7 +15,7 @@ use dynamo_llm::{
         openai::chat_completions::{
             NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
         },
-        openai::completions::{CompletionRequest, CompletionResponse},
+        openai::completions::{CompletionResponse, NvCreateCompletionRequest},
     },
 };
 use dynamo_runtime::pipeline::RouterMode;
@@ -76,10 +76,10 @@ pub async fn run(
             .await?;
             manager.add_chat_completions_model(model.service_name(), chat_pipeline)?;
 
-            let cmpl_pipeline = common::build_pipeline::<CompletionRequest, CompletionResponse>(
-                model.card(),
-                inner_engine,
-            )
+            let cmpl_pipeline = common::build_pipeline::<
+                NvCreateCompletionRequest,
+                CompletionResponse,
+            >(model.card(), inner_engine)
             .await?;
             manager.add_completions_model(model.service_name(), cmpl_pipeline)?;
         }

--- a/lib/engines/mistralrs/src/lib.rs
+++ b/lib/engines/mistralrs/src/lib.rs
@@ -25,7 +25,7 @@ use dynamo_runtime::protocols::annotated::Annotated;
 
 use dynamo_llm::protocols::openai::{
     chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
-    completions::{prompt_to_string, CompletionRequest, CompletionResponse},
+    completions::{prompt_to_string, CompletionResponse, NvCreateCompletionRequest},
     embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
 };
 
@@ -470,12 +470,12 @@ fn to_logit_bias(lb: HashMap<String, serde_json::Value>) -> HashMap<u32, f32> {
 }
 
 #[async_trait]
-impl AsyncEngine<SingleIn<CompletionRequest>, ManyOut<Annotated<CompletionResponse>>, Error>
+impl AsyncEngine<SingleIn<NvCreateCompletionRequest>, ManyOut<Annotated<CompletionResponse>>, Error>
     for MistralRsEngine
 {
     async fn generate(
         &self,
-        request: SingleIn<CompletionRequest>,
+        request: SingleIn<NvCreateCompletionRequest>,
     ) -> Result<ManyOut<Annotated<CompletionResponse>>, Error> {
         let (request, context) = request.transfer(());
         let ctx = context.context();

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -25,7 +25,7 @@ use crate::{
     protocols::openai::chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
     },
-    protocols::openai::completions::{CompletionRequest, CompletionResponse},
+    protocols::openai::completions::{CompletionResponse, NvCreateCompletionRequest},
     protocols::openai::embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
 };
 
@@ -235,7 +235,7 @@ impl ModelWatcher {
                     .add_chat_completions_model(&model_entry.name, chat_engine)?;
 
                 let frontend = SegmentSource::<
-                    SingleIn<CompletionRequest>,
+                    SingleIn<NvCreateCompletionRequest>,
                     ManyOut<Annotated<CompletionResponse>>,
                 >::new();
                 let preprocessor = OpenAIPreprocessor::new(card.clone()).await?.into_operator();
@@ -286,12 +286,11 @@ impl ModelWatcher {
                     .add_chat_completions_model(&model_entry.name, engine)?;
             }
             ModelType::Completion => {
-                let push_router =
-                    PushRouter::<CompletionRequest, Annotated<CompletionResponse>>::from_client(
-                        client,
-                        Default::default(),
-                    )
-                    .await?;
+                let push_router = PushRouter::<
+                    NvCreateCompletionRequest,
+                    Annotated<CompletionResponse>,
+                >::from_client(client, Default::default())
+                .await?;
                 let engine = Arc::new(push_router);
                 self.manager
                     .add_completions_model(&model_entry.name, engine)?;

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -33,7 +33,9 @@ use crate::protocols::openai::{
 };
 use crate::request_template::RequestTemplate;
 use crate::types::{
-    openai::{chat_completions::NvCreateChatCompletionRequest, completions::CompletionRequest},
+    openai::{
+        chat_completions::NvCreateChatCompletionRequest, completions::NvCreateCompletionRequest,
+    },
     Annotated,
 };
 
@@ -120,7 +122,7 @@ impl From<HttpError> for ErrorResponse {
 #[tracing::instrument(skip_all)]
 async fn completions(
     State(state): State<Arc<service_v2::State>>,
-    Json(request): Json<CompletionRequest>,
+    Json(request): Json<NvCreateCompletionRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     // return a 503 if the service is not ready
     check_ready(&state)?;
@@ -137,7 +139,7 @@ async fn completions(
         ..request.inner
     };
 
-    let request = CompletionRequest {
+    let request = NvCreateCompletionRequest {
         inner,
         nvext: request.nvext,
     };

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -46,7 +46,7 @@ use crate::protocols::{
     common::{SamplingOptionsProvider, StopConditionsProvider},
     openai::{
         chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
-        completions::{CompletionRequest, CompletionResponse},
+        completions::{CompletionResponse, NvCreateCompletionRequest},
         nvext::NvExtProvider,
         DeltaGeneratorExt,
     },
@@ -341,7 +341,7 @@ impl
 #[async_trait]
 impl
     Operator<
-        SingleIn<CompletionRequest>,
+        SingleIn<NvCreateCompletionRequest>,
         ManyOut<Annotated<CompletionResponse>>,
         SingleIn<PreprocessedRequest>,
         ManyOut<Annotated<BackendOutput>>,
@@ -349,7 +349,7 @@ impl
 {
     async fn generate(
         &self,
-        request: SingleIn<CompletionRequest>,
+        request: SingleIn<NvCreateCompletionRequest>,
         next: Arc<
             dyn AsyncEngine<
                 SingleIn<PreprocessedRequest>,

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -18,7 +18,7 @@ use super::*;
 use minijinja::{context, value::Value};
 
 use crate::protocols::openai::{
-    chat_completions::NvCreateChatCompletionRequest, completions::CompletionRequest,
+    chat_completions::NvCreateChatCompletionRequest, completions::NvCreateCompletionRequest,
 };
 use tracing;
 
@@ -55,7 +55,7 @@ impl OAIChatLikeRequest for NvCreateChatCompletionRequest {
     }
 }
 
-impl OAIChatLikeRequest for CompletionRequest {
+impl OAIChatLikeRequest for NvCreateCompletionRequest {
     fn messages(&self) -> minijinja::value::Value {
         let message = async_openai::types::ChatCompletionRequestMessage::User(
             async_openai::types::ChatCompletionRequestUserMessage {

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -34,7 +34,7 @@ use super::{
 use dynamo_runtime::protocols::annotated::AnnotationsProvider;
 
 #[derive(Serialize, Deserialize, Validate, Debug, Clone)]
-pub struct CompletionRequest {
+pub struct NvCreateCompletionRequest {
     #[serde(flatten)]
     pub inner: async_openai::types::CreateCompletionRequest,
 
@@ -141,7 +141,7 @@ pub fn prompt_to_string(prompt: &async_openai::types::Prompt) -> String {
     }
 }
 
-impl NvExtProvider for CompletionRequest {
+impl NvExtProvider for NvCreateCompletionRequest {
     fn nvext(&self) -> Option<&NvExt> {
         self.nvext.as_ref()
     }
@@ -158,7 +158,7 @@ impl NvExtProvider for CompletionRequest {
     }
 }
 
-impl AnnotationsProvider for CompletionRequest {
+impl AnnotationsProvider for NvCreateCompletionRequest {
     fn annotations(&self) -> Option<Vec<String>> {
         self.nvext
             .as_ref()
@@ -174,7 +174,7 @@ impl AnnotationsProvider for CompletionRequest {
     }
 }
 
-impl OpenAISamplingOptionsProvider for CompletionRequest {
+impl OpenAISamplingOptionsProvider for NvCreateCompletionRequest {
     fn get_temperature(&self) -> Option<f32> {
         self.inner.temperature
     }
@@ -196,7 +196,7 @@ impl OpenAISamplingOptionsProvider for CompletionRequest {
     }
 }
 
-impl OpenAIStopConditionsProvider for CompletionRequest {
+impl OpenAIStopConditionsProvider for NvCreateCompletionRequest {
     fn get_max_tokens(&self) -> Option<u32> {
         self.inner.max_tokens
     }
@@ -255,10 +255,10 @@ impl ResponseFactory {
 }
 
 /// Implements TryFrom for converting an OpenAI's CompletionRequest to an Engine's CompletionRequest
-impl TryFrom<CompletionRequest> for common::CompletionRequest {
+impl TryFrom<NvCreateCompletionRequest> for common::CompletionRequest {
     type Error = anyhow::Error;
 
-    fn try_from(request: CompletionRequest) -> Result<Self, Self::Error> {
+    fn try_from(request: NvCreateCompletionRequest) -> Result<Self, Self::Error> {
         // openai_api_rs::v1::completion::CompletionRequest {
         // NA  pub model: String,
         //     pub prompt: String,

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{CompletionChoice, CompletionRequest, CompletionResponse};
+use super::{CompletionChoice, CompletionResponse, NvCreateCompletionRequest};
 use crate::protocols::common;
 use crate::protocols::openai::CompletionUsage;
 
-impl CompletionRequest {
+impl NvCreateCompletionRequest {
     // put this method on the request
     // inspect the request to extract options
     pub fn response_generator(&self) -> DeltaGenerator {

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -24,14 +24,15 @@ pub mod openai {
     pub mod completions {
         use super::*;
 
-        pub use protocols::openai::completions::{CompletionRequest, CompletionResponse};
+        pub use protocols::openai::completions::{CompletionResponse, NvCreateCompletionRequest};
 
         /// A [`UnaryEngine`] implementation for the OpenAI Completions API
-        pub type OpenAICompletionsUnaryEngine = UnaryEngine<CompletionRequest, CompletionResponse>;
+        pub type OpenAICompletionsUnaryEngine =
+            UnaryEngine<NvCreateCompletionRequest, CompletionResponse>;
 
         /// A [`ServerStreamingEngine`] implementation for the OpenAI Completions API
         pub type OpenAICompletionsStreamingEngine =
-            ServerStreamingEngine<CompletionRequest, Annotated<CompletionResponse>>;
+            ServerStreamingEngine<NvCreateCompletionRequest, Annotated<CompletionResponse>>;
     }
 
     pub mod chat_completions {

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -24,7 +24,7 @@ use dynamo_llm::http::service::{
 use dynamo_llm::protocols::{
     openai::{
         chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
-        completions::{CompletionRequest, CompletionResponse},
+        completions::{CompletionResponse, NvCreateCompletionRequest},
     },
     Annotated,
 };
@@ -101,12 +101,12 @@ impl
 }
 
 #[async_trait]
-impl AsyncEngine<SingleIn<CompletionRequest>, ManyOut<Annotated<CompletionResponse>>, Error>
+impl AsyncEngine<SingleIn<NvCreateCompletionRequest>, ManyOut<Annotated<CompletionResponse>>, Error>
     for AlwaysFailEngine
 {
     async fn generate(
         &self,
-        _request: SingleIn<CompletionRequest>,
+        _request: SingleIn<NvCreateCompletionRequest>,
     ) -> Result<ManyOut<Annotated<CompletionResponse>>, Error> {
         Err(HttpError {
             code: 401,

--- a/lib/llm/tests/openai_completions.rs
+++ b/lib/llm/tests/openai_completions.rs
@@ -14,12 +14,12 @@
 // limitations under the License.
 
 use async_openai::types::CreateCompletionRequestArgs;
-use dynamo_llm::protocols::openai::{self, completions::CompletionRequest};
+use dynamo_llm::protocols::openai::{self, completions::NvCreateCompletionRequest};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct CompletionSample {
-    request: CompletionRequest,
+    request: NvCreateCompletionRequest,
     description: String,
 }
 
@@ -36,7 +36,7 @@ impl CompletionSample {
 
         let inner = builder.build().unwrap();
 
-        let request = CompletionRequest { inner, nvext: None };
+        let request = NvCreateCompletionRequest { inner, nvext: None };
 
         Ok(Self {
             request,


### PR DESCRIPTION
#### Overview:

Renames CompletionRequest to NvCreateCompletionRequest.

This change is to be consistent with previous renaming attempts for protocols:

- [!284 - refactor: rename ChatCompletionRequest to NvCreateChatCompletionRequest](https://github.com/triton-inference-server/triton_distributed/pull/284)
- [!291 - refactor: rename ChatCompletionResponse to NvCreateChatCompletionResponse](https://github.com/triton-inference-server/triton_distributed/pull/291)
- [!292 - refactor: rename ChatCompletionResponseDelta to NvCreateChatCompletionStreamResponse](https://github.com/triton-inference-server/triton_distributed/pull/292)
- [!296 - refactor: removes wrapper for ChatCompletionContent and adds documentation](https://github.com/triton-inference-server/triton_distributed/pull/296)
- [!310 - refactor: use async-openai CompletionRequest](https://github.com/triton-inference-server/triton_distributed/pull/310)

#### Details:

Renames CompletionRequest to NvCreateCompletionRequest.

#### Where should the reviewer start?

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the OpenAI completions request type from `CompletionRequest` to `NvCreateCompletionRequest` throughout the application and tests.
  - Updated all relevant interfaces, endpoints, and internal processing to use the new request type for completions.
- **Tests**
  - Adjusted test cases to align with the new request type, ensuring continued test coverage and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->