### PR TITLE
fix(block-manager): Allows the immutable block to hold a duplicate as well as the original.

### DIFF
--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -34,7 +34,7 @@ name = "_core"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["block-manager"]
+default = []
 block-manager = ["dynamo-llm/block-manager", "dep:dlpark"]
 
 [dependencies]

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -34,7 +34,7 @@ name = "_core"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
+default = ["block-manager"]
 block-manager = ["dynamo-llm/block-manager", "dep:dlpark"]
 
 [dependencies]

--- a/lib/bindings/python/rust/llm/block_manager/vllm/request.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/request.rs
@@ -34,12 +34,12 @@ impl KvbmRequest {
             lora_name: lora_name.clone(),
         };
 
-        tracing::debug!("salt: {:?}", salt);
+        tracing::trace!("salt: {:?}", salt);
 
         let salt_bytes = serde_json::to_vec(&salt).unwrap();
         let salt_hash = compute_hash_v2(&salt_bytes, 0);
 
-        tracing::debug!("salt_hash: {:?}", salt_hash);
+        tracing::trace!("salt_hash: {:?}", salt_hash);
 
         Self {
             request_id,

--- a/lib/bindings/python/rust/llm/block_manager/vllm/slot.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/slot.rs
@@ -137,6 +137,7 @@ impl<S: Storage, L: LocalityProvider> Slot<S, L> {
 
         let mut blocks_to_register = Vec::new();
         tracing::debug!("registering {} blocks", num_blocks_to_register);
+        assert!(self.mutable.len() >= num_blocks_to_register);
 
         // create an iterator over the mutable blocks zipped with the token blocks
         let zipped_blocks = self

--- a/lib/bindings/python/rust/llm/block_manager/vllm/slot.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/slot.rs
@@ -57,6 +57,7 @@ impl<S: Storage, L: LocalityProvider> Slot<S, L> {
 
     /// Updates the sequence with the given tokens.
     /// These tokens will advance the computed sequence position.
+    #[tracing::instrument(level = "debug", skip_all, fields(tokens_to_append = ?tokens_to_append))]
     pub fn apply_computed_tokens(
         &mut self,
         mut tokens_to_append: Vec<u32>,
@@ -79,8 +80,6 @@ impl<S: Storage, L: LocalityProvider> Slot<S, L> {
 
         // if we are still prefilling, we don't extend the sequence, but verify the tokens match what is already present.
         if self.computed_position < self.prefill_position {
-            tracing::debug!("applying {} prefill tokens", tokens_to_append.len());
-
             // In chunked prefill, vLLM may combine the final prefill chunk with some decode tokens.
             // We need to split off the decode tokens and apply them below.
             let remaining_decode_tokens = if self.computed_position + tokens_to_append.len()
@@ -100,11 +99,15 @@ impl<S: Storage, L: LocalityProvider> Slot<S, L> {
                 &tokens_to_append,
             );
             self.computed_position += tokens_to_append.len();
+            tracing::debug!(
+                "applying {} prefill tokens; new computed_position: {}",
+                tokens_to_append.len(),
+                self.computed_position
+            );
             tokens_to_append = remaining_decode_tokens;
         }
 
         if !tokens_to_append.is_empty() {
-            tracing::debug!("applying {} tokens", tokens_to_append.len());
             // if we are not prefilling, we extend the sequence and advance the sequence position.
             // first advance the sequence, then the position -- this covers the case where the extend fails.
             let count = tokens_to_append.len();
@@ -112,6 +115,12 @@ impl<S: Storage, L: LocalityProvider> Slot<S, L> {
                 .extend(tokens_to_append.into())
                 .map_err(|e| SlotError::from_str(&format!("failed to extend sequence: {:?}", e)))?;
             self.computed_position += count;
+
+            tracing::debug!(
+                "applied {} tokens; new computed_position: {}",
+                count,
+                self.computed_position
+            );
         }
 
         // determine if we need to register any blocks
@@ -147,10 +156,20 @@ impl<S: Storage, L: LocalityProvider> Slot<S, L> {
             blocks_to_register.push(mutable_block);
         }
 
+        assert_eq!(blocks_to_register.len(), num_blocks_to_register);
+
         // register the mutable blocks and extend the slot's immutable blocks
         let immutable_blocks = block_pool
             .register_blocks_blocking(blocks_to_register)
             .map_err(|e| SlotError::from_str(&format!("failed to register blocks: {:?}", e)))?;
+
+        assert_eq!(immutable_blocks.len(), num_blocks_to_register);
+
+        tracing::debug!(
+            "registered {} blocks; new computed_position: {}",
+            immutable_blocks.len(),
+            self.computed_position
+        );
 
         self.immutable.extend(immutable_blocks);
 
@@ -163,6 +182,7 @@ impl<S: Storage, L: LocalityProvider> Slot<S, L> {
     /// Here we clear the list of immutable blocks before applying them because vLLM can try to apply
     /// this multiple times if the slot was unable acquire blocks for the remainder of the sequence.
     // TODO: What about something like chunked prefill?
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn apply_computed_blocks(
         &mut self,
         computed_blocks: Vec<ImmutableBlock<S, L, BasicMetadata>>,
@@ -194,6 +214,7 @@ impl<S: Storage, L: LocalityProvider> Slot<S, L> {
     /// otherwise returns the block ids of the new blocks.
     ///
     /// An empty vector is returned if no new blocks are required.
+    #[tracing::instrument(level = "debug", skip_all, fields(num_new_tokens = %num_new_tokens))]
     pub fn allocate_blocks(
         &mut self,
         num_new_tokens: usize,
@@ -222,6 +243,7 @@ impl<S: Storage, L: LocalityProvider> Slot<S, L> {
 
     /// Frees the blocks in the slot.
     /// This will return the blocks in reverse order so that the tail blocks are evicted first.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn free_blocks(&mut self) {
         self.mutable.clear();
         let mut immutable_blocks = std::mem::take(&mut self.immutable);

--- a/lib/bindings/python/rust/llm/block_manager/vllm/slot.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/slot.rs
@@ -550,8 +550,12 @@ mod tests {
         assert_eq!(slot.num_tokens(SlotPosition::Prefill), 4);
         assert_eq!(slot.num_tokens(SlotPosition::All), 4);
 
+        assert_eq!(slot.mutable.len(), 0);
+        assert_eq!(slot.immutable.len(), 1);
+
         // Now we're in decode mode - add new tokens one at a time
-        for i in 0..3 {
+        for i in 0..5 {
+            println!("=== Decode Pass {} ===", i);
             let decode_token = 100 + i as u32; // Use distinct tokens for decode
 
             // Allocate space for the new token
@@ -561,6 +565,8 @@ mod tests {
                 "Failed to allocate block for decode token {}",
                 i
             );
+
+            assert_eq!(slot.mutable.len(), 1);
 
             // Apply the decode token
             let result = slot.apply_computed_tokens(vec![decode_token], &fixture.pool);
@@ -577,6 +583,14 @@ mod tests {
             assert_eq!(slot.num_tokens(SlotPosition::All), expected_total);
             // Prefill count should remain unchanged
             assert_eq!(slot.num_tokens(SlotPosition::Prefill), 4);
+
+            if expected_total % BLOCK_SIZE == 0 {
+                assert_eq!(slot.mutable.len(), 0);
+                assert_eq!(slot.immutable.len(), expected_total / BLOCK_SIZE);
+            } else {
+                assert_eq!(slot.mutable.len(), 1);
+                assert_eq!(slot.immutable.len(), expected_total / BLOCK_SIZE);
+            }
         }
 
         // Final verification

--- a/lib/bindings/python/rust/llm/block_manager/vllm/slot.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/slot.rs
@@ -594,9 +594,12 @@ mod tests {
         }
 
         // Final verification
-        assert_eq!(slot.num_tokens(SlotPosition::Computed), 7);
-        assert_eq!(slot.num_tokens(SlotPosition::All), 7);
+        assert_eq!(slot.num_tokens(SlotPosition::Computed), 9);
+        assert_eq!(slot.num_tokens(SlotPosition::All), 9);
         assert_eq!(slot.num_tokens(SlotPosition::Prefill), 4);
+
+        assert_eq!(slot.mutable.len(), 1);
+        assert_eq!(slot.immutable.len(), 2);
     }
 
     // Debug Assertion Bug Analysis - demonstrates the issue

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -25,7 +25,7 @@ readme.workspace = true
 description = "Dynamo LLM Library"
 
 [features]
-default = ["block-manager"]
+default = []
 
 # todo: get this working in CI as a default.
 # default = ["block-manager"]

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -25,7 +25,7 @@ readme.workspace = true
 description = "Dynamo LLM Library"
 
 [features]
-default = []
+default = ["block-manager", "testing-full"]
 
 # todo: get this working in CI as a default.
 # default = ["block-manager"]

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -25,7 +25,7 @@ readme.workspace = true
 description = "Dynamo LLM Library"
 
 [features]
-# default = []
+default = ["block-manager"]
 
 # todo: get this working in CI as a default.
 # default = ["block-manager"]

--- a/lib/llm/src/block_manager/block.rs
+++ b/lib/llm/src/block_manager/block.rs
@@ -114,7 +114,7 @@ pub trait BlockMetadata: Default + std::fmt::Debug + Clone + Ord + Send + Sync +
 pub trait MaybeReturnableBlock<S: Storage, L: LocalityProvider, M: BlockMetadata> {
     /// At the time of the call, the block is singularly owned and therefore will be returned to the pool
     /// if dropped.
-    fn is_droppable(&self) -> bool;
+    fn is_returnable(&self) -> bool;
 
     /// Try to take ownership of the block.
     ///
@@ -737,7 +737,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> IntoReadableBlocks<L, M>
 impl<S: Storage, L: LocalityProvider, M: BlockMetadata> MaybeReturnableBlock<S, L, M>
     for MutableBlock<S, L, M>
 {
-    fn is_droppable(&self) -> bool {
+    fn is_returnable(&self) -> bool {
         self.block.is_some()
     }
 
@@ -877,7 +877,7 @@ impl<S: Storage + 'static, L: LocalityProvider, M: BlockMetadata> ImmutableBlock
 impl<S: Storage, L: LocalityProvider, M: BlockMetadata> MaybeReturnableBlock<S, L, M>
     for ImmutableBlock<S, L, M>
 {
-    fn is_droppable(&self) -> bool {
+    fn is_returnable(&self) -> bool {
         // determine if the arc use count is 1; if duplicate, evaluate that arc, otherwise evaluate the primary
         match &self.duplicate {
             Some(duplicate) => Arc::strong_count(duplicate) == 1,

--- a/lib/llm/src/block_manager/block.rs
+++ b/lib/llm/src/block_manager/block.rs
@@ -52,6 +52,7 @@ use std::{
 use thiserror::Error;
 
 pub mod private {
+    #[derive(Clone, Copy)]
     pub struct PrivateToken;
 }
 
@@ -103,6 +104,23 @@ pub trait BlockMetadata: Default + std::fmt::Debug + Clone + Ord + Send + Sync +
     /// The offload priority of the block. Higher priority blocks are offloaded first.
     /// If the block should not be offloaded, return None.
     fn offload_priority(&self) -> Option<u64>;
+}
+
+/// A trait for blocks that can be returned to the pool.
+///
+/// This is used to determine if a block can be dropped when it is returned to the pool.
+/// If the block is droppable, it will be returned to the pool.
+/// If the block is not droppable, it will be kept alive until the pool is reset.
+pub trait MaybeReturnableBlock<S: Storage, L: LocalityProvider, M: BlockMetadata> {
+    /// At the time of the call, the block is singularly owned and therefore will be returned to the pool
+    /// if dropped.
+    fn is_droppable(&self) -> bool;
+
+    /// Try to take ownership of the block.
+    ///
+    /// This is an internal function guarded by the PrivateToken and is used to implement the public facing
+    /// [`super::pool::BlockPool::return_block`] and [`super::pool::BlockPool::return_block_blocking`] functions.
+    fn try_take_block(self, token: private::PrivateToken) -> Option<Vec<Block<S, L, M>>>;
 }
 
 /// Marker trait for types that are mutable blocks
@@ -716,6 +734,18 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> IntoReadableBlocks<L, M>
     }
 }
 
+impl<S: Storage, L: LocalityProvider, M: BlockMetadata> MaybeReturnableBlock<S, L, M>
+    for MutableBlock<S, L, M>
+{
+    fn is_droppable(&self) -> bool {
+        self.block.is_some()
+    }
+
+    fn try_take_block(mut self, _: private::PrivateToken) -> Option<Vec<Block<S, L, M>>> {
+        self.block.take().map(|block| vec![block])
+    }
+}
+
 #[derive(Debug)]
 pub struct ImmutableBlock<S: Storage, L: LocalityProvider, M: BlockMetadata> {
     block: Arc<MutableBlock<S, L, M>>,
@@ -766,6 +796,12 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> ImmutableBlock<S, L, M> 
         self.duplicate
             .as_ref()
             .map_or(self.block.block_id(), |duplicate| duplicate.block_id())
+    }
+
+    /// Returns true if the ImmutableBlock holds a duplicate block.
+    #[allow(unused)]
+    pub(crate) fn is_duplicate(&self) -> bool {
+        self.duplicate.is_some()
     }
 }
 
@@ -835,6 +871,40 @@ impl<S: Storage + 'static, L: LocalityProvider, M: BlockMetadata> ImmutableBlock
             tracing::warn!("Block is not managed. Unable to enqueue offload.");
         }
         Ok(())
+    }
+}
+
+impl<S: Storage, L: LocalityProvider, M: BlockMetadata> MaybeReturnableBlock<S, L, M>
+    for ImmutableBlock<S, L, M>
+{
+    fn is_droppable(&self) -> bool {
+        // determine if the arc use count is 1; if duplicate, evaluate that arc, otherwise evaluate the primary
+        match &self.duplicate {
+            Some(duplicate) => Arc::strong_count(duplicate) == 1,
+            None => Arc::strong_count(&self.block) == 1,
+        }
+    }
+
+    fn try_take_block(mut self, token: private::PrivateToken) -> Option<Vec<Block<S, L, M>>> {
+        let blocks = [
+            Arc::try_unwrap(self.block).ok(),
+            self.duplicate
+                .take()
+                .and_then(|duplicate| Arc::try_unwrap(duplicate).ok()),
+        ];
+
+        let blocks = blocks
+            .into_iter()
+            .flatten()
+            .filter_map(|block| block.try_take_block(token))
+            .flatten()
+            .collect::<Vec<_>>();
+
+        if blocks.is_empty() {
+            None
+        } else {
+            Some(blocks)
+        }
     }
 }
 

--- a/lib/llm/src/block_manager/component.rs
+++ b/lib/llm/src/block_manager/component.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::block_manager::pool::BlockPoolError;
 
 use super::*;

--- a/lib/llm/src/block_manager/component.rs
+++ b/lib/llm/src/block_manager/component.rs
@@ -1,0 +1,182 @@
+use crate::block_manager::pool::BlockPoolError;
+
+use super::*;
+
+use dynamo_runtime::{
+    pipeline::{
+        async_trait, network::Ingress, AsyncEngine, AsyncEngineContextProvider, Error, ManyOut,
+        ResponseStream, SingleIn,
+    },
+    protocols::annotated::Annotated,
+    traits::DistributedRuntimeProvider,
+    utils::task::CriticalTaskExecutionHandle,
+};
+
+use futures::stream;
+
+pub struct DynamoKvbmController<Locality: LocalityProvider, Metadata: BlockMetadata> {
+    _locality: std::marker::PhantomData<Locality>,
+    _metadata: std::marker::PhantomData<Metadata>,
+}
+
+impl<Locality: LocalityProvider, Metadata: BlockMetadata> DynamoKvbmController<Locality, Metadata> {
+    pub async fn new(
+        block_manager: KvBlockManager<Locality, Metadata>,
+        component: dynamo_runtime::component::Component,
+    ) -> anyhow::Result<Self> {
+        let service = component.service_builder().create().await?;
+
+        let reset_handler = ResetHandler::new(block_manager.clone());
+        let reset_handler = Ingress::for_engine(reset_handler)?;
+
+        let reset_task = CriticalTaskExecutionHandle::new(
+            |_cancel_token| async move {
+                service
+                    .endpoint("reset_cache_level")
+                    .endpoint_builder()
+                    .handler(reset_handler)
+                    .start()
+                    .await
+            },
+            component.drt().primary_token(),
+            "reset_cache_level",
+        )?;
+
+        reset_task.detach();
+
+        Ok(Self {
+            _locality: std::marker::PhantomData,
+            _metadata: std::marker::PhantomData,
+        })
+    }
+}
+
+struct ResetHandler<Locality: LocalityProvider, Metadata: BlockMetadata> {
+    block_manager: KvBlockManager<Locality, Metadata>,
+}
+
+impl<Locality: LocalityProvider, Metadata: BlockMetadata> ResetHandler<Locality, Metadata> {
+    fn new(block_manager: KvBlockManager<Locality, Metadata>) -> Arc<Self> {
+        Arc::new(Self { block_manager })
+    }
+}
+
+#[async_trait]
+impl<Locality: LocalityProvider, Metadata: BlockMetadata>
+    AsyncEngine<SingleIn<CacheLevel>, ManyOut<Annotated<()>>, Error>
+    for ResetHandler<Locality, Metadata>
+{
+    async fn generate(&self, input: SingleIn<CacheLevel>) -> Result<ManyOut<Annotated<()>>> {
+        let (data, ctx) = input.into_parts();
+
+        let result: anyhow::Result<()> = match data {
+            CacheLevel::G1 => {
+                self.block_manager
+                    .device()
+                    .ok_or(anyhow::anyhow!("Device pool not found"))?
+                    .reset()
+                    .await?;
+
+                Ok(())
+            }
+            CacheLevel::G2 => Ok(self
+                .block_manager
+                .host()
+                .ok_or(anyhow::anyhow!("Host pool not found"))?
+                .reset_blocking()?),
+            CacheLevel::G3 => Ok(self
+                .block_manager
+                .disk()
+                .ok_or(anyhow::anyhow!("Disk pool not found"))?
+                .reset_blocking()?),
+            CacheLevel::G4 => Err(BlockPoolError::UnsupportedCacheLevel(data))?,
+        };
+
+        let annotated = match result {
+            Ok(()) => Annotated::from_data(()),
+            Err(e) => Annotated::from_error(e.to_string()),
+        };
+
+        let stream = stream::once(async move { annotated });
+
+        Ok(ResponseStream::new(Box::pin(stream), ctx.context()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::create_reference_block_manager;
+    use super::*;
+
+    use dynamo_runtime::{pipeline::PushRouter, protocols::annotated::Annotated};
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn test_reset_cache_level() {
+        dynamo_runtime::logging::init();
+
+        let rt = dynamo_runtime::Runtime::from_current().unwrap();
+        let drt = dynamo_runtime::DistributedRuntime::from_settings(rt)
+            .await
+            .unwrap();
+
+        let worker_id = drt.primary_lease().unwrap().id();
+
+        let block_manager = create_reference_block_manager().await;
+
+        let component = drt
+            .namespace("test-kvbm")
+            .unwrap()
+            .component("kvbm")
+            .unwrap();
+
+        let _controller =
+            component::DynamoKvbmController::new(block_manager.clone(), component.clone())
+                .await
+                .unwrap();
+
+        let client = component
+            .endpoint("reset_cache_level")
+            .client()
+            .await
+            .unwrap();
+
+        client.wait_for_instances().await.unwrap();
+
+        let client =
+            PushRouter::<CacheLevel, Annotated<()>>::from_client(client, Default::default())
+                .await
+                .unwrap();
+
+        let mut stream = client
+            .direct(CacheLevel::G1.into(), worker_id)
+            .await
+            .unwrap();
+        while let Some(resp) = stream.next().await {
+            assert!(resp.is_ok());
+        }
+
+        let device_block = block_manager
+            .device()
+            .unwrap()
+            .allocate_blocks(1)
+            .await
+            .unwrap();
+        assert_eq!(device_block.len(), 1);
+
+        let stream = client.direct(CacheLevel::G1.into(), worker_id).await;
+        assert!(stream.is_err());
+        // let resp = stream.next().await.unwrap();
+        // assert!(resp.is_err());
+
+        drop(device_block);
+
+        let mut stream = client
+            .direct(CacheLevel::G1.into(), worker_id)
+            .await
+            .unwrap();
+        while let Some(resp) = stream.next().await {
+            assert!(resp.is_ok());
+        }
+    }
+}

--- a/lib/llm/src/block_manager/config.rs
+++ b/lib/llm/src/block_manager/config.rs
@@ -202,6 +202,10 @@ pub struct KvBlockManagerConfig {
     /// Event manager to handle block related events
     #[builder(default)]
     pub event_manager: Option<Arc<dyn EventManager>>,
+
+    /// Channel to reset the block manager to a specific cache level
+    #[builder(default)]
+    pub block_reset_channel: Option<BlockResetChannel>,
 }
 
 impl KvBlockManagerConfig {

--- a/lib/llm/src/block_manager/offload/pending.rs
+++ b/lib/llm/src/block_manager/offload/pending.rs
@@ -112,12 +112,7 @@ impl<Source: Storage, Target: Storage, Locality: LocalityProvider, Metadata: Blo
             transfer_metadata(source, target)?;
         }
 
-        let blocks = target_pool
-            .register_blocks_with_duplication_setting(
-                targets,
-                BlockRegistrationDuplicationSetting::Disabled,
-            )
-            .await?;
+        let blocks = target_pool.register_blocks(targets).await?;
 
         tracing::debug!("Transfer complete. Registered {} blocks.", blocks.len());
 

--- a/lib/llm/src/block_manager/offload/pending.rs
+++ b/lib/llm/src/block_manager/offload/pending.rs
@@ -52,7 +52,7 @@ use crate::block_manager::block::{
     BlockDataProvider, BlockDataProviderMut, BlockError, BlockMetadata, BlockState, ImmutableBlock,
     MutableBlock, ReadableBlock, WritableBlock,
 };
-use crate::block_manager::pool::{BlockPoolError, BlockRegistrationDuplicationSetting};
+use crate::block_manager::pool::BlockPoolError;
 use crate::block_manager::storage::{Local, Storage};
 use crate::block_manager::BlockPool;
 

--- a/lib/llm/src/block_manager/offload/pending.rs
+++ b/lib/llm/src/block_manager/offload/pending.rs
@@ -52,7 +52,7 @@ use crate::block_manager::block::{
     BlockDataProvider, BlockDataProviderMut, BlockError, BlockMetadata, BlockState, ImmutableBlock,
     MutableBlock, ReadableBlock, WritableBlock,
 };
-use crate::block_manager::pool::BlockPoolError;
+use crate::block_manager::pool::{BlockPoolError, BlockRegistrationDuplicationSetting};
 use crate::block_manager::storage::{Local, Storage};
 use crate::block_manager::BlockPool;
 
@@ -112,7 +112,12 @@ impl<Source: Storage, Target: Storage, Locality: LocalityProvider, Metadata: Blo
             transfer_metadata(source, target)?;
         }
 
-        let blocks = target_pool.register_blocks(targets).await?;
+        let blocks = target_pool
+            .register_blocks_with_duplication_setting(
+                targets,
+                BlockRegistrationDuplicationSetting::Disabled,
+            )
+            .await?;
 
         tracing::debug!("Transfer complete. Registered {} blocks.", blocks.len());
 

--- a/lib/llm/src/block_manager/pool.rs
+++ b/lib/llm/src/block_manager/pool.rs
@@ -77,6 +77,7 @@ use super::metrics::{BlockManagerMetrics, PoolMetrics};
 use super::storage::Storage;
 
 use crate::block_manager::block::locality::LocalityProvider;
+use crate::block_manager::CacheLevel;
 use crate::tokens::{SequenceHash, TokenBlock};
 
 use prometheus::Registry;
@@ -178,6 +179,9 @@ pub enum BlockPoolError {
 
     #[error("Block is not returnable")]
     NotReturnable,
+
+    #[error("Unsupported cache level: {0:?}")]
+    UnsupportedCacheLevel(CacheLevel),
 }
 
 #[derive(Builder, Dissolve)]

--- a/lib/llm/src/block_manager/pool.rs
+++ b/lib/llm/src/block_manager/pool.rs
@@ -182,6 +182,9 @@ pub enum BlockPoolError {
 
     #[error("Unsupported cache level: {0:?}")]
     UnsupportedCacheLevel(CacheLevel),
+
+    #[error("No blocks to register")]
+    NoBlocksToRegister,
 }
 
 #[derive(Builder, Dissolve)]
@@ -562,6 +565,10 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> BlockPool<S, L, M> {
         blocks: Vec<MutableBlock<S, L, M>>,
         duplication_setting: BlockRegistrationDuplicationSetting,
     ) -> AsyncResponse<BlockPoolResult<ImmutableBlocks<S, L, M>>> {
+        if blocks.is_empty() {
+            return Err(BlockPoolError::NoBlocksToRegister);
+        }
+
         let (req, resp_rx) = RegisterBlocksReq::new((blocks, duplication_setting));
 
         self.priority_tx

--- a/lib/llm/src/block_manager/pool.rs
+++ b/lib/llm/src/block_manager/pool.rs
@@ -483,7 +483,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> BlockPool<S, L, M> {
             .map_err(|_| BlockPoolError::ProgressEngineShutdown)?
     }
 
-    pub(crate) async fn register_blocks_with_duplication_setting(
+    pub(crate) async fn _register_blocks_with_duplication_setting(
         &self,
         blocks: Vec<MutableBlock<S, L, M>>,
         duplication_setting: BlockRegistrationDuplicationSetting,

--- a/lib/llm/src/block_manager/pool.rs
+++ b/lib/llm/src/block_manager/pool.rs
@@ -238,12 +238,17 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> BlockPoolArgsBuilder<S, 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlockRegistrationDuplicationSetting {
     /// On registration, if duplication is allowed, blocks with duplicate hashes cannot be registered directly,
-    /// but instead can be held live with a strong reference to the primary block. This maintains the lifetime of
+    /// but instead can be held live with a strong arc to the primary block. This maintains the lifetime of
     /// the duplicate block.
     Allowed,
 
-    /// On registration, if duplication is disabled, blocks with duplicate hashes will be returned to the inactive pool
-    /// and the primary block, the one first registered, will be returned to the sequence from the registration.
+    /// On registration, if duplication is disabled, blocks with duplicate hashes will be returned immediately
+    /// to the inactive pool and the primary block, the one first registered, will be returned to the caller,
+    /// replacing the duplicate block.
+    ///
+    /// Note: If block duplication is disabled, then the implementation must always respect the fact that the
+    /// mutable block that was registered, may not be the same block returned by the registration function, and
+    /// thus be able to update any references that wish to use the block after registration.
     Disabled,
 }
 

--- a/lib/llm/src/block_manager/pool.rs
+++ b/lib/llm/src/block_manager/pool.rs
@@ -109,10 +109,10 @@ pub enum OwnedBlock<S: Storage, L: LocalityProvider, M: BlockMetadata> {
 impl<S: Storage, L: LocalityProvider, M: BlockMetadata> MaybeReturnableBlock<S, L, M>
     for OwnedBlock<S, L, M>
 {
-    fn is_droppable(&self) -> bool {
+    fn is_returnable(&self) -> bool {
         match self {
-            OwnedBlock::Mutable(block) => block.is_droppable(),
-            OwnedBlock::Immutable(block) => block.is_droppable(),
+            OwnedBlock::Mutable(block) => block.is_returnable(),
+            OwnedBlock::Immutable(block) => block.is_returnable(),
         }
     }
 

--- a/lib/llm/src/block_manager/pool.rs
+++ b/lib/llm/src/block_manager/pool.rs
@@ -214,7 +214,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> Clone for BlockPool<S, L
             ctrl_tx: self.ctrl_tx.clone(),
             available_blocks_counter: self.available_blocks_counter.clone(),
             total_blocks_counter: self.total_blocks_counter.clone(),
-            default_duplication_setting: self.default_duplication_setting.clone(),
+            default_duplication_setting: self.default_duplication_setting,
         }
     }
 }
@@ -343,7 +343,6 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> BlockPool<S, L, M> {
             global_registry,
             async_runtime,
             metrics,
-            default_duplication_setting,
         );
 
         let available_blocks_counter = progress_engine.available_blocks_counter.clone();
@@ -597,7 +596,6 @@ struct State<S: Storage, L: LocalityProvider, M: BlockMetadata> {
     return_tx: tokio::sync::mpsc::UnboundedSender<Block<S, L, M>>,
     event_manager: Arc<dyn EventManager>,
     metrics: Arc<PoolMetrics>,
-    default_duplication_setting: BlockRegistrationDuplicationSetting,
 }
 
 struct ProgressEngine<S: Storage, L: LocalityProvider, M: BlockMetadata> {
@@ -1116,7 +1114,7 @@ mod tests {
         assert!(block.state().is_registered());
         assert_eq!(block.sequence_hash(), sequence_hash);
 
-        let primary = block.clone();
+        let _primary = block.clone();
         let primary_id = block.block_id();
 
         // Now allocate another and register it with the same sequence
@@ -1220,7 +1218,7 @@ mod tests {
         assert!(block.state().is_registered());
         assert_eq!(block.sequence_hash(), sequence_hash);
 
-        let primary = block.clone();
+        let _primary = block.clone();
         let primary_id = block.block_id();
 
         // Now allocate another and register it with the same sequence

--- a/lib/llm/src/block_manager/pool/state.rs
+++ b/lib/llm/src/block_manager/pool/state.rs
@@ -27,7 +27,6 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> State<S, L, M>
         global_registry: GlobalRegistry,
         async_runtime: Handle,
         metrics: Arc<PoolMetrics>,
-        default_duplication_setting: BlockRegistrationDuplicationSetting,
     ) -> Self {
         Self {
             active: ActiveBlockPool::new(),
@@ -36,7 +35,6 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> State<S, L, M>
             return_tx,
             event_manager,
             metrics,
-            default_duplication_setting,
         }
     }
 
@@ -340,7 +338,6 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> ProgressEngine
         global_registry: GlobalRegistry,
         async_runtime: Handle,
         metrics: Arc<PoolMetrics>,
-        default_duplication_setting: BlockRegistrationDuplicationSetting,
     ) -> Self {
         let (return_tx, return_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut state = State::<S, L, M>::new(
@@ -349,7 +346,6 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> ProgressEngine
             global_registry,
             async_runtime,
             metrics.clone(),
-            default_duplication_setting,
         );
 
         let count = blocks.len();

--- a/lib/llm/src/block_manager/pool/state.rs
+++ b/lib/llm/src/block_manager/pool/state.rs
@@ -167,6 +167,8 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> State<S, L, M>
         duplication_setting: BlockRegistrationDuplicationSetting,
         return_rx: &mut tokio::sync::mpsc::UnboundedReceiver<Block<S, L, M>>,
     ) -> Result<Vec<ImmutableBlock<S, L, M>>, BlockPoolError> {
+        assert!(!blocks.is_empty(), "no blocks to register");
+
         let expected_len = blocks.len();
         let mut immutable_blocks = Vec::new();
 

--- a/lib/llm/src/block_manager/pool/state.rs
+++ b/lib/llm/src/block_manager/pool/state.rs
@@ -160,6 +160,7 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> State<S, L, M>
         Ok(blocks)
     }
 
+    #[tracing::instrument(level = "debug", skip_all, fields(blocks = ?blocks))]
     pub async fn register_blocks(
         &mut self,
         blocks: Vec<MutableBlock<S, L, M>>,
@@ -188,6 +189,7 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> State<S, L, M>
                     }
                     immutable
                 };
+
                 immutable_blocks.push(immutable);
                 continue;
             }

--- a/lib/runtime/src/pipeline/network/ingress/push_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_endpoint.rs
@@ -83,7 +83,11 @@ impl PushEndpoint {
                             tracing::trace!(worker_id, "request handled successfully");
                         }
                         Err(e) => {
+                            #[cfg(debug_assertions)]
                             tracing::warn!("Failed to handle request: {:?}", e);
+
+                            #[cfg(not(debug_assertions))]
+                            tracing::warn!("Failed to handle request: {}", e.to_string());
                         }
                     }
 

--- a/lib/runtime/src/pipeline/network/ingress/push_handler.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_handler.rs
@@ -89,8 +89,21 @@ where
                 stream
             }
             Err(e) => {
-                tracing::error!("Failed to generate response stream: {:?}", e);
-                let _result = publisher.send_prologue(Some(e.to_string())).await;
+                let error_string = e.to_string();
+
+                #[cfg(debug_assertions)]
+                {
+                    tracing::debug!(
+                        "Failed to generate response stream (with debug backtrace): {:?}",
+                        e
+                    );
+                }
+                #[cfg(not(debug_assertions))]
+                {
+                    tracing::error!("Failed to generate response stream: {}", error_string);
+                }
+
+                let _result = publisher.send_prologue(Some(error_string)).await;
                 Err(e)?
             }
         };


### PR DESCRIPTION
Allows the immutable block to hold a duplicate ad well as the original.  

This would allow the slot manager to hold a duplicate block which was decoded, but since vLLM v1 doesn't dedup, we have to ensure the duplicate lives as long as the slot.

If the slot were to be evicted, it would clear all the blocks, then when rescheduled, it would rematch against the original, but since that will repopulate the block list on the worker, we are safe and essentially get/recover the deduplication on the restore.

Also improves testing by adding new pool functionality
- reset - wipes the block state if and only if all blocks are inactive
- try_return_block - provides as synchronous mechanism to try to return a block to the pool.  immutable blocks that are potentially shared or have duplicates may fail if the block to be returned to the pull is shared.  for duplicate blocks, an Ok result is simply that that duplicate is able to be returned to the inactive pool, regardless of if the primary block could be returned.