### PR TITLE
fix: use non-dev golang image for operator

### DIFF
--- a/deploy/cloud/operator/Earthfile
+++ b/deploy/cloud/operator/Earthfile
@@ -40,7 +40,7 @@ docker:
     ARG DOCKER_SERVER=my-registry
     ARG IMAGE_TAG=latest
     ARG IMAGE_SUFFIX=dynamo-operator
-    FROM nvcr.io/nvidia/distroless/go:v3.1.9-dev
+    FROM nvcr.io/nvidia/distroless/go:v3.1.10
     WORKDIR /
     COPY +build/manager .
     USER 65532:65532


### PR DESCRIPTION
#### Overview:

Issue: dont use `nvcr.io/nvidia/distroless/go:v3.1.9-dev` dev image

closes: DYN-723

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base image version used for deployments to improve stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->