### PR TITLE
fix: not raising error when the slot is not found with the request id

### DIFF
--- a/lib/bindings/python/rust/llm/block_manager/vllm.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm.rs
@@ -433,11 +433,14 @@ impl<R: RequestKey> SlotManager<R> {
     pub fn free_blocks(&mut self, request_id: &R) {
         if let Some(slot) = self.slots.get_mut(request_id) {
             slot.free_blocks();
+        } else {
+            tracing::warn!(request_id, "request id {} not found in the slot manager", request_id);
         }
-        // Do nothing if not found
     }
 
     pub fn drop_slot(&mut self, request_id: &R) {
-        self.slots.remove(request_id);
+        if self.slots.remove(request_id).is_none() {
+            tracing::warn!(request_id, "request id {} not found in the slot manager during drop", request_id);
+        }
     }
 }

--- a/lib/bindings/python/rust/llm/block_manager/vllm.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm.rs
@@ -434,12 +434,14 @@ impl<R: RequestKey> SlotManager<R> {
         if let Some(slot) = self.slots.get_mut(request_id) {
             slot.free_blocks();
         } else {
+            // Request ID may not be found if the client aborts the request.
             tracing::debug!(request_id, "request id {} not found in the slot manager", request_id);
         }
     }
 
     pub fn drop_slot(&mut self, request_id: &R) {
         if self.slots.remove(request_id).is_none() {
+            // Request ID may not be found if the client aborts the request.
             tracing::debug!(request_id, "request id {} not found in the slot manager during drop", request_id);
         }
     }

--- a/lib/bindings/python/rust/llm/block_manager/vllm.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm.rs
@@ -434,13 +434,13 @@ impl<R: RequestKey> SlotManager<R> {
         if let Some(slot) = self.slots.get_mut(request_id) {
             slot.free_blocks();
         } else {
-            tracing::warn!(request_id, "request id {} not found in the slot manager", request_id);
+            tracing::debug!(request_id, "request id {} not found in the slot manager", request_id);
         }
     }
 
     pub fn drop_slot(&mut self, request_id: &R) {
         if self.slots.remove(request_id).is_none() {
-            tracing::warn!(request_id, "request id {} not found in the slot manager during drop", request_id);
+            tracing::debug!(request_id, "request id {} not found in the slot manager during drop", request_id);
         }
     }
 }


### PR DESCRIPTION
#### Overview:

fix the issue that freeing the slot of the request that haven't been allocated by the vllm scheduler will cause the vllm core crash.

#### Details:
vLLM's scheduler will not allocate the blocks immediately for each request. But when the request is being aborted due to client side canceling the request, vLLM's scheduler will call the free() method of the kvcachemanager anyway. This is safe for vLLM default kvcachemanager, since it will not execute anything when the request is not found in the kvcachemanager. 
https://github.com/vllm-project/vllm/blob/main/vllm/v1/core/single_type_kv_cache_manager.py#L165

But for KVBM, it will raise a fetal error that causes the engine core to crash. 

This PR make the free() method of kvbm not raising exception when the request id is not found.

#### Where should the reviewer start?


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
