### PR TITLE
build: fix the trtllm arm build with nixl python module

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -220,7 +220,8 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv
 # TEMP: disable gds backend for arm64
 RUN if [ "$ARCH" = "arm64" ]; then \
         cd ${NIXL_SRC_DIR} && uv build . --out-dir /workspace/wheels/nixl \
-        --config-settings=setup-args="-Ddisable_gds_backend=true -Dgds_path=/usr/local/cuda/targets/sbsa-linux"; \
+        --config-settings=setup-args=-Ddisable_gds_backend=true \
+        --config-settings=setup-args=-Dgds_path=/usr/local/cuda/targets/sbsa-linux; \
     else \
         cd ${NIXL_SRC_DIR} && uv build . --out-dir /workspace/wheels/nixl; \
     fi && \


### PR DESCRIPTION
#### Overview:

The current uv build settings for nixl python module cannot consume the correct build args. Change the build command to make it consume the correct settings.

#### Details:

```
 ../meson.build:16:0: ERROR: Option "disable_gds_backend" value true -Dgds_path=/usr/local/cuda/targets/sbsa-linux is not boolean (true or false).
```
The current command, will forward the entire "true -Dgds_path=/usr/local/cuda/targets/sbsa-linux" as a string to "-Ddisable_gds_backend", change the build command to have two different setup-args to make the build command be able to parse. 

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings for improved compatibility on arm64 platforms. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->