### PR TITLE
fix: github ci triggers

### DIFF
--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -47,11 +47,9 @@ jobs:
         filters: |
           vllm:
             - 'container/Dockerfile.vllm'
-            - 'container/Dockerfile.vllm_v1'
-            - 'examples/vllm/**'
-            - 'examples/python_rs/llm/**'
             - 'container/deps/requirements.vllm.txt'
             - 'container/deps/vllm/**'
+            - 'components/backends/vllm/**'
             - 'tests/serve/test_vllm.py'
           trtllm:
             - 'container/Dockerfile.tensorrt_llm'
@@ -65,7 +63,7 @@ jobs:
           sglang:
             - 'container/Dockerfile.sglang'
             - 'container/Dockerfile.sglang-deepep'
-            - 'examples/sglang/**'
+            - 'components/backends/sglang/**'
             - 'container/build.sh'
     - name: Check if Validation Workflow has run
       id: check_workflow


### PR DESCRIPTION
#### Overview:

1. examples have moved from `examples/*` to `components/backend/*`


closes: DYN-756

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to monitor backend component directories instead of example directories for triggering specific jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->