### PR TITLE
[WIP] feat(eventpublisher): add event sink concept 

### DIFF
--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -148,7 +148,7 @@ fn dynamo_create_kv_publisher(
     {
         Ok(drt) => {
             let backend = drt.namespace(namespace)?.component(component)?;
-            KvEventPublisher::new(backend, worker_id, kv_block_size, None)
+            KvEventPublisher::new(backend, worker_id, kv_block_size, None, None)
         }
         Err(e) => Err(e),
     }

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -156,7 +156,7 @@ impl ZmqKvEventPublisherConfig {
         worker_id,
         kv_block_size,
         zmq_endpoint = "tcp://127.0.0.1:5557".to_string(),
-        zmq_topic = "".to_string()
+        zmq_topic = "".to_string(),
         sink = KvEventSink::Event
     ))]
     pub fn new(


### PR DESCRIPTION
#### Overview:

Instead of just using component to publish events to NATS, we add the concept of a `sink`. Events can be published to any `sink` which now implements the `EventPublisher` trait. I've added an `Echo` which will just print events out. I'll try to add a Recorder (based on work done by @PeaBrane) and just a plain ZMQ sink which was recommended by a customer

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
