### PR TITLE
docs: Add example etcd/nats commands to the container banner

### DIFF
--- a/container/launch_message.txt
+++ b/container/launch_message.txt
@@ -50,8 +50,14 @@ Try the following to begin interacting with a model:
 > dynamo --help
 > dynamo run Qwen/Qwen2.5-3B-Instruct
 
-For more complete deployment configurations, check out the examples folder.
-To run the examples instances of etcd and nats are needed from the host system.
+To run more complete deployment examples, instances of etcd and nats need to be
+accessible within the container. This is generally done by connecting to
+existing etcd/nats services from the host or other containers. For simple
+cases, you can start them in the container as well:
+> nats-server -js &
+> etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://0.0.0.0:2379 --data-dir /tmp/etcd &
+
+With etcd/nats accessible, run the examples:
 > cd examples/hello_world
 > dynamo serve hello_world:Frontend
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Adds etcd/nats commands to container banner.

**Context**: On clusters where I don't already have etcd/nats running and docker isn't easily accessible, I need to start them within the container. When doing so, I _always_ need to go look up the commands. Putting them in the banner makes it much more accessible for copy/paste.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded instructions for deployment examples to clarify requirements for etcd and nats accessibility inside the container.
  - Added explicit example commands for starting nats-server and etcd within the container for simple setups.
  - Improved guidance by replacing the previous brief note with detailed steps and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->