### PR TITLE
feat: claim support for AL2023 x86_64

### DIFF
--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -73,6 +73,16 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 > [!Important]
 > ² Specific versions of TensorRT-LLM supported by Dynamo are subject to change.
 
+## Cloud Service Provider Compatibility
+
+### AWS
+
+| **Host Operating System** | **Version** | **Architecture** | **Status**   |
+| :------------------------ | :---------- | :--------------- | :----------- |
+| **Amazon Linux**          | 2023        | x86_64           | Supported    |
+
+
+
 ## Build Support
 
 **Dynamo** currently provides build support in the following ways:


### PR DESCRIPTION
#### Overview:

Update support matrix to include support for Amazon Linux 2023

#### Details:

This claim of support is such that an inference request for a 0.3.2 container is able to run on AL2023 

Fixes OPS-449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Cloud Service Provider Compatibility" section to the support matrix, specifying support for Amazon Linux 2023 on AWS (x86_64).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->