### PR TITLE
fix: update UID and GID of the user in Dockerfile.vllm

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -295,6 +295,9 @@ ENV USERNAME=ubuntu
 ARG USER_UID=1000
 ARG USER_GID=1000
 
+# Change uid and gid of the user
+RUN usermod -u $USER_UID $USERNAME && groupmod -g $USER_GID $USERNAME
+
 RUN apt-get update && apt-get install -y sudo gnupg2 gnupg1 \
     && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \


### PR DESCRIPTION
#### Overview:

Fix a UID/GID mismatch issue in `Dockerfile.vllm` that caused `Permission denied` error when accessing chowned directories as $USER_UID:$USER_GID.

#### Details:

When building `Dockerfile.vllm` using  `./container/build.sh --target local-dev`, I encountered the following permission error:
```bash
$ ./container/build.sh --target local-dev
fatal: ambiguous argument 'main': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: Not a valid object name
No git release tag found, setting to unknown version: 0.0.1
Warning: /tmp/nixl/nixl_src already exists, skipping clone
HEAD is now at f531404 SRC/BINDINGS/RUST: Revert has_overlaps to pub (#401)

Building Dynamo Image: '--tag dynamo:v0.3.0-vllm-local-dev'

   Base: 'nvcr.io/nvidia/cuda-dl-base'
   Base_Image_Tag: '25.01-cuda12.8-devel-ubuntu24.04'
   Build Context: '/home/jinu/workspace/git/dynamo'
   Build Arguments: ' --build-arg NIXL_COMMIT=f531404be4866d85ed618b3baf4008c636798d63  --build-arg USER_UID=1002 --build-arg USER_GID=1002  --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base --build-arg BASE_IMAGE_TAG=25.01-cuda12.8-devel-ubuntu24.04 --build-arg FRAMEWORK=VLLM --build-arg VLLM_FRAMEWORK=1 --build-arg VERSION=v0.3.0 --build-arg PYTHON_PACKAGE_VERSION=0.3.0'
   Framework: 'VLLM'

+ docker build -f /home/jinu/workspace/git/dynamo/container/Dockerfile.vllm --target local-dev --platform linux/amd64 --build-arg NIXL_COMMIT=f531404be4866d85ed618b3baf4008c636798d63 --build-arg USER_UID=1002 --build-arg USER_GID=1002 --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base --build-arg BASE_IMAGE_TAG=25.01-cuda12.8-devel-ubuntu24.04 --build-arg FRAMEWORK=VLLM --build-arg VLLM_FRAMEWORK=1 --build-arg VERSION=v0.3.0 --build-arg PYTHON_PACKAGE_VERSION=0.3.0 --tag dynamo:v0.3.0-vllm-local-dev --tag dynamo:latest-vllm-local-dev --build-context nixl=/tmp/nixl/nixl_src /home/jinu/workspace/git/dynamo
[+] Building 2.5s (41/43)                                                                                                                                                    docker:default
 => [internal] load build definition from Dockerfile.vllm                                                                                                                              0.0s
 => => transferring dockerfile: 20.03kB                                                                                                                                                0.0s
 => [internal] load metadata for ghcr.io/astral-sh/uv:latest                                                                                                                           0.6s
 => [internal] load metadata for nvcr.io/nvidia/cuda-dl-base:25.01-cuda12.8-devel-ubuntu24.04                                                                                          1.3s
 => [context nixl] load .dockerignore                                                                                                                                                  0.0s
 => => transferring nixl: 2B                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                      0.0s
 => => transferring context: 1.16kB                                                                                                                                                    0.0s
 => [internal] load build context                                                                                                                                                      0.0s
 => => transferring context: 769B                                                                                                                                                      0.0s
 => FROM ghcr.io/astral-sh/uv:latest@sha256:9653efd4380d5a0e5511e337dcfc3b8ba5bc4e6ea7fa3be7716598261d5503fa                                                                           0.0s
 => [context nixl] load from client                                                                                                                                                    0.0s
 => => transferring nixl: 48.93kB                                                                                                                                                      0.0s
 => [nixl_base 1/4] FROM nvcr.io/nvidia/cuda-dl-base:25.01-cuda12.8-devel-ubuntu24.04@sha256:f077f4257d4cb725287b89094f6f110637f9c3f0eb34c5f63c2a0acfd4cff6bc                          0.0s
 => CACHED [base  2/24] RUN apt-get update -y &&     apt-get install -y     cmake     meson     ninja-build     pybind11-dev  clang     libclang-dev  git     nvtop     tmux     vim   0.0s
 => CACHED [base  3/24] WORKDIR /workspace                                                                                                                                             0.0s
 => CACHED [base  4/24] RUN rm -rf /opt/hpcx/ucx                                                                                                                                       0.0s
 => CACHED [base  5/24] RUN rm -rf /usr/local/ucx                                                                                                                                      0.0s
 => CACHED [base  6/24] RUN cd /usr/local/src &&     git clone https://github.com/openucx/ucx.git &&     cd ucx &&                       git checkout v1.19.x &&         ./autogen.sh  0.0s
 => CACHED [base  7/24] WORKDIR /workspace                                                                                                                                             0.0s
 => CACHED [nixl_base 2/4] WORKDIR /opt/nixl                                                                                                                                           0.0s
 => CACHED [nixl_base 3/4] RUN echo "NIXL commit: f531404be4866d85ed618b3baf4008c636798d63" > /opt/nixl/commit.txt                                                                     0.0s
 => CACHED [nixl_base 4/4] COPY --from=nixl . .                                                                                                                                        0.0s
 => CACHED [base  8/24] COPY --from=nixl_base /opt/nixl /opt/nixl                                                                                                                      0.0s
 => CACHED [base  9/24] COPY --from=nixl_base /opt/nixl/commit.txt /opt/nixl/commit.txt                                                                                                0.0s
 => CACHED [base 10/24] RUN if [ "amd64" = "arm64" ]; then         cd /opt/nixl &&         mkdir build &&         meson setup build/ --prefix=/usr/local/nixl -Dgds_path=/usr/local/c  0.0s
 => CACHED [base 11/24] RUN wget --tries=3 --waitretry=5 https://github.com/nats-io/nats-server/releases/download/v2.10.24/nats-server-v2.10.24-amd64.deb &&     dpkg -i nats-server-  0.0s
 => CACHED [base 12/24] RUN wget --tries=3 --waitretry=5 https://github.com/etcd-io/etcd/releases/download/v3.5.18/etcd-v3.5.18-linux-amd64.tar.gz -O /tmp/etcd.tar.gz &&     mkdir -  0.0s
 => CACHED [base 13/24] COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/                                                                                                         0.0s
 => CACHED [base 14/24] RUN mkdir /opt/dynamo &&     uv venv /opt/dynamo/venv --python 3.12                                                                                            0.0s
 => CACHED [base 15/24] RUN if [ "amd64" = "arm64" ]; then         cd /opt/nixl && uv build . --out-dir /workspace/wheels/nixl         --config-settings=setup-args="-Dgds_path=/usr/  0.0s
 => CACHED [base 16/24] RUN uv pip install /workspace/wheels/nixl/*.whl                                                                                                                0.0s
 => CACHED [base 17/24] RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps     --mount=type=cache,target=/root/.cache/uv     mkdir /tmp/vllm &&     uv pip install pip w  0.0s
 => CACHED [base 18/24] RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt     uv pip install --requirement /tmp/requirements.txt             0.0s
 => CACHED [base 19/24] RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt     uv pip install --requirement /tmp/requirements.txt        0.0s
 => CACHED [base 20/24] RUN pyright --help > /dev/null 2>&1                                                                                                                            0.0s
 => CACHED [base 21/24] RUN printf "[safe]\n      directory=/workspace\n" > /root/.gitconfig                                                                                           0.0s
 => CACHED [base 22/24] RUN ln -sf /bin/bash /bin/sh                                                                                                                                   0.0s
 => CACHED [base 23/24] RUN apt update -y &&     apt install --no-install-recommends -y     build-essential     protobuf-compiler     cmake     libssl-dev     pkg-config              0.0s
 => CACHED [base 24/24] RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/x86_64-unknown-linux-gnu/rustup-init" &&     chmod +x rustup-init &&      0.0s
 => CACHED [local-dev 1/8] RUN apt-get update && apt-get install -y sudo gnupg2 gnupg1     && echo "ubuntu ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu     && chmod 0440 /etc/su  0.0s
 => CACHED [local-dev 2/8] COPY --from=base --chown=1002:1002 /opt/dynamo/venv/ /opt/dynamo/venv/                                                                                      0.0s
 => CACHED [local-dev 3/8] RUN chown ubuntu:ubuntu /opt/dynamo/venv                                                                                                                    0.0s
 => CACHED [local-dev 4/8] COPY --from=base --chown=ubuntu:ubuntu /usr/local/bin /usr/local/bin                                                                                        0.0s
 => CACHED [local-dev 5/8] WORKDIR /home/ubuntu                                                                                                                                        0.0s
 => ERROR [local-dev 6/8] RUN uv pip install maturin                                                                                                                                   1.1s
------
 > [local-dev 6/8] RUN uv pip install maturin:
0.412 Using Python 3.12.3 environment at: /opt/dynamo/venv
0.507 Resolved 1 package in 88ms
0.511 Downloading maturin (8.4MiB)
1.017  Downloading maturin
1.018 Prepared 1 package in 510ms
1.024 error: Failed to install: maturin-1.9.0-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl (maturin==1.9.0)
1.024   Caused by: failed to create directory `/opt/dynamo/venv/lib/python3.12/site-packages/maturin-1.9.0.dist-info`: Permission denied (os error 13)
------
Dockerfile.vllm:309
--------------------
 307 |     # so we can use maturin develop
 308 |     CMD ls -l /opt/dynamo/venv
 309 | >>> RUN uv pip install maturin
 310 |
 311 |     # https://code.visualstudio.com/remote/advancedcontainers/persist-bash-history
--------------------
ERROR: failed to solve: process "/bin/bash -c uv pip install maturin" did not complete successfully: exit code: 2
```

The issue was caused by a mismatch between the UID and GID of the existing `ubuntu` user in the base image and the ownership of the directories, which had been assigned to the host’s UID:GID (e.g., 1002:1002) using `--chown` and `chown`. Since the `ubuntu` user retained its default UID and GID (e.g., 1000:1000), it did not have permission to write to the relevant paths in `/opt/dynamo/venv`.
To resolve this, I added a command to update the `ubuntu` user's UID and GID using `usermod` and `groupmod` before performing any ownership-related operations. 

#### Where should the reviewer start?

- `container/Docker.vllm`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development container setup to adjust user and group IDs during build, improving compatibility with host systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->