### PR TITLE
fix: copy whole workspace for pre-merge vllm tests

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -483,14 +483,9 @@ $LD_LIBRARY_PATH
 COPY --from=ci_minimum /workspace/target/release/metrics /usr/local/bin/metrics
 COPY --from=ci_minimum ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
-# Once UX refactor is merged
-# Python components will have been pip installed and packaged in wheel
-# Can remove these files
-COPY components/ /workspace/components/
-COPY tests/ /workspace/tests/
-COPY examples/ /workspace/examples/
-COPY deploy/ /workspace/deploy/
-COPY benchmarks/ /workspace/benchmarks/
+# Keep everything from ci_minimum for mypy and other pre-merge tests
+# TODO: Remove this once we have a functional CI image built on top of the runtime image
+COPY --from=ci_minimum /workspace/ /workspace/
 
 # Copy launch banner
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \


### PR DESCRIPTION
#### Overview:

Copy whole dynamo repo into runtime container to run all pre-merge and mypy CI tests


#### Details:

ref: OPS-440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the Docker image build process by consolidating file copying steps, resulting in improved efficiency and maintainability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->