### PR TITLE
fix: fall back to 127.0.0.1 if hostname is not available

### DIFF
--- a/examples/vllm_v1/components/main.py
+++ b/examples/vllm_v1/components/main.py
@@ -113,6 +113,17 @@ def set_side_channel_host_and_port(
     """
     if hostname is None:
         hostname = socket.gethostname()
+        # Test if hostname is usable by attempting to bind to it
+        try:
+            test_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            test_socket.bind((hostname, 0))
+            test_socket.close()
+        except (socket.error, socket.gaierror):
+            # If hostname is not usable, fall back to localhost
+            logger.warning(
+                f"Hostname '{hostname}' is not usable, falling back to '127.0.0.1'"
+            )
+            hostname = "127.0.0.1"
     if port is None:
         port = find_free_port()
     logger.debug("Setting VLLM_NIXL_SIDE_CHANNEL_HOST to %s", hostname)

--- a/examples/vllm_v1/components/main.py
+++ b/examples/vllm_v1/components/main.py
@@ -115,9 +115,8 @@ def set_side_channel_host_and_port(
         hostname = socket.gethostname()
         # Test if hostname is usable by attempting to bind to it
         try:
-            test_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            test_socket.bind((hostname, 0))
-            test_socket.close()
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as test_socket:
+                test_socket.bind((hostname, 0))
         except (socket.error, socket.gaierror):
             # If hostname is not usable, fall back to localhost
             logger.warning(


### PR DESCRIPTION
fall back to 127.0.0.1 if hostname is not available (i.e., wrong dns registration, host not tied to NICs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when setting the side channel host by automatically falling back to a safe default if the default hostname is unusable, reducing potential connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->