### PR TITLE
chore: cleanup examples codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,7 @@ Cargo.toml @ai-dynamo/dynamo-rust-codeowners
 
 # Examples
 /examples/*/deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @mohammedabdulwahhab @atchernych
-/examples/ @ai-dynamo/Devops @nnshah1 @whoisj @nealvaidya @ai-dynamo/dynamo-rust-codeowners
+/examples/ @ai-dynamo/Devops @nnshah1 @whoisj @nealvaidya @ishandhanani @ai-dynamo/dynamo-rust-codeowners
 /examples/multimodal/ @indrajit96 @krishung5 @whoisj @hhzhang16
 
 # CI/CD

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,15 +18,8 @@ Cargo.toml @ai-dynamo/dynamo-rust-codeowners
 
 # Examples
 /examples/*/deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @mohammedabdulwahhab @atchernych
-/examples/ @ai-dynamo/Devops @nnshah1 @whoisj @ai-dynamo/dynamo-rust-codeowners
-/examples/common/ @ai-dynamo/Devops @tedzhouhk
-/examples/hello_world/ @alec-flowers @biswapanda @grahamking @hhzhang16 @ishandhanani @julienmancuso @kkranen @mohammedabdulwahhab @nnshah1 @tedzhouhk
-/examples/llm/ @alec-flowers @biswapanda @grahamking @guanluo @hhzhang16 @ishandhanani @julienmancuso @kkranen @mohammedabdulwahhab @nnshah1 @piotrm-nvidia @ptarasiewiczNV @rmccorm4 @tanmayv25 @tedzhouhk @PeaBrane
+/examples/ @ai-dynamo/Devops @nnshah1 @whoisj @nealvaidya @ai-dynamo/dynamo-rust-codeowners
 /examples/multimodal/ @indrajit96 @krishung5 @whoisj @hhzhang16
-/examples/sglang/ @biswapanda @ishandhanani @tedzhouhk @rmccorm4 @alec-flowers @grahamking @PeaBrane
-/examples/tensorrt_llm/ @guanluo @richardhuo-nv @rmccorm4 @tanmayv25
-/examples/vllm_v0/ @alec-flowers @tedzhouhk @PeaBrane
-/examples/vllm/ @biswapanda @ptarasiewiczNV @tedzhouhk @PeaBrane
 
 # CI/CD
 /.github/ @ai-dynamo/Devops @nnshah1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,8 +17,8 @@ Cargo.toml @ai-dynamo/dynamo-rust-codeowners
 /deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @nnshah1 @mohammedabdulwahhab
 
 # Examples
-/examples/*/deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @mohammedabdulwahhab @atchernych
 /examples/ @ai-dynamo/Devops @nnshah1 @whoisj @nealvaidya @ishandhanani @ai-dynamo/dynamo-rust-codeowners
+/examples/*/deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @mohammedabdulwahhab @atchernych
 /examples/multimodal/ @indrajit96 @krishung5 @whoisj @hhzhang16
 
 # CI/CD


### PR DESCRIPTION
Cleanup code owners for examples that don't exist anymore 
Added self as examples code owner 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ownership of the `/examples/` directory to a unified group, simplifying and consolidating previous individual ownership entries. No changes made outside the examples section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->