### PR TITLE
docs: Update dynamo_glossary.md

### DIFF
--- a/docs/dynamo_glossary.md
+++ b/docs/dynamo_glossary.md
@@ -11,15 +11,11 @@
 ## D
 **Decode Phase** - The second phase of LLM inference that generates output tokens one at a time.
 
-**depends()** - A Dynamo function that creates dependencies between services, enabling automatic client generation and service discovery.
-
 **Disaggregated Serving** - Dynamo's core architecture that separates prefill and decode phases into specialized engines to maximize GPU throughput and improve performance.
 
 **Distributed Runtime** - Dynamo's Rust-based core system that manages service discovery, communication, and component lifecycle across distributed clusters.
 
 **Dynamo** - NVIDIA's high-performance distributed inference framework for Large Language Models (LLMs) and generative AI models, designed for multinode environments with disaggregated serving and cache-aware routing.
-
-**Dynamo Artifact** - A packaged archive containing an inference graph and its dependencies, created using `dynamo build`. It's the containerized, deployable version of a Graph.
 
 **Dynamo Cloud** - A Kubernetes platform providing managed deployment experience for Dynamo inference graphs.
 

--- a/docs/dynamo_glossary.md
+++ b/docs/dynamo_glossary.md
@@ -24,8 +24,6 @@
 **Dynamo Cloud** - A Kubernetes platform providing managed deployment experience for Dynamo inference graphs.
 
 ## E
-**@endpoint** - A Python decorator used to define service endpoints within a Dynamo component.
-
 **Endpoint** - A specific network-accessible API within a Dynamo component, such as `generate` or `load_metrics`.
 
 ## F
@@ -70,8 +68,6 @@
 **RDMA (Remote Direct Memory Access)** - Technology that allows direct memory access between distributed systems, used for efficient KV cache transfers.
 
 ## S
-**@service** - Python decorator used to define a Dynamo service class.
-
 **SGLang** - Fast LLM inference framework with native embedding support and RadixAttention.
 
 ## T
@@ -83,6 +79,9 @@
 
 ## V
 **vLLM** - High-throughput LLM serving engine with Ray distributed support and PagedAttention.
+
+## W
+**Wide Expert Parallelism (WideEP)** - Mixture-of-Experts deployment strategy that spreads experts across many GPUs (e.g., 64-way EP) so each GPU hosts only a few experts.
 
 ## X
 **xPyD (x Prefill y Decode)** - Dynamo notation describing disaggregated serving configurations where x prefill workers serve y decode workers. Dynamo supports runtime-reconfigurable xPyD.


### PR DESCRIPTION
adding in wideEP definition based on confusion in morning meeting with stakeholders and removing decorator call outs

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the glossary by removing entries for `@endpoint` and `@service` decorators.
  * Added a new entry explaining "Wide Expert Parallelism (WideEP)".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->