### PR TITLE
chore: install datagen in vllm image and CI

### DIFF
--- a/.github/workflows/pre-merge-python.yml
+++ b/.github/workflows/pre-merge-python.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           PYTEST_MARKS: "pre_merge or mypy"
         run: |
-          docker run -w /workspace --name ${{ env.CONTAINER_ID }}_pytest ${{ steps.define_image_tag.outputs.image_tag }} bash -c "pip install -e /workspace/benchmarks && pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m \"${{ env.PYTEST_MARKS }}\""
+          docker run -w /workspace --name ${{ env.CONTAINER_ID }}_pytest ${{ steps.define_image_tag.outputs.image_tag }} bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m \"${{ env.PYTEST_MARKS }}\""
       - name: Copy test report from test Container
         if: always()
         run: |

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -235,10 +235,6 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
     uv pip install --requirement /tmp/requirements.txt
 
-# Install benchmarks package
-RUN --mount=type=bind,source=./benchmarks,target=/tmp/benchmarks \
-    cd /tmp/benchmarks && uv pip install -e .
-
 # ### MISC UTILITY SETUP ###
 
 # Finish pyright install

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -235,6 +235,10 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
     uv pip install --requirement /tmp/requirements.txt
 
+# Install benchmarks package
+RUN --mount=type=bind,source=./benchmarks,target=/tmp/benchmarks \
+    cd /tmp/benchmarks && uv pip install -e .
+
 # ### MISC UTILITY SETUP ###
 
 # Finish pyright install
@@ -442,6 +446,9 @@ RUN uv pip install /workspace/dist/ai_dynamo_runtime*cp312*.whl && \
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \
     sed '/^#\s/d' /workspace/launch_message.txt > ~/.launch_screen && \
     echo "cat ~/.launch_screen" >> ~/.bashrc
+
+# Reinstall benchmarks to pick up any source changes for CI testing
+RUN cd /workspace/benchmarks && uv pip install -e .
 
 # Tell vllm to use the Dynamo LLM C API for KV Cache Routing
 ENV VLLM_KV_CAPI_PATH=/opt/dynamo/bindings/lib/libdynamo_llm_capi.so

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -235,6 +235,10 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
     uv pip install --requirement /tmp/requirements.txt
 
+# Install benchmarks package
+RUN --mount=type=bind,source=./benchmarks,target=/tmp/benchmarks \
+    cd /tmp/benchmarks && uv pip install .
+
 # ### MISC UTILITY SETUP ###
 
 # Finish pyright install
@@ -442,9 +446,6 @@ RUN uv pip install /workspace/dist/ai_dynamo_runtime*cp312*.whl && \
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \
     sed '/^#\s/d' /workspace/launch_message.txt > ~/.launch_screen && \
     echo "cat ~/.launch_screen" >> ~/.bashrc
-
-# Reinstall benchmarks to pick up any source changes for CI testing
-RUN cd /workspace/benchmarks && uv pip install -e .
 
 # Tell vllm to use the Dynamo LLM C API for KV Cache Routing
 ENV VLLM_KV_CAPI_PATH=/opt/dynamo/bindings/lib/libdynamo_llm_capi.so

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -236,8 +236,8 @@ RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/
     uv pip install --requirement /tmp/requirements.txt
 
 # Install benchmarks package
-RUN --mount=type=bind,source=./benchmarks,target=/tmp/benchmarks \
-    cd /tmp/benchmarks && uv pip install .
+COPY ./benchmarks /tmp/benchmarks
+RUN cd /tmp/benchmarks && uv pip install .
 
 # ### MISC UTILITY SETUP ###
 

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -235,10 +235,6 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
     uv pip install --requirement /tmp/requirements.txt
 
-# Install benchmarks package
-COPY ./benchmarks /tmp/benchmarks
-RUN cd /tmp/benchmarks && uv pip install .
-
 # ### MISC UTILITY SETUP ###
 
 # Finish pyright install
@@ -441,6 +437,8 @@ RUN mkdir -p /opt/dynamo/bindings/wheels && \
 
 RUN uv pip install /workspace/dist/ai_dynamo_runtime*cp312*.whl && \
     uv pip install /workspace/dist/ai_dynamo*any.whl
+
+RUN uv pip install /workspace/benchmarks
 
 # Copy launch banner
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \


### PR DESCRIPTION
#### Overview:

Addresses failing CI tests in #1087 and also make `datagen` on dynamo installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow and Dockerfile to streamline the installation process of the benchmarks package during testing and CI, improving efficiency without affecting user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->