### PR TITLE
fix: add missing await in vllm-v1 `clear_kv_blocks` endpoint

### DIFF
--- a/launch/dynamo-run/src/subprocess/vllm_v1_inc.py
+++ b/launch/dynamo-run/src/subprocess/vllm_v1_inc.py
@@ -126,7 +126,7 @@ class RequestHandler:
 
     async def clear_kv_blocks(self, request=None):
         try:
-            self.engine_client.reset_prefix_cache()
+            await self.engine_client.reset_prefix_cache()
             yield {"status": "success", "message": "KV cache cleared"}
         except Exception as e:
             yield {"status": "error", "message": str(e)}


### PR DESCRIPTION
#### Overview:

This PR adds a missing await for an async function call. The embedded subprocess vllm-v1 `clear_kv_blocks` endpoint should `await` the required call. I discovered this when trying to use the endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of clearing cached data during certain operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->