### PR TITLE
fix: Prometheus to pull from dcgm-exporter:9400 instead of 9401

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ hf-hub = { version = "0.4.2", default-features = false, features = ["tokio", "ru
 humantime = { version = "2.2.0" }
 libc = { version = "0.2" }
 oneshot = { version = "0.1.11", features = ["std", "async"] }
+opentelemetry = { version = "0.27" }
 prometheus = { version = "0.14" }
 rand = { version = "0.9.0" }
 serde = { version = "1", features = ["derive"] }

--- a/deploy/metrics/docker-compose.yml
+++ b/deploy/metrics/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       # Remap from 9400 to 9401 (public port) to avoid conflict with an existing dcgm-exporter
       # on dlcluster. To access dcgm:
       # Outside the container: curl http://localhost:9401/metrics
-      # Inside the container: curl http://dcgm-exporter:9400/metrics
+      # Inside the container (container-to-container): curl http://dcgm-exporter:9400/metrics
       - 9401:9400
     cap_add:
       - SYS_ADMIN

--- a/deploy/metrics/docker-compose.yml
+++ b/deploy/metrics/docker-compose.yml
@@ -57,10 +57,16 @@ services:
     depends_on:
       - nats-server
 
+  # DCGM stands for Data Center GPU Manager: https://developer.nvidia.com/dcgm
+  # dcgm-exporter is a tool from NVIDIA that exposes DCGM metrics in Prometheus format.
   dcgm-exporter:
     image: nvidia/dcgm-exporter:4.2.3-4.1.3-ubi9
     ports:
-      - 9401:9400  # Remap from 9400 to 9401 to avoid conflict with an existing dcgm-exporter (on dlcluster)
+      # Remap from 9400 to 9401 (public port) to avoid conflict with an existing dcgm-exporter
+      # on dlcluster. To access dcgm:
+      # Outside the container: curl http://localhost:9401/metrics
+      # Inside the container: curl http://dcgm-exporter:9400/metrics
+      - 9401:9400
     cap_add:
       - SYS_ADMIN
     deploy:

--- a/deploy/metrics/prometheus.yml
+++ b/deploy/metrics/prometheus.yml
@@ -31,7 +31,7 @@ scrape_configs:
   - job_name: 'dcgm-exporter'
     scrape_interval: 5s
     static_configs:
-      - targets: ['dcgm-exporter:9401']  # on the "monitoring" network
+      - targets: ['dcgm-exporter:9400']  # on the "monitoring" network
 
   # Uncomment to see its own Prometheus metrics
   # - job_name: 'prometheus'


### PR DESCRIPTION
#### Overview:

This PR fixes a configuration mismatch in the Prometheus monitoring setup where Prometheus was incorrectly trying to scrape metrics from dcgm-exporter:9401 instead of the correct internal port dcgm-exporter:9400.

#### Details:

- Fixed Prometheus configuration: Changed target from dcgm-exporter:9401 to dcgm-exporter:9400 in prometheus.yml
- Enhanced documentation: Added comments explaining DCGM exporter purpose and port mapping in docker-compose.yml. The port mapping 9401:9400 correctly maps external port 9401 to internal port 9400, but Prometheus (running inside Docker network) should use internal port 9400.


#### Where should the reviewer start?

- deploy/metrics/prometheus.yml - Check the corrected target port
- deploy/metrics/docker-compose.yml - Review enhanced documentation

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: [1698](https://github.com/ai-dynamo/dynamo/issues/1698)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanatory comments to the GPU metrics exporter service configuration, including descriptions and usage instructions.
* **Refactor**
  * Updated the Prometheus configuration to change the scrape target port for the GPU metrics exporter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->