### PR TITLE
fix: Fix planner dependency import when running dynamo CLI

### DIFF
--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -15,6 +15,8 @@
 
 accelerate==1.6.0
 fastapi==0.115.6
+# filelock: used by planner
+filelock
 ftfy
 genai-perf==0.0.13
 grpcio-tools==1.66.0

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -15,8 +15,6 @@
 
 accelerate==1.6.0
 fastapi==0.115.6
-# filelock: used by planner
-filelock
 ftfy
 genai-perf==0.0.13
 grpcio-tools==1.66.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "ai-dynamo-runtime==0.3.0",
     "fastapi==0.115.6",
     "distro",
+    # filelock: required by planner
+    "filelock",
     "typer",
     "circus==0.19.0",
     "click<8.2.0",


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Repro:
```bash
uv venv --python 3.10
source .venv/bin/activate

uv pip install ai-dynamo==0.3.0
dynamo -v 
```

Error:
```
Traceback (most recent call last):
  File "/tmp/tmp.k4rBIxFJW6/.venv/bin/dynamo", line 4, in <module>
    from dynamo.sdk.cli.cli import cli
  File "/tmp/tmp.k4rBIxFJW6/.venv/lib/python3.10/site-packages/dynamo/sdk/cli/cli.py", line 26, in <module>
    from dynamo.sdk.cli.deployment import app as deployment_app
  File "/tmp/tmp.k4rBIxFJW6/.venv/lib/python3.10/site-packages/dynamo/sdk/cli/deployment.py", line 27, in <module>
    from dynamo.sdk.cli.utils import resolve_service_config
  File "/tmp/tmp.k4rBIxFJW6/.venv/lib/python3.10/site-packages/dynamo/sdk/cli/utils.py", line 34, in <module>
    from dynamo.planner.defaults import PlannerDefaults  # type: ignore[attr-defined]
  File "/tmp/tmp.k4rBIxFJW6/.venv/lib/python3.10/site-packages/dynamo/planner/__init__.py", line 28, in <module>
    from dynamo.planner.local_connector import LocalConnector
  File "/tmp/tmp.k4rBIxFJW6/.venv/lib/python3.10/site-packages/dynamo/planner/local_connector.py", line 23, in <module>
    import filelock
ModuleNotFoundError: No module named 'filelock'
```

Fix:
- Add `filelock` to pip install dependencies (outside container)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependencies to include the "filelock" package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->