### PR TITLE
fix(sglang): use lmsysorg/sglang:deepep official image directly

### DIFF
--- a/container/Dockerfile.sglang-deepep
+++ b/container/Dockerfile.sglang-deepep
@@ -15,7 +15,7 @@
 
 # Note this container is built from a local dockerfile
 # Please see instructions in examples/sglang/README.md
-FROM deepep:latest
+FROM lmsysorg/sglang:deepep
 
 # Add NIXL build dependencies
 RUN apt-get update -y && \

--- a/examples/sglang/README.md
+++ b/examples/sglang/README.md
@@ -108,13 +108,7 @@ Steps to run:
 
 1. Build the SGLang DeepEP container.
 
-```bash
-git clone -b v0.4.8 https://github.com/sgl-project/sglang.git
-cd sglang/docker
-docker build -f Dockerfile -t deepep .
-```
-
-You will now have a `deepep:latest` image
+Currently SGLang does not provide an official Dockerfile to create SGLang DeepEP image. Please use lmsysorg/sglang:deepep, the official SGLang DeepEP image directly.
 
 2. Build the Dynamo container
 


### PR DESCRIPTION

#### Overview:

fix(sglang): use lmsysorg/sglang:deepep official image directly for Disaggregated with WideEP

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions to recommend using the official prebuilt Docker image for SGLang DeepEP instead of building it locally.
* **Chores**
  * Changed the Dockerfile to use the official remote base image for SGLang DeepEP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->