### PR TITLE
fix: fix the if statement for checking tllm_disagg_params.opaque_state is none

### DIFF
--- a/examples/tensorrt_llm/common/protocol.py
+++ b/examples/tensorrt_llm/common/protocol.py
@@ -57,7 +57,7 @@ class DisaggregatedTypeConverter:
         else:
             encoded_opaque_state = (
                 base64.b64encode(tllm_disagg_params.opaque_state).decode("utf-8")
-                if tllm_disagg_params is not None
+                if tllm_disagg_params.opaque_state is not None
                 else None
             )
             return DisaggregatedParams(


### PR DESCRIPTION
#### Overview:

 fix the if statement for checking tllm_disagg_params.opaque_state is none

#### Details:

bug caught in the disagg test:
https://gitlab-master.nvidia.com/dl/ai-dynamo/dynamo-ci/-/jobs/181914935

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the condition for base64 encoding to ensure the `opaque_state` attribute is only encoded when it is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->