### PR TITLE
fix: copy attributions and license to trtllm runtime container

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -495,6 +495,10 @@ COPY benchmarks /workspace/benchmarks
 COPY examples /workspace/examples
 RUN uv pip install /workspace/benchmarks
 
+# Copy files for legal compliance
+COPY ATTRIBUTION* /workspace/
+COPY LICENSE /workspace/
+
 # Copy launch banner
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \
     sed '/^#\s/d' /workspace/launch_message.txt > ~/.launch_screen && \

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -496,8 +496,7 @@ COPY examples /workspace/examples
 RUN uv pip install /workspace/benchmarks
 
 # Copy files for legal compliance
-COPY ATTRIBUTION* /workspace/
-COPY LICENSE /workspace/
+COPY ATTRIBUTION* LICENSE /workspace/
 
 # Copy launch banner
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \


### PR DESCRIPTION
#### Overview:

Copy attributions and license files to trtllm runtime container

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes: OPS-382


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Legal compliance files (ATTRIBUTION* and LICENSE) are now included in the container runtime image for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->