### PR TITLE
chore: Rename dynamo.ingress to dynamo.frontend

### DIFF
--- a/components/frontend/README
+++ b/components/frontend/README
@@ -1,6 +1,6 @@
-# Dynamo ingress / frontend node.
+# Dynamo frontend node.
 
-Usage: `python -m dynamo.ingress [--http-port <port>]`. Port defaults to 8080.
+Usage: `python -m dynamo.frontend [--http-port 8080]`.
 
 This runs an OpenAI compliant HTTP server, a pre-processor, and a router in a single process. Engines / workers are auto-discovered when they call `register_llm`.
 

--- a/components/frontend/src/dynamo/frontend/__main__.py
+++ b/components/frontend/src/dynamo/frontend/__main__.py
@@ -1,7 +1,7 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-from dynamo.ingress.main import main
+from dynamo.frontend.main import main
 
 if __name__ == "__main__":
     main()

--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -1,7 +1,7 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-# Usage: `python -m dynamo.ingress [args]`
+# Usage: `python -m dynamo.frontend [args]`
 #
 # Start a frontend node. This runs:
 # - OpenAI HTTP server.
@@ -24,18 +24,15 @@ def parse_args():
         formatter_class=argparse.RawTextHelpFormatter,  # To preserve multi-line help formatting
     )
     parser.add_argument(
+        "-i", "--interactive", action="store_true", help="Interactive text chat"
+    )
+    parser.add_argument(
         "--kv-cache-block-size", type=int, help="KV cache block size (u32)."
     )
     parser.add_argument(
         "--http-port", type=int, default=8080, help="HTTP port for the engine (u16)."
     )
-    flags = parser.parse_args()
-
-    kwargs = {"http_port": flags.http_port}
-    if flags.kv_cache_block_size is not None:
-        kwargs["kv_cache_block_size"] = flags.kv_cache_block_size
-
-    return kwargs
+    return parser.parse_args()
 
 
 async def async_main():
@@ -43,12 +40,18 @@ async def async_main():
     flags = parse_args()
 
     # out=dyn
-    e = EntrypointArgs(EngineType.Dynamic, **flags)
+    e = EntrypointArgs(
+        EngineType.Dynamic,
+        http_port=flags.http_port,
+        kv_cache_block_size=flags.kv_cache_block_size,
+    )
     engine = await make_engine(runtime, e)
 
-    # in=http
     try:
-        await run_input(runtime, "http", engine)
+        if flags.interactive:
+            await run_input(runtime, "text", engine)
+        else:
+            await run_input(runtime, "http", engine)
     except asyncio.exceptions.CancelledError:
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["deploy/sdk/src/dynamo", "components/planner/src/dynamo", "components/ingress/src/dynamo", "components/backends/llama_cpp/src/dynamo"]
+packages = ["deploy/sdk/src/dynamo", "components/planner/src/dynamo", "components/frontend/src/dynamo", "components/backends/llama_cpp/src/dynamo"]
 
 # This section is for including the binaries in the wheel package
 # but doesn't make them executable scripts in the venv bin directory


### PR DESCRIPTION
We now start HTTP+pre-process+router like this:
```
python -m dynamo.frontend [--http-port 8080]
```

This fits the naming we agreed on. Previously the dynamo.frontend namespace was taken up by the examples, but those are gone now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated frontend README to clarify node description and usage instructions.

* **Chores**
  * Updated internal references and build configuration to use the new frontend module path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->