### PR TITLE
fix: add missing av dependency in contanier for multimodal examples (#1881)

### DIFF
--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 accelerate==1.6.0
+av==15.0.0
 fastapi==0.115.6
 ftfy
 genai-perf==0.0.13

--- a/examples/multimodal/README.md
+++ b/examples/multimodal/README.md
@@ -254,13 +254,6 @@ For more details on managing deployments, testing, and troubleshooting, please r
 
 This example demonstrates deploying an aggregated multimodal model that can process video inputs.
 
-### Dependency
-
-Video example relies on `av` package for video preprocessing inside the encode_worker.
-Please install `av` inside the dynamo container to enable video example.
-
-`pip install av`
-
 ### Components
 
 - workers: For video serving, we have two workers, [video_encode_worker](components/video_encode_worker.py) for decoding video into frames, and [video_decode_worker](components/video_decode_worker.py) for prefilling and decoding.


### PR DESCRIPTION
#### Overview:

nvbug: [5383740](https://nvbugspro.nvidia.com/bug/5383740?commentNumber=5)

Adds missing dep `av` for video model.

PR from #1881 

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

TODO:
- separate Dockerfile: [DYN-700](https://linear.app/nvidia-dynamo/issue/DYN-700/new-dockerfile-to-install-python-deps) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiple Kubernetes deployment manifests for multimodal applications, enabling easy deployment of complex multimodal graphs with distinct service roles and resource configurations.

* **Bug Fixes**
  * Updated GPU resource specification in deployment files to use a generic `gpu` key instead of vendor-specific keys, improving compatibility.

* **Documentation**
  * Enhanced and clarified Kubernetes deployment instructions for multimodal examples.
  * Updated vLLM installation and multi-node deployment instructions for improved clarity and accuracy.

* **Chores**
  * Added a new dependency (`av==15.0.0`) for video processing.
  * Updated default service port for Dynamo from 3000 to 8000.
  * Removed in-cluster MinIO Helm chart and related configuration.

* **Refactor**
  * Consolidated Python package installation steps and improved comment consistency.
  * Replaced hardcoded port numbers in tests with a shared constant.
  * Deferred certain imports to avoid runtime errors in non-GPU environments.

* **Style**
  * Fixed minor typos and standardized comment formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->