### PR TITLE
feat: add runtime image for trtllm container build

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -460,8 +460,6 @@ COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging-${PACKAGING_
 COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn /usr/local/lib/python3.12/dist-packages/flash_attn
 COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn-${FLASH_ATTN_VER}.dist-info /usr/local/lib/python3.12/dist-packages/flash_attn-${FLASH_ATTN_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn_2_cuda.cpython-312-*-linux-gnu.so /usr/local/lib/python3.12/dist-packages/
-# COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath /usr/local/lib/python3.12/dist-packages/mpmath
-# COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath-${MPMATH_VER}.dist-info /usr/local/lib/python3.12/dist-packages/mpmath-${MPMATH_VER}.dist-info
 
 # Setup environment variables
 ARG ARCH_ALT

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -17,7 +17,7 @@ ARG BASE_IMAGE="nvcr.io/nvidia/pytorch"
 ARG BASE_IMAGE_TAG="25.05-py3"
 ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
-ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
+ARG RUNTIME_IMAGE_TAG="12.9.0-devel-ubuntu24.04"
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
 #   ARCH: Used for package suffixes (e.g., amd64, arm64)
@@ -395,9 +395,20 @@ ENV PATH=/usr/local/bin/etcd/:$PATH
 # Copy NIXL source from build image (required for NIXL plugins)
 COPY --from=build /usr/local/ucx /usr/local/ucx
 COPY --from=build /usr/local/nixl /usr/local/nixl
+# Copy HPCX from base image
+COPY --from=build /opt/hpcx /opt/hpcx
+# Copy NUMA library from build image
+COPY --from=build /usr/lib/x86_64-linux-gnu/libnuma.so* /usr/lib/x86_64-linux-gnu/
 ARG ARCH_ALT
 ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins
-ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu:/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins:/usr/local/ucx/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu:/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins:/usr/local/ucx/lib:/opt/hpcx/ompi/lib:$LD_LIBRARY_PATH
+ENV OMPI_HOME=/opt/hpcx/ompi
+ENV PATH=/opt/hpcx/ompi/bin:$PATH
+ENV OPAL_PREFIX=/opt/hpcx/ompi
+# Configure OpenMPI to use local process launch manager
+ENV OMPI_MCA_plm_rsh_agent=""
+ENV OMPI_MCA_plm="isolated"
+ENV OMPI_MCA_btl_base_warn_component_unused="0"
 
 # Setup the python environment
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -414,28 +425,31 @@ RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/
     uv pip install --requirement /tmp/requirements.txt
 
 COPY --from=build /usr/local/lib/lib* /usr/local/lib/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/torch $VIRTUAL_ENV/lib/python3.12/dist-packages/torch
-COPY --from=build /usr/local/lib/python3.12/dist-packages/torch-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/torchgen $VIRTUAL_ENV/lib/python3.12/dist-packages/torchgen
-COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision $VIRTUAL_ENV/lib/python3.12/dist-packages/torchvision
-COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision.libs $VIRTUAL_ENV/lib/python3.12/dist-packages/torchvision.libs
-COPY --from=build /usr/local/lib/python3.12/dist-packages/setuptools $VIRTUAL_ENV/lib/python3.12/dist-packages/setuptools
-COPY --from=build /usr/local/lib/python3.12/dist-packages/setuptools-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/functorch $VIRTUAL_ENV/lib/python3.12/dist-packages/functorch
-COPY --from=build /usr/local/lib/python3.12/dist-packages/pytorch_triton-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/triton $VIRTUAL_ENV/lib/python3.12/dist-packages/triton
-COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2 $VIRTUAL_ENV/lib/python3.12/dist-packages/jinja2
-COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/networkx $VIRTUAL_ENV/lib/python3.12/dist-packages/networkx
-COPY --from=build /usr/local/lib/python3.12/dist-packages/networkx-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/sympy $VIRTUAL_ENV/lib/python3.12/dist-packages/sympy
-COPY --from=build /usr/local/lib/python3.12/dist-packages/sympy-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging $VIRTUAL_ENV/lib/python3.12/dist-packages/packaging
-COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn $VIRTUAL_ENV/lib/python3.12/dist-packages/flash_attn
-COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn_2_cuda.cpython-312-*-linux-gnu.so $VIRTUAL_ENV/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torch /usr/local/lib/python3.12/dist-packages/torch
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torch-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torchgen /usr/local/lib/python3.12/dist-packages/torchgen
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision /usr/local/lib/python3.12/dist-packages/torchvision
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision.libs /usr/local/lib/python3.12/dist-packages/torchvision.libs
+COPY --from=build /usr/local/lib/python3.12/dist-packages/setuptools /usr/local/lib/python3.12/dist-packages/setuptools
+COPY --from=build /usr/local/lib/python3.12/dist-packages/functorch /usr/local/lib/python3.12/dist-packages/functorch
+COPY --from=build /usr/local/lib/python3.12/dist-packages/pytorch_triton-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/triton /usr/local/lib/python3.12/dist-packages/triton
+COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2 /usr/local/lib/python3.12/dist-packages/jinja2
+COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/networkx /usr/local/lib/python3.12/dist-packages/networkx
+COPY --from=build /usr/local/lib/python3.12/dist-packages/networkx-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/sympy /usr/local/lib/python3.12/dist-packages/sympy
+COPY --from=build /usr/local/lib/python3.12/dist-packages/sympy-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging /usr/local/lib/python3.12/dist-packages/packaging
+COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn /usr/local/lib/python3.12/dist-packages/flash_attn
+COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn_2_cuda.cpython-312-*-linux-gnu.so /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/mpi4py /usr/local/lib/python3.12/dist-packages/mpi4py
+COPY --from=build /usr/local/lib/python3.12/dist-packages/mpi4py-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath /usr/local/lib/python3.12/dist-packages/mpmath
+COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath-*.dist-info /usr/local/lib/python3.12/dist-packages/
 
 #TODO: Remove this once we have a functional dev image built on top of the runtime image
 COPY . /workspace

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -397,8 +397,8 @@ COPY --from=build /usr/local/bin/etcd/ /usr/local/bin/etcd/
 COPY --from=build /usr/local/ucx /usr/local/ucx
 # Copy NIXL source from build image (required for NIXL plugins)
 COPY --from=build /usr/local/nixl /usr/local/nixl
-# Copy HPCX from base image
-COPY --from=build /opt/hpcx /opt/hpcx
+# Copy OpenMPI from build image
+COPY --from=build /opt/hpcx/ompi /opt/hpcx/ompi
 # Copy NUMA library from build image
 COPY --from=build /usr/lib/x86_64-linux-gnu/libnuma.so* /usr/lib/x86_64-linux-gnu/
 
@@ -408,21 +408,22 @@ RUN uv venv $VIRTUAL_ENV --python 3.12 && \
     echo "source $VIRTUAL_ENV/bin/activate" >> ~/.bashrc
 
 # Common dependencies
+# ToDo: Remove extra install and use pyproject.toml to define all dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
     uv pip install --requirement /tmp/requirements.txt
 
 # Install test dependencies
-#TODO: Remove this once we have a functional dev image built on top of the runtime image
+# TODO: Remove this once we have a functional CI image built on top of the runtime image
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
     uv pip install --requirement /tmp/requirements.txt
 
 # Copy CUDA toolkit components needed for nvcc, cudafe, cicc etc.
-COPY --from=build /usr/local/cuda/bin/ /usr/local/cuda/bin/
-COPY --from=build /usr/local/cuda/include /usr/local/cuda/include
+COPY --from=build /usr/local/cuda/bin/nvcc /usr/local/cuda/bin/nvcc
+COPY --from=build /usr/local/cuda/bin/cudafe++ /usr/local/cuda/bin/cudafe++
+COPY --from=build /usr/local/cuda/bin/ptxas /usr/local/cuda/bin/ptxas
+COPY --from=build /usr/local/cuda/bin/fatbinary /usr/local/cuda/bin/fatbinary
+COPY --from=build /usr/local/cuda/include/ /usr/local/cuda/include/
 COPY --from=build /usr/local/cuda/lib64/libcudart.so* /usr/local/cuda/lib64/
-COPY --from=build /usr/local/cuda/lib64/libnvvm.so* /usr/local/cuda/lib64/
-COPY --from=build /usr/local/cuda/lib64/libnvvmx.so* /usr/local/cuda/lib64/
-COPY --from=build /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/
 COPY --from=build /usr/local/cuda/nvvm /usr/local/cuda/nvvm
 
 # Copy pytorch installation from NGC PyTorch
@@ -435,7 +436,6 @@ ARG NETWORKX_VER=3.4.2
 ARG SYMPY_VER=1.14.0
 ARG PACKAGING_VER=23.2
 ARG FLASH_ATTN_VER=2.7.3
-ARG MPI4PY_VER
 ARG MPMATH_VER=1.3.0
 COPY --from=build /usr/local/lib/lib* /usr/local/lib/
 COPY --from=build /usr/local/lib/python3.12/dist-packages/torch /usr/local/lib/python3.12/dist-packages/torch
@@ -447,8 +447,8 @@ COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision.libs /usr/
 COPY --from=build /usr/local/lib/python3.12/dist-packages/setuptools /usr/local/lib/python3.12/dist-packages/setuptools
 COPY --from=build /usr/local/lib/python3.12/dist-packages/setuptools-${SETUPTOOLS_VER}.dist-info /usr/local/lib/python3.12/dist-packages/setuptools-${SETUPTOOLS_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/functorch /usr/local/lib/python3.12/dist-packages/functorch
-COPY --from=build /usr/local/lib/python3.12/dist-packages/pytorch_triton-${PYTORCH_TRITON_VER}.dist-info /usr/local/lib/python3.12/dist-packages/pytorch_triton-${PYTORCH_TRITON_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/triton /usr/local/lib/python3.12/dist-packages/triton
+COPY --from=build /usr/local/lib/python3.12/dist-packages/pytorch_triton-${PYTORCH_TRITON_VER}.dist-info /usr/local/lib/python3.12/dist-packages/pytorch_triton-${PYTORCH_TRITON_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2 /usr/local/lib/python3.12/dist-packages/jinja2
 COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2-${JINJA2_VER}.dist-info /usr/local/lib/python3.12/dist-packages/jinja2-${JINJA2_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/networkx /usr/local/lib/python3.12/dist-packages/networkx
@@ -460,20 +460,15 @@ COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging-${PACKAGING_
 COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn /usr/local/lib/python3.12/dist-packages/flash_attn
 COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn-${FLASH_ATTN_VER}.dist-info /usr/local/lib/python3.12/dist-packages/flash_attn-${FLASH_ATTN_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn_2_cuda.cpython-312-*-linux-gnu.so /usr/local/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath /usr/local/lib/python3.12/dist-packages/mpmath
-COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath-${MPMATH_VER}.dist-info /usr/local/lib/python3.12/dist-packages/mpmath-${MPMATH_VER}.dist-info
+# COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath /usr/local/lib/python3.12/dist-packages/mpmath
+# COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath-${MPMATH_VER}.dist-info /usr/local/lib/python3.12/dist-packages/mpmath-${MPMATH_VER}.dist-info
 
 # Setup environment variables
 ARG ARCH_ALT
 ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins
 ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu:/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins:/usr/local/ucx/lib:/opt/hpcx/ompi/lib:$LD_LIBRARY_PATH
-ENV OMPI_HOME=/opt/hpcx/ompi
-ENV PATH=/opt/hpcx/ompi/bin:/usr/local/bin/etcd/:$PATH
+ENV PATH=/opt/hpcx/ompi/bin:/usr/local/bin/etcd/:/usr/local/cuda/nvvm/bin:$PATH
 ENV OPAL_PREFIX=/opt/hpcx/ompi
-
-#TODO: Remove this once we have a functional dev image built on top of the runtime image
-COPY . /workspace
-RUN uv pip install /workspace/benchmarks
 
 # Install TensorRT-LLM (same as in build stage)
 ARG HAS_TRTLLM_CONTEXT=0
@@ -490,8 +485,17 @@ RUN uv pip install --index-url "${TENSORRTLLM_INDEX_URL}" \
     uv pip install ai-dynamo --find-links wheelhouse && \
     uv pip install nixl --find-links wheelhouse
 
-# Copy TensorRT-LLM environment setup script
+# Setup TRTLLM environment variables, same as in dev image
+ENV TRTLLM_USE_UCX_KVCACHE=1
 COPY --from=dev /usr/local/bin/set_trtllm_env.sh /usr/local/bin/set_trtllm_env.sh
+RUN echo 'source /usr/local/bin/set_trtllm_env.sh' >> /root/.bashrc
+
+# Copy benchmarks, exmaples and tests for CI
+# TODO: Remove this once we have a functional CI image built on top of the runtime image
+COPY tests /workspace/tests
+COPY benchmarks /workspace/benchmarks
+COPY examples /workspace/examples
+RUN uv pip install /workspace/benchmarks
 
 # Copy launch banner
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -16,6 +16,8 @@
 ARG BASE_IMAGE="nvcr.io/nvidia/pytorch"
 ARG BASE_IMAGE_TAG="25.05-py3"
 ARG RELEASE_BUILD
+ARG RUNTIME_IMAGE="nvcr.io/nvidia/pytorch"
+ARG RUNTIME_IMAGE_TAG="25.05-py3"
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
 #   ARCH: Used for package suffixes (e.g., amd64, arm64)
@@ -217,6 +219,17 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN mkdir /opt/dynamo && \
     uv venv /opt/dynamo/venv --python 3.12
 
+# Activate virtual environment
+ENV VIRTUAL_ENV=/opt/dynamo/venv
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+# Install NIXL Python module
+RUN cd /opt/nixl && uv build . --out-dir /workspace/wheels/nixl
+
+# Install the wheel
+# TODO: Move NIXL wheel install to the wheel_builder stage
+RUN uv pip install /workspace/wheels/nixl/*.whl
+
 ###################################
 ####### WHEEL BUILD STAGE #########
 ###################################
@@ -348,5 +361,110 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
     echo "cat ~/.launch_screen" >> ~/.bashrc
 
 # FIXME: May want a modification with dynamo banner on entry
+ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
+CMD []
+
+####################################
+########## Runtime Image ###########
+####################################
+
+FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
+
+WORKDIR /workspace
+ENV DYNAMO_HOME=/workspace
+ENV VIRTUAL_ENV=/opt/dynamo/venv
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+# Install build-essential and python3-dev as apt dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        python3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+### COPY BINDINGS ###
+# Copy all bindings (wheels, lib, include) from dev image
+COPY --from=dev /opt/dynamo/bindings /opt/dynamo/bindings
+### COPY NATS & ETCD ###
+# Copy nats and etcd from build image
+COPY --from=build /usr/bin/nats-server /usr/bin/nats-server
+COPY --from=build /usr/local/bin/etcd/ /usr/local/bin/etcd/
+ENV PATH=/usr/local/bin/etcd/:$PATH
+
+# Copy TensorRT-LLM wheel context if it exists
+COPY --from=trtllm_wheel . /trtllm_wheel/
+
+# Copy UCX from build image as plugin for NIXL
+# Copy NIXL source from build image (required for NIXL plugins)
+COPY --from=build /usr/local/ucx /usr/local/ucx
+COPY --from=build /usr/local/nixl /usr/local/nixl
+ARG ARCH_ALT
+ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins
+ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu:/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins:/usr/local/ucx/lib:$LD_LIBRARY_PATH
+
+# Setup the python environment
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+RUN uv venv $VIRTUAL_ENV --python 3.12 && \
+    echo "source $VIRTUAL_ENV/bin/activate" >> ~/.bashrc
+
+# Common dependencies
+RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
+    uv pip install --requirement /tmp/requirements.txt
+
+# Install test dependencies
+#TODO: Remove this once we have a functional dev image built on top of the runtime image
+RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
+    uv pip install --requirement /tmp/requirements.txt
+
+#TODO: Remove this once we have a functional dev image built on top of the runtime image
+COPY . /workspace
+RUN uv pip install /workspace/benchmarks
+
+# Install TensorRT-LLM (same as in build stage)
+ARG HAS_TRTLLM_CONTEXT=0
+ARG TENSORRTLLM_PIP_WHEEL="tensorrt-llm"
+ARG TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"
+
+# TODO: Currently, ABI compatibility issues with TRTLLM wheel and NGC PyTorch prevent us
+# from using the TRTLLM wheel in a uv venv. Once the issues are resolved, we can
+# use uv to install TensorRT-LLM wheel within the uv venv.
+# Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel
+# because there might be mismatched versions of TensorRT between the NGC PyTorch
+# and the TRTLLM wheel.
+RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
+    pip uninstall -y tensorrt && \
+    if [ "$HAS_TRTLLM_CONTEXT" = "1" ]; then \
+        # Install from local wheel directory in build context
+        WHEEL_FILE=$(find /trtllm_wheel -name "*.whl" | head -n 1); \
+        if [ -n "$WHEEL_FILE" ]; then \
+            pip install "$WHEEL_FILE"; \
+        else \
+            echo "No wheel file found in /trtllm_wheel directory."; \
+            exit 1; \
+        fi; \
+    else \
+         # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
+         pip install --index-url "${TENSORRTLLM_INDEX_URL}" \
+         --extra-index-url https://pypi.org/simple \
+         "${TENSORRTLLM_PIP_WHEEL}" ; \
+    fi
+
+# Install the wheels and symlink executables to /usr/local/bin so dynamo components can use them
+# Dynamo components currently do not have the VIRTUAL_ENV in their PATH, so we need to symlink the executables
+# Copy Dynamo wheels into wheelhouse
+COPY --from=dev /workspace/wheels/nixl/*.whl wheelhouse/
+COPY --from=wheel_builder /workspace/dist/*.whl wheelhouse/
+RUN uv pip install ai-dynamo --find-links wheelhouse && \
+    uv pip install nixl --find-links wheelhouse && \
+    ln -sf $VIRTUAL_ENV/bin/* /usr/local/bin/
+
+# Copy TensorRT-LLM environment setup script
+COPY --from=dev /usr/local/bin/set_trtllm_env.sh /usr/local/bin/set_trtllm_env.sh
+
+# Copy launch banner
+RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \
+    sed '/^#\s/d' /workspace/launch_message.txt > ~/.launch_screen && \
+    echo "cat ~/.launch_screen" >> ~/.bashrc
+
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -17,7 +17,7 @@ ARG BASE_IMAGE="nvcr.io/nvidia/pytorch"
 ARG BASE_IMAGE_TAG="25.05-py3"
 ARG RELEASE_BUILD
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
-ARG RUNTIME_IMAGE_TAG="12.9.0-devel-ubuntu24.04"
+ARG RUNTIME_IMAGE_TAG="12.9.0-runtime-ubuntu24.04"
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
 #   ARCH: Used for package suffixes (e.g., amd64, arm64)
@@ -423,6 +423,15 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 #TODO: Remove this once we have a functional dev image built on top of the runtime image
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
     uv pip install --requirement /tmp/requirements.txt
+
+# Copy CUDA toolkit components needed for nvcc
+COPY --from=build /usr/local/cuda/bin/ /usr/local/cuda/bin/
+COPY --from=build /usr/local/cuda/include /usr/local/cuda/include
+COPY --from=build /usr/local/cuda/lib64/libcudart.so* /usr/local/cuda/lib64/
+COPY --from=build /usr/local/cuda/lib64/libnvvm.so* /usr/local/cuda/lib64/
+COPY --from=build /usr/local/cuda/lib64/libnvvmx.so* /usr/local/cuda/lib64/
+COPY --from=build /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/
+COPY --from=build /usr/local/cuda/nvvm /usr/local/cuda/nvvm
 
 COPY --from=build /usr/local/lib/lib* /usr/local/lib/
 COPY --from=build /usr/local/lib/python3.12/dist-packages/torch /usr/local/lib/python3.12/dist-packages/torch

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -375,7 +375,8 @@ ENV DYNAMO_HOME=/workspace
 ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
-# Install build-essential and python3-dev as apt dependencies
+# Install apt dependencies
+# openssh-client, openssh-server are needed for OpenMPI
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
@@ -391,22 +392,15 @@ COPY --from=dev /opt/dynamo/bindings /opt/dynamo/bindings
 # Copy nats and etcd from build image
 COPY --from=build /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=build /usr/local/bin/etcd/ /usr/local/bin/etcd/
-ENV PATH=/usr/local/bin/etcd/:$PATH
 
 # Copy UCX from build image as plugin for NIXL
-# Copy NIXL source from build image (required for NIXL plugins)
 COPY --from=build /usr/local/ucx /usr/local/ucx
+# Copy NIXL source from build image (required for NIXL plugins)
 COPY --from=build /usr/local/nixl /usr/local/nixl
 # Copy HPCX from base image
 COPY --from=build /opt/hpcx /opt/hpcx
 # Copy NUMA library from build image
 COPY --from=build /usr/lib/x86_64-linux-gnu/libnuma.so* /usr/lib/x86_64-linux-gnu/
-ARG ARCH_ALT
-ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins
-ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu:/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins:/usr/local/ucx/lib:/opt/hpcx/ompi/lib:$LD_LIBRARY_PATH
-ENV OMPI_HOME=/opt/hpcx/ompi
-ENV PATH=/opt/hpcx/ompi/bin:$PATH
-ENV OPAL_PREFIX=/opt/hpcx/ompi
 
 # Setup the python environment
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -432,32 +426,50 @@ COPY --from=build /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/s
 COPY --from=build /usr/local/cuda/nvvm /usr/local/cuda/nvvm
 
 # Copy pytorch installation from NGC PyTorch
+ARG TORCH_VER=2.8.0a0+5228986c39.nv25.5
+ARG TORCHVISION_VER=0.22.0a0
+ARG SETUPTOOLS_VER=78.1.1
+ARG PYTORCH_TRITON_VER=3.3.0+git96316ce52.nvinternal
+ARG JINJA2_VER=3.1.6
+ARG NETWORKX_VER=3.4.2
+ARG SYMPY_VER=1.14.0
+ARG PACKAGING_VER=23.2
+ARG FLASH_ATTN_VER=2.7.3
+ARG MPI4PY_VER
+ARG MPMATH_VER=1.3.0
 COPY --from=build /usr/local/lib/lib* /usr/local/lib/
 COPY --from=build /usr/local/lib/python3.12/dist-packages/torch /usr/local/lib/python3.12/dist-packages/torch
-COPY --from=build /usr/local/lib/python3.12/dist-packages/torch-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torch-${TORCH_VER}.dist-info /usr/local/lib/python3.12/dist-packages/torch-${TORCH_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/torchgen /usr/local/lib/python3.12/dist-packages/torchgen
 COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision /usr/local/lib/python3.12/dist-packages/torchvision
-COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision-${TORCHVISION_VER}.dist-info /usr/local/lib/python3.12/dist-packages/torchvision-${TORCHVISION_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision.libs /usr/local/lib/python3.12/dist-packages/torchvision.libs
 COPY --from=build /usr/local/lib/python3.12/dist-packages/setuptools /usr/local/lib/python3.12/dist-packages/setuptools
+COPY --from=build /usr/local/lib/python3.12/dist-packages/setuptools-${SETUPTOOLS_VER}.dist-info /usr/local/lib/python3.12/dist-packages/setuptools-${SETUPTOOLS_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/functorch /usr/local/lib/python3.12/dist-packages/functorch
-COPY --from=build /usr/local/lib/python3.12/dist-packages/pytorch_triton-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/pytorch_triton-${PYTORCH_TRITON_VER}.dist-info /usr/local/lib/python3.12/dist-packages/pytorch_triton-${PYTORCH_TRITON_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/triton /usr/local/lib/python3.12/dist-packages/triton
 COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2 /usr/local/lib/python3.12/dist-packages/jinja2
-COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2-${JINJA2_VER}.dist-info /usr/local/lib/python3.12/dist-packages/jinja2-${JINJA2_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/networkx /usr/local/lib/python3.12/dist-packages/networkx
-COPY --from=build /usr/local/lib/python3.12/dist-packages/networkx-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/networkx-${NETWORKX_VER}.dist-info /usr/local/lib/python3.12/dist-packages/networkx-${NETWORKX_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/sympy /usr/local/lib/python3.12/dist-packages/sympy
-COPY --from=build /usr/local/lib/python3.12/dist-packages/sympy-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/sympy-${SYMPY_VER}.dist-info /usr/local/lib/python3.12/dist-packages/sympy-${SYMPY_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging /usr/local/lib/python3.12/dist-packages/packaging
-COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging-${PACKAGING_VER}.dist-info /usr/local/lib/python3.12/dist-packages/packaging-${PACKAGING_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn /usr/local/lib/python3.12/dist-packages/flash_attn
-COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn-${FLASH_ATTN_VER}.dist-info /usr/local/lib/python3.12/dist-packages/flash_attn-${FLASH_ATTN_VER}.dist-info
 COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn_2_cuda.cpython-312-*-linux-gnu.so /usr/local/lib/python3.12/dist-packages/
-COPY --from=build /usr/local/lib/python3.12/dist-packages/mpi4py /usr/local/lib/python3.12/dist-packages/mpi4py
-COPY --from=build /usr/local/lib/python3.12/dist-packages/mpi4py-*.dist-info /usr/local/lib/python3.12/dist-packages/
 COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath /usr/local/lib/python3.12/dist-packages/mpmath
-COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath-*.dist-info /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/mpmath-${MPMATH_VER}.dist-info /usr/local/lib/python3.12/dist-packages/mpmath-${MPMATH_VER}.dist-info
+
+# Setup environment variables
+ARG ARCH_ALT
+ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins
+ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu:/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu/plugins:/usr/local/ucx/lib:/opt/hpcx/ompi/lib:$LD_LIBRARY_PATH
+ENV OMPI_HOME=/opt/hpcx/ompi
+ENV PATH=/opt/hpcx/ompi/bin:/usr/local/bin/etcd/:$PATH
+ENV OPAL_PREFIX=/opt/hpcx/ompi
 
 #TODO: Remove this once we have a functional dev image built on top of the runtime image
 COPY . /workspace

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -16,8 +16,8 @@
 ARG BASE_IMAGE="nvcr.io/nvidia/pytorch"
 ARG BASE_IMAGE_TAG="25.05-py3"
 ARG RELEASE_BUILD
-ARG RUNTIME_IMAGE="nvcr.io/nvidia/pytorch"
-ARG RUNTIME_IMAGE_TAG="25.05-py3"
+ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
+ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
 #   ARCH: Used for package suffixes (e.g., amd64, arm64)
@@ -391,9 +391,6 @@ COPY --from=build /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=build /usr/local/bin/etcd/ /usr/local/bin/etcd/
 ENV PATH=/usr/local/bin/etcd/:$PATH
 
-# Copy TensorRT-LLM wheel context if it exists
-COPY --from=trtllm_wheel . /trtllm_wheel/
-
 # Copy UCX from build image as plugin for NIXL
 # Copy NIXL source from build image (required for NIXL plugins)
 COPY --from=build /usr/local/ucx /usr/local/ucx
@@ -416,6 +413,30 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
     uv pip install --requirement /tmp/requirements.txt
 
+COPY --from=build /usr/local/lib/lib* /usr/local/lib/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torch $VIRTUAL_ENV/lib/python3.12/dist-packages/torch
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torch-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torchgen $VIRTUAL_ENV/lib/python3.12/dist-packages/torchgen
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision $VIRTUAL_ENV/lib/python3.12/dist-packages/torchvision
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/torchvision.libs $VIRTUAL_ENV/lib/python3.12/dist-packages/torchvision.libs
+COPY --from=build /usr/local/lib/python3.12/dist-packages/setuptools $VIRTUAL_ENV/lib/python3.12/dist-packages/setuptools
+COPY --from=build /usr/local/lib/python3.12/dist-packages/setuptools-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/functorch $VIRTUAL_ENV/lib/python3.12/dist-packages/functorch
+COPY --from=build /usr/local/lib/python3.12/dist-packages/pytorch_triton-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/triton $VIRTUAL_ENV/lib/python3.12/dist-packages/triton
+COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2 $VIRTUAL_ENV/lib/python3.12/dist-packages/jinja2
+COPY --from=build /usr/local/lib/python3.12/dist-packages/jinja2-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/networkx $VIRTUAL_ENV/lib/python3.12/dist-packages/networkx
+COPY --from=build /usr/local/lib/python3.12/dist-packages/networkx-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/sympy $VIRTUAL_ENV/lib/python3.12/dist-packages/sympy
+COPY --from=build /usr/local/lib/python3.12/dist-packages/sympy-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging $VIRTUAL_ENV/lib/python3.12/dist-packages/packaging
+COPY --from=build /usr/local/lib/python3.12/dist-packages/packaging-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn $VIRTUAL_ENV/lib/python3.12/dist-packages/flash_attn
+COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn-*.dist-info $VIRTUAL_ENV/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/flash_attn_2_cuda.cpython-312-*-linux-gnu.so $VIRTUAL_ENV/lib/python3.12/dist-packages/
+
 #TODO: Remove this once we have a functional dev image built on top of the runtime image
 COPY . /workspace
 RUN uv pip install /workspace/benchmarks
@@ -425,38 +446,15 @@ ARG HAS_TRTLLM_CONTEXT=0
 ARG TENSORRTLLM_PIP_WHEEL="tensorrt-llm"
 ARG TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"
 
-# TODO: Currently, ABI compatibility issues with TRTLLM wheel and NGC PyTorch prevent us
-# from using the TRTLLM wheel in a uv venv. Once the issues are resolved, we can
-# use uv to install TensorRT-LLM wheel within the uv venv.
-# Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel
-# because there might be mismatched versions of TensorRT between the NGC PyTorch
-# and the TRTLLM wheel.
-RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
-    pip uninstall -y tensorrt && \
-    if [ "$HAS_TRTLLM_CONTEXT" = "1" ]; then \
-        # Install from local wheel directory in build context
-        WHEEL_FILE=$(find /trtllm_wheel -name "*.whl" | head -n 1); \
-        if [ -n "$WHEEL_FILE" ]; then \
-            pip install "$WHEEL_FILE"; \
-        else \
-            echo "No wheel file found in /trtllm_wheel directory."; \
-            exit 1; \
-        fi; \
-    else \
-         # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
-         pip install --index-url "${TENSORRTLLM_INDEX_URL}" \
-         --extra-index-url https://pypi.org/simple \
-         "${TENSORRTLLM_PIP_WHEEL}" ; \
-    fi
-
-# Install the wheels and symlink executables to /usr/local/bin so dynamo components can use them
-# Dynamo components currently do not have the VIRTUAL_ENV in their PATH, so we need to symlink the executables
 # Copy Dynamo wheels into wheelhouse
 COPY --from=dev /workspace/wheels/nixl/*.whl wheelhouse/
 COPY --from=wheel_builder /workspace/dist/*.whl wheelhouse/
-RUN uv pip install ai-dynamo --find-links wheelhouse && \
-    uv pip install nixl --find-links wheelhouse && \
-    ln -sf $VIRTUAL_ENV/bin/* /usr/local/bin/
+
+RUN uv pip install --index-url "${TENSORRTLLM_INDEX_URL}" \
+    --extra-index-url https://pypi.org/simple \
+    "${TENSORRTLLM_PIP_WHEEL}" && \
+    uv pip install ai-dynamo --find-links wheelhouse && \
+    uv pip install nixl --find-links wheelhouse
 
 # Copy TensorRT-LLM environment setup script
 COPY --from=dev /usr/local/bin/set_trtllm_env.sh /usr/local/bin/set_trtllm_env.sh

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -218,8 +218,6 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 ### VIRTUAL ENVIRONMENT SETUP ###
 RUN mkdir /opt/dynamo && \
     uv venv /opt/dynamo/venv --python 3.12
-
-# Activate virtual environment
 ENV VIRTUAL_ENV=/opt/dynamo/venv
 
 # Install NIXL Python module

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -379,7 +379,9 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
-        python3-dev && \
+        python3-dev \
+        openssh-client \
+        openssh-server && \
     rm -rf /var/lib/apt/lists/*
 
 ### COPY BINDINGS ###
@@ -405,10 +407,6 @@ ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/${ARCH_ALT}-linux-gnu:/usr/local/nixl/li
 ENV OMPI_HOME=/opt/hpcx/ompi
 ENV PATH=/opt/hpcx/ompi/bin:$PATH
 ENV OPAL_PREFIX=/opt/hpcx/ompi
-# Configure OpenMPI to use local process launch manager
-ENV OMPI_MCA_plm_rsh_agent=""
-ENV OMPI_MCA_plm="isolated"
-ENV OMPI_MCA_btl_base_warn_component_unused="0"
 
 # Setup the python environment
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -424,7 +422,7 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
     uv pip install --requirement /tmp/requirements.txt
 
-# Copy CUDA toolkit components needed for nvcc
+# Copy CUDA toolkit components needed for nvcc, cudafe, cicc etc.
 COPY --from=build /usr/local/cuda/bin/ /usr/local/cuda/bin/
 COPY --from=build /usr/local/cuda/include /usr/local/cuda/include
 COPY --from=build /usr/local/cuda/lib64/libcudart.so* /usr/local/cuda/lib64/
@@ -433,6 +431,7 @@ COPY --from=build /usr/local/cuda/lib64/libnvvmx.so* /usr/local/cuda/lib64/
 COPY --from=build /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/
 COPY --from=build /usr/local/cuda/nvvm /usr/local/cuda/nvvm
 
+# Copy pytorch installation from NGC PyTorch
 COPY --from=build /usr/local/lib/lib* /usr/local/lib/
 COPY --from=build /usr/local/lib/python3.12/dist-packages/torch /usr/local/lib/python3.12/dist-packages/torch
 COPY --from=build /usr/local/lib/python3.12/dist-packages/torch-*.dist-info /usr/local/lib/python3.12/dist-packages/

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -221,7 +221,6 @@ RUN mkdir /opt/dynamo && \
 
 # Activate virtual environment
 ENV VIRTUAL_ENV=/opt/dynamo/venv
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 # Install NIXL Python module
 RUN cd /opt/nixl && uv build . --out-dir /workspace/wheels/nixl

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -397,7 +397,7 @@ COPY --from=build /usr/local/nixl /usr/local/nixl
 # Copy OpenMPI from build image
 COPY --from=build /opt/hpcx/ompi /opt/hpcx/ompi
 # Copy NUMA library from build image
-COPY --from=build /usr/lib/x86_64-linux-gnu/libnuma.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=build /usr/lib/${ARCH_ALT}-linux-gnu/libnuma.so* /usr/lib/${ARCH_ALT}-linux-gnu/
 
 # Setup the python environment
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -382,10 +382,9 @@ RUN apt-get update && \
         openssh-server && \
     rm -rf /var/lib/apt/lists/*
 
-### COPY BINDINGS ###
 # Copy all bindings (wheels, lib, include) from dev image
 COPY --from=dev /opt/dynamo/bindings /opt/dynamo/bindings
-### COPY NATS & ETCD ###
+
 # Copy nats and etcd from build image
 COPY --from=build /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=build /usr/local/bin/etcd/ /usr/local/bin/etcd/


### PR DESCRIPTION
#### Overview:

Add new runtime image (~21 GB) to the TensorRT-LLM Dockerfile, enabling the creation of optimized production containers that are significantly smaller than the development image (~31 GB) while maintaining all necessary runtime dependencies.

Key Details -
* Runtime base image: nvcr.io/nvidia/cuda:12.9.0-runtime-ubuntu24.04
* Installs essential deb packages (build-essential, python3-dev, openssh-client, openssh-server)
* Copies only the necessary components from build stages:
  * Dynamo bindings (wheels, libraries, headers)
  * NATS and etcd
  * UCX and NIXL libraries for NIXL plugins
  * OpenMPI components
  * CUDA toolkit components (nvcc, cudafe++, ptxas, fatbinary, headers, libcudart)
  * PyTorch installation from NGC PyTorch base image
  * Installs TensorRT-LLM and Dynamo wheels using uv package manager
  * Setup required environment variables
  * Includes benchmarks, examples, tests and test dependencies for CI pipeline compatibility. ToDo: remove these later and build CI image on top of runtime image

Tested only for amd64 architecture.

closes: OPS-167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new runtime container image for TensorRT-LLM, optimized for deployment with essential system packages and pre-installed dependencies.
  * Python 3.12 virtual environment is now set up automatically with all required libraries and tools.
  * Benchmarks, examples, and test directories are included in the runtime image for easier validation and CI workflows.

* **Chores**
  * Updated environment variable configurations and improved dependency installation in the development image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->