### PR TITLE
fix: mismatch GAP and PA version

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -10,7 +10,6 @@ ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
-ARG GENAI_PERF_VERSION=0.0.13
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
 #   ARCH: Used for package suffixes (e.g., amd64, arm64)
@@ -363,11 +362,6 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/nvidia/nvda_nixl/lib/x86_64-linux-gnu/
 ########## Development Image ###########
 ########################################
 FROM ci_minimum AS dev
-
-ARG GENAI_PERF_VERSION
-
-# Install genai-perf for benchmarking
-RUN uv pip install genai-perf==$GENAI_PERF_VERSION
 
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -16,7 +16,6 @@
 ARG BASE_IMAGE="nvcr.io/nvidia/pytorch"
 ARG BASE_IMAGE_TAG="25.04-py3"
 ARG RELEASE_BUILD
-ARG GENAI_PERF_VERSION=0.0.13
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
 #   ARCH: Used for package suffixes (e.g., amd64, arm64)
@@ -162,11 +161,6 @@ RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
          --extra-index-url https://pypi.org/simple \
          "${TENSORRTLLM_PIP_WHEEL}" ; \
     fi
-
-ARG GENAI_PERF_VERSION
-
-# Install genai-perf for benchmarking
-RUN pip install genai-perf==$GENAI_PERF_VERSION
 
 # Install test dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -10,7 +10,6 @@ ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
-ARG GENAI_PERF_VERSION=0.0.13
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
 #   ARCH: Used for package suffixes (e.g., amd64, arm64)
@@ -454,11 +453,6 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/nvidia/nvda_nixl/lib/x86_64-linux-gnu/
 ########## Development Image ###########
 ########################################
 FROM ci_minimum AS dev
-
-ARG GENAI_PERF_VERSION
-
-# Install genai-perf for benchmarking
-RUN uv pip install genai-perf==$GENAI_PERF_VERSION
 
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -16,6 +16,7 @@
 accelerate==1.6.0
 fastapi==0.115.6
 ftfy
+genai-perf==0.0.13
 grpcio-tools==1.66.0
 httpx
 kubernetes==32.0.1
@@ -36,6 +37,5 @@ sentencepiece
 tensorboard==2.19.0
 tensorboardX==2.6.2.2
 transformers
-tritonclient==2.53.0
 types-PyYAML
 uvicorn


### PR DESCRIPTION
Install tritonclient as dependency of GAP in requirements.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management by adding `genai-perf` and removing `tritonclient` from the requirements list.
  - Streamlined Docker build process by removing related build arguments and installation steps for `genai-perf` from multiple Dockerfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->