### PR TITLE
docs: add the ability to specify varying concurrency to perf.sh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "jobserver",
  "libc",

--- a/benchmarks/llm/perf.sh
+++ b/benchmarks/llm/perf.sh
@@ -14,42 +14,103 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-model=neuralmagic/DeepSeek-R1-Distill-Llama-70B-FP8-dynamic
-
-# Input Sequence Length (isl) 3000 and Output Sequence Length (osl) 150 are
-# selected for chat use case. Note that for other use cases, the results and
-# tuning would vary.
+# Default values
+model="neuralmagic/DeepSeek-R1-Distill-Llama-70B-FP8-dynamic"
 isl=3000
 osl=150
+url="http://localhost:8000"
+concurrency_list="1 2 4 8 16 32 64 128 256"
 
-# Concurrency levels to test
-for concurrency in 1 2 4 8 16 32 64 128 256; do
+print_help() {
+  echo "Usage: $0 [OPTIONS]
 
-  # NOTE: For Dynamo HTTP OpenAI frontend, use `nvext` for fields like
-  # `ignore_eos` since they are not in the official OpenAI spec.
+Options:
+  --model <MODEL_ID>         Model ID to be used from HuggingFace.
+                             Default: ${model}
+
+  --isl <INPUT_SEQ_LENGTH>   Input Sequence Length (ISL).
+                             Default: ${isl}
+
+  --osl <OUTPUT_SEQ_LENGTH>  Output Sequence Length (OSL).
+                             Default: ${osl}
+
+  --url <URL>                Full URL of the benchmarking endpoint.
+                             Default: ${url}
+
+  --concurrency <LEVELS>     Concurrency levels to test.
+                             Accepts a single value (e.g., 64) or
+                             a comma-separated list (e.g., 1,2,4,8).
+                             Default: ${concurrency_list}
+
+  --help                     Show this help message and exit.
+"
+}
+
+# Function to validate if concurrency values are positive integers
+validate_concurrency() {
+  for val in "${concurrency_array[@]}"; do
+    if ! [[ "$val" =~ ^[0-9]+$ ]] || [ "$val" -le 0 ]; then
+      echo "Error: Invalid concurrency value '$val'. Must be a positive integer." >&2
+      exit 1
+    fi
+  done
+}
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --model) model="$2"; shift ;;
+        --isl) isl="$2"; shift ;;
+        --osl) osl="$2"; shift ;;
+        --url) url="$2"; shift ;;
+        --concurrency) IFS=',' read -r -a concurrency_array <<< "$2"; shift ;;
+        --help) print_help; exit 0 ;;
+        *) echo "Unknown parameter passed: $1"; print_help; exit 1 ;;
+    esac
+    shift
+done
+
+# If concurrency_array is not set by user, use default
+if [ -z "${concurrency_array+x}" ]; then
+    concurrency_array=($concurrency_list)
+fi
+
+# Validate concurrency values
+validate_concurrency
+
+echo "Running genai-perf with:"
+echo "Model: $model"
+echo "ISL: $isl"
+echo "OSL: $osl"
+echo "Concurrency levels: ${concurrency_array[@]}"
+
+
+for concurrency in "${concurrency_array[@]}"; do
+  echo "Run concurrency: $concurrency"
+
   genai-perf profile \
-    --model ${model} \
-    --tokenizer ${model} \
+    --model "${model}" \
+    --tokenizer "${model}" \
     --endpoint-type chat \
     --endpoint /v1/chat/completions \
     --streaming \
-    --url http://localhost:8000 \
-    --synthetic-input-tokens-mean ${isl} \
+    --url "${url}" \
+    --synthetic-input-tokens-mean "${isl}" \
     --synthetic-input-tokens-stddev 0 \
-    --output-tokens-mean ${osl} \
+    --output-tokens-mean "${osl}" \
     --output-tokens-stddev 0 \
-    --extra-inputs max_tokens:${osl} \
-    --extra-inputs min_tokens:${osl} \
+    --extra-inputs max_tokens:"${osl}" \
+    --extra-inputs min_tokens:"${osl}" \
     --extra-inputs ignore_eos:true \
-    --extra-inputs "{\"nvext\":{\"ignore_eos\":true}}" \
-    --concurrency ${concurrency} \
-    --request-count $(($concurrency*10)) \
-    --warmup-request-count $(($concurrency*2)) \
-    --num-dataset-entries $(($concurrency*12)) \
+    --extra-inputs '{"nvext":{"ignore_eos":true}}' \
+    --concurrency "${concurrency}" \
+    --request-count $(($concurrency * 10)) \
+    --warmup-request-count $(($concurrency * 2)) \
+    --num-dataset-entries $(($concurrency * 12)) \
     --random-seed 100 \
     -- \
     -v \
-    --max-threads 256 \
+    --max-threads "${concurrency}" \
     -H 'Authorization: Bearer NOT USED' \
     -H 'Accept: text/event-stream'
 

--- a/benchmarks/llm/perf.sh
+++ b/benchmarks/llm/perf.sh
@@ -102,7 +102,7 @@ for concurrency in "${concurrency_array[@]}"; do
     --extra-inputs max_tokens:"${osl}" \
     --extra-inputs min_tokens:"${osl}" \
     --extra-inputs ignore_eos:true \
-    --extra-inputs '{"nvext":{"ignore_eos":true}}' \
+    --extra-inputs "{\"nvext\":{\"ignore_eos\":true}}" \
     --concurrency "${concurrency}" \
     --request-count $(($concurrency * 10)) \
     --warmup-request-count $(($concurrency * 2)) \

--- a/examples/llm/benchmarks/README.md
+++ b/examples/llm/benchmarks/README.md
@@ -216,11 +216,18 @@ With the Dynamo repository and the benchmarking image available, perform the fol
 
 ## Collecting Performance Numbers
 
-Run the benchmarking script
-
+Run the benchmarking script and specify the model, input sequence length, output sequence length, and concurrency levels to target for benchmarking:
 ```bash
-bash -x /workspace/benchmarks/llm/perf.sh
+bash -x /workspace/benchmarks/llm/perf.sh \
+  --model neuralmagic/DeepSeek-R1-Distill-Llama-70B-FP8-dynamic \
+  --isl 3000 \
+  --osl 150 \
+  --url http://localhost:8000 \
+  --concurrency 1,2,4,8,16,32,64,128,256
 ```
+Note:
+* You can also run `bash -x /workspace/benchmarks/llm/perf.sh` without any parameters, in which case the script will use the default values shown above.
+* The `--concurrency` option accepts either a single value (e.g., 64) or a comma-separated list (e.g., 1,2,4,8) to specify multiple concurrency levels for benchmarking.
 
 > [!Tip]
 > See [GenAI-Perf tutorial](https://github.com/triton-inference-server/perf_analyzer/blob/main/genai-perf/docs/tutorial.md)


### PR DESCRIPTION
#### Overview:

improve the perf.sh script a bit to add the ability to specify varying concurrency

#### Details:

improve the perf.sh script a bit to add the ability to specify varying concurrency, as well as some commonly adjustable variables, like isl, osl, model_id, etc

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved instructions for running the benchmarking script, including detailed examples and clarification of command-line options.
- **New Features**
  - Enhanced benchmarking script to support customizable command-line arguments for model, input/output lengths, endpoint URL, and concurrency levels.
  - Added validation and help messages for user input.
  - Script now displays configuration details before running benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->