### PR TITLE
fix: Dockerfile.sglang-deepep, sglang 0.4.7  compatible with sgl-kernel <= 0.1.8

### DIFF
--- a/container/Dockerfile.sglang-deepep
+++ b/container/Dockerfile.sglang-deepep
@@ -45,7 +45,7 @@ WORKDIR /sgl-workspace
 RUN pip uninstall --break-system-packages -y sglang
 RUN rm -rf sglang
 # 0.4.7
-RUN pip install --break-system-packages "sglang==0.4.7"
+RUN pip install --break-system-packages "sglang==0.4.7" "sgl-kernel==0.1.8"
 
 WORKDIR /sgl-workspace
 # https://github.com/ai-dynamo/dynamo/pull/1510


### PR DESCRIPTION


#### Overview:

fix dockerfile for sglang deepep, should use sgl-kernel <=0.1.8 for sglang 0.4.7

#### Details:

when using current sglang main branch to build base image, it will install sgl-kernel==0.1.9.
this will cause the following error when launch decode nodes:

```
2025-06-19T08:18:45.701Z ERROR scheduler.run_scheduler_process: Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 2490, in run_scheduler_process
    scheduler = Scheduler(server_args, port_args, gpu_id, tp_rank, pp_rank, dp_rank)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 282, in __init__
    self.tp_worker = TpWorkerClass(
                     ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/tp_worker_overlap_thread.py", line 64, in __init__
    self.worker = TpModelWorker(
                  ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/tp_worker.py", line 78, in __init__
    self.model_runner = ModelRunner(
                        ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/model_executor/model_runner.py", line 212, in __init__
    self.initialize(min_per_gpu_memory)
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/model_executor/model_runner.py", line 287, in initialize
    self.init_cuda_graphs()
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/model_executor/model_runner.py", line 1138, in init_cuda_graphs
    self.cuda_graph_runner = CudaGraphRunner(self)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/model_executor/cuda_graph_runner.py", line 305, in __init__
    self.capture()
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/model_executor/cuda_graph_runner.py", line 374, in capture
    ) = self.capture_one_batch_size(bs, forward)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-pa
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/models/deepseek_v2.py", line 1485, in forward
    hidden_states = self.self_attn(
                    ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/models/deepseek_v2.py", line 822, in forward
    s = self.forward_prepare(
        ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/models/deepseek_v2.py", line 857, in forward_prepare
    inner_state = self.forward_absorb_prepare(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/models/deepseek_v2.py", line 946, in forward_absorb_prepare
    q, latent_cache = self.fused_qkv_a_proj_with_mqa(hidden_states)[0].split(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/layers/linear.py", line 288, in forward
    output = self.quant_method.apply(self, x, bias)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/layers/quantization/fp8.py", line 422, in apply
    return self.w8a8_block_fp8_linear(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/layers/quantization/fp8_utils.py", line 236, in deepgemm_w8a8_block_fp8_linear_with_fallback
    q_input, x_scale = sglang_per_token_group_quant_fp8(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/layers/quantization/fp8_kernel.py", line 312, in sglang_per_token_group_quant_fp8
    sgl_per_token_group_quant_fp8(x, x_q, x_s, group_size, eps, fp8_min, fp8_max)
TypeError: sgl_per_token_group_quant_fp8() missing 1 required positional argument: 'scale_ue8m0'
```

#### Where should the reviewer start?

container/Dockerfile.sglang-deepep

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment to include the "sgl-kernel" package version 0.1.8 during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->