### PR TITLE
feat(frontend): router-mode settings

### DIFF
--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -60,11 +60,18 @@ def parse_args():
         help="KV Router: Temperature for worker sampling via softmax. Higher values promote more randomness, and 0 fallbacks to deterministic.",
     )
     parser.add_argument(
-        "--use-kv-events",
-        type=bool,
-        default=True,
+        "--kv-events",
+        action="store_true",
+        dest="use_kv_events",
         help=" KV Router: Whether to use KV events to maintain the view of cached blocks. If false, would use ApproxKvRouter for predicting block creation / deletion based only on incoming requests at a timer.",
     )
+    parser.add_argument(
+        "--no-kv-events",
+        action="store_false",
+        dest="use_kv_events",
+        help=" KV Router. Disable KV events.",
+    )
+    parser.set_defaults(use_kv_events=True)
 
     return parser.parse_args()
 

--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -14,7 +14,15 @@ import asyncio
 
 import uvloop
 
-from dynamo.llm import EngineType, EntrypointArgs, make_engine, run_input
+from dynamo.llm import (
+    EngineType,
+    EntrypointArgs,
+    KvRouterConfig,
+    RouterConfig,
+    RouterMode,
+    make_engine,
+    run_input,
+)
 from dynamo.runtime import DistributedRuntime
 
 
@@ -32,6 +40,32 @@ def parse_args():
     parser.add_argument(
         "--http-port", type=int, default=8080, help="HTTP port for the engine (u16)."
     )
+    parser.add_argument(
+        "--router-mode",
+        type=str,
+        choices=["round-robin", "random", "kv"],
+        default="round-robin",
+        help="How to route the request",
+    )
+    parser.add_argument(
+        "--kv-overlap-score-weight",
+        type=float,
+        default=1.0,
+        help="KV Router: Weight for overlap score in worker selection. Higher values prioritize KV cache reuse.",
+    )
+    parser.add_argument(
+        "--router-temperature",
+        type=float,
+        default=0.0,
+        help="KV Router: Temperature for worker sampling via softmax. Higher values promote more randomness, and 0 fallbacks to deterministic.",
+    )
+    parser.add_argument(
+        "--use-kv-events",
+        type=bool,
+        default=True,
+        help=" KV Router: Whether to use KV events to maintain the view of cached blocks. If false, would use ApproxKvRouter for predicting block creation / deletion based only on incoming requests at a timer.",
+    )
+
     return parser.parse_args()
 
 
@@ -39,12 +73,28 @@ async def async_main():
     runtime = DistributedRuntime(asyncio.get_running_loop(), False)
     flags = parse_args()
 
+    if flags.router_mode == "kv":
+        router_mode = RouterMode.KV
+        kv_router_config = KvRouterConfig(
+            overlap_score_weight=flags.kv_overlap_score_weight,
+            router_temperature=flags.router_temperature,
+            use_kv_events=flags.use_kv_events,
+        )
+    elif flags.router_mode == "random":
+        router_mode = RouterMode.Random
+        kv_router_config = None
+    else:
+        router_mode = RouterMode.RoundRobin
+        kv_router_config = None
+
+    kwargs = {
+        "http_port": flags.http_port,
+        "kv_cache_block_size": flags.kv_cache_block_size,
+        "router_config": RouterConfig(router_mode, kv_router_config),
+    }
+
     # out=dyn
-    e = EntrypointArgs(
-        EngineType.Dynamic,
-        http_port=flags.http_port,
-        kv_cache_block_size=flags.kv_cache_block_size,
-    )
+    e = EntrypointArgs(EngineType.Dynamic, **kwargs)
     engine = await make_engine(runtime, e)
 
     try:

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -44,7 +44,7 @@ pub async fn run(
         // Only set if user provides. Usually loaded from tokenizer_config.json
         .context_length(flags.context_length)
         .http_port(Some(flags.http_port))
-        .router_config(flags.router_config())
+        .router_config(Some(flags.router_config()))
         .request_template(flags.request_template.clone());
 
     // If `in=dyn` we want the trtllm/sglang/vllm subprocess to listen on that endpoint.

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -78,6 +78,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<llm::entrypoint::EntrypointArgs>()?;
     m.add_class::<llm::entrypoint::EngineConfig>()?;
     m.add_class::<llm::entrypoint::EngineType>()?;
+    m.add_class::<llm::entrypoint::RouterConfig>()?;
+    m.add_class::<llm::entrypoint::KvRouterConfig>()?;
     m.add_class::<llm::kv::WorkerMetricsPublisher>()?;
     m.add_class::<llm::model_card::ModelDeploymentCard>()?;
     m.add_class::<llm::preprocessor::OAIChatPreprocessor>()?;
@@ -160,7 +162,7 @@ fn register_llm<'p>(
             .model_name(model_name)
             .context_length(context_length)
             .kv_cache_block_size(kv_cache_block_size)
-            .router_config(router_config);
+            .router_config(Some(router_config));
         // Download from HF, load the ModelDeploymentCard
         let mut local_model = builder.build().await.map_err(to_pyerr)?;
         // Advertise ourself on etcd so ingress can find us

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
 from typing import (
     Any,
     AsyncGenerator,
@@ -829,11 +830,20 @@ class ModelType:
     """What type of request this model needs: Chat, Component or Backend (pre-processed)"""
     ...
 
-class RouterMode:
+class RouterMode(Enum):
     """Router mode for load balancing requests across workers"""
-    RoundRobin: 'RouterMode'
-    Random: 'RouterMode'
-    KV: 'RouterMode'
+    ...
+    #RoundRobin: 'RouterMode'
+    #Random: 'RouterMode'
+    #KV: 'RouterMode'
+
+class RouterConfig:
+    """How to route the request"""
+    ...
+
+class KvRouterConfig:
+    """Values for KV router"""
+    ...
 
 async def register_llm(model_type: ModelType, endpoint: Endpoint, model_path: str, model_name: Optional[str] = None, context_length: Optional[int] = None, kv_cache_block_size: Optional[int] = None, router_mode: Optional[RouterMode] = None) -> None:
     """Attach the model at path to the given endpoint, and advertise it as model_type"""

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1,19 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-from enum import Enum
 from typing import (
     Any,
     AsyncGenerator,
@@ -830,12 +817,9 @@ class ModelType:
     """What type of request this model needs: Chat, Component or Backend (pre-processed)"""
     ...
 
-class RouterMode(Enum):
+class RouterMode:
     """Router mode for load balancing requests across workers"""
     ...
-    #RoundRobin: 'RouterMode'
-    #Random: 'RouterMode'
-    #KV: 'RouterMode'
 
 class RouterConfig:
     """How to route the request"""

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -24,10 +24,13 @@ from dynamo._core import KvEventPublisher as KvEventPublisher
 from dynamo._core import KvIndexer as KvIndexer
 from dynamo._core import KvMetricsAggregator as KvMetricsAggregator
 from dynamo._core import KvRecorder as KvRecorder
+from dynamo._core import KvRouterConfig as KvRouterConfig
 from dynamo._core import KvStats as KvStats
 from dynamo._core import ModelType as ModelType
 from dynamo._core import OverlapScores as OverlapScores
 from dynamo._core import RadixTree as RadixTree
+from dynamo._core import RouterConfig as RouterConfig
+from dynamo._core import RouterMode as RouterMode
 from dynamo._core import SpecDecodeStats as SpecDecodeStats
 from dynamo._core import WorkerMetricsPublisher as WorkerMetricsPublisher
 from dynamo._core import WorkerStats as WorkerStats

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -212,7 +212,7 @@ impl ModelManager {
         kv_cache_block_size: u32,
         kv_router_config: Option<KvRouterConfig>,
     ) -> anyhow::Result<Arc<KvRouter>> {
-        let selector = Box::new(DefaultWorkerSelector::new(kv_router_config.clone()));
+        let selector = Box::new(DefaultWorkerSelector::new(kv_router_config));
         let chooser = KvRouter::new(
             component.clone(),
             kv_cache_block_size,

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -220,7 +220,7 @@ impl ModelWatcher {
                                 &model_entry.name,
                                 &component,
                                 card.kv_cache_block_size,
-                                self.kv_router_config.clone(),
+                                self.kv_router_config,
                             )
                             .await?;
                         let kv_push_router = KvPushRouter::new(router, chooser);
@@ -261,7 +261,7 @@ impl ModelWatcher {
                                 &model_entry.name,
                                 &component,
                                 card.kv_cache_block_size,
-                                self.kv_router_config.clone(),
+                                self.kv_router_config,
                             )
                             .await?;
                         let kv_push_router = KvPushRouter::new(router, chooser);

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -42,7 +42,7 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
                         etcd_client.clone(),
                         MODEL_ROOT_PATH,
                         router_config.router_mode,
-                        Some(router_config.kv_router_config.clone()),
+                        Some(router_config.kv_router_config),
                     )
                     .await?;
                 }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -62,7 +62,7 @@ pub trait WorkerSelector {
 }
 
 /// KV Router configuration parameters
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct KvRouterConfig {
     pub overlap_score_weight: f64,
 

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -102,8 +102,8 @@ impl LocalModelBuilder {
         self
     }
 
-    pub fn router_config(&mut self, router_config: RouterConfig) -> &mut Self {
-        self.router_config = Some(router_config);
+    pub fn router_config(&mut self, router_config: Option<RouterConfig>) -> &mut Self {
+        self.router_config = router_config;
         self
     }
 


### PR DESCRIPTION
To match `dynamo-run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new command-line options to configure request routing, including router mode selection and advanced key-value routing parameters.
  * Introduced new configuration classes for routing, now accessible from Python bindings.
  * Enabled selection between round-robin, random, and key-value router modes for more flexible request handling.

* **Documentation**
  * Updated Python type stubs and imports to reflect new routing configuration options and enums.

* **Refactor**
  * Improved configuration handling by encapsulating routing settings in dedicated configuration objects and updating builder patterns for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->