### PR TITLE
test: several fixes for e2e vllm tests

### DIFF
--- a/components/planner/src/dynamo/planner/local_connector.py
+++ b/components/planner/src/dynamo/planner/local_connector.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class LocalConnector(PlannerConnector):
-    def __init__(self, namespace: str, runtime: DistributedRuntime, backend: str):
+    def __init__(self, namespace: str, runtime: DistributedRuntime):
         """
         Initialize LocalConnector and connect to CircusController.
 

--- a/components/planner/src/dynamo/planner/local_connector.py
+++ b/components/planner/src/dynamo/planner/local_connector.py
@@ -39,7 +39,6 @@ class LocalConnector(PlannerConnector):
         Args:
             namespace: The Dynamo namespace
             runtime: Optional DistributedRuntime instance
-            backend: The backend to use ("vllm_v0", "vllm_v1")
         """
         self.namespace = namespace
         self.runtime = runtime

--- a/tests/serve/conftest.py
+++ b/tests/serve/conftest.py
@@ -12,3 +12,69 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import logging
+import os
+
+import pytest
+
+# List of models used in the serve tests
+SERVE_TEST_MODELS = [
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+    "llava-hf/llava-1.5-7b-hf",
+]
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def predownload_models():
+    # Check for HF_TOKEN in environment
+    hf_token = os.environ.get("HF_TOKEN")
+    if hf_token:
+        logger.info("HF_TOKEN found in environment")
+    else:
+        logger.warning(
+            "HF_TOKEN not found in environment. "
+            "Some models may fail to download or you may encounter rate limits. "
+            "Get a token from https://huggingface.co/settings/tokens"
+        )
+
+    try:
+        from huggingface_hub import snapshot_download
+
+        for model_id in SERVE_TEST_MODELS:
+            logger.info(f"Pre-downloading model: {model_id}")
+
+            try:
+                # Download the full model snapshot (includes all files)
+                # HuggingFace will handle caching automatically
+                snapshot_download(
+                    repo_id=model_id,
+                    token=hf_token,
+                )
+                logger.info(f"Successfully pre-downloaded: {model_id}")
+
+            except Exception as e:
+                logger.error(f"Failed to pre-download {model_id}: {e}")
+                # Don't fail the fixture - let individual tests handle missing models
+
+    except ImportError:
+        logger.warning(
+            "huggingface_hub not installed. "
+            "Models will be downloaded during test execution."
+        )
+
+    yield
+
+
+# Automatically use the predownload fixture for all serve tests
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        # Only apply to tests in the serve directory
+        if "serve" in str(item.fspath):
+            # Check if the test already uses the fixture
+            if "predownload_models" not in item.fixturenames:
+                # Don't add if test explicitly marks to skip model download
+                if not item.get_closest_marker("skip_model_download"):
+                    item.fixturenames.append("predownload_models")

--- a/tests/serve/conftest.py
+++ b/tests/serve/conftest.py
@@ -76,7 +76,7 @@ def pytest_collection_modifyitems(config, items):
             continue
 
         # Only apply to tests in the serve directory
-        if "serve" in str(item.fspath):
+        if "serve" in str(item.path):
             # Check if the test already uses the fixture
             if "predownload_models" not in item.fixturenames:
                 # Don't add if test explicitly marks to skip model download

--- a/tests/serve/conftest.py
+++ b/tests/serve/conftest.py
@@ -71,6 +71,10 @@ def predownload_models():
 # Automatically use the predownload fixture for all serve tests
 def pytest_collection_modifyitems(config, items):
     for item in items:
+        # Skip items that don't have fixturenames (like MypyFileItem)
+        if not hasattr(item, "fixturenames"):
+            continue
+
         # Only apply to tests in the serve directory
         if "serve" in str(item.fspath):
             # Check if the test already uses the fixture

--- a/tests/serve/conftest.py
+++ b/tests/serve/conftest.py
@@ -81,4 +81,5 @@ def pytest_collection_modifyitems(config, items):
             if "predownload_models" not in item.fixturenames:
                 # Don't add if test explicitly marks to skip model download
                 if not item.get_closest_marker("skip_model_download"):
+                    item.fixturenames = list(item.fixturenames)
                     item.fixturenames.append("predownload_models")

--- a/tests/serve/test_dynamo_serve.py
+++ b/tests/serve/test_dynamo_serve.py
@@ -159,7 +159,7 @@ deployment_graphs = {
     "multimodal_agg": (
         DeploymentGraph(
             module="graphs.agg:Frontend",
-            config="configs/agg.yaml",
+            config="configs/agg-llava.yaml",
             directory="/workspace/examples/multimodal",
             endpoints=["v1/chat/completions"],
             response_handlers=[


### PR DESCRIPTION
#### Overview:

as titled:

1. pre-download models to prevent rate limiting
2. removed `backend` arg from `LocalConnector`
3. point to `agg-llava.yaml` for multimodal test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved serve test reliability by automatically pre-downloading required HuggingFace models before test execution, reducing test-time download delays.
  - Tests now log a warning if authentication tokens are missing or if model downloads fail, but will not fail due to these issues.
  - Serve tests are now set up to use this pre-download process by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->