### PR TITLE
fix: bump vLLM commit and revert side channel host change for DS R1 DEP deployment

### DIFF
--- a/container/Dockerfile.vllm_v1
+++ b/container/Dockerfile.vllm_v1
@@ -175,7 +175,7 @@ RUN uv pip install /workspace/wheels/nixl/*.whl
 
 # Install patched vllm - keep this early in Dockerfile to avoid
 # rebuilds from unrelated source code changes
-ARG VLLM_REF="7e8d97dd3f0aaf05265f947997310ca3827d3c06"
+ARG VLLM_REF="3c545c0c3b98ee642373a308197d750d0e449403"
 ENV CUDA_HOME=/usr/local/cuda
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     --mount=type=cache,target=/root/.cache/uv \

--- a/examples/vllm_v1/components/worker.py
+++ b/examples/vllm_v1/components/worker.py
@@ -112,7 +112,7 @@ class VllmBaseWorker:
         This sets the port number for the side channel.
         """
         if hostname is None:
-            hostname = "127.0.0.1"
+            hostname = socket.gethostname()
         if port is None:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind(("", 0))  # Bind to a free port provided by the host.


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying vllm version used in the Docker image to a newer commit.

* **Bug Fixes**
  * Improved side channel connection reliability by setting the default host to the system's hostname instead of a fixed IP address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->