### PR TITLE
fix: remove containers from required property of extraPodSpec

### DIFF
--- a/deploy/cloud/helm/crds/templates/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/cloud/helm/crds/templates/nvidia.com_dynamocomponentdeployments.yaml
@@ -4805,8 +4805,7 @@ spec:
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
-                  required:
-                    - containers
+                  required: []
                   type: object
                 ingress:
                   properties:

--- a/deploy/cloud/helm/crds/templates/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/cloud/helm/crds/templates/nvidia.com_dynamographdeployments.yaml
@@ -4860,8 +4860,7 @@ spec:
                             x-kubernetes-list-map-keys:
                               - name
                             x-kubernetes-list-type: map
-                        required:
-                          - containers
+                        required: []
                         type: object
                       ingress:
                         properties:

--- a/deploy/cloud/operator/Makefile
+++ b/deploy/cloud/operator/Makefile
@@ -63,6 +63,10 @@ manifests: controller-gen ensure-yq ## Generate WebhookConfiguration, ClusterRol
 	for file in config/crd/bases/*.yaml; do \
 		yq eval '(.. | select(has("mainContainer")) | .mainContainer.required) |= (. - ["name"])' -i --indent 2 $$file || exit 1; \
 	done
+	echo "Removing containers from extraPodSpec required fields"
+	for file in config/crd/bases/*.yaml; do \
+		yq eval '(.. | select(has("extraPodSpec")) | .extraPodSpec.required) |= (. - ["containers"])' -i --indent 2 $$file || exit 1; \
+	done
 	echo "Adding NVIDIA header to CRD files"
 	for file in config/crd/bases/*.yaml; do \
 		if ! head -20 "$$file" | grep -q "NVIDIA CORPORATION"; then \

--- a/deploy/cloud/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/cloud/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
@@ -4805,8 +4805,7 @@ spec:
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
-                  required:
-                    - containers
+                  required: []
                   type: object
                 ingress:
                   properties:

--- a/deploy/cloud/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/cloud/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -4860,8 +4860,7 @@ spec:
                             x-kubernetes-list-map-keys:
                               - name
                             x-kubernetes-list-type: map
-                        required:
-                          - containers
+                        required: []
                         type: object
                       ingress:
                         properties:


### PR DESCRIPTION
#### Overview:

remove containers from required property of extraPodSpec


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made the `containers` field optional in the configuration schemas for DynamoComponentDeployment and DynamoGraphDeployment resources.
  * Updated deployment tools to reflect the new optional status of the `containers` field in generated manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->