### PR TITLE
perf(runtime): Use all available parallelism

### DIFF
--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -62,8 +62,9 @@ fn main() -> anyhow::Result<()> {
 
     // max_worker_threads and max_blocking_threads from env vars or config file.
     let rt_config = dynamo_runtime::RuntimeConfig::from_settings()?;
+    tracing::debug!("Runtime config: {rt_config}");
 
-    // One per process. Wraps a Runtime with holds two tokio runtimes.
+    // One per process. Wraps a Runtime with holds one or two tokio runtimes.
     let worker = dynamo_runtime::Worker::from_config(rt_config)?;
 
     worker.execute(wrapper)


### PR DESCRIPTION
Performance work showed a drop-off in performance scaling when concurrency exceeds 16. Which is the number of threads we were giving tokio. Now we use all the cores on the machine which is the tokio default (and also what Go does).

Also ensure in most cases we only use a single tokio runtime. I still contend the secondary runtime is an unnecessary complication, but this way we preserve optionality (in case we choose to pin the secondary runtime to a single core), but also simplify the performance characteristics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved configuration options for runtime worker threads, allowing the number of worker threads to be automatically set based on available CPU cores if not specified.
  * Enhanced display formatting for runtime configuration, clearly indicating when default values are used.

* **Bug Fixes**
  * Improved accuracy in documentation and comments regarding runtime behavior and configuration.

* **Chores**
  * Updated internal logging for better runtime configuration visibility.
  * Minor documentation and formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->