### PR TITLE
fix: never sleep on the eos

### DIFF
--- a/examples/vllm/components/handlers.py
+++ b/examples/vllm/components/handlers.py
@@ -122,14 +122,12 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         sampling_params = SamplingParams(**self.default_sampling_params)
         for key, value in request["sampling_options"].items():
-            if not value:
-                continue
-            if hasattr(sampling_params, key):
+            if value is not None and hasattr(sampling_params, key):
                 setattr(sampling_params, key, value)
 
-        max_tokens = request["stop_conditions"]["max_tokens"]
-        if max_tokens:
-            sampling_params.max_tokens = max_tokens
+        for key, value in request["stop_conditions"].items():
+            if value is not None and hasattr(sampling_params, key):
+                setattr(sampling_params, key, value)
 
         if self.can_prefill:
             # Create a copy for prefill with specific modifications


### PR DESCRIPTION
#### Overview:

Wasn't handling EOS properly, this caused our benchmarks to be off compared to vLLM. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sampling parameters in text generation, allowing valid falsy values (such as 0 or False) to be set correctly from requests. This ensures more accurate and flexible control over generation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->