### PR TITLE
fix: remove repeat PYTHONPATH variable and enhance robustness

### DIFF
--- a/container/Dockerfile.vllm_v1
+++ b/container/Dockerfile.vllm_v1
@@ -296,7 +296,7 @@ RUN uv pip install maturin[patchelf]
 
 USER $USERNAME
 ENV HOME=/home/$USERNAME
-ENV PYTHONPATH=$HOME/dynamo/deploy/sdk/src:$PYTHONPATH:$HOME/dynamo/components/planner/src:$PYTHONPATH
+ENV PYTHONPATH=$HOME/dynamo/deploy/sdk/src:$HOME/dynamo/components/planner/src:${PYTHONPATH:-}
 ENV CARGO_TARGET_DIR=$HOME/dynamo/.build/target
 WORKDIR $HOME
 


### PR DESCRIPTION
#### Overview:

fix: Exception exit when building local-dev docker image because of PYTHONPATH not found

#### Details:

Remove the repeat PYTHONPATH  in Dockerfile and add the default empty string for it
