### PR TITLE
fix: boolean flags can now be set in ServiceConfig

### DIFF
--- a/deploy/sdk/src/dynamo/sdk/lib/config.py
+++ b/deploy/sdk/src/dynamo/sdk/lib/config.py
@@ -105,7 +105,9 @@ class ServiceConfig(dict):
             # Convert to CLI format
             if isinstance(value, bool):
                 if value:
-                    args.append(f"--{arg_key}")
+                    args.extend([f"--{arg_key}", "true"])
+                else:
+                    args.extend([f"--{arg_key}", "false"])
             elif isinstance(value, dict):
                 args.extend([f"--{arg_key}", json.dumps(value)])
             else:


### PR DESCRIPTION
#### Overview:

Fixes issue where a config flag like `enable_my_feature: false` would be ignored

#### Details:

Now arguments will be parsed like:
```
arg: true -> "--arg true"
arg: false -> "--arg false"
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Boolean configuration options are now always passed as explicit string values ("true" or "false") in command-line arguments, ensuring consistent and clear handling of boolean flags.

- **Tests**
	- Added a new test to verify that boolean configuration values are correctly converted to explicit string arguments in the generated command-line arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->