### PR TITLE
fix: port race condition through deterministic ports

### DIFF
--- a/examples/vllm/components/args.py
+++ b/examples/vllm/components/args.py
@@ -13,8 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
+import os
+import socket
 import sys
+import time
 from typing import Optional
 
 from vllm.config import KVTransferConfig
@@ -27,28 +31,6 @@ logger = logging.getLogger(__name__)
 # Only used if you run it manually from the command line
 DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
 DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
-DEFAULT_BASE_PORT = 20000
-SIDE_CHANNEL_PORT_OFFSET = 1000
-
-# Port allocation strategy:
-# - KV Events: base_port + dp_rank (deterministic per rank)
-# - Side Channel: base_port + SIDE_CHANNEL_PORT_OFFSET + dp_rank (deterministic per rank)
-# This ensures no overlap between services
-# To change base port use --base-port
-
-
-def get_kv_events_port(base_port: int, dp_rank: int) -> int:
-    """Get deterministic port for KV events based on data parallel rank."""
-    port = base_port + dp_rank
-    logger.debug(f"Allocated KV events ZMQ port {port} for dp_rank {dp_rank}")
-    return port
-
-
-def get_side_channel_port(base_port: int, dp_rank: int) -> int:
-    """Get deterministic port for NIXL side channel based on data parallel rank."""
-    port = base_port + SIDE_CHANNEL_PORT_OFFSET + dp_rank
-    logger.debug(f"Allocated NIXL side channel port {port} for dp_rank {dp_rank}")
-    return port
 
 
 class Config:
@@ -59,7 +41,8 @@ class Config:
     component: str
     endpoint: str
     is_prefill_worker: bool
-    base_port: int
+    kv_port: Optional[int] = None
+    side_channel_port: Optional[int] = None
 
     # mirror vLLM
     model: str
@@ -67,42 +50,6 @@ class Config:
 
     # rest vLLM args
     engine_args: AsyncEngineArgs
-
-
-def overwrite_args(config):
-    dp_rank = config.engine_args.data_parallel_rank or 0
-
-    kv_port = get_kv_events_port(config.base_port, dp_rank)
-
-    defaults = {
-        "task": "generate",
-        "skip_tokenizer_init": True,
-        "disable_log_requests": True,
-        "enable_prefix_caching": True,
-        # KV routing relies on logging KV metrics
-        "disable_log_stats": False,
-        # Always set up KV Events for routing
-        "kv_events_config": KVEventsConfig(
-            enable_kv_cache_events=True,
-            publisher="zmq",
-            endpoint=f"tcp://*:{kv_port - dp_rank}",  # vLLM will iterate dp_rank for us, so we need to subtract it out TODO: fix in vLLM
-        ),
-        # Always setting up kv transfer for disagg
-        "kv_transfer_config": KVTransferConfig(
-            kv_connector="NixlConnector", kv_role="kv_both"
-        ),
-    }
-
-    # Made decision to always overwrite.
-    # Respecting users original cmd line args at all costs requires a bunch of arg parse work
-
-    logger.debug("Setting Dynamo defaults for vLLM")
-    for key, value in defaults.items():
-        if hasattr(config.engine_args, key):
-            setattr(config.engine_args, key, value)
-            logger.debug(f" engine_args.{key} = {value}")
-        else:
-            raise ValueError(f"{key} not found in AsyncEngineArgs from vLLM.")
 
 
 def parse_args() -> Config:
@@ -119,12 +66,6 @@ def parse_args() -> Config:
         "--is-prefill-worker",
         action="store_true",
         help="Enable prefill functionality for this worker. Currently overwrites the --endpoint to be a specially chosen dyn://dynamo.prefill.generate",
-    )
-    parser.add_argument(
-        "--base-port",
-        type=int,
-        default=DEFAULT_BASE_PORT,
-        help=f"Base port for allocating service ports. KV events will use base_port+dp_rank, side channels will use base_port+SIDE_CHANNEL_PORT_OFFSET onwards. Default: {DEFAULT_BASE_PORT}",
     )
 
     parser = AsyncEngineArgs.add_cli_args(parser)
@@ -160,7 +101,6 @@ def parse_args() -> Config:
     config.endpoint = parsed_endpoint_name
     config.engine_args = engine_args
     config.is_prefill_worker = args.is_prefill_worker
-    config.base_port = args.base_port
 
     if config.engine_args.block_size is None:
         config.engine_args.block_size = 16
@@ -168,6 +108,129 @@ def parse_args() -> Config:
             f"Setting reasonable default of {config.engine_args.block_size} for block_size"
         )
 
-    overwrite_args(config)
-
     return config
+
+
+async def allocate_and_reserve_port(
+    namespace,
+    etcd_client,
+    worker_id: str,
+    reason: str,
+) -> int:
+    """Get an OS-assigned port and atomically reserve it in ETCD."""
+
+    node_name = socket.gethostname()
+
+    # Hold socket open just long enough to reserve in ETCD
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("", 0))
+        port = sock.getsockname()[1]
+
+        # Reserve in ETCD while holding the socket
+        key = f"dyn://{namespace}/ports/{node_name}/{port}"
+        value = {
+            "worker_id": worker_id,
+            "reason": reason,
+            "reserved_at": time.time(),
+            "pid": os.getpid(),
+        }
+
+        await etcd_client.kv_create(
+            key=key,
+            value=json.dumps(value).encode(),
+            lease_id=etcd_client.primary_lease_id(),  # Auto-cleanup
+        )
+        logger.debug(f"Reserved OS-assigned port {port} for {worker_id}")
+
+    return port
+
+
+async def configure_ports_with_etcd(config: Config, etcd_client):
+    """Configure all settings that require ETCD, including port allocation and vLLM overrides."""
+
+    # First, allocate ports
+    dp_rank = config.engine_args.data_parallel_rank or 0
+    worker_id = f"vllm-{config.component}-dp{dp_rank}"
+
+    # Allocate KV events port
+    kv_port = await allocate_and_reserve_port(
+        namespace=config.namespace,
+        etcd_client=etcd_client,
+        worker_id=f"{worker_id}",
+        reason="zmq_kv_event_port",
+    )
+
+    # Allocate side channel port
+    side_channel_port = await allocate_and_reserve_port(
+        namespace=config.namespace,
+        etcd_client=etcd_client,
+        worker_id=f"{worker_id}",
+        reason="nixl_side_channel_port",
+    )
+
+    # Update config with allocated ports
+    config.kv_port = kv_port
+    config.side_channel_port = side_channel_port
+
+
+def overwrite_args(config):
+    """Set vLLM defaults for Dynamo."""
+    assert (
+        config.kv_port is not None
+    ), "Must set the kv_port, use configure_ports_with_etcd"
+    assert (
+        config.side_channel_port is not None
+    ), "Must set the kv_port, use configure_ports_with_etcd"
+
+    dp_rank = config.engine_args.data_parallel_rank or 0
+
+    defaults = {
+        "task": "generate",
+        "skip_tokenizer_init": True,
+        "disable_log_requests": True,
+        "enable_prefix_caching": True,
+        # KV routing relies on logging KV metrics
+        "disable_log_stats": False,
+        # Always setting up kv transfer for disagg
+        "kv_transfer_config": KVTransferConfig(
+            kv_connector="NixlConnector", kv_role="kv_both"
+        ),
+        "kv_events_config": KVEventsConfig(
+            enable_kv_cache_events=True,
+            publisher="zmq",
+            endpoint=f"tcp://*:{config.kv_port - dp_rank}",  # vLLM will iterate dp_rank for us, so we need to subtract it out TODO: fix in vLLM
+        ),
+    }
+
+    set_side_channel_host_and_port(config)
+
+    logger.debug("Setting Dynamo defaults for vLLM")
+    for key, value in defaults.items():
+        if hasattr(config.engine_args, key):
+            setattr(config.engine_args, key, value)
+            logger.debug(f" engine_args.{key} = {value}")
+        else:
+            raise ValueError(f"{key} not found in AsyncEngineArgs from vLLM.")
+
+
+def set_side_channel_host_and_port(config: Config, hostname: Optional[str] = None):
+    """vLLM V1 NixlConnector creates a side channel to exchange metadata with other NIXL connectors.
+    This sets the port number for the side channel.
+    """
+    if hostname is None:
+        hostname = socket.gethostname()
+        # Test if hostname is usable by attempting to bind to it
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as test_socket:
+                test_socket.bind((hostname, 0))
+        except (socket.error, socket.gaierror):
+            # If hostname is not usable, fall back to localhost
+            logger.warning(
+                f"Hostname '{hostname}' is not usable, falling back to '127.0.0.1'"
+            )
+            hostname = "127.0.0.1"
+
+    os.environ["VLLM_NIXL_SIDE_CHANNEL_HOST"] = hostname
+    os.environ["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(config.side_channel_port)
+    logger.debug(f"Set NIXL side channel to {hostname}:{config.side_channel_port}")

--- a/examples/vllm/components/main.py
+++ b/examples/vllm/components/main.py
@@ -17,11 +17,9 @@ import asyncio
 import logging
 import os
 import signal
-import socket
-from typing import Optional
 
 import uvloop
-from args import Config, get_side_channel_port, parse_args
+from args import Config, configure_ports_with_etcd, overwrite_args, parse_args
 from handlers import DecodeWorkerHandler, PrefillWorkerHandler
 from publisher import StatLoggerFactory
 from vllm.distributed.kv_events import ZmqEventPublisher
@@ -57,6 +55,10 @@ async def graceful_shutdown(runtime):
 async def worker(runtime: DistributedRuntime):
     config = parse_args()
 
+    etcd_client = runtime.etcd_client()
+    await configure_ports_with_etcd(config, etcd_client)
+    overwrite_args(config)
+
     # Set up signal handler for graceful shutdown
     loop = asyncio.get_running_loop()
 
@@ -77,8 +79,6 @@ async def worker(runtime: DistributedRuntime):
 def setup_vllm_engine(config, stat_logger=None):
     os.environ["VLLM_NO_USAGE_STATS"] = "1"  # Avoid internal HTTP requests
     os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
-
-    set_side_channel_host_and_port(config)
 
     engine_args = config.engine_args
     # Load default sampling params from `generation_config.json`
@@ -103,33 +103,6 @@ def setup_vllm_engine(config, stat_logger=None):
     )
     logger.info(f"VllmWorker for {config.model} has been initialized")
     return engine_client, vllm_config, default_sampling_params
-
-
-def set_side_channel_host_and_port(config: Config, hostname: Optional[str] = None):
-    """vLLM V1 NixlConnector creates a side channel to exchange metadata with other NIXL connectors.
-    This sets the port number for the side channel using deterministic port allocation.
-    """
-    if hostname is None:
-        hostname = socket.gethostname()
-        # Test if hostname is usable by attempting to bind to it
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as test_socket:
-                test_socket.bind((hostname, 0))
-        except (socket.error, socket.gaierror):
-            # If hostname is not usable, fall back to localhost
-            logger.warning(
-                f"Hostname '{hostname}' is not usable, falling back to '127.0.0.1'"
-            )
-            hostname = "127.0.0.1"
-
-    # Use deterministic port allocation based on data parallel rank
-    dp_rank = config.engine_args.data_parallel_rank or 0
-    port = get_side_channel_port(config.base_port, dp_rank)
-
-    logger.debug("Setting VLLM_NIXL_SIDE_CHANNEL_HOST to %s", hostname)
-    os.environ["VLLM_NIXL_SIDE_CHANNEL_HOST"] = hostname
-    logger.debug("Setting VLLM_NIXL_SIDE_CHANNEL_PORT to %s", port)
-    os.environ["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(port)
 
 
 async def init_prefill(runtime: DistributedRuntime, config: Config):

--- a/examples/vllm/launch/dep.sh
+++ b/examples/vllm/launch/dep.sh
@@ -16,8 +16,7 @@ for i in {0..3}; do
     --data-parallel-rank $i \
     --data-parallel-size 4 \
     --enable-expert-parallel \
-    --enforce-eager \
-    --kv-events-port 49500 &
+    --enforce-eager &
 done
 
 echo "All workers starting. (press Ctrl+C to stop)..."

--- a/examples/vllm/launch/dsr1_dep.sh
+++ b/examples/vllm/launch/dsr1_dep.sh
@@ -98,8 +98,7 @@ for ((i=0; i<GPUS_PER_NODE; i++)); do
         --data-parallel-address $MASTER_ADDR \
         --data-parallel-rpc-port 13345 \
         --gpu-memory-utilization 0.95 \
-        --enforce-eager \
-        --kv-events-port 49700 2>&1 | tee $LOG_DIR/dsr1_dep_${dp_rank}.log &
+        --enforce-eager 2>&1 | tee $LOG_DIR/dsr1_dep_${dp_rank}.log &
 done
 
 echo "All workers starting. (press Ctrl+C to stop)..."


### PR DESCRIPTION
#### Overview:

Using a dynamic free port finder seemed like a good idea, but it just leads to race conditions since we don't actually hold the port and then make the connection later. 

Here we use etcd to to let other workers know what ports we have taken on a given node so we don't collide. 