### PR TITLE
fix: use non-dev golang image for operator#1993

### DIFF
--- a/deploy/cloud/operator/Earthfile
+++ b/deploy/cloud/operator/Earthfile
@@ -40,7 +40,7 @@ docker:
     ARG DOCKER_SERVER=my-registry
     ARG IMAGE_TAG=latest
     ARG IMAGE_SUFFIX=dynamo-operator
-    FROM nvcr.io/nvidia/distroless/go:v3.1.9-dev
+    FROM nvcr.io/nvidia/distroless/go:v3.1.10
     WORKDIR /
     COPY +build/manager .
     USER 65532:65532


### PR DESCRIPTION
#### Overview:

Issue: dev image nvcr.io/nvidia/distroless/go:v3.1.9-dev is causing CVE issues during OSRB process

cheery-pick: https://github.com/ai-dynamo/dynamo/pull/1993


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
