### PR TITLE
feat: Add tests to OpenAI api request data validation functions

### DIFF
--- a/lib/llm/src/engines.rs
+++ b/lib/llm/src/engines.rs
@@ -149,7 +149,7 @@ impl<E> EngineDispatcher<E> {
 
 /// Trait on request types that allows us to validate the data
 pub trait ValidateRequest {
-    fn validate(&self) -> Result<(), anyhow::Error>;
+    fn validate_fields(&self) -> Result<(), anyhow::Error>;
 }
 
 /// Trait that allows handling both completion and chat completions requests
@@ -297,7 +297,7 @@ where
         let (request, context) = incoming_request.into_parts();
 
         // Validate the request first
-        if let Err(validation_error) = request.validate() {
+        if let Err(validation_error) = request.validate_fields() {
             return Err(anyhow::anyhow!("Validation failed: {}", validation_error));
         }
 

--- a/lib/llm/src/engines.rs
+++ b/lib/llm/src/engines.rs
@@ -491,6 +491,7 @@ mod tests {
                             model: "test".to_string(),
                             choices: vec![],
                             usage: None,
+                            service_tier: None,
                             system_fingerprint: None,
                         }
                     }
@@ -517,7 +518,7 @@ mod tests {
             nvext: None,
         };
 
-        let single_in = SingleIn::new(nv_request, SingleInContext::new(()));
+        let single_in = SingleIn::new(nv_request);
         let result = validate_engine.generate(single_in).await;
 
         assert!(result.is_ok());
@@ -539,7 +540,7 @@ mod tests {
             nvext: None,
         };
 
-        let single_in = SingleIn::new(nv_request, SingleInContext::new(()));
+        let single_in = SingleIn::new(nv_request);
         let result = validate_engine.generate(single_in).await;
 
         assert!(result.is_err());
@@ -572,7 +573,7 @@ mod tests {
             nvext: None,
         };
 
-        let single_in = SingleIn::new(nv_request, SingleInContext::new(()));
+        let single_in = SingleIn::new(nv_request);
         let result = validate_engine.generate(single_in).await;
 
         assert!(result.is_ok());
@@ -601,7 +602,7 @@ mod tests {
             nvext: None,
         };
 
-        let single_in = SingleIn::new(nv_request, SingleInContext::new(()));
+        let single_in = SingleIn::new(nv_request);
         let result = validate_engine.generate(single_in).await;
 
         assert!(result.is_err());
@@ -609,14 +610,5 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Validation failed"));
-    }
-
-    #[test]
-    fn test_validate_engine_new() {
-        let inner_engine = MockEngine;
-        let validate_engine = ValidateEngine::new(inner_engine);
-
-        // Just ensure we can create the engine
-        assert!(std::mem::size_of_val(&validate_engine) > 0);
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -180,7 +180,7 @@ impl OpenAIStopConditionsProvider for NvCreateChatCompletionRequest {
 /// Implements `ValidateRequest` for `NvCreateChatCompletionRequest`,
 /// allowing us to validate the data.
 impl ValidateRequest for NvCreateChatCompletionRequest {
-    fn validate(&self) -> Result<(), anyhow::Error> {
+    fn validate_fields(&self) -> Result<(), anyhow::Error> {
         validate::validate_messages(&self.inner.messages)?;
         validate::validate_model(&self.inner.model)?;
         // none for store
@@ -219,20 +219,20 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_openai::types::{CreateChatCompletionRequestArgs, ChatCompletionRequestMessage};
+    use async_openai::types::{ChatCompletionRequestMessage, CreateChatCompletionRequestArgs};
 
     #[test]
-    fn test_validate_request_integration_valid() {
+    fn test_validate_request_basic_valid() {
         let request = CreateChatCompletionRequestArgs::default()
             .model("gpt-3.5-turbo")
-            .messages(vec![
-                ChatCompletionRequestMessage::User(
-                    async_openai::types::ChatCompletionRequestUserMessage {
-                        content: async_openai::types::ChatCompletionRequestUserMessageContent::Text("Hello".to_string()),
-                        name: None,
-                    }
-                )
-            ])
+            .messages(vec![ChatCompletionRequestMessage::User(
+                async_openai::types::ChatCompletionRequestUserMessage {
+                    content: async_openai::types::ChatCompletionRequestUserMessageContent::Text(
+                        "Hello".to_string(),
+                    ),
+                    name: None,
+                },
+            )])
             .build()
             .unwrap();
 
@@ -241,22 +241,22 @@ mod tests {
             nvext: None,
         };
 
-        let result = nv_request.validate();
+        let result = nv_request.validate_fields();
         assert!(result.is_ok());
     }
 
     #[test]
-    fn test_validate_request_integration_invalid() {
+    fn test_validate_request_basic_invalid() {
         let request = CreateChatCompletionRequestArgs::default()
             .model("") // Invalid empty model - should trigger validate::validate_model error
-            .messages(vec![
-                ChatCompletionRequestMessage::User(
-                    async_openai::types::ChatCompletionRequestUserMessage {
-                        content: async_openai::types::ChatCompletionRequestUserMessageContent::Text("Hello".to_string()),
-                        name: None,
-                    }
-                )
-            ])
+            .messages(vec![ChatCompletionRequestMessage::User(
+                async_openai::types::ChatCompletionRequestUserMessage {
+                    content: async_openai::types::ChatCompletionRequestUserMessageContent::Text(
+                        "Hello".to_string(),
+                    ),
+                    name: None,
+                },
+            )])
             .build()
             .unwrap();
 
@@ -265,29 +265,27 @@ mod tests {
             nvext: None,
         };
 
-        let result = nv_request.validate();
+        let result = nv_request.validate_fields();
         assert!(result.is_err());
     }
 
     #[test]
     fn test_validate_request_calls_all_validation_functions() {
-        // Test that validate() calls the underlying validation functions
-        // This ensures the integration works correctly
         let request = CreateChatCompletionRequestArgs::default()
             .model("gpt-3.5-turbo")
-            .messages(vec![
-                ChatCompletionRequestMessage::User(
-                    async_openai::types::ChatCompletionRequestUserMessage {
-                        content: async_openai::types::ChatCompletionRequestUserMessageContent::Text("Hello".to_string()),
-                        name: None,
-                    }
-                )
-            ])
+            .messages(vec![ChatCompletionRequestMessage::User(
+                async_openai::types::ChatCompletionRequestUserMessage {
+                    content: async_openai::types::ChatCompletionRequestUserMessageContent::Text(
+                        "Hello".to_string(),
+                    ),
+                    name: None,
+                },
+            )])
             .temperature(0.7)
             .top_p(0.9)
             .frequency_penalty(0.1)
             .presence_penalty(0.1)
-            .max_completion_tokens(100)
+            .max_completion_tokens(100u32)
             .n(1)
             .build()
             .unwrap();
@@ -297,8 +295,7 @@ mod tests {
             nvext: None,
         };
 
-        // This should succeed and exercise all validation paths
-        let result = nv_request.validate();
+        let result = nv_request.validate_fields();
         assert!(result.is_ok());
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -215,3 +215,90 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_openai::types::{CreateChatCompletionRequestArgs, ChatCompletionRequestMessage};
+
+    #[test]
+    fn test_validate_request_integration_valid() {
+        let request = CreateChatCompletionRequestArgs::default()
+            .model("gpt-3.5-turbo")
+            .messages(vec![
+                ChatCompletionRequestMessage::User(
+                    async_openai::types::ChatCompletionRequestUserMessage {
+                        content: async_openai::types::ChatCompletionRequestUserMessageContent::Text("Hello".to_string()),
+                        name: None,
+                    }
+                )
+            ])
+            .build()
+            .unwrap();
+
+        let nv_request = NvCreateChatCompletionRequest {
+            inner: request,
+            nvext: None,
+        };
+
+        let result = nv_request.validate();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_request_integration_invalid() {
+        let request = CreateChatCompletionRequestArgs::default()
+            .model("") // Invalid empty model - should trigger validate::validate_model error
+            .messages(vec![
+                ChatCompletionRequestMessage::User(
+                    async_openai::types::ChatCompletionRequestUserMessage {
+                        content: async_openai::types::ChatCompletionRequestUserMessageContent::Text("Hello".to_string()),
+                        name: None,
+                    }
+                )
+            ])
+            .build()
+            .unwrap();
+
+        let nv_request = NvCreateChatCompletionRequest {
+            inner: request,
+            nvext: None,
+        };
+
+        let result = nv_request.validate();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_request_calls_all_validation_functions() {
+        // Test that validate() calls the underlying validation functions
+        // This ensures the integration works correctly
+        let request = CreateChatCompletionRequestArgs::default()
+            .model("gpt-3.5-turbo")
+            .messages(vec![
+                ChatCompletionRequestMessage::User(
+                    async_openai::types::ChatCompletionRequestUserMessage {
+                        content: async_openai::types::ChatCompletionRequestUserMessageContent::Text("Hello".to_string()),
+                        name: None,
+                    }
+                )
+            ])
+            .temperature(0.7)
+            .top_p(0.9)
+            .frequency_penalty(0.1)
+            .presence_penalty(0.1)
+            .max_completion_tokens(100)
+            .n(1)
+            .build()
+            .unwrap();
+
+        let nv_request = NvCreateChatCompletionRequest {
+            inner: request,
+            nvext: None,
+        };
+
+        // This should succeed and exercise all validation paths
+        let result = nv_request.validate();
+        assert!(result.is_ok());
+    }
+}

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -304,3 +304,71 @@ impl ValidateRequest for NvCreateCompletionRequest {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_openai::types::CreateCompletionRequestArgs;
+
+    #[test]
+    fn test_validate_request_integration_valid() {
+        let request = CreateCompletionRequestArgs::default()
+            .model("gpt-3.5-turbo")
+            .prompt("Test prompt")
+            .build()
+            .unwrap();
+
+        let nv_request = NvCreateCompletionRequest {
+            inner: request,
+            nvext: None,
+        };
+
+        let result = nv_request.validate();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_request_integration_invalid() {
+        let request = CreateCompletionRequestArgs::default()
+            .model("") // Invalid empty model - should trigger validate::validate_model error
+            .prompt("Test prompt")
+            .build()
+            .unwrap();
+
+        let nv_request = NvCreateCompletionRequest {
+            inner: request,
+            nvext: None,
+        };
+
+        let result = nv_request.validate();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_request_calls_all_validation_functions() {
+        // Test that validate() calls the underlying validation functions
+        // This ensures the integration works correctly
+        let request = CreateCompletionRequestArgs::default()
+            .model("gpt-3.5-turbo")
+            .prompt("Test prompt")
+            .temperature(0.7)
+            .top_p(0.9)
+            .frequency_penalty(0.1)
+            .presence_penalty(0.1)
+            .max_tokens(100)
+            .n(1)
+            .logprobs(5)
+            .suffix("test suffix")
+            .build()
+            .unwrap();
+
+        let nv_request = NvCreateCompletionRequest {
+            inner: request,
+            nvext: None,
+        };
+
+        // This should succeed and exercise all validation paths
+        let result = nv_request.validate();
+        assert!(result.is_ok());
+    }
+}

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -281,7 +281,7 @@ impl TryFrom<common::StreamingCompletionResponse> for async_openai::types::Choic
 /// Implements `ValidateRequest` for `NvCreateCompletionRequest`,
 /// allowing us to validate the data.
 impl ValidateRequest for NvCreateCompletionRequest {
-    fn validate(&self) -> Result<(), anyhow::Error> {
+    fn validate_fields(&self) -> Result<(), anyhow::Error> {
         validate::validate_model(&self.inner.model)?;
         validate::validate_prompt(&self.inner.prompt)?;
         validate::validate_suffix(self.inner.suffix.as_deref())?;
@@ -311,7 +311,7 @@ mod tests {
     use async_openai::types::CreateCompletionRequestArgs;
 
     #[test]
-    fn test_validate_request_integration_valid() {
+    fn test_validate_request_basic_valid() {
         let request = CreateCompletionRequestArgs::default()
             .model("gpt-3.5-turbo")
             .prompt("Test prompt")
@@ -323,12 +323,12 @@ mod tests {
             nvext: None,
         };
 
-        let result = nv_request.validate();
+        let result = nv_request.validate_fields();
         assert!(result.is_ok());
     }
 
     #[test]
-    fn test_validate_request_integration_invalid() {
+    fn test_validate_request_basic_invalid() {
         let request = CreateCompletionRequestArgs::default()
             .model("") // Invalid empty model - should trigger validate::validate_model error
             .prompt("Test prompt")
@@ -340,14 +340,12 @@ mod tests {
             nvext: None,
         };
 
-        let result = nv_request.validate();
+        let result = nv_request.validate_fields();
         assert!(result.is_err());
     }
 
     #[test]
     fn test_validate_request_calls_all_validation_functions() {
-        // Test that validate() calls the underlying validation functions
-        // This ensures the integration works correctly
         let request = CreateCompletionRequestArgs::default()
             .model("gpt-3.5-turbo")
             .prompt("Test prompt")
@@ -355,7 +353,7 @@ mod tests {
             .top_p(0.9)
             .frequency_penalty(0.1)
             .presence_penalty(0.1)
-            .max_tokens(100)
+            .max_tokens(100u32)
             .n(1)
             .logprobs(5)
             .suffix("test suffix")
@@ -368,7 +366,7 @@ mod tests {
         };
 
         // This should succeed and exercise all validation paths
-        let result = nv_request.validate();
+        let result = nv_request.validate_fields();
         assert!(result.is_ok());
     }
 }

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -98,10 +98,7 @@ pub fn validate_temperature(temperature: Option<f32>) -> Result<(), anyhow::Erro
     if let Some(temp) = temperature {
         if !(MIN_TEMPERATURE..=MAX_TEMPERATURE).contains(&temp) {
             anyhow::bail!(
-                "Temperature must be between {} and {}, got {}",
-                MIN_TEMPERATURE,
-                MAX_TEMPERATURE,
-                temp
+                "Temperature must be between {MIN_TEMPERATURE} and {MAX_TEMPERATURE}, got {temp}"
             );
         }
     }
@@ -112,12 +109,7 @@ pub fn validate_temperature(temperature: Option<f32>) -> Result<(), anyhow::Erro
 pub fn validate_top_p(top_p: Option<f32>) -> Result<(), anyhow::Error> {
     if let Some(p) = top_p {
         if !(MIN_TOP_P..=MAX_TOP_P).contains(&p) {
-            anyhow::bail!(
-                "Top_p must be between {} and {}, got {}",
-                MIN_TOP_P,
-                MAX_TOP_P,
-                p
-            );
+            anyhow::bail!("Top_p must be between {MIN_TOP_P} and {MAX_TOP_P}, got {p}",);
         }
     }
     Ok(())
@@ -141,10 +133,7 @@ pub fn validate_frequency_penalty(frequency_penalty: Option<f32>) -> Result<(), 
     if let Some(penalty) = frequency_penalty {
         if !(MIN_FREQUENCY_PENALTY..=MAX_FREQUENCY_PENALTY).contains(&penalty) {
             anyhow::bail!(
-                "Frequency penalty must be between {} and {}, got {}",
-                MIN_FREQUENCY_PENALTY,
-                MAX_FREQUENCY_PENALTY,
-                penalty
+                "Frequency penalty must be between {MIN_FREQUENCY_PENALTY} and {MAX_FREQUENCY_PENALTY}, got {penalty}",
             );
         }
     }
@@ -156,10 +145,7 @@ pub fn validate_presence_penalty(presence_penalty: Option<f32>) -> Result<(), an
     if let Some(penalty) = presence_penalty {
         if !(MIN_PRESENCE_PENALTY..=MAX_PRESENCE_PENALTY).contains(&penalty) {
             anyhow::bail!(
-                "Presence penalty must be between {} and {}, got {}",
-                MIN_PRESENCE_PENALTY,
-                MAX_PRESENCE_PENALTY,
-                penalty
+                "Presence penalty must be between {MIN_PRESENCE_PENALTY} and {MAX_PRESENCE_PENALTY}, got {penalty}",
             );
         }
     }
@@ -178,19 +164,13 @@ pub fn validate_logit_bias(
     for (token, bias_value) in logit_bias {
         let bias = bias_value.as_f64().ok_or_else(|| {
             anyhow::anyhow!(
-                "Logit bias value for token '{}' must be a number, got {:?}",
-                token,
-                bias_value
+                "Logit bias value for token '{token}' must be a number, got {bias_value}",
             )
         })? as f32;
 
         if !(MIN_LOGIT_BIAS..=MAX_LOGIT_BIAS).contains(&bias) {
             anyhow::bail!(
-                "Logit bias for token '{}' must be between {} and {}, got {}",
-                token,
-                MIN_LOGIT_BIAS,
-                MAX_LOGIT_BIAS,
-                bias
+                "Logit bias for token '{token}' must be between {MIN_LOGIT_BIAS} and {MAX_LOGIT_BIAS}, got {bias}",
             );
         }
     }
@@ -201,7 +181,7 @@ pub fn validate_logit_bias(
 pub fn validate_n(n: Option<u8>) -> Result<(), anyhow::Error> {
     if let Some(value) = n {
         if !(MIN_N..=MAX_N).contains(&value) {
-            anyhow::bail!("n must be between {} and {}, got {}", MIN_N, MAX_N, value);
+            anyhow::bail!("n must be between {MIN_N} and {MAX_N}, got {value}");
         }
     }
     Ok(())
@@ -247,7 +227,7 @@ pub fn validate_stop(stop: &Option<async_openai::types::Stop>) -> Result<(), any
                 }
                 for (i, sequence) in sequences.iter().enumerate() {
                     if sequence.is_empty() {
-                        anyhow::bail!("Stop sequence at index {} cannot be empty", i);
+                        anyhow::bail!("Stop sequence at index {i} cannot be empty");
                     }
                 }
             }
@@ -274,11 +254,7 @@ pub fn validate_messages(
 pub fn validate_top_logprobs(top_logprobs: Option<u8>) -> Result<(), anyhow::Error> {
     if let Some(value) = top_logprobs {
         if !(0..=20).contains(&value) {
-            anyhow::bail!(
-                "Top_logprobs must be between 0 and {}, got {}",
-                MAX_TOP_LOGPROBS,
-                value
-            );
+            anyhow::bail!("Top_logprobs must be between 0 and {MAX_TOP_LOGPROBS}, got {value}");
         }
     }
     Ok(())
@@ -311,7 +287,7 @@ pub fn validate_tools(
             );
         }
         if tool.function.name.trim().is_empty() {
-            anyhow::bail!("Function name at index {} cannot be empty", i);
+            anyhow::bail!("Function name at index {i} cannot be empty");
         }
     }
     Ok(())
@@ -324,32 +300,27 @@ pub fn validate_metadata(metadata: &Option<serde_json::Value>) -> Result<(), any
         None => return Ok(()),
     };
 
-    if let Some(obj) = metadata.as_object() {
-        if obj.len() > MAX_METADATA_PAIRS {
-            anyhow::bail!(
-                "Metadata cannot have more than {} key-value pairs, got {}",
-                MAX_METADATA_PAIRS,
-                obj.len()
-            );
+    let Some(obj) = metadata.as_object() else {
+        return Ok(());
+    };
+    if obj.len() > MAX_METADATA_PAIRS {
+        anyhow::bail!(
+            "Metadata cannot have more than {} key-value pairs, got {}",
+            MAX_METADATA_PAIRS,
+            obj.len()
+        );
+    }
+
+    for (key, value) in obj {
+        if key.len() > MAX_METADATA_KEY_LENGTH {
+            anyhow::bail!("Metadata key '{key}' exceeds {MAX_METADATA_KEY_LENGTH} character limit",);
         }
 
-        for (key, value) in obj {
-            if key.len() > MAX_METADATA_KEY_LENGTH {
+        if let Some(value_str) = value.as_str() {
+            if value_str.len() > MAX_METADATA_VALUE_LENGTH {
                 anyhow::bail!(
-                    "Metadata key '{}' exceeds {} character limit",
-                    key,
-                    MAX_METADATA_KEY_LENGTH
+                    "Metadata value for key '{key}' exceeds {MAX_METADATA_VALUE_LENGTH} character limit",
                 );
-            }
-
-            if let Some(value_str) = value.as_str() {
-                if value_str.len() > MAX_METADATA_VALUE_LENGTH {
-                    anyhow::bail!(
-                        "Metadata value for key '{}' exceeds {} character limit",
-                        key,
-                        MAX_METADATA_VALUE_LENGTH
-                    );
-                }
             }
         }
     }
@@ -392,7 +363,7 @@ pub fn validate_prompt(prompt: &async_openai::types::Prompt) -> Result<(), anyho
             }
             for (i, s) in arr.iter().enumerate() {
                 if s.is_empty() {
-                    anyhow::bail!("Prompt string at index {} cannot be empty", i);
+                    anyhow::bail!("Prompt string at index {i} cannot be empty");
                 }
             }
         }
@@ -403,10 +374,7 @@ pub fn validate_prompt(prompt: &async_openai::types::Prompt) -> Result<(), anyho
             for (i, &token_id) in arr.iter().enumerate() {
                 if token_id > MAX_PROMPT_TOKEN_ID {
                     anyhow::bail!(
-                        "Token ID at index {} must be between 0 and {}, got {}",
-                        i,
-                        MAX_PROMPT_TOKEN_ID,
-                        token_id
+                        "Token ID at index {i} must be between 0 and {MAX_PROMPT_TOKEN_ID}, got {token_id}",
                     );
                 }
             }
@@ -422,11 +390,7 @@ pub fn validate_prompt(prompt: &async_openai::types::Prompt) -> Result<(), anyho
                 for (j, &token_id) in inner_arr.iter().enumerate() {
                     if token_id > MAX_PROMPT_TOKEN_ID {
                         anyhow::bail!(
-                            "Token ID at index [{}][{}] must be between 0 and {}, got {}",
-                            i,
-                            j,
-                            MAX_PROMPT_TOKEN_ID,
-                            token_id
+                            "Token ID at index [{i}][{j}] must be between 0 and {MAX_PROMPT_TOKEN_ID}, got {token_id}",
                         );
                     }
                 }
@@ -440,11 +404,7 @@ pub fn validate_prompt(prompt: &async_openai::types::Prompt) -> Result<(), anyho
 pub fn validate_logprobs(logprobs: Option<u8>) -> Result<(), anyhow::Error> {
     if let Some(value) = logprobs {
         if !(MIN_LOGPROBS..=MAX_LOGPROBS).contains(&value) {
-            anyhow::bail!(
-                "Logprobs must be between 0 and {}, got {}",
-                MAX_LOGPROBS,
-                value
-            );
+            anyhow::bail!("Logprobs must be between 0 and {MAX_LOGPROBS}, got {value}",);
         }
     }
     Ok(())
@@ -454,19 +414,13 @@ pub fn validate_logprobs(logprobs: Option<u8>) -> Result<(), anyhow::Error> {
 pub fn validate_best_of(best_of: Option<u8>, n: Option<u8>) -> Result<(), anyhow::Error> {
     if let Some(best_of_value) = best_of {
         if !(MIN_BEST_OF..=MAX_BEST_OF).contains(&best_of_value) {
-            anyhow::bail!(
-                "Best_of must be between 0 and {}, got {}",
-                MAX_BEST_OF,
-                best_of_value
-            );
+            anyhow::bail!("Best_of must be between 0 and {MAX_BEST_OF}, got {best_of_value}",);
         }
 
         if let Some(n_value) = n {
             if best_of_value < n_value {
                 anyhow::bail!(
-                    "Best_of must be greater than or equal to n, got best_of={} and n={}",
-                    best_of_value,
-                    n_value
+                    "Best_of must be greater than or equal to n, got best_of={best_of_value} and n={n_value}",
                 );
             }
         }
@@ -488,7 +442,7 @@ pub fn validate_suffix(suffix: Option<&str>) -> Result<(), anyhow::Error> {
 pub fn validate_max_tokens(max_tokens: Option<u32>) -> Result<(), anyhow::Error> {
     if let Some(tokens) = max_tokens {
         if tokens == 0 {
-            anyhow::bail!("Max tokens must be greater than 0, got {}", tokens);
+            anyhow::bail!("Max tokens must be greater than 0, got {tokens}");
         }
     }
     Ok(())
@@ -500,10 +454,7 @@ pub fn validate_max_completion_tokens(
 ) -> Result<(), anyhow::Error> {
     if let Some(tokens) = max_completion_tokens {
         if tokens == 0 {
-            anyhow::bail!(
-                "Max completion tokens must be greater than 0, got {}",
-                tokens
-            );
+            anyhow::bail!("Max completion tokens must be greater than 0, got {tokens}");
         }
     }
     Ok(())


### PR DESCRIPTION
#### Overview:

This PR adds tests to feat: Validation engine for validating OpenAI api request data #1674 that I previously did.

#### Details:

Added unit tests in `validate.rs` for each validate method. Also included a few basic tests in `engine.rs` and `completion.rs`/`chat_completion.rs`.
I also renamed the `.validate()` method for the `ValidateRequest` trait to `.validate_fields()` do to conflicting with the `.validate()` method that is automatically created for Request types (like `NvCreateChatCompletionRequest`) via `#[derive(Validate)]`, which currently validates `NvExt` fields.
Also added some style suggestions from the previous PR discussion.

#### Where should the reviewer start?

Only 4 files with tests, pretty self-explanatory

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

No issue opened for this, was mentioned in the previous PR discussion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error messages for better clarity and consistency.
  * Updated model suffix validation to enforce a maximum length of 64 characters.

* **Tests**
  * Added comprehensive unit tests for all major validation functions, covering edge cases and boundary conditions.
  * Introduced new tests for both valid and invalid completion and chat completion requests.

* **Refactor**
  * Renamed validation method for requests to `validate_fields` for improved clarity.
  * Streamlined metadata validation logic for better readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->