### PR TITLE
test: Remove completions endpoint from vllm tests.

### DIFF
--- a/tests/serve/test_dynamo_serve.py
+++ b/tests/serve/test_dynamo_serve.py
@@ -161,10 +161,9 @@ deployment_graphs = {
             module="graphs.agg:Frontend",
             config="configs/agg.yaml",
             directory="/workspace/examples/multimodal",
-            endpoints=["v1/chat/completions", "v1/completions"],
+            endpoints=["v1/chat/completions"],
             response_handlers=[
                 chat_completions_response_handler,
-                completions_response_handler,
             ],
             marks=[pytest.mark.gpu_2, pytest.mark.vllm],
         ),

--- a/tests/serve/test_dynamo_serve.py
+++ b/tests/serve/test_dynamo_serve.py
@@ -87,10 +87,9 @@ deployment_graphs = {
             module="graphs.agg:Frontend",
             config="configs/agg.yaml",
             directory="/workspace/examples/llm",
-            endpoints=["v1/chat/completions", "v1/completions"],
+            endpoints=["v1/chat/completions"],
             response_handlers=[
                 chat_completions_response_handler,
-                completions_response_handler,
             ],
             marks=[pytest.mark.gpu_1, pytest.mark.vllm],
         ),
@@ -115,10 +114,9 @@ deployment_graphs = {
             module="graphs.disagg:Frontend",
             config="configs/disagg.yaml",
             directory="/workspace/examples/llm",
-            endpoints=["v1/chat/completions", "v1/completions"],
+            endpoints=["v1/chat/completions"],
             response_handlers=[
                 chat_completions_response_handler,
-                completions_response_handler,
             ],
             marks=[pytest.mark.gpu_2, pytest.mark.vllm],
         ),
@@ -129,10 +127,9 @@ deployment_graphs = {
             module="graphs.agg_router:Frontend",
             config="configs/agg_router.yaml",
             directory="/workspace/examples/llm",
-            endpoints=["v1/chat/completions", "v1/completions"],
+            endpoints=["v1/chat/completions"],
             response_handlers=[
                 chat_completions_response_handler,
-                completions_response_handler,
             ],
             marks=[pytest.mark.gpu_1, pytest.mark.vllm],
             # FIXME: This is a hack to allow deployments to start before sending any requests.
@@ -147,10 +144,9 @@ deployment_graphs = {
             module="graphs.disagg_router:Frontend",
             config="configs/disagg_router.yaml",
             directory="/workspace/examples/llm",
-            endpoints=["v1/chat/completions", "v1/completions"],
+            endpoints=["v1/chat/completions"],
             response_handlers=[
                 chat_completions_response_handler,
-                completions_response_handler,
             ],
             marks=[pytest.mark.gpu_2, pytest.mark.vllm],
             # FIXME: This is a hack to allow deployments to start before sending any requests.


### PR DESCRIPTION
#### Overview:

Removing the completions/ endpoint from llm tests. The completions/ endpoint are expected to fail and the solution is to use dynamo run for ingress and registering endpoints. 

TRTLLM, VLLM v0 and vLLM v1 are using dynamo run for ingress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test configurations to remove the "v1/completions" endpoint from several deployment graph tests. Only the "v1/chat/completions" endpoint remains tested for these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->