### PR TITLE
chore: add high availability etcd docker compose

### DIFF
--- a/lib/runtime/docker-compose.yml
+++ b/lib/runtime/docker-compose.yml
@@ -22,13 +22,53 @@ services:
       - 6222:6222
       - 8222:8222
 
-  etcd-server:
-    image: bitnami/etcd
+  etcd0:
+    image: bitnami/etcd:latest
     environment:
       - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_NAME=etcd0
+      - ETCD_INITIAL_ADVERTISE_PEER_URLS=http://etcd0:2380
+      - ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_INITIAL_CLUSTER=etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380
+      - ETCD_INITIAL_CLUSTER_STATE=new
+      - ETCD_INITIAL_CLUSTER_TOKEN=etcd-cluster-1
     ports:
-      - 2379:2379
-      - 2380:2380
+      - "2379:2379"
+      - "2380:2380"
+
+  etcd1:
+    image: bitnami/etcd:latest
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_NAME=etcd1
+      - ETCD_INITIAL_ADVERTISE_PEER_URLS=http://etcd1:2380
+      - ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_INITIAL_CLUSTER=etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380
+      - ETCD_INITIAL_CLUSTER_STATE=new
+      - ETCD_INITIAL_CLUSTER_TOKEN=etcd-cluster-1
+    ports:
+      - "23791:2379"
+      - "23801:2380"
+
+  etcd2:
+    image: bitnami/etcd:latest
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_NAME=etcd2
+      - ETCD_INITIAL_ADVERTISE_PEER_URLS=http://etcd2:2380
+      - ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_INITIAL_CLUSTER=etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380
+      - ETCD_INITIAL_CLUSTER_STATE=new
+      - ETCD_INITIAL_CLUSTER_TOKEN=etcd-cluster-1
+    ports:
+      - "23792:2379"
+      - "23802:2380"
 
   prometheus:
     image: prom/prometheus:latest


### PR DESCRIPTION
We now spin up 3 ETCD replicas with the first one having the default `2379` port so a user does not have to change anything. The other two are also up allowing developers to test what happens when 1 goes down. 

If a user wants to test - they can now do 

```bash
export ETCD_ENDPOINTS=localhost:2379,localhost:23791,localhost:23792
dynamo serve graphs.agg:Frontend -f configs/agg.yaml
```

Take any of the 3 ETCD replicas down (we need 2 for consensus). Logs looks like 

```bash
025-06-11T19:55:34.820Z  INFO dynamo_runtime::transports::etcd: kv watch stream closed
2025-06-11T19:55:34.821Z  INFO dynamo_runtime::transports::etcd: kv watch stream closed
2025-06-11T19:55:34.822Z DEBUG dynamo_runtime::component::client: watch stream has closed; shutting down endpoint watcher for prefix: instances/dynamo/SGLangDecodeWorker/generate
2025-06-11T19:55:34.822Z DEBUG dynamo_runtime::component::client: Completed endpoint watcher for prefix: instances/dynamo/SGLangDecodeWorker/generate
2025-06-11T19:55:52.451Z DEBUG chat_completions: dynamo_runtime::pipeline::network::tcp::server: Registering new TcpStream on 10.128.0.190:41555
```

But lease won't be canceled taking everything down

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgraded etcd setup from a single server to a three-node etcd cluster for improved reliability and availability.
- **Chores**
  - Updated service names and port mappings to support the new multi-node cluster configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->