### PR TITLE
build: DIS-148 use the tensorrt_llm public wheel from pypi by default in container build

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -349,7 +349,7 @@ show_help() {
     echo "  [--framework framework one of ${!FRAMEWORKS[*]}]"
     echo "  [--tensorrtllm-pip-wheel-dir path to tensorrtllm pip wheel directory]"
     echo "  [--tensorrtllm-commit tensorrtllm commit to use for building the trtllm wheel if the wheel is not provided]"
-    echo "  [--use-default-experimental-trtllm-commit] Use the default experimental commit (${DEFAULT_EXPERIMENTAL_TRTLLM_COMMIT}) to build TensorRT-LLM. This is a flag (no argument). Do not combine with --tensorrtllm-commit or --tensorrtllm-pip-wheel."
+    echo "  [--use-default-experimental-tensorrtllm-commit] Use the default experimental commit (${DEFAULT_EXPERIMENTAL_TRTLLM_COMMIT}) to build TensorRT-LLM. This is a flag (no argument). Do not combine with --tensorrtllm-commit or --tensorrtllm-pip-wheel."
     echo "  [--tensorrtllm-pip-wheel tensorrtllm pip wheel on artifactory]"
     echo "  [--tensorrtllm-index-url tensorrtllm PyPI index URL if providing the wheel from artifactory]"
     echo "  [--build-arg additional build args to pass to docker build]"

--- a/container/build.sh
+++ b/container/build.sh
@@ -88,12 +88,13 @@ TENSORRTLLM_PIP_WHEEL_DIR="/tmp/trtllm_wheel/"
 # TensorRT-LLM commit to use for building the trtllm wheel if not provided.
 # Important Note: This commit is not used in our CI pipeline. See the CI
 # variables to learn how to run a pipeline with a specific commit.
-TRTLLM_COMMIT="137fe35539ea182f1495f5021bfda97c729e50c3"
+DEFAULT_EXPERIMENTAL_TRTLLM_COMMIT="137fe35539ea182f1495f5021bfda97c729e50c3"
+TRTLLM_COMMIT=""
 
 # TensorRT-LLM PyPI index URL
 TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"
+DEFAULT_TENSORRTLLM_PIP_WHEEL="tensorrt_llm==0.21.0rc1"
 TENSORRTLLM_PIP_WHEEL=""
-
 
 
 VLLM_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
@@ -154,6 +155,13 @@ get_options() {
             else
                 missing_requirement "$1"
             fi
+            ;;
+        --use-default-experimental-tensorrtllm-commit)
+            if [ -n "$2" ] && [[ "$2" != --* ]]; then
+                echo "ERROR: --use-default-experimental-tensorrtllm-commit does not take any argument"
+                exit 1
+            fi
+            USE_DEFAULT_EXPERIMENTAL_TRTLLM_COMMIT=true
             ;;
         --tensorrtllm-pip-wheel)
             if [ "$2" ]; then
@@ -341,6 +349,7 @@ show_help() {
     echo "  [--framework framework one of ${!FRAMEWORKS[*]}]"
     echo "  [--tensorrtllm-pip-wheel-dir path to tensorrtllm pip wheel directory]"
     echo "  [--tensorrtllm-commit tensorrtllm commit to use for building the trtllm wheel if the wheel is not provided]"
+    echo "  [--use-default-experimental-trtllm-commit] Use the default experimental commit (${DEFAULT_EXPERIMENTAL_TRTLLM_COMMIT}) to build TensorRT-LLM. This is a flag (no argument). Do not combine with --tensorrtllm-commit or --tensorrtllm-pip-wheel."
     echo "  [--tensorrtllm-pip-wheel tensorrtllm pip wheel on artifactory]"
     echo "  [--tensorrtllm-index-url tensorrtllm PyPI index URL if providing the wheel from artifactory]"
     echo "  [--build-arg additional build args to pass to docker build]"
@@ -470,6 +479,19 @@ check_wheel_file() {
 }
 
 if [[ $FRAMEWORK == "TENSORRTLLM" ]]; then
+    if [ "$USE_DEFAULT_EXPERIMENTAL_TRTLLM_COMMIT" = true ]; then
+        if [ -n "$TRTLLM_COMMIT" ] || [ -n "$TENSORRTLLM_PIP_WHEEL" ]; then
+            echo "ERROR: When using --use-default-experimental-trtllm-commit, do not set --tensorrtllm-commit or --tensorrtllm-pip-wheel."
+            exit 1
+        fi
+        TRTLLM_COMMIT="$DEFAULT_EXPERIMENTAL_TRTLLM_COMMIT"
+    fi
+
+    # If user didn't set both wheel and commit, use default tensorrt_llm pip wheel
+    if [ -z "$TENSORRTLLM_PIP_WHEEL" ] && [ -z "$TRTLLM_COMMIT" ]; then
+        TENSORRTLLM_PIP_WHEEL="$DEFAULT_TENSORRTLLM_PIP_WHEEL"
+    fi
+
     if [ -z "${TENSORRTLLM_PIP_WHEEL}" ]; then
         # Use option 1
         if [ ! -d "${TENSORRTLLM_PIP_WHEEL_DIR}" ]; then

--- a/container/build.sh
+++ b/container/build.sh
@@ -93,7 +93,7 @@ TRTLLM_COMMIT=""
 
 # TensorRT-LLM PyPI index URL
 TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"
-DEFAULT_TENSORRTLLM_PIP_WHEEL="tensorrt_llm==0.21.0rc1"
+DEFAULT_TENSORRTLLM_PIP_WHEEL="tensorrt-llm==0.21.0rc0"
 TENSORRTLLM_PIP_WHEEL=""
 
 

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -143,7 +143,7 @@ dynamo serve graphs.agg:Frontend -f configs/deepseek_r1/mtp/mtp_agg.yaml
 Notes:
 - MTP is only available within the container built with the experimental TensorRT-LLM commit. Please add --use-default-experimental-tensorrtllm-commit to the arguments of the build.sh script.
 
-  ex: `./container/build.sh --framework tensorrtllm --use-default-experimental-tensorrtllm-commit`
+  Example: `./container/build.sh --framework tensorrtllm --use-default-experimental-tensorrtllm-commit`
 
 - There is a noticeable latency for the first two inference requests. Please send warm-up requests before starting the benchmark.
 - MTP performance may vary depending on the acceptance rate of predicted tokens, which is dependent on the dataset or queries used while benchmarking. Additionally, `ignore_eos` should generally be omitted or set to `false` when using MTP to avoid speculating garbage outputs and getting unrealistic acceptance rates.

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -62,6 +62,11 @@ apt-get update && apt-get -y install git git-lfs
 
 # On an ARM machine:
 ./container/build.sh --framework tensorrtllm --platform linux/arm64
+
+# Build the container with the default experimental TensorRT-LLM commit
+# WARNING: This is for experimental feature testing only.
+# The container should not be used in a production environment.
+./container/build.sh --framework tensorrtllm --use-default-experimental-tensorrtllm-commit
 ```
 
 > [!NOTE]
@@ -136,6 +141,10 @@ dynamo serve graphs.agg:Frontend -f configs/deepseek_r1/mtp/mtp_agg.yaml
 ```
 
 Notes:
+- MTP is only available within the container built with the experimental TensorRT-LLM commit. Please add --use-default-experimental-tensorrtllm-commit to the arguments of the build.sh script.
+
+  ex: `./container/build.sh --framework tensorrtllm --use-default-experimental-tensorrtllm-commit`
+
 - There is a noticeable latency for the first two inference requests. Please send warm-up requests before starting the benchmark.
 - MTP performance may vary depending on the acceptance rate of predicted tokens, which is dependent on the dataset or queries used while benchmarking. Additionally, `ignore_eos` should generally be omitted or set to `false` when using MTP to avoid speculating garbage outputs and getting unrealistic acceptance rates.
 
@@ -275,6 +284,9 @@ dynamo serve components.prefill_worker:TensorRTLLMPrefillWorker -f configs/deeps
 ```
 
 Notes:
+- MTP is only available within the container built with the experimental TensorRT-LLM commit. Please add --use-default-experimental-tensorrtllm-commit to the arguments of the build.sh script.
+
+  Example: `./container/build.sh --framework tensorrtllm --use-default-experimental-tensorrtllm-commit`
 - There is a noticeable latency for the first two inference requests. Please send warm-up requests before starting the benchmark.
 - MTP performance may vary depending on the acceptance rate of predicted tokens, which is dependent on the dataset or queries used while benchmarking. Additionally, `ignore_eos` should generally be omitted or set to `false` when using MTP to avoid speculating garbage outputs and getting unrealistic acceptance rates.
 


### PR DESCRIPTION
#### Overview:
change the build.sh to use the tensorrt_llm public release version from pypi by default. Since we don't own the CI pipeline of tensorrt llm, guiding our user to use a random commit from Tensorrt-LLM might cause sadness. 

#### Details:
1. if users run `./container/build.sh --framework tensorrtllm`, it will install the default tensorrt llm public pip wheel from the pypi
2. Users could attach the `--use-default-experimental-tensorrtllm-commit` arg to the build.sh to pick up the tensorrt llm build we are currently experimenting.
3. users could still run build.sh with `--tensorrtllm-commit` to specify any commit.

build pipeline with the public tensorrt llm pip wheel:
https://gitlab-master.nvidia.com/dl/ai-dynamo/dynamo-ci/-/pipelines/30052494

Unit tests on tensorrt llm examples:
```
root@ptyche0016:/workspace# pytest -v -m tensorrtllm --ignore=benchmarks/data_generator/tests/ --ignore=lib/bindings/python/tests/ --ignore=tutorials/advanced_source/torch_script_custom_classes --ignore=tutorials/advanced_source/torch_script_custom_ops/
=========================================================================================================================== test session starts ===========================================================================================================================
platform linux -- Python 3.12.3, pytest-8.4.0, pluggy-1.5.0 -- /usr/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/workspace/.hypothesis/examples'))
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspace
configfile: pyproject.toml
plugins: anyio-4.9.0, hypothesis-6.130.8, asyncio-1.0.0, benchmark-5.1.0, pytest_codeblocks-0.17.0, cov-6.2.1, flakefinder-1.1.0, md-report-0.7.0, mypy-1.0.1, rerunfailures-15.0, shard-0.1.2, timeout-2.4.0, xdist-3.6.1, xdoctest-1.0.2, typeguard-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 298 items / 294 deselected / 4 selected
Running 4 items in this shard: tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_agg], tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_agg_router], tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_disagg], tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_disagg_router]

tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_agg] PASSED                                                                                                                                                                                          [ 25%]
tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_agg_router] PASSED                                                                                                                                                                                   [ 50%]
tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_disagg] PASSED                                                                                                                                                                                       [ 75%]
tests/serve/test_dynamo_serve.py::test_serve_deployment[trtllm_disagg_router] PASSED                                                                                                                                                                                [100%]

============================================================================================================== 4 passed, 294 deselected in 586.99s (0:09:46) ==============================================================================================================
```

Test with the DS R1 multi node example in ptyche:
```
data: [DONE]

200rihuo@ptyche0011:~$ curl -w "%{http_code}" ${HOST}:${PORT}/v1/chat/completions   -H "Content-Type: application/json"   -d '{
  "model": "'${MODEL}'",
  "messages": [
  {
    "role": "user",
    "content": "Tell me a story as if we were playing dungeons and dragons."
  }
  ],
  "stream": true,
  "max_tokens": 30
}'
 0: 2025-06-13 13:13:08,398 - INFO - flashinfer.jit: Loading JIT ops: rope
 0: 2025-06-13 13:13:32,993 - INFO - flashinfer.jit: Finished loading JIT ops: rope
data: {"id":"chatcmpl-33eb5724-c3ff-4a10-87cc-912e48004682","choices":[{"index":0,"delta":{"content":"Okay","function_call":null,"tool_calls":null,"role":"assistant","refusal":null},"finish_reason":null,"logprobs":null}],"created":1749845588,"model":"hf-574fdb8-nim_fp4","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":19,"completion_tokens":1,"total_tokens":0,"prompt_tokens_details":null,"completion_tokens_details":null}}
```

Perf benchmark pareto graph:
https://gitlab-master.nvidia.com/dl/ai-dynamo/dynamo-ci/-/jobs/178323320/artifacts/file/benchmark_results/deepseek-ai/DeepSeek-R1-FP4/pareto_plot.png

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a new build option to use an experimental TensorRT-LLM commit when building containers.
- **Documentation**
  - Updated instructions to explain the new build flag and its usage, including warnings about experimental status.
  - Clarified requirements for Multi-Token Prediction (MTP) and provided example usage with the new flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->