### PR TITLE
fix: not raising error when the slot is not found with the request id…

### DIFF
--- a/lib/bindings/python/rust/llm/block_manager/vllm.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm.rs
@@ -563,14 +563,22 @@ impl<R: RequestKey> SlotManager<R> {
             slot.free_blocks();
         } else {
             // Request ID may not be found if the client aborts the request.
-            tracing::debug!(request_id, "request id {} not found in the slot manager", request_id);
+            tracing::debug!(
+                request_id,
+                "request id {} not found in the slot manager",
+                request_id
+            );
         }
     }
 
     pub fn drop_slot(&mut self, request_id: &R) {
         if self.slots.remove(request_id).is_none() {
             // Request ID may not be found if the client aborts the request.
-            tracing::debug!(request_id, "request id {} not found in the slot manager during drop", request_id);
+            tracing::debug!(
+                request_id,
+                "request id {} not found in the slot manager during drop",
+                request_id
+            );
         }
     }
 }


### PR DESCRIPTION
… (#1673)

#### Overview:

fix the issue that freeing the slot of the request that haven't been allocated by the vllm scheduler will cause the vllm core crash.

#### Details:

https://github.com/ai-dynamo/dynamo/pull/1673

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
