### PR TITLE
fix: remove unused arg in planner

### DIFF
--- a/examples/llm/components/planner_service.py
+++ b/examples/llm/components/planner_service.py
@@ -57,9 +57,6 @@ class Planner:
         self.args = argparse.Namespace(
             namespace=self.namespace,
             environment=config_instance.get("environment", PlannerDefaults.environment),
-            served_model_name=config_instance.get(
-                "served-model-name", PlannerDefaults.served_model_name
-            ),
             no_operation=config_instance.get(
                 "no-operation", PlannerDefaults.no_operation
             ),


### PR DESCRIPTION
removed unused arg in planner after https://github.com/ai-dynamo/dynamo/pull/1377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the unused configuration option for specifying the served model name in the planner service setup. This change does not affect user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->