### PR TITLE
docs: fix typo and add mount-workspace to vllm doc

### DIFF
--- a/examples/vllm/README.md
+++ b/examples/vllm/README.md
@@ -40,7 +40,7 @@ docker compose -f deploy/metrics/docker-compose.yml up -d
 ```
 
 ```bash
-./container/run.sh -it --framework VLLM_V1
+./container/run.sh -it --framework VLLM_V1 --mount-workspace
 ```
 
 This includes the specific commit [vllm-project/vllm#19790](https://github.com/vllm-project/vllm/pull/19790) which enables support for external control of the DP ranks.
@@ -74,7 +74,7 @@ Note: The above architecture illustrates all the components. The final component
 
 ```bash
 # requires one gpu
-cd examples/vllm_v1
+cd examples/vllm
 bash launch/agg.sh
 ```
 
@@ -82,7 +82,7 @@ bash launch/agg.sh
 
 ```bash
 # requires two gpus
-cd examples/vllm_v1
+cd examples/vllm
 bash launch/agg_router.sh
 ```
 
@@ -90,7 +90,7 @@ bash launch/agg_router.sh
 
 ```bash
 # requires two gpus
-cd examples/vllm_v1
+cd examples/vllm
 bash launch/disagg.sh
 ```
 
@@ -98,7 +98,7 @@ bash launch/disagg.sh
 
 ```bash
 # requires three gpus
-cd examples/vllm_v1
+cd examples/vllm
 bash launch/disagg_router.sh
 ```
 
@@ -108,7 +108,7 @@ This example is not meant to be performant but showcases dynamo routing to data 
 
 ```bash
 # requires four gpus
-cd examples/vllm_v1
+cd examples/vllm
 bash launch/dep.sh
 ```
 

--- a/examples/vllm/README.md
+++ b/examples/vllm/README.md
@@ -40,7 +40,7 @@ docker compose -f deploy/metrics/docker-compose.yml up -d
 ```
 
 ```bash
-./container/run.sh -it --framework VLLM_V1 --mount-workspace
+./container/run.sh -it --framework VLLM_V1 [--mount-workspace]
 ```
 
 This includes the specific commit [vllm-project/vllm#19790](https://github.com/vllm-project/vllm/pull/19790) which enables support for external control of the DP ranks.


### PR DESCRIPTION
#### Overview:

fix some small typos

#### Details:

Add mount-workspace flag. Fix typos: vllm_v1 -> vllm



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README instructions to use the new directory name and include the `--mount-workspace` flag in example deployment commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->