### PR TITLE
fix: install rdma libs in runtime image.

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -58,6 +58,10 @@ RUN apt-get update -y && \
     meson \
     ninja-build \
     pybind11-dev \
+    # These headers are missing with the hpcx installer, required
+    # by UCX to find RDMA devices
+    libibverbs-dev rdma-core ibverbs-utils libibumad-dev \
+    libnuma-dev librdmacm-dev ibverbs-providers \
     # Rust build dependencies
 	clang \
     libclang-dev \
@@ -423,7 +427,15 @@ $LD_LIBRARY_PATH
 # libnuma-dev is a required dependency for sglang integration with NIXL
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential python3-dev libnuma-dev && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential python3-dev libnuma-dev \
+        # Curl for polling various endpoints.
+        curl \
+        # For debugging
+        vim \
+        # Libraries required by UCX to find RDMA devices
+        libibverbs1 rdma-core ibverbs-utils libibumad3 \
+        libnuma1 librdmacm1 ibverbs-providers && \
     rm -rf /var/lib/apt/lists/* && \
     uv venv $VIRTUAL_ENV --python 3.12 && \
     echo "source $VIRTUAL_ENV/bin/activate" >> ~/.bashrc

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -65,8 +65,14 @@ RUN apt update -y && \
     tmux \
     vim \
     ## NIXL dependencies
+    cmake \
     meson \
-    ninja-build
+    ninja-build \
+    pybind11-dev \
+    # These headers are missing with the hpcx installer, required
+    # by UCX to find RDMA devices
+    libibverbs-dev rdma-core ibverbs-utils libibumad-dev \
+    libnuma-dev librdmacm-dev ibverbs-providers
 
 ### UCX EFA Setup ###
 RUN rm -rf /opt/hpcx/ucx && \
@@ -374,6 +380,13 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         python3-dev \
+        # Curl for polling various endpoints.
+        curl \
+        # For debugging
+        vim \
+        # Libraries required by UCX to find RDMA devices
+        libibverbs1 rdma-core ibverbs-utils libibumad3 \
+        libnuma1 librdmacm1 ibverbs-providers \
         openssh-client \
         openssh-server && \
     rm -rf /var/lib/apt/lists/*

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -56,6 +56,10 @@ RUN apt-get update -y && \
     meson \
     ninja-build \
     pybind11-dev \
+    # These headers are missing with the hpcx installer, required
+    # by UCX to find RDMA devices
+    libibverbs-dev rdma-core ibverbs-utils libibumad-dev \
+    libnuma-dev librdmacm-dev ibverbs-providers \
     # Rust build dependencies
 	clang \
     libclang-dev \
@@ -72,10 +76,6 @@ RUN apt-get update -y && \
     automake \
     libtool \
     net-tools \
-    # These headers are missing with the hpcx installer, required
-    # by UCX to find RDMA devices
-    libibverbs-dev rdma-core ibverbs-utils libibumad-dev \
-    libnuma-dev librdmacm-dev ibverbs-providers \
     # For Prometheus
     curl tar ca-certificates && \
     rm -rf /var/lib/apt/lists/*
@@ -437,6 +437,13 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         python3-dev \
+        # Curl for polling various endpoints.
+        curl \
+        # For debugging
+        vim \
+        # Libraries required by UCX to find RDMA devices
+        libibverbs1 rdma-core ibverbs-utils libibumad3 \
+        libnuma1 librdmacm1 ibverbs-providers \
         # JIT Kernel Compilation, flashinfer
         ninja-build \
         g++ \


### PR DESCRIPTION
#### Overview:

The runtime container image for VLLM is missing packages related to ibverbs, etc., which are essential for UCX to discover underlying RDMA devices. Further, curl is rather helpful in communicating with the dynamo endpoint and polling other service and their health endpoints.

The impact on container size is relatively negligible (~28 MB).

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the runtime environment by adding support for network and RDMA devices, and included `curl` for improved endpoint polling capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->