### PR TITLE
feat: skip router when worker id is pre-determined

### DIFF
--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -337,14 +337,16 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         match self.inner.client.instance_source.as_ref() {
             InstanceSource::Static => self.inner.r#static(request).await,
             InstanceSource::Dynamic(_) => {
+                let context_id = request.context().id().to_string();
                 let (instance_id, overlap_amount) = if let Some(id) = request.backend_instance_id {
                     // If instance_id is set, use it
                     (id, 0)
                 } else {
                     // Otherwise, find the best match
-                    self.chooser.find_best_match(&request.token_ids).await?
+                    self.chooser
+                        .find_best_match(&context_id, &request.token_ids)
+                        .await?
                 };
-
                 let query_instance_id = request.has_annotation("query_instance_id");
                 // Extract context information before moving the request
                 let stream_context = request.context().clone();

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -337,12 +337,14 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         match self.inner.client.instance_source.as_ref() {
             InstanceSource::Static => self.inner.r#static(request).await,
             InstanceSource::Dynamic(_) => {
-                // Extract context ID for request tracking
-                let context_id = request.context().id().to_string();
-                let (instance_id, overlap_amount) = self
-                    .chooser
-                    .find_best_match(&context_id, &request.token_ids)
-                    .await?;
+                let (instance_id, overlap_amount) = if let Some(id) = request.backend_instance_id {
+                    // If instance_id is set, use it
+                    (id, 0)
+                } else {
+                    // Otherwise, find the best match
+                    self.chooser.find_best_match(&request.token_ids).await?
+                };
+
                 let query_instance_id = request.has_annotation("query_instance_id");
                 // Extract context information before moving the request
                 let stream_context = request.context().clone();

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -203,7 +203,6 @@ mod tests {
             top_logprobs: None,
             finish_reason: None,
             index: None,
-            backend_instance_id: None,
         })
     }
 

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -188,6 +188,7 @@ mod tests {
             mdc_sum: None,
             annotations: vec![],
             estimated_prefix_hit_num_blocks: None,
+            backend_instance_id: None,
         }
     }
 
@@ -202,6 +203,7 @@ mod tests {
             top_logprobs: None,
             finish_reason: None,
             index: None,
+            backend_instance_id: None,
         })
     }
 

--- a/lib/llm/src/mocker/engine.rs
+++ b/lib/llm/src/mocker/engine.rs
@@ -647,6 +647,7 @@ mod integration_tests {
             mdc_sum: None,
             annotations: vec![format!("dp_rank:{dp_rank}")],
             estimated_prefix_hit_num_blocks: None,
+            backend_instance_id: None,
         };
 
         let requests = vec![

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -254,6 +254,10 @@ impl OpenAIPreprocessor {
         builder.annotations(request.annotations().unwrap_or_default());
         builder.mdc_sum(Some(self.mdcsum.clone()));
         builder.estimated_prefix_hit_num_blocks(None);
+        // Extract backend_instance_id from nvext if present
+        if let Some(nvext) = request.nvext() {
+            builder.backend_instance_id(nvext.backend_instance_id);
+        }
 
         Ok((builder.build()?, annotations))
     }

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -50,6 +50,10 @@ pub struct PreprocessedRequest {
     /// Estimated number of prefix hit tokens (only used in kv aware routing)
     #[builder(default)]
     pub estimated_prefix_hit_num_blocks: Option<u32>,
+
+    /// Targeted backend instance ID for the request
+    #[builder(default)]
+    pub backend_instance_id: Option<i64>,
 }
 
 impl PreprocessedRequest {

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -87,6 +87,13 @@ pub struct NvExt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub guided_decoding_backend: Option<String>,
+
+    /// Targeted backend instance ID for the request
+    /// If set, the request will be routed to backend instance with the given ID.
+    /// If not set, the request will be routed to the best matching instance.
+    #[builder(default, setter(strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_instance_id: Option<i64>,
 }
 
 impl Default for NvExt {


### PR DESCRIPTION
#### Overview:

When `nvext.backend_instance_id` is set, forward request directly the pre-scheduled worker instance. 
This by-passes the routing logic.


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Linear: https://linear.app/nvidia-dynamo/issue/DEP-266/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a targeted backend instance ID in requests, allowing for direct routing to a chosen backend instance when provided.
  * Requests now recognize and utilize the backend instance ID from the request extension field if available.

* **Bug Fixes**
  * Improved instance selection logic to prioritize a provided backend instance ID, ensuring more accurate routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->