### PR TITLE
fix: switch operator and api store to use approved distroless containers

### DIFF
--- a/deploy/cloud/api-store/Earthfile
+++ b/deploy/cloud/api-store/Earthfile
@@ -28,14 +28,20 @@ uv-base:
     WORKDIR /app
     COPY uv.lock pyproject.toml README.md /app
     RUN uv sync --frozen --no-install-project --no-dev --no-install-workspace --no-editable
+    # Copy project files
+    COPY ai_dynamo_store ai_dynamo_store
+    RUN uv pip install .
+    # Save the entire app directory with installed packages
+    SAVE ARTIFACT /app /app
 
 docker:
     ARG DOCKER_SERVER=my-registry
     ARG IMAGE_TAG=latest
     ARG IMAGE=dynamo-api-store
-    FROM +uv-base
-    # Copy project files
-    COPY ai_dynamo_store ai_dynamo_store
-    RUN uv pip install .
+    FROM nvcr.io/nvidia/distroless/python:3.12-v3.4.13-dev
+    # Copy the entire installed environment from uv-base
+    COPY +uv-base/app /app
+    WORKDIR /app
+    ENV PATH="/app/.venv/bin:$PATH"
     ENTRYPOINT ["ai-dynamo-store"]
     SAVE IMAGE --push $DOCKER_SERVER/$IMAGE:$IMAGE_TAG

--- a/deploy/cloud/operator/Earthfile
+++ b/deploy/cloud/operator/Earthfile
@@ -40,7 +40,7 @@ docker:
     ARG DOCKER_SERVER=my-registry
     ARG IMAGE_TAG=latest
     ARG IMAGE_SUFFIX=dynamo-operator
-    FROM gcr.io/distroless/static-debian11
+    FROM nvcr.io/nvidia/distroless/go:v3.1.9-dev
     WORKDIR /
     COPY +build/manager .
     USER 65532:65532


### PR DESCRIPTION
#### Overview:

Switch the Dynamo API store and operator to use NVIDIA-approved distroless containers
API store: https://catalog.ngc.nvidia.com/orgs/nvidia/teams/distroless/containers/python
Operator: https://catalog.ngc.nvidia.com/orgs/nvidia/teams/distroless/containers/go

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
