### PR TITLE
feat: support separate chat_template.jinja file

### DIFF
--- a/lib/llm/src/model_card/create.rs
+++ b/lib/llm/src/model_card/create.rs
@@ -163,13 +163,14 @@ impl PromptFormatterArtifact {
         // Some HF model (i.e. meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8)
         // stores the chat template as a separate file, we want to optionally store
         // the content if it exists and put the chat template into config as normalization
-        let template : anyhow::Result<Self> = Ok(Self::HfChatTemplate(
+        let template: anyhow::Result<Self> = Ok(Self::HfChatTemplate(
             check_for_file(repo_id, "chat_template.jinja").await?,
         ));
-        Ok(template.with_context(|| format!("unable to extract prompt format from repo {}", repo_id))
+        Ok(template
+            .with_context(|| format!("unable to extract prompt format from repo {}", repo_id))
             .ok())
     }
-    
+
     async fn try_is_hf_repo(repo: &str) -> anyhow::Result<Self> {
         Ok(Self::HfTokenizerConfigJson(
             check_for_file(repo, "tokenizer_config.json").await?,

--- a/lib/llm/src/model_card/create.rs
+++ b/lib/llm/src/model_card/create.rs
@@ -160,9 +160,6 @@ impl PromptFormatterArtifact {
     }
 
     pub async fn chat_template_from_repo(repo_id: &str) -> Result<Option<Self>> {
-        // Some HF model (i.e. meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8)
-        // stores the chat template as a separate file, we want to optionally store
-        // the content if it exists and put the chat template into config as normalization
         Ok(Self::chat_template_try_is_hf_repo(repo_id)
             .await
             .with_context(|| format!("unable to extract prompt format from repo {}", repo_id))

--- a/lib/llm/src/model_card/create.rs
+++ b/lib/llm/src/model_card/create.rs
@@ -163,12 +163,16 @@ impl PromptFormatterArtifact {
         // Some HF model (i.e. meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8)
         // stores the chat template as a separate file, we want to optionally store
         // the content if it exists and put the chat template into config as normalization
-        let template: anyhow::Result<Self> = Ok(Self::HfChatTemplate(
-            check_for_file(repo_id, "chat_template.jinja").await?,
-        ));
-        Ok(template
+        Ok(Self::chat_template_try_is_hf_repo(repo_id)
+            .await
             .with_context(|| format!("unable to extract prompt format from repo {}", repo_id))
             .ok())
+    }
+
+    async fn chat_template_try_is_hf_repo(repo: &str) -> anyhow::Result<Self> {
+        Ok(Self::HfChatTemplate(
+            check_for_file(repo, "chat_template.jinja").await?,
+        ))
     }
 
     async fn try_is_hf_repo(repo: &str) -> anyhow::Result<Self> {

--- a/lib/llm/src/model_card/create.rs
+++ b/lib/llm/src/model_card/create.rs
@@ -86,6 +86,7 @@ impl ModelDeploymentCard {
             tokenizer: Some(TokenizerKind::from_gguf(gguf_file)?),
             gen_config: None, // AFAICT there is no equivalent in a GGUF
             prompt_formatter: Some(PromptFormatterArtifact::GGUF(gguf_file.to_path_buf())),
+            chat_template_file: None,
             prompt_context: None, // TODO - auto-detect prompt context
             revision: 0,
             last_published: None,
@@ -124,6 +125,7 @@ impl ModelDeploymentCard {
             tokenizer: Some(TokenizerKind::from_repo(repo_id).await?),
             gen_config: GenerationConfig::from_repo(repo_id).await.ok(), // optional
             prompt_formatter: PromptFormatterArtifact::from_repo(repo_id).await?,
+            chat_template_file: PromptFormatterArtifact::chat_template_from_repo(repo_id).await?,
             prompt_context: None, // TODO - auto-detect prompt context
             revision: 0,
             last_published: None,
@@ -157,6 +159,17 @@ impl PromptFormatterArtifact {
             .ok())
     }
 
+    pub async fn chat_template_from_repo(repo_id: &str) -> Result<Option<Self>> {
+        // Some HF model (i.e. meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8)
+        // stores the chat template as a separate file, we want to optionally store
+        // the content if it exists and put the chat template into config as normalization
+        let template : anyhow::Result<Self> = Ok(Self::HfChatTemplate(
+            check_for_file(repo_id, "chat_template.jinja").await?,
+        ));
+        Ok(template.with_context(|| format!("unable to extract prompt format from repo {}", repo_id))
+            .ok())
+    }
+    
     async fn try_is_hf_repo(repo: &str) -> anyhow::Result<Self> {
         Ok(Self::HfTokenizerConfigJson(
             check_for_file(repo, "tokenizer_config.json").await?,

--- a/lib/llm/src/model_card/model.rs
+++ b/lib/llm/src/model_card/model.rs
@@ -62,6 +62,7 @@ pub enum TokenizerKind {
 #[serde(rename_all = "snake_case")]
 pub enum PromptFormatterArtifact {
     HfTokenizerConfigJson(String),
+    HfChatTemplate(String),
     GGUF(PathBuf),
 }
 
@@ -100,6 +101,10 @@ pub struct ModelDeploymentCard {
     /// Prompt Formatter configuration
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_formatter: Option<PromptFormatterArtifact>,
+
+    /// Prompt Formatter configuration
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_template_file: Option<PromptFormatterArtifact>,
 
     /// Generation config - default sampling params
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -260,6 +265,11 @@ impl ModelDeploymentCard {
             "tokenizer_config.json"
         );
         nats_upload!(
+            self.chat_template_file,
+            PromptFormatterArtifact::HfChatTemplate,
+            "chat_template.jinja"
+        );
+        nats_upload!(
             self.tokenizer,
             TokenizerKind::HfTokenizerJson,
             "tokenizer.json"
@@ -307,6 +317,11 @@ impl ModelDeploymentCard {
             self.prompt_formatter,
             PromptFormatterArtifact::HfTokenizerConfigJson,
             "tokenizer_config.json"
+        );
+        nats_download!(
+            self.chat_template_file,
+            PromptFormatterArtifact::HfChatTemplate,
+            "chat_template.jinja"
         );
         nats_download!(
             self.tokenizer,

--- a/lib/llm/src/model_card/model.rs
+++ b/lib/llm/src/model_card/model.rs
@@ -102,7 +102,7 @@ pub struct ModelDeploymentCard {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_formatter: Option<PromptFormatterArtifact>,
 
-    /// Prompt Formatter configuration
+    /// chat template may be stored as a separate file instead of in `prompt_formatter`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_template_file: Option<PromptFormatterArtifact>,
 

--- a/lib/llm/src/preprocessor/prompt/template.rs
+++ b/lib/llm/src/preprocessor/prompt/template.rs
@@ -39,7 +39,9 @@ impl PromptFormatter {
                     .with_context(|| format!("fs:read_to_string '{file}'"))?;
                 let mut config: ChatTemplate = serde_json::from_str(&content)?;
                 // chat template may be stored in a separate file
-                if let Some(PromptFormatterArtifact::HfChatTemplate(chat_template_file)) = mdc.chat_template_file {
+                if let Some(PromptFormatterArtifact::HfChatTemplate(chat_template_file)) =
+                    mdc.chat_template_file
+                {
                     let chat_template = std::fs::read_to_string(&chat_template_file)
                         .with_context(|| format!("fs:read_to_string '{}'", chat_template_file))?;
                     // clean up the string to remove newlines
@@ -52,11 +54,9 @@ impl PromptFormatter {
                         .map_or(ContextMixins::default(), |x| ContextMixins::new(&x)),
                 )
             }
-            PromptFormatterArtifact::HfChatTemplate(_) => {
-                Err(anyhow::anyhow!(
-                    "prompt_formatter should not have type HfChatTemplate"
-                ))
-            }
+            PromptFormatterArtifact::HfChatTemplate(_) => Err(anyhow::anyhow!(
+                "prompt_formatter should not have type HfChatTemplate"
+            )),
             PromptFormatterArtifact::GGUF(gguf_path) => {
                 let config = ChatTemplate::from_gguf(&gguf_path)?;
                 Self::from_parts(config, ContextMixins::default())

--- a/lib/llm/src/preprocessor/prompt/template.rs
+++ b/lib/llm/src/preprocessor/prompt/template.rs
@@ -38,7 +38,9 @@ impl PromptFormatter {
                 let content = std::fs::read_to_string(&file)
                     .with_context(|| format!("fs:read_to_string '{file}'"))?;
                 let mut config: ChatTemplate = serde_json::from_str(&content)?;
-                // chat template may be stored in a separate file
+                // Some HF model (i.e. meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8)
+                // stores the chat template in a separate file, we check if the file exists and
+                // put the chat template into config as normalization.
                 if let Some(PromptFormatterArtifact::HfChatTemplate(chat_template_file)) =
                     mdc.chat_template_file
                 {


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Some HF model (i.e. meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8) stores the chat template as a separate file, we want to use that file if it exists and put the chat template into config as normalization

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling chat template files as a new prompt formatter artifact in model deployment cards.
  * Integrated chat template file upload and download in deployment workflows.

* **Bug Fixes**
  * Improved error handling when chat template files are missing or incorrectly used.

* **Other**
  * Enhanced prompt formatting logic to utilize chat templates stored in separate files when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->