### PR TITLE
fix: fix gpu resource spec in llm deployments

### DIFF
--- a/examples/llm/deploy/agg.yaml
+++ b/examples/llm/deploy/agg.yaml
@@ -79,11 +79,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest

--- a/examples/llm/deploy/agg_router.yaml
+++ b/examples/llm/deploy/agg_router.yaml
@@ -104,11 +104,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest

--- a/examples/llm/deploy/disagg.yaml
+++ b/examples/llm/deploy/disagg.yaml
@@ -79,11 +79,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest
@@ -106,11 +106,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest

--- a/examples/llm/deploy/disagg_router.yaml
+++ b/examples/llm/deploy/disagg_router.yaml
@@ -104,11 +104,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest
@@ -131,11 +131,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest

--- a/examples/vllm_v0/deploy/agg.yaml
+++ b/examples/vllm_v0/deploy/agg.yaml
@@ -54,11 +54,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest

--- a/examples/vllm_v0/deploy/disagg.yaml
+++ b/examples/vllm_v0/deploy/disagg.yaml
@@ -54,11 +54,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest
@@ -81,11 +81,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest

--- a/examples/vllm_v0/deploy/disagg_planner.yaml
+++ b/examples/vllm_v0/deploy/disagg_planner.yaml
@@ -55,11 +55,11 @@ spec:
         requests:
           cpu: "20"
           memory: "40Gi"
-          nvidia.com/gpu: "2"
+          gpu: "2"
         limits:
           cpu: "20"
           memory: "40Gi"
-          nvidia.com/gpu: "2"
+          gpu: "2"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest
@@ -83,11 +83,11 @@ spec:
         requests:
           cpu: "20"
           memory: "40Gi"
-          nvidia.com/gpu: "2"
+          gpu: "2"
         limits:
           cpu: "20"
           memory: "40Gi"
-          nvidia.com/gpu: "2"
+          gpu: "2"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest

--- a/examples/vllm_v1/deploy/agg.yaml
+++ b/examples/vllm_v1/deploy/agg.yaml
@@ -79,11 +79,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest

--- a/examples/vllm_v1/deploy/disagg.yaml
+++ b/examples/vllm_v1/deploy/disagg.yaml
@@ -79,11 +79,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest
@@ -106,11 +106,11 @@ spec:
         requests:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
         limits:
           cpu: "10"
           memory: "20Gi"
-          nvidia.com/gpu: "1"
+          gpu: "1"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest

--- a/examples/vllm_v1/deploy/disagg_planner.yaml
+++ b/examples/vllm_v1/deploy/disagg_planner.yaml
@@ -81,11 +81,11 @@ spec:
         requests:
           cpu: "20"
           memory: "40Gi"
-          nvidia.com/gpu: "2"
+          gpu: "2"
         limits:
           cpu: "20"
           memory: "40Gi"
-          nvidia.com/gpu: "2"
+          gpu: "2"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest
@@ -109,11 +109,11 @@ spec:
         requests:
           cpu: "20"
           memory: "40Gi"
-          nvidia.com/gpu: "2"
+          gpu: "2"
         limits:
           cpu: "20"
           memory: "40Gi"
-          nvidia.com/gpu: "2"
+          gpu: "2"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest


### PR DESCRIPTION
#### Overview:
Fixes gpu resources spec in examples:

* Change `nvidia.com/gpu` to `gpu` in resources specification

```bash
yq '.spec.services.[].extraPodSpec.mainContainer.image = env(VLLM_RUNTIME_IMAGE)' deploy/agg.yaml
++ kubectl apply -n ci-ephemeral-185605286 -f -

Error from server (BadRequest): error when creating "STDIN": DynamoGraphDeployment in version "v1alpha1" cannot be handled as a DynamoGraphDeployment: strict decoding error: unknown field "spec.services.VllmWorker.resources.limits.nvidia.com/gpu", unknown field "spec.services.VllmWorker.resources.requests.nvidia.com/gpu"
```

#### Where should the reviewer start?


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration files to use a generic GPU resource key instead of a vendor-specific one for GPU resource requests and limits. No other configuration changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->