### PR TITLE
chore: Add SERVED_MODEL_NAME for consistent model name regardless of MODEL_PATH

### DIFF
--- a/examples/tensorrt_llm/configs/deepseek_r1/multinode/README.md
+++ b/examples/tensorrt_llm/configs/deepseek_r1/multinode/README.md
@@ -168,7 +168,7 @@ To verify the deployed model is working, send a `curl` request:
 # NOTE: $HOST assumes running on head node, but can be changed to $HEAD_NODE_IP instead.
 HOST=localhost
 PORT=8000
-# "model" here should match SERVED_MODEL_NAME, or whatever is returned by the /v1/models endpoint
+# "model" here should match the model name returned by the /v1/models endpoint
 curl -w "%{http_code}" ${HOST}:${PORT}/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{

--- a/examples/tensorrt_llm/configs/deepseek_r1/multinode/README.md
+++ b/examples/tensorrt_llm/configs/deepseek_r1/multinode/README.md
@@ -99,6 +99,13 @@ export MOUNTS="${PWD}:/mnt"
 # https://huggingface.co/deepseek-ai/DeepSeek-R1
 export MODEL_PATH="nvidia/DeepSeek-R1-FP4"
 
+# The name the model will be served/queried under, matching what's
+# returned by the /v1/models endpoint.
+#
+# By default this is inferred from MODEL_PATH, but when using locally downloaded
+# model weights, it can be nice to have explicit control over the name.
+export SERVED_MODEL_NAME="nvidia/DeepSeek-R1-FP4"
+
 # NOTE: This path assumes you have mounted the config file into /mnt inside
 # the container. See the MOUNTS variable in srun_script.sh
 export ENGINE_CONFIG="/mnt/agg_DEP16_dsr1.yaml"
@@ -148,7 +155,7 @@ export ENGINE_CONFIG="/mnt/agg_DEP16_dsr1.yaml"
 4. After the model fully finishes loading on all ranks, the worker will register itself,
    and the OpenAI frontend will detect it, signaled by this output:
     ```
-    0: 2025-06-13T02:46:35.040Z  INFO dynamo_llm::discovery::watcher: added model model_name="Deepseek-R1-FP4"
+    0: 2025-06-13T02:46:35.040Z  INFO dynamo_llm::discovery::watcher: added model model_name="nvidia/DeepSeek-R1-FP4"
     ```
 5. At this point, with the worker fully initialized and detected by the frontend,
    it is now ready for inference.
@@ -161,11 +168,11 @@ To verify the deployed model is working, send a `curl` request:
 # NOTE: $HOST assumes running on head node, but can be changed to $HEAD_NODE_IP instead.
 HOST=localhost
 PORT=8000
-MODEL=Deepseek-R1-FP4
+# "model" here should match SERVED_MODEL_NAME, or whatever is returned by the /v1/models endpoint
 curl -w "%{http_code}" ${HOST}:${PORT}/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-  "model": "'${MODEL}'",
+  "model": "'${SERVED_MODEL_NAME}'",
   "messages": [
   {
     "role": "user",

--- a/examples/tensorrt_llm/configs/deepseek_r1/multinode/start_trtllm_worker.sh
+++ b/examples/tensorrt_llm/configs/deepseek_r1/multinode/start_trtllm_worker.sh
@@ -10,6 +10,13 @@ if [[ -z ${MODEL_PATH} ]]; then
     exit 1
 fi
 
+if [[ -z ${SERVED_MODEL_NAME} ]]; then
+    echo "WARNING: SERVED_MODEL_NAME was not set. It will be derived from MODEL_PATH."
+    exit 1
+fi
+
+
+
 if [[ -z ${ENGINE_CONFIG} ]]; then
     echo "ERROR: ENGINE_CONFIG was not set."
     echo "ERROR: ENGINE_CONFIG must be set to a valid Dynamo+TRTLLM engine config file."
@@ -23,4 +30,5 @@ fi
 trtllm-llmapi-launch \
   python3 /workspace/launch/dynamo-run/src/subprocess/trtllm_inc.py \
     --model-path "${MODEL_PATH}" \
+    --model-name "${SERVED_MODEL_NAME}" \
     --extra-engine-args "${ENGINE_CONFIG}"

--- a/examples/tensorrt_llm/configs/deepseek_r1/multinode/start_trtllm_worker.sh
+++ b/examples/tensorrt_llm/configs/deepseek_r1/multinode/start_trtllm_worker.sh
@@ -12,7 +12,6 @@ fi
 
 if [[ -z ${SERVED_MODEL_NAME} ]]; then
     echo "WARNING: SERVED_MODEL_NAME was not set. It will be derived from MODEL_PATH."
-    exit 1
 fi
 
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

To avoid inconsistency in served model name when using locally downloaded model weights path vs. HF ID, set a SERVED_MODEL_NAME and use it on deployment and in curl request.

Fixes QA feedback in nvbugs/5354157 as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to introduce the `SERVED_MODEL_NAME` environment variable for explicitly setting the served model's name.
  - Revised example commands and outputs to use `SERVED_MODEL_NAME` for consistency.

- **Chores**
  - Modified the worker startup script to require `SERVED_MODEL_NAME` and ensure it is passed when launching the worker process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->