### PR TITLE
refactor: refactored using Choice and CompletionFinishReason

### DIFF
--- a/lib/llm/src/engines.rs
+++ b/lib/llm/src/engines.rs
@@ -237,7 +237,7 @@ impl AsyncEngine<SingleIn<NvCreateCompletionRequest>, ManyOut<Annotated<Completi
                 yield Annotated{ id: Some(id.to_string()), data: Some(response), event: None, comment: None };
                 id += 1;
             }
-            let response = deltas.create_choice(0, None, Some("stop".to_string()));
+            let response = deltas.create_choice(0, None, Some(async_openai::types::CompletionFinishReason::Stop));
             yield Annotated { id: Some(id.to_string()), data: Some(response), event: None, comment: None };
 
         };

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -198,6 +198,9 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
             Some(common::FinishReason::Stop) => Some(async_openai::types::FinishReason::Stop),
             Some(common::FinishReason::Length) => Some(async_openai::types::FinishReason::Length),
             Some(common::FinishReason::Cancelled) => Some(async_openai::types::FinishReason::Stop),
+            Some(common::FinishReason::ContentFilter) => {
+                Some(async_openai::types::FinishReason::ContentFilter)
+            }
             Some(common::FinishReason::Error(err_msg)) => {
                 return Err(anyhow::anyhow!(err_msg));
             }

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{CompletionChoice, CompletionResponse, NvCreateCompletionRequest};
+use super::{CompletionResponse, NvCreateCompletionRequest};
 use crate::protocols::common;
 
 impl NvCreateCompletionRequest {
@@ -82,7 +82,7 @@ impl DeltaGenerator {
         &self,
         index: u64,
         text: Option<String>,
-        finish_reason: Option<String>,
+        finish_reason: Option<async_openai::types::CompletionFinishReason>,
     ) -> CompletionResponse {
         // todo - update for tool calling
 
@@ -92,9 +92,9 @@ impl DeltaGenerator {
             created: self.created,
             model: self.model.clone(),
             system_fingerprint: self.system_fingerprint.clone(),
-            choices: vec![CompletionChoice {
+            choices: vec![async_openai::types::Choice {
                 text: text.unwrap_or_default(),
-                index,
+                index: index as u32,
                 finish_reason,
                 logprobs: None,
             }],
@@ -117,18 +117,9 @@ impl crate::protocols::openai::DeltaGeneratorExt<CompletionResponse> for DeltaGe
             self.usage.completion_tokens += delta.token_ids.len() as u32;
         }
 
-        // todo logprobs
+        // TODO logprobs
 
-        let finish_reason = match delta.finish_reason {
-            Some(common::FinishReason::EoS) => Some("stop".to_string()),
-            Some(common::FinishReason::Stop) => Some("stop".to_string()),
-            Some(common::FinishReason::Length) => Some("length".to_string()),
-            Some(common::FinishReason::Cancelled) => Some("cancelled".to_string()),
-            Some(common::FinishReason::Error(err_msg)) => {
-                return Err(anyhow::anyhow!(err_msg));
-            }
-            None => None,
-        };
+        let finish_reason = delta.finish_reason.map(Into::into);
 
         // create choice
         let index = 0;


### PR DESCRIPTION
#### Overview:

Refactoring to use `async_openai::types::Logprobs`

#### Details:

This change is to be consistent with previous renaming and refactoring for protocols:

- [!261 - refactor: using async_openai](https://github.com/triton-inference-server/triton_distributed/pull/261)
- [!284 - refactor: rename ChatCompletionRequest to NvCreateChatCompletionRequest](https://github.com/triton-inference-server/triton_distributed/pull/284)
- [!291 - refactor: rename ChatCompletionResponse to NvCreateChatCompletionResponse](https://github.com/triton-inference-server/triton_distributed/pull/291)
- [!292 - refactor: rename ChatCompletionResponseDelta to NvCreateChatCompletionStreamResponse](https://github.com/triton-inference-server/triton_distributed/pull/292)
- [!296 - refactor: removes wrapper for ChatCompletionContent and adds documentation](https://github.com/triton-inference-server/triton_distributed/pull/296)
- [!310 - refactor: use async-openai CompletionRequest](https://github.com/triton-inference-server/triton_distributed/pull/310)
- [!1383 - refactor: Rename CompletionRequest to NvCreateCompletionRequest ](https://github.com/ai-dynamo/dynamo/pull/1383)
- [!1397 - refactor: refactoring to use async_openai::types::CompletionUsage ](https://github.com/ai-dynamo/dynamo/pull/1397)
- [!1625 - refactor: using async_openai::types::Logprobs ](https://github.com/ai-dynamo/dynamo/pull/1625)

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the "content_filter" finish reason in completion responses, allowing more detailed feedback when content is filtered.

* **Refactor**
  * Unified completion choice handling to use official async_openai types, replacing legacy custom structures.
  * Improved type safety and consistency by switching from string-based finish reasons to strongly typed enums throughout the completion and aggregation logic.

* **Bug Fixes**
  * Enhanced propagation of finish reasons, ensuring accurate mapping and display in streaming and aggregated responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->