### PR TITLE
fix: Throw exception if inadequate GPUs.

### DIFF
--- a/deploy/sdk/src/dynamo/sdk/cli/allocator.py
+++ b/deploy/sdk/src/dynamo/sdk/cli/allocator.py
@@ -78,7 +78,7 @@ class ResourceAllocator:
             List of GPU indices that were assigned
         """
         if count > self.remaining_gpus:
-            logger.warning(
+            raise ResourceError(
                 f"Requested {count} GPUs, but only {self.remaining_gpus} are remaining. "
                 f"Serving may fail due to inadequate GPUs. Set {DYN_DISABLE_AUTO_GPU_ALLOCATION}=1 "
                 "to disable automatic allocation and allocate GPUs manually."


### PR DESCRIPTION
#### Overview:

Throw exception if inadequate GPUs in `dynamo serve`.

#### Details:

3 GPUs are needed for disagg EPD serving. 1 gpu for each E P and D. If the number of GPUs available to the user is less than the number of GPUs that an EPD service needs, the service "starts up" normally and hangs when the user tries to make an inference call, without any sign or error that the user doesn't have enough GPUs available to run the service.

#### Expected Behavior

When serving, an error should be thrown at/around the GPU allocation step.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #1373
