### PR TITLE
feat: log info stats per request

### DIFF
--- a/lib/bindings/python/rust/llm/block_manager/vllm.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm.rs
@@ -546,14 +546,12 @@ impl<R: RequestKey> SlotManager<R> {
         match self.slots.remove(request_id) {
             Some(slot) => {
                 let isl = slot.num_tokens(SlotPosition::Prefill);
-                let tsl = slot.num_tokens(SlotPosition::All);
                 let isl_device = slot.num_blocks_cached_from_device() * self.block_size;
                 let isl_host = slot.num_blocks_cached_from_host() * self.block_size;
                 let isl_disk = slot.num_blocks_cached_from_disk() * self.block_size;
                 tracing::info!(
-                    request_id, "request complete isl: {}, osl: {} - cache hits: device: {}, host: {}, disk: {} - prefilled: {}",
+                    request_id, "request complete isl: {} - cache hits: device: {}, host: {}, disk: {} - prefilled: {}",
                     isl,
-                    tsl - isl,
                     isl_device,
                     isl_host,
                     isl_disk,


### PR DESCRIPTION
improved info logging

same request, issued twice.

first time:
```
2025-07-23T12:19:08.597Z  INFO _core::llm::block_manager::vllm: request complete isl: 95 - cache hits: device: 0, host: 0, disk: 0 - prefilled: 95 request_id="chatcmpl-6943453268d74fd1a579276eda36aa24"
```

second time:
```
2025-07-23T12:19:19.393Z  INFO _core::llm::block_manager::vllm: request complete isl: 95 - cache hits: device: 80, host: 0, disk: 0 - prefilled: 15 request_id="chatcmpl-f4d5076ebc974281b1d40a29441fda4d"
```