### PR TITLE
chore: http_server to not require DistributedRuntime, re-enable test_spawn_http_server_endpoints, and fix Cargo.toml

### DIFF
--- a/components/metrics/Cargo.toml
+++ b/components/metrics/Cargo.toml
@@ -38,4 +38,4 @@ tracing = { workspace = true }
 # TODO: Update axum to 0.8
 axum = { version = "0.6" }
 clap = { version = "4.5", features = ["derive", "env"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true }

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -80,10 +80,3 @@ env_logger = { version = "0.11" }
 reqwest = { workspace = true }
 rstest = { version = "0.23.0" }
 temp-env = { version = "0.3.6" }
-
-# These patches are to address issues in reqwest, which is used in the HTTP server test (but not on servers).
-# These are transitive dependencies to use secure versions and mitigate known vulnerabilities.
-[patch.crates-io]
-tokio  = { version = "1.18.4" }   # addresses RUSTSEC-2023-0001
-h2     = { version = "0.4.4"   }   # addresses RUSTSEC-2024-0332
-rustls = { version = "0.23.18" }   # addresses RUSTSEC-2024-0399

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -82,7 +82,8 @@ impl DistributedRuntime {
             let drt_arc = Arc::new(distributed_runtime.clone());
             let runtime_clone = distributed_runtime.runtime.clone();
             // spawn_http_server spawns its own background task:
-            let uptime_fn = Arc::new(move || drt_arc.uptime()) as Arc<dyn Fn() -> std::time::Duration + Send + Sync>;
+            let uptime_fn = Arc::new(move || drt_arc.uptime())
+                as Arc<dyn Fn() -> std::time::Duration + Send + Sync>;
             match crate::http_server::spawn_http_server(
                 &config.system_host,
                 config.system_port,

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -82,11 +82,12 @@ impl DistributedRuntime {
             let drt_arc = Arc::new(distributed_runtime.clone());
             let runtime_clone = distributed_runtime.runtime.clone();
             // spawn_http_server spawns its own background task:
+            let uptime_fn = Arc::new(move || drt_arc.uptime()) as Arc<dyn Fn() -> std::time::Duration + Send + Sync>;
             match crate::http_server::spawn_http_server(
                 &config.system_host,
                 config.system_port,
                 runtime_clone.child_token(),
-                drt_arc,
+                uptime_fn,
             )
             .await
             {

--- a/lib/runtime/src/http_server.rs
+++ b/lib/runtime/src/http_server.rs
@@ -55,7 +55,9 @@ pub struct HttpServerState {
 
 impl HttpServerState {
     /// Create new HTTP server state with pre-created metrics
-    pub fn new(uptime_fn: Arc<dyn Fn() -> std::time::Duration + Send + Sync>) -> anyhow::Result<Self> {
+    pub fn new(
+        uptime_fn: Arc<dyn Fn() -> std::time::Duration + Send + Sync>,
+    ) -> anyhow::Result<Self> {
         let registry = Arc::new(Registry::new());
 
         // Create runtime metrics


### PR DESCRIPTION
#### Overview:

1) Fix unit test to properly release DistributedRuntime. 2)Clean up Cargo.toml by pointing to a common reqwest pkg

#### Details:

1) The test doesn't release DistributedRuntime, so the tests would non-deterministically fail. Fix is to always drop drt properly. 2) Make children Cargo.toml point to the root

#### Where should the reviewer start?

lib/runtime/src/http_server.rs and individual Cargo.toml files

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-239


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `reqwest` dependency to be managed at the workspace level, ensuring consistent versioning and features across all components.
  * Removed local version and feature specifications for `reqwest` in individual crates.
  * Removed a patch section that previously pinned certain dependencies to address security vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->