### PR TITLE
chore: Default to pytorch backend in trtllm worker

### DIFF
--- a/launch/dynamo-run/src/subprocess/trtllm_inc.py
+++ b/launch/dynamo-run/src/subprocess/trtllm_inc.py
@@ -352,6 +352,7 @@ async def init(runtime: DistributedRuntime, config: Config):
     arg_map = {
         "model": model_path,
         "tensor_parallel_size": config.tensor_parallel_size,
+        "backend": "pytorch",
         "skip_tokenizer_init": True,
         "disable_log_requests": True,
         "enable_prefix_caching": True,


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Default to pytorch backend in TRTLLM worker if left unspecified.
- Pytorch backend is currently the only supported path for Deepseek R1
- Pytorch backend seems like best supported path for use of `trtllm-llmapi-launch` currently
- Only pytorch backend supports kv events/metrics currently

Power users can override backend field in extra engine args YAML if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Explicitly sets the backend to "pytorch" for the TensorRT-LLM engine configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->