### PR TITLE
chore: add some details to dynamo deploy quickstart and fix deploy.sh

### DIFF
--- a/deploy/cloud/helm/deploy.sh
+++ b/deploy/cloud/helm/deploy.sh
@@ -196,5 +196,5 @@ helm upgrade --install dynamo-platform ./platform/ \
   --set "dynamo-operator.controllerManager.manager.image.repository=${DOCKER_SERVER}/dynamo-operator" \
   --set "dynamo-operator.controllerManager.manager.image.tag=${IMAGE_TAG}" \
   --set "dynamo-operator.imagePullSecrets[0].name=docker-imagepullsecret" \
-  --set controller.env.DYNAMO_CLOUD=${DYNAMO_CLOUD}
+ # --set controller.env.DYNAMO_CLOUD=${DYNAMO_CLOUD}
 echo "Helm chart deployment complete"

--- a/deploy/cloud/helm/deploy.sh
+++ b/deploy/cloud/helm/deploy.sh
@@ -196,5 +196,4 @@ helm upgrade --install dynamo-platform ./platform/ \
   --set "dynamo-operator.controllerManager.manager.image.repository=${DOCKER_SERVER}/dynamo-operator" \
   --set "dynamo-operator.controllerManager.manager.image.tag=${IMAGE_TAG}" \
   --set "dynamo-operator.imagePullSecrets[0].name=docker-imagepullsecret" \
- # --set controller.env.DYNAMO_CLOUD=${DYNAMO_CLOUD}
 echo "Helm chart deployment complete"

--- a/docs/guides/dynamo_deploy/quickstart.md
+++ b/docs/guides/dynamo_deploy/quickstart.md
@@ -91,7 +91,7 @@ kubectl create secret docker-registry docker-imagepullsecret \
   --namespace=${NAMESPACE}
 ```
 
-If bitnami is not installed, install it by
+You need to add the bitnami helm repository by running:
 
 ```bash
 helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/docs/guides/dynamo_deploy/quickstart.md
+++ b/docs/guides/dynamo_deploy/quickstart.md
@@ -72,6 +72,8 @@ export DOCKER_SERVER=your-docker-registry.com
 export IMAGE_TAG=your-image-tag
 ```
 
+The operator image will be pulled from `$DOCKER_SERVER/dynamo-operator:$IMAGE_TAG`.
+
 ### Install Dynamo Cloud
 
 You could run the `deploy.sh` or use the manual commands under Step 1 and Step 2.
@@ -87,6 +89,12 @@ kubectl create secret docker-registry docker-imagepullsecret \
   --docker-username=${DOCKER_USERNAME} \
   --docker-password=${DOCKER_PASSWORD} \
   --namespace=${NAMESPACE}
+```
+
+If bitnami is not installed, install it by
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
 ```bash


### PR DESCRIPTION
- add some details to dynamo deploy quickstart
- comment out unused line in `deploy.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the source of the operator image and provided explicit instructions for adding the Bitnami Helm chart repository in the deployment quickstart guide.

* **Chores**
  * Updated deployment configuration to no longer set the DYNAMO_CLOUD environment variable during Helm installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->