### PR TITLE
fix: Update docker-compose.yml path for examples/llm/benchmarks

### DIFF
--- a/examples/llm/benchmarks/README.md
+++ b/examples/llm/benchmarks/README.md
@@ -43,7 +43,7 @@ This guide provides detailed steps on benchmarking Large Language Models (LLMs) 
  3. Start NATS and ETCD
 
     ```bash
-    docker compose -f deploy/docker_compose.yml up -d
+    docker compose -f deploy/metrics/docker-compose.yml up -d
     ```
 
 > [!NOTE]


### PR DESCRIPTION
#### Overview:

Update the docker-compose.yml path that has been moved from deploy to deploy/metrics.

#### Details:

N/A

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the LLM benchmarking guide to correct the Docker Compose command for starting NATS and ETCD services, ensuring accurate setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->