### PR TITLE
fix: update inference gateway deployment instructions

### DIFF
--- a/deploy/inference-gateway/example/README.md
+++ b/deploy/inference-gateway/example/README.md
@@ -19,24 +19,35 @@ Follow the instructions in [deploy/cloud/README.md](../../deploy/cloud/README.md
 
 Deploy 2 Dynamo aggregated graphs following the instructions in [examples/llm/README.md](../../examples/llm/README.md):
 
-### Build Dynamo Graph
-```bash
-export DYNAMO_IMAGE=<your-registry>/<your-image-name>:<your-tag>
-
-# Build the service
-cd $PROJECT_ROOT/examples/llm
-export DYNAMO_TAG=$(dynamo build graphs.agg:Frontend | grep "Successfully built" |  awk '{ print $NF }' | sed 's/\.$//')
-```
-
 ### Deploy Dynamo Graphs
+
+Follow the commands to deploy 2 dynamo graphs -
+
 ```bash
+# Set pre-built vLLM dynamo base container image
+export VLLM_RUNTIME_IMAGE=<dynamo-vllm-base-image>
+# for example:
+# export VLLM_RUNTIME_IMAGE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.3.1
+
+# run the following commands from dynamo repo's root folder
+
 # Deploy first graph
 export DEPLOYMENT_NAME=llm-agg1
-# TODO: Deploy your service using a DynamoGraphDeployment CR.
+yq eval '
+  .metadata.name = env(DEPLOYMENT_NAME) |
+  .spec.services[].extraPodSpec.mainContainer.image = env(VLLM_RUNTIME_IMAGE)
+' examples/vllm_v0/deploy/agg.yaml > examples/vllm_v0/deploy/agg1.yaml
+
+kubectl apply -f examples/vllm_v0/deploy/agg1.yaml
 
 # Deploy second graph
 export DEPLOYMENT_NAME=llm-agg2
-# TODO: Deploy your service using a DynamoGraphDeployment CR.
+yq eval '
+  .metadata.name = env(DEPLOYMENT_NAME) |
+  .spec.services[].extraPodSpec.mainContainer.image = env(VLLM_RUNTIME_IMAGE)
+' examples/vllm_v0/deploy/agg.yaml > examples/vllm_v0/deploy/agg2.yaml
+
+kubectl apply -f examples/vllm_v0/deploy/agg2.yaml
 ```
 
 3. **Deploy Inference Gateway**

--- a/deploy/inference-gateway/example/resources/dynamo-epp.yaml
+++ b/deploy/inference-gateway/example/resources/dynamo-epp.yaml
@@ -33,8 +33,8 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
       - name: epp
-        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:main
-        imagePullPolicy: Always
+        image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v0.4.0
+        imagePullPolicy: IfNotPresent
         args:
         - -poolName
         - "dynamo-deepseek"

--- a/deploy/inference-gateway/example/resources/inference-pool.yaml
+++ b/deploy/inference-gateway/example/resources/inference-pool.yaml
@@ -18,11 +18,11 @@ metadata:
   name: dynamo-deepseek
   namespace: default
 spec:
-  targetPortNumber: 3000
+  targetPortNumber: 8000
   selector:
-    nvidia.com/dynamo-component-type: Frontend
+    nvidia.com/dynamo-component: Frontend
   extensionRef:
-    failureMode: FailClose
+    failureMode: FailOpen
     group: ""
     kind: Service
     name: dynamo-deepseek-epp


### PR DESCRIPTION
#### Overview:

* Builderless k8s dyanmo graph deployment based example for inference gateway set up
* This is targeted at `vllm_v0` examples specifically for release/0.3.2

fixes: https://nvbugs/5357930
closes: DEP-230

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions to use pre-built Dynamo graph images and clarified deployment steps in the README.

* **Chores**
  * Updated container image for the EPP component to a specific version and adjusted the image pull policy.
  * Modified InferencePool configuration: changed target port, updated selector label, and adjusted failure mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->