### PR TITLE
fix: remove binary linking

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -52,22 +52,13 @@ export CARGO_TARGET_DIR=$HOME/dynamo/.build/target
 cargo build --locked --profile dev --features mistralrs
 cargo doc --no-deps
 
-# create symlinks for the binaries in the deploy directory
-mkdir -p $HOME/dynamo/deploy/sdk/src/dynamo/sdk/cli/bin
-ln -sf $HOME/dynamo/.build/target/debug/dynamo-run $HOME/dynamo/deploy/sdk/src/dynamo/sdk/cli/bin/dynamo-run
-
 # install the python bindings
 cd $HOME/dynamo/lib/bindings/python && retry maturin develop
 
 # installs overall python packages, grabs binaries from .build/target/debug
-cd $HOME/dynamo && retry env DYNAMO_BIN_PATH=$HOME/dynamo/.build/target/debug uv pip install -e .
+cd $HOME/dynamo && retry uv pip install -e .
 
 export PYTHONPATH=/home/ubuntu/dynamo/components/planner/src:$PYTHONPATH
-
-# TODO: Deprecated except vLLM v0
-if ! grep -q "export VLLM_KV_CAPI_PATH=" ~/.bashrc; then
-    echo "export VLLM_KV_CAPI_PATH=$HOME/dynamo/.build/target/debug/libdynamo_llm_capi.so" >> ~/.bashrc
-fi
 
 if ! grep -q "export GPG_TTY=" ~/.bashrc; then
     echo "export GPG_TTY=$(tty)" >> ~/.bashrc


### PR DESCRIPTION
#### Overview:

New builds don't require dynamic linking. Can remove from devcontainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified development environment setup by removing deprecated environment variables and unnecessary symlink creation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->