### PR TITLE
perf(router): Remove lock from router hot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,6 +1875,7 @@ name = "dynamo-runtime"
 version = "0.3.2"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "assert_matches",
  "async-nats",
  "async-once-cell",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -148,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1707,7 @@ name = "dynamo-runtime"
 version = "0.3.2"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-nats",
  "async-once-cell",
  "async-stream",

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -62,6 +62,7 @@ url = { workspace = true }
 validator = { workspace = true }
 xxhash-rust = { workspace = true }
 
+arc-swap = { version = "1" }
 async-once-cell = { version = "0.5.4" }
 educe = { version = "0.6.0" }
 figment = { version = "0.10.19", features = ["env", "json", "toml", "test"] }

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +686,7 @@ name = "dynamo-runtime"
 version = "0.3.2"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-nats",
  "async-once-cell",
  "async-stream",


### PR DESCRIPTION
Update the list of active instances in a background thread, and use [arc-swap](https://crates.io/crates/arc-swap) to make the new list active. This is broadly similar to updating an atomic pointer.

This makes the router's `client.random(request)` and `client.round_robin(request)` lock-free and usually wait-free.

Lock was introduced here: https://github.com/ai-dynamo/dynamo/pull/1424


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and responsiveness by caching available instance IDs and updating them in the background, resulting in faster instance selection.
  * Instance down reporting is now handled synchronously for quicker updates.
  * Internal logic for selecting instances is now fully synchronous, reducing delays in routing operations.

* **Chores**
  * Updated dependencies to include a new library for efficient atomic caching.
  * Removed license header comments from one file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->