### PR TITLE
chore: updated health checks to use new probes

### DIFF
--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -88,7 +88,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/dynamo:nnshah1-vllm-latest
+          image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -63,7 +63,7 @@ spec:
         failureThreshold: 60
       dynamoNamespace: vllm-agg
       componentType: worker
-      replicas: 2
+      replicas: 1
       resources:
         requests:
           cpu: "10"

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -49,7 +49,7 @@ spec:
       envFromSecret: hf-token-secret
       livenessProbe:
         httpGet:
-          path: /health
+          path: /live
           port: 9090
         periodSeconds: 5
         timeoutSeconds: 30

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -48,27 +48,22 @@ spec:
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - "exit 0"
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 5
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 1
       readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'grep "VllmWorker.*has been initialized" /tmp/vllm.log'
-        initialDelaySeconds: 60
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 10
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 60
       dynamoNamespace: vllm-agg
       componentType: worker
-      replicas: 1
+      replicas: 2
       resources:
         requests:
           cpu: "10"
@@ -78,8 +73,19 @@ spec:
           cpu: "10"
           memory: "20Gi"
           gpu: "1"
+      envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
+        - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
+          value: "[\"generate\"]"
       extraPodSpec:
         mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -78,6 +78,8 @@ spec:
           value: "true"
         - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
           value: "[\"generate\"]"
+        - name: DYN_SYSTEM_PORT
+          value: "9090"
       extraPodSpec:
         mainContainer:
           startupProbe:
@@ -86,7 +88,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
+          image: gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/dynamo:nnshah1-vllm-latest
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -63,7 +63,7 @@ spec:
         failureThreshold: 60
       dynamoNamespace: vllm-agg-router
       componentType: worker
-      replicas: 1
+      replicas: 2
       resources:
         requests:
           cpu: "10"

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -78,6 +78,8 @@ spec:
           value: "true"
         - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
           value: "[\"generate\"]"
+        - name: DYN_SYSTEM_PORT
+          value: "9090"
       extraPodSpec:
         mainContainer:
           startupProbe:

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -49,7 +49,7 @@ spec:
       envFromSecret: hf-token-secret
       livenessProbe:
         httpGet:
-          path: /health
+          path: /live
           port: 9090
         periodSeconds: 5
         timeoutSeconds: 30

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -38,13 +38,13 @@ spec:
           memory: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/dynamo:nnshah1-vllm-latest
+          image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
             - -c
           args:
-            - "python3 -m dynamo.frontend --http-port 8000"
+            - "python3 -m dynamo.frontend --http-port 8000 --router-mode kv"
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       livenessProbe:
@@ -86,7 +86,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/dynamo:nnshah1-vllm-latest
+          image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -38,37 +38,32 @@ spec:
           memory: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
+          image: gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/dynamo:nnshah1-vllm-latest
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
             - -c
           args:
-            - "python3 -m dynamo.frontend --http-port 8000 --router-mode kv"
+            - "python3 -m dynamo.frontend --http-port 8000"
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - "exit 0"
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 5
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 1
       readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'grep "VllmWorker.*has been initialized" /tmp/vllm.log'
-        initialDelaySeconds: 60
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 10
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 60
       dynamoNamespace: vllm-agg-router
       componentType: worker
-      replicas: 2
+      replicas: 1
       resources:
         requests:
           cpu: "10"
@@ -78,9 +73,20 @@ spec:
           cpu: "10"
           memory: "20Gi"
           gpu: "1"
+      envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
+        - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
+          value: "[\"generate\"]"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
+          image: gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/dynamo:nnshah1-vllm-latest
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/disagg.yaml
+++ b/components/backends/vllm/deploy/disagg.yaml
@@ -78,6 +78,8 @@ spec:
           value: "true"
         - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
           value: "[\"generate\"]"
+        - name: DYN_SYSTEM_PORT
+          value: "9090"
       extraPodSpec:
         mainContainer:
           startupProbe:
@@ -126,6 +128,8 @@ spec:
           value: "true"
         - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
           value: "[\"generate\"]"
+        - name: DYN_SYSTEM_PORT
+          value: "9090"
       extraPodSpec:
         mainContainer:
           startupProbe:

--- a/components/backends/vllm/deploy/disagg.yaml
+++ b/components/backends/vllm/deploy/disagg.yaml
@@ -51,24 +51,19 @@ spec:
       componentType: worker
       replicas: 1
       livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - "exit 0"
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 5
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 1
       readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'grep "VllmWorker.*has been initialized" /tmp/vllm.log'
-        initialDelaySeconds: 60
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 10
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 60
       resources:
         requests:
           cpu: "32"
@@ -78,8 +73,19 @@ spec:
           cpu: "32"
           memory: "40Gi"
           gpu: "1"
+      envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
+        - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
+          value: "[\"generate\"]"
       extraPodSpec:
         mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:
@@ -93,24 +99,19 @@ spec:
       componentType: worker
       replicas: 1
       livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - "exit 0"
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 5
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 1
       readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'grep "VllmWorker.*has been initialized" /tmp/vllm.log'
-        initialDelaySeconds: 60
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 10
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 60
       resources:
         requests:
           cpu: "32"
@@ -120,8 +121,19 @@ spec:
           cpu: "32"
           memory: "40Gi"
           gpu: "1"
+      envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
+        - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
+          value: "[\"generate\"]"
       extraPodSpec:
         mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:

--- a/components/backends/vllm/deploy/disagg.yaml
+++ b/components/backends/vllm/deploy/disagg.yaml
@@ -52,7 +52,7 @@ spec:
       replicas: 1
       livenessProbe:
         httpGet:
-          path: /health
+          path: /live
           port: 9090
         periodSeconds: 5
         timeoutSeconds: 30
@@ -100,7 +100,7 @@ spec:
       replicas: 1
       livenessProbe:
         httpGet:
-          path: /health
+          path: /live
           port: 9090
         periodSeconds: 5
         timeoutSeconds: 30

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -78,6 +78,8 @@ spec:
           value: "true"
         - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
           value: "[\"generate\"]"
+        - name: DYN_SYSTEM_PORT
+          value: "9090"
       extraPodSpec:
         mainContainer:
           startupProbe:
@@ -126,6 +128,8 @@ spec:
           value: "true"
         - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
           value: "[\"generate\"]"
+        - name: DYN_SYSTEM_PORT
+          value: "9090"
       extraPodSpec:
         mainContainer:
           startupProbe:

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -52,7 +52,7 @@ spec:
       replicas: 1
       livenessProbe:
         httpGet:
-          path: /health
+          path: /live
           port: 9090
         periodSeconds: 5
         timeoutSeconds: 30

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -51,24 +51,19 @@ spec:
       componentType: worker
       replicas: 1
       livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - "exit 0"
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 5
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 1
       readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'grep "VllmWorker.*has been initialized" /tmp/vllm.log'
-        initialDelaySeconds: 60
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 10
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 60
       resources:
         requests:
           cpu: "10"
@@ -78,8 +73,19 @@ spec:
           cpu: "10"
           memory: "20Gi"
           gpu: "1"
+      envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
+        - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
+          value: "[\"generate\"]"
       extraPodSpec:
         mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:
@@ -93,24 +99,19 @@ spec:
       componentType: worker
       replicas: 1
       livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - "exit 0"
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 5
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 1
       readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'grep "VllmWorker.*has been initialized" /tmp/vllm.log'
-        initialDelaySeconds: 60
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 10
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 60
       resources:
         requests:
           cpu: "10"
@@ -120,8 +121,19 @@ spec:
           cpu: "10"
           memory: "20Gi"
           gpu: "1"
+      envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
+        - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
+          value: "[\"generate\"]"
       extraPodSpec:
         mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:

--- a/components/backends/vllm/deploy/disagg_router.yaml
+++ b/components/backends/vllm/deploy/disagg_router.yaml
@@ -51,24 +51,19 @@ spec:
       componentType: worker
       replicas: 2
       livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - "exit 0"
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 5
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 1
       readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'grep "VllmWorker.*has been initialized" /tmp/vllm.log'
-        initialDelaySeconds: 60
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 10
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 60
       resources:
         requests:
           cpu: "10"
@@ -78,8 +73,19 @@ spec:
           cpu: "10"
           memory: "20Gi"
           gpu: "1"
+      envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
+        - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
+          value: "[\"generate\"]"
       extraPodSpec:
         mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:
@@ -93,24 +99,19 @@ spec:
       componentType: worker
       replicas: 1
       livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - "exit 0"
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 5
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 1
       readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'grep "VllmWorker.*has been initialized" /tmp/vllm.log'
-        initialDelaySeconds: 60
-        periodSeconds: 60
+        httpGet:
+          path: /health
+          port: 9090
+        periodSeconds: 10
         timeoutSeconds: 30
-        failureThreshold: 10
+        failureThreshold: 60
       resources:
         requests:
           cpu: "10"
@@ -120,8 +121,19 @@ spec:
           cpu: "10"
           memory: "20Gi"
           gpu: "1"
+      envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
+        - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
+          value: "[\"generate\"]"
       extraPodSpec:
         mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:

--- a/components/backends/vllm/deploy/disagg_router.yaml
+++ b/components/backends/vllm/deploy/disagg_router.yaml
@@ -52,7 +52,7 @@ spec:
       replicas: 2
       livenessProbe:
         httpGet:
-          path: /health
+          path: /live
           port: 9090
         periodSeconds: 5
         timeoutSeconds: 30
@@ -100,7 +100,7 @@ spec:
       replicas: 1
       livenessProbe:
         httpGet:
-          path: /health
+          path: /live
           port: 9090
         periodSeconds: 5
         timeoutSeconds: 30

--- a/components/backends/vllm/deploy/disagg_router.yaml
+++ b/components/backends/vllm/deploy/disagg_router.yaml
@@ -126,6 +126,8 @@ spec:
           value: "true"
         - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
           value: "[\"generate\"]"
+        - name: DYN_SYSTEM_PORT
+          value: "9090"
       extraPodSpec:
         mainContainer:
           startupProbe:


### PR DESCRIPTION
#### Overview:

Now that we have enabled health checks natively in the worker - updating to use these instead of the place holder checks.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

yamls

@tedzhouhk - question for confirmation - do the prefill workers register a "generate" endpoint with the dynamo runtime? Want to make sure that is the flow.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health check probes for worker services to use HTTP-based checks for improved monitoring.
  * Added startup health probes for more robust service initialization checks.
  * Introduced new environment variables to enable dynamic system features.
  * Adjusted health check timing and thresholds for better responsiveness.
  * Reduced the number of worker replicas in one deployment for resource optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->