### PR TITLE
feat: block locality

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,6 +30,7 @@
         "--network=host",
         "--ipc=host",
         "--cap-add=SYS_PTRACE",
+        "--cap-add=IPC_LOCK",
         "--shm-size=10G",
         "--ulimit=memlock=-1",
         "--ulimit=stack=67108864",
@@ -49,7 +50,6 @@
                 "python.defaultInterpreterPath": "/opt/dynamo/venv/bin/python",
                 "python.linting.enabled": true,
                 "python.linting.pylintEnabled": true,
-
                 "rust-analyzer.memoryLimit": 4096, // larger memory limit to reduce latency
                 "rust-analyzer.checkOnSave.command": "clippy",
                 "rust-analyzer.checkOnSave.enable": true,
@@ -57,7 +57,6 @@
                 "rust-analyzer.cargo.targetDir": "/home/ubuntu/dynamo/.build/target",
                 "rust-analyzer.procMacro.enable": true,
                 "rust-analyzer.completion.autoimport.enable": true,
-
                 // Enhanced rust-analyzer configuration
                 "rust-analyzer.linkedProjects": [
                     "dynamo/Cargo.toml",
@@ -67,7 +66,6 @@
                     "dynamo/lib/bindings/python/Cargo.toml",
                     "dynamo/launch/dynamo-run/Cargo.toml"
                 ],
-
                 "files.trimTrailingWhitespace": true,
                 "files.insertFinalNewline": true
             }
@@ -86,6 +84,7 @@
     "mounts": [
         // Default mounts
         "source=/tmp/,target=/tmp/,type=bind",
+        "source=/run/udev/,target=/run/udev/,type=bind",
         "source=dynamo-bashhistory,target=/home/ubuntu/.commandhistory,type=volume", // For bash history
         "source=dynamo-precommit-cache,target=/home/ubuntu/.cache/pre-commit,type=volume" // For pre-commit cache
         // Uncomment for additional functionality

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,7 @@ dependencies = [
  "tmq",
  "tokenizers",
  "tokio",
+ "tokio-retry",
  "tokio-stream",
  "tokio-util",
  "toktrie 0.6.31",
@@ -6566,6 +6567,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf33a76e0b1dd03b778f83244137bd59887abf25c0e87bc3e7071105f457693"
 dependencies = [
  "rayon",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -138,3 +138,6 @@ insta = { version = "1.41", features = [
 ] }
 aligned-vec = "0.6.4"
 lazy_static = "1.4"
+
+# block-manager
+tokio-retry = "0.3"

--- a/lib/llm/src/block_manager/block.rs
+++ b/lib/llm/src/block_manager/block.rs
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod factory;
+pub mod locality;
+
 pub mod registry;
 pub mod state;
 pub mod transfer;
@@ -76,6 +79,15 @@ pub enum BlockError {
 
     #[error("Invalid state: {0}")]
     InvalidState(String),
+
+    #[error("Invalid block ID: {0}")]
+    InvalidBlockID(BlockId),
+
+    #[error("Misconfigured block data parallelism: {0}")]
+    MisconfiguredBlockDataParallelism(String),
+
+    #[error("Incompatible storage type: {0}")]
+    IncompatibleStorageType(String),
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/lib/llm/src/block_manager/block/factory.rs
+++ b/lib/llm/src/block_manager/block/factory.rs
@@ -1,0 +1,123 @@
+use super::*;
+
+use derive_getters::Dissolve;
+
+/// Collection that holds shared storage and layout
+#[derive(Debug, Dissolve)]
+pub struct LocalBlockDataFactoryMut<L: BlockLayout> {
+    layout: L,
+    block_set_idx: usize,
+    worker_id: WorkerID,
+}
+
+pub struct LocalBlockDataFactory<L: BlockLayout> {
+    layout: Arc<L>,
+    block_set_idx: usize,
+    worker_id: WorkerID,
+}
+
+impl<L: BlockLayout + 'static> LocalBlockDataFactoryMut<L> {
+    /// Create a new block storage collection
+    pub fn new(layout: L, block_set_idx: usize, worker_id: WorkerID) -> BlockResult<Self> {
+        Ok(Self {
+            layout,
+            block_set_idx,
+            worker_id,
+        })
+    }
+
+    pub fn into_factory(self) -> LocalBlockDataFactory<L> {
+        let (layout, block_set_idx, worker_id) = self.dissolve();
+        let layout = Arc::new(layout);
+
+        LocalBlockDataFactory {
+            layout,
+            block_set_idx,
+            worker_id,
+        }
+    }
+}
+
+impl<L: BlockLayout + 'static> LocalBlockDataFactory<L> {
+    pub fn create_block_data(&self, block_idx: BlockId) -> BlockResult<BlockData<L::StorageType>> {
+        if block_idx >= self.layout.num_blocks() {
+            return Err(BlockError::InvalidBlockID(block_idx));
+        }
+
+        let data = BlockData::new(
+            self.layout.clone(),
+            block_idx,
+            self.block_set_idx,
+            self.worker_id,
+        );
+        Ok(data)
+    }
+}
+
+pub mod nixl {
+    use super::*;
+    use crate::block_manager::{
+        layout::nixl::{NixlLayout, SerializedNixlBlockLayout},
+        storage::nixl::{NixlRegisterableStorage, NixlStorage},
+    };
+    use nixl_sys::{Agent as NixlAgent, OptArgs};
+
+    impl<L: NixlLayout> LocalBlockDataFactoryMut<L>
+    where
+        L::StorageType: NixlRegisterableStorage,
+    {
+        /// Register the blocks with an NIXL agent
+        pub fn nixl_register(
+            &mut self,
+            agent: &NixlAgent,
+            opt_args: Option<&OptArgs>,
+        ) -> anyhow::Result<()> {
+            self.layout.nixl_register(agent, opt_args)
+        }
+
+        /// Convert the factory into a remote factory
+        pub fn into_remote_factory(self) -> BlockResult<RemoteBlockDataFactory> {
+            let serialized_layout = self.layout.serialize()?;
+            let layout = serialized_layout.deserialize()?;
+
+            Ok(RemoteBlockDataFactory {
+                layout,
+                block_set_idx: self.block_set_idx,
+                worker_id: self.worker_id,
+            })
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct RemoteBlockDataFactory {
+        layout: Arc<dyn BlockLayout<StorageType = NixlStorage>>,
+        block_set_idx: usize,
+        worker_id: WorkerID,
+    }
+}
+
+// // /// Convert collection into Vec<Block> with default metadata/state
+// // pub fn into_blocks(self) -> BlockResult<Vec<Block<L::StorageType, M>>> {
+// //     // convert box to arc
+// //     let layout: Arc<dyn BlockLayout<StorageType = L::StorageType>> = Arc::new(*self.layout);
+// //     layout_to_blocks(layout, self.block_set_idx, self.worker_id)
+// // }
+
+// pub fn create_block_data(&self, block_id: BlockID) -> BlockResult<BlockData<L::StorageType>> {
+//     let layout = Arc::new(self.layout);
+//     let data = BlockData::new(layout, block_id, self.block_set_idx, self.worker_id);
+//     Ok(data)
+// }
+
+pub(crate) fn layout_to_data<S: Storage, M: BlockMetadata>(
+    layout: Arc<dyn BlockLayout<StorageType = S>>,
+    block_set_idx: usize,
+    worker_id: WorkerID,
+) -> BlockResult<Vec<Block<S, M>>> {
+    (0..layout.num_blocks())
+        .map(|idx| {
+            let data = BlockData::new(layout.clone(), idx, block_set_idx, worker_id);
+            Block::new(data, M::default())
+        })
+        .collect()
+}

--- a/lib/llm/src/block_manager/block/locality.rs
+++ b/lib/llm/src/block_manager/block/locality.rs
@@ -1,0 +1,163 @@
+use super::{
+    transfer::{TransferStrategy, WriteToStrategy},
+    *,
+};
+
+pub trait BlockDataLocality: Send + Sync + std::fmt::Debug {}
+
+pub trait Locality: Send + Sync + std::fmt::Debug + PartialEq + Eq + std::hash::Hash {
+    fn is_compatible_storage(storage_type: &StorageType) -> Result<(), BlockError>;
+    fn storage_type(&self) -> &StorageType;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Host {
+    storage_type: StorageType,
+}
+
+impl Host {
+    pub fn new(storage_type: StorageType) -> Result<Self, BlockError> {
+        Self::is_compatible_storage(&storage_type)?;
+        Ok(Self { storage_type })
+    }
+}
+
+impl Locality for Host {
+    fn is_compatible_storage(storage_type: &StorageType) -> Result<(), BlockError> {
+        match storage_type {
+            StorageType::System => Ok(()),
+            StorageType::Pinned => Ok(()),
+            _ => Err(BlockError::IncompatibleStorageType(
+                "Host is not compatible with this storage type; only system and pinned are allowed"
+                    .to_string(),
+            )),
+        }
+    }
+
+    fn storage_type(&self) -> &StorageType {
+        &self.storage_type
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Device {
+    storage_type: StorageType,
+}
+
+impl Device {
+    pub fn new(storage_type: StorageType) -> Result<Self, BlockError> {
+        Self::is_compatible_storage(&storage_type)?;
+        Ok(Self { storage_type })
+    }
+}
+
+impl Locality for Device {
+    fn storage_type(&self) -> &StorageType {
+        &self.storage_type
+    }
+    fn is_compatible_storage(storage_type: &StorageType) -> Result<(), BlockError> {
+        match storage_type {
+            StorageType::Device(_device) => Ok(()),
+            _ => Err(BlockError::IncompatibleStorageType(
+                "Device is not compatible with this storage type; only device are allowed"
+                    .to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Disk;
+
+impl Disk {
+    pub fn new(storage_type: StorageType) -> Result<Self, BlockError> {
+        Self::is_compatible_storage(&storage_type)?;
+        Ok(Self)
+    }
+}
+
+impl Locality for Disk {
+    fn storage_type(&self) -> &StorageType {
+        &StorageType::Disk
+    }
+
+    fn is_compatible_storage(storage_type: &StorageType) -> Result<(), BlockError> {
+        match storage_type {
+            StorageType::Disk => Ok(()),
+            _ => Err(BlockError::IncompatibleStorageType(
+                "Disk is not compatible with this storage type; only disk are allowed".to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct LocalBlockData<S: Storage> {
+    block_data: BlockData<S>,
+}
+
+impl<S: Storage> BlockDataLocality for LocalBlockData<S> {}
+
+pub mod nixl {
+    use super::*;
+    use crate::block_manager::storage::{nixl::NixlStorage, StorageType};
+    use std::collections::HashSet;
+
+    #[derive(Debug)]
+    pub struct RemoteBlockData {
+        block_data: BlockData<NixlStorage>,
+    }
+
+    impl BlockDataLocality for RemoteBlockData {}
+
+    #[derive(Debug)]
+    pub struct ActiveMessageClient {}
+
+    #[derive(Debug)]
+    pub struct ReplicatedBlockDataParallel<L: Locality> {
+        block_data: Vec<RemoteBlockData>,
+        am_client: Vec<ActiveMessageClient>,
+        storage: std::marker::PhantomData<L>,
+    }
+
+    impl<L: Locality> ReplicatedBlockDataParallel<L> {
+        pub fn new(
+            block_data: Vec<RemoteBlockData>,
+            am_client: Vec<ActiveMessageClient>,
+        ) -> Result<Self, BlockError> {
+            let storage_type = block_data
+                .iter()
+                .map(|bd| bd.block_data.storage_type())
+                .collect::<HashSet<StorageType>>();
+
+            // determine that all the block data have the same storage type
+            if storage_type.len() != 1 {
+                return Err(BlockError::MisconfiguredBlockDataParallelism(
+                    "All block data must have the same storage type".to_string(),
+                ));
+            }
+
+            let remote_storage_type = storage_type.iter().next().unwrap();
+            L::is_compatible_storage(remote_storage_type)?;
+
+            Ok(Self {
+                block_data,
+                am_client,
+                storage: std::marker::PhantomData,
+            })
+        }
+    }
+
+    impl<L: Locality> BlockDataLocality for ReplicatedBlockDataParallel<L> {}
+}
+
+pub mod v2 {
+
+    use super::{BlockDataLocality, BlockMetadata, BlockState};
+
+    pub struct Block<L: BlockDataLocality, M: BlockMetadata> {
+        locality: L,
+        metadata: M,
+        state: BlockState,
+    }
+}

--- a/lib/llm/src/block_manager/storage.rs
+++ b/lib/llm/src/block_manager/storage.rs
@@ -100,7 +100,7 @@ use thiserror::Error;
 pub type StorageResult<T> = std::result::Result<T, StorageError>;
 
 /// Represents the type of storage used for a block
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum StorageType {
     /// System memory
     System,


### PR DESCRIPTION
Rebased a consider update from @jthomson04 

This adds Locality to Blocks.  Blocks and everything upstream have a concept of Locality.  Local = present on physical machine and directly addressable.  Remote means present on a remote process, possible in the same machine or a different machine.  Local can perform transfers to/from local and with NIXL to/from Remote -- provided in both cases the mutability constraints are met.

New to locality is Logical.

Logical doesn't own any memory/storage per se, but can perform ownership and operation on logical blocks. Operation on logical block trigger active message based rpc-like operation on workers in the leader-worker model.  A copy of a logical block from Device --> Host memory would trigger an RPC on a worker(s) to copy its local data from a representative disk block to a host block.  Note, in the leader-worker model, all ownership and ops are performed by the leader and the resulting transactions are executed by the worker(s).  In the case of multi-workers where data is shared, we currently only support shared data and transfers within individual workers.  However, more sophisticated transfers involving data movement between works could be added by providing a new Parallelism implementation.