### PR TITLE
feat: add flush_cache endpoint to sglang

### DIFF
--- a/examples/sglang/components/decode_worker.py
+++ b/examples/sglang/components/decode_worker.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import sys
 
 import msgspec
@@ -55,9 +54,12 @@ class DecodeRequestHandler:
             yield result
 
     async def flush_cache(self, request: dict):
-        _ = request 
+        _ = request
         asyncio.create_task(self.engine.tokenizer_manager.flush_cache())
-        yield {"status": "success", "message": "Cache flush initiated. Check backend logs for status"}
+        yield {
+            "status": "success",
+            "message": "Cache flush initiated. Check backend logs for status",
+        }
 
 
 @dynamo_worker(static=False)
@@ -81,7 +83,7 @@ async def init(runtime: DistributedRuntime, server_args: ServerArgs):
 
     tasks = [gen_endpoint.serve_endpoint(handler.generate)]
     tasks.append(flush_endpoint.serve_endpoint(handler.flush_cache))
-    
+
     await asyncio.gather(*tasks)
 
 

--- a/examples/sglang/components/worker.py
+++ b/examples/sglang/components/worker.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import random
 import socket
+import os
 import sys
 from typing import Any, Dict, Optional, Union
 
@@ -288,8 +289,9 @@ async def init(runtime: DistributedRuntime, server_args: ServerArgs):
     _ = ZmqKvEventPublisher(component=component, config=zmq_config)
 
     # Setup HTTP server (TODO: make this configurabel via CLI arg)
-    http_server = SglangHttpServer(engine, port=8888)
-    asyncio.create_task(http_server.start_server())
+    if os.environ.get("DYN_SGL_HTTP_SERVER"):
+        http_server = SglangHttpServer(engine, server_args, runtime)
+        asyncio.create_task(http_server.start_server())
 
     await endpoint.serve_endpoint(handler.generate)
 

--- a/examples/sglang/components/worker.py
+++ b/examples/sglang/components/worker.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 import random
 import socket
-import os
 import sys
 from typing import Any, Dict, Optional, Union
 
@@ -15,7 +14,6 @@ from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_ip
 from utils.protocol import DisaggPreprocessedRequest
 from utils.sgl_utils import parse_sglang_args_inc
-from utils.sgl_http_server import SglangHttpServer
 
 from dynamo.llm import (
     ModelType,
@@ -244,14 +242,19 @@ class RequestHandler:
             pass
 
     async def flush_cache(self, request: dict):
-        _ = request 
+        _ = request
         asyncio.create_task(self.engine.tokenizer_manager.flush_cache())
-        yield {"status": "success", "message": "Cache flush initiated. Check backend logs for status"}
+        yield {
+            "status": "success",
+            "message": "Cache flush initiated. Check backend logs for status",
+        }
+
 
 @dynamo_worker(static=False)
 async def worker(runtime: DistributedRuntime):
     server_args = parse_sglang_args_inc(sys.argv[1:])
     await init(runtime, server_args)
+
 
 async def init(runtime: DistributedRuntime, server_args: ServerArgs):
     """Initialize worker (either prefill or aggregated)"""

--- a/examples/sglang/components/worker.py
+++ b/examples/sglang/components/worker.py
@@ -243,12 +243,37 @@ class RequestHandler:
         async for _ in prefill:
             pass
 
+    async def flush_cache(self, request: dict):
+        _ = request  # Suppress mypy unused variable warning
+        print(f"DEBUG: Worker flush_cache called with request: {request}")
+        
+        try:
+            # Add timeout to prevent hanging
+            await asyncio.wait_for(
+                self.engine.tokenizer_manager.flush_cache(), 
+                timeout=10.0
+            )
+            logging.info("Prefill worker cache flushed")
+            print(f"DEBUG: About to yield response")
+            yield {"status": "success", "message": "Cache flushed"}
+            print(f"DEBUG: Yielded response")
+        except asyncio.TimeoutError:
+            print(f"DEBUG: flush_cache timed out after 10 seconds")
+            yield {"status": "error", "message": "Cache flush timed out"}
+        except Exception as e:
+            print(f"DEBUG: flush_cache error: {e}")
+            yield {"status": "error", "message": f"Cache flush failed: {str(e)}"}
+
 
 @dynamo_worker(static=False)
 async def worker(runtime: DistributedRuntime):
     server_args = parse_sglang_args_inc(sys.argv[1:])
     await init(runtime, server_args)
 
+
+async def setup_flush_endpoint(component: Any):
+    flush_endpoint = component.endpoint("flush_cache")
+    return flush_endpoint
 
 async def init(runtime: DistributedRuntime, server_args: ServerArgs):
     """Initialize worker (either prefill or aggregated)"""
@@ -288,12 +313,15 @@ async def init(runtime: DistributedRuntime, server_args: ServerArgs):
     )
     _ = ZmqKvEventPublisher(component=component, config=zmq_config)
 
-    # Setup HTTP server (TODO: make this configurabel via CLI arg)
+    tasks = [endpoint.serve_endpoint(handler.generate)]
+
     if os.environ.get("DYN_SGL_HTTP_SERVER"):
-        http_server = SglangHttpServer(engine, server_args, runtime)
+        flush_endpoint = component.endpoint("flush_cache")
+        tasks.append(flush_endpoint.serve_endpoint(handler.flush_cache))
+        http_server = SglangHttpServer(server_args, runtime)
         asyncio.create_task(http_server.start_server())
 
-    await endpoint.serve_endpoint(handler.generate)
+    await asyncio.gather(*tasks)
 
 
 if __name__ == "__main__":

--- a/examples/sglang/components/worker.py
+++ b/examples/sglang/components/worker.py
@@ -14,6 +14,7 @@ from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_ip
 from utils.protocol import DisaggPreprocessedRequest
 from utils.sgl_utils import parse_sglang_args_inc
+from utils.sgl_http_server import SglangHttpServer
 
 from dynamo.llm import (
     ModelType,
@@ -285,6 +286,10 @@ async def init(runtime: DistributedRuntime, server_args: ServerArgs):
         kv_block_size=server_args.page_size,
     )
     _ = ZmqKvEventPublisher(component=component, config=zmq_config)
+
+    # Setup HTTP server (TODO: make this configurabel via CLI arg)
+    http_server = SglangHttpServer(engine, port=8888)
+    asyncio.create_task(http_server.start_server())
 
     await endpoint.serve_endpoint(handler.generate)
 

--- a/examples/sglang/launch/agg.sh
+++ b/examples/sglang/launch/agg.sh
@@ -15,7 +15,7 @@ trap cleanup EXIT INT TERM
 python3 utils/clear_namespace.py --namespace dynamo
 
 # run ingress
-dynamo run in=http out=dyn --http-port=8000 &
+dynamo run in=http out=dyn --http-port 8000 &
 DYNAMO_PID=$!
 
 # run worker

--- a/examples/sglang/launch/agg.sh
+++ b/examples/sglang/launch/agg.sh
@@ -15,7 +15,7 @@ trap cleanup EXIT INT TERM
 python3 utils/clear_namespace.py --namespace dynamo
 
 # run ingress
-dynamo run in=http out=dyn --http-port 8000 &
+dynamo run in=http out=dyn --http-port=8000 &
 DYNAMO_PID=$!
 
 # run worker

--- a/examples/sglang/utils/sgl_http_server.py
+++ b/examples/sglang/utils/sgl_http_server.py
@@ -44,6 +44,6 @@ class SglangHttpServer:
         server = uvicorn.Server(config)
         
         # Single nice log with available endpoints
-        logging.info(f"🚀 Admin server running on http://0.0.0.0:{self.port} - Endpoints: POST /flush_cache")
+        logging.info(f"🚀 SGL engine HTTP server running on http://0.0.0.0:{self.port} - Endpoints: POST /flush_cache")
         
         await server.serve()

--- a/examples/sglang/utils/sgl_http_server.py
+++ b/examples/sglang/utils/sgl_http_server.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import asyncio
 import logging

--- a/examples/sglang/utils/sgl_http_server.py
+++ b/examples/sglang/utils/sgl_http_server.py
@@ -1,0 +1,45 @@
+import logging
+import uvicorn
+from fastapi import FastAPI, HTTPException
+import sglang as sgl
+import asyncio
+from dynamo.runtime import DistributedRuntime
+
+class SglangHttpServer:
+    # TODO: add decode client conditional as well
+    def __init__(self, engine: sgl.Engine, drt: DistributedRuntime, port: int = 8888):
+        self.engine = engine
+        self.port = port
+        self.app = FastAPI()
+        self.setup_routes()
+        
+    def setup_routes(self):
+        @self.app.post("/flush_cache")
+        async def flush_cache():
+            """Flush the radix cache."""
+            try:
+                # this targets the prefill/aggregated worker
+                asyncio.create_task(self.engine.tokenizer_manager.flush_cache())
+                
+                # then we target the decode worker over nats
+                await self.drt.namespace("dynamo").component("decode").endpoint("generate").client()
+                
+                return {"message": "Cache flush initiated", "success": True}
+            except Exception as e:
+                logging.error(f"Cache flush error: {e}")
+                return {"message": f"Cache flush failed: {str(e)}", "success": False}
+        
+    async def start_server(self):
+        """Start the HTTP server"""
+        config = uvicorn.Config(
+            self.app, 
+            host="0.0.0.0", 
+            port=self.port, 
+            log_config=None  # Disable all uvicorn logging
+        )
+        server = uvicorn.Server(config)
+        
+        # Single nice log with available endpoints
+        logging.info(f"🚀 Admin server running on http://0.0.0.0:{self.port} - Endpoints: POST /flush_cache")
+        
+        await server.serve()

--- a/examples/sglang/utils/sgl_http_server.py
+++ b/examples/sglang/utils/sgl_http_server.py
@@ -3,31 +3,60 @@ import uvicorn
 from fastapi import FastAPI, HTTPException
 import sglang as sgl
 import asyncio
-from sglang.server_args import ServerArgs
+from sglang.srt.server_args import ServerArgs
 from dynamo.runtime import DistributedRuntime
 
 class SglangHttpServer:
-    # TODO: add decode client conditional as well
-    def __init__(self, engine: sgl.Engine, server_args: ServerArgs, drt: DistributedRuntime, port: int = 9001):
-        self.engine = engine
+    def __init__(self, server_args: ServerArgs, drt: DistributedRuntime, port: int = 9001):
         self.port = port
         self.app = FastAPI()
-        if server_args.disaggregation_mode != "null":
-            self.decode_flush_client = drt.namespace("dynamo").component("decode").endpoint("flush_cache").client()
-
+        self.server_args = server_args
+        self.drt = drt
+        self.worker_client = None
+        self.decode_flush_client = None
+        self._clients_initialized = False
         self.setup_routes()
         
+    async def _ensure_clients(self):
+        if not self._clients_initialized:
+            self.worker_client = await self.drt.namespace("dynamo").component("worker").endpoint("flush_cache").client()
+            if self.server_args.disaggregation_mode != "null":
+                self.decode_flush_client = await self.drt.namespace("dynamo").component("decode").endpoint("flush_cache").client()
+            self._clients_initialized = True
+
     def setup_routes(self):
         @self.app.post("/flush_cache")
         async def flush_cache():
             """Flush the radix cache."""
+            await self._ensure_clients()
             try:
-                # this targets the prefill/aggregated worker
-                asyncio.create_task(self.engine.tokenizer_manager.flush_cache())
+                # Flush worker instances
+                await self.worker_client.wait_for_instances()
+                worker_ids = self.worker_client.instance_ids()
+                print(f"DEBUG: Found {len(worker_ids)} worker instances: {worker_ids}")
                 
-                # then we target the decode worker over nats
-                await self.decode_flush_client.flush_cache()
+                for inst_id in worker_ids:
+                    try:
+                        print(f"DEBUG: Calling worker instance {inst_id}")
+                        stream = await self.worker_client.direct("{}", inst_id)
+                        print(f"DEBUG: Got stream for worker {inst_id}")
+                        
+                        async for payload in stream:
+                            print(f"Worker[{inst_id}] -> {payload}")
+                    except Exception as e:
+                        print(f"DEBUG: Exception for worker {inst_id}: {e}")
+                        logging.error(f"Worker[{inst_id}] flush error: {e}")
                 
+                # Handle decode workers if in disaggregation mode
+                if self.server_args.disaggregation_mode != "null":
+                    await self.decode_flush_client.wait_for_instances()
+                    decode_ids = self.decode_flush_client.instance_ids()
+                    
+                    for inst_id in decode_ids:
+                        stream = await self.decode_flush_client.direct("{}", inst_id)
+                        async for payload in stream:
+                            print(f"Decode[{inst_id}] -> {payload}")
+
                 return {"message": "Cache flush initiated", "success": True}
             except Exception as e:
                 logging.error(f"Cache flush error: {e}")


### PR DESCRIPTION
Setup
1. `worker` and `decode_worker` both have a NATS based `flush_cache` endpoint
2. You can optionally spin up the http server in this PR (which will connect to the DRT) which exposes a sglang style `flush_cache` endpoint

TODO
- [x] Debug why the flush cache endpoint hangs
- [x] Connect HTTP server to DRT and make it a component 

Future
- Use with #1689 (SGL benchmark requires a cache reset) 
- Add this as a step after warmup (in dsr1 instructions) so cache is cleared after any warmups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cache flushing via a new endpoint, allowing users to trigger cache flush operations for both worker and decode worker components.
  * Introduced an HTTP server utility with a POST endpoint to manage distributed cache flushing across runtime instances.

* **Chores**
  * Updated command-line argument syntax for launching components to improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->