### PR TITLE
feat: use service DNS instead of port forwarding for K8s-deployed SLA profiler

### DIFF
--- a/benchmarks/profiler/profile_sla.py
+++ b/benchmarks/profiler/profile_sla.py
@@ -91,7 +91,10 @@ async def run_profile(args):
             yaml.dump(prefill_config, f)
 
         client = DynamoDeploymentClient(
-            namespace=args.namespace, base_log_dir=work_dir, model_name=model_name
+            namespace=args.namespace,
+            base_log_dir=work_dir,
+            model_name=model_name,
+            service_name=args.service_name,
         )
         await client.create_deployment(prefill_config_fn)
         logger.info("Waiting for deployment to be ready...")
@@ -152,7 +155,10 @@ async def run_profile(args):
             yaml.dump(decode_config, f)
 
         client = DynamoDeploymentClient(
-            namespace=args.namespace, base_log_dir=work_dir, model_name=model_name
+            namespace=args.namespace,
+            base_log_dir=work_dir,
+            model_name=model_name,
+            service_name=args.service_name,
         )
         await client.create_deployment(decode_config_fn)
         logger.info("Waiting for deployment to be ready...")
@@ -289,7 +295,10 @@ async def run_profile(args):
         yaml.dump(prefill_config, f)
 
     client = DynamoDeploymentClient(
-        namespace=args.namespace, base_log_dir=work_dir, model_name=model_name
+        namespace=args.namespace,
+        base_log_dir=work_dir,
+        model_name=model_name,
+        service_name=args.service_name,
     )
     await client.create_deployment(prefill_config_fn)
     logger.info("Waiting for deployment to be ready...")
@@ -366,7 +375,9 @@ async def run_profile(args):
     with open(decode_config_fn, "w") as f:
         yaml.dump(decode_config, f)
 
-    client = DynamoDeploymentClient(namespace=args.namespace, base_log_dir=work_dir)
+    client = DynamoDeploymentClient(
+        namespace=args.namespace, base_log_dir=work_dir, service_name=args.service_name
+    )
     await client.create_deployment(decode_config_fn)
     logger.info("Waiting for deployment to be ready...")
     await client.wait_for_deployment_ready()
@@ -517,6 +528,11 @@ if __name__ == "__main__":
         type=int,
         default=6,
         help="how many samples to benchmark to interpolate ITL under different active kv cache size and decode context length",
+    )
+    parser.add_argument(
+        "--service-name",
+        type=str,
+        help="Service name for port forwarding (default: {deployment_name}-frontend)",
     )
     args = parser.parse_args()
 

--- a/benchmarks/profiler/profile_sla.py
+++ b/benchmarks/profiler/profile_sla.py
@@ -108,16 +108,16 @@ async def run_profile(args):
         )
 
         # run genai-perf
-        with client.get_service_url_with_port_forward() as base_url:
-            genai_perf_artifact_dir = f"{work_dir}/gap_isl{args.isl}"
-            gap_result = benchmark_prefill(
-                args.isl, genai_perf_artifact_dir, model_name, base_url=base_url
-            )
-            if gap_result is not None:
-                ttft = gap_result["time_to_first_token"]["avg"]
-                prefill_tp_size.append(tp_size)
-                prefill_ttft.append(ttft)
-                prefill_thpt_per_gpu.append(args.isl / ttft / tp_size * 1000)
+        base_url = client.get_service_url()
+        genai_perf_artifact_dir = f"{work_dir}/gap_isl{args.isl}"
+        gap_result = benchmark_prefill(
+            args.isl, genai_perf_artifact_dir, model_name, base_url=base_url
+        )
+        if gap_result is not None:
+            ttft = gap_result["time_to_first_token"]["avg"]
+            prefill_tp_size.append(tp_size)
+            prefill_ttft.append(ttft)
+            prefill_thpt_per_gpu.append(args.isl / ttft / tp_size * 1000)
 
         print("Cleaning up deployment...")
         await client.delete_deployment()
@@ -184,29 +184,27 @@ async def run_profile(args):
 
         engine_decode_itl = []
         engine_decode_thpt_per_gpu = []
-        with client.get_service_url_with_port_forward() as base_url:
-            for num_request in sweep_num_request:
-                genai_perf_artifact_dir = f"{work_dir}/gap_request{num_request}_isl{args.isl}_osl{args.osl}_n{num_request}"
-                gap_result = benchmark_decode(
-                    args.isl,
-                    args.osl,
-                    num_request,
-                    genai_perf_artifact_dir,
-                    model_name,
-                    base_url=base_url,
-                )
-                if gap_result is not None:
-                    itl = gap_result["inter_token_latency"]["avg"]
-                    thpt_per_gpu = (
-                        gap_result["output_token_throughput"]["avg"] / tp_size
-                    )
-                    engine_decode_itl.append(itl)
-                    engine_decode_thpt_per_gpu.append(thpt_per_gpu)
-                    decode_tp_size.append(tp_size)
-                    decode_itl.append(itl)
-                    decode_thpt_per_gpu.append(thpt_per_gpu)
-                    decode_concurrency.append(num_request)
-                    decode_kv_cache_size.append(max_kv_tokens)
+        base_url = client.get_service_url()
+        for num_request in sweep_num_request:
+            genai_perf_artifact_dir = f"{work_dir}/gap_request{num_request}_isl{args.isl}_osl{args.osl}_n{num_request}"
+            gap_result = benchmark_decode(
+                args.isl,
+                args.osl,
+                num_request,
+                genai_perf_artifact_dir,
+                model_name,
+                base_url=base_url,
+            )
+            if gap_result is not None:
+                itl = gap_result["inter_token_latency"]["avg"]
+                thpt_per_gpu = gap_result["output_token_throughput"]["avg"] / tp_size
+                engine_decode_itl.append(itl)
+                engine_decode_thpt_per_gpu.append(thpt_per_gpu)
+                decode_tp_size.append(tp_size)
+                decode_itl.append(itl)
+                decode_thpt_per_gpu.append(thpt_per_gpu)
+                decode_concurrency.append(num_request)
+                decode_kv_cache_size.append(max_kv_tokens)
 
         print("Cleaning up deployment...")
         await client.delete_deployment()
@@ -311,22 +309,22 @@ async def run_profile(args):
         f"Logs have been saved to {client.base_log_dir / client.deployment_name}"
     )
 
-    with client.get_service_url_with_port_forward() as base_url:
-        for isl in range(
-            100,
-            args.max_context_length,
-            (args.max_context_length - 100) // args.prefill_interpolation_granularity,
-        ):
-            # run genai-perf
-            genai_perf_artifact_dir = f"{work_dir}/gap_isl{isl}"
-            gap_result = benchmark_prefill(
-                isl, genai_perf_artifact_dir, model_name, base_url=base_url
-            )
-            if gap_result is not None:
-                ttft = gap_result["time_to_first_token"]["avg"]
-                prefill_isl.append(isl)
-                prefill_ttft.append(ttft)
-                prefill_thpt_per_gpu.append(isl / ttft / best_prefill_tp * 1000)
+    base_url = client.get_service_url()
+    for isl in range(
+        100,
+        args.max_context_length,
+        (args.max_context_length - 100) // args.prefill_interpolation_granularity,
+    ):
+        # run genai-perf
+        genai_perf_artifact_dir = f"{work_dir}/gap_isl{isl}"
+        gap_result = benchmark_prefill(
+            isl, genai_perf_artifact_dir, model_name, base_url=base_url
+        )
+        if gap_result is not None:
+            ttft = gap_result["time_to_first_token"]["avg"]
+            prefill_isl.append(isl)
+            prefill_ttft.append(ttft)
+            prefill_thpt_per_gpu.append(isl / ttft / best_prefill_tp * 1000)
 
     print("Cleaning up deployment...")
     await client.delete_deployment()
@@ -394,40 +392,38 @@ async def run_profile(args):
     )
 
     osl = 500  # not too large to reduce ITL variance, not too small to have stable measurement
-    with client.get_service_url_with_port_forward() as base_url:
-        for isl in range(
-            100,
-            args.max_context_length - osl,
-            (args.max_context_length - osl) // args.decode_interpolation_granularity,
-        ):
-            max_concurrency = max_kv_tokens // (isl + osl)
-            sweep_num_request = list(
-                range(
-                    1,
-                    max_concurrency,
-                    max_concurrency // args.decode_interpolation_granularity,
-                )
+    base_url = client.get_service_url()
+    for isl in range(
+        100,
+        args.max_context_length - osl,
+        (args.max_context_length - osl) // args.decode_interpolation_granularity,
+    ):
+        max_concurrency = max_kv_tokens // (isl + osl)
+        sweep_num_request = list(
+            range(
+                1,
+                max_concurrency,
+                max_concurrency // args.decode_interpolation_granularity,
             )
-            for num_request in sweep_num_request:
-                genai_perf_artifact_dir = (
-                    f"{work_dir}/gap_isl{isl}_osl{osl}_n{num_request}"
+        )
+        for num_request in sweep_num_request:
+            genai_perf_artifact_dir = f"{work_dir}/gap_isl{isl}_osl{osl}_n{num_request}"
+            gap_result = benchmark_decode(
+                isl,
+                osl,
+                num_request,
+                genai_perf_artifact_dir,
+                model_name,
+                base_url=base_url,
+            )
+            if gap_result is not None:
+                itl = gap_result["inter_token_latency"]["avg"]
+                x_kv_usage.append((isl + osl / 2) * num_request / max_kv_tokens)
+                y_context_length.append(isl + osl / 2)
+                z_itl.append(itl)
+                z_thpt_per_gpu.append(
+                    gap_result["output_token_throughput"]["avg"] / tp_size
                 )
-                gap_result = benchmark_decode(
-                    isl,
-                    osl,
-                    num_request,
-                    genai_perf_artifact_dir,
-                    model_name,
-                    base_url=base_url,
-                )
-                if gap_result is not None:
-                    itl = gap_result["inter_token_latency"]["avg"]
-                    x_kv_usage.append((isl + osl / 2) * num_request / max_kv_tokens)
-                    y_context_length.append(isl + osl / 2)
-                    z_itl.append(itl)
-                    z_thpt_per_gpu.append(
-                        gap_result["output_token_throughput"]["avg"] / tp_size
-                    )
 
     print("Cleaning up deployment...")
     await client.delete_deployment()

--- a/benchmarks/profiler/utils/config.py
+++ b/benchmarks/profiler/utils/config.py
@@ -31,6 +31,7 @@ formatter = logging.Formatter(
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
+
 def break_arguments(args: list[str]) -> list[str]:
     ans = []
     if isinstance(args, str):
@@ -40,8 +41,10 @@ def break_arguments(args: list[str]) -> list[str]:
             ans.extend(arg.split(" "))
     return ans
 
+
 def join_arguments(args: list[str]) -> str:
     return [" ".join(args)]
+
 
 def append_argument(args: list[str], to_append) -> list[str]:
     idx = find_arg_index(args)
@@ -50,6 +53,7 @@ def append_argument(args: list[str], to_append) -> list[str]:
     else:
         args.insert(idx, to_append)
     return args
+
 
 def find_arg_index(args: list[str]) -> int:
     # find the correct index to insert an argument
@@ -107,10 +111,10 @@ class VllmV1ConfigModifier:
                 args.remove("--enable-prefix-caching")
             if "--no-enable-prefix-caching" not in args:
                 args = append_argument(args, "--no-enable-prefix-caching")
-            
-            config["spec"]["services"][
-                WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker
-            ]["extraPodSpec"]["mainContainer"]["args"] = join_arguments(args)
+
+            config["spec"]["services"][WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker][
+                "extraPodSpec"
+            ]["mainContainer"]["args"] = join_arguments(args)
 
         elif target == "decode":
             # delete prefill worker
@@ -130,9 +134,9 @@ class VllmV1ConfigModifier:
             if "--no-enable-prefix-caching" in args:
                 args.remove("--no-enable-prefix-caching")
 
-            config["spec"]["services"][
-                WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker
-            ]["extraPodSpec"]["mainContainer"]["args"] = join_arguments(args)
+            config["spec"]["services"][WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker][
+                "extraPodSpec"
+            ]["mainContainer"]["args"] = join_arguments(args)
 
         # set num workers to 1
         decode_worker_config = config["spec"]["services"][
@@ -146,8 +150,12 @@ class VllmV1ConfigModifier:
     def set_config_tp_size(cls, config: dict, tp_size: int):
         config = deepcopy(config)
 
-        config["spec"]["services"][WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker]["resources"]["requests"]["gpu"] = str(tp_size)
-        config["spec"]["services"][WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker]["resources"]["limits"]["gpu"] = str(tp_size)
+        config["spec"]["services"][WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker][
+            "resources"
+        ]["requests"]["gpu"] = str(tp_size)
+        config["spec"]["services"][WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker][
+            "resources"
+        ]["limits"]["gpu"] = str(tp_size)
 
         args = config["spec"]["services"][
             WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker
@@ -160,10 +168,10 @@ class VllmV1ConfigModifier:
             args[idx + 1] = str(tp_size)
         except ValueError:
             args = append_argument(args, ["--tensor-parallel-size", str(tp_size)])
-        
-        config["spec"]["services"][
-            WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker
-        ]["extraPodSpec"]["mainContainer"]["args"] = join_arguments(args)
+
+        config["spec"]["services"][WORKER_COMPONENT_NAMES["vllm_v1"].decode_worker][
+            "extraPodSpec"
+        ]["mainContainer"]["args"] = join_arguments(args)
 
         return config
 

--- a/benchmarks/profiler/utils/dynamo_deployment.py
+++ b/benchmarks/profiler/utils/dynamo_deployment.py
@@ -13,9 +13,10 @@
 
 import argparse
 import asyncio
+import os
 import random
-import time 
 import socket
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional, Union
@@ -77,6 +78,26 @@ class DynamoDeploymentClient:
         self.custom_api = client.CustomObjectsApi(self.k8s_client)
         self.core_api = client.CoreV1Api(self.k8s_client)
 
+    def _is_running_in_kubernetes(self) -> bool:
+        """
+        Detect if we're running inside a Kubernetes cluster by checking for the service account token.
+        """
+        return os.path.exists("/var/run/secrets/kubernetes.io/serviceaccount/token")
+
+    def _get_service_url(self) -> str:
+        """
+        Get the service URL. Returns service DNS if running in Kubernetes, otherwise localhost with port forwarding.
+        """
+        if self._is_running_in_kubernetes():
+            # Use Kubernetes service DNS: service-name.namespace.svc.cluster.local:port
+            svc_name = f"{self.deployment_name}-frontend"
+            return f"http://{svc_name}.{self.namespace}.svc.cluster.local:8000"
+        else:
+            # For local development, we need to use port forwarding
+            raise RuntimeError(
+                "Port forwarding is required when not running in Kubernetes. Use get_service_url_with_port_forward() instead."
+            )
+
     async def create_deployment(self, deployment: Union[dict, str]):
         """
         Create a DynamoGraphDeployment from either a dict or yaml file path.
@@ -128,20 +149,22 @@ class DynamoDeploymentClient:
         # TODO: A little brittle, also should output intermediate status every so often.
         while (time.time() - start_time) < timeout:
             try:
-                status = await self.custom_api.get_namespaced_custom_object_status(
+                status = await self.custom_api.get_namespaced_custom_object(
                     group="nvidia.com",
                     version="v1alpha1",
                     namespace=self.namespace,
                     plural="dynamographdeployments",
                     name=self.deployment_name,
                 )
-                # print(f"Current status: {status.get('status', {})}")
-
                 # Check both conditions:
                 # 1. Ready condition is True
                 # 2. State is successful
                 status_obj = status.get("status", {})
                 conditions = status_obj.get("conditions", [])
+                current_state = status_obj.get("state", "unknown")
+
+                print(f"Current deployment state: {current_state}")
+                print(f"Current conditions: {conditions}")
 
                 ready_condition = False
                 for condition in conditions:
@@ -159,11 +182,31 @@ class DynamoDeploymentClient:
                         "Deployment is ready: Ready condition is True and state is successful"
                     )
                     return True
+                else:
+                    print(
+                        f"Deployment not ready yet - Ready condition: {ready_condition}, State successful: {state_successful}"
+                    )
 
             except kubernetes.client.rest.ApiException:
                 pass
             await asyncio.sleep(20)
         raise TimeoutError("Deployment failed to become ready within timeout")
+
+    @contextmanager
+    def get_service_url_with_port_forward(self, port: Optional[int] = None):
+        """
+        Get the service URL with automatic detection of environment.
+
+        When running in Kubernetes: yields the service DNS URL directly (no port forwarding needed)
+        When running locally: sets up port forwarding and yields localhost URL
+        """
+        if self._is_running_in_kubernetes():
+            # No port forwarding needed, use service DNS directly
+            yield self._get_service_url()
+        else:
+            # Use port forwarding for local development - delegate to existing method
+            with self.port_forward(port) as forwarded_port:
+                yield f"http://localhost:{forwarded_port}"
 
     @contextmanager
     def port_forward(self, port: Optional[int] = None):
@@ -176,7 +219,7 @@ class DynamoDeploymentClient:
                 candidate_port = random.randint(49152, 65535)
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                     try:
-                        s.bind(('localhost', candidate_port))
+                        s.bind(("localhost", candidate_port))
                         port = candidate_port
                         break
                     except OSError:
@@ -198,8 +241,8 @@ class DynamoDeploymentClient:
         Test the deployment with a chat completion request using httpx.
         """
         EXAMPLE_CHAT_REQUEST["model"] = self.model_name
-        with self.port_forward() as port:
-            url = f"http://localhost:{port}/v1/chat/completions"
+        with self.get_service_url_with_port_forward() as base_url:
+            url = f"{base_url}/v1/chat/completions"
             async with httpx.AsyncClient() as client:
                 response = await client.post(url, json=EXAMPLE_CHAT_REQUEST)
                 response.raise_for_status()

--- a/benchmarks/profiler/utils/dynamo_deployment.py
+++ b/benchmarks/profiler/utils/dynamo_deployment.py
@@ -1,15 +1,17 @@
-#!/usr/bin/env -S uv run --script
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
-# /// script
-# requires-python = ">=3.10"
-# dependencies = [
-#   "PyYAML",
-#   "aiofiles",
-#   "kubernetes-asyncio",
-#   "kr8s",           # added
-#   "httpx",          # added
-# ]
-# ///
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import argparse
 import asyncio

--- a/benchmarks/profiler/utils/genai_perf.py
+++ b/benchmarks/profiler/utils/genai_perf.py
@@ -34,7 +34,7 @@ def _get_common_genai_perf_cmd(
     artifact_dir,
     seed=100,
     model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
-    port=8000,
+    base_url="http://localhost:8000",
 ):
     return [
         "genai-perf",
@@ -49,7 +49,7 @@ def _get_common_genai_perf_cmd(
         "/v1/chat/completions",
         "--streaming",
         "--url",
-        f"http://localhost:{port}",
+        base_url,
         "--extra-inputs",
         "ignore_eos:true",
         "--extra-inputs",
@@ -69,13 +69,13 @@ def get_prefill_genai_perf_cmd(
     seed=100,
     model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
     osl=5,
-    port=8000,
+    base_url="http://localhost:8000",
 ):
     return _get_common_genai_perf_cmd(
         artifact_dir,
         seed,
         model,
-        port,
+        base_url,
     ) + [
         "--synthetic-input-tokens-mean",
         str(isl),
@@ -103,13 +103,13 @@ def get_decode_genai_perf_cmd(
     num_request,
     seed=100,
     model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
-    port=8000,
+    base_url="http://localhost:8000",
 ):
     return _get_common_genai_perf_cmd(
         artifact_dir,
         seed,
         model,
-        port,
+        base_url,
     ) + [
         "--synthetic-input-tokens-mean",
         str(isl),
@@ -146,10 +146,12 @@ def get_gap_result(artifact_dir: str) -> dict:
         return json.load(f)
 
 
-def benchmark_prefill(isl, genai_perf_artifact_dir, model_name, port):
+def benchmark_prefill(
+    isl, genai_perf_artifact_dir, model_name, base_url="http://localhost:8000"
+):
     logger.info(f"Running genai-perf with isl {isl}")
     genai_perf_cmd = get_prefill_genai_perf_cmd(
-        isl, genai_perf_artifact_dir, model=model_name, port=port
+        isl, genai_perf_artifact_dir, model=model_name, base_url=base_url
     )
     print(f"genai-perf cmd: {genai_perf_cmd}")
     # import pdb; pdb.set_trace()
@@ -171,12 +173,20 @@ def benchmark_prefill(isl, genai_perf_artifact_dir, model_name, port):
         return None
 
 
-def benchmark_decode(isl, osl, num_request, genai_perf_artifact_dir, model_name, port):
+def benchmark_decode(
+    isl,
+    osl,
+    num_request,
+    genai_perf_artifact_dir,
+    model_name,
+    base_url="http://localhost:8000",
+):
     logger.info(f"Profiling decode with num_request {num_request}...")
 
     # first warm-up the engine by pre-computing all prefill tokens
     # we use the same random seed to make sure the prompt is the same
     seed = random.randint(0, 1000000)
+
     genai_perf_cmd = get_decode_genai_perf_cmd(
         isl,
         osl,
@@ -184,7 +194,7 @@ def benchmark_decode(isl, osl, num_request, genai_perf_artifact_dir, model_name,
         num_request,
         seed=seed,
         model=model_name,
-        port=port,
+        base_url=base_url,
     )
     gap_process = subprocess.Popen(
         genai_perf_cmd,
@@ -201,7 +211,7 @@ def benchmark_decode(isl, osl, num_request, genai_perf_artifact_dir, model_name,
         num_request,
         seed=seed,
         model=model_name,
-        port=port,
+        base_url=base_url,
     )
     gap_process = subprocess.Popen(
         genai_perf_cmd,

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -14,13 +14,16 @@
 # limitations under the License.
 
 accelerate==1.6.0
+aiofiles
 av==15.0.0
 fastapi==0.115.6
 ftfy
 genai-perf==0.0.13
 grpcio-tools==1.66.0
 httpx
+kr8s
 kubernetes==32.0.1
+kubernetes_asyncio
 matplotlib
 msgspec
 mypy
@@ -45,6 +48,3 @@ tensorboardX==2.6.2.2
 transformers
 types-PyYAML
 uvicorn
-aiofiles
-kubernetes_asyncio
-kr8s

--- a/examples/vllm/deploy/profile_sla_binding.yaml
+++ b/examples/vllm/deploy/profile_sla_binding.yaml
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/examples/vllm/deploy/profile_sla_rbac.yaml
+++ b/examples/vllm/deploy/profile_sla_rbac.yaml
@@ -18,22 +18,22 @@ metadata:
   name: profile-sla-role
   namespace: ${NAMESPACE}
 rules:
-  # DynamoGraphDeployment custom resources
+  # DynamoGraphDeployment custom resources - needed for create/get/delete operations
   - apiGroups: ["nvidia.com"]
     resources: ["dynamographdeployments"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Core resources needed for deployment management
+    verbs: ["get", "create", "delete"]
+  # Pods - needed for listing pods by label selector and getting logs
   - apiGroups: [""]
-    resources: ["pods", "services", "configmaps", "secrets"]
-    verbs: ["get", "list", "watch"]
+    resources: ["pods"]
+    verbs: ["list"]
   - apiGroups: [""]
     resources: ["pods/log"]
-    verbs: ["get", "list"]
-  # Apps resources
-  - apiGroups: ["apps"]
-    resources: ["deployments", "replicasets"]
-    verbs: ["get", "list", "watch"]
-  # For port forwarding
+    verbs: ["get"]
+  # Services - needed for Service.get() to enable port forwarding
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get"]
+  # Port forwarding - needed when running locally (outside cluster)
   - apiGroups: [""]
     resources: ["pods/portforward"]
     verbs: ["create"]

--- a/examples/vllm/deploy/profile_sla_rbac.yaml
+++ b/examples/vllm/deploy/profile_sla_rbac.yaml
@@ -29,11 +29,3 @@ rules:
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]
-  # Services - needed for Service.get() to enable port forwarding
-  - apiGroups: [""]
-    resources: ["services"]
-    verbs: ["get"]
-  # Port forwarding - needed when running locally (outside cluster)
-  - apiGroups: [""]
-    resources: ["pods/portforward"]
-    verbs: ["create"]

--- a/examples/vllm/deploy/profile_sla_rbac.yaml
+++ b/examples/vllm/deploy/profile_sla_rbac.yaml
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/examples/vllm/deploy/profile_sla_sa.yaml
+++ b/examples/vllm/deploy/profile_sla_sa.yaml
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/k8s.sh
+++ b/k8s.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 set -euo pipefail
 
 # 1. Install Homebrew if missing


### PR DESCRIPTION
#### Overview:

This MR modifies the SLA profiler to automatically detect when it's running inside a Kubernetes cluster and use service DNS for communicating with DynamoGraphDeployments instead of port forwarding

#### Details:

- Added `_is_running_in_kubernetes()` method to detect cluster environment by checking for service account token
- Added `get_service_url_with_port_forward()` context manager that automatically chooses between service DNS and port forwarding. This replaces the widespread use of the old `port_forward()` function, which is now used as a helper function to `get_service_url_with_port_forward()`

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- follow-up to #1975 
