### PR TITLE
feat: allow using ApproxKvIndexer for routing via use_kv_events flag

### DIFF
--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -207,7 +207,7 @@ The KV-aware routing arguments:
 
 - `--router-temperature`: Sets the temperature when randomly selecting workers to route to via softmax sampling on the router cost logits. Setting it to 0 recovers the deterministic behavior where the min logit is picked.
 
-- `--use-kv-events`: Sets whether to listen to KV events for maintaining the global view of cached blocks. If true, then we use the `KvIndexer` to listen to the block creation and deletion events. If false, then we use the `ApproxKvIndexer` to predict them based on the incoming requests. Set false if your backend engine does not emit KV events.
+- `--use-kv-events`: Sets whether to listen to KV events for maintaining the global view of cached blocks. If true, then we use the `KvIndexer` to listen to the block creation and deletion events. If false, `ApproxKvIndexer`, which assumes the kv cache of historical prompts exists for fixed time durations (hard-coded to 120s), is used to predict the kv cache hit ratio in each engine. Set false if your backend engine does not emit KV events.
 
 ## Full usage details
 

--- a/docs/guides/dynamo_run.md
+++ b/docs/guides/dynamo_run.md
@@ -8,7 +8,7 @@ It supports these engines: mistralrs, llamacpp, sglang, vllm, and tensorrt-llm. 
 
 Usage:
 ```
-dynamo-run in=[http|text|dyn://<path>|batch:<folder>] out=echo_core|echo_full|mistralrs|llamacpp|sglang|vllm|dyn [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--context-length=N] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin|kv] [--kv-overlap-score-weight=1.0] [--router-temperature=0.5] [--verbosity (-v|-vv)]
+dynamo-run in=[http|text|dyn://<path>|batch:<folder>] out=echo_core|echo_full|mistralrs|llamacpp|sglang|vllm|dyn [--http-port 8080] [--model-path <path>] [--model-name <served-model-name>] [--model-config <hf-repo>] [--tensor-parallel-size=1] [--context-length=N] [--num-nodes=1] [--node-rank=0] [--leader-addr=127.0.0.1:9876] [--base-gpu-id=0] [--extra-engine-args=args.json] [--router-mode random|round-robin|kv] [--kv-overlap-score-weight=1.0] [--router-temperature=0.5] [--use-kv-events=true] [--verbosity (-v|-vv)]
 ```
 
 Example: `dynamo run Qwen/Qwen3-0.6B`
@@ -201,7 +201,13 @@ The only difference from the distributed system above is `--router-mode kv`. The
 
 For performance testing, compare a typical workload with `--router-mode random|round-robin` to see if it can benefit from KV-aware routing.
 
-The argument `--kv-overlap-score-weight` sets the amount weighting on overlaps with prefix caches, which directly contributes to the prefill cost, so a large weight is expected to yield a better TTFT (at the expense of worse ITL). When this is set 0, we do not consider the prefix caches at all (falling back to pure load balancing behavior on the active blocks), in which case we do not require the backend engines to emit any KV events. The argument `--router-temperature` sets the temperature when randomly selecting the workers to route to via softmax sampling on the router cost logits, setting it to 0 recovers the deterministic behavior where the min logit is picked.
+The KV-aware routing arguments:
+
+- `--kv-overlap-score-weight`: Sets the amount of weighting on overlaps with prefix caches, which directly contributes to the prefill cost. A large weight is expected to yield a better TTFT (at the expense of worse ITL). When set to 0, prefix caches are not considered at all (falling back to pure load balancing behavior on the active blocks).
+
+- `--router-temperature`: Sets the temperature when randomly selecting workers to route to via softmax sampling on the router cost logits. Setting it to 0 recovers the deterministic behavior where the min logit is picked.
+
+- `--use-kv-events`: Sets whether to listen to KV events for maintaining the global view of cached blocks. If true, then we use the `KvIndexer` to listen to the block creation and deletion events. If false, then we use the `ApproxKvIndexer` to predict them based on the incoming requests. Set false if your backend engine does not emit KV events.
 
 ## Full usage details
 

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -128,6 +128,12 @@ pub struct Flags {
     #[arg(long)]
     pub router_temperature: Option<f64>,
 
+    /// KV Router: Whether to use KV events to maintain the view of cached blocks
+    /// If false, would use ApproxKvRouter for predictions.
+    /// Default: true
+    #[arg(long)]
+    pub use_kv_events: Option<bool>,
+
     /// Max model context length. Reduce this if you don't have enough VRAM for the full model
     /// context length (e.g. Llama 4).
     /// Defaults to the model's max, which is usually model_max_length in tokenizer_config.json.
@@ -215,6 +221,7 @@ impl Flags {
             KvRouterConfig::new(
                 self.kv_overlap_score_weight,
                 self.router_temperature,
+                self.use_kv_events,
                 self.max_num_batched_tokens,
             ),
         )

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -129,7 +129,8 @@ pub struct Flags {
     pub router_temperature: Option<f64>,
 
     /// KV Router: Whether to use KV events to maintain the view of cached blocks
-    /// If false, would use ApproxKvRouter for predictions.
+    /// If false, would use ApproxKvRouter for predicting block creation / deletion
+    /// based only on incoming requests at a timer.
     /// Default: true
     #[arg(long)]
     pub use_kv_events: Option<bool>,

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -212,18 +212,14 @@ impl ModelManager {
         kv_cache_block_size: u32,
         kv_router_config: Option<KvRouterConfig>,
     ) -> anyhow::Result<Arc<KvRouter>> {
-        // Determine if we should use KV events based on overlap score weight
-        let use_kv_events = kv_router_config
-            .as_ref()
-            .map(|config| config.overlap_score_weight > 0.0)
-            .unwrap_or(false);
-
-        let selector = Box::new(DefaultWorkerSelector::new(kv_router_config));
+        let selector = Box::new(DefaultWorkerSelector::new(kv_router_config.clone()));
         let chooser = KvRouter::new(
             component.clone(),
             kv_cache_block_size,
             Some(selector),
-            use_kv_events,
+            kv_router_config
+                .unwrap_or(KvRouterConfig::default())
+                .use_kv_events,
         )
         .await?;
         let new_kv_chooser = Arc::new(chooser);

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -217,9 +217,7 @@ impl ModelManager {
             component.clone(),
             kv_cache_block_size,
             Some(selector),
-            kv_router_config
-                .unwrap_or(KvRouterConfig::default())
-                .use_kv_events,
+            kv_router_config.unwrap_or_default().use_kv_events,
         )
         .await?;
         let new_kv_chooser = Arc::new(chooser);

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -29,7 +29,7 @@ pub mod sequence;
 use crate::{
     kv_router::{
         approx::ApproxKvIndexer,
-        indexer::{KvIndexer, KvIndexerInterface, RouterEvent},
+        indexer::{compute_block_hash_for_seq, KvIndexer, KvIndexerInterface, RouterEvent},
         metrics_aggregator::EndpointCollector,
         protocols::{LocalBlockHash, RouterRequest, RouterResponse, WorkerSelectionResult},
         scheduler::{KvScheduler, KvSchedulerError, SchedulingRequest},
@@ -185,13 +185,7 @@ impl KvRouter {
         let isl_tokens = tokens.len();
         let block_size = self.block_size;
 
-        let (complete_blocks, _partial_block) =
-            TokenBlockSequence::split_tokens(tokens, block_size, 1337_u64);
-
-        let local_block_hashes = complete_blocks
-            .into_iter()
-            .map(|block| LocalBlockHash(block.block_hash()))
-            .collect();
+        let local_block_hashes = compute_block_hash_for_seq(tokens, self.block_size);
         let overlap_scores = match &self.maybe_indexer {
             Some(indexer) => indexer.find_matches(local_block_hashes).await?,
             None => Default::default(), // Returns empty/default instance

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -30,7 +30,10 @@ pub mod sequence;
 use crate::{
     kv_router::{
         approx::ApproxKvIndexer,
-        indexer::{compute_block_hash_for_seq, KvIndexer, KvIndexerInterface, RouterEvent},
+        indexer::{
+            compute_block_hash_for_seq, KvIndexer, KvIndexerInterface, KvRouterError,
+            OverlapScores, RouterEvent,
+        },
         metrics_aggregator::EndpointCollector,
         protocols::{LocalBlockHash, RouterRequest, RouterResponse, WorkerSelectionResult},
         scheduler::{KvScheduler, KvSchedulerError, SchedulingRequest},
@@ -38,7 +41,6 @@ use crate::{
     },
     preprocessor::PreprocessedRequest,
     protocols::common::llm_backend::LLMEngineOutput,
-    tokens::TokenBlockSequence,
 };
 
 use dynamo_runtime::traits::events::EventSubscriber;
@@ -66,6 +68,8 @@ pub struct KvRouterConfig {
 
     pub router_temperature: f64,
 
+    pub use_kv_events: bool,
+
     // note: this is not actually used for now
     pub max_num_batched_tokens: u32,
 }
@@ -75,6 +79,7 @@ impl Default for KvRouterConfig {
         Self {
             overlap_score_weight: 1.0,
             router_temperature: 0.5,
+            use_kv_events: true,
             max_num_batched_tokens: 8192,
         }
     }
@@ -86,14 +91,35 @@ impl KvRouterConfig {
     pub fn new(
         overlap_score_weight: Option<f64>,
         temperature: Option<f64>,
+        use_kv_events: Option<bool>,
         max_num_batched_tokens: Option<u32>,
     ) -> Self {
         let default = Self::default();
         Self {
             overlap_score_weight: overlap_score_weight.unwrap_or(default.overlap_score_weight),
             router_temperature: temperature.unwrap_or(default.router_temperature),
+            use_kv_events: use_kv_events.unwrap_or(default.use_kv_events),
             max_num_batched_tokens: max_num_batched_tokens
                 .unwrap_or(default.max_num_batched_tokens),
+        }
+    }
+}
+
+// TODO: is there a way (macro) to auto-derive the KvIndexerInterface trait for this
+// since both variants implement it
+pub enum Indexer {
+    KvIndexer(KvIndexer),
+    ApproxKvIndexer(ApproxKvIndexer),
+}
+
+impl Indexer {
+    async fn find_matches(
+        &self,
+        sequence: Vec<LocalBlockHash>,
+    ) -> Result<OverlapScores, KvRouterError> {
+        match self {
+            Indexer::KvIndexer(indexer) => indexer.find_matches(sequence).await,
+            Indexer::ApproxKvIndexer(indexer) => indexer.find_matches(sequence).await,
         }
     }
 }
@@ -101,10 +127,15 @@ impl KvRouterConfig {
 /// A KvRouter only decides which worker you should use. It doesn't send you there.
 /// TODO: Rename this to indicate it only selects a worker, it does not route.
 pub struct KvRouter {
-    maybe_indexer: Option<ApproxKvIndexer>,
+    indexer: Indexer,
+
+    // How about a Box<dyn KvIndexerInterface>
     scheduler: KvScheduler,
+
     block_size: u32,
-    // Add mutex for serializing find_best_match calls
+
+    // To ensure blocking reads / writes
+    // TODO: benchmark tradeoffs
     find_best_match_mutex: Mutex<()>,
 }
 
@@ -123,16 +154,16 @@ impl KvRouter {
         let metrics_aggregator =
             EndpointCollector::new(component.clone(), cancellation_token.clone()).await;
 
-        // let maybe_indexer =
-        //     use_kv_events.then(|| KvIndexer::new(cancellation_token.clone(), block_size));
-
-        let maybe_indexer = use_kv_events.then(|| {
-            ApproxKvIndexer::new(
+        let indexer = if use_kv_events {
+            Indexer::KvIndexer(KvIndexer::new(cancellation_token.clone(), block_size))
+        } else {
+            // hard code 120 seconds for now
+            Indexer::ApproxKvIndexer(ApproxKvIndexer::new(
                 cancellation_token.clone(),
                 block_size,
                 Duration::from_secs(120),
-            )
-        });
+            ))
+        };
 
         let scheduler = KvScheduler::start(
             component.namespace().clone(),
@@ -144,34 +175,34 @@ impl KvRouter {
 
         // [gluo TODO] try subscribe_with_type::<RouterEvent>,
         // error checking below will be different.
-        // if let Some(ref indexer) = maybe_indexer {
-        //     let mut kv_events_rx = component.subscribe(KV_EVENT_SUBJECT).await?;
-        //     let kv_events_tx = indexer.event_sender();
+        if let Indexer::KvIndexer(ref kv_indexer) = indexer {
+            let mut kv_events_rx = component.subscribe(KV_EVENT_SUBJECT).await?;
+            let kv_events_tx = kv_indexer.event_sender();
 
-        //     tokio::spawn(async move {
-        //         while let Some(event) = kv_events_rx.next().await {
-        //             let event: RouterEvent = match serde_json::from_slice(&event.payload) {
-        //                 Ok(event) => event,
-        //                 Err(e) => {
-        //                     tracing::warn!("Failed to deserialize RouterEvent: {:?}", e);
-        //                     // Choosing warn and continue to process other events from other workers
-        //                     // A bad event likely signals a problem with a worker, but potentially other workers are still healthy
-        //                     continue;
-        //                 }
-        //             };
-        //             if let Err(e) = kv_events_tx.send(event).await {
-        //                 tracing::debug!(
-        //                     "failed to send kv event to indexer; shutting down: {:?}",
-        //                     e
-        //                 );
-        //             }
-        //         }
-        //     });
-        // }
+            tokio::spawn(async move {
+                while let Some(event) = kv_events_rx.next().await {
+                    let event: RouterEvent = match serde_json::from_slice(&event.payload) {
+                        Ok(event) => event,
+                        Err(e) => {
+                            tracing::warn!("Failed to deserialize RouterEvent: {:?}", e);
+                            // Choosing warn and continue to process other events from other workers
+                            // A bad event likely signals a problem with a worker, but potentially other workers are still healthy
+                            continue;
+                        }
+                    };
+                    if let Err(e) = kv_events_tx.send(event).await {
+                        tracing::debug!(
+                            "failed to send kv event to indexer; shutting down: {:?}",
+                            e
+                        );
+                    }
+                }
+            });
+        }
 
         tracing::info!("KV Routing initialized");
         Ok(Self {
-            maybe_indexer,
+            indexer,
             scheduler,
             block_size,
             find_best_match_mutex: Mutex::new(()), // Add this
@@ -187,16 +218,14 @@ impl KvRouter {
         tokens: &[u32],
     ) -> anyhow::Result<(i64, u32)> {
         // Acquire mutex to serialize access
+        // TODO: may as well make all the subroutines synchrnous if benchmarking favors this
         let _guard = self.find_best_match_mutex.lock().await;
 
         let isl_tokens = tokens.len();
         let block_size = self.block_size;
 
         let local_block_hashes = compute_block_hash_for_seq(tokens, self.block_size);
-        let overlap_scores = match &self.maybe_indexer {
-            Some(indexer) => indexer.find_matches(local_block_hashes).await?,
-            None => Default::default(), // Returns empty/default instance
-        };
+        let overlap_scores = self.indexer.find_matches(local_block_hashes).await?;
 
         let best_worker_id = self
             .scheduler
@@ -209,7 +238,7 @@ impl KvRouter {
             )
             .await?;
 
-        if let Some(ref indexer) = self.maybe_indexer {
+        if let Indexer::ApproxKvIndexer(ref indexer) = self.indexer {
             indexer
                 .process_routing_decision_for_request(tokens, best_worker_id)
                 .await

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -218,7 +218,7 @@ impl KvRouter {
         tokens: &[u32],
     ) -> anyhow::Result<(i64, u32)> {
         // Acquire mutex to serialize access
-        // TODO: may as well make all the subroutines synchrnous if benchmarking favors this
+        // TODO: may as well make all the subroutines synchronous if benchmarking favors this
         let _guard = self.find_best_match_mutex.lock().await;
 
         let isl_tokens = tokens.len();


### PR DESCRIPTION
#### Overview:

Additionally:
1. Guard `find_best_matches` such that only one request can run it at a time. Performance tradeoff for more optimal routing empirically.
2. Set a threshold for `TimerManager` to rebuild the binary heap when it gets too large (too many stale entries). Should not be normally needed unless the time duration is set very long
3. Cosmetic cleanups
<img width="5370" height="1779" alt="approx" src="https://github.com/user-attachments/assets/f1fd99af-1885-4f2b-8e24-98017fe78312" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the user guide for the CLI tool to include a new optional argument for KV event handling, with clearer explanations and improved formatting for related options.

* **New Features**
  * Added a configuration option to control whether the router listens to KV events or uses an approximate prediction method for cached blocks.

* **Improvements**
  * Enhanced internal logic for managing cached block routing, including improved concurrency control and more efficient handling of stale entries. 

No changes to public APIs outside of the new configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->