### PR TITLE
feat: Add multimodal support fields to NVIDIA extensions (nvext) inside request

### DIFF
--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -224,7 +224,7 @@ mod tests {
         fn test_modality_validation(modality in any::<String>()) {
             let nv_ext = NvExt::builder().modality(modality.clone()).build().unwrap();
             let validation_result = nv_ext.validate();
-            
+
             if modality == "image" {
                 assert!(validation_result.is_ok(), "modality 'image' should be valid");
             } else {


### PR DESCRIPTION
#### Overview:

Add multimodal support fields to NVIDIA extensions (nvext) inside request. To be consumed by example multimodal workers if needed.

#### Details:

New Fields Added:

- multimodal_url: Option<String> - URL for multimodal model assets
- modality: Option<String> - Type of modality with validation

Test Coverage:

- Updated default tests to verify new fields are None
- Updated custom builder tests with proper .to_string() conversions
- New proptest for comprehensive modality validation

Additional Notes:

Current support only for `ModelType.Chat`

#### Where should the reviewer start?

[lib/llm/src/protocols/openai/nvext.rs](https://github.com/ai-dynamo/dynamo/compare/main...ibhosale_rust_mm?expand=1#diff-5a241967f0a7090a27b071e715fdf3b2d08d38e1ff43a0405fbcb9ec01aee79f)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a multimodal URL and its modality for relevant assets.
* **Bug Fixes**
  * Improved validation to ensure only "image" is accepted as a valid modality.
* **Tests**
  * Enhanced tests to cover new fields and modality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->