### PR TITLE
docs: add concurrency choice to the perf.sh

### DIFF
--- a/benchmarks/llm/perf.sh
+++ b/benchmarks/llm/perf.sh
@@ -39,21 +39,21 @@ print_help() {
   echo "Usage: $0 [OPTIONS]"
   echo
   echo "Options:"
-  echo "  --tensor-parallelism <int>           Set tensor parallelism (default: $tp)"
-  echo "  --data-parallelism <int>             Set data parallelism (default: $dp)"
-  echo "  --prefill-tensor-parallelism <int>   Set prefill tensor parallelism (default: $prefill_tp)"
-  echo "  --prefill-data-parallelism <int>     Set prefill data parallelism (default: $prefill_dp)"
-  echo "  --decode-tensor-parallelism <int>    Set decode tensor parallelism (default: $decode_tp)"
-  echo "  --decode-data-parallelism <int>      Set decode data parallelism (default: $decode_dp)"
-  echo "  --model <model_id>                   Model Id to benchmark from HuggingFace (default: $model)"
-  echo "  --input-sequence-length <int>        Input sequence length (default: $isl)"
-  echo "  --output-sequence-length <int>       Output sequence length (default: $osl)"
-  echo "  --url <http://host:port>             Target URL for inference requests (default: $url)"
-  echo "  --concurrency <list>                 Comma-separated list (default: $concurrency_list)"
-  echo "  --mode <aggregated|...>              serving mode: aggregated/disaggregated (default: $mode)"
-  echo "  --artifacts-root-dir <path>          Root directory to save benchmarking results (default: $artifacts_root_dir)"
-  echo "  --deployment-kind <type>             special tag for the pareto graph to distingish the plots (default: $deployment_kind)"
-  echo "  --help                               Show this help message and exit"
+  echo "  --tensor-parallelism, --tp <int>           Tensor parallelism (default: $tp)"
+  echo "  --data-parallelism, --dp <int>             Data parallelism (default: $dp)"
+  echo "  --prefill-tensor-parallelism, --prefill-tp <int>   Prefill tensor parallelism (default: $prefill_tp)"
+  echo "  --prefill-data-parallelism, --prefill-dp <int>     Prefill data parallelism (default: $prefill_dp)"
+  echo "  --decode-tensor-parallelism, --decode-tp <int>     Decode tensor parallelism (default: $decode_tp)"
+  echo "  --decode-data-parallelism, --decode-dp <int>       Decode data parallelism (default: $decode_dp)"
+  echo "  --model <model_id>                         Hugging Face model ID to benchmark (default: $model)"
+  echo "  --input-sequence-length, --isl <int>       Input sequence length (default: $isl)"
+  echo "  --output-sequence-length, --osl <int>      Output sequence length (default: $osl)"
+  echo "  --url <http://host:port>                   Target URL for inference requests (default: $url)"
+  echo "  --concurrency <list>                       Comma-separated concurrency levels (default: $concurrency_list)"
+  echo "  --mode <aggregated|disaggregated>          Serving mode (default: $mode)"
+  echo "  --artifacts-root-dir <path>                Root directory to store benchmark results (default: $artifacts_root_dir)"
+  echo "  --deployment-kind <type>                   Deployment tag used for pareto chart labels (default: $deployment_kind)"
+  echo "  --help                                     Show this help message and exit"
   echo
   exit 0
 }
@@ -62,27 +62,27 @@ print_help() {
 # The defaults can be overridden by command line arguments.
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --tensor-parallelism)
+    --tensor-parallelism|--tp)
       tp="$2"
       shift 2
       ;;
-    --data-parallelism)
+    --data-parallelism|--dp)
       dp="$2"
       shift 2
       ;;
-    --prefill-tensor-parallelism)
+    --prefill-tensor-parallelism|--prefill-tp)
       prefill_tp="$2"
       shift 2
       ;;
-    --prefill-data-parallelism)
+    --prefill-data-parallelism|--prefill-dp)
       prefill_dp="$2"
       shift 2
       ;;
-    --decode-tensor-parallelism)
+    --decode-tensor-parallelism|--decode-tp)
       decode_tp="$2"
       shift 2
       ;;
-    --decode-data-parallelism)
+    --decode-data-parallelism|--decode-dp)
       decode_dp="$2"
       shift 2
       ;;
@@ -90,11 +90,11 @@ while [[ $# -gt 0 ]]; do
       model="$2"
       shift 2
       ;;
-    --input-sequence-length)
+    --input-sequence-length|--isl)
       isl="$2"
       shift 2
       ;;
-    --output-sequence-length)
+    --output-sequence-length|--osl)
       osl="$2"
       shift 2
       ;;

--- a/examples/llm/benchmarks/README.md
+++ b/examples/llm/benchmarks/README.md
@@ -246,6 +246,8 @@ Single-Node
 
  ```bash
  bash -x /workspace/benchmarks/llm/perf.sh \
+  --mode aggregated \
+  --deployment-kind vllm_serve \
   --tensor-parallelism 1 \
   --data-parallelism 1 \
   --model neuralmagic/DeepSeek-R1-Distill-Llama-70B-FP8-dynamic \

--- a/examples/llm/benchmarks/README.md
+++ b/examples/llm/benchmarks/README.md
@@ -254,7 +254,7 @@ Single-Node
   --input-sequence-length 3000 \
   --output-sequence-length 150 \
   --url http://localhost:8000 \
-  --concurrency 1,2,4,8,16,32,64,128,256 \
+  --concurrency 1,2,4,8,16,32,64,128,256
 
   # The `--concurrency` option accepts either a single value (e.g., 64) or a comma-separated list (e.g., 1,2,4,8) to specify multiple concurrency levels for benchmarking.
  ```

--- a/examples/llm/benchmarks/README.md
+++ b/examples/llm/benchmarks/README.md
@@ -242,6 +242,21 @@ Single-Node
  bash -x /workspace/benchmarks/llm/perf.sh --mode aggregated --deployment-kind vllm_serve --tensor-parallelism 8 --data-parallelism 2
  ```
 
+ We could also run the benchmarking script and specify the model, input sequence length, output sequence length, and concurrency levels to target for benchmarking:
+
+ ```bash
+ bash -x /workspace/benchmarks/llm/perf.sh \
+  --tensor-parallelism 1
+  --data-parallelism 1
+  --model neuralmagic/DeepSeek-R1-Distill-Llama-70B-FP8-dynamic \
+  --input-sequence-length 3000 \
+  --output-sequence-length 150 \
+  --url http://localhost:8000 \
+  --concurrency 1,2,4,8,16,32,64,128,256 \
+
+  # The `--concurrency` option accepts either a single value (e.g., 64) or a comma-separated list (e.g., 1,2,4,8) to specify multiple concurrency levels for benchmarking.
+ ```
+
  > [!Important]
  > We should be careful in specifying these options in `perf.sh` script. They should closely reflect the deployment config that is being benchmarked. See `perf.sh --help` to learn more about these option. In the above command, we described that our deployment is using aggregated serving in `vllm serve`. We have also accurately described that we have 2 workers with TP=4(or TP=8 for two nodes).
 

--- a/examples/llm/benchmarks/README.md
+++ b/examples/llm/benchmarks/README.md
@@ -246,8 +246,8 @@ Single-Node
 
  ```bash
  bash -x /workspace/benchmarks/llm/perf.sh \
-  --tensor-parallelism 1
-  --data-parallelism 1
+  --tensor-parallelism 1 \
+  --data-parallelism 1 \
   --model neuralmagic/DeepSeek-R1-Distill-Llama-70B-FP8-dynamic \
   --input-sequence-length 3000 \
   --output-sequence-length 150 \


### PR DESCRIPTION
#### Overview:

add concurrency choice to the perf.sh 

#### Details:

1. add concurrency choice to the perf.sh for quick iteration for concurrency configuration
2. add --help function to print the help message.
3. add some short alias for the arguments

#### Where should the reviewer start?

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for customizing concurrency levels in the benchmarking script via a new command-line option.
	- Introduced a help option to display usage information.
- **Documentation**
	- Updated documentation with an example demonstrating how to specify custom concurrency values when running benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->