### PR TITLE
refactor: using async_openai::types::Logprobs

### DIFF
--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
 use derive_builder::Builder;
 use dynamo_runtime::protocols::annotated::AnnotationsProvider;
 use serde::{Deserialize, Serialize};
@@ -92,7 +90,7 @@ pub struct CompletionChoice {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
-    pub logprobs: Option<LogprobResult>,
+    pub logprobs: Option<async_openai::types::Logprobs>,
 }
 
 impl ContentProvider for CompletionChoice {
@@ -105,16 +103,6 @@ impl CompletionChoice {
     pub fn builder() -> CompletionChoiceBuilder {
         CompletionChoiceBuilder::default()
     }
-}
-
-// TODO: validate this is the correct format
-/// Legacy OpenAI LogprobResult component
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct LogprobResult {
-    pub tokens: Vec<String>,
-    pub token_logprobs: Vec<f32>,
-    pub top_logprobs: Vec<HashMap<String, f32>>,
-    pub text_offset: Vec<i32>,
 }
 
 pub fn prompt_to_string(prompt: &async_openai::types::Prompt) -> String {

--- a/lib/llm/src/protocols/openai/completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/completions/aggregator.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, str::FromStr};
 use anyhow::Result;
 use futures::StreamExt;
 
-use super::{CompletionChoice, CompletionResponse, LogprobResult};
+use super::{CompletionChoice, CompletionResponse};
 use crate::protocols::{
     codec::{Message, SseCodecError},
     common::FinishReason,
@@ -40,7 +40,7 @@ struct DeltaChoice {
     index: u64,
     text: String,
     finish_reason: Option<FinishReason>,
-    logprobs: Option<LogprobResult>,
+    logprobs: Option<async_openai::types::Logprobs>,
 }
 
 impl Default for DeltaAggregator {


### PR DESCRIPTION
#### Overview:

Refactoring to use `async_openai::types::Logprobs`

#### Details:

This change is to be consistent with previous renaming and refactoring for protocols:

- [!261 - refactor: using async_openai](https://github.com/triton-inference-server/triton_distributed/pull/261)
- [!284 - refactor: rename ChatCompletionRequest to NvCreateChatCompletionRequest](https://github.com/triton-inference-server/triton_distributed/pull/284)
- [!291 - refactor: rename ChatCompletionResponse to NvCreateChatCompletionResponse](https://github.com/triton-inference-server/triton_distributed/pull/291)
- [!292 - refactor: rename ChatCompletionResponseDelta to NvCreateChatCompletionStreamResponse](https://github.com/triton-inference-server/triton_distributed/pull/292)
- [!296 - refactor: removes wrapper for ChatCompletionContent and adds documentation](https://github.com/triton-inference-server/triton_distributed/pull/296)
- [!310 - refactor: use async-openai CompletionRequest](https://github.com/triton-inference-server/triton_distributed/pull/310)
- [!1383 - refactor: Rename CompletionRequest to NvCreateCompletionRequest ](https://github.com/ai-dynamo/dynamo/pull/1383)
- [!1397 - refactor: refactoring to use async_openai::types::CompletionUsage ](https://github.com/ai-dynamo/dynamo/pull/1397)

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal data handling for log probability results to improve consistency with external systems. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->