### PR TITLE
fix: Fix NATS_SERVER value, add details on customizing MOUNTS

### DIFF
--- a/examples/tensorrt_llm/configs/deepseek_r1/multinode/README.md
+++ b/examples/tensorrt_llm/configs/deepseek_r1/multinode/README.md
@@ -68,6 +68,25 @@ inside an interactive shell on one of the allocated nodes:
 # https://github.com/ai-dynamo/dynamo/tree/main/examples/tensorrt_llm#build-docker
 export IMAGE="<dynamo_trtllm_image>"
 
+# MOUNTS are the host:container path pairs that are mounted into the containers
+# launched by each `srun` command.
+#
+# If you want to reference files, such as $MODEL_PATH below, in a
+# different location, you can customize MOUNTS or specify additional
+# comma-separated mount pairs here.
+#
+# NOTE: Currently, this example assumes that the local bash scripts and configs
+# referenced are mounted into into /mnt inside the container. If you want to
+# customize the location of the scripts, make sure to modify `srun_script.sh`
+# accordingly for the new locations of `start_frontend_services.sh` and
+# `start_trtllm_worker.sh`.
+#
+# For example, assuming your cluster had a `/lustre` directory on the host, you
+# could add that as a mount like so:
+#
+# export MOUNTS="${PWD}:/mnt,/lustre:/lustre"
+export MOUNTS="${PWD}:/mnt"
+
 # NOTE: In general, Deepseek R1 is very large, so it is recommended to
 # pre-download the model weights and save them in some shared location,
 # NFS storage, HF_CACHE, etc. and modify the `--model-path` below

--- a/examples/tensorrt_llm/configs/deepseek_r1/multinode/srun_script.sh
+++ b/examples/tensorrt_llm/configs/deepseek_r1/multinode/srun_script.sh
@@ -10,7 +10,8 @@ IMAGE="${IMAGE:-""}"
 # but you may freely customize the mounts based on your cluster. A common practice
 # is to mount paths to NFS storage for common scripts, model weights, etc.
 # NOTE: This can be a comma separated list of multiple mounts as well.
-MOUNTS="$PWD:/mnt"
+DEFAULT_MOUNT="${PWD}:/mnt"
+MOUNTS="${MOUNTS:-"${DEFAULT_MOUNT}"}"
 
 # Example values, assuming 4 nodes with 4 GPUs on each node, such as 4xGB200 nodes.
 # For 8xH100 nodes as an example, you may set this to 2 nodes x 16 gpus, or 4 nodes x 32 gpus instead.
@@ -23,7 +24,7 @@ ACCOUNT="$(sacctmgr -nP show assoc where user=$(whoami) format=account)"
 export HEAD_NODE="${SLURMD_NODENAME}"
 export HEAD_NODE_IP="$(hostname -i)"
 export ETCD_ENDPOINTS="${HEAD_NODE_IP}:2379"
-export NATS_SERVER="${HEAD_NODE_IP}:4222"
+export NATS_SERVER="nats://${HEAD_NODE_IP}:4222"
 
 if [[ -z ${IMAGE} ]]; then
   echo "ERROR: You need to set the IMAGE environment variable to the " \

--- a/examples/tensorrt_llm/configs/deepseek_r1/multinode/srun_script.sh
+++ b/examples/tensorrt_llm/configs/deepseek_r1/multinode/srun_script.sh
@@ -11,7 +11,7 @@ IMAGE="${IMAGE:-""}"
 # is to mount paths to NFS storage for common scripts, model weights, etc.
 # NOTE: This can be a comma separated list of multiple mounts as well.
 DEFAULT_MOUNT="${PWD}:/mnt"
-MOUNTS="${MOUNTS:-"${DEFAULT_MOUNT}"}"
+MOUNTS="${MOUNTS:-${DEFAULT_MOUNT}}"
 
 # Example values, assuming 4 nodes with 4 GPUs on each node, such as 4xGB200 nodes.
 # For 8xH100 nodes as an example, you may set this to 2 nodes x 16 gpus, or 4 nodes x 32 gpus instead.


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

- There was a bug when workers didn't land on head node (ex: allocate 8 nodes, run workers on 4 nodes), revealing NATS_SERVER wasn't set correctly. This fixes it.
- It's very likely that MODEL_PATH will be somewhere other than $PWD, so add details on how to customize container MOUNTS for more flexibility

Tested custom scenario:
```bash
# Allocate 8 nodes
salloc -N 8 ...

export IMAGE="<prebuilt_dynamo_trtllm_image>"

# Mount /lustre for path to shared pre-downloaded DS R1 FP4 weights
export MOUNTS="${PWD}:/mnt,/lustre/lustre"
export MODEL_PATH="/lustre/.../Deepseek-R1-FP4"

# Default example config
export ENGINE_CONFIG="/mnt/agg_DEP16_dsr1.yaml"

# Only launch worker on 4 of the 8 nodes (randomly selected by slurm scheduler)
# where none of the workers land on head node with nats/etcd/openai
./srun_script.sh
 ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Added detailed instructions and examples for configuring the `MOUNTS` environment variable in the multi-node Slurm setup.
  - Clarified how to customize mount paths and provided guidance for adjusting related scripts.

- **Bug Fixes**
  - Improved handling of the `MOUNTS` variable to allow user customization, defaulting only if not already set.
  - Updated the `NATS_SERVER` environment variable to use the correct URI format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->