### PR TITLE
fix: remove lib.real from LD_LIBRARY_PATH

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -92,7 +92,7 @@ RUN cd /usr/local/src && \
     make -j install-strip &&    \
     ldconfig
 
-ENV LD_LIBRARY_PATH=/usr/lib:/usr/local/ucx/lib:/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/lib:/usr/local/ucx/lib:$LD_LIBRARY_PATH
 ENV CPATH=/usr/include:$CPATH
 ENV PATH=/usr/bin:$PATH
 ENV PKG_CONFIG_PATH=/usr/lib/pkgconfig:$PKG_CONFIG_PATH


### PR DESCRIPTION
#### Overview:

Follow-up fix from https://github.com/ai-dynamo/dynamo/pull/1117.
The PR missed removing lib.real from TensorRT-LLM container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment configuration in the Docker image to remove an unused library path, improving container setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->