### PR TITLE
fix: remove LLMMetricAnnotation from response stream 

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -496,10 +496,10 @@ impl<T> From<Annotated<T>> for EventConverter<T> {
 }
 
 fn process_event_converter<T: Serialize>(
-    mut annotated: EventConverter<T>,
+    annotated: EventConverter<T>,
     response_collector: &mut ResponseMetricCollector,
 ) -> Result<Event, axum::Error> {
-    let annotated = annotated.0;
+    let mut annotated = annotated.0;
 
     // update metrics
     if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(&annotated) {

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -499,7 +499,7 @@ fn process_event_converter<T: Serialize>(
     mut annotated: EventConverter<T>,
     response_collector: &mut ResponseMetricCollector,
 ) -> Result<Event, axum::Error> {
-    let mut annotated = annotated.0;
+    let annotated = annotated.0;
 
     // update metrics
     if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(&annotated) {

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -507,6 +507,7 @@ fn process_event_converter<T: Serialize>(
         response_collector.observe_response(metrics.input_tokens, metrics.chunk_tokens);
 
         // Chomp the LLMMetricAnnotation so it's not returned in the response stream
+        // TODO: add a flag to control what is returned in the SSE stream
         if annotated.event.as_deref() == Some(crate::preprocessor::ANNOTATION_LLM_METRICS) {
             annotated.event = None;
             annotated.comment = None;


### PR DESCRIPTION
remove LLMMetricAnnotation from response stream to unblock GAP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of LLM metric annotations to prevent certain internal metrics from appearing in the event stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->