### PR TITLE
feat: query instance_id based on routing strategy

### DIFF
--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -313,12 +313,11 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             InstanceSource::Dynamic(_) => {
                 // Extract context ID for request tracking
                 let context_id = request.context().id().to_string();
-
                 let (instance_id, overlap_amount) = self
                     .chooser
                     .find_best_match(&context_id, &request.token_ids)
                     .await?;
-                let has_worker_id_annotation = request.has_annotation("query_instance_id");
+                let query_instance_id = request.has_annotation("query_instance_id");
                 // Extract context information before moving the request
                 let stream_context = request.context().clone();
                 // Update the request with the estimated prefix hit blocks
@@ -326,10 +325,10 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 let isl = backend_input.token_ids.len();
                 backend_input.estimated_prefix_hit_num_blocks = Some(overlap_amount);
                 let updated_request = context.map(|_| backend_input);
-                // Take this branch when request has the annotation "query_instance_id"
-                // "nvext": { "annotations": ["query_instance_id"]}}
-                // This is used to indicate that the request will be routed to a worker
-                if has_worker_id_annotation {
+                // if request has the annotation "query_instance_id", for example
+                // curl -d '{... ,"nvext": { "annotations": ["query_instance_id"]}}'
+                // request will not be routed to worker immediately
+                if query_instance_id {
                     let instance_id_str = instance_id.to_string();
                     let response =
                         Annotated::from_annotation("worker_instance_id", &instance_id_str)?;

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -397,8 +397,8 @@ impl OpenAIPreprocessor {
                         // Only set event if not already set to avoid overriding existing events (like errors)
                         if response.event.is_none() {
                             response.event = metrics_annotated.event;
+                            response.comment = metrics_annotated.comment;
                         }
-                        response.comment = metrics_annotated.comment;
                     }
 
                     tracing::trace!(


### PR DESCRIPTION
#### Overview:
Why:

This change supports [inference gateway integration integration](https://github.com/ai-dynamo/enhancements/blob/bis/inference-gw/0001-TBD-inference-gw-integration/0001-TBD-inference-gw-integration.md#alt-2-dynamo-epp-integration-with-router)

Gateway extension applies filters/scorers to identify target worker which will handle an incoming request.

1. In scheduling path, we want to extract the `worker_id` and don't want to route the request yet. 
2.In service path , we want to enforce the `worker_id` which will bypass the router


What:
* Added early-return in KvPushRouter::generate to emit routing info if "query_instance_id" annotation is present.
*  Modified logic to set comment only if event is not already set in OpenAIPreprocessor.



![](https://raw.githubusercontent.com/ai-dynamo/enhancements/refs/heads/bis/inference-gw/0001-TBD-inference-gw-integration/dyn_alt_2.png)

closes: https://linear.app/nvidia-dynamo/issue/DEP-161

#### Details:

The changes introduce a conditional early-return path in the KvPushRouter's generate method to respond with routing information when a specific annotation (`query_instance_id`)  is present. 

Additionally, the logic for setting the comment field in OpenAIPreprocessor is refined to prevent overwriting it when an event is already set.


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for requests to receive routing information directly when a specific annotation is present, returning the matched instance ID in the response.

* **Bug Fixes**
  * Improved handling of response comments to prevent overwriting existing comments when an event is already set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->