### PR TITLE
refactor: Log subprocess stderr as WARN (#1563)

### DIFF
--- a/launch/dynamo-run/src/subprocess.rs
+++ b/launch/dynamo-run/src/subprocess.rs
@@ -98,7 +98,11 @@ pub async fn start(
     tokio::spawn(async move {
         let mut lines = stderr.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            tracing::error!("{}", strip_log_prefix(&line));
+            // FIXME: always logging INFO/DEBUG will hide real errors, but
+            // some libraries log non-errors to stderr, which confuses users
+            // when we log those as ERROR. Using WARN as a middle ground for
+            // now, but we can probably be smarter here.
+            tracing::warn!("{}", strip_log_prefix(&line));
         }
     });
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Cherry-pick #1563 into release 0.3.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated logging to display certain subprocess messages as warnings instead of errors for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->