### PR TITLE
feat: Python frontend / ingress node

### DIFF
--- a/components/ingress/README
+++ b/components/ingress/README
@@ -1,0 +1,9 @@
+# Dynamo ingress / frontend node.
+
+Usage: `python -m dynamo.ingress [--http-port <port>]`. Port defaults to 8080.
+
+This runs an OpenAI compliant HTTP server, a pre-processor, and a router in a single process. Engines / workers are auto-discovered when they call `register_llm`.
+
+Requires `etcd` and `nats-server -js`.
+
+This is the same as `dynamo-run in=http out=dyn`.

--- a/components/ingress/src/dynamo/ingress/__main__.py
+++ b/components/ingress/src/dynamo/ingress/__main__.py
@@ -1,0 +1,7 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from dynamo.ingress.main import main
+
+if __name__ == "__main__":
+    main()

--- a/components/ingress/src/dynamo/ingress/main.py
+++ b/components/ingress/src/dynamo/ingress/main.py
@@ -1,0 +1,63 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# Usage: `python -m dynamo.ingress [args]`
+#
+# Start a frontend node. This runs:
+# - OpenAI HTTP server.
+# - Auto-discovery: Watches etcd for engine/worker registration (via `register_llm`).
+# - Pre-processor: Prompt templating and tokenization.
+# - Router, defaulting to round-robin (TODO: Add flags to enable KV routing).
+
+import argparse
+import asyncio
+
+import uvloop
+
+from dynamo.llm import EngineType, EntrypointArgs, make_engine, run_input
+from dynamo.runtime import DistributedRuntime
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Dynamo Frontend: HTTP+Pre-processor+Router",
+        formatter_class=argparse.RawTextHelpFormatter,  # To preserve multi-line help formatting
+    )
+    parser.add_argument(
+        "--kv-cache-block-size", type=int, help="KV cache block size (u32)."
+    )
+    parser.add_argument(
+        "--http-port", type=int, default=8080, help="HTTP port for the engine (u16)."
+    )
+    flags = parser.parse_args()
+
+    kwargs = {}
+    if flags.http_port is not None:
+        kwargs["http_port"] = flags.http_port
+    if flags.kv_cache_block_size is not None:
+        kwargs["kv_cache_block_size"] = flags.kv_cache_block_size
+
+    return kwargs
+
+
+async def async_main():
+    runtime = DistributedRuntime(asyncio.get_running_loop(), False)
+    flags = parse_args()
+
+    # out=dyn
+    e = EntrypointArgs(EngineType.Dynamic, **flags)
+    engine = await make_engine(runtime, e)
+
+    # in=http
+    try:
+        await run_input(runtime, "http", engine)
+    except asyncio.exceptions.CancelledError:
+        pass
+
+
+def main():
+    uvloop.run(async_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/components/ingress/src/dynamo/ingress/main.py
+++ b/components/ingress/src/dynamo/ingress/main.py
@@ -31,9 +31,7 @@ def parse_args():
     )
     flags = parser.parse_args()
 
-    kwargs = {}
-    if flags.http_port is not None:
-        kwargs["http_port"] = flags.http_port
+    kwargs = {"http_port": flags.http_port}
     if flags.kv_cache_block_size is not None:
         kwargs["kv_cache_block_size"] = flags.kv_cache_block_size
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["deploy/sdk/src/dynamo", "components/planner/src/dynamo"]
+packages = ["deploy/sdk/src/dynamo", "components/planner/src/dynamo", "components/ingress/src/dynamo"]
 
 # This section is for including the binaries in the wheel package
 # but doesn't make them executable scripts in the venv bin directory

--- a/tests/serve/test_dynamo_serve.py
+++ b/tests/serve/test_dynamo_serve.py
@@ -285,7 +285,6 @@ class DynamoServeProcess(ManagedProcess):
                 (f"http://localhost:{port}/v1/models", self._check_model)
             ]
             health_check_ports = [port]
-            env = None
 
         self.port = port
         self.graph = graph
@@ -305,7 +304,6 @@ class DynamoServeProcess(ManagedProcess):
                 "from multiprocessing.spawn",
             ],
             log_dir=request.node.name,
-            env=env,  # Pass the environment variables
         )
 
     def _check_model(self, response):


### PR DESCRIPTION
Before: `dynamo-run in=http out=dyn [flags]`
After: `python -m dynamo.ingress [flags]`

No need to build or install the dynamo-run Rust binary. This will have the same performance as dynamo-run, it uses the Rust library.

Note we want to use `dynamo.frontend` but the older examples still use that namespace. As soon as they are removed we can rename this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new frontend node that provides an OpenAI-compatible HTTP server with integrated pre-processing and routing capabilities.
  * Added command-line options for customizing HTTP port and cache block size.
  * The frontend node now automatically discovers and registers engines or workers.

* **Documentation**
  * Added a README with usage instructions and dependency requirements for the new frontend node.

* **Chores**
  * Updated build configuration to include the new frontend package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->