### PR TITLE
feat: Set NIXL env vars in ci_minimum and dev images

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -449,7 +449,6 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
 
 # Tell vllm to use the Dynamo LLM C API for KV Cache Routing
 ENV VLLM_KV_CAPI_PATH=/opt/dynamo/bindings/lib/libdynamo_llm_capi.so
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/nvidia/nvda_nixl/lib/x86_64-linux-gnu/
 
 ARG ARCH_ALT
 ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -451,6 +451,10 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
 ENV VLLM_KV_CAPI_PATH=/opt/dynamo/bindings/lib/libdynamo_llm_capi.so
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/nvidia/nvda_nixl/lib/x86_64-linux-gnu/
 
+ARG ARCH_ALT
+ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins
+ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu:/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins:/usr/local/ucx/lib:$LD_LIBRARY_PATH
+
 ########################################
 ########## Development Image ###########
 ########################################


### PR DESCRIPTION
Previously, the `NIXL_PLUGIN_DIR` and `LD_LIBRARY_PATH` settings for NIXL were only being set in the runtime container. Because of this, running block manager tests in the `ci_minimum` and `dev` containers would fail. This MR sets these two env vars in both the `ci_minimum` and `dev` containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build process to improve compatibility with different architecture variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->