### PR TITLE
fix: prevent null second token output & reduce time to second token l…

### DIFF
--- a/examples/tensorrt_llm/common/base_engine.py
+++ b/examples/tensorrt_llm/common/base_engine.py
@@ -314,7 +314,6 @@ class BaseTensorrtLLMEngine:
             ):
                 yield remote_prefill_response
                 return
-            num_output_tokens_so_far = len(remote_prefill_response["token_ids"])
 
             # Decode the disaggregated params from the remote prefill response
             # Decode the disaggregated params from the remote prefill response
@@ -325,11 +324,6 @@ class BaseTensorrtLLMEngine:
                     )
                 )
             )
-
-            # Send the first token response to the client
-            first_token_response = remote_prefill_response
-            first_token_response.pop("disaggregated_params")
-            yield first_token_response
 
             # Set the disaggregated params to generation_only for the rest of the generation
             disaggregated_params.request_type = "generation_only"


### PR DESCRIPTION

#### Overview:

1. Fixes the issue where the second output token is null
2. Reduce the time to second token latency, pushing the pareto frontier rightward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated token streaming behavior to no longer send the first token response separately in certain generation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->