### PR TITLE
build: update the default trtllm version to 1.0.0rc4

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -96,7 +96,7 @@ TRTLLM_USE_NIXL_KVCACHE_EXPERIMENTAL="0"
 TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"
 # TODO: Remove the version specification from here and use the ai-dynamo[trtllm] package.
 # Need to update the Dockerfile.tensorrt_llm to use the ai-dynamo[trtllm] package.
-DEFAULT_TENSORRTLLM_PIP_WHEEL="tensorrt-llm==1.0.0rc0"
+DEFAULT_TENSORRTLLM_PIP_WHEEL="tensorrt-llm==1.0.0rc4"
 TENSORRTLLM_PIP_WHEEL=""
 
 


### PR DESCRIPTION
#### Overview:

update the default trtllm version to 1.0.0rc4

#### Details:

This includes the supports for variable sliding window attention, as well as some fixes that could support the benchmarking pipeline. 

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default TensorRT-LLM version used in Docker builds to 1.0.0rc4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->