### PR TITLE
feat: create descriptor and entity separation - partial #1489

### DIFF
--- a/lib/runtime/src/descriptor.rs
+++ b/lib/runtime/src/descriptor.rs
@@ -1,0 +1,953 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Descriptors for pure data representation of components without runtime dependencies
+//!
+//! All descriptor types implement Display to produce canonical string representations
+//! in the `dynamo://` path format. Use `.to_string()` to get the canonical path string.
+//!
+//! The Keys descriptor always inserts `_path_` before additional segments.
+//! User-provided segments cannot start with underscore (reserved for internal use).
+//!
+//! ```ignore
+//! // Always inserts _path_
+//! let keys = Keys::from_identifier(id, vec!["config".to_string(), "v1".to_string()])?;
+//! assert_eq!(keys.to_string(), "dynamo://ns/_component_/comp/_path_/config/v1");
+//!
+//! // Segments starting with underscore are rejected
+//! let err = Keys::from_identifier(id, vec!["_invalid".to_string()]); // Error!
+//! ```
+
+use once_cell::sync::Lazy;
+use std::str::FromStr;
+use validator::ValidationError;
+
+pub const ETCD_ROOT_PATH: &str = "dynamo://";
+pub const COMPONENT_KEYWORD: &str = "_component_";
+pub const ENDPOINT_KEYWORD: &str = "_endpoint_";
+pub const PATH_KEYWORD: &str = "_path_";
+pub const BARRIER_KEYWORD: &str = "_barrier_";
+
+/// Errors that can occur during descriptor operations
+#[derive(Debug, thiserror::Error)]
+pub enum DescriptorError {
+    #[error("Path must start with '{}'", ETCD_ROOT_PATH)]
+    InvalidPrefix,
+    #[error("Invalid namespace: {0}")]
+    InvalidNamespace(String),
+    #[error("Invalid component name: {0}")]
+    InvalidComponent(String),
+    #[error("Invalid endpoint name: {0}")]
+    InvalidEndpoint(String),
+    #[error("Invalid path segment: {0}")]
+    InvalidPathSegment(String),
+    #[error("Endpoint requires component to be present")]
+    EndpointWithoutComponent,
+    #[error("Reserved keyword '{0}' cannot be used in path segments")]
+    ReservedKeyword(String),
+    #[error("Empty namespace not allowed")]
+    EmptyNamespace,
+    #[error("Empty component name not allowed")]
+    EmptyComponent,
+    #[error("Empty endpoint name not allowed")]
+    EmptyEndpoint,
+    #[error("Missing instance ID in path")]
+    MissingInstanceId,
+    #[error("Invalid instance ID format: {0}")]
+    InvalidInstanceId(String),
+}
+
+/// Intermediate representation of a parsed dynamo path
+#[derive(Debug)]
+struct DynamoPath {
+    namespace: String,
+    component: Option<String>,
+    endpoint: Option<String>,
+    instance_id: Option<i64>,
+    extra_segments: Vec<String>,
+}
+
+impl DynamoPath {
+    /// Parse any dynamo:// path into intermediate representation
+    fn parse(input: &str) -> Result<Self, DescriptorError> {
+        // Check for required prefix
+        if !input.starts_with(ETCD_ROOT_PATH) {
+            return Err(DescriptorError::InvalidPrefix);
+        }
+
+        // Remove prefix and split into segments
+        let path_without_prefix = &input[ETCD_ROOT_PATH.len()..];
+        let segments: Vec<&str> = path_without_prefix.split('/').collect();
+
+        if segments.is_empty() || segments[0].is_empty() {
+            return Err(DescriptorError::EmptyNamespace);
+        }
+
+        let namespace = segments[0].to_string();
+        validate_namespace(&namespace)?;
+
+        let mut component: Option<String> = None;
+        let mut endpoint: Option<String> = None;
+        let mut instance_id: Option<i64> = None;
+        let mut extra_segments = Vec::new();
+
+        let mut i = 1;
+        while i < segments.len() {
+            match segments[i] {
+                COMPONENT_KEYWORD => {
+                    // Check if component was already set
+                    if component.is_some() {
+                        return Err(DescriptorError::InvalidPathSegment(
+                            "Duplicate _component_ keyword in path".to_string()
+                        ));
+                    }
+                    if i + 1 >= segments.len() {
+                        return Err(DescriptorError::EmptyComponent);
+                    }
+                    let component_name = segments[i + 1];
+                    validate_component(component_name)?;
+                    component = Some(component_name.to_string());
+                    i += 2;
+                }
+                ENDPOINT_KEYWORD => {
+                    if component.is_none() {
+                        return Err(DescriptorError::EndpointWithoutComponent);
+                    }
+                    // Check if endpoint was already set
+                    if endpoint.is_some() {
+                        return Err(DescriptorError::InvalidPathSegment(
+                            "Duplicate _endpoint_ keyword in path".to_string()
+                        ));
+                    }
+                    if i + 1 >= segments.len() {
+                        return Err(DescriptorError::EmptyEndpoint);
+                    }
+
+                    let endpoint_segment = segments[i + 1];
+
+                    // Check for instance ID suffix (:hex_id)
+                    if let Some(colon_pos) = endpoint_segment.find(':') {
+                        let endpoint_name = &endpoint_segment[..colon_pos];
+                        let id_str = &endpoint_segment[colon_pos + 1..];
+
+                        // Parse instance ID as hexadecimal
+                        instance_id = Some(i64::from_str_radix(id_str, 16).map_err(|_| {
+                            DescriptorError::InvalidInstanceId(id_str.to_string())
+                        })?);
+
+                        validate_endpoint(endpoint_name)?;
+                        endpoint = Some(endpoint_name.to_string());
+                    } else {
+                        validate_endpoint(endpoint_segment)?;
+                        endpoint = Some(endpoint_segment.to_string());
+                    }
+                    i += 2;
+                }
+                PATH_KEYWORD => {
+                    // Valid _path_ extension at any level
+                    i += 1;
+                    while i < segments.len() {
+                        validate_extra_path_segment(segments[i])?;
+                        extra_segments.push(segments[i].to_string());
+                        i += 1;
+                    }
+                }
+                _ => {
+                    // Any other segment is invalid - must use _path_ for extensions
+                    return Err(DescriptorError::InvalidPathSegment(format!(
+                        "Invalid path format: unexpected segment '{}' - use '{}' keyword for path extensions",
+                        segments[i], PATH_KEYWORD
+                    )));
+                }
+            }
+        }
+
+        Ok(DynamoPath {
+            namespace,
+            component,
+            endpoint,
+            instance_id,
+            extra_segments,
+        })
+    }
+
+    /// Convert to Identifier (drops instance_id and extra segments if present)
+    fn try_into_identifier(self) -> Result<Identifier, DescriptorError> {
+        // Note: We allow parsing paths with instance_id or extra segments,
+        // we just drop them. This enables more flexible parsing.
+
+        Ok(Identifier {
+            namespace: self.namespace,
+            component: self.component,
+            endpoint: self.endpoint,
+        })
+    }
+
+    /// Convert to Instance (drops extra segments if present)
+    fn try_into_instance(self) -> Result<Instance, DescriptorError> {
+        // Must have instance_id to be an Instance
+        if self.instance_id.is_none() {
+            return Err(DescriptorError::MissingInstanceId);
+        }
+
+        // Must have endpoint for an Instance
+        let component = self.component.ok_or(DescriptorError::EmptyComponent)?;
+        let endpoint = self.endpoint.ok_or(DescriptorError::EmptyEndpoint)?;
+        let instance_id = self.instance_id.unwrap();
+
+        // Note: We allow extra segments but drop them
+        let identifier = Identifier {
+            namespace: self.namespace,
+            component: Some(component),
+            endpoint: Some(endpoint),
+        };
+
+        Ok(Instance { identifier, instance_id })
+    }
+
+    /// Convert to Keys (with validation)
+    fn try_into_keys(self) -> Result<Keys, DescriptorError> {
+        let base = if let Some(instance_id) = self.instance_id {
+            // Has instance ID - create Instance base
+            let component = self.component.ok_or(DescriptorError::EmptyComponent)?;
+            let endpoint = self.endpoint.ok_or(DescriptorError::EmptyEndpoint)?;
+
+            let identifier = Identifier {
+                namespace: self.namespace,
+                component: Some(component),
+                endpoint: Some(endpoint),
+            };
+
+            KeysBase::Instance(Instance { identifier, instance_id })
+        } else {
+            // No instance ID - create Identifier base
+            let identifier = Identifier {
+                namespace: self.namespace,
+                component: self.component,
+                endpoint: self.endpoint,
+            };
+
+            KeysBase::Identifier(identifier)
+        };
+
+        Ok(Keys {
+            base,
+            keys: self.extra_segments,
+        })
+    }
+}
+
+/// Pure data descriptor for component identification
+/// Owns the canonical path format and validation logic
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Identifier {
+    namespace: String,
+    component: Option<String>,
+    endpoint: Option<String>,
+}
+
+impl Identifier {
+    /// Create namespace-only identifier
+    pub fn new_namespace(namespace: &str) -> Result<Self, DescriptorError> {
+        validate_namespace(namespace)?;
+        Ok(Self {
+            namespace: namespace.to_string(),
+            component: None,
+            endpoint: None,
+        })
+    }
+
+    /// Create component identifier
+    pub fn new_component(namespace: &str, component: &str) -> Result<Self, DescriptorError> {
+        validate_namespace(namespace)?;
+        validate_component(component)?;
+        Ok(Self {
+            namespace: namespace.to_string(),
+            component: Some(component.to_string()),
+            endpoint: None,
+        })
+    }
+
+    /// Create endpoint identifier
+    pub fn new_endpoint(namespace: &str, component: &str, endpoint: &str) -> Result<Self, DescriptorError> {
+        validate_namespace(namespace)?;
+        validate_component(component)?;
+        validate_endpoint(endpoint)?;
+        Ok(Self {
+            namespace: namespace.to_string(),
+            component: Some(component.to_string()),
+            endpoint: Some(endpoint.to_string()),
+        })
+    }
+
+    /// Parse from canonical string representation
+    pub fn parse(input: &str) -> Result<Self, DescriptorError> {
+        input.try_into()
+    }
+
+    /// Get the namespace
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// Get the component if present
+    pub fn component(&self) -> Option<&str> {
+        self.component.as_deref()
+    }
+
+    /// Get the endpoint if present
+    pub fn endpoint(&self) -> Option<&str> {
+        self.endpoint.as_deref()
+    }
+
+    /// Validate the identifier
+    pub fn validate(&self) -> Result<(), DescriptorError> {
+        validate_namespace(&self.namespace)?;
+
+        if let Some(ref component) = self.component {
+            validate_component(component)?;
+        }
+
+        if let Some(ref endpoint) = self.endpoint {
+            validate_endpoint(endpoint)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for Identifier {
+    /// Builds the canonical string representation in the format:
+    /// dynamo://namespace[/_component_/component][/_endpoint_/endpoint]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", ETCD_ROOT_PATH, self.namespace)?;
+
+        if let Some(ref component) = self.component {
+            write!(f, "/{}/{}", COMPONENT_KEYWORD, component)?;
+
+            if let Some(ref endpoint) = self.endpoint {
+                write!(f, "/{}/{}", ENDPOINT_KEYWORD, endpoint)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl std::str::FromStr for Identifier {
+    type Err = DescriptorError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl TryFrom<&str> for Identifier {
+    type Error = DescriptorError;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        DynamoPath::parse(input)?.try_into_identifier()
+    }
+}
+
+/// Identifier extended with instance_id (lease_id)
+/// Immutable - identifier cannot be changed after construction
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Instance {
+    identifier: Identifier,  // Private to enforce immutability
+    instance_id: i64,
+}
+
+impl Instance {
+    /// Create from identifier, takes ownership to enforce immutability
+    pub fn new(identifier: Identifier, instance_id: i64) -> Result<Self, DescriptorError> {
+        identifier.validate()?;
+        if identifier.endpoint().is_none() {
+            return Err(DescriptorError::InvalidEndpoint(
+                "Instance ID can only be attached to endpoints".to_string()
+            ));
+        }
+        Ok(Self {
+            identifier,
+            instance_id,
+        })
+    }
+
+    /// Create directly with endpoint details
+    pub fn new_endpoint_with_id(
+        namespace: &str,
+        component: &str,
+        endpoint: &str,
+        instance_id: i64,
+    ) -> Result<Self, DescriptorError> {
+        let identifier = Identifier::new_endpoint(namespace, component, endpoint)?;
+        Self::new(identifier, instance_id)
+    }
+
+    /// Parse from canonical string representation
+    pub fn parse(input: &str) -> Result<Self, DescriptorError> {
+        input.try_into()
+    }
+
+    /// Get reference to underlying identifier
+    pub fn identifier(&self) -> &Identifier {
+        &self.identifier
+    }
+
+    /// Get instance ID
+    pub fn instance_id(&self) -> i64 {
+        self.instance_id
+    }
+}
+
+impl std::fmt::Display for Instance {
+    /// Builds the canonical string representation in the format:
+    /// dynamo://namespace/_component_/component/_endpoint_/endpoint:hex_id
+    /// The instance_id is formatted as lowercase hexadecimal after the endpoint
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", ETCD_ROOT_PATH, self.identifier.namespace)?;
+
+        if let Some(ref component) = self.identifier.component {
+            write!(f, "/{}/{}", COMPONENT_KEYWORD, component)?;
+
+            if let Some(ref endpoint) = self.identifier.endpoint {
+                write!(f, "/{}/{}:{:x}", ENDPOINT_KEYWORD, endpoint, self.instance_id)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl std::str::FromStr for Instance {
+    type Err = DescriptorError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl TryFrom<&str> for Instance {
+    type Error = DescriptorError;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        DynamoPath::parse(input)?.try_into_instance()
+    }
+}
+
+/// Descriptor with additional path segments for extended paths
+/// Always inserts _path_ before the segments
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Keys {
+    base: KeysBase,  // Either Identifier or Instance
+    keys: Vec<String>,
+}
+
+/// Base can be either Identifier or Instance
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeysBase {
+    Identifier(Identifier),
+    Instance(Instance),
+}
+
+impl Keys {
+    /// Create from identifier with path segments
+    /// All segments will be placed under _path_
+    pub fn from_identifier(identifier: Identifier, keys: Vec<String>) -> Result<Self, DescriptorError> {
+        identifier.validate()?;
+        for key in &keys {
+            validate_path_segment(key)?;
+        }
+        Ok(Self {
+            base: KeysBase::Identifier(identifier),
+            keys,
+        })
+    }
+
+    /// Create from instance with path segments
+    /// All segments will be placed under _path_
+    pub fn from_instance(instance: Instance, keys: Vec<String>) -> Result<Self, DescriptorError> {
+        for key in &keys {
+            validate_path_segment(key)?;
+        }
+        Ok(Self {
+            base: KeysBase::Instance(instance),
+            keys,
+        })
+    }
+
+    /// Parse from canonical string representation
+    pub fn parse(input: &str) -> Result<Self, DescriptorError> {
+        input.try_into()
+    }
+
+    /// Get the base descriptor
+    pub fn base(&self) -> &KeysBase {
+        &self.base
+    }
+
+    /// Get the additional keys
+    pub fn keys(&self) -> &[String] {
+        &self.keys
+    }
+
+    /// Check if this path contains a specific reserved keyword
+    /// Always returns false since user segments cannot start with underscore
+    pub fn has_reserved_keyword(&self, _keyword: &str) -> bool {
+        false
+    }
+}
+
+impl std::fmt::Display for Keys {
+    /// Builds the canonical string representation by combining the base path
+    /// (either Identifier or Instance) with _path_ and additional segments.
+    /// Format: base_path/_path_/segment1/segment2...
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.base {
+            KeysBase::Identifier(id) => write!(f, "{}", id)?,
+            KeysBase::Instance(inst) => write!(f, "{}", inst)?,
+        }
+
+        // Always insert _path_
+        write!(f, "/{}", PATH_KEYWORD)?;
+
+        // Add the segments
+        for key in &self.keys {
+            write!(f, "/{}", key)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::str::FromStr for Keys {
+    type Err = DescriptorError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl TryFrom<&str> for Keys {
+    type Error = DescriptorError;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        DynamoPath::parse(input)?.try_into_keys()
+    }
+}
+
+// Validation helpers
+
+static ALLOWED_CHARS_REGEX: Lazy<regex::Regex> =
+    Lazy::new(|| regex::Regex::new(r"^[a-z0-9-_]+$").unwrap());
+
+/// Validation for namespace segments
+fn validate_namespace(namespace: &str) -> Result<(), DescriptorError> {
+    if namespace.is_empty() {
+        return Err(DescriptorError::EmptyNamespace);
+    }
+
+    // Split by dots and validate each part
+    for part in namespace.split('.') {
+        if part.is_empty() {
+            return Err(DescriptorError::InvalidNamespace(format!(
+                "Empty namespace segment in '{}'",
+                namespace
+            )));
+        }
+        // Namespace segments cannot start with underscore (reserved for internal use)
+        if part.starts_with('_') {
+            return Err(DescriptorError::InvalidNamespace(
+                format!("Namespace segment '{}' cannot start with underscore (reserved for internal use)", part)
+            ));
+        }
+        validate_allowed_chars(part).map_err(|_| {
+            DescriptorError::InvalidNamespace(format!("Invalid characters in '{}'", part))
+        })?;
+    }
+    Ok(())
+}
+
+/// Validation for component names
+fn validate_component(component: &str) -> Result<(), DescriptorError> {
+    if component.is_empty() {
+        return Err(DescriptorError::EmptyComponent);
+    }
+    // Component names cannot start with underscore (reserved for internal use)
+    if component.starts_with('_') {
+        return Err(DescriptorError::InvalidComponent(
+            format!("Component name '{}' cannot start with underscore (reserved for internal use)", component)
+        ));
+    }
+    validate_allowed_chars(component)
+        .map_err(|_| DescriptorError::InvalidComponent(component.to_string()))
+}
+
+/// Validation for endpoint names
+fn validate_endpoint(endpoint: &str) -> Result<(), DescriptorError> {
+    if endpoint.is_empty() {
+        return Err(DescriptorError::EmptyEndpoint);
+    }
+    // Endpoint names cannot start with underscore (reserved for internal use)
+    if endpoint.starts_with('_') {
+        return Err(DescriptorError::InvalidEndpoint(
+            format!("Endpoint name '{}' cannot start with underscore (reserved for internal use)", endpoint)
+        ));
+    }
+    validate_allowed_chars(endpoint)
+        .map_err(|_| DescriptorError::InvalidEndpoint(endpoint.to_string()))
+}
+
+/// Validation for path segments (no segments starting with underscore)
+fn validate_path_segment(segment: &str) -> Result<(), DescriptorError> {
+    if segment.is_empty() {
+        return Err(DescriptorError::InvalidPathSegment(
+            "Empty path segment".to_string(),
+        ));
+    }
+
+    // No segments starting with underscore (reserved for internal use)
+    if segment.starts_with('_') {
+        return Err(DescriptorError::InvalidPathSegment(
+            format!("Path segment '{}' cannot start with underscore (reserved for internal use)", segment)
+        ));
+    }
+
+    validate_allowed_chars(segment)
+        .map_err(|_| DescriptorError::InvalidPathSegment(segment.to_string()))
+}
+
+/// Validate extra path segments (used by DynamoPath parsing)
+fn validate_extra_path_segment(segment: &str) -> Result<(), DescriptorError> {
+    if segment.is_empty() {
+        return Err(DescriptorError::InvalidPathSegment(
+            "Empty path segment".to_string(),
+        ));
+    }
+
+    // No segments starting with underscore (reserved for internal use)
+    if segment.starts_with('_') {
+        return Err(DescriptorError::ReservedKeyword(segment.to_string()));
+    }
+
+    validate_allowed_chars(segment)
+        .map_err(|_| DescriptorError::InvalidPathSegment(segment.to_string()))
+}
+
+/// Core validation for allowed characters
+fn validate_allowed_chars(input: &str) -> Result<(), ValidationError> {
+    if ALLOWED_CHARS_REGEX.is_match(input) {
+        Ok(())
+    } else {
+        Err(ValidationError::new("invalid_characters"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_identifier_namespace_only() {
+        let id = Identifier::new_namespace("production.api.v1").unwrap();
+        assert_eq!(id.namespace(), "production.api.v1");
+        assert_eq!(id.component(), None);
+        assert_eq!(id.endpoint(), None);
+        assert_eq!(id.to_string(), "dynamo://production.api.v1");
+    }
+
+    #[test]
+    fn test_identifier_with_component() {
+        let id = Identifier::new_component("production.api.v1", "gateway").unwrap();
+        assert_eq!(id.namespace(), "production.api.v1");
+        assert_eq!(id.component(), Some("gateway"));
+        assert_eq!(id.endpoint(), None);
+        assert_eq!(id.to_string(), "dynamo://production.api.v1/_component_/gateway");
+    }
+
+    #[test]
+    fn test_identifier_with_endpoint() {
+        let id = Identifier::new_endpoint("production.api.v1", "gateway", "http").unwrap();
+        assert_eq!(id.namespace(), "production.api.v1");
+        assert_eq!(id.component(), Some("gateway"));
+        assert_eq!(id.endpoint(), Some("http"));
+        assert_eq!(
+            id.to_string(),
+            "dynamo://production.api.v1/_component_/gateway/_endpoint_/http"
+        );
+    }
+
+    #[test]
+    fn test_identifier_parse() {
+        let id: Identifier = "dynamo://production.api.v1".parse().unwrap();
+        assert_eq!(id.namespace(), "production.api.v1");
+
+        let id: Identifier = "dynamo://production.api.v1/_component_/gateway".parse().unwrap();
+        assert_eq!(id.component(), Some("gateway"));
+
+        let id: Identifier = "dynamo://production.api.v1/_component_/gateway/_endpoint_/http"
+            .parse()
+            .unwrap();
+        assert_eq!(id.endpoint(), Some("http"));
+    }
+
+    #[test]
+    fn test_instance_creation() {
+        let identifier = Identifier::new_endpoint("ns1", "comp1", "ep1").unwrap();
+        let instance = Instance::new(identifier, 0x1234).unwrap();
+        assert_eq!(instance.instance_id(), 0x1234);
+        assert_eq!(instance.to_string(), "dynamo://ns1/_component_/comp1/_endpoint_/ep1:1234");
+    }
+
+    #[test]
+    fn test_instance_parse() {
+        let inst: Instance = "dynamo://ns1/_component_/comp1/_endpoint_/ep1:1234"
+            .parse()
+            .unwrap();
+        assert_eq!(inst.instance_id(), 0x1234);
+        assert_eq!(inst.identifier().namespace(), "ns1");
+        assert_eq!(inst.identifier().component(), Some("comp1"));
+        assert_eq!(inst.identifier().endpoint(), Some("ep1"));
+    }
+
+    #[test]
+    fn test_keys_with_path() {
+        let id = Identifier::new_component("ns1", "comp1").unwrap();
+        // _path_ is always auto-inserted
+        let keys = Keys::from_identifier(id.clone(), vec!["config".to_string()]).unwrap();
+        assert_eq!(keys.to_string(), "dynamo://ns1/_component_/comp1/_path_/config");
+        assert!(!keys.has_reserved_keyword("_path_")); // Always false now
+
+        // Multiple segments
+        let keys2 = Keys::from_identifier(id, vec!["config".to_string(), "v1".to_string()]).unwrap();
+        assert_eq!(keys2.to_string(), "dynamo://ns1/_component_/comp1/_path_/config/v1");
+    }
+
+    #[test]
+    fn test_lenient_parsing() {
+        // Valid path with _path_ keyword
+        let valid_path = "dynamo://ns/_component_/comp/_endpoint_/ep:1234/_path_/extra/data";
+
+        // Can parse as Identifier (drops instance_id and extra segments)
+        let as_identifier: Identifier = valid_path.try_into().unwrap();
+        assert_eq!(as_identifier.to_string(), "dynamo://ns/_component_/comp/_endpoint_/ep");
+
+        // Can parse as Instance (drops extra segments)
+        let as_instance: Instance = valid_path.try_into().unwrap();
+        assert_eq!(as_instance.to_string(), "dynamo://ns/_component_/comp/_endpoint_/ep:1234");
+
+        // Can parse as Keys (preserves everything)
+        let as_keys: Keys = valid_path.try_into().unwrap();
+        assert_eq!(as_keys.to_string(), "dynamo://ns/_component_/comp/_endpoint_/ep:1234/_path_/extra/data");
+
+        // Invalid paths should fail to parse entirely with InvalidPathSegment
+        let invalid_paths = vec![
+            "dynamo://ns/_component_/comp/_endpoint_/ep:1234/extra/data",  // Missing _path_
+            "dynamo://ns/_component_/comp/config/v1",                       // Missing _path_
+            "dynamo://ns/some/random/path",                                 // No structure
+        ];
+
+        for invalid_path in invalid_paths {
+            // Should fail with InvalidPathSegment for all types
+            assert!(matches!(
+                TryInto::<Identifier>::try_into(invalid_path),
+                Err(DescriptorError::InvalidPathSegment(_))
+            ), "Expected InvalidPathSegment for Identifier parse of '{}'", invalid_path);
+
+            assert!(matches!(
+                TryInto::<Instance>::try_into(invalid_path),
+                Err(DescriptorError::InvalidPathSegment(_))
+            ), "Expected InvalidPathSegment for Instance parse of '{}'", invalid_path);
+
+            assert!(matches!(
+                TryInto::<Keys>::try_into(invalid_path),
+                Err(DescriptorError::InvalidPathSegment(_))
+            ), "Expected InvalidPathSegment for Keys parse of '{}'", invalid_path);
+        }
+    }
+
+    #[test]
+    fn test_keys_underscore_validation() {
+        let id = Identifier::new_component("ns", "comp").unwrap();
+
+        // Test that segments starting with underscore are rejected
+        assert!(Keys::from_identifier(id.clone(), vec!["_invalid".to_string()]).is_err());
+        assert!(Keys::from_identifier(id.clone(), vec!["_path_".to_string()]).is_err());
+        assert!(Keys::from_identifier(id.clone(), vec!["_barrier_".to_string()]).is_err());
+
+        // Test valid segments
+        let keys = Keys::from_identifier(id.clone(), vec!["config".to_string(), "v1".to_string()]).unwrap();
+        assert_eq!(keys.to_string(), "dynamo://ns/_component_/comp/_path_/config/v1");
+
+        // Test parsing paths with _path_ already present
+        let parsed: Keys = "dynamo://ns/_component_/comp/_path_/config/v1".parse().unwrap();
+        assert_eq!(parsed.keys(), &["config", "v1"]);
+        assert_eq!(parsed.to_string(), "dynamo://ns/_component_/comp/_path_/config/v1");
+
+        let parsed = Keys::parse("dynamo://ns/_path_/config").unwrap();
+        assert_eq!(parsed.keys(), &["config"]);
+        assert_eq!(parsed.to_string(), "dynamo://ns/_path_/config");
+
+
+        // Test parsing paths without _path_ - should fail
+        let result: Result<Keys, _> = "dynamo://ns/_component_/comp/config/v1".parse();
+        assert!(result.is_err());
+        assert!(matches!(result, Err(DescriptorError::InvalidPathSegment(_))));
+
+        // Underscore in middle - allowed
+        assert!(Keys::from_identifier(id.clone(), vec!["config_v2".to_string()]).is_ok());
+        assert!(Keys::from_identifier(id.clone(), vec!["some_file_name".to_string()]).is_ok());
+    }
+
+    #[test]
+    fn test_validation_errors() {
+        // Invalid prefix
+        assert!(matches!(
+            Identifier::parse("invalid://ns1"),
+            Err(DescriptorError::InvalidPrefix)
+        ));
+
+        // Empty namespace
+        assert!(matches!(
+            Identifier::new_namespace(""),
+            Err(DescriptorError::EmptyNamespace)
+        ));
+
+        // Invalid characters in namespace
+        assert!(matches!(
+            Identifier::new_namespace("ns!@#"),
+            Err(DescriptorError::InvalidNamespace(_))
+        ));
+
+        // Invalid characters in component
+        assert!(matches!(
+            Identifier::new_component("ns1", "comp!@#"),
+            Err(DescriptorError::InvalidComponent(_))
+        ));
+
+        // Invalid characters in endpoint
+        assert!(matches!(
+            Identifier::new_endpoint("ns1", "comp1", "ep!@#"),
+            Err(DescriptorError::InvalidEndpoint(_))
+        ));
+
+        // Instance without endpoint
+        let id = Identifier::new_component("ns1", "comp1").unwrap();
+        assert!(matches!(
+            Instance::new(id, 1234),
+            Err(DescriptorError::InvalidEndpoint(_))
+        ));
+
+        // Keys with segments starting with underscore
+        let id = Identifier::new_component("ns1", "comp1").unwrap();
+        assert!(matches!(
+            Keys::from_identifier(id.clone(), vec!["_invalid".to_string()]),
+            Err(DescriptorError::InvalidPathSegment(_))
+        ));
+        assert!(matches!(
+            Keys::from_identifier(id, vec!["valid".to_string(), "_path_".to_string()]),
+            Err(DescriptorError::InvalidPathSegment(_))
+        ));
+
+        // Test colons in various positions (not allowed except for instance IDs)
+        assert!(matches!(
+            Identifier::parse("dynamo://ns:invalid"),
+            Err(DescriptorError::InvalidNamespace(_))
+        ));
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_component_/comp:invalid"),
+            Err(DescriptorError::InvalidComponent(_))
+        ));
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_component_/_invali:d"),
+            Err(DescriptorError::InvalidComponent(_))
+        ));
+
+    }
+
+    #[test]
+    fn test_invalid_path_formats() {
+        // These paths are invalid and should be rejected with InvalidPathSegment errors
+        let invalid_paths = vec![
+            "dynamo://ns/_component_/comp/config/v1",          // Missing _path_ keyword
+            "dynamo://ns/_component_/comp/_endpoint_/ep/extra", // Extra segment after endpoint
+            "dynamo://ns/random/path/segments",                 // Random segments without structure
+        ];
+
+        for path in invalid_paths {
+            assert!(matches!(
+                Identifier::parse(path),
+                Err(DescriptorError::InvalidPathSegment(_))
+            ), "Expected InvalidPathSegment for Identifier::parse({})", path);
+
+            assert!(matches!(
+                Instance::parse(path),
+                Err(DescriptorError::InvalidPathSegment(_))
+            ), "Expected InvalidPathSegment for Instance::parse({})", path);
+
+            assert!(matches!(
+                Keys::parse(path),
+                Err(DescriptorError::InvalidPathSegment(_))
+            ), "Expected InvalidPathSegment for Keys::parse({})", path);
+        }
+
+        // Valid formats should parse correctly
+        let valid1 = "dynamo://ns/_component_/comp/_path_/config/v1";
+        assert!(Keys::parse(valid1).is_ok());
+
+        let valid2 = "dynamo://ns/_component_/comp/_endpoint_/ep/_path_/extra";
+        assert!(Keys::parse(valid2).is_ok());
+    }
+
+    #[test]
+    fn test_out_of_order_reserved_keywords() {
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_endpoint_/ep/_component_/comp"),
+            Err(DescriptorError::EndpointWithoutComponent)
+        ));
+
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_path_/config/_component_/comp"),
+            Err(DescriptorError::ReservedKeyword(_))
+        ));
+
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_component_/comp1/_component_/comp2"),
+            Err(DescriptorError::InvalidPathSegment(_))
+        ));
+
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_component_/comp/_endpoint_/ep1/_endpoint_/ep2"),
+            Err(DescriptorError::InvalidPathSegment(_))
+        ));
+
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_component_/comp/_path_/p1/_path_/p2"),
+            Err(DescriptorError::ReservedKeyword(_))
+        ));
+
+        // Endpoint without component - specific error
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_endpoint_/ep"),
+            Err(DescriptorError::EndpointWithoutComponent)
+        ));
+
+        // Component name starting with underscore - validation error
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_component_/_invalid"),
+            Err(DescriptorError::InvalidComponent(_))
+        ));
+
+        // Missing component name
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_component_"),
+            Err(DescriptorError::EmptyComponent)
+        ));
+
+        // Missing endpoint name
+        assert!(matches!(
+            Identifier::parse("dynamo://ns/_component_/comp/_endpoint_"),
+            Err(DescriptorError::EmptyEndpoint)
+        ));
+    }
+}

--- a/lib/runtime/src/discovery.rs
+++ b/lib/runtime/src/discovery.rs
@@ -13,74 +13,372 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{transports::etcd, Result};
+use crate::{transports::etcd, Result, DistributedRuntime};
 
-pub use etcd::Lease;
+pub use etcd::{Lease, PrefixWatcher};
+pub use etcd_client::{GetResponse, GetOptions, PutOptions, DeleteOptions, KeyValue};
 
-pub struct DiscoveryClient {
-    namespace: String,
-    etcd_client: etcd::Client,
+/// Storage handle that provides etcd operations scoped to a specific key
+/// We are borrowing from distributed runtime, hence the lifetime parameter
+pub struct Storage<'a> {
+    client: &'a etcd::Client,
+    key: String,
 }
 
-impl DiscoveryClient {
-    /// Create a new [`DiscoveryClient`]
-    ///
-    /// This will establish a connection to the etcd server, create a primary lease,
-    /// and spawn a task to keep the lease alive and tie the lifetime of the [`Runtime`]
-    /// to the lease.
-    ///
-    /// If the lease expires, the [`Runtime`] will be shutdown.
-    /// If the [`Runtime`] is shutdown, the lease will be revoked.
-    pub(crate) fn new(namespace: String, etcd_client: etcd::Client) -> Self {
-        DiscoveryClient {
-            namespace,
-            etcd_client,
+impl<'a> Storage<'a> {
+    /// Create a new lease with specified TTL
+    pub async fn create_lease(&self, ttl: i64) -> Result<Lease> {
+        self.client.create_lease(ttl).await
+    }
+
+    /// Revoke a lease
+    pub async fn revoke_lease(&self, lease_id: i64) -> Result<()> {
+        self.client.revoke_lease(lease_id).await
+    }
+
+    /// Atomically create only if key doesn't exist
+    pub async fn create(&self, value: Vec<u8>, lease_id: Option<i64>) -> Result<()> {
+        self.client.kv_create(self.key.clone(), value, lease_id).await
+    }
+
+    /// Create or validate existing value matches
+    pub async fn create_or_validate(&self, value: Vec<u8>, lease_id: Option<i64>) -> Result<()> {
+        self.client.kv_create_or_validate(self.key.clone(), value, lease_id).await
+    }
+
+    /// Put a value (create or overwrite)
+    pub async fn put(&self, value: Vec<u8>, lease_id: Option<i64>) -> Result<()> {
+        self.client.kv_put(&self.key, value, lease_id).await
+    }
+
+    /// Put with custom options
+    pub async fn put_with_options(&self, value: Vec<u8>, options: Option<PutOptions>) -> Result<etcd_client::PutResponse> {
+        self.client.kv_put_with_options(&self.key, value, options).await
+    }
+
+    /// Get by exact key
+    pub async fn get(&self) -> Result<Vec<KeyValue>> {
+        self.client.kv_get(self.key.as_bytes(), None).await
+    }
+
+    /// Get with options
+    pub async fn get_with_options(&self, options: Option<GetOptions>) -> Result<Vec<KeyValue>> {
+        self.client.kv_get(self.key.as_bytes(), options).await
+    }
+
+    /// Get all with prefix
+    pub async fn get_prefix(&self) -> Result<Vec<KeyValue>> {
+        self.client.kv_get_prefix(&self.key).await
+    }
+
+    /// Delete and return count
+    pub async fn delete(&self, options: Option<DeleteOptions>) -> Result<i64> {
+        self.client.kv_delete(self.key.as_bytes(), options).await
+    }
+
+    /// Get and watch prefix
+    pub async fn watch_prefix(&self) -> Result<PrefixWatcher> {
+        self.client.kv_get_and_watch_prefix(&self.key).await
+    }
+
+    /// Get the key this storage is scoped to
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+/// Minimal trait for entities that have etcd storage
+pub trait DiscoveryClient: crate::traits::DistributedRuntimeProvider {
+    /// Get the etcd key for this entity
+    fn etcd_key(&self) -> String;
+
+    /// Get a storage handle for this entity's etcd operations
+    fn storage(&self) -> Result<Storage> {
+        let client = self.drt()
+            .etcd_client_internal()
+            .ok_or_else(|| anyhow::anyhow!("etcd client not available"))?;
+
+        Ok(Storage {
+            client,
+            key: self.etcd_key(),
+        })
+    }
+}
+
+// the following two commented out codes are not implemented, but are placeholders for proposed ectd usage patterns
+
+// /// Create an ephemeral key/value pair tied to a lease_id.
+// /// This is an atomic create. If the key already exists, this will fail.
+// /// The [`etcd_client::KeyValue`] will be removed when the lease expires or is revoked.
+// pub async fn create_ephemerial_key(&self, key: &str, value: &str, lease_id: i64) -> Result<()> {
+//     // self.etcd_client.create_ephemeral_key(key, value, lease_id).await
+//     unimplemented!()
+// }
+
+// /// Create a shared [`etcd_client::KeyValue`] which behaves similar to a C++ `std::shared_ptr` or a
+// /// Rust [std::sync::Arc]. Instead of having one owner of the lease, multiple owners participate in
+// /// maintaining the lease. In this manner, when the last member of the group sharing the lease is gone,
+// /// the lease will be expired.
+// ///
+// /// Implementation notes: At the time of writing, it is unclear if we have atomics that control leases,
+// /// so in our initial implementation, the last member of the group will not revoke the lease, so the object
+// /// will live for upto the TTL after the last member is gone.
+// ///
+// /// Notes
+// /// -----
+// ///
+// /// - Multiple members sharing the lease and contributing to the heartbeat might cause some overheads.
+// ///   The implementation will try to randomize the heartbeat intervals to avoid thundering herd problem,
+// ///   and with any luck, the heartbeat watchers will be able to detect when if a external member triggered
+// ///   the heartbeat checking this interval and skip unnecessary heartbeat messages.
+// ///
+// /// A new lease will be created for this object. If you wish to add an object to a shared group s
+// ///
+// /// The [`etcd_client::KeyValue`] will be removed when the lease expires or is revoked.
+// pub async fn create_shared_key(&self, key: &str, value: &str, lease_id: i64) -> Result<()> {
+//     // self.etcd_client.create_ephemeral_key(key, value, lease_id).await
+//     unimplemented!()
+// }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Runtime, DistributedRuntime, distributed::DistributedConfig};
+    use tokio;
+
+    // Test entity that implements DiscoveryClient
+    struct TestEntity {
+        key: String,
+        drt: DistributedRuntime,
+    }
+
+    impl crate::traits::DistributedRuntimeProvider for TestEntity {
+        fn drt(&self) -> &DistributedRuntime {
+            &self.drt
         }
     }
 
-    /// Get the primary lease ID
-    pub fn primary_lease_id(&self) -> i64 {
-        self.etcd_client.lease_id()
+    impl DiscoveryClient for TestEntity {
+        fn etcd_key(&self) -> String {
+            self.key.clone()
+        }
     }
 
-    /// Create a [`Lease`] with a given time-to-live (TTL).
-    /// This [`Lease`] will be tied to the [`crate::Runtime`], but has its own independent [`crate::CancellationToken`].
-    pub async fn create_lease(&self, ttl: i64) -> Result<Lease> {
-        self.etcd_client.create_lease(ttl).await
+    // Helper to check if ETCD is available
+    async fn is_etcd_available() -> bool {
+        // Try to connect to default ETCD endpoint
+        etcd_client::Client::connect(["localhost:2379"], None).await.is_ok()
     }
 
-    // the following two commented out codes are not implemented, but are placeholders for proposed ectd usage patterns
+    // Helper to create test runtime with ETCD
+    async fn create_test_runtime() -> Result<DistributedRuntime> {
+        let runtime = Runtime::from_current()?;
+        let mut config = DistributedConfig::from_settings(false);
+        // Ensure we're using localhost:2379 for tests
+        config.etcd_config.etcd_url = vec!["http://localhost:2379".to_string()];
+        DistributedRuntime::new(runtime, config).await
+    }
 
-    // /// Create an ephemeral key/value pair tied to a lease_id.
-    // /// This is an atomic create. If the key already exists, this will fail.
-    // /// The [`etcd_client::KeyValue`] will be removed when the lease expires or is revoked.
-    // pub async fn create_ephemerial_key(&self, key: &str, value: &str, lease_id: i64) -> Result<()> {
-    //     // self.etcd_client.create_ephemeral_key(key, value, lease_id).await
-    //     unimplemented!()
-    // }
+    #[tokio::test]
+    async fn test_storage_put_get() -> Result<()> {
+        if !is_etcd_available().await {
+            eprintln!("Skipping test: ETCD not available");
+            return Ok(());
+        }
 
-    // /// Create a shared [`etcd_client::KeyValue`] which behaves similar to a C++ `std::shared_ptr` or a
-    // /// Rust [std::sync::Arc]. Instead of having one owner of the lease, multiple owners participate in
-    // /// maintaining the lease. In this manner, when the last member of the group sharing the lease is gone,
-    // /// the lease will be expired.
-    // ///
-    // /// Implementation notes: At the time of writing, it is unclear if we have atomics that control leases,
-    // /// so in our initial implementation, the last member of the group will not revoke the lease, so the object
-    // /// will live for upto the TTL after the last member is gone.
-    // ///
-    // /// Notes
-    // /// -----
-    // ///
-    // /// - Multiple members sharing the lease and contributing to the heartbeat might cause some overheads.
-    // ///   The implementation will try to randomize the heartbeat intervals to avoid thundering herd problem,
-    // ///   and with any luck, the heartbeat watchers will be able to detect when if a external member triggered
-    // ///   the heartbeat checking this interval and skip unnecessary heartbeat messages.
-    // ///
-    // /// A new lease will be created for this object. If you wish to add an object to a shared group s
-    // ///
-    // /// The [`etcd_client::KeyValue`] will be removed when the lease expires or is revoked.
-    // pub async fn create_shared_key(&self, key: &str, value: &str, lease_id: i64) -> Result<()> {
-    //     // self.etcd_client.create_ephemeral_key(key, value, lease_id).await
-    //     unimplemented!()
-    // }
+        let drt = create_test_runtime().await?;
+        let entity = TestEntity {
+            key: format!("test/storage/{}", uuid::Uuid::new_v4()),
+            drt,
+        };
+
+        let storage = entity.storage()?;
+
+        // Test put and get
+        let test_data = b"hello world".to_vec();
+        storage.put(test_data.clone(), None).await?;
+
+        let values = storage.get().await?;
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].value(), &test_data);
+
+        // Cleanup
+        storage.delete(None).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_storage_create_atomic() -> Result<()> {
+        if !is_etcd_available().await {
+            eprintln!("Skipping test: ETCD not available");
+            return Ok(());
+        }
+
+        let drt = create_test_runtime().await?;
+        let entity = TestEntity {
+            key: format!("test/storage/{}", uuid::Uuid::new_v4()),
+            drt,
+        };
+
+        let storage = entity.storage()?;
+
+        // First create should succeed
+        let test_data = b"first".to_vec();
+        storage.create(test_data.clone(), None).await?;
+
+        // Second create should fail (key exists)
+        let result = storage.create(b"second".to_vec(), None).await;
+        assert!(result.is_err());
+
+        // Verify original value unchanged
+        let values = storage.get().await?;
+        assert_eq!(values[0].value(), &test_data);
+
+        // Cleanup
+        storage.delete(None).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_storage_create_or_validate() -> Result<()> {
+        if !is_etcd_available().await {
+            eprintln!("Skipping test: ETCD not available");
+            return Ok(());
+        }
+
+        let drt = create_test_runtime().await?;
+        let entity = TestEntity {
+            key: format!("test/storage/{}", uuid::Uuid::new_v4()),
+            drt,
+        };
+
+        let storage = entity.storage()?;
+        let test_data = b"consistent".to_vec();
+
+        // First call creates
+        storage.create_or_validate(test_data.clone(), None).await?;
+
+        // Second call with same data succeeds
+        storage.create_or_validate(test_data.clone(), None).await?;
+
+        // Call with different data fails
+        let result = storage.create_or_validate(b"different".to_vec(), None).await;
+        assert!(result.is_err());
+
+        // Cleanup
+        storage.delete(None).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_storage_lease_operations() -> Result<()> {
+        if !is_etcd_available().await {
+            eprintln!("Skipping test: ETCD not available");
+            return Ok(());
+        }
+
+        let drt = create_test_runtime().await?;
+        let entity = TestEntity {
+            key: format!("test/storage/{}", uuid::Uuid::new_v4()),
+            drt,
+        };
+
+        let storage = entity.storage()?;
+
+        // Create a lease
+        let lease = storage.create_lease(5).await?; // 5 second TTL
+
+        // Put with lease
+        storage.put(b"leased_data".to_vec(), Some(lease.id())).await?;
+
+        // Verify data exists
+        let values = storage.get().await?;
+        assert_eq!(values.len(), 1);
+
+        // Revoke lease (should delete the key)
+        storage.revoke_lease(lease.id()).await?;
+
+        // Give etcd a moment to process
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // Verify data is gone
+        let values = storage.get().await?;
+        assert_eq!(values.len(), 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_storage_prefix_operations() -> Result<()> {
+        if !is_etcd_available().await {
+            eprintln!("Skipping test: ETCD not available");
+            return Ok(());
+        }
+
+        let drt = create_test_runtime().await?;
+        let prefix = format!("test/prefix/{}", uuid::Uuid::new_v4());
+
+        // Create multiple entities with same prefix
+        let entities: Vec<TestEntity> = (0..3)
+            .map(|i| TestEntity {
+                key: format!("{}/item_{}", prefix, i),
+                drt: drt.clone(),
+            })
+            .collect();
+
+        // Put data for each entity
+        for (i, entity) in entities.iter().enumerate() {
+            let storage = entity.storage()?;
+            storage.put(format!("data_{}", i).into_bytes(), None).await?;
+        }
+
+        // Use first entity to get all with prefix
+        let base_entity = TestEntity {
+            key: prefix.clone(),
+            drt: drt.clone(),
+        };
+        let storage = base_entity.storage()?;
+        let values = storage.get_prefix().await?;
+
+        assert_eq!(values.len(), 3);
+
+        // Cleanup
+        for entity in &entities {
+            entity.storage()?.delete(None).await?;
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_storage_delete_operations() -> Result<()> {
+        if !is_etcd_available().await {
+            eprintln!("Skipping test: ETCD not available");
+            return Ok(());
+        }
+
+        let drt = create_test_runtime().await?;
+        let entity = TestEntity {
+            key: format!("test/storage/{}", uuid::Uuid::new_v4()),
+            drt,
+        };
+
+        let storage = entity.storage()?;
+
+        // Put some data
+        storage.put(b"to_delete".to_vec(), None).await?;
+
+        // Delete and check count
+        let count = storage.delete(None).await?;
+        assert_eq!(count, 1);
+
+        // Delete again should return 0
+        let count = storage.delete(None).await?;
+        assert_eq!(count, 0);
+
+        Ok(())
+    }
 }

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -122,14 +122,14 @@ impl DistributedRuntime {
     //         .build()?)
     // }
 
-    pub(crate) fn discovery_client(&self, namespace: impl Into<String>) -> DiscoveryClient {
-        DiscoveryClient::new(
-            namespace.into(),
-            self.etcd_client
-                .clone()
-                .expect("Attempt to get discovery_client on static DistributedRuntime"),
-        )
-    }
+    // pub(crate) fn discovery_client(&self, namespace: impl Into<String>) -> DiscoveryClient {
+    //     DiscoveryClient::new(
+    //         namespace.into(),
+    //         self.etcd_client
+    //             .clone()
+    //             .expect("Attempt to get discovery_client on static DistributedRuntime"),
+    //     )
+    // }
 
     pub(crate) fn service_client(&self) -> ServiceClient {
         ServiceClient::new(self.nats_client.clone())
@@ -151,7 +151,16 @@ impl DistributedRuntime {
         self.nats_client.clone()
     }
 
-    // todo(ryan): deprecate this as we move to Discovery traits and Component Identifiers
+    /// Internal method for accessing etcd client. Only available within this crate.
+    /// This is used by the Discovery trait implementations.
+    pub(crate) fn etcd_client_internal(&self) -> Option<&etcd::Client> {
+        self.etcd_client.as_ref()
+    }
+
+    #[deprecated(
+        since = "0.3.0",
+        note = "Use discovery traits on entities to read and write from etcd."
+    )]
     pub fn etcd_client(&self) -> Option<etcd::Client> {
         self.etcd_client.clone()
     }

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -106,9 +106,9 @@ impl DistributedRuntime {
     }
 
     /// Create a [`Namespace`]
-    pub fn namespace(&self, name: impl Into<String>) -> Result<Namespace> {
-        Namespace::new(self.clone(), name.into(), self.is_static)
-    }
+    // pub fn namespace(&self, name: impl Into<String>) -> Result<Namespace> {
+    //     Namespace::new(self.clone(), name.into(), self.is_static)
+    // }
 
     // /// Create a [`Component`]
     // pub fn component(

--- a/lib/runtime/src/entity.rs
+++ b/lib/runtime/src/entity.rs
@@ -1,0 +1,451 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Entities for distributed runtime operations on descriptors
+//! WIP
+
+use crate::{
+    descriptor::{
+        Identifier, Instance, Keys, KeysBase, DescriptorError,
+        BARRIER_KEYWORD, COMPONENT_KEYWORD, ENDPOINT_KEYWORD, PATH_KEYWORD,
+    },
+    DistributedRuntime,
+};
+
+/// Error type for entity operations
+#[derive(Debug, thiserror::Error)]
+pub enum EntityError {
+    #[error("Invalid descriptor: {0}")]
+    InvalidDescriptor(&'static str),
+    #[error("Descriptor error: {0}")]
+    DescriptorError(#[from] DescriptorError),
+}
+
+/// Factory trait for creating entities from descriptors
+pub trait ToEntity {
+    type Entity;
+
+    fn to_entity(self, runtime: DistributedRuntime) -> Result<Self::Entity, EntityError>;
+}
+
+/// Operational namespace with distributed runtime
+#[derive(Clone)]
+pub struct Namespace {
+    descriptor: Identifier,  // Always namespace-only
+    runtime: DistributedRuntime,
+}
+
+impl Namespace {
+    /// Create from descriptor
+    pub fn from_descriptor(descriptor: Identifier, runtime: DistributedRuntime) -> Result<Self, EntityError> {
+        if descriptor.component().is_some() || descriptor.endpoint().is_some() {
+            return Err(EntityError::InvalidDescriptor("Expected namespace-only descriptor"));
+        }
+        Ok(Self { descriptor, runtime })
+    }
+
+    /// Direct construction (uses descriptor internally)
+    pub fn new(namespace: &str, runtime: DistributedRuntime) -> Result<Self, EntityError> {
+        let descriptor = Identifier::new_namespace(namespace)?;
+        Self::from_descriptor(descriptor, runtime)
+    }
+
+    /// Convert back to descriptor
+    pub fn to_descriptor(&self) -> Identifier {
+        self.descriptor.clone()
+    }
+
+    /// Get namespace hierarchy segments
+    pub fn segments(&self) -> Vec<&str> {
+        self.descriptor.namespace().split('.').collect()
+    }
+
+    /// Get parent namespace if not root
+    pub fn parent(&self) -> Option<Namespace> {
+        let segments = self.segments();
+        if segments.len() <= 1 {
+            return None;
+        }
+
+        let parent_path = segments[..segments.len()-1].join(".");
+        Namespace::new(&parent_path, self.runtime.clone()).ok()
+    }
+
+    /// Create child namespace
+    pub fn child(&self, name: &str) -> Result<Namespace, EntityError> {
+        let child_path = format!("{}.{}", self.descriptor.namespace(), name);
+        Namespace::new(&child_path, self.runtime.clone())
+    }
+
+    /// Access to runtime for operations
+    pub fn runtime(&self) -> &DistributedRuntime {
+        &self.runtime
+    }
+
+    /// Get the namespace name
+    pub fn name(&self) -> &str {
+        self.descriptor.namespace()
+    }
+}
+
+/// Operational component with distributed runtime
+#[derive(Clone)]
+pub struct Component {
+    descriptor: Identifier,  // Must have component
+    runtime: DistributedRuntime,
+}
+
+impl Component {
+    /// Create from descriptor
+    pub fn from_descriptor(descriptor: Identifier, runtime: DistributedRuntime) -> Result<Self, EntityError> {
+        if descriptor.component().is_none() {
+            return Err(EntityError::InvalidDescriptor("Descriptor must have component"));
+        }
+        if descriptor.endpoint().is_some() {
+            return Err(EntityError::InvalidDescriptor("Expected component-only descriptor"));
+        }
+        Ok(Self { descriptor, runtime })
+    }
+
+    /// Direct construction
+    pub fn new(namespace: &str, component: &str, runtime: DistributedRuntime) -> Result<Self, EntityError> {
+        let descriptor = Identifier::new_component(namespace, component)?;
+        Self::from_descriptor(descriptor, runtime)
+    }
+
+    /// Convert back to descriptor
+    pub fn to_descriptor(&self) -> Identifier {
+        self.descriptor.clone()
+    }
+
+    /// Get parent namespace
+    pub fn namespace(&self) -> Namespace {
+        Namespace::new(self.descriptor.namespace(), self.runtime.clone()).unwrap()
+    }
+
+    /// Access to runtime for operations
+    pub fn runtime(&self) -> &DistributedRuntime {
+        &self.runtime
+    }
+
+    /// Get the component name
+    pub fn name(&self) -> &str {
+        self.descriptor.component().unwrap()
+    }
+
+    /// Get the namespace name
+    pub fn namespace_name(&self) -> &str {
+        self.descriptor.namespace()
+    }
+}
+
+/// Operational endpoint with distributed runtime
+#[derive(Clone)]
+pub struct Endpoint {
+    descriptor: Identifier,  // Must have endpoint
+    instance_id: Option<i64>,
+    runtime: DistributedRuntime,
+}
+
+impl Endpoint {
+    /// Create from identifier descriptor
+    pub fn from_identifier(descriptor: Identifier, runtime: DistributedRuntime) -> Result<Self, EntityError> {
+        if descriptor.endpoint().is_none() {
+            return Err(EntityError::InvalidDescriptor("Descriptor must have endpoint"));
+        }
+        Ok(Self {
+            descriptor,
+            instance_id: None,
+            runtime,
+        })
+    }
+
+    /// Create from instance descriptor
+    pub fn from_instance(instance: Instance, runtime: DistributedRuntime) -> Result<Self, EntityError> {
+        let descriptor = instance.identifier().clone();
+        if descriptor.endpoint().is_none() {
+            return Err(EntityError::InvalidDescriptor("Instance must have endpoint"));
+        }
+        Ok(Self {
+            descriptor,
+            instance_id: Some(instance.instance_id()),
+            runtime,
+        })
+    }
+
+    /// Direct construction
+    pub fn new(namespace: &str, component: &str, endpoint: &str, runtime: DistributedRuntime) -> Result<Self, EntityError> {
+        let descriptor = Identifier::new_endpoint(namespace, component, endpoint)?;
+        Self::from_identifier(descriptor, runtime)
+    }
+
+    /// Convert to descriptor (loses instance_id if present)
+    pub fn to_descriptor(&self) -> Identifier {
+        self.descriptor.clone()
+    }
+
+    /// Convert to instance descriptor if has instance_id
+    pub fn to_instance(&self) -> Option<Instance> {
+        self.instance_id.map(|id| Instance::new(self.descriptor.clone(), id).unwrap())
+    }
+
+    /// Get parent component
+    pub fn component(&self) -> Component {
+        Component::new(
+            self.descriptor.namespace(),
+            self.descriptor.component().unwrap(),
+            self.runtime.clone()
+        ).unwrap()
+    }
+
+    /// Access to runtime for operations
+    pub fn runtime(&self) -> &DistributedRuntime {
+        &self.runtime
+    }
+
+    /// Get the endpoint name
+    pub fn name(&self) -> &str {
+        self.descriptor.endpoint().unwrap()
+    }
+
+    /// Get the component name
+    pub fn component_name(&self) -> &str {
+        self.descriptor.component().unwrap()
+    }
+
+    /// Get the namespace name
+    pub fn namespace_name(&self) -> &str {
+        self.descriptor.namespace()
+    }
+
+    /// Get the instance ID if present
+    pub fn instance_id(&self) -> Option<i64> {
+        self.instance_id
+    }
+}
+
+/// Operational path with extended segments and distributed runtime
+#[derive(Clone)]
+pub struct Path {
+    keys: Keys,
+    runtime: DistributedRuntime,
+}
+
+impl Path {
+    /// Create from Keys descriptor
+    pub fn from_keys(keys: Keys, runtime: DistributedRuntime) -> Result<Self, EntityError> {
+        Ok(Self { keys, runtime })
+    }
+
+    /// Convert back to Keys descriptor
+    pub fn to_keys(&self) -> Keys {
+        self.keys.clone()
+    }
+
+    /// Check if path uses reserved keywords
+    pub fn has_reserved_keyword(&self) -> bool {
+        self.keys.keys().iter().any(|k| {
+            k == BARRIER_KEYWORD || k == PATH_KEYWORD || k == COMPONENT_KEYWORD || k == ENDPOINT_KEYWORD
+        })
+    }
+
+    /// Get base entity (Namespace, Component, or Endpoint)
+    pub fn base_entity(&self) -> BaseEntity {
+        match self.keys.base() {
+            KeysBase::Identifier(id) => {
+                if id.endpoint().is_some() {
+                    BaseEntity::Endpoint(Endpoint::from_identifier(id.clone(), self.runtime.clone()).unwrap())
+                } else if id.component().is_some() {
+                    BaseEntity::Component(Component::from_descriptor(id.clone(), self.runtime.clone()).unwrap())
+                } else {
+                    BaseEntity::Namespace(Namespace::from_descriptor(id.clone(), self.runtime.clone()).unwrap())
+                }
+            }
+            KeysBase::Instance(inst) => {
+                BaseEntity::Endpoint(Endpoint::from_instance(inst.clone(), self.runtime.clone()).unwrap())
+            }
+        }
+    }
+
+    /// Access to runtime for operations
+    pub fn runtime(&self) -> &DistributedRuntime {
+        &self.runtime
+    }
+
+    /// Get the additional path segments
+    pub fn segments(&self) -> &[String] {
+        self.keys.keys()
+    }
+}
+
+/// Base entity types that can be the foundation of a Path
+pub enum BaseEntity {
+    Namespace(Namespace),
+    Component(Component),
+    Endpoint(Endpoint),
+}
+
+/// Entity result from identifier conversion
+pub enum IdentifierEntity {
+    Namespace(Namespace),
+    Component(Component),
+    Endpoint(Endpoint),
+}
+
+// ToEntity implementations
+
+impl ToEntity for Identifier {
+    type Entity = IdentifierEntity;
+
+    fn to_entity(self, runtime: DistributedRuntime) -> Result<Self::Entity, EntityError> {
+        if self.endpoint().is_some() {
+            Ok(IdentifierEntity::Endpoint(Endpoint::from_identifier(self, runtime)?))
+        } else if self.component().is_some() {
+            Ok(IdentifierEntity::Component(Component::from_descriptor(self, runtime)?))
+        } else {
+            Ok(IdentifierEntity::Namespace(Namespace::from_descriptor(self, runtime)?))
+        }
+    }
+}
+
+impl ToEntity for Instance {
+    type Entity = Endpoint;
+
+    fn to_entity(self, runtime: DistributedRuntime) -> Result<Self::Entity, EntityError> {
+        Endpoint::from_instance(self, runtime)
+    }
+}
+
+impl ToEntity for Keys {
+    type Entity = Path;
+
+    fn to_entity(self, runtime: DistributedRuntime) -> Result<Self::Entity, EntityError> {
+        Path::from_keys(self, runtime)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Runtime;
+
+    async fn create_test_runtime() -> DistributedRuntime {
+        let runtime = Runtime::default();
+        DistributedRuntime::from_settings_without_discovery(runtime).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_namespace_entity() {
+        let drt = create_test_runtime().await;
+
+        let ns = Namespace::new("production.api.v1", drt.clone()).unwrap();
+        assert_eq!(ns.name(), "production.api.v1");
+        assert_eq!(ns.segments(), vec!["production", "api", "v1"]);
+
+        // Test parent
+        let parent = ns.parent().unwrap();
+        assert_eq!(parent.name(), "production.api");
+
+        // Test child
+        let child = ns.child("v2").unwrap();
+        assert_eq!(child.name(), "production.api.v1.v2");
+
+        // Test conversion back to descriptor
+        let desc = ns.to_descriptor();
+        assert_eq!(desc.namespace(), "production.api.v1");
+        assert_eq!(desc.component(), None);
+        assert_eq!(desc.endpoint(), None);
+    }
+
+    #[tokio::test]
+    async fn test_component_entity() {
+        let drt = create_test_runtime().await;
+
+        let comp = Component::new("production", "gateway", drt.clone()).unwrap();
+        assert_eq!(comp.name(), "gateway");
+        assert_eq!(comp.namespace_name(), "production");
+
+        // Test parent namespace
+        let ns = comp.namespace();
+        assert_eq!(ns.name(), "production");
+
+        // Test conversion back to descriptor
+        let desc = comp.to_descriptor();
+        assert_eq!(desc.namespace(), "production");
+        assert_eq!(desc.component(), Some("gateway"));
+        assert_eq!(desc.endpoint(), None);
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_entity() {
+        let drt = create_test_runtime().await;
+
+        let ep = Endpoint::new("production", "gateway", "http", drt.clone()).unwrap();
+        assert_eq!(ep.name(), "http");
+        assert_eq!(ep.component_name(), "gateway");
+        assert_eq!(ep.namespace_name(), "production");
+        assert_eq!(ep.instance_id(), None);
+
+        // Test parent component
+        let comp = ep.component();
+        assert_eq!(comp.name(), "gateway");
+
+        // Test with instance
+        let id = Identifier::new_endpoint("production", "gateway", "http").unwrap();
+        let inst = Instance::new(id, 0x1234).unwrap();
+        let ep_with_inst = Endpoint::from_instance(inst, drt).unwrap();
+        assert_eq!(ep_with_inst.instance_id(), Some(0x1234));
+
+        // Test conversion to instance
+        let inst_opt = ep_with_inst.to_instance();
+        assert!(inst_opt.is_some());
+        assert_eq!(inst_opt.unwrap().instance_id(), 0x1234);
+    }
+
+    #[tokio::test]
+    async fn test_path_entity() {
+        let drt = create_test_runtime().await;
+
+        let id = Identifier::new_component("production", "gateway").unwrap();
+        let keys = Keys::from_identifier(id, vec!["_barrier_".to_string(), "leader".to_string()]).unwrap();
+        let path = Path::from_keys(keys, drt.clone()).unwrap();
+
+        assert!(path.has_reserved_keyword());
+        assert_eq!(path.segments(), &["_barrier_", "leader"]);
+
+        // Test base entity extraction
+        match path.base_entity() {
+            BaseEntity::Component(comp) => {
+                assert_eq!(comp.name(), "gateway");
+            }
+            _ => panic!("Expected component base entity"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_to_entity_trait() {
+        let drt = create_test_runtime().await;
+
+        // Test identifier to entity
+        let id = Identifier::new_endpoint("ns1", "comp1", "ep1").unwrap();
+        let entity = id.to_entity(drt.clone()).unwrap();
+        match entity {
+            IdentifierEntity::Endpoint(ep) => {
+                assert_eq!(ep.name(), "ep1");
+            }
+            _ => panic!("Expected endpoint entity"),
+        }
+
+        // Test instance to entity
+        let id = Identifier::new_endpoint("ns1", "comp1", "ep1").unwrap();
+        let inst = Instance::new(id, 0x5678).unwrap();
+        let ep = inst.to_entity(drt.clone()).unwrap();
+        assert_eq!(ep.instance_id(), Some(0x5678));
+
+        // Test keys to entity
+        let id = Identifier::new_namespace("ns1").unwrap();
+        let keys = Keys::from_identifier(id, vec!["_path_".to_string(), "config".to_string()]).unwrap();
+        let path = keys.to_entity(drt).unwrap();
+        assert_eq!(path.segments(), &["_path_", "config"]);
+    }
+}

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -34,8 +34,10 @@ mod config;
 pub use config::RuntimeConfig;
 
 pub mod component;
+pub mod descriptor;
 pub mod discovery;
 pub mod engine;
+pub mod entity;
 pub mod logging;
 pub mod pipeline;
 pub mod prelude;


### PR DESCRIPTION
Brings in the first few isolated commits from #1489 

Next step will be deprecating current bits and providing replacements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a robust descriptor system for distributed component identification, supporting hierarchical namespaces, components, endpoints, instances, and extended paths with strict validation and canonical formatting.
  * Added a comprehensive entity layer, enabling fluent, hierarchical management of distributed runtime entities (namespaces, components, endpoints, paths) with built-in etcd-backed coordination and navigation.
  * Expanded service discovery capabilities with a rich abstraction over etcd, providing atomic operations, leasing, prefix watching, and detailed error handling.

* **Bug Fixes**
  * Improved validation and error reporting for descriptor parsing and entity creation, preventing use of invalid names and reserved keywords.

* **Documentation**
  * Added extensive module-level and API documentation for descriptors, entities, and discovery features.

* **Tests**
  * Included thorough unit and integration tests for descriptor parsing, entity navigation, discovery operations, and error scenarios.

* **Refactor**
  * Refactored internal APIs, deprecated direct etcd client access, and improved separation between immutable descriptors and operational entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->