### PR TITLE
fix: Don't detokenize twice in TRT-LLM examples

### DIFF
--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -126,6 +126,9 @@ async def init(runtime: DistributedRuntime, config: Config):
     default_sampling_params._setup(tokenizer)
     default_sampling_params.stop = None
 
+    # We already detokenize inside HandlerBase. No need to also do it in TRTLLM.
+    default_sampling_params.detokenize = False
+
     async with get_tensorrtllm_engine(engine_args) as engine:
         endpoint = component.endpoint(config.endpoint)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text generation handling to prevent duplicate detokenization in generated outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->