### PR TITLE
chore: add exempt issue labels to stale cleaner config

### DIFF
--- a/.github/workflows/stale_cleaner.yml
+++ b/.github/workflows/stale_cleaner.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days. As a reminder, please use backlog label to avoid issues being marked as stale.'
           close-issue-message: 'This issue has been closed due to inactivity. If you believe this issue is still relevant, please feel free to reopen it with additional context or information.'
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           close-pr-message: 'This PR has been closed due to inactivity. If you believe this PR is still relevant, please feel free to reopen it with additional context or information.'
@@ -35,3 +35,4 @@ jobs:
           days-before-stale: 30
           days-before-close: 5
           any-of-issue-labels: 'bug'
+          exempt-issue-labels: 'backlog'


### PR DESCRIPTION
#### Overview:

Skip any issues with `backlog` label from being marked as stale. `backlog` label will be used issues or bugs that will be tracked for long term fixes

closes: OPS-289


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated stale issue notifications to remind users that applying the "backlog" label prevents issues from being marked as stale.
  - Issues labeled "backlog" are now exempt from being marked as stale or automatically closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->