### PR TITLE
feat: proper local hashes for mockers + router watches endpoints

### DIFF
--- a/components/router/src/main.rs
+++ b/components/router/src/main.rs
@@ -27,9 +27,9 @@ use clap::Parser;
 use dynamo_llm::kv_router::{
     protocols::WorkerSelectionResult,
     scheduler::{DefaultWorkerSelector, KvSchedulerError, SchedulingRequest},
-    scoring::ProcessedEndpoints,
     KvRouter, WorkerSelector,
 };
+use dynamo_runtime::component::Instance;
 use dynamo_runtime::{
     logging, pipeline::network::Ingress, DistributedRuntime, Result, Runtime, Worker,
 };
@@ -86,7 +86,7 @@ pub struct CustomWorkerSelector(DefaultWorkerSelector);
 impl WorkerSelector for CustomWorkerSelector {
     fn select_worker(
         &self,
-        workers: &ProcessedEndpoints,
+        workers: &[Instance],
         request: &SchedulingRequest,
         block_size: u32,
     ) -> Result<WorkerSelectionResult, KvSchedulerError> {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -334,6 +334,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 let isl = backend_input.token_ids.len();
                 backend_input.estimated_prefix_hit_num_blocks = Some(overlap_amount);
                 let updated_request = context.map(|_| backend_input);
+
                 // if request has the annotation "query_instance_id", for example
                 // curl -d '{... ,"nvext": { "annotations": ["query_instance_id"]}}'
                 // request will not be routed to worker immediately
@@ -342,61 +343,59 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                     let response =
                         Annotated::from_annotation("worker_instance_id", &instance_id_str)?;
                     let stream = stream::iter(vec![response]);
-                    Ok(ResponseStream::new(Box::pin(stream), stream_context))
-                } else {
-                    // Get the response stream from the worker
-                    let mut response_stream =
-                        self.inner.direct(updated_request, instance_id).await?;
+                    return Ok(ResponseStream::new(Box::pin(stream), stream_context));
+                }
+                // Get the response stream from the worker
+                let mut response_stream = self.inner.direct(updated_request, instance_id).await?;
 
-                    // Wrap the stream to track tokens
-                    let stream_context = response_stream.context();
-                    let chooser = self.chooser.clone();
-                    let request_id = context_id.clone();
-                    let block_size = chooser.block_size() as usize;
+                // Wrap the stream to track tokens
+                let stream_context = response_stream.context();
+                let chooser = self.chooser.clone();
+                let request_id = context_id.clone();
+                let block_size = chooser.block_size() as usize;
 
-                    let wrapped_stream = Box::pin(async_stream::stream! {
-                        let mut accumulated_tokens = Vec::new();
-                        let mut total_output_length = 0usize;
-                        let mut last_block_index = (isl.saturating_sub(1)) / block_size;
-                        let mut first_push_done = false;
+                let wrapped_stream = Box::pin(async_stream::stream! {
+                    let mut accumulated_tokens = Vec::new();
+                    let mut total_output_length = 0usize;
+                    let mut last_block_index = (isl.saturating_sub(1)) / block_size;
+                    let mut first_push_done = false;
 
-                        while let Some(item) = response_stream.next().await {
-                            // Track tokens if they exist in the response
-                            let Some(ref output) = item.data else {
-                                yield item;
-                                continue;
-                            };
-                            if output.token_ids.is_empty() {
-                                yield item;
-                                continue;
-                            }
-
-                            // Add tokens to accumulator
-                            accumulated_tokens.extend_from_slice(&output.token_ids);
-                            total_output_length += output.token_ids.len();
-
-                            // Always push for the first generated token (to mark prefill done)
-                            // or when we've moved to a new block
-                            let current_block_index = (isl + total_output_length).saturating_sub(1) / block_size;
-                            let should_push = (!first_push_done && total_output_length >= 1) ||
-                                        (first_push_done && current_block_index > last_block_index);
-
-                            if should_push {
-                                chooser.push(&request_id, &accumulated_tokens).await;
-                                accumulated_tokens.clear();
-                                last_block_index = current_block_index;
-                                if !first_push_done {
-                                    first_push_done = true;
-                                }
-                            }
-
+                    while let Some(item) = response_stream.next().await {
+                        // Track tokens if they exist in the response
+                        let Some(ref output) = item.data else {
                             yield item;
+                            continue;
+                        };
+                        if output.token_ids.is_empty() {
+                            yield item;
+                            continue;
                         }
 
-                        chooser.free(&request_id).await;
-                    });
-                    Ok(ResponseStream::new(wrapped_stream, stream_context))
-                }
+                        // Add tokens to accumulator
+                        accumulated_tokens.extend_from_slice(&output.token_ids);
+                        total_output_length += output.token_ids.len();
+
+                        // Always push for the first generated token (to mark prefill done)
+                        // or when we've moved to a new block
+                        let current_block_index = (isl + total_output_length).saturating_sub(1) / block_size;
+                        let should_push = (!first_push_done && total_output_length >= 1) ||
+                                    (first_push_done && current_block_index > last_block_index);
+
+                        if should_push {
+                            chooser.push(&request_id, &accumulated_tokens).await;
+                            accumulated_tokens.clear();
+                            last_block_index = current_block_index;
+                            if !first_push_done {
+                                first_push_done = true;
+                            }
+                        }
+
+                        yield item;
+                    }
+
+                    chooser.free(&request_id).await;
+                });
+                Ok(ResponseStream::new(wrapped_stream, stream_context))
             }
         }
     }

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -26,11 +26,11 @@ use super::protocols::WorkerSelectionResult;
 use super::WorkerSelector;
 use crate::kv_router::indexer::OverlapScores;
 use crate::kv_router::protocols::LoadMetrics;
-use crate::kv_router::scoring::ProcessedEndpoints;
 use crate::kv_router::sequence::ActiveSequencesMultiWorker;
 use crate::kv_router::KvRouterConfig;
 use crate::kv_router::KV_HIT_RATE_SUBJECT;
 use crate::tokens::TokenBlockSequence;
+use dynamo_runtime::component::Instance;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KVHitRateEvent {
@@ -107,12 +107,14 @@ impl KvScheduler {
     pub async fn start(
         ns: Namespace,
         block_size: u32,
-        endpoints_rx: tokio::sync::watch::Receiver<ProcessedEndpoints>,
+        mut instances_rx: tokio::sync::watch::Receiver<Vec<Instance>>, // Changed from ProcessedEndpoints
         selector: Option<Box<dyn WorkerSelector + Send + Sync>>,
     ) -> Result<Self, KvSchedulerError> {
         let selector = selector.unwrap_or(Box::new(DefaultWorkerSelector::default()));
-        let mut endpoints_rx = endpoints_rx;
-        let mut endpoints: ProcessedEndpoints = endpoints_rx.borrow_and_update().clone();
+        let mut instances: Vec<Instance> = instances_rx.borrow_and_update().clone();
+
+        // Get worker IDs from instances
+        let worker_ids: Vec<i64> = instances.iter().map(|i| i.instance_id).collect();
 
         let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<KVHitRateEvent>();
         tokio::spawn(async move {
@@ -126,7 +128,7 @@ impl KvScheduler {
 
         let sequences = Arc::new(Mutex::new(ActiveSequencesMultiWorker::new(
             block_size as usize,
-            endpoints.worker_ids(),
+            worker_ids,
         )));
 
         // Channel to accept new scheduling requests
@@ -142,9 +144,10 @@ impl KvScheduler {
                 request = tokio::select! {
                     biased;
 
-                    _ = endpoints_rx.changed() => {
-                        endpoints = endpoints_rx.borrow_and_update().clone();
-                        pending_endpoint_update = Some(endpoints.worker_ids());
+                    _ = instances_rx.changed() => {
+                        instances = instances_rx.borrow_and_update().clone();
+                        let worker_ids: Vec<i64> = instances.iter().map(|i| i.instance_id).collect();
+                        pending_endpoint_update = Some(worker_ids);
                         continue 'outer;
                     }
 
@@ -159,7 +162,8 @@ impl KvScheduler {
                 };
 
                 loop {
-                    match selector.select_worker(&endpoints, &request, block_size) {
+                    // When calling selector.select_worker, we need to adapt
+                    match selector.select_worker(&instances, &request, block_size) {
                         Ok(selection) => {
                             if let Err(e) = event_tx.send(KVHitRateEvent {
                                 worker_id: selection.worker_id,
@@ -179,9 +183,11 @@ impl KvScheduler {
                         }
                         Err(KvSchedulerError::NoEndpoints) => {
                             tracing::trace!("no endpoints available; waiting for endpoints update");
-                            endpoints_rx.changed().await.ok();
-                            endpoints = endpoints_rx.borrow_and_update().clone();
-                            pending_endpoint_update = Some(endpoints.worker_ids());
+                            instances_rx.changed().await.ok();
+                            instances = instances_rx.borrow_and_update().clone();
+                            let worker_ids: Vec<i64> =
+                                instances.iter().map(|i| i.instance_id).collect();
+                            pending_endpoint_update = Some(worker_ids);
                             continue;
                         }
                         // TODO: this is not actually hooked up
@@ -353,13 +359,13 @@ impl DefaultWorkerSelector {
 impl WorkerSelector for DefaultWorkerSelector {
     fn select_worker(
         &self,
-        workers: &ProcessedEndpoints,
+        workers: &[Instance],
         request: &SchedulingRequest,
         block_size: u32,
     ) -> Result<WorkerSelectionResult, KvSchedulerError> {
         assert!(request.isl_tokens > 0);
 
-        if workers.endpoints.is_empty() {
+        if workers.is_empty() {
             return Err(KvSchedulerError::NoEndpoints);
         }
 
@@ -376,9 +382,10 @@ impl WorkerSelector for DefaultWorkerSelector {
         let mut max_logit = f64::NEG_INFINITY;
 
         // Calculate logits for each worker
-        for (worker_id, _) in workers.endpoints.iter() {
+        for instance in workers.iter() {
+            let worker_id = instance.instance_id;
             // this is the number of tokens each worker would have if the request were scheduled there
-            let potential_tokens = *potential_active_tokens.get(worker_id).unwrap_or_else(|| {
+            let potential_tokens = *potential_active_tokens.get(&worker_id).unwrap_or_else(|| {
                 tracing::warn!(
                     "assuming {isl} tokens for {worker_id}, as the endpoint does not exist yet"
                 );
@@ -386,7 +393,7 @@ impl WorkerSelector for DefaultWorkerSelector {
             }) as f64;
 
             // this is the number of blocks each worker would have if the request were scheduled there
-            let potential_blocks = *potential_active_blocks.get(worker_id).unwrap_or_else(||
+            let potential_blocks = *potential_active_blocks.get(&worker_id).unwrap_or_else(||
                 {tracing::warn!("assuming {request_blocks} decoding blocks for {worker_id}, as the endpoint does not exist yet");
                 &request_blocks
             }) as f64;
@@ -398,12 +405,12 @@ impl WorkerSelector for DefaultWorkerSelector {
                 + potential_blocks;
             max_logit = max_logit.max(logit);
 
-            worker_logits.insert(*worker_id, logit);
+            worker_logits.insert(worker_id, logit);
 
             tracing::info!(
                 "Formula for {worker_id}: {logit:.3} = {:.1} * {potential_prefill_blocks:.3} + {potential_blocks:.3}  (cached_blocks: {})",
                 self.kv_router_config.overlap_score_weight,
-                overlaps.get(worker_id).unwrap_or(&0),
+                overlaps.get(&worker_id).unwrap_or(&0),
             );
         }
 

--- a/lib/llm/src/mocker/sequence.rs
+++ b/lib/llm/src/mocker/sequence.rs
@@ -90,7 +90,7 @@ impl ActiveSequence {
         assert!(block_size > 1, "block_size must be greater than 1");
         let num_input_tokens = tokens.len();
 
-        let tokens = Tokens::from(tokens).into_sequence(block_size as u32, None);
+        let tokens = Tokens::from(tokens).into_sequence(block_size as u32, Some(1337));
         let unique_blocks =
             create_unique_blocks_from_sequence(&tokens, None, block_size, enable_prefix_caching);
         let creation_signal = Some(MoveBlock::Use(unique_blocks.clone()));
@@ -122,6 +122,14 @@ impl ActiveSequence {
 
     pub fn take_creation_signal(&mut self) -> Option<MoveBlock> {
         self.creation_signal.take()
+    }
+
+    pub fn block_hashes(&self) -> Vec<u64> {
+        self.tokens
+            .blocks()
+            .iter()
+            .map(|block| block.block_hash())
+            .collect()
     }
 
     /// Create a new ActiveSequence instance and return the creation signal

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 MODEL_NAME = "Qwen/Qwen3-0.6B"
 NUM_MOCKERS = 2
+BLOCK_SIZE = 16
 SPEEDUP_RATIO = 10.0
 NUM_REQUESTS = 100
 PORT = 8090  # Starting port for mocker instances
@@ -59,6 +60,8 @@ class KVRouterProcess(ManagedProcess):
             "python",
             "-m",
             "dynamo.frontend",
+            "--kv-cache-block-size",
+            str(BLOCK_SIZE),
             "--router-mode",
             "kv",
             "--http-port",
@@ -100,7 +103,7 @@ def test_mocker_kv_router(request, runtime_services):
     logger.info("Starting mocker KV router test")
 
     # Create mocker args file
-    mocker_args = {"speedup_ratio": SPEEDUP_RATIO}
+    mocker_args = {"speedup_ratio": SPEEDUP_RATIO, "block_size": BLOCK_SIZE}
 
     mocker_args_file = os.path.join(request.node.name, "mocker_args.json")
     with open(mocker_args_file, "w") as f:


### PR DESCRIPTION
#### Overview:

Somewhat of a 2-in-1 PR. Changes:
1. `mocker` now computes the actual `local_block_hashes` the Kv router expects (with salt hash of `1337`)
2. `KvRouter` now directly watches the "generate" endpoints using `Client` for instant updates of endpoint changes, instead of the previous `EndpointCollector`, which incurred a 100ms polling interval delay

Closes #2095 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public method to retrieve block hashes from active sequences.
  * Block size configuration is now propagated to both the KV router and mocker engine in end-to-end tests.

* **Bug Fixes**
  * Improved type specificity and correctness when handling block hashes in cache events.

* **Refactor**
  * Worker selection and scheduling now operate on a more general instance representation, improving flexibility and maintainability.
  * Enhanced propagation of block hash information during scheduler operations for better event correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->