### PR TITLE
chore: update support matrix with kvbm changes

### DIFF
--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -28,9 +28,9 @@ This document provides the support matrix for Dynamo, including hardware, softwa
 | **x86_64**            | Supported     |
 | **ARM64**             | Experimental  |
 
-```{note}
-While **x86_64** architecture is supported on systems with a minimum of 32 GB RAM and at least 4 CPU cores, the **ARM64** support is experimental and may have limitations.
-```
+> **Note**:
+> While **x86_64** architecture is supported on systems with a minimum of 32 GB RAM and at least 4 CPU cores, the **ARM64** support is experimental and may have limitations.
+
 
 ### GPU Compatibility
 
@@ -54,9 +54,12 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Ubuntu**           | 24.04       | ARM64            | Experimental |
 | **CentOS Stream**    | 9           | x86_64           | Experimental |
 
-```{note}
-For **Linux**, the **ARM64** support is experimental and may have limitations. Wheels are built using a manylinux_2_28-compatible environment and they have been validated on CentOS 9 and Ubuntu (22.04, 24.04). Compatibility with other Linux distributions is expected but has not been officially verified yet.
-```
+> **Note**:
+> - For **Linux**, the **ARM64** support is experimental and may have limitations. Wheels are built using a manylinux_2_28-compatible environment and they have been validated on CentOS 9 and Ubuntu (22.04, 24.04). Compatibility with other Linux distributions is expected but has not been officially verified yet.
+
+> - **Known Issues**: KV Block Manager is supported only with Python 3.12. Python 3.12 support is currently limited to Ubuntu 24.04.
+
+
 
 ## Software Compatibility
 ### Runtime Dependency

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -56,7 +56,6 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 
 > **Note**:
 > - For **Linux**, the **ARM64** support is experimental and may have limitations. Wheels are built using a manylinux_2_28-compatible environment and they have been validated on CentOS 9 and Ubuntu (22.04, 24.04). Compatibility with other Linux distributions is expected but has not been officially verified yet.
-
 > - **Known Issues**: KV Block Manager is supported only with Python 3.12. Python 3.12 support is currently limited to Ubuntu 24.04.
 
 

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -28,9 +28,9 @@ This document provides the support matrix for Dynamo, including hardware, softwa
 | **x86_64**            | Supported     |
 | **ARM64**             | Experimental  |
 
-> **Note**:
-> While **x86_64** architecture is supported on systems with a minimum of 32 GB RAM and at least 4 CPU cores, the **ARM64** support is experimental and may have limitations.
-
+```{note}
+While **x86_64** architecture is supported on systems with a minimum of 32 GB RAM and at least 4 CPU cores, the **ARM64** support is experimental and may have limitations.
+```
 
 ### GPU Compatibility
 
@@ -54,10 +54,11 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Ubuntu**           | 24.04       | ARM64            | Experimental |
 | **CentOS Stream**    | 9           | x86_64           | Experimental |
 
-> **Note**:
-> - For **Linux**, the **ARM64** support is experimental and may have limitations. Wheels are built using a manylinux_2_28-compatible environment and they have been validated on CentOS 9 and Ubuntu (22.04, 24.04). Compatibility with other Linux distributions is expected but has not been officially verified yet.
-> - **Known Issues**: KV Block Manager is supported only with Python 3.12. Python 3.12 support is currently limited to Ubuntu 24.04.
+```{note}
+For **Linux**, the **ARM64** support is experimental and may have limitations. Wheels are built using a manylinux_2_28-compatible environment and they have been validated on CentOS 9 and Ubuntu (22.04, 24.04). Compatibility with other Linux distributions is expected but has not been officially verified yet.
 
+**Known Issues**: KV Block Manager is supported only with Python 3.12. Python 3.12 support is currently limited to Ubuntu 24.04.
+```
 
 
 ## Software Compatibility
@@ -77,10 +78,11 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **TensorRT-LLM**     |    0.19.0** |
 | **NIXL**             |    0.3.0    |
 
-> **Note**:
-> - *ai-dynamo-vllm v0.8.4.post2 is a customized patch of v0.8.4 from vLLM.
-> - **Specific versions of TensorRT-LLM supported by Dynamo are subject to change.
+```{note}
+*ai-dynamo-vllm v0.8.4.post2 is a customized patch of v0.8.4 from vLLM.
 
+**Specific versions of TensorRT-LLM supported by Dynamo are subject to change.
+```
 
 ## Build Support
 **Dynamo** currently provides build support in the following ways:

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -60,7 +60,6 @@ For **Linux**, the **ARM64** support is experimental and may have limitations. W
 **Known Issues**: KV Block Manager is supported only with Python 3.12. Python 3.12 support is currently limited to Ubuntu 24.04.
 ```
 
-
 ## Software Compatibility
 ### Runtime Dependency
 | **Python Package** | **Version**   | glibc version        | CUDA Version |


### PR DESCRIPTION
#### Overview:

 update support matrix with kvbm changes in #1393 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the support matrix notes to use a clearer blockquote format.
  - Expanded notes to specify that the KV Block Manager is only supported with Python 3.12, which is currently limited to Ubuntu 24.04.
  - Reformatted notes on ai-dynamo-vllm and TensorRT-LLM versions for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->