### PR TITLE
refactor: Log subprocess stderr as WARN

### DIFF
--- a/launch/dynamo-run/src/subprocess.rs
+++ b/launch/dynamo-run/src/subprocess.rs
@@ -98,7 +98,11 @@ pub async fn start(
     tokio::spawn(async move {
         let mut lines = stderr.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            tracing::error!("{}", strip_log_prefix(&line));
+            // FIXME: always logging INFO/DEBUG will hide real errors, but
+            // some libraries log non-errors to stderr, which confuses users
+            // when we log those as ERROR. Using WARN as a middle ground for
+            // now, but we can probably be smarter here.
+            tracing::warn!("{}", strip_log_prefix(&line));
         }
     });
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

To unblock v0.3.1 release feedback from QA (nvbugs/5344071)

Context:
- Previously, real errors were getting logged as DEBUG/INFO (ex: CUDA OOM on vllm startup), which made them either completely hidden (DEBUG), or blended in with healthy outputs (INFO)
- After https://github.com/ai-dynamo/dynamo/pull/1484, it was discovered that some healthy output (ex: MPI logs, flashinfer.jit logs, etc.) are writing to stderr and thus being logged as ERROR, confusing users thinking something went wrong

This PR proposes a temporary middle ground of WARN for v0.3.1 release, so that genuine errors aren't easily hidden, but genuine healthy logs aren't mistakenly read as ERROR.

Hopefully we can come up with a better solution in the future.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted logging for subprocess standard error output to display warnings instead of errors, reducing confusion from non-critical messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->