### PR TITLE
test: Add dynamo serve TRTLLM example to pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,12 +33,15 @@ logging.basicConfig(
 
 
 def pytest_collection_modifyitems(config, items):
-    # Handle tests marked with tensorrtllm
-    if config.getoption("-m") and "tensorrtllm" in config.getoption("-m"):
-        # User explicitly asked for tensorrtllm tests, do nothing
-        return
+    """
+    This function is called to modify the list of tests to run.
+    It is used to skip tests that are not supported on all environments.
+    """
 
-    # Otherwise, skip all tests marked with tensorrtllm
+    # Tests marked with tensorrtllm requires specific environment with tensorrtllm
+    # installed. Hence, we skip them if the user did not explicitly ask for them.
+    if config.getoption("-m") and "tensorrtllm" in config.getoption("-m"):
+        return
     skip_tensorrtllm = pytest.mark.skip(reason="need -m tensorrtllm to run")
     for item in items:
         if "tensorrtllm" in item.keywords:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,19 @@ logging.basicConfig(
 )
 
 
+def pytest_collection_modifyitems(config, items):
+    # Handle tests marked with tensorrtllm
+    if config.getoption("-m") and "tensorrtllm" in config.getoption("-m"):
+        # User explicitly asked for tensorrtllm tests, do nothing
+        return
+
+    # Otherwise, skip all tests marked with tensorrtllm
+    skip_tensorrtllm = pytest.mark.skip(reason="need -m tensorrtllm to run")
+    for item in items:
+        if "tensorrtllm" in item.keywords:
+            item.add_marker(skip_tensorrtllm)
+
+
 class EtcdServer(ManagedProcess):
     def __init__(self, request, port=2379, timeout=300):
         port_string = str(port)

--- a/tests/serve/test_dynamo_serve.py
+++ b/tests/serve/test_dynamo_serve.py
@@ -24,8 +24,8 @@ import requests
 from tests.utils.deployment_graph import (
     DeploymentGraph,
     Payload,
-    completions_response_handler,
     chat_completions_response_handler,
+    completions_response_handler,
 )
 from tests.utils.managed_process import ManagedProcess
 
@@ -88,7 +88,10 @@ deployment_graphs = {
             config="configs/agg.yaml",
             directory="/workspace/examples/llm",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_1, pytest.mark.vllm],
         ),
         text_payload,
@@ -99,7 +102,10 @@ deployment_graphs = {
             config="configs/agg.yaml",
             directory="/workspace/examples/sglang",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_1, pytest.mark.sglang],
         ),
         text_payload,
@@ -110,7 +116,10 @@ deployment_graphs = {
             config="configs/disagg.yaml",
             directory="/workspace/examples/llm",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_2, pytest.mark.vllm],
         ),
         text_payload,
@@ -121,7 +130,10 @@ deployment_graphs = {
             config="configs/agg_router.yaml",
             directory="/workspace/examples/llm",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_1, pytest.mark.vllm],
         ),
         text_payload,
@@ -132,7 +144,10 @@ deployment_graphs = {
             config="configs/disagg_router.yaml",
             directory="/workspace/examples/llm",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_2, pytest.mark.vllm],
         ),
         text_payload,
@@ -143,7 +158,10 @@ deployment_graphs = {
             config="configs/agg.yaml",
             directory="/workspace/examples/multimodal",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_2, pytest.mark.vllm],
         ),
         multimodal_payload,
@@ -154,7 +172,10 @@ deployment_graphs = {
             config="configs/agg.yaml",
             directory="/workspace/examples/vllm_v1",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_1, pytest.mark.vllm],
         ),
         text_payload,
@@ -165,7 +186,10 @@ deployment_graphs = {
             config="configs/agg.yaml",
             directory="/workspace/examples/tensorrt_llm",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_1, pytest.mark.tensorrtllm],
         ),
         text_payload,
@@ -176,7 +200,10 @@ deployment_graphs = {
             config="configs/agg_router.yaml",
             directory="/workspace/examples/tensorrt_llm",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_1, pytest.mark.tensorrtllm],
             # FIXME: This is a hack to allow deployments to start before sending any requests.
             # When using KV-router, if all the endpoints are not registered, the service
@@ -191,7 +218,10 @@ deployment_graphs = {
             config="configs/disagg.yaml",
             directory="/workspace/examples/tensorrt_llm",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_2, pytest.mark.tensorrtllm],
         ),
         text_payload,
@@ -202,7 +232,10 @@ deployment_graphs = {
             config="configs/disagg_router.yaml",
             directory="/workspace/examples/tensorrt_llm",
             endpoints=["v1/chat/completions", "v1/completions"],
-            response_handlers=[chat_completions_response_handler, completions_response_handler],
+            response_handlers=[
+                chat_completions_response_handler,
+                completions_response_handler,
+            ],
             marks=[pytest.mark.gpu_2, pytest.mark.tensorrtllm],
             # FIXME: This is a hack to allow deployments to start before sending any requests.
             # When using KV-router, if all the endpoints are not registered, the service
@@ -301,17 +334,27 @@ def test_serve_deployment(deployment_graph_test, request, runtime_services):
         assert content, "Empty response content"
         for expected in payload.expected_response:
             assert expected in content, "Expected '%s' not found in response" % expected
+
     with DynamoServeProcess(deployment_graph, request) as server_process:
         first_success_pending = True
-        for endpoint, response_handler in zip(deployment_graph.endpoints, deployment_graph.response_handlers):
+        for endpoint, response_handler in zip(
+            deployment_graph.endpoints, deployment_graph.response_handlers
+        ):
             url = f"http://localhost:{server_process.port}/{endpoint}"
             start_time = time.time()
             retry_delay = 5
             elapsed = 0.0
-            request_body = payload.payload_chat if endpoint == "v1/chat/completions" else payload.payload_completions
+            request_body = (
+                payload.payload_chat
+                if endpoint == "v1/chat/completions"
+                else payload.payload_completions
+            )
 
-            # We can skip this 
-            while time.time() - start_time < deployment_graph.timeout and first_success_pending:
+            # We can skip this
+            while (
+                time.time() - start_time < deployment_graph.timeout
+                and first_success_pending
+            ):
                 elapsed = time.time() - start_time
                 try:
                     response = requests.post(

--- a/tests/serve/test_dynamo_serve.py
+++ b/tests/serve/test_dynamo_serve.py
@@ -168,7 +168,9 @@ deployment_graphs = {
             endpoint="v1/chat/completions",
             response_handler=completions_response_handler,
             marks=[pytest.mark.gpu_1, pytest.mark.tensorrtllm],
-            # The agg_router can not handle the request immediately, so we delay the start.
+            # FIXME: This is a hack to allow deployments to start before sending any requests.
+            # When using KV-router, if all the endpoints are not registered, the service
+            # enters a non-recoverable state.
             delayed_start=60,
         ),
         text_payload,
@@ -192,7 +194,9 @@ deployment_graphs = {
             endpoint="v1/chat/completions",
             response_handler=completions_response_handler,
             marks=[pytest.mark.gpu_2, pytest.mark.tensorrtllm],
-            # The disagg_router can not handle the request immediately, so we delay the start.
+            # FIXME: This is a hack to allow deployments to start before sending any requests.
+            # When using KV-router, if all the endpoints are not registered, the service
+            # enters a non-recoverable state.
             delayed_start=120,
         ),
         text_payload,

--- a/tests/serve/test_dynamo_serve.py
+++ b/tests/serve/test_dynamo_serve.py
@@ -25,13 +25,14 @@ from tests.utils.deployment_graph import (
     DeploymentGraph,
     Payload,
     completions_response_handler,
+    chat_completions_response_handler,
 )
 from tests.utils.managed_process import ManagedProcess
 
 text_prompt = "Tell me a short joke about AI."
 
 multimodal_payload = Payload(
-    payload={
+    payload_chat={
         "model": "llava-hf/llava-1.5-7b-hf",
         "messages": [
             {
@@ -50,12 +51,13 @@ multimodal_payload = Payload(
         "max_tokens": 300,  # Reduced from 500
         "stream": False,
     },
+    repeat_count=1,
     expected_log=[],
     expected_response=["bus"],
 )
 
 text_payload = Payload(
-    payload={
+    payload_chat={
         "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
         "messages": [
             {
@@ -67,6 +69,14 @@ text_payload = Payload(
         "temperature": 0.1,
         "seed": 0,
     },
+    payload_completions={
+        "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+        "prompt": text_prompt,
+        "max_tokens": 150,
+        "temperature": 0.1,
+        "seed": 0,
+    },
+    repeat_count=10,
     expected_log=[],
     expected_response=["AI"],
 )
@@ -77,8 +87,8 @@ deployment_graphs = {
             module="graphs.agg:Frontend",
             config="configs/agg.yaml",
             directory="/workspace/examples/llm",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_1, pytest.mark.vllm],
         ),
         text_payload,
@@ -88,8 +98,8 @@ deployment_graphs = {
             module="graphs.agg:Frontend",
             config="configs/agg.yaml",
             directory="/workspace/examples/sglang",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_1, pytest.mark.sglang],
         ),
         text_payload,
@@ -99,8 +109,8 @@ deployment_graphs = {
             module="graphs.disagg:Frontend",
             config="configs/disagg.yaml",
             directory="/workspace/examples/llm",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_2, pytest.mark.vllm],
         ),
         text_payload,
@@ -110,8 +120,8 @@ deployment_graphs = {
             module="graphs.agg_router:Frontend",
             config="configs/agg_router.yaml",
             directory="/workspace/examples/llm",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_1, pytest.mark.vllm],
         ),
         text_payload,
@@ -121,8 +131,8 @@ deployment_graphs = {
             module="graphs.disagg_router:Frontend",
             config="configs/disagg_router.yaml",
             directory="/workspace/examples/llm",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_2, pytest.mark.vllm],
         ),
         text_payload,
@@ -132,8 +142,8 @@ deployment_graphs = {
             module="graphs.agg:Frontend",
             config="configs/agg.yaml",
             directory="/workspace/examples/multimodal",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_2, pytest.mark.vllm],
         ),
         multimodal_payload,
@@ -143,8 +153,8 @@ deployment_graphs = {
             module="graphs.agg:Frontend",
             config="configs/agg.yaml",
             directory="/workspace/examples/vllm_v1",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_1, pytest.mark.vllm],
         ),
         text_payload,
@@ -154,8 +164,8 @@ deployment_graphs = {
             module="graphs.agg:Frontend",
             config="configs/agg.yaml",
             directory="/workspace/examples/tensorrt_llm",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_1, pytest.mark.tensorrtllm],
         ),
         text_payload,
@@ -165,8 +175,8 @@ deployment_graphs = {
             module="graphs.agg_router:Frontend",
             config="configs/agg_router.yaml",
             directory="/workspace/examples/tensorrt_llm",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_1, pytest.mark.tensorrtllm],
             # FIXME: This is a hack to allow deployments to start before sending any requests.
             # When using KV-router, if all the endpoints are not registered, the service
@@ -180,8 +190,8 @@ deployment_graphs = {
             module="graphs.disagg:Frontend",
             config="configs/disagg.yaml",
             directory="/workspace/examples/tensorrt_llm",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_2, pytest.mark.tensorrtllm],
         ),
         text_payload,
@@ -191,8 +201,8 @@ deployment_graphs = {
             module="graphs.disagg_router:Frontend",
             config="configs/disagg_router.yaml",
             directory="/workspace/examples/tensorrt_llm",
-            endpoint="v1/chat/completions",
-            response_handler=completions_response_handler,
+            endpoints=["v1/chat/completions", "v1/completions"],
+            response_handlers=[chat_completions_response_handler, completions_response_handler],
             marks=[pytest.mark.gpu_2, pytest.mark.tensorrtllm],
             # FIXME: This is a hack to allow deployments to start before sending any requests.
             # When using KV-router, if all the endpoints are not registered, the service
@@ -283,75 +293,79 @@ def test_serve_deployment(deployment_graph_test, request, runtime_services):
 
     deployment_graph, payload = deployment_graph_test
 
-    def check_response(response):
+    def check_response(response, response_handler):
         assert response.status_code == 200, "Server is not healthy"
-        content = deployment_graph.response_handler(response)
+        content = response_handler(response)
         logger.info("Received Content: %s", content)
         # Check for expected responses
         assert content, "Empty response content"
         for expected in payload.expected_response:
             assert expected in content, "Expected '%s' not found in response" % expected
-
     with DynamoServeProcess(deployment_graph, request) as server_process:
-        url = f"http://localhost:{server_process.port}/{deployment_graph.endpoint}"
-        start_time = time.time()
-        retry_delay = 5
-        elapsed = 0.0
-        while time.time() - start_time < deployment_graph.timeout:
-            elapsed = time.time() - start_time
-            try:
+        first_success_pending = True
+        for endpoint, response_handler in zip(deployment_graph.endpoints, deployment_graph.response_handlers):
+            url = f"http://localhost:{server_process.port}/{endpoint}"
+            start_time = time.time()
+            retry_delay = 5
+            elapsed = 0.0
+            request_body = payload.payload_chat if endpoint == "v1/chat/completions" else payload.payload_completions
+
+            # We can skip this 
+            while time.time() - start_time < deployment_graph.timeout and first_success_pending:
+                elapsed = time.time() - start_time
+                try:
+                    response = requests.post(
+                        url,
+                        json=request_body,
+                        timeout=deployment_graph.timeout - elapsed,
+                    )
+                except (requests.RequestException, requests.Timeout) as e:
+                    logger.warning("Retrying due to Request failed: %s", e)
+                    time.sleep(retry_delay)
+                    continue
+                logger.info("Response%r", response)
+                if response.status_code == 500:
+                    error = response.json().get("error", "")
+                    if "no instances" in error:
+                        logger.warning("Retrying due to no instances available")
+                        time.sleep(retry_delay)
+                        continue
+                if response.status_code == 404:
+                    error = response.json().get("error", "")
+                    if "Model not found" in error:
+                        logger.warning("Retrying due to model not found")
+                        time.sleep(retry_delay)
+                        continue
+                # Process the response
+                if response.status_code != 200:
+                    logger.error(
+                        "Service returned status code %s: %s",
+                        response.status_code,
+                        response.text,
+                    )
+                    pytest.fail(
+                        "Service returned status code %s: %s"
+                        % (response.status_code, response.text)
+                    )
+                else:
+                    check_response(response, response_handler)
+                    first_success_pending = False
+                    break
+            else:
+                if first_success_pending:
+                    logger.error(
+                        "Service did not return a successful response within %s s",
+                        deployment_graph.timeout,
+                    )
+                    pytest.fail(
+                        "Service did not return a successful response within %s s"
+                        % deployment_graph.timeout
+                    )
+
+            for _ in range(payload.repeat_count):
                 response = requests.post(
                     url,
-                    json=payload.payload,
+                    json=request_body,
                     timeout=deployment_graph.timeout - elapsed,
                 )
-            except (requests.RequestException, requests.Timeout) as e:
-                logger.warning("Retrying due to Request failed: %s", e)
-                time.sleep(retry_delay)
-                continue
-            logger.info("Response%r", response)
-            if response.status_code == 500:
-                error = response.json().get("error", "")
-                if "no instances" in error:
-                    logger.warning("Retrying due to no instances available")
-                    time.sleep(retry_delay)
-                    continue
-            if response.status_code == 404:
-                error = response.json().get("error", "")
-                if "Model not found" in error:
-                    logger.warning("Retrying due to model not found")
-                    time.sleep(retry_delay)
-                    continue
-            # Process the response
-            if response.status_code != 200:
-                logger.error(
-                    "Service returned status code %s: %s",
-                    response.status_code,
-                    response.text,
-                )
-                pytest.fail(
-                    "Service returned status code %s: %s"
-                    % (response.status_code, response.text)
-                )
-            else:
-                break
-        else:
-            logger.error(
-                "Service did not return a successful response within %s s",
-                deployment_graph.timeout,
-            )
-            pytest.fail(
-                "Service did not return a successful response within %s s"
-                % deployment_graph.timeout
-            )
-
-        check_response(response)
-
-        # Run one more request to check the server is still healthy
-        # Router mode activates after the first request
-        response = requests.post(
-            url,
-            json=payload.payload,
-            timeout=deployment_graph.timeout - elapsed,
-        )
-        check_response(response)
+                check_response(response, response_handler)

--- a/tests/utils/deployment_graph.py
+++ b/tests/utils/deployment_graph.py
@@ -59,6 +59,7 @@ def chat_completions_response_handler(response):
     assert "content" in result["choices"][0]["message"], "Missing 'content' in message"
     return result["choices"][0]["message"]["content"]
 
+
 def completions_response_handler(response):
     """
     Process completions API responses.

--- a/tests/utils/deployment_graph.py
+++ b/tests/utils/deployment_graph.py
@@ -26,8 +26,8 @@ class DeploymentGraph:
     module: str
     config: str
     directory: str
-    endpoint: str
-    response_handler: Callable[[Any], str]
+    endpoints: List[str]
+    response_handlers: List[Callable[[Any], str]]
     timeout: int = 900
     delayed_start: int = 0
     marks: Optional[List[Any]] = field(default_factory=list)
@@ -39,12 +39,14 @@ class Payload:
     Represents a test payload with expected response and log patterns.
     """
 
-    payload: Dict[str, Any]
+    payload_chat: Dict[str, Any]
     expected_response: List[str]
     expected_log: List[str]
+    repeat_count: int = 1
+    payload_completions: Optional[Dict[str, Any]] = None
 
 
-def completions_response_handler(response):
+def chat_completions_response_handler(response):
     """
     Process chat completions API responses.
     """
@@ -56,3 +58,15 @@ def completions_response_handler(response):
     assert "message" in result["choices"][0], "Missing 'message' in first choice"
     assert "content" in result["choices"][0]["message"], "Missing 'content' in message"
     return result["choices"][0]["message"]["content"]
+
+def completions_response_handler(response):
+    """
+    Process completions API responses.
+    """
+    if response.status_code != 200:
+        return ""
+    result = response.json()
+    assert "choices" in result, "Missing 'choices' in response"
+    assert len(result["choices"]) > 0, "Empty choices in response"
+    assert "text" in result["choices"][0], "Missing 'text' in first choice"
+    return result["choices"][0]["text"]

--- a/tests/utils/deployment_graph.py
+++ b/tests/utils/deployment_graph.py
@@ -29,6 +29,7 @@ class DeploymentGraph:
     endpoint: str
     response_handler: Callable[[Any], str]
     timeout: int = 900
+    delayed_start: int = 0
     marks: Optional[List[Any]] = field(default_factory=list)
 
 

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -60,7 +60,6 @@ class ManagedProcess:
 
             self._terminate_existing()
             self._start_process()
-            print(f"delaying start: {self.delayed_start}")
             time.sleep(self.delayed_start)
             elapsed = self._check_ports(self.timeout)
             self._check_urls(self.timeout - elapsed)

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -32,6 +32,7 @@ class ManagedProcess:
     env: Optional[dict] = None
     health_check_ports: List[int] = field(default_factory=list)
     health_check_urls: List[Any] = field(default_factory=list)
+    delayed_start: int = 0
     timeout: int = 300
     working_dir: Optional[str] = None
     display_output: bool = False
@@ -59,6 +60,8 @@ class ManagedProcess:
 
             self._terminate_existing()
             self._start_process()
+            print(f"delaying start: {self.delayed_start}")
+            time.sleep(self.delayed_start)
             elapsed = self._check_ports(self.timeout)
             self._check_urls(self.timeout - elapsed)
 


### PR DESCRIPTION
#### Overview:
Updates pytest to test tensorrt_llm examples. 

As next step, would add the test to be run on gitlab CI.

Important note: will run TensorRT-LLM specific tests only when tensorrtllm marker is specified. 

#### Details:

Within Dynamo + TensorRT-LLM container on current main: 

>  pytest -v -m tensorrtllm --ignore=benchmarks/data_generator/tests/ --ignore=lib/bindings/python/tests/
> =================================== test session starts ===================================
> platform linux -- Python 3.12.3, pytest-8.4.0, pluggy-1.5.0 -- /usr/bin/python
> cachedir: .pytest_cache
> benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
> hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/workspace/.hypothesis/examples'))
> rootdir: /workspace
> configfile: pyproject.toml
> plugins: cov-6.1.1, asyncio-1.0.0, mypy-1.0.1, md-report-0.7.0, timeout-2.4.0, benchmark-5.1.0, pytest_codeblocks-0.17.0, anyio-4.9.0, hypothesis-6.130.8, xdist-3.6.1, xdoctest-1.0.2, rerunfailures-15.0, shard-0.1.2, flakefinder-1.1.0, typeguard-4.3.0
> asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
> collected 222 items / 218 deselected / 4 selected                                         
> Running 4 items in this shard: tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_agg], tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_agg_router], tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_disagg], tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_disagg_router]
> 
> tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_agg] PASSED          [ 25%]
> tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_agg_router] PASSED   [ 50%]
> tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_disagg] PASSED       [ 75%]
> tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_disagg_router] PASSED [100%]
> 
> ====================== 4 passed, 218 deselected in 249.13s (0:04:09) ======================


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new deployment graph test configurations for TensorRT LLM variants, including support for delayed server start.
- **Tests**
  - Enhanced test coverage for serve deployments with additional TensorRT LLM scenarios and improved response validation.
  - Introduced configurable delay before health checks in managed test processes.
  - Adjusted test collection behavior so that TensorRT LLM tests are only run when explicitly requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->