### PR TITLE
fix: resolve incorrect finish reason propagation

### DIFF
--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -164,7 +164,9 @@ impl
 
                     let result = state.decoder.process_token_ids(&data.token_ids).unwrap();
 
-                    // todo - propagate finish reason details - possibly an annotation
+                    // NOTE: the `finish_reason` is computed from the generated `token_ids` alone.
+                    // The `data` field can have a `finish_reason` set, coming from the underlying
+                    // LLM inference `Engine`, and empty `token_ids`. See comment below for more details.
                     let finish_reason = match &result.stop_trigger {
                         Some(StopTrigger::MaxTokensLimit) => Some(FinishReason::Length),
                         Some(StopTrigger::HiddenStopTokenDetected(_)) => Some(FinishReason::Stop),
@@ -203,7 +205,15 @@ impl
                     let mut output = output;
                     let mut data = output.data.take().unwrap();
 
-                    data.finish_reason = finish_reason;
+                    // NOTE: If `finish_reason.is_some()`, then one of the stop conditions was triggered
+                    // by the token generation. We should update the `data.finish_reason` in that case.
+                    // However, if `finish_reason.is_none()`, it is possible that we are in the case where
+                    // `data.token_ids` is empty, and `data.finish_reason` is already correctly set.
+                    // In that case, `process_token_ids` above will rewrite `finish_reason` to `None`,
+                    // which we don't want to propagate to `data.finish_reason`.
+                    if finish_reason.is_some() {
+                        data.finish_reason = finish_reason;
+                    }
                     data.text = text;
                     data.tokens = Some(tokens);
 


### PR DESCRIPTION
#### Overview:

Fix streaming chat completions final chunk returning `finish_reason: null` instead of the actual finish reason (`"stop"`, `"length"`, etc.). This issue caused OpenAI API compatibility problems where clients couldn't properly detect when streaming responses had completed.

#### Details:

The bug was in the Backend operator's stream processing logic. When engines (vLLM/TensorRT/SGLang) send the final streaming chunk with empty `token_ids` and a valid `finish_reason` (e.g., `{"finish_reason": "stop", "token_ids": []}`), the Backend was incorrectly overwriting the engine's `finish_reason` with `None`.

**Root Cause:**
- Backend calls `decoder.process_token_ids([])` on empty token arrays
- Decoder returns `SeqResult { stop_trigger: None }` for empty arrays  
- Backend unconditionally overwrites `data.finish_reason = None`
- Final chunk reaches client with `"finish_reason": null`

**Fix:**
- Only overwrite `data.finish_reason` when decoder detects a stop condition (`finish_reason.is_some()`)
- Preserve the engine's original `finish_reason` when decoder finds no stop triggers
- Added comprehensive comments explaining the edge case and solution

This ensures that final streaming chunks correctly propagate the finish reason from engines through the processing pipeline to the OpenAI API response.

#### Where should the reviewer start?

- **Primary change:** `lib/llm/src/backend.rs` lines 167-200
  - Focus on the conditional logic around `if finish_reason.is_some()`
  - Review the added comments explaining the engine vs decoder finish_reason handling

#### Related Issues:

- Fixes GitHub issue: #1856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved comments to clarify how finish reasons are handled and propagated in token processing.

* **Bug Fixes**
  * Prevented overwriting of existing finish reasons when no tokens are generated, ensuring accurate reporting from the inference engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->