### PR TITLE
chore: Fix failing doctests

### DIFF
--- a/lib/runtime/src/engine.rs
+++ b/lib/runtime/src/engine.rs
@@ -51,7 +51,7 @@
 //!
 //! ## Usage Example
 //!
-//! ```rust
+//! ```rust,ignore
 //! use std::collections::HashMap;
 //! use std::sync::Arc;
 //! use crate::engine::{AsyncEngine, AsAnyAsyncEngine, DowncastAnyAsyncEngine};
@@ -350,7 +350,7 @@ where
 /// enabling ergonomic type erasure without explicit wrapper construction.
 ///
 /// ## Usage
-/// ```rust
+/// ```rust,ignore
 /// use crate::engine::AsAnyAsyncEngine;
 ///
 /// let typed_engine: Arc<dyn AsyncEngine<String, String, ()>> = Arc::new(MyEngine::new());
@@ -385,7 +385,7 @@ where
 /// It will only succeed if the type parameters exactly match the original engine's types.
 ///
 /// ## Usage
-/// ```rust
+/// ```rust,ignore
 /// use crate::engine::DowncastAnyAsyncEngine;
 ///
 /// let any_engine: Arc<dyn AnyAsyncEngine> = // ... from collection


### PR DESCRIPTION
This other MR broke doctests, and is causing Rust CI to fail: https://github.com/ai-dynamo/dynamo/pull/1601.

This ignores the failing code snippets to get CI passing.

A bit of a side note, but we should really require Rust CI to pass in order to merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation code examples to prevent them from being compiled or tested automatically. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->