### PR TITLE
fix: dynamo-run change python subprocess from debug to info

### DIFF
--- a/launch/dynamo-run/src/subprocess.rs
+++ b/launch/dynamo-run/src/subprocess.rs
@@ -92,13 +92,13 @@ pub async fn start(
     tokio::spawn(async move {
         let mut lines = stdout.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            tracing::debug!("{}", strip_log_prefix(&line));
+            tracing::info!("{}", strip_log_prefix(&line));
         }
     });
     tokio::spawn(async move {
         let mut lines = stderr.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            tracing::debug!("{}", strip_log_prefix(&line));
+            tracing::info!("{}", strip_log_prefix(&line));
         }
     });
 

--- a/launch/dynamo-run/src/subprocess.rs
+++ b/launch/dynamo-run/src/subprocess.rs
@@ -98,7 +98,7 @@ pub async fn start(
     tokio::spawn(async move {
         let mut lines = stderr.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            tracing::info!("{}", strip_log_prefix(&line));
+            tracing::error!("{}", strip_log_prefix(&line));
         }
     });
 


### PR DESCRIPTION
#### Overview:

Fixes: https://github.com/ai-dynamo/dynamo/issues/1422


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Increased the visibility of subprocess output by logging stdout lines at the info level and stderr lines at the error level instead of debug.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->