### PR TITLE
feat: add vllm_v1 framework to run command

### DIFF
--- a/container/run.sh
+++ b/container/run.sh
@@ -24,7 +24,7 @@ RUN_PREFIX=
 # dependencies are specified in the /container/deps folder and
 # installed within framework specific sections of the Dockerfile.
 
-declare -A FRAMEWORKS=(["VLLM"]=1 ["TENSORRTLLM"]=2 ["SGLANG"]=3)
+declare -A FRAMEWORKS=(["VLLM"]=1 ["TENSORRTLLM"]=2 ["SGLANG"]=3 ["VLLM_V1"]=4)
 DEFAULT_FRAMEWORK=VLLM
 
 SOURCE_DIR=$(dirname "$(readlink -f "$0")")


### PR DESCRIPTION
#### Overview:

Add VLLM_V1 framework to run.sh so developers can run vllm_v1 examples


#### Where should the reviewer start?

Only change is in `container/run.sh`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
