### PR TITLE
feat: Remove batch_token_ids and replace token_ids with nested Vec #1648

### DIFF
--- a/examples/sglang/components/decode_worker.py
+++ b/examples/sglang/components/decode_worker.py
@@ -45,9 +45,7 @@ class SGLangDecodeWorker:
     @endpoint()
     async def generate(self, req: DisaggPreprocessedRequest):
         g = await self.engine.async_generate(
-            input_ids=req.request.token_ids
-            if req.request.batch_token_ids is None
-            else req.request.batch_token_ids,
+            input_ids=req.request.token_ids,
             sampling_params=req.sampling_params,
             stream=True,
             bootstrap_host=req.bootstrap_host,

--- a/examples/sglang/components/worker.py
+++ b/examples/sglang/components/worker.py
@@ -28,7 +28,7 @@ import asyncio
 import logging
 import random
 import socket
-from typing import Dict, Union, List
+from typing import Dict, Union
 
 import sglang as sgl
 from components.decode_worker import SGLangDecodeWorker
@@ -155,9 +155,7 @@ class SGLangWorker:
 
             decode = await self.decode_client.generate(disagg_request.model_dump_json())
 
-            async for out in self._process_stream(
-                decode, unpack=True
-            ):
+            async for out in self._process_stream(decode, unpack=True):
                 yield out
 
             await prefill_task

--- a/examples/sglang/components/worker.py
+++ b/examples/sglang/components/worker.py
@@ -28,7 +28,7 @@ import asyncio
 import logging
 import random
 import socket
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 import sglang as sgl
 from components.decode_worker import SGLangDecodeWorker
@@ -113,36 +113,25 @@ class SGLangWorker:
             sampling_params["ignore_eos"] = request.stop_conditions.ignore_eos
         return sampling_params
 
-    def _get_request_batch_size(self, request: PreprocessedRequest):
+    def _get_request_size(self, request: PreprocessedRequest):
         """Get batch size from request, returns None for single requests"""
-        if request.batch_token_ids is not None:
-            return len(request.batch_token_ids)
+        if request.token_ids is not None:
+            return len(request.token_ids)
         return None
-
-    def _is_batch_request(self, request: PreprocessedRequest):
-        """Check if request is in batch mode"""
-        return request.batch_token_ids is not None
 
     @endpoint()
     async def generate(self, request: PreprocessedRequest):
-        # Check if we're in batch mode at the start
-        is_batch = self._is_batch_request(request)
-        batch_size = self._get_request_batch_size(request)
+        request_size = self._get_request_size(request)
 
         # TODO: maintain a mapping from SGLang's Ouput struct to LLMEngineOuput
         sampling_params = self._build_sampling_params(request)
 
         if self.engine_args.disaggregation_mode != "null":
-            if is_batch:
-                bootstrap_room = [
-                    self._generate_bootstrap_room() for _ in range(batch_size)
-                ]
-                bootstrap_host = [self.bootstrap_host] * batch_size
-                bootstrap_port = [self.bootstrap_port] * batch_size
-            else:
-                bootstrap_host = self.bootstrap_host
-                bootstrap_port = self.bootstrap_port
-                bootstrap_room = self._generate_bootstrap_room()
+            bootstrap_room = [
+                self._generate_bootstrap_room() for _ in range(request_size)
+            ]
+            bootstrap_host = [self.bootstrap_host] * request_size
+            bootstrap_port = [self.bootstrap_port] * request_size
 
             # decode worker request
             disagg_request = DisaggPreprocessedRequest(
@@ -155,9 +144,7 @@ class SGLangWorker:
 
             # prefill response is not used
             prefill = await self.engine.async_generate(
-                input_ids=request.token_ids
-                if not is_batch
-                else request.batch_token_ids,
+                input_ids=request.token_ids,
                 sampling_params=sampling_params,
                 stream=True,
                 bootstrap_host=bootstrap_host,
@@ -169,65 +156,49 @@ class SGLangWorker:
             decode = await self.decode_client.generate(disagg_request.model_dump_json())
 
             async for out in self._process_stream(
-                decode, unpack=True, is_batch=is_batch
+                decode, unpack=True
             ):
                 yield out
 
             await prefill_task
         else:
             g = await self.engine.async_generate(
-                input_ids=request.token_ids
-                if not is_batch
-                else request.batch_token_ids,
+                input_ids=request.token_ids,
                 sampling_params=sampling_params,
                 stream=True,
             )
 
-            async for out in self._process_stream(g, unpack=False, is_batch=is_batch):
+            async for out in self._process_stream(g, unpack=False):
                 yield out
 
-    async def _process_stream(self, stream_source, unpack: bool, is_batch: bool):
-        # Initialize based on batch mode
+    async def _process_stream(self, stream_source, unpack: bool):
         num_output_tokens_so_far: Union[Dict[int, int], int]
-        if is_batch:
-            num_output_tokens_so_far = {}
-        else:
-            num_output_tokens_so_far = 0
+        num_output_tokens_so_far = {}
 
         async for res in stream_source:
             data = res.data() if unpack else res
             finish_reason = data["meta_info"]["finish_reason"]
 
-            if is_batch:
-                # Handle batch response
-                assert isinstance(num_output_tokens_so_far, dict)
-                index = data.get("index", 0)
-                if index not in num_output_tokens_so_far:
-                    num_output_tokens_so_far[index] = 0
+            # Handle response
+            assert isinstance(num_output_tokens_so_far, dict)
+            index = data.get("index", 0)
+            if index not in num_output_tokens_so_far:
+                num_output_tokens_so_far[index] = 0
 
-                if finish_reason:
-                    out = {
-                        "token_ids": [],
-                        "finish_reason": finish_reason["type"],
-                        "index": index,
-                    }
-                else:
-                    next_total_toks = len(data["output_ids"])
-                    new_tokens = data["output_ids"][num_output_tokens_so_far[index] :]
-                    out = {
-                        "token_ids": new_tokens,
-                        "index": index,
-                    }
-                    num_output_tokens_so_far[index] = next_total_toks
+            if finish_reason:
+                out = {
+                    "token_ids": [],
+                    "finish_reason": finish_reason["type"],
+                    "index": index,
+                }
             else:
-                # Handle single response
-                assert isinstance(num_output_tokens_so_far, int)
-                if finish_reason:
-                    out = {"token_ids": [], "finish_reason": finish_reason["type"]}
-                else:
-                    next_total_toks = len(data["output_ids"])
-                    out = {"token_ids": data["output_ids"][num_output_tokens_so_far:]}
-                    num_output_tokens_so_far = next_total_toks
+                next_total_toks = len(data["output_ids"])
+                new_tokens = data["output_ids"][num_output_tokens_so_far[index] :]
+                out = {
+                    "token_ids": new_tokens,
+                    "index": index,
+                }
+                num_output_tokens_so_far[index] = next_total_toks
 
             yield out
 

--- a/examples/sglang/utils/protocol.py
+++ b/examples/sglang/utils/protocol.py
@@ -46,8 +46,7 @@ class SamplingOptions(BaseModel):
 
 
 class PreprocessedRequest(BaseModel):
-    token_ids: List[TokenIdType]
-    batch_token_ids: Optional[List[List[TokenIdType]]] = None
+    token_ids: List[List[TokenIdType]] = Field(default_factory=list)
     stop_conditions: StopConditions
     sampling_options: SamplingOptions
     eos_token_ids: List[TokenIdType] = Field(default_factory=list)

--- a/launch/dynamo-run/src/subprocess/sglang_inc.py
+++ b/launch/dynamo-run/src/subprocess/sglang_inc.py
@@ -61,68 +61,42 @@ class RequestHandler:
             "max_new_tokens": request["stop_conditions"]["max_tokens"],
         }
 
-        # Check if this is a batch request
-        is_batch = "batch_token_ids" in request and request["batch_token_ids"]
-
-        if is_batch:
-            # Track tokens separately for each batch item
-            num_output_tokens_so_far = {}
-            logging.debug("received batch token ids")
-            gen = await self.engine_client.async_generate(
-                input_ids=request["batch_token_ids"],
-                sampling_params=sampling_params,
-                stream=True,
-            )
-        else:
-            num_output_tokens_so_far = 0
-            logging.debug("received token ids")
-            gen = await self.engine_client.async_generate(
-                input_ids=request["token_ids"],
-                sampling_params=sampling_params,
-                stream=True,
-            )
+        # Track tokens separately for each request item
+        num_output_tokens_so_far = {}
+        logging.debug("received token ids")
+        gen = await self.engine_client.async_generate(
+            input_ids=request["token_ids"],
+            sampling_params=sampling_params,
+            stream=True,
+        )
 
         async for res in gen:
             # res is a dict
             logging.debug(f"res: {res}")
             finish_reason = res["meta_info"]["finish_reason"]
 
-            if is_batch:
-                # Handle batch response - get index from SGLang response
-                index = res.get("index", 0)
-                if index not in num_output_tokens_so_far:
-                    num_output_tokens_so_far[index] = 0
+            # Handle request response - get index from SGLang response
+            index = res.get("index", 0)
+            if index not in num_output_tokens_so_far:
+                num_output_tokens_so_far[index] = 0
 
-                if finish_reason:
-                    logging.warning(f"finish_reason: {finish_reason}")
-                    # Final response for this batch item
-                    out = {
-                        "token_ids": [],
-                        "finish_reason": finish_reason["type"],
-                        "index": index,
-                    }
-                else:
-                    # Streaming response for this batch item
-                    next_total_toks = len(res["output_ids"])
-                    new_tokens = res["output_ids"][num_output_tokens_so_far[index] :]
-                    out = {
-                        "token_ids": new_tokens,
-                        "index": index,
-                    }
-                    num_output_tokens_so_far[index] = next_total_toks
+            if finish_reason:
+                logging.warning(f"finish_reason: {finish_reason}")
+                # Final response for this batch item
+                out = {
+                    "token_ids": [],
+                    "finish_reason": finish_reason["type"],
+                    "index": index,
+                }
             else:
-                if finish_reason:
-                    out = {
-                        "token_ids": [],
-                        "finish_reason": finish_reason["type"],
-                    }
-                else:
-                    next_total_toks = len(res["output_ids"])
-                    new_tokens = res["output_ids"][num_output_tokens_so_far:]
-                    out = {
-                        "token_ids": new_tokens,
-                    }
-                    num_output_tokens_so_far = next_total_toks
+                # Streaming response for this batch item
+                next_total_toks = len(res["output_ids"])
+                new_tokens = res["output_ids"][num_output_tokens_so_far[index] :]
+                out = {
+                    "token_ids": new_tokens,
+                    "index": index,
+                }
+                num_output_tokens_so_far[index] = next_total_toks
 
             yield out
 

--- a/lib/engines/llamacpp/src/lib.rs
+++ b/lib/engines/llamacpp/src/lib.rs
@@ -206,11 +206,7 @@ fn run_request(
     work_request: WorkRequest,
     llama_context: &mut ContextWrapper,
 ) -> Result<()> {
-    let tokens_to_process = work_request
-        .request
-        .token_ids
-        .first()
-        .unwrap();
+    let tokens_to_process = work_request.request.token_ids.first().unwrap();
     let tokens_list: Vec<LlamaToken> = tokens_to_process
         .iter()
         .map(|&u| LlamaToken::new(u as i32))

--- a/lib/engines/llamacpp/src/lib.rs
+++ b/lib/engines/llamacpp/src/lib.rs
@@ -206,11 +206,14 @@ fn run_request(
     work_request: WorkRequest,
     llama_context: &mut ContextWrapper,
 ) -> Result<()> {
-    let tokens_list: Vec<LlamaToken> = work_request
+    let tokens_to_process = work_request
         .request
         .token_ids
-        .into_iter()
-        .map(|u| LlamaToken::new(u as i32))
+        .first()
+        .unwrap();
+    let tokens_list: Vec<LlamaToken> = tokens_to_process
+        .iter()
+        .map(|&u| LlamaToken::new(u as i32))
         .collect();
 
     let limit = DEFAULT_MAX_TOKENS; // - prompt_tokens;

--- a/lib/llm/src/engines.rs
+++ b/lib/llm/src/engines.rs
@@ -97,9 +97,11 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         let ctx = context.context();
 
         let output = stream! {
-            for tok in request.token_ids {
-                tokio::time::sleep(*TOKEN_ECHO_DELAY).await;
-                yield delta_core(tok);
+            for sequence_tokens in request.token_ids {
+                for tok in sequence_tokens {
+                    tokio::time::sleep(*TOKEN_ECHO_DELAY).await;
+                    yield delta_core(tok);
+                }
             }
             yield Annotated::from_data(LLMEngineOutput::stop());
         };

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -242,8 +242,9 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         match self.inner.client.instance_source.as_ref() {
             InstanceSource::Static => self.inner.r#static(request).await,
             InstanceSource::Dynamic(_) => {
+                let tokens_for_lookup = request.token_ids.first().unwrap();
                 let (instance_id, overlap_amount) =
-                    self.chooser.find_best_match(&request.token_ids).await?;
+                    self.chooser.find_best_match(tokens_for_lookup).await?;
                 // Update the request with the estimated prefix hit blocks
                 let (mut backend_input, context) = request.into_parts();
                 backend_input.estimated_prefix_hit_num_blocks = Some(overlap_amount);

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -166,15 +166,10 @@ impl OpenAIPreprocessor {
                 if let Some(token_input) = request.extract_tokens() {
                     match token_input {
                         TokenInput::Single(tokens) => {
-                            builder.token_ids(tokens);
+                            builder.token_ids(vec![tokens]);
                         }
                         TokenInput::Batch(token_batches) => {
-                            if token_batches.len() == 1 {
-                                builder.token_ids(token_batches[0].clone());
-                            } else {
-                                builder.batch_token_ids(Some(token_batches));
-                                builder.token_ids(vec![]);
-                            }
+                            builder.token_ids(token_batches);
                         }
                     }
                 }
@@ -217,7 +212,7 @@ impl OpenAIPreprocessor {
                                 );
                             }
 
-                            builder.token_ids(encoding.token_ids);
+                            builder.token_ids(vec![encoding.token_ids]);
                         }
                         TextInput::Batch(texts) => {
                             let mut token_batches = Vec::new();
@@ -227,8 +222,7 @@ impl OpenAIPreprocessor {
                                     tokio::task::block_in_place(|| self.tokenizer.encode(&text))?;
                                 token_batches.push(encoding.token_ids);
                             }
-                            builder.batch_token_ids(Some(token_batches));
-                            builder.token_ids(vec![]);
+                            builder.token_ids(token_batches);
                         }
                     }
                 }

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -27,9 +27,9 @@ pub struct PreprocessedRequest {
     /// Each inner `Vec<TokenIdType>` represents a single sequence.
     /// A single 1D sequence (e.g., `[1,2,3]`) will now be wrapped as `[[1,2,3]]` to
     /// ensure a consistent `Vec<Vec<TokenIdType>>` structure.
-    #[builder(default)] // Keep default, an empty Vec<Vec<TokenIdType>> is a valid default state
+    #[builder(default)]
+    // Keep default, an empty Vec<Vec<TokenIdType>> is a valid default state
     pub token_ids: Vec<Vec<TokenIdType>>,
-
 
     /// StopConditions are conditions that the inference engine will use to stop generation.
     pub stop_conditions: StopConditions,

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -23,12 +23,13 @@ use crate::protocols::TokenIdType;
 /// crate is responsible for converting request from the public APIs to this internal representation.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
 pub struct PreprocessedRequest {
-    /// Type of prompt
-    pub token_ids: Vec<TokenIdType>,
+    /// Token IDs representing a batch of sequences for the LLM request.
+    /// Each inner `Vec<TokenIdType>` represents a single sequence.
+    /// A single 1D sequence (e.g., `[1,2,3]`) will now be wrapped as `[[1,2,3]]` to
+    /// ensure a consistent `Vec<Vec<TokenIdType>>` structure.
+    #[builder(default)] // Keep default, an empty Vec<Vec<TokenIdType>> is a valid default state
+    pub token_ids: Vec<Vec<TokenIdType>>,
 
-    /// Batch Token Ids = for batch completion requests (i.e using ArrayOfIntegerArray type from OpenAI /completions)
-    #[builder(default)]
-    pub batch_token_ids: Option<Vec<Vec<TokenIdType>>>,
 
     /// StopConditions are conditions that the inference engine will use to stop generation.
     pub stop_conditions: StopConditions,


### PR DESCRIPTION
#### Overview:

This pull request implements the proposed simplification of `token_ids` by uniformly representing it as `Vec<Vec<TokenIdType>>` (or its Python equivalent) throughout the system. This change eliminates the need for `if/else` checks for 1D vs. batched `token_ids` on each worker, streamlining downstream logic and improving code consistency.

#### Details:

This PR addresses the change in `PreprocessedRequest.token_ids` from `Vec<u32>` to `Vec<Vec<u32>>` (or equivalent types in Python components), ensuring all `token_ids` are consistently treated as potentially batched inputs, even for single-sequence cases which are now wrapped as `[[1,2,3]]`.

The core changes involve updating engine and worker logic to correctly interpret and utilize this new, unified batched structure:

* **`EchoEngineCore`**: Modified to properly iterate over nested `Vec<u32>` sequences within `token_ids`, ensuring that all tokens in a batch are processed and streamed out correctly.
* **`KvPushRouter`**: Adjusted the `find_best_match` call to explicitly use the `first()` token sequence from the batch for prefix matching. This aligns with the current assumption that KV cache lookups operate on a single sequence.
    * *(Note: Per specific request, explicit error handling for empty batches (e.g., `ok_or_else`) has been replaced with `unwrap()`, which will cause a runtime panic if an empty batch is encountered at this stage.)*
* **`LlamacppEngine`**: Updated the `run_request` function to also extract and process the `first()` token sequence from the batch for `LlamaToken. This specifically fixed a `non-primitive cast` error by correctly iterating over the individual `u32` tokens within the extracted `Vec<u32>`.
    * *(Note: Similar to `KvPushRouter`, explicit error handling for empty batches has been replaced with `unwrap()` here, which will panic if `token_ids` is empty.)*
* **Python Components (`examples/sglang/components/decode_worker.py`, `examples/sglang/components/worker.py`, `examples/sglang/utils/protocol.py`, `launch/dynamo-run/src/subprocess/sglang_inc.py`):** These files have been updated to ensure `token_ids` are consistently handled as lists of lists (or equivalent batched structures) for both input and internal processing, removing conditional logic related to `batch_token_ids`.
* **`lib/llm/src/preprocessor.rs`**: Modified to ensure its output `token_ids` are always in the `Vec<Vec<u32>>` format.
* **`lib/llm/src/protocols/common/preprocessor.rs`**: Updated the `PreprocessedRequest` definition to reflect the `token_ids: Vec<Vec<u32>>` type.

These adaptations ensure that `PreprocessedRequest` with batched `token_ids` can be consistently consumed and processed across various LLM engine and worker components, simplifying future code.

#### Where should the reviewer start?

Reviewers should primarily focus on the following files, paying close attention to how `request.token_ids` is now handled and how conditional logic for batching has been removed:

* `lib/llm/src/protocols/common/preprocessor.rs` (the core type definition change)
* `lib/llm/src/preprocessor.rs` (how the preprocessor now consistently outputs this format, and its `token_ids.len()` usages)
* `lib/llm/src/engines.rs` (specifically `EchoEngineCore`'s `generate` method)
* `lib/llm/src/kv_router.rs` (specifically `KvPushRouter`'s `generate` method)
* `lib/engines/llamacpp/src/lib.rs` (specifically the `run_request` function)
* Python files in `examples/sglang/components/` and `launch/dynamo-run/src/subprocess/` where `token_ids` are used.

#### Related Issues:

-   **Resolves** GitHub issue: #1648

---

### A Question for Reviewers regarding `.len()`:

With `request.token_ids` now being `Vec<Vec<u32>>`, its `.len()` method directly returns the **number of sequences in the batch** (i.e., the batch size), rather than the total number of tokens.

For `lib/llm/src/preprocessor.rs` and any other parts of the codebase that previously relied on `token_ids.len()` to get a total token count, what is the intended behavior? Should these be adjusted to sum the lengths of all inner sequences if a total token count is needed, or should their usage be re-evaluated in the context of batched inputs? Your guidance on this architectural decision would be appreciated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified handling of token IDs by consolidating single and batch processing into a consistent structure across the platform.
  * Simplified request and response flows for both single and batch operations, removing separate code paths and reducing complexity.
  * Updated internal data structures to always treat token IDs as a list of sequences, ensuring consistent behavior.

* **Bug Fixes**
  * Improved reliability when processing both single and batch requests by standardizing token ID handling.

* **Documentation**
  * Clarified usage and expected structure for token ID fields in relevant data models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->