### PR TITLE
fix: Add handling for ignore_eos sampling param in trtllm example base engine

### DIFF
--- a/examples/tensorrt_llm/common/base_engine.py
+++ b/examples/tensorrt_llm/common/base_engine.py
@@ -345,6 +345,10 @@ class BaseTensorrtLLMEngine:
         if max_tokens:
             sampling_params.max_tokens = max_tokens
 
+        ignore_eos = request.stop_conditions.ignore_eos
+        if ignore_eos:
+            sampling_params.ignore_eos = ignore_eos
+
         # TODO: Disable streaming for context only requests when adding disagg support
         async for res in self._llm_engine.llm.generate_async(
             inputs=inputs,


### PR DESCRIPTION
#### Overview:

Improve trtllm example base_engine.py

#### Details:

Add handling for `ignore_eos` sampling param

Old behavior : `ignore_eos` in the request was getting ignored.

```
New behavior : 
curl -X POST "http://localhost:8000/v1/completions"   -H "Content-Type: application/json"   --data '{
    "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
    "prompt": "How many hrs in day?",
    "max_tokens": 1020,
    "temperature": 0.7,
    "nvext": {
        "ignore_eos": false
    }
  }'
{"id":"cmpl-3715c756-4ebb-4bfa-b346-7b12eec02014","choices":[{"text":"Okay, so I need to figure out how many hours are in a day. Hmm, I know that a day has 24 hours, but let me think through this step by step to make sure I understand it properly.\n\nFirst, I remember that the Earth rotates on its axis. The time it takes for one full rotation is what we consider a day. But I'm not entirely sure about the exact number of hours in a day. Maybe I should break it down into smaller parts.\n\nI know that there are 24 hours in a day, but why is that? Let me think about the time periods in a day. There's AM and PM, which stand for Ante Meridiem (before noon) and Post Meridiem (after noon). So, from 12 AM to 12 PM is 12 hours, and from 12 PM to 12 AM is another 12 hours, making it 24 hours in total.\n\nWait, but sometimes people talk about a day having 36 hours or 48 hours. How does that work? Oh, I think that's when we count the hours from midnight to midnight, including the hours before and after midnight. But in the 24-hour clock, we don't count those extra hours because we start and end the day at the same point.\n\nLet me also consider different time zones. Do they affect the number of hours in a day? I don't think so because each time zone adjusts its clock to match the Earth's rotation. So, regardless of where you are, a day still has 24 hours.\n\nAnother way to think about it is by breaking down the day into smaller units. There are 60 minutes in an hour, and 60 seconds in a minute. So, if I multiply 24 hours by 60 minutes, I get 1440 minutes in a day. If I multiply that by 60 seconds, that's 86,400 seconds in a day. But the question is about hours, so 24 is the correct answer.\n\nI also remember that in some contexts, like stock markets or 24-hour news, they operate on a 24-hour clock. So, they report events happening around the world at different times, but each day still has 24 hours.\n\nWait, but sometimes people might refer to a \"day\" as a period from sunrise to sunset. That can vary because the Earth's rotation isn't perfectly consistent, and the length of a day can change slightly throughout the year due to factors like Earth's tilt and the gravitational pull of the Moon. However, for most practical purposes, especially in standard timekeeping, a day is defined as 24 hours.\n\nSo, to sum it up, a day has 24 hours, regardless of time zones or how we measure time. It's a consistent number used worldwide for scheduling and daily activities.\n</think>\n\nA day consists of 24 hours. This consistent measurement is used globally for scheduling and daily activities, despite variations in time zones and other factors.","index":0,"finish_reason":"stop"}],"created":1751411882,"model":"deepseek-ai/DeepSeek-R1-Distill-Llama-8B","object":"text_completion","usage":{"completion_tokens":609,"prompt_tokens":11,"total_tokens":0}}


curl -X POST "http://localhost:8000/v1/completions"   -H "Content-Type: application/json"   --data '{
    "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
    "prompt": "How many hrs in day?",
    "max_tokens": 1020,
    "temperature": 0.7,
    "nvext": {
        "ignore_eos": true
    }
  }'
{"id":"cmpl-009fee9e-78a2-47e6-9e86-aaae6946d2b1","choices":[{"text":"Okay, so I need to figure out how many hours are in a day. Hmm, I know that a day has 24 hours, but let me think through this step by step to make sure I understand it properly.\n\nFirst, I remember that the Earth rotates on its axis. The time it takes for one full rotation is what we consider a day. But I'm not entirely sure about the exact number of hours in a day. Maybe I should break it down into smaller parts.\n\nI know that there are 24 hours in a day, but why is that? Let me think about the time periods in a day. There's AM and PM, which stand for Ante Meridiem (before noon) and Post Meridiem (after noon). So, from 12 AM to 12 PM is 12 hours, and from 12 PM to 12 AM is another 12 hours, making it 24 hours in total.\n\nWait, but sometimes people talk about a day having 36 hours or 48 hours. How does that work? Oh, I think that's when we count the hours from midnight to midnight, including the hours before and after midnight. But in the 24-hour clock, we don't count those extra hours because we start and end the day at the same point.\n\nLet me also consider different time zones. Do they affect the number of hours in a day? I don't think so because each time zone adjusts its clock to match the Earth's rotation. So, regardless of where you are, a day still has 24 hours.\n\nAnother way to think about it is by breaking down the day into smaller units. There are 60 minutes in an hour, and 60 seconds in a minute. So, if I multiply 24 hours by 60 minutes, I get 1440 minutes in a day. If I multiply that by 60 seconds, that's 86,400 seconds in a day. But the question is about hours, so 24 is the correct answer.\n\nI also remember that in some contexts, like stock markets or 24-hour news, they operate on a 24-hour clock. So, they report events happening around the world at different times, but each day still has 24 hours.\n\nWait, but sometimes people might refer to a \"day\" as a period from sunrise to sunset. That can vary because the Earth's rotation isn't perfectly consistent, and the length of a day can change slightly throughout the year due to factors like Earth's tilt and the gravitational pull of the Moon. However, for most practical purposes, especially in standard timekeeping, a day is defined as 24 hours.\n\nSo, to sum it up, a day has 24 hours, regardless of time zones or how we measure time. It's a consistent number used worldwide for scheduling and daily activities.\n</think>\n\nA day consists of 24 hours. This consistent measurement is used globally for scheduling and daily activities, despite variations in time zones and other factors.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.<｜end▁of▁sentence｜><｜begin▁of▁sentence｜>://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24.://\n\nThe number of hours in a day is 24","index":0,"finish_reason":null}],"created":1751411845,"model":"deepseek-ai/DeepSeek-R1-Distill-Llama-8B","object":"text_completion","usage":{"completion_tokens":1019,"prompt_tokens":11,"total_tokens":0}}
```
When `"ignore_eos": true` the response continues till max-tokens length which not the case earlier

#### Where should the reviewer start?

 base_engine.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: https://github.com/ai-dynamo/dynamo/issues/1705


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of stop conditions during text generation, allowing requests to specify whether to ignore end-of-sequence tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->