### PR TITLE
test: no seed in e2e tests

### DIFF
--- a/tests/serve/test_dynamo_serve.py
+++ b/tests/serve/test_dynamo_serve.py
@@ -67,14 +67,14 @@ text_payload = Payload(
         ],
         "max_tokens": 150,  # Reduced from 500
         "temperature": 0.1,
-        "seed": 0,
+        # "seed": 0,
     },
     payload_completions={
         "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
         "prompt": text_prompt,
         "max_tokens": 150,
         "temperature": 0.1,
-        "seed": 0,
+        # "seed": 0,
     },
     repeat_count=10,
     expected_log=[],

--- a/tests/serve/test_dynamo_serve.py
+++ b/tests/serve/test_dynamo_serve.py
@@ -257,12 +257,22 @@ class DynamoServeProcess(ManagedProcess):
         if graph.config:
             command.extend(["-f", os.path.join(graph.directory, graph.config)])
 
-        command.extend(["--Frontend.port", str(port)])
-
-        health_check_urls = [(f"http://localhost:{port}/v1/models", self._check_model)]
-
+        # Handle multimodal deployments differently
         if "multimodal" in graph.directory:
+            # Set DYNAMO_PORT environment variable for multimodal
+            env = os.environ.copy()
+            env["DYNAMO_PORT"] = str(port)
             health_check_urls = []
+            # Don't add health check on port since multimodal uses DYNAMO_PORT
+            health_check_ports = []
+        else:
+            # Regular LLM deployments
+            command.extend(["--Frontend.port", str(port)])
+            health_check_urls = [
+                (f"http://localhost:{port}/v1/models", self._check_model)
+            ]
+            health_check_ports = [port]
+            env = None
 
         self.port = port
 
@@ -271,11 +281,12 @@ class DynamoServeProcess(ManagedProcess):
             timeout=timeout,
             display_output=True,
             working_dir=graph.directory,
-            health_check_ports=[port],
+            health_check_ports=health_check_ports,
             health_check_urls=health_check_urls,
             delayed_start=graph.delayed_start,
             stragglers=["http"],
             log_dir=request.node.name,
+            env=env,  # Pass the environment variables
         )
 
     def _check_model(self, response):


### PR DESCRIPTION
#### Overview:
1. Removed `seed: 0` from the test payloads to make `disagg` tests pass.
2. Structure the port args correctly for `multimodal_agg`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test payloads by disabling the fixed seed setting for model generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->