### PR TITLE
fix: endpoint changes should be prioritized over new requests in kv scheduler

### DIFF
--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -142,23 +142,19 @@ impl KvScheduler {
                 request = tokio::select! {
                     biased;
 
-                    new_request = request_rx.recv() => {
-                        match new_request {
-                            Some(new_request) => {
-                                tracing::trace!("received request to be scheduled");
-                                new_request
-                            },
-                            None => {
-                                tracing::trace!("scheduler shutdown");
-                                break 'outer;
-                            }
-                        }
-                    }
-
                     _ = endpoints_rx.changed() => {
                         endpoints = endpoints_rx.borrow_and_update().clone();
                         pending_endpoint_update = Some(endpoints.worker_ids());
                         continue 'outer;
+                    }
+
+                    maybe_new_request = request_rx.recv() => {
+                        let Some(new_request) = maybe_new_request else {
+                            tracing::warn!("scheduler shutdown");
+                            break 'outer;
+                        };
+                        tracing::trace!("received request to be scheduled");
+                        new_request
                     }
                 };
 
@@ -181,6 +177,7 @@ impl KvScheduler {
                             request.respond(response);
                             continue 'outer;
                         }
+                        // NOTE: this is not actually hooked up
                         Err(KvSchedulerError::AllWorkersBusy) => {
                             tracing::trace!("all workers busy; waiting for more capacity");
                             tokio::time::sleep(Duration::from_millis(5)).await;

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -177,7 +177,7 @@ impl KvScheduler {
                             request.respond(response);
                             continue 'outer;
                         }
-                        // NOTE: this is not actually hooked up
+                        // TODO: this is not actually hooked up
                         Err(KvSchedulerError::AllWorkersBusy) => {
                             tracing::trace!("all workers busy; waiting for more capacity");
                             tokio::time::sleep(Duration::from_millis(5)).await;


### PR DESCRIPTION
#### Overview:

Before, the tokio select prioritizes the new request arm, and would not account for the endpoint change when scheduling the request.

This change prioritizes the endpoint change, while at the same time receiving the new request if any in the same scheduling cycle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of scheduling requests and shutdown behavior for the background task, resulting in more robust logging and streamlined code execution. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->