### PR TITLE
fix: Minor fixes to resolve vllm test failures in CI

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -181,7 +181,7 @@ RUN uv pip install /workspace/wheels/nixl/*.whl
 
 # Install vllm - keep this early in Dockerfile to avoid
 # rebuilds from unrelated source code changes
-ARG VLLM_REF="059d4cd"
+ARG VLLM_VERSION
 ARG MAX_JOBS=16
 ENV MAX_JOBS=$MAX_JOBS
 ENV CUDA_HOME=/usr/local/cuda

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -26,6 +26,8 @@ ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
 ARG ARCH=amd64
 ARG ARCH_ALT=x86_64
 
+ARG VLLM_VERSION="0.9.2"
+
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS nixl_base
 
 # Redeclare ARCH and ARCH_ALT so they're available in this stage
@@ -191,7 +193,7 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         cd /opt/vllm && \
         git clone https://github.com/vllm-project/vllm.git && \
         cd vllm && \
-        git checkout $VLLM_REF && \
+        git checkout v${VLLM_VERSION} && \
         uv pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128 && \
         python use_existing_torch.py && \
         uv pip install -r requirements/build.txt && \
@@ -208,7 +210,7 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
         cd /opt/vllm && \
         git clone https://github.com/vllm-project/vllm.git && \
         cd vllm && \
-        git checkout $VLLM_REF && \
+        git checkout v${VLLM_VERSION} && \
         VLLM_USE_PRECOMPILED=1 uv pip install -e . && \
         cd tools/ep_kernels && \
         bash install_python_libraries.sh && \
@@ -516,10 +518,8 @@ RUN uv pip install /workspace/benchmarks
 #Copy NIXL and Dynamo wheels into wheelhouse
 COPY --from=base /workspace/wheels/nixl/*.whl wheelhouse/
 COPY --from=wheel_builder /workspace/dist/*.whl wheelhouse/
-RUN uv pip install ai-dynamo[vllm] --find-links wheelhouse && \
-    uv pip install nixl --find-links wheelhouse && \
-    ln -sf $VIRTUAL_ENV/bin/* /usr/local/bin/ && \
-    rm -r wheelhouse
+ARG VLLM_VERSION
+RUN uv pip install ai-dynamo nixl vllm==${VLLM_VERSION} --find-links wheelhouse
 
 # Copy launch banner
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,12 +60,12 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 
 [project.optional-dependencies]
 all = [
-    "ai-dynamo-vllm~=0.8.4",
+    "vllm~=0.9.2",
     "nixl",
 ]
 
 vllm = [
-    "ai-dynamo-vllm~=0.8.4"
+    "vllm~=0.9.2",
 ]
 
 [project.scripts]


### PR DESCRIPTION
#### Overview:

There are test failures in CI due to the recent refactor to move all code from vllm_v0 to vllm_v1: https://github.com/ai-dynamo/dynamo/commit/6d2be14375e4f56759f6695edc2d80d5addd2917

At a minimum, this should resolve CI failures that are currently failing. We will also look to add DSR1 wide ep packages to the vllm runtime image once I have it figured out. 


#### Details:

Changes include: 

- Using release tags for vllm references instead of commits, since release tags are easier to track across devel and runtime build
- Update pyproject.toml to use the vllm_v1 version instead of vllm_v0

#### Where should the reviewer start?

- container/Dockerfile.vllm
- pyproject.toml

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the vLLM version used in the build process and dependency specifications to 0.9.2.
  * Simplified and streamlined Python package installation steps in the runtime environment.
  * Adjusted optional dependencies to reference the new vLLM package and version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->