### PR TITLE
feat: add liveness/readiness probes in graph helm chart

### DIFF
--- a/deploy/helm/chart/templates/deployment.yaml
+++ b/deploy/helm/chart/templates/deployment.yaml
@@ -79,4 +79,35 @@ spec:
         - name: NATS_SERVER
           value: "{{ $.Values.natsAddr }}"
         {{- end }}
+        ports:
+        - name: health
+          containerPort: {{ $.Values.healthPort | default 5000 }}
+        livenessProbe:
+          {{- if $serviceSpec.extraPodSpec.mainContainer.livenessProbe }}
+          {{ $serviceSpec.extraPodSpec.mainContainer.livenessProbe | toYaml | nindent 8 }}
+          {{- else }}
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 10
+          successThreshold: 1
+          httpGet:
+            path: /healthz
+            port: health
+            scheme: HTTP
+          {{- end }}
+        readinessProbe:
+          {{- if $serviceSpec.extraPodSpec.mainContainer.readinessProbe }}
+          {{ $serviceSpec.extraPodSpec.mainContainer.readinessProbe | toYaml | nindent 8 }}
+          {{- else }}
+          initialDelaySeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 10
+          successThreshold: 1
+          httpGet:
+            path: /readyz
+            port: health
+            scheme: HTTP
+          {{- end }}
 {{- end }}

--- a/deploy/helm/chart/templates/deployment.yaml
+++ b/deploy/helm/chart/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           containerPort: {{ $.Values.healthPort | default 5000 }}
         livenessProbe:
           {{- if $serviceSpec.extraPodSpec.mainContainer.livenessProbe }}
-          {{ $serviceSpec.extraPodSpec.mainContainer.livenessProbe | toYaml | nindent 8 }}
+          {{ $serviceSpec.extraPodSpec.mainContainer.livenessProbe | toYaml | nindent 10 }}
           {{- else }}
           initialDelaySeconds: 60
           periodSeconds: 60
@@ -98,7 +98,7 @@ spec:
           {{- end }}
         readinessProbe:
           {{- if $serviceSpec.extraPodSpec.mainContainer.readinessProbe }}
-          {{ $serviceSpec.extraPodSpec.mainContainer.readinessProbe | toYaml | nindent 8 }}
+          {{ $serviceSpec.extraPodSpec.mainContainer.readinessProbe | toYaml | nindent 10 }}
           {{- else }}
           initialDelaySeconds: 60
           periodSeconds: 60


### PR DESCRIPTION
#### Overview:

add liveness/readiness probes in graph helm chart


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health checking capabilities to deployments, including liveness and readiness probes for improved monitoring and reliability.
  * Container ports now explicitly include a configurable "health" port (default: 5000).

* **Chores**
  * Deployment templates updated to support customizable health probe configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->