### PR TITLE
feat: Expose the task flag from dynamo-run cli for trtllm

### DIFF
--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -455,6 +455,35 @@ Execute the following to load the TensorRT-LLM model specified in the configurat
 dynamo-run in=http out=trtllm TinyLlama/TinyLlama-1.1B-Chat-v1.0
 ```
 
+**Multi-GPU**
+
+Pass `--tensor-parallel-size <NUM-GPUS>` to `dynamo-run`.
+
+To specify which GPUs to use set environment variable `CUDA_VISIBLE_DEVICES`.
+
+**Multinode:**
+
+See the instructions [here](../../examples/tensorrt_llm/configs/deepseek_r1/multinode/) to learn how to launch tensorrtllm model on multiple nodes.
+
+**Disaggregated Serving:**
+The trtllm engine can be configured to run in disaggregated way using `--task`.
+
+```
+# Ingress
+dynamo run in=http out=dyn
+
+# Prefill
+dynamo-run in=dyn://dynamo.prefill.generate out=trtllm --task prefill --extra-engine-args=trtllm_config/sample.yaml TinyLlama/TinyLlama-1.1B-Chat-v1.0
+
+# Decode
+dynamo-run in=dyn://dynamo.decode.generate out=trtllm --task decode --extra-engine-args=trtllm_config/sample.yaml TinyLlama/TinyLlama-1.1B-Chat-v1.0
+
+```
+The environment variable `CUDA_VISIBLE_DEVICES` can be set for each invocation to specify GPUs for each worker.
+
+> [!Important]
+> The current implementation of disaggregated serving uses hard-coded endpoints (`dyn://dynamo.prefill.generate` and `dyn://dynamo.decode.generate`). This limitation means you can only deploy one model at a time in your system. We are actively working on making the endpoint configuration more flexible to support multiple models simultaneously.
+
 #### Echo Engines
 
 Dynamo includes two echo engines for testing and debugging purposes:

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -46,6 +46,17 @@ pub struct Flags {
     #[arg(long)]
     pub model_name: Option<String>,
 
+    /// TRTLLM only
+    ///
+    /// The task to perform with the model. Can be used to execute engines in disaggregated mode.
+    ///
+    /// Supported tasks:
+    /// - prefill_and_decode: Prefill and decode (default)
+    /// - decode: Decode
+    /// - prefill: Prefill
+    #[arg(long)]
+    pub task: Option<String>,
+
     /// Verbose output (-v for debug, -vv for trace)
     #[arg(short = 'v', action = clap::ArgAction::Count, default_value_t = 0)]
     pub verbosity: u8,

--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -35,7 +35,7 @@ Example:
 - OR: ./dynamo-run /data/models/Llama-3.2-1B-Instruct-Q4_K_M.gguf
 "#;
 
-const USAGE: &str = "USAGE: dynamo-run in=[http|text|dyn://<path>|batch:<folder>] out=ENGINE_LIST|dyn [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--context-length=N] [--kv-cache-block-size=16] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin|kv] [--kv-overlap-score-weight=2.0] [--kv-gpu-cache-usage-weight=1.0] [--kv-waiting-requests-weight=1.0] [--verbosity (-v|-vv)]";
+const USAGE: &str = "USAGE: dynamo-run in=[http|text|dyn://<path>|batch:<folder>] out=ENGINE_LIST|dyn [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--task prefill_and_decode|decode|prefill] [--tensor-parallel-size=1] [--context-length=N] [--kv-cache-block-size=16] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin|kv] [--kv-overlap-score-weight=2.0] [--kv-gpu-cache-usage-weight=1.0] [--kv-waiting-requests-weight=1.0] [--verbosity (-v|-vv)]";
 
 fn main() -> anyhow::Result<()> {
     // Set log level based on verbosity flag

--- a/launch/dynamo-run/src/subprocess.rs
+++ b/launch/dynamo-run/src/subprocess.rs
@@ -53,9 +53,15 @@ pub async fn start(
         card.context_length.to_string(),
     ];
     // TRTLLM only
+    //
     // The worker node will only publish events and metrics if the router mode is KV
     if flags.router_mode == RouterMode::KV {
         args.push("--publish-events-and-metrics".to_string());
+    }
+    // Specific task for TRTLLM engine
+    if flags.task.is_some() {
+        args.push("--task".to_string());
+        args.push(flags.task.clone().unwrap());
     }
 
     // sglang only

--- a/launch/dynamo-run/src/subprocess/trtllm_config/sample.yaml
+++ b/launch/dynamo-run/src/subprocess/trtllm_config/sample.yaml
@@ -20,5 +20,6 @@
 # You might have to tweak this config based on your model size and GPU memory.
 
 backend: pytorch
+disable_overlap_scheduler: true
 kv_cache_config:
   free_gpu_memory_fraction: 0.40


### PR DESCRIPTION
#### Overview:

Allow passing task flag from dynamo-run cli. 
Tested the instructions locally. 
Follow-up work from: https://github.com/ai-dynamo/dynamo/pull/1355

#### Details:

There is planned future work for describing the workflow via `--next` argument and self-discovery for remote prefill worker.
Currently, I have described the limitation in the instructions.

Graham had ideas to express component graph in dynamo run which is somewhat more work. We are having more conversations around how to better synchronize dynamo-run and dynamo-serve [here](https://github.com/ai-dynamo/enhancements/pull/10).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for specifying a task mode (`prefill_and_decode`, `decode`, or `prefill`) when running the TensorRT-LLM engine, enabling more flexible serving configurations.
- **Documentation**
	- Expanded instructions for using the TensorRT-LLM engine in multi-GPU, multinode, and disaggregated serving setups, including detailed examples and important usage notes.
- **Configuration**
	- Introduced a new `disable_overlap_scheduler` option in the sample configuration file for advanced engine tuning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->