### PR TITLE
fix: cryptic error message for empty messages list in /chat/completions #2067

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -570,7 +570,8 @@ pub fn validate_chat_completion_required_fields(
     if inner.messages.is_empty() {
         return Err(ErrorMessage::from_http_error(HttpError {
             code: 400,
-            message: "The 'messages' field cannot be empty. At least one message is required.".to_string(),
+            message: "The 'messages' field cannot be empty. At least one message is required."
+                .to_string(),
         }));
     }
 


### PR DESCRIPTION
#### Overview:

This PR addresses issue #2064 where the /chat/completions endpoint returns a cryptic internal error when receiving an empty messages array. The fix adds proper validation and returns a clear, user-friendly error message instead.

#### Details:

Added validation: Check for empty messages array before processing the request
Improved error handling: Return HTTP 400 with descriptive error message instead of internal server error

#### Where should the reviewer start?

Added a function to validate chat completion required field in llm->http->service->openai.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes #2064


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for chat completion requests to ensure that required fields are present, returning an error if the messages field is missing or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->