### PR TITLE
feat: Add KV cache retention config to the inference request

### DIFF
--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -455,6 +455,55 @@ Execute the following to load the TensorRT-LLM model specified in the configurat
 dynamo-run in=http out=trtllm TinyLlama/TinyLlama-1.1B-Chat-v1.0
 ```
 
+**KV Cache Retention Configuration**
+
+You can pass KV cache retention configuration in your curl requests to control how the KV cache is managed during generation. This is useful for optimizing memory usage and performance in scenarios where you want to retain specific parts of the KV cache for longer periods.
+
+Example curl request with KV cache retention config:
+
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Explain quantum computing in detail, covering fundamental concepts like quantum bits (qubits), superposition, entanglement, quantum gates, and quantum algorithms. Describe how quantum computers differ from classical computers, the principles of quantum mechanics that enable quantum computing, and discuss major quantum algorithms such as Shor's algorithm for factoring and Grover's algorithm for search. Include information about quantum error correction, the current state of quantum computing technology, and potential applications in cryptography, drug discovery, optimization problems, and artificial intelligence. Also explain the challenges facing quantum computing development, including decoherence, scalability issues, and the race for quantum supremacy."
+      }
+    ],
+    "max_tokens": 500,
+    "temperature": 0.6,
+    "nvext": {
+      "kv_cache_retention_config": {
+        "token_range_retention_configs": [
+          {
+            "token_start": 0,
+            "token_end": 20,
+            "priority": 95,
+            "duration_ms": 120000
+          },
+          {
+            "token_start": 20,
+            "token_end": 100,
+            "priority": 75,
+            "duration_ms": 60000
+          },
+          {
+            "token_start": 100,
+            "priority": 50,
+            "duration_ms": 30000
+          }
+        ],
+        "decode_retention_priority": 85,
+        "decode_duration_ms": 180000,
+        "transfer_mode": "DRAM",
+        "directory": "/var/cache/dynamo/kv"
+      }
+    }
+  }'
+```
+
 #### Echo Engines
 
 Dynamo includes two echo engines for testing and debugging purposes:

--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -469,7 +469,7 @@ curl -X POST http://localhost:8000/v1/chat/completions \
     "messages": [
       {
         "role": "user",
-        "content": "Explain quantum computing in detail, covering fundamental concepts like quantum bits (qubits), superposition, entanglement, quantum gates, and quantum algorithms. Describe how quantum computers differ from classical computers, the principles of quantum mechanics that enable quantum computing, and discuss major quantum algorithms such as Shor's algorithm for factoring and Grover's algorithm for search. Include information about quantum error correction, the current state of quantum computing technology, and potential applications in cryptography, drug discovery, optimization problems, and artificial intelligence. Also explain the challenges facing quantum computing development, including decoherence, scalability issues, and the race for quantum supremacy."
+        "content": "Explain quantum computing in detail, covering fundamental concepts like quantum bits (qubits), superposition, entanglement, quantum gates, and quantum algorithms. Describe how quantum computers differ from classical computers, the principles of quantum mechanics that enable quantum computing, and discuss major quantum algorithms such as Shors algorithm for factoring and Grovers algorithm for search. Include information about quantum error correction, the current state of quantum computing technology, and potential applications in cryptography, drug discovery, optimization problems, and artificial intelligence. Also explain the challenges facing quantum computing development, including decoherence, scalability issues, and the race for quantum supremacy."
       }
     ],
     "max_tokens": 500,

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -296,15 +296,17 @@ TensorRT-LLM supports KV cache retention configuration to control how key-value 
 
 The KV cache retention configuration supports the following parameters:
 
-- **token_range_retention_configs**: List of configurations for specific token ranges
-  - `token_start`: Starting token index for the range
-  - `token_end`: Ending token index for the range
+- **token_range_retention_configs**: List of configurations for specific token ranges in the input sequence.
+  - `token_start`: Starting token index for a range in input sequence.
+  - `token_end`: Ending token index for a range range in input sequence. If not provided, the range covers for all the remaining sequence tokens.
   - `priority`: Retention priority (higher values = higher priority)
   - `duration_ms`: How long to retain the cache in milliseconds
 - **decode_retention_priority**: Priority for decode phase cache retention
 - **decode_duration_ms**: Duration to retain decode cache in milliseconds
 - **transfer_mode**: Cache transfer mode between nodes
 - **directory**: Directory for persistent cache storage
+
+[Priority-Based KV Cache Eviction](https://developer.nvidia.com/blog/introducing-new-kv-cache-reuse-optimizations-in-nvidia-tensorrt-llm/#priority-based_kv_cache_eviction) describes the feature in further detail.
 
 #### Example Usage
 

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -288,6 +288,71 @@ See [client](../llm/README.md#client) section to learn how to send request to th
 
 NOTE: To send a request to a multi-node deployment, target the node which deployed the `Frontend` component.
 
+### KV Cache Retention Configuration
+
+TensorRT-LLM supports KV cache retention configuration to control how key-value cache is managed during inference. This feature allows you to specify retention policies for different token ranges and control the duration and priority of cache retention.
+
+#### Configuration Options
+
+The KV cache retention configuration supports the following parameters:
+
+- **token_range_retention_configs**: List of configurations for specific token ranges
+  - `token_start`: Starting token index for the range
+  - `token_end`: Ending token index for the range
+  - `priority`: Retention priority (higher values = higher priority)
+  - `duration_ms`: How long to retain the cache in milliseconds
+- **decode_retention_priority**: Priority for decode phase cache retention
+- **decode_duration_ms**: Duration to retain decode cache in milliseconds
+- **transfer_mode**: Cache transfer mode between nodes
+- **directory**: Directory for persistent cache storage
+
+#### Example Usage
+
+To send a request with KV cache retention configuration, include the `kv_cache_retention_config` field in your request:
+
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Explain quantum computing in detail, covering fundamental concepts like quantum bits (qubits), superposition, entanglement, quantum gates, and quantum algorithms. Describe how quantum computers differ from classical computers, the principles of quantum mechanics that enable quantum computing, and discuss major quantum algorithms such as Shor's algorithm for factoring and Grover's algorithm for search. Include information about quantum error correction, the current state of quantum computing technology, and potential applications in cryptography, drug discovery, optimization problems, and artificial intelligence. Also explain the challenges facing quantum computing development, including decoherence, scalability issues, and the race for quantum supremacy."
+      }
+    ],
+    "max_tokens": 500,
+    "temperature": 0.6,
+    "nvext": {
+      "kv_cache_retention_config": {
+        "token_range_retention_configs": [
+          {
+            "token_start": 0,
+            "token_end": 20,
+            "priority": 95,
+            "duration_ms": 120000
+          },
+          {
+            "token_start": 20,
+            "token_end": 100,
+            "priority": 75,
+            "duration_ms": 60000
+          },
+          {
+            "token_start": 100,
+            "priority": 50,
+            "duration_ms": 30000
+          }
+        ],
+        "decode_retention_priority": 85,
+        "decode_duration_ms": 180000,
+        "transfer_mode": "DRAM",
+        "directory": "/var/cache/dynamo/kv"
+      }
+    }
+  }'
+```
+
 ### Close deployment
 
 See [close deployment](../../docs/guides/dynamo_serve.md#close-deployment) section to learn about how to close the deployment.

--- a/examples/tensorrt_llm/README.md
+++ b/examples/tensorrt_llm/README.md
@@ -318,7 +318,7 @@ curl -X POST http://localhost:8000/v1/chat/completions \
     "messages": [
       {
         "role": "user",
-        "content": "Explain quantum computing in detail, covering fundamental concepts like quantum bits (qubits), superposition, entanglement, quantum gates, and quantum algorithms. Describe how quantum computers differ from classical computers, the principles of quantum mechanics that enable quantum computing, and discuss major quantum algorithms such as Shor's algorithm for factoring and Grover's algorithm for search. Include information about quantum error correction, the current state of quantum computing technology, and potential applications in cryptography, drug discovery, optimization problems, and artificial intelligence. Also explain the challenges facing quantum computing development, including decoherence, scalability issues, and the race for quantum supremacy."
+        "content": "Explain quantum computing in detail, covering fundamental concepts like quantum bits (qubits), superposition, entanglement, quantum gates, and quantum algorithms. Describe how quantum computers differ from classical computers, the principles of quantum mechanics that enable quantum computing, and discuss major quantum algorithms such as Shors algorithm for factoring and Grovers algorithm for search. Include information about quantum error correction, the current state of quantum computing technology, and potential applications in cryptography, drug discovery, optimization problems, and artificial intelligence. Also explain the challenges facing quantum computing development, including decoherence, scalability issues, and the race for quantum supremacy."
       }
     ],
     "max_tokens": 500,

--- a/examples/tensorrt_llm/common/base_engine.py
+++ b/examples/tensorrt_llm/common/base_engine.py
@@ -53,13 +53,6 @@ def parse_endpoint(endpoint: str) -> tuple[str, str, str]:
 
 
 def log_kv_cache_retention_config_details(kv_cache_retention_config, logger):
-    """
-    Log detailed information about KV cache retention config only when debug mode is enabled.
-
-    Args:
-        kv_cache_retention_config: The TensorRT-LLM KvCacheRetentionConfig object
-        logger: The logger instance to use
-    """
     if kv_cache_retention_config and logger.isEnabledFor(logging.DEBUG):
         config_details = {
             "token_range_configs_count": len(
@@ -99,15 +92,6 @@ def log_kv_cache_retention_config_details(kv_cache_retention_config, logger):
 
 
 def convert_dynamo_kv_cache_retention_config(dynamo_config):
-    """
-    Convert Dynamo KV cache retention config to TensorRT-LLM format.
-
-    Args:
-        dynamo_config: The KV cache retention config from Dynamo request (Pydantic model)
-
-    Returns:
-        TensorRT-LLM KvCacheRetentionConfig object or None if no config provided
-    """
     if not dynamo_config:
         return None
 

--- a/examples/tensorrt_llm/common/base_engine.py
+++ b/examples/tensorrt_llm/common/base_engine.py
@@ -133,6 +133,11 @@ def convert_dynamo_kv_cache_retention_config(dynamo_config):
                 transfer_mode = trtllm.KvCacheTransferMode.GDS
             elif transfer_mode_str == "POSIX_DEBUG_FALLBACK":
                 transfer_mode = trtllm.KvCacheTransferMode.POSIX_DEBUG_FALLBACK
+            else:
+                raise ValueError(
+                    f"Invalid transfer mode: {transfer_mode_str}. "
+                    "Expected 'DRAM', 'GDS', or 'POSIX_DEBUG_FALLBACK'."
+                )
 
         return KvCacheRetentionConfig(
             token_range_retention_configs=token_range_configs,

--- a/examples/tensorrt_llm/common/protocol.py
+++ b/examples/tensorrt_llm/common/protocol.py
@@ -20,6 +20,33 @@ from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
 from tensorrt_llm.serve.openai_protocol import DisaggregatedParams
 
 
+class TokenRangeRetentionConfig(BaseModel):
+    token_start: int = Field(..., description="Start token index for retention")
+    token_end: Optional[int] = Field(
+        None, description="End token index for retention (exclusive)"
+    )
+    priority: int = Field(..., description="Priority level for retention")
+    duration_ms: Optional[int] = Field(
+        None, description="Duration in milliseconds for retention"
+    )
+
+
+class KvCacheRetentionConfig(BaseModel):
+    token_range_retention_configs: Optional[List[TokenRangeRetentionConfig]] = Field(
+        None, description="List of token range retention configurations"
+    )
+    decode_retention_priority: Optional[int] = Field(
+        None, description="Priority for decode retention"
+    )
+    decode_duration_ms: Optional[int] = Field(
+        None, description="Duration in milliseconds for decode retention"
+    )
+    transfer_mode: Optional[str] = Field(
+        None, description="Transfer mode: 'DRAM', 'GDS', or 'POSIX_DEBUG_FALLBACK'"
+    )
+    directory: Optional[str] = Field(None, description="Directory for KV cache storage")
+
+
 class Tokens(BaseModel):
     tokens: list[int]
 
@@ -102,3 +129,4 @@ class TRTLLMWorkerRequest(BaseModel):
     annotations: List[str] = Field(default_factory=list)
     estimated_prefix_hit_num_blocks: Optional[int] = None
     disaggregated_params: Optional[DisaggregatedParams] = Field(default=None)
+    kv_cache_retention_config: Optional[KvCacheRetentionConfig] = Field(default=None)

--- a/launch/dynamo-run/src/subprocess/trtllm_inc.py
+++ b/launch/dynamo-run/src/subprocess/trtllm_inc.py
@@ -149,6 +149,11 @@ def convert_dynamo_kv_cache_retention_config(dynamo_config):
                 transfer_mode = trtllm.KvCacheTransferMode.GDS
             elif transfer_mode_str == "POSIX_DEBUG_FALLBACK":
                 transfer_mode = trtllm.KvCacheTransferMode.POSIX_DEBUG_FALLBACK
+            else:
+                raise ValueError(
+                    f"Invalid transfer mode: {transfer_mode_str}. "
+                    "Expected 'DRAM', 'GDS', or 'POSIX_DEBUG_FALLBACK'."
+                )
 
         return KvCacheRetentionConfig(
             token_range_retention_configs=token_range_configs,

--- a/launch/dynamo-run/src/subprocess/trtllm_inc.py
+++ b/launch/dynamo-run/src/subprocess/trtllm_inc.py
@@ -69,12 +69,6 @@ def parse_endpoint(endpoint: str) -> tuple[str, str, str]:
 
 
 def log_kv_cache_retention_config_details(kv_cache_retention_config):
-    """
-    Log detailed information about KV cache retention config only when debug mode is enabled.
-
-    Args:
-        kv_cache_retention_config: The TensorRT-LLM KvCacheRetentionConfig object
-    """
     if kv_cache_retention_config and logging.getLogger().isEnabledFor(logging.DEBUG):
         config_details = {
             "token_range_configs_count": len(
@@ -114,15 +108,6 @@ def log_kv_cache_retention_config_details(kv_cache_retention_config):
 
 
 def convert_dynamo_kv_cache_retention_config(dynamo_config):
-    """
-    Convert Dynamo KV cache retention config to TensorRT-LLM format.
-
-    Args:
-        dynamo_config: The KV cache retention config from Dynamo request
-
-    Returns:
-        TensorRT-LLM KvCacheRetentionConfig object or None if no config provided
-    """
     if not dynamo_config:
         return None
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -160,6 +160,13 @@ impl OpenAIPreprocessor {
         let mut annotations = HashMap::new();
         let mut builder = PreprocessedRequest::builder();
 
+        // Extract KV cache retention configuration from nvext if present
+        if let Some(nvext) = request.nvext() {
+            if let Some(kv_config) = &nvext.kv_cache_retention_config {
+                builder.kv_cache_retention_config(Some(kv_config.clone()));
+            }
+        }
+
         // match request type before any conversion/processing
         match request.prompt_input_type() {
             PromptInput::Tokens(_) => {

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -19,6 +19,9 @@ use serde::{Deserialize, Serialize};
 use super::{SamplingOptions, StopConditions};
 use crate::protocols::TokenIdType;
 
+// Add this import for KV cache retention config
+use crate::protocols::openai::nvext::KvCacheRetentionConfig;
+
 /// [`PreprocessedRequest`] is the internal representation of an LLM request. The [`dynamo.llm-preprocessor`]
 /// crate is responsible for converting request from the public APIs to this internal representation.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
@@ -55,6 +58,10 @@ pub struct PreprocessedRequest {
     /// Estimated number of prefix hit tokens (only used in kv aware routing)
     #[builder(default)]
     pub estimated_prefix_hit_num_blocks: Option<u32>,
+
+    /// KV Cache retention configuration
+    #[builder(default)]
+    pub kv_cache_retention_config: Option<KvCacheRetentionConfig>,
 }
 
 impl PreprocessedRequest {

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -22,6 +22,50 @@ pub trait NvExtProvider {
     fn raw_prompt(&self) -> Option<String>;
 }
 
+// Add this new struct for KV cache retention configuration
+#[derive(Serialize, Deserialize, Debug, Clone, Builder, Validate)]
+pub struct KvCacheRetentionConfig {
+    /// Token range retention configurations
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub token_range_retention_configs: Option<Vec<TokenRangeRetentionConfig>>,
+
+    /// Decode retention priority (0-100)
+    #[builder(default, setter(strip_option))]
+    #[validate(range(min = 0, max = 100))]
+    pub decode_retention_priority: Option<u32>,
+
+    /// Decode duration in milliseconds
+    #[builder(default, setter(strip_option))]
+    pub decode_duration_ms: Option<u64>,
+
+    /// Transfer mode: "DRAM", "GDS", or "POSIX_DEBUG_FALLBACK"
+    #[builder(default, setter(strip_option))]
+    pub transfer_mode: Option<String>,
+
+    /// Directory for KV cache storage
+    #[builder(default, setter(strip_option))]
+    pub directory: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Builder, Validate)]
+pub struct TokenRangeRetentionConfig {
+    /// Start token index (inclusive)
+    pub token_start: u32,
+
+    /// End token index (exclusive), None means to end of sequence
+    #[builder(default, setter(strip_option))]
+    pub token_end: Option<u32>,
+
+    /// Retention priority (0-100)
+    #[validate(range(min = 0, max = 100))]
+    pub priority: u32,
+
+    /// Duration in milliseconds
+    #[builder(default, setter(strip_option))]
+    pub duration_ms: Option<u64>,
+}
+
 /// NVIDIA LLM extensions to the OpenAI API
 #[derive(Serialize, Deserialize, Builder, Validate, Debug, Clone)]
 #[validate(schema(function = "validate_nv_ext"))]
@@ -61,6 +105,12 @@ pub struct NvExt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub annotations: Option<Vec<String>>,
+
+    /// KV Cache retention configuration
+    /// This is only supported by the TensorRT-LLM.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub kv_cache_retention_config: Option<KvCacheRetentionConfig>,
 }
 
 impl Default for NvExt {

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -141,14 +141,19 @@ fn validate_top_k(top_k: i64) -> Result<(), ValidationError> {
     Err(error)
 }
 
-fn validate_token_range_retention_config(config: &TokenRangeRetentionConfig) -> Result<(), ValidationError> {
+fn validate_token_range_retention_config(
+    config: &TokenRangeRetentionConfig,
+) -> Result<(), ValidationError> {
     if let Some(token_end) = config.token_end {
         if config.token_start >= token_end {
             let mut error = ValidationError::new("token_range");
-            error.message = Some(format!(
-                "token_start ({}) must be less than token_end ({}) when both are set",
-                config.token_start, token_end
-            ).into());
+            error.message = Some(
+                format!(
+                    "token_start ({}) must be less than token_end ({}) when both are set",
+                    config.token_start, token_end
+                )
+                .into(),
+            );
             return Err(error);
         }
     }
@@ -160,10 +165,13 @@ fn validate_transfer_mode(transfer_mode: &str) -> Result<(), ValidationError> {
         "DRAM" | "GDS" | "POSIX_DEBUG_FALLBACK" => Ok(()),
         _ => {
             let mut error = ValidationError::new("transfer_mode");
-            error.message = Some(format!(
-                "transfer_mode must be one of: DRAM, GDS, or POSIX_DEBUG_FALLBACK, got: {}",
-                transfer_mode
-            ).into());
+            error.message = Some(
+                format!(
+                    "transfer_mode must be one of: DRAM, GDS, or POSIX_DEBUG_FALLBACK, got: {}",
+                    transfer_mode
+                )
+                .into(),
+            );
             Err(error)
         }
     }


### PR DESCRIPTION
#### Overview:

Adds optional kv_cache_retention_config field to nvext such that it can pass through the ingress and into the engine/component. 

#### Details:

Also adds documentation of the feature. Unfortunately there is no clean documentation in TensorRT-LLM project. These fields are only supported for TRTLLM example.
I have manually tested with debug logging that correct config was being passed to the TRTLLM engine.

Follow-up (not in scope of this PR):
1. Because of the duplicity of dynamo run and dynamo-serve, I have to maintain both.
2. Breakdown the trtllm example for easier user onboarding and visibility.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring KV cache retention during model generation and inference, allowing users to specify token ranges, retention priorities, durations, transfer modes, and cache storage directories.
  * Users can now include KV cache retention settings in API requests to optimize memory usage and performance.
* **Documentation**
  * Updated user guides and example READMEs with detailed instructions and examples for using the new KV cache retention configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->