### PR TITLE
docs: merge changes from 0.3.1 release (#1543)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,19 +62,6 @@ Dive in: Examples
 
         Presents TensorRT-LLM examples and reference implementations for deploying Large Language Models (LLMs) in various configurations.
 
-Overview
---------
-
-Dynamo is inference engine agnostic, supporting TRT-LLM, vLLM, SGLang, and others, and captures LLM-specific capabilities such as:
-
-* **Disaggregated prefill & decode inference** - Maximizes GPU throughput and facilitates trade off between throughput and latency.
-* **Dynamic GPU scheduling** - Optimizes performance based on fluctuating demand.
-* **LLM-aware request routing** - Eliminates unnecessary KV cache re-computation.
-* **Accelerated data transfer** - Reduces inference response time using NIXL.
-* **KV cache offloading** - Leverages several memory hierarchies for higher system throughput.
-
-Built in Rust for performance and in Python for extensibility, Dynamo is fully open-source
-and is driven by a transparent development approach. Check out our repo at https://github.com/ai-dynamo/.
 
 .. toctree::
    :hidden:
@@ -120,6 +107,7 @@ and is driven by a transparent development approach. Check out our repo at https
    Dynamo Cloud Kubernetes Platform <guides/dynamo_deploy/dynamo_cloud.md>
    Deploying Dynamo Inference Graphs to Kubernetes using the Dynamo Cloud Platform <guides/dynamo_deploy/operator_deployment.md>
    Manual Helm Deployment <guides/dynamo_deploy/manual_helm_deployment.md>
+   GKE Setup Guide <guides/dynamo_deploy/gke_setup.md>
    Minikube Setup Guide <guides/dynamo_deploy/minikube.md>
    Model Caching with Fluid <guides/dynamo_deploy/model_caching_with_fluid.md>
 
@@ -127,7 +115,7 @@ and is driven by a transparent development approach. Check out our repo at https
    :hidden:
    :caption: Benchmarking
 
-   Planner Benchmark Example <guides/planner_benchmark/benchmark_planner.md>
+   Planner Benchmark Example <guides/planner_benchmark/README.md>
 
 
 .. toctree::


### PR DESCRIPTION
#### Overview:

add #1543 back to main

ref: OPS-240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Overview" section from the documentation.
  * Added a new "GKE Setup Guide" to the Deployment Guides.
  * Updated the Planner Benchmark Example link to point to a new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->