### PR TITLE
docs: Add GitHub Pages deployment to private website for release branches

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -103,7 +103,7 @@ jobs:
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Deploy to internal GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.DOCS_TOKEN }}
           external_repository: ${{ env.DOCS_REPOSITORY }}

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -57,3 +57,105 @@ jobs:
           name: dynamo-docs-${{ github.run_id }}
           path: dynamo-docs
           retention-days: 15
+
+  deploy:
+    name: Deploy to private documentation repository
+    needs: build-docs
+    runs-on: ubuntu-latest
+
+    # Deploy on PRs targeting release branches
+    if: github.event_name == 'pull_request' && startsWith(github.base_ref, 'release')
+
+    # Prevent multiple deployments from running simultaneously
+    concurrency:
+      group: deploy-docs-${{ github.base_ref }}
+      cancel-in-progress: false
+
+    env:
+      DOCS_BASE_URL: "https://crispy-winner-3jnj38w.pages.github.io"
+      DOCS_REPOSITORY: "ai-dynamo/dynamo-docs"
+      DOCS_BRANCH: "main"
+      DOCS_ARTIFACT_NAME: "dynamo-docs"
+
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      - name: Download documentation artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.DOCS_ARTIFACT_NAME }}-${{ github.run_id }}
+          path: ${{ env.DOCS_ARTIFACT_NAME }}
+
+      - name: Clean potentially stale metadata files (but preserve index)
+        run: |
+          rm -f ./${{ env.DOCS_ARTIFACT_NAME }}/CNAME
+          rm -f ./${{ env.DOCS_ARTIFACT_NAME }}/_config.yml
+          # Don't remove index.html - it's needed for navigation
+
+      - name: Determine deployment directory
+        id: deploy_dir
+        run: |
+          # For PRs, use consistent directory (latest commit overwrites previous)
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
+          echo "dir_name=${{ github.base_ref }}/pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+          echo "commit_ref=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+
+      - name: Deploy to internal GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.DOCS_TOKEN }}
+          external_repository: ${{ env.DOCS_REPOSITORY }}
+          publish_branch: ${{ env.DOCS_BRANCH }}
+          publish_dir: ./${{ env.DOCS_ARTIFACT_NAME }}
+          destination_dir: ${{ steps.deploy_dir.outputs.dir_name }}
+          commit_message: 'Deploy documentation from ${{ github.repository }}@${{ steps.deploy_dir.outputs.commit_ref }} (branch: ${{ steps.deploy_dir.outputs.dir_name }})'
+          keep_files: true
+
+      - name: Comment on PR with docs link
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const docsUrl = `${{ env.DOCS_BASE_URL }}/${{ steps.deploy_dir.outputs.dir_name }}/`;
+            const comment = `## 📚 Documentation Preview
+
+            **📖 View Latest Documentation:** [${docsUrl}](${docsUrl})
+            > **Latest Deployment:**
+            > - **Commit:** [\`${{ steps.deploy_dir.outputs.short_sha }}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) *(latest push)*
+            > - **Target:** \`${{ github.base_ref }}\`
+            > - **Updated:** ${new Date().toLocaleString('en-US', { timeZone: 'UTC', timeStyle: 'short', dateStyle: 'short' })} UTC
+            >
+            > **Note:** This link always shows the documentation for the latest commit. It may take a few minutes for GitHub Pages to update after each push.
+            ---
+
+            *Auto-updated by the documentation deployment workflow*`;
+
+            // Find and update existing comment, or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('📚 Documentation Preview')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: comment
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment
+              });
+            }


### PR DESCRIPTION
https://github.com/ai-dynamo/dynamo/pull/1542

This PR adds deployment automation to deploy documentation to a private repository when pushing to release branches.

<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
<!-- walkthrough_start -->

## Walkthrough

A new `deploy` job was added to the GitHub Actions workflow for documentation generation. This job depends on the `build-docs` job, runs only on `release` branches, and deploys generated documentation to an external repository using a GitHub Pages action, with deployment details dynamically set from the branch and commit.

## Changes

| File(s)                                   | Change Summary                                                                                                             |
|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
| .github/workflows/generate-docs.yml        | Added a `deploy` job that downloads the docs artifact, extracts the branch name, and deploys documentation to an external repo using GitHub Pages. |

## Sequence Diagram(s)

```mermaid
sequenceDiagram
    participant GitHub Actions
    participant build-docs Job
    participant deploy Job
    participant ai-dynamo/dynamo.github.io Repo

    GitHub Actions->>build-docs Job: Trigger on push to release branch
    build-docs Job-->>GitHub Actions: Generate and upload docs artifact
    GitHub Actions->>deploy Job: Start if build-docs succeeds
    deploy Job->>deploy Job: Download docs artifact
    deploy Job->>deploy Job: Extract branch name from GITHUB_REF
    deploy Job->>ai-dynamo/dynamo.github.io Repo: Deploy docs via gh-pages action
```

1. Trying to resolve 404 issue 
https://****.pages.github.io/release/0.3.1/

The current condition if: startsWith(github.ref, 'refs/heads/release') only runs when pushing directly to a release branch, not on PRs targeting release branches.
For PRs, we need to check the target branch (github.base_ref) rather than the source branch (github.ref).

2. Adding a PR comment with the docs link
