### PR TITLE
chore: envvars for http paths and live health endpoint

### DIFF
--- a/lib/llm/src/http/service/health.rs
+++ b/lib/llm/src/http/service/health.rs
@@ -52,27 +52,12 @@ pub fn live_check_router(
     state: Arc<service_v2::State>,
     path: Option<String>,
 ) -> (Vec<RouteDoc>, Router) {
-    let live_path = path.unwrap_or_else(|| "/v1/health/live".to_string());
+    let live_path = path.unwrap_or_else(|| "/live".to_string());
 
     let docs: Vec<RouteDoc> = vec![RouteDoc::new(Method::GET, &live_path)];
 
     let router = Router::new()
         .route(&live_path, get(live_handler))
-        .with_state(state);
-
-    (docs, router)
-}
-
-pub fn ready_check_router(
-    state: Arc<service_v2::State>,
-    path: Option<String>,
-) -> (Vec<RouteDoc>, Router) {
-    let ready_path = path.unwrap_or_else(|| "/v1/health/ready".to_string());
-
-    let docs: Vec<RouteDoc> = vec![RouteDoc::new(Method::GET, &ready_path)];
-
-    let router = Router::new()
-        .route(&ready_path, get(health_handler))
         .with_state(state);
 
     (docs, router)

--- a/lib/llm/src/http/service/health.rs
+++ b/lib/llm/src/http/service/health.rs
@@ -37,15 +37,57 @@ pub fn health_check_router(
     state: Arc<service_v2::State>,
     path: Option<String>,
 ) -> (Vec<RouteDoc>, Router) {
-    let path = path.unwrap_or_else(|| "/health".to_string());
+    let health_path = path.unwrap_or_else(|| "/health".to_string());
 
-    let docs: Vec<RouteDoc> = vec![RouteDoc::new(Method::GET, &path)];
+    let docs: Vec<RouteDoc> = vec![RouteDoc::new(Method::GET, &health_path)];
 
     let router = Router::new()
-        .route(&path, get(health_handler))
+        .route(&health_path, get(health_handler))
         .with_state(state);
 
     (docs, router)
+}
+
+pub fn live_check_router(
+    state: Arc<service_v2::State>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let live_path = path.unwrap_or_else(|| "/v1/health/live".to_string());
+
+    let docs: Vec<RouteDoc> = vec![RouteDoc::new(Method::GET, &live_path)];
+
+    let router = Router::new()
+        .route(&live_path, get(live_handler))
+        .with_state(state);
+
+    (docs, router)
+}
+
+pub fn ready_check_router(
+    state: Arc<service_v2::State>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let ready_path = path.unwrap_or_else(|| "/v1/health/ready".to_string());
+
+    let docs: Vec<RouteDoc> = vec![RouteDoc::new(Method::GET, &ready_path)];
+
+    let router = Router::new()
+        .route(&ready_path, get(health_handler))
+        .with_state(state);
+
+    (docs, router)
+}
+
+async fn live_handler(
+    axum::extract::State(_state): axum::extract::State<Arc<service_v2::State>>,
+) -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(json!({
+            "status": "live",
+            "message": "Service is live"
+        })),
+    )
 }
 
 async fn health_handler(

--- a/lib/llm/src/http/service/health.rs
+++ b/lib/llm/src/http/service/health.rs
@@ -64,10 +64,8 @@ pub fn live_check_router(
 }
 
 async fn live_handler(
-    axum::extract::State(state): axum::extract::State<Arc<service_v2::State>>,
+    axum::extract::State(_state): axum::extract::State<Arc<service_v2::State>>,
 ) -> impl IntoResponse {
-    // This will panic if we can get the list of models
-    let _ = state.manager().get_model_entries();
     (
         StatusCode::OK,
         Json(json!({

--- a/lib/llm/src/http/service/health.rs
+++ b/lib/llm/src/http/service/health.rs
@@ -64,8 +64,10 @@ pub fn live_check_router(
 }
 
 async fn live_handler(
-    axum::extract::State(_state): axum::extract::State<Arc<service_v2::State>>,
+    axum::extract::State(state): axum::extract::State<Arc<service_v2::State>>,
 ) -> impl IntoResponse {
+    // This will panic if we can get the list of models
+    let _ = state.manager().get_model_entries();
     (
         StatusCode::OK,
         Json(json!({

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -151,6 +151,8 @@ impl HttpServiceConfigBuilder {
             metrics::router(registry, None),
             super::openai::list_models_router(state.clone(), None),
             super::health::health_check_router(state.clone(), None),
+            super::health::live_check_router(state.clone(), None),
+            super::health::ready_check_router(state.clone(), None),
         ];
 
         if config.enable_chat_endpoints {

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -133,13 +133,21 @@ impl HttpService {
     }
 }
 
+/// Environment variable to set the metrics endpoint path (default: `/metrics`)
 static HTTP_SVC_METRICS_PATH_ENV: &str = "DYN_HTTP_SVC_METRICS_PATH";
+/// Environment variable to set the models endpoint path (default: `/v1/models`)
 static HTTP_SVC_MODELS_PATH_ENV: &str = "DYN_HTTP_SVC_MODELS_PATH";
+/// Environment variable to set the health endpoint path (default: `/health`)
 static HTTP_SVC_HEALTH_PATH_ENV: &str = "DYN_HTTP_SVC_HEALTH_PATH";
+/// Environment variable to set the live endpoint path (default: `/live`)
 static HTTP_SVC_LIVE_PATH_ENV: &str = "DYN_HTTP_SVC_LIVE_PATH";
+/// Environment variable to set the chat completions endpoint path (default: `/v1/chat/completions`)
 static HTTP_SVC_CHAT_PATH_ENV: &str = "DYN_HTTP_SVC_CHAT_PATH";
+/// Environment variable to set the completions endpoint path (default: `/v1/completions`)
 static HTTP_SVC_CMP_PATH_ENV: &str = "DYN_HTTP_SVC_CMP_PATH";
+/// Environment variable to set the embeddings endpoint path (default: `/v1/embeddings`)
 static HTTP_SVC_EMB_PATH_ENV: &str = "DYN_HTTP_SVC_EMB_PATH";
+/// Environment variable to set the responses endpoint path (default: `/v1/responses`)
 static HTTP_SVC_RESPONSES_PATH_ENV: &str = "DYN_HTTP_SVC_RESPONSES_PATH";
 
 impl HttpServiceConfigBuilder {


### PR DESCRIPTION
#### Overview:

Add `/live` endpoint

Add environment variables to set http paths.  useful if we need to move health or metrics to conform with existing schemas. move `/health` to `/v1/health/ready` for example

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

health.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new health check endpoints for service liveness and readiness, accessible at `/v1/health/live` and `/v1/health/ready`.
  * The liveness endpoint returns a fixed JSON response indicating the service is operational.
  * The readiness endpoint reports service health based on model endpoint availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->