### PR TITLE
build: Upgrade the NATS + ETCD version in vllm container

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -129,10 +129,10 @@ RUN cd /opt/nixl && \
 
 ### NATS & ETCD SETUP ###
 # nats
-RUN wget --tries=3 --waitretry=5 https://github.com/nats-io/nats-server/releases/download/v2.10.24/nats-server-v2.10.24-${ARCH}.deb && \
-    dpkg -i nats-server-v2.10.24-${ARCH}.deb && rm nats-server-v2.10.24-${ARCH}.deb
+RUN wget --tries=3 --waitretry=5 https://github.com/nats-io/nats-server/releases/download/v2.10.28/nats-server-v2.10.28-${ARCH}.deb && \
+    dpkg -i nats-server-v2.10.28-${ARCH}.deb && rm nats-server-v2.10.28-${ARCH}.deb
 # etcd
-ENV ETCD_VERSION="v3.5.18"
+ENV ETCD_VERSION="v3.5.21"
 RUN wget --tries=3 --waitretry=5 https://github.com/etcd-io/etcd/releases/download/$ETCD_VERSION/etcd-$ETCD_VERSION-linux-${ARCH}.tar.gz -O /tmp/etcd.tar.gz && \
     mkdir -p /usr/local/bin/etcd && \
     tar -xvf /tmp/etcd.tar.gz -C /usr/local/bin/etcd --strip-components=1 && \


### PR DESCRIPTION
#### Overview:

Upgrade NATS + ETCD version to resolve CVE's found in transitive packages. 

NATS version was updated to v2.10.28 which updates golang.org/x/crypto to v0.37.0 https://github.com/nats-io/nats-server/blob/release/v2.10.28/go.mod#L15

ETCD version was upgraded to v3.5.21 which updates jwt to v4.5.2: https://github.com/etcd-io/etcd/blob/v3.5.21/go.mod#L50


#### Details:

- NATS + ETCD version were upgraded to resolve current CVE's in vllm runtime container. 

#### Where should the reviewer start?

- container/Dockerfile.vllm

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
