### PR TITLE
fix: Disable NIXL backend for TRTLLM on ARM

### DIFF
--- a/container/build_trtllm_wheel.sh
+++ b/container/build_trtllm_wheel.sh
@@ -90,11 +90,14 @@ cp $MAIN_DIR/deps/tensorrt_llm/install_nixl.sh docker/common/install_nixl.sh
 sed -i "s/NIXL_COMMIT=\"[^\"]*\"/NIXL_COMMIT=\"${NIXL_COMMIT}\"/" docker/common/install_nixl.sh
 
 
-# Need to build in the Triton Devel Image for NIXL support.
+
 make -C docker tritondevel_build
 if [ "$ARCH" = "amd64" ]; then
+    # Need to build in the Triton Devel Image for NIXL support.
     make -C docker wheel_build DEVEL_IMAGE=tritondevel BUILD_WHEEL_OPTS='--extra-cmake-vars NIXL_ROOT=/opt/nvidia/nvda_nixl'
 else
+    # NIXL backend is not supported on arm64 for TensorRT-LLM.
+    # See here: https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/common/install_nixl.sh
     make -C docker wheel_build DEVEL_IMAGE=tritondevel
 fi
 

--- a/container/build_trtllm_wheel.sh
+++ b/container/build_trtllm_wheel.sh
@@ -91,14 +91,15 @@ sed -i "s/NIXL_COMMIT=\"[^\"]*\"/NIXL_COMMIT=\"${NIXL_COMMIT}\"/" docker/common/
 
 
 
-make -C docker tritondevel_build
+
 if [ "$ARCH" = "amd64" ]; then
     # Need to build in the Triton Devel Image for NIXL support.
+    make -C docker tritondevel_build
     make -C docker wheel_build DEVEL_IMAGE=tritondevel BUILD_WHEEL_OPTS='--extra-cmake-vars NIXL_ROOT=/opt/nvidia/nvda_nixl'
 else
     # NIXL backend is not supported on arm64 for TensorRT-LLM.
     # See here: https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/common/install_nixl.sh
-    make -C docker wheel_build DEVEL_IMAGE=tritondevel
+    make -C docker wheel_build
 fi
 
 # Copy the wheel to the host

--- a/container/build_trtllm_wheel.sh
+++ b/container/build_trtllm_wheel.sh
@@ -92,7 +92,11 @@ sed -i "s/NIXL_COMMIT=\"[^\"]*\"/NIXL_COMMIT=\"${NIXL_COMMIT}\"/" docker/common/
 
 # Need to build in the Triton Devel Image for NIXL support.
 make -C docker tritondevel_build
-make -C docker wheel_build DEVEL_IMAGE=tritondevel BUILD_WHEEL_OPTS='--extra-cmake-vars NIXL_ROOT=/opt/nvidia/nvda_nixl'
+if [ "$ARCH" = "amd64" ]; then
+    make -C docker wheel_build DEVEL_IMAGE=tritondevel BUILD_WHEEL_OPTS='--extra-cmake-vars NIXL_ROOT=/opt/nvidia/nvda_nixl'
+else
+    make -C docker wheel_build DEVEL_IMAGE=tritondevel
+fi
 
 # Copy the wheel to the host
 mkdir -p $OUTPUT_DIR

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -312,6 +312,8 @@ TensorRT-LLM also provides experimental support for using **NIXL** (NVIDIA Infer
 
 #### Using NIXL for KV Cache Transfer
 
+**Note:** NIXL backend for TensorRT-LLM is currently only supported on AMD64 (x86_64) architecture. If you're running on ARM64, you'll need to use the default UCX method for KV cache transfer.
+
 To enable NIXL for KV cache transfer in disaggregated serving:
 
 1. **Build the container with NIXL support:**


### PR DESCRIPTION
#### Overview:

The NIXL backend is [not supported](https://github.com/NVIDIA/TensorRT-LLM/blob/205c97a4ae4f7db656bab5347ee91c009ee4ae46/docker/common/install_nixl.sh#L44) for TRTLLM on ARM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build process to adjust options based on system architecture, ensuring compatibility for different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->