### PR TITLE
feat: update active blocks in chunks only when necessary

### DIFF
--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -206,9 +206,9 @@ impl KvRouter {
         Ok((best_worker_id, overlap_amount))
     }
 
-    /// Push a token to a specific request's sequence
-    pub async fn push(&self, request_id: &String, token: u32) {
-        self.scheduler.push(request_id, token).await
+    /// Push tokens to a specific request's sequence
+    pub async fn push(&self, request_id: &String, tokens: &[u32]) {
+        self.scheduler.push(request_id, tokens).await
     }
 
     /// Free all blocks associated with a request
@@ -273,6 +273,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                     .await?;
                 // Update the request with the estimated prefix hit blocks
                 let (mut backend_input, context) = request.into_parts();
+                let isl = backend_input.token_ids.len();
                 backend_input.estimated_prefix_hit_num_blocks = Some(overlap_amount);
                 let updated_request = context.map(|_| backend_input);
 
@@ -283,17 +284,33 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 let stream_context = response_stream.context();
                 let chooser = self.chooser.clone();
                 let request_id = context_id.clone();
+                let block_size = chooser.block_size() as usize;
 
                 let wrapped_stream = Box::pin(async_stream::stream! {
+                    let mut accumulated_tokens = Vec::new();
+                    let mut total_output_length = 0usize;
+                    let mut last_block_index = (isl.saturating_sub(1)) / block_size;
+
                     while let Some(item) = response_stream.next().await {
                         // Track tokens if they exist in the response
                         if let Some(ref output) = item.data {
-                            for token_id in &output.token_ids {
-                                chooser.push(&request_id, *token_id).await;
+                            if !output.token_ids.is_empty() {
+                                // Add tokens to accumulator
+                                accumulated_tokens.extend_from_slice(&output.token_ids);
+                                total_output_length += output.token_ids.len();
+
+                                // Check if we've moved to a new block
+                                let current_block_index = (isl + total_output_length).saturating_sub(1) / block_size;
+                                if current_block_index > last_block_index {
+                                    chooser.push(&request_id, &accumulated_tokens).await;
+                                    accumulated_tokens.clear();
+                                    last_block_index = current_block_index;
+                                }
                             }
                         }
                         yield item;
                     }
+
                     chooser.free(&request_id).await;
                 });
 

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -401,8 +401,10 @@ impl WorkerSelector for DefaultWorkerSelector {
         }
 
         // Normalize by dividing by max value
-        for logit in worker_logits.values_mut() {
-            *logit /= max_logit;
+        if max_logit > 0.0 {
+            for logit in worker_logits.values_mut() {
+                *logit /= max_logit;
+            }
         }
 
         // Use softmax sampling to select worker

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -259,10 +259,10 @@ impl KvScheduler {
         sequences.add_request(request_id, token_sequence, worker_id)
     }
 
-    /// Push a token to a specific request's sequence
-    pub async fn push(&self, request_id: &String, token: u32) {
+    /// Push tokens to a specific request's sequence
+    pub async fn push(&self, request_id: &String, tokens: &[u32]) {
         let mut sequences = self.sequences.lock().await;
-        sequences.push(request_id, token)
+        sequences.push(request_id, tokens)
     }
 
     /// Free all blocks associated with a request


### PR DESCRIPTION
#### Overview:

Only update the active blocks when 
(isl + current osl - 1) / block_size  
changes, meaning that a generation block is committed and a new generation block is allocated

#### Benchmarks

not really sure what happened at hit rate 0.7, but generally looks good, particularly pure load balancer
![load_balancer](https://github.com/user-attachments/assets/18f23745-c2dc-4545-bf58-96842988b6c6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved performance by allowing batch processing of multiple tokens at once, rather than handling tokens individually.

* **Bug Fixes**
  * Enhanced accuracy in block management when processing sequences of tokens.

* **Tests**
  * Updated tests to cover scenarios with multiple tokens pushed in a single operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->