### PR TITLE
fix: Little kv routing fix

### DIFF
--- a/examples/llm/components/kv_router.py
+++ b/examples/llm/components/kv_router.py
@@ -100,8 +100,7 @@ def parse_args(service_name, prefix) -> Namespace:
     )
     parser.add_argument(
         "--softmax-sample",
-        type=bool,
-        default=False,
+        action="store_true",
         help="Whether to do softmax sampling based on worker logits (default is to pick smallest)",
     )
     config = ServiceConfig.get_instance()

--- a/examples/llm/configs/agg_router.yaml
+++ b/examples/llm/configs/agg_router.yaml
@@ -29,7 +29,7 @@ Processor:
 
 Router:
   min-workers: 1
-  softmax_sample: true
+  softmax-sample: true
   common-configs: [model, block-size, router]
 
 VllmWorker:


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/ai-dynamo/dynamo/pull/1638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the command-line flag for softmax sampling to be a simpler on/off switch.
  * Renamed the related configuration key from `softmax_sample` to `softmax-sample` for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->