### PR TITLE
fix: update nixl build and keep wheels dir in vllm container

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -520,8 +520,7 @@ COPY --from=base /workspace/wheels/nixl/*.whl wheelhouse/
 COPY --from=wheel_builder /workspace/dist/*.whl wheelhouse/
 RUN uv pip install ai-dynamo[vllm] --find-links wheelhouse && \
     uv pip install nixl --find-links wheelhouse && \
-    ln -sf $VIRTUAL_ENV/bin/* /usr/local/bin/ && \
-    rm -r wheelhouse
+    ln -sf $VIRTUAL_ENV/bin/* /usr/local/bin/
 
 # Tell vllm to use the Dynamo LLM C API for KV Cache Routing
 ENV VLLM_KV_CAPI_PATH="/opt/dynamo/bindings/lib/libdynamo_llm_capi.so"

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -120,21 +120,12 @@ WORKDIR /workspace
 # Copy nixl source, and use commit hash as cache hint
 COPY --from=nixl_base /opt/nixl /opt/nixl
 COPY --from=nixl_base /opt/nixl/commit.txt /opt/nixl/commit.txt
-RUN if [ "$ARCH" = "arm64" ]; then \
-        cd /opt/nixl && \
-        mkdir build && \
-        meson setup build/ --buildtype=release --prefix=/usr/local/nixl -Dgds_path=/usr/local/cuda/targets/sbsa-linux && \
-        cd build/ && \
-        ninja && \
-        ninja install; \
-    else \
-        cd /opt/nixl && \
-        mkdir build && \
-        meson setup build/ --buildtype=release --prefix=/usr/local/nixl && \
-        cd build/ && \
-        ninja && \
-        ninja install; \
-    fi
+RUN cd /opt/nixl && \
+    mkdir build && \
+    meson setup build/ --buildtype=release --prefix=/usr/local/nixl && \
+    cd build/ && \
+    ninja && \
+    ninja install
 
 ### NATS & ETCD SETUP ###
 # nats

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -152,13 +152,7 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 # Install NIXL Python module
-# TODO: Move gds_path selection based on arch into NIXL build
-RUN if [ "$ARCH" = "arm64" ]; then \
-        cd /opt/nixl && uv build . --out-dir /workspace/wheels/nixl \
-        --config-settings=setup-args="-Dgds_path=/usr/local/cuda/targets/sbsa-linux"; \
-    else \
-        cd /opt/nixl && uv build . --out-dir /workspace/wheels/nixl; \
-    fi
+RUN cd /opt/nixl && uv build . --out-dir /workspace/wheels/nixl
 
 # Install the wheel
 # TODO: Move NIXL wheel install to the wheel_builder stage


### PR DESCRIPTION
#### Overview:

* NIXL now supports arm builds, so no need to pass in gds-path args. Ref: https://github.com/ai-dynamo/nixl/commit/2a88836d17df499a72e981dd5f3557ca63f8c9ae
* Do not delete wheelhouse directory from runtime container, need it in CI

closes: OPS-272, OPS-273


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified the build and installation process for all architectures, removing architecture-specific logic.
  - Standardized build commands and configuration across platforms.
  - The wheelhouse directory is now retained after installation, instead of being deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->