### PR TITLE
fix: enable block manager feature only for py3.12 build

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -393,7 +393,7 @@ RUN uv build --wheel --out-dir /workspace/dist && \
     uv pip install maturin[patchelf] && \
     maturin build --release --features block-manager --out /workspace/dist && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
-        # do not enable KVBM feature, ensure compatibility with lower glibc (libnixl)
+        # do not enable KVBM feature, ensure compatibility with lower glibc
         uv run --python 3.11 maturin build --release --out /workspace/dist && \
         uv run --python 3.10 maturin build --release --out /workspace/dist; \
     fi

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -393,8 +393,9 @@ RUN uv build --wheel --out-dir /workspace/dist && \
     uv pip install maturin[patchelf] && \
     maturin build --release --features block-manager --out /workspace/dist && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
-        uv run --python 3.11 maturin build --release --features block-manager --out /workspace/dist && \
-        uv run --python 3.10 maturin build --release --features block-manager --out /workspace/dist; \
+        # do not enable KVBM feature, ensure compatibility with lower glibc (libnixl)
+        uv run --python 3.11 maturin build --release --out /workspace/dist && \
+        uv run --python 3.10 maturin build --release --out /workspace/dist; \
     fi
 
 #######################################


### PR DESCRIPTION
#### Overview:

Adding KV manger bindings to runtime wheels forces python to package libnixl and few other libs to the wheel and since dynamo builds nixl on ubuntu 24, the same glibc is required to run runtime wheel now. 

Enable block manager feature only for py3.12 build, default version for ubuntu24.

related to: DYN-433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Docker image build process to disable the Key-Value Block Manager feature for improved compatibility with older systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->