### PR TITLE
test: Add trtllm kv router sanity tests

### DIFF
--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -192,7 +192,7 @@ trtllm_configs = {
             completions_response_handler,
         ],
         model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
-        delayed_start=45,
+        delayed_start=60,
     ),
     "disaggregated": TRTLLMConfig(
         name="disaggregated",
@@ -205,7 +205,33 @@ trtllm_configs = {
             completions_response_handler,
         ],
         model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
-        delayed_start=45,
+        delayed_start=60,
+    ),
+    "aggregated_router": TRTLLMConfig(
+        name="aggregated_router",
+        directory="/workspace/components/backends/trtllm",
+        script_name="agg_router.sh",
+        marks=[pytest.mark.gpu_1, pytest.mark.tensorrtllm],
+        endpoints=["v1/chat/completions", "v1/completions"],
+        response_handlers=[
+            chat_completions_response_handler,
+            completions_response_handler,
+        ],
+        model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+        delayed_start=60,
+    ),
+    "disaggregated_router": TRTLLMConfig(
+        name="disaggregated_router",
+        directory="/workspace/components/backends/trtllm",
+        script_name="disagg_router.sh",
+        marks=[pytest.mark.gpu_2, pytest.mark.tensorrtllm],
+        endpoints=["v1/chat/completions", "v1/completions"],
+        response_handlers=[
+            chat_completions_response_handler,
+            completions_response_handler,
+        ],
+        model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+        delayed_start=60,
     ),
 }
 

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -207,6 +207,9 @@ trtllm_configs = {
         model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
         delayed_start=60,
     ),
+    # TODO: These are sanity tests that the kv router examples launch
+    # and inference without error, but do not do detailed checks on the
+    # behavior of KV routing.
     "aggregated_router": TRTLLMConfig(
         name="aggregated_router",
         directory="/workspace/components/backends/trtllm",


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

This PR:
- Add sanity tests for agg_router and disagg_router examples to catch any obvious functional regressions to avoid example scripts breaking.
    - This PR's scope does not include detailed tests of actual kv routing behavior or confirming things like non-zero scores, selection of workers based on prompts, etc. -- this can be a future enhancement.
- Increase startup delays for better consistency

Future PR:
- Improve kv routing tests to validate kv router behavior, selection of workers, non-zero scores, etc.

CI Pipeline [here](https://gitlab-master.nvidia.com/dl/ai-dynamo/dynamo-ci/-/pipelines/31896300).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new test configurations for "aggregated_router" and "disaggregated_router" scenarios to enhance coverage of router examples.

* **Tests**
  * Increased the delayed start time for certain test configurations from 45 to 60 seconds to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->