### PR TITLE
fix: incorrect helm upgrade command

### DIFF
--- a/deploy/cloud/helm/deploy.sh
+++ b/deploy/cloud/helm/deploy.sh
@@ -195,5 +195,5 @@ helm upgrade --install dynamo-platform ./platform/ \
   --namespace ${NAMESPACE} \
   --set "dynamo-operator.controllerManager.manager.image.repository=${DOCKER_SERVER}/dynamo-operator" \
   --set "dynamo-operator.controllerManager.manager.image.tag=${IMAGE_TAG}" \
-  --set "dynamo-operator.imagePullSecrets[0].name=docker-imagepullsecret" \
+  --set "dynamo-operator.imagePullSecrets[0].name=docker-imagepullsecret"
 echo "Helm chart deployment complete"


### PR DESCRIPTION
#### Overview:

fixes incorrect helm upgrade command - remove trailing `\` character
closes: DYN-724

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment script reliability by correcting command-line argument formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->