### PR TITLE
fix: Fix NIXL 0.3.1 build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4085,9 +4085,8 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ed1b2b73a39516cb082cc2e0c8cf5fa9aadf7364b3b7851f43fbcda70566ee"
+version = "0.3.1"
+source = "git+https://github.com/ai-dynamo/nixl?rev=a7c654d46a14cd5ce635cc8c02433d71df93dedf#a7c654d46a14cd5ce635cc8c02433d71df93dedf"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2811,9 +2811,8 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ed1b2b73a39516cb082cc2e0c8cf5fa9aadf7364b3b7851f43fbcda70566ee"
+version = "0.3.1"
+source = "git+https://github.com/ai-dynamo/nixl?rev=a7c654d46a14cd5ce635cc8c02433d71df93dedf#a7c654d46a14cd5ce635cc8c02433d71df93dedf"
 dependencies = [
  "bindgen",
  "cc",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -81,7 +81,7 @@ regex = "1"
 rayon = "1"
 
 # block_manager
-nixl-sys = { version = "0.3.0-rc.2", optional = true }
+nixl-sys = {git="https://github.com/ai-dynamo/nixl", rev = "a7c654d46a14cd5ce635cc8c02433d71df93dedf", optional = true }
 cudarc = { version = "0.16.2", features = ["cuda-12020"], optional = true }
 ndarray = { version = "0.16", optional = true }
 nix = { version = "0.26", optional = true }

--- a/lib/llm/src/block_manager/block/transfer/nixl.rs
+++ b/lib/llm/src/block_manager/block/transfer/nixl.rs
@@ -117,8 +117,8 @@ where
         .storage_type()
         .nixl_mem_type();
 
-    let mut src_dl = XferDescList::new(src_mem_type)?;
-    let mut dst_dl = XferDescList::new(dst_mem_type)?;
+    let mut src_dl = XferDescList::new(src_mem_type, true)?;
+    let mut dst_dl = XferDescList::new(dst_mem_type, true)?;
 
     for (src, dst) in src.iter().zip(dst.iter_mut()) {
         append_xfer_request(src, dst, &mut src_dl, &mut dst_dl)?;


### PR DESCRIPTION
Fixes a issue that kept `nixl-sys` pinned at 0.3.0, even though we're using NIXL 0.3.1. See https://github.com/ai-dynamo/dynamo/pull/1517#discussion_r2145706772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated an internal dependency to use a specific Git commit for improved consistency.

- **Refactor**
  - Adjusted initialization parameters for transfer descriptor lists to enhance internal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->