### PR TITLE
fix: Fix sample disagg config for trtllm standalone

### DIFF
--- a/launch/dynamo-run/src/subprocess/trtllm_config/sample.yaml
+++ b/launch/dynamo-run/src/subprocess/trtllm_config/sample.yaml
@@ -20,5 +20,6 @@
 # You might have to tweak this config based on your model size and GPU memory.
 
 backend: pytorch
+disable_overlap_scheduler: true
 kv_cache_config:
   free_gpu_memory_fraction: 0.40


### PR DESCRIPTION
#### Overview:

The context worker needs the overlap scheduler to be disabled. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new configuration option to disable the overlap scheduler in the settings file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->