### PR TITLE
fix: Fix flaky test

### DIFF
--- a/lib/llm/src/block_manager/pool.rs
+++ b/lib/llm/src/block_manager/pool.rs
@@ -953,6 +953,8 @@ mod tests {
             4
         );
 
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
         // Now, we match only the last 2 blocks
         let matched_suffix = pool.match_sequence_hashes(&sequence_hashes[2..]).await?;
         assert_eq!(matched_suffix.len(), 2);


### PR DESCRIPTION
The `test_block_pool_match_partial` is intermittently failing in CI, despite working when running locally. This fixes it.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of partial block matching tests by adding a short asynchronous delay to ensure proper state updates before assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->