### PR TITLE
docs: Reference Deepseek R1 configs in TRTLLM README

### DIFF
--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -130,8 +130,8 @@ For example, to deploy Deepseek R1, you could replace the referenced example
 configs (`configs/agg.yaml`, `configs/disagg.yaml`) with corresponding Deepseek R1
 example configs (`configs/deepseek_r1/agg.yaml`, `configs/deepseek_r1/disagg.yaml`).
 You can find the example Deepseek R1 configs for GB200
-[here](configs/deepseek_r1), but the parallelism settings in the configs can be
-customized for other hardware configurations.
+[here](configs/deepseek_r1), but the config settings can be customized for testing
+other hardware configurations or parallelism strategies.
 
 ##### Head Node
 

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -126,6 +126,13 @@ deploy a single Decode worker on one node, and a single Prefill worker on the ot
 However, the instance counts, TP sizes, other configs, and responsibilities of each node
 can be customized and deployed in similar ways.
 
+For example, to deploy Deepseek R1, you could replace the referenced example
+configs (`configs/agg.yaml`, `configs/disagg.yaml`) with corresponding Deepseek R1
+example configs (`configs/deepseek_r1/agg.yaml`, `configs/deepseek_r1/disagg.yaml`).
+You can find the example Deepseek R1 configs for GB200
+[here](configs/deepseek_r1), but the parallelism settings in the configs can be
+customized for other hardware configurations.
+
 ##### Head Node
 
 Start nats/etcd:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Add explicit reference to Deepseek R1 configs for discoverability. Note these are just example configs for a particular configuration on GB200. They can be customized as needed for different parallelism strategies and hardware configurations, such as 8xH200 nodes.

Currently, these configs assume that each worker can fit on a single node (4xGB200, 8xH200, etc.), but support and steps for serving a single worker instance on multiple nodes (ex: 16xH100) will come in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to include an example for multi-node deployment.
  - Added instructions for deploying Deepseek R1 by using specific configuration files.
  - Provided a link to example configs for GB200 hardware and clarified customization options for other hardware or parallelism strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->