### PR TITLE
feat: forward logprobs and handle more sampling params

### DIFF
--- a/launch/dynamo-run/src/subprocess/trtllm_inc.py
+++ b/launch/dynamo-run/src/subprocess/trtllm_inc.py
@@ -443,15 +443,7 @@ def process_sampling_params(
     request, default_sampling_params: SamplingParams
 ) -> SamplingParams:
     """
-    Process sampling parameters from vllm to a common format.
-    Returns a dictionary with processed parameter values that can be used to construct
-    either tensorrt_llm.SamplingParams or trtllm.SamplingConfig
-
-    Args:
-        sampling_params: vllm SamplingParams object
-
-    Returns:
-        dict: A dictionary with processed parameter values
+    Process sampling parameters from request to trtllm.SamplingParams.
     """
     sampling_params = request["sampling_options"]
     output_options = request["output_options"]
@@ -530,7 +522,6 @@ def process_sampling_params(
         n_seq = 1
 
     trtllm_sampling_params = default_sampling_params
-    trtllm_sampling_params.use_beam_search = False
     trtllm_sampling_params.use_beam_search = False  #  changes output if set to True
     trtllm_sampling_params.top_k = top_k
     trtllm_sampling_params.top_p = top_p

--- a/lib/llm/src/mocker/engine.rs
+++ b/lib/llm/src/mocker/engine.rs
@@ -525,7 +525,7 @@ mod integration_tests {
     use super::*;
     use crate::kv_router::indexer::RouterEvent;
     use crate::kv_router::KV_EVENT_SUBJECT;
-    use crate::protocols::common::{SamplingOptions, StopConditions};
+    use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
     use dynamo_runtime::{
         pipeline::Context,
         pipeline::{network::Ingress, PushRouter},
@@ -640,6 +640,7 @@ mod integration_tests {
                 ..Default::default()
             },
             sampling_options: SamplingOptions::default(),
+            output_options: OutputOptions::default(),
             eos_token_ids: vec![],
             mdc_sum: None,
             annotations: vec![format!("dp_rank:{dp_rank}")],

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -45,7 +45,7 @@ use dynamo_runtime::pipeline::{
 use dynamo_runtime::protocols::annotated::{Annotated, AnnotationsProvider};
 
 use crate::protocols::{
-    common::{SamplingOptionsProvider, StopConditionsProvider},
+    common::{OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider},
     openai::{
         chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
         completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
@@ -158,6 +158,7 @@ impl OpenAIPreprocessor {
             + AnnotationsProvider
             + SamplingOptionsProvider
             + StopConditionsProvider
+            + OutputOptionsProvider
             + NvExtProvider,
     >(
         &self,
@@ -263,6 +264,7 @@ impl OpenAIPreprocessor {
 
         builder.stop_conditions(stop_conditions);
         builder.sampling_options(request.extract_sampling_options()?);
+        builder.output_options(request.extract_output_options()?);
         builder.annotations(request.annotations().unwrap_or_default());
         builder.mdc_sum(Some(self.mdcsum.clone()));
         builder.estimated_prefix_hit_num_blocks(None);

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -45,6 +45,10 @@ pub trait StopConditionsProvider {
     fn extract_stop_conditions(&self) -> Result<StopConditions>;
 }
 
+pub trait OutputOptionsProvider {
+    fn extract_output_options(&self) -> Result<OutputOptions>;
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum FinishReason {
     #[serde(rename = "eos")]
@@ -178,6 +182,9 @@ pub struct CompletionRequest {
     /// More documentation on how and on the order in which sampling options are applied
     /// are needed.
     pub sampling_options: SamplingOptions,
+
+    #[builder(default)]
+    pub output_options: OutputOptions,
 
     /// The computed checksum of the Model Deployment Card (MDC).
     #[builder(default)]

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -16,7 +16,7 @@
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use super::{SamplingOptions, StopConditions};
+use super::{OutputOptions, SamplingOptions, StopConditions};
 use crate::protocols::TokenIdType;
 
 /// [`PreprocessedRequest`] is the internal representation of an LLM request. The [`dynamo.llm-preprocessor`]
@@ -37,6 +37,9 @@ pub struct PreprocessedRequest {
     /// More documentation on how and on the order in which sampling options are applied
     /// are needed.
     pub sampling_options: SamplingOptions,
+
+    /// OutputOptions are options that control the output of the inference engine.
+    pub output_options: OutputOptions,
 
     /// The EOS token ID(s) for the Model
     /// Not every backend needs this, but those that do can find it here.

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -38,7 +38,8 @@ pub struct PreprocessedRequest {
     /// are needed.
     pub sampling_options: SamplingOptions,
 
-    /// OutputOptions are options that control the output of the inference engine.
+    /// OutputOptions are options that control the output of the inference engine such as whether
+    /// to return log probabilities, or whether to skip special tokens in output.
     pub output_options: OutputOptions,
 
     /// The EOS token ID(s) for the Model

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -184,7 +184,7 @@ impl OpenAIOutputOptionsProvider for NvCreateChatCompletionRequest {
                 if logprobs {
                     match self.inner.top_logprobs {
                         Some(top_logprobs) => Some(top_logprobs as u32),
-                        None => Some(1 as u32),
+                        None => Some(1_u32),
                     }
                 } else {
                     None

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -20,8 +20,8 @@ use validator::Validate;
 use crate::engines::ValidateRequest;
 
 use super::{
-    nvext::NvExt, nvext::NvExtProvider, validate, OpenAISamplingOptionsProvider,
-    OpenAIStopConditionsProvider,
+    nvext::NvExt, nvext::NvExtProvider, validate, OpenAIOutputOptionsProvider,
+    OpenAISamplingOptionsProvider, OpenAIStopConditionsProvider,
 };
 
 mod aggregator;
@@ -174,6 +174,36 @@ impl OpenAIStopConditionsProvider for NvCreateChatCompletionRequest {
     /// Returns a reference to the optional `NvExt` extension, if available.
     fn nvext(&self) -> Option<&NvExt> {
         self.nvext.as_ref()
+    }
+}
+
+impl OpenAIOutputOptionsProvider for NvCreateChatCompletionRequest {
+    fn get_logprobs(&self) -> Option<u32> {
+        match self.inner.logprobs {
+            Some(logprobs) => {
+                if logprobs {
+                    match self.inner.top_logprobs {
+                        Some(top_logprobs) => Some(top_logprobs as u32),
+                        None => Some(1 as u32),
+                    }
+                } else {
+                    None
+                }
+            }
+            None => None,
+        }
+    }
+
+    fn get_prompt_logprobs(&self) -> Option<u32> {
+        None
+    }
+
+    fn get_skip_special_tokens(&self) -> Option<bool> {
+        None
+    }
+
+    fn get_formatted_prompt(&self) -> Option<bool> {
+        None
     }
 }
 

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -242,9 +242,9 @@ impl TryFrom<NvCreateCompletionRequest> for common::CompletionRequest {
             prompt,
             stop_conditions,
             sampling_options,
+            output_options,
             mdc_sum: None,
             annotations: None,
-            output_options: output_options,
         })
     }
 }
@@ -286,17 +286,14 @@ impl TryFrom<common::StreamingCompletionResponse> for async_openai::types::Choic
 
 impl OpenAIOutputOptionsProvider for NvCreateCompletionRequest {
     fn get_logprobs(&self) -> Option<u32> {
-        match self.inner.logprobs {
-            Some(logprobs) => Some(logprobs as u32),
-            None => None,
-        }
+        self.inner.logprobs.map(|logprobs| logprobs as u32)
     }
 
     fn get_prompt_logprobs(&self) -> Option<u32> {
         match self.inner.echo {
             Some(echo) => {
                 if echo {
-                    Some(1 as u32)
+                    Some(1_u32)
                 } else {
                     None
                 }

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -290,16 +290,10 @@ impl OpenAIOutputOptionsProvider for NvCreateCompletionRequest {
     }
 
     fn get_prompt_logprobs(&self) -> Option<u32> {
-        match self.inner.echo {
-            Some(echo) => {
-                if echo {
-                    Some(1_u32)
-                } else {
-                    None
-                }
-            }
-            None => None,
-        }
+        self.inner.echo.map(|echo| match echo {
+            true => 1,
+            false => 0,
+        })
     }
 
     fn get_skip_special_tokens(&self) -> Option<bool> {


### PR DESCRIPTION
#### Overview:

- Forwards sampling params in `OutputOptions` (e.g. logprobs) to `PreprocessedOutput` -> engine worker.
- Populate `logprobs` in trtllm output
- Add better handling for sampling params and trtllm specific params

NB: Additional changes are needed to populate `logprobs` in chat / completion responses. Those changes will be in a follow up MR.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

- trtllm_inc.py
- preprocessor.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for output options in request processing, allowing users to specify additional output-related parameters such as log probabilities.
  * Output options are now consistently extracted and applied across different request types, improving flexibility and control over generated responses.

* **Refactor**
  * Streamlined the handling and normalization of sampling and output parameters for more predictable and robust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->