### PR TITLE
fix: add setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "typer",
     "circus==0.19.0",
     "click<8.2.0",
+    "setuptools",
 ]
 
 classifiers = [


### PR DESCRIPTION
add setuptools dependency for dynamo CLI 

related GitHub issue - #1737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated required dependencies to include setuptools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->