### PR TITLE
fix: frontend metrics to be renamed from nv_llm_http_service_* => dynamo_frontend_*

### DIFF
--- a/components/metrics/Cargo.toml
+++ b/components/metrics/Cargo.toml
@@ -38,4 +38,4 @@ tracing = { workspace = true }
 # TODO: Update axum to 0.8
 axum = { version = "0.6" }
 clap = { version = "4.5", features = ["derive", "env"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12.22", default-features = false, features = ["json", "rustls-tls"] }

--- a/components/metrics/README.md
+++ b/components/metrics/README.md
@@ -1,13 +1,26 @@
 # Metrics
 
-The `metrics` component is a utility that can collect, aggregate, and publish
-metrics from a Dynamo deployment. After collecting and aggregating metrics from
-workers, it exposes them via an HTTP `/metrics` endpoint in Prometheus format
-that other applications or visualization tools like Prometheus server and Grafana can
-pull from.
+⚠️ **DEPRECATION NOTICE** ⚠️
+
+**This `metrics` component is being deprecated and will be removed in a future release.**
+
+The `metrics` component is being replaced by the **`MetricsRegistry`** built-in functionality that is now available directly in the `DistributedRuntime` framework. The `MetricsRegistry` provides:
+
+- **Automatic metric registration** when creating metrics via endpoint factory methods
+- **Built-in Prometheus HTTP endpoint** accessible via `DYN_SYSTEM_ENABLED=true` and `DYN_SYSTEM_PORT=<port>`
+- **Automatic labeling** with namespace, component, and endpoint information
+- **Simplified API** that eliminates the need for manual Prometheus setup
+
+**For new projects and existing deployments, please migrate to using `MetricsRegistry` instead of this component.**
+
+See the [Dynamo MetricsRegistry Guide](../../docs/guides/metrics.md) for detailed information on using the new metrics system.
+
+---
+
+The `metrics` component is a utility for collecting, aggregating, and publishing metrics from a Dynamo deployment, but it is being deprecated and replaced by `MetricsRegistry`.
 
 **Note**: This is a demo implementation. The metrics component is currently under active development and this documentation will change as the implementation evolves.
-- In this demo the metrics names use the prefix "llm", but in production they will be prefixed with "nv_llm" (e.g., the HTTP `/metrics` endpoint will serve metrics with "nv_llm" prefixes)
+- In this demo the metrics names use the prefix "llm", but in production they will be prefixed with "dynamo" (e.g., the HTTP `/metrics` endpoint will serve metrics with "dynamo" prefixes)
 - This demo will only work when using examples/llm/configs/agg.yml-- other configurations will not work
 
 <div align="center">

--- a/components/metrics/README.md
+++ b/components/metrics/README.md
@@ -4,12 +4,7 @@
 
 **This `metrics` component is being deprecated and will be removed in a future release.**
 
-The `metrics` component is being replaced by the **`MetricsRegistry`** built-in functionality that is now available directly in the `DistributedRuntime` framework. The `MetricsRegistry` provides:
-
-- **Automatic metric registration** when creating metrics via endpoint factory methods
-- **Built-in Prometheus HTTP endpoint** accessible via `DYN_SYSTEM_ENABLED=true` and `DYN_SYSTEM_PORT=<port>`
-- **Automatic labeling** with namespace, component, and endpoint information
-- **Simplified API** that eliminates the need for manual Prometheus setup
+The deprecated `metrics` component is being replaced by the **`MetricsRegistry`** built-in functionality that is now available directly in the `DistributedRuntime` framework. The `MetricsRegistry` provides:
 
 **For new projects and existing deployments, please migrate to using `MetricsRegistry` instead of this component.**
 
@@ -17,9 +12,9 @@ See the [Dynamo MetricsRegistry Guide](../../docs/guides/metrics.md) for detaile
 
 ---
 
-The `metrics` component is a utility for collecting, aggregating, and publishing metrics from a Dynamo deployment, but it is being deprecated and replaced by `MetricsRegistry`.
+The deprecated `metrics` component is a utility for collecting, aggregating, and publishing metrics from a Dynamo deployment, but it is being deprecated and replaced by `MetricsRegistry`.
 
-**Note**: This is a demo implementation. The metrics component is currently under active development and this documentation will change as the implementation evolves.
+**Note**: This is a demo implementation. The deprecated `metrics` component is currently under active development and this documentation will change as the implementation evolves.
 - In this demo the metrics names use the prefix "llm", but in production they will be prefixed with "dynamo" (e.g., the HTTP `/metrics` endpoint will serve metrics with "dynamo" prefixes)
 - This demo will only work when using examples/llm/configs/agg.yml-- other configurations will not work
 
@@ -29,7 +24,7 @@ The `metrics` component is a utility for collecting, aggregating, and publishing
 
 ## Quickstart
 
-To start the `metrics` component, simply point it at the `namespace/component/endpoint`
+To start the deprecated `metrics` component, simply point it at the `namespace/component/endpoint`
 trio for the Dynamo workers that you're interested in monitoring metrics on.
 
 This will:
@@ -58,14 +53,14 @@ will get automatically discovered and the warnings will stop.
 
 ## Workers
 
-The `metrics` component needs running workers to gather metrics from,
+The deprecated `metrics` component needs running workers to gather metrics from,
 so below are some examples of workers and how they can be monitored.
 
 ### Mock Worker
 
-To try out how `metrics` works, there is a demo Rust-based
+To try out how the deprecated `metrics` component works, there is a demo Rust-based
 [mock worker](src/bin/mock_worker.rs) that provides sample data through two mechanisms:
-1. Exposes a stats handler at `dynamo/MyComponent/my_endpoint` that responds to polling requests (from `metrics`) with randomly generated `ForwardPassMetrics` data
+1. Exposes a stats handler at `dynamo/MyComponent/my_endpoint` that responds to polling requests (from the deprecated `metrics` component) with randomly generated `ForwardPassMetrics` data
 2. Publishes mock `KVHitRateEvent` data every second to demonstrate event-based metrics
 
 Step 1: Launch a mock workers via the following command (if already built):
@@ -112,11 +107,11 @@ docker compose -f deploy/docker-compose.yml --profile metrics up -d
 
 ## Metrics Collection Modes
 
-The metrics component supports two modes for exposing metrics in a Prometheus format:
+The deprecated `metrics` component supports two modes for exposing metrics in a Prometheus format:
 
 ### Pull Mode (Default)
 
-When running in pull mode (the default), the metrics component will expose a
+When running in pull mode (the default), the deprecated `metrics` component will expose a
 Prometheus metrics endpoint on the specified host and port that a
 Prometheus server or curl client can pull from:
 
@@ -149,7 +144,7 @@ curl localhost:9091/metrics
 ### Push Mode
 
 For ephemeral or batch jobs, or when metrics need to be pushed through a firewall,
-you can use Push mode. In this mode, the metrics component will periodically push
+you can use Push mode. In this mode, the deprecated `metrics` component will periodically push
 metrics to an externally hosted
 [Prometheus PushGateway](https://prometheus.io/docs/instrumenting/pushing/):
 
@@ -158,7 +153,7 @@ Start a prometheus push gateway service via docker:
 docker run --rm -d -p 9091:9091 --name pushgateway prom/pushgateway
 ```
 
-Start the metrics component in `--push` mode, specifying the host and port of your PushGateway:
+Start the deprecated `metrics` component in `--push` mode, specifying the host and port of your PushGateway:
 ```bash
 # Push metrics to a Prometheus PushGateway every --push-interval seconds
 metrics \
@@ -186,7 +181,7 @@ curl 127.0.0.1:9091/metrics
 ```
 ## Building/Running from Source
 
-For easy iteration while making edits to the metrics component, you can use `cargo run`
+For easy iteration while making edits to the deprecated `metrics` component, you can use `cargo run`
 to build and run with your local changes:
 
 ```bash

--- a/components/metrics/README.md
+++ b/components/metrics/README.md
@@ -2,19 +2,21 @@
 
 ⚠️ **DEPRECATION NOTICE** ⚠️
 
-**This `metrics` component is being deprecated and will be removed in a future release.**
+**This `metrics` component is unmaintained and being deprecated.**
 
 The deprecated `metrics` component is being replaced by the **`MetricsRegistry`** built-in functionality that is now available directly in the `DistributedRuntime` framework. The `MetricsRegistry` provides:
 
 **For new projects and existing deployments, please migrate to using `MetricsRegistry` instead of this component.**
 
-See the [Dynamo MetricsRegistry Guide](../../docs/guides/metrics.md) for detailed information on using the new metrics system.
+This component may be migrated to the MetricsRegistry in the future.
+
+**📖 See the [Dynamo MetricsRegistry Guide](../../docs/guides/metrics.md) for detailed information on using the new metrics system.**
 
 ---
 
-The deprecated `metrics` component is a utility for collecting, aggregating, and publishing metrics from a Dynamo deployment, but it is being deprecated and replaced by `MetricsRegistry`.
+The deprecated `metrics` component is a utility for collecting, aggregating, and publishing metrics from a Dynamo deployment, but it is unmaintained and being deprecated in favor of `MetricsRegistry`.
 
-**Note**: This is a demo implementation. The deprecated `metrics` component is currently under active development and this documentation will change as the implementation evolves.
+**Note**: This is a demo implementation. The deprecated `metrics` component is no longer under active development.
 - In this demo the metrics names use the prefix "llm", but in production they will be prefixed with "dynamo" (e.g., the HTTP `/metrics` endpoint will serve metrics with "dynamo" prefixes)
 - This demo will only work when using examples/llm/configs/agg.yml-- other configurations will not work
 

--- a/components/metrics/README.md
+++ b/components/metrics/README.md
@@ -4,7 +4,12 @@
 
 **This `metrics` component is being deprecated and will be removed in a future release.**
 
-The deprecated `metrics` component is being replaced by the **`MetricsRegistry`** built-in functionality that is now available directly in the `DistributedRuntime` framework. The `MetricsRegistry` provides:
+The `metrics` component is being replaced by the **`MetricsRegistry`** built-in functionality that is now available directly in the `DistributedRuntime` framework. The `MetricsRegistry` provides:
+
+- **Automatic metric registration** when creating metrics via endpoint factory methods
+- **Built-in Prometheus HTTP endpoint** accessible via `DYN_SYSTEM_ENABLED=true` and `DYN_SYSTEM_PORT=<port>`
+- **Automatic labeling** with namespace, component, and endpoint information
+- **Simplified API** that eliminates the need for manual Prometheus setup
 
 **For new projects and existing deployments, please migrate to using `MetricsRegistry` instead of this component.**
 
@@ -12,9 +17,9 @@ See the [Dynamo MetricsRegistry Guide](../../docs/guides/metrics.md) for detaile
 
 ---
 
-The deprecated `metrics` component is a utility for collecting, aggregating, and publishing metrics from a Dynamo deployment, but it is being deprecated and replaced by `MetricsRegistry`.
+The `metrics` component is a utility for collecting, aggregating, and publishing metrics from a Dynamo deployment, but it is being deprecated and replaced by `MetricsRegistry`.
 
-**Note**: This is a demo implementation. The deprecated `metrics` component is currently under active development and this documentation will change as the implementation evolves.
+**Note**: This is a demo implementation. The metrics component is currently under active development and this documentation will change as the implementation evolves.
 - In this demo the metrics names use the prefix "llm", but in production they will be prefixed with "dynamo" (e.g., the HTTP `/metrics` endpoint will serve metrics with "dynamo" prefixes)
 - This demo will only work when using examples/llm/configs/agg.yml-- other configurations will not work
 
@@ -24,7 +29,7 @@ The deprecated `metrics` component is a utility for collecting, aggregating, and
 
 ## Quickstart
 
-To start the deprecated `metrics` component, simply point it at the `namespace/component/endpoint`
+To start the `metrics` component, simply point it at the `namespace/component/endpoint`
 trio for the Dynamo workers that you're interested in monitoring metrics on.
 
 This will:
@@ -53,14 +58,14 @@ will get automatically discovered and the warnings will stop.
 
 ## Workers
 
-The deprecated `metrics` component needs running workers to gather metrics from,
+The `metrics` component needs running workers to gather metrics from,
 so below are some examples of workers and how they can be monitored.
 
 ### Mock Worker
 
-To try out how the deprecated `metrics` component works, there is a demo Rust-based
+To try out how `metrics` works, there is a demo Rust-based
 [mock worker](src/bin/mock_worker.rs) that provides sample data through two mechanisms:
-1. Exposes a stats handler at `dynamo/MyComponent/my_endpoint` that responds to polling requests (from the deprecated `metrics` component) with randomly generated `ForwardPassMetrics` data
+1. Exposes a stats handler at `dynamo/MyComponent/my_endpoint` that responds to polling requests (from `metrics`) with randomly generated `ForwardPassMetrics` data
 2. Publishes mock `KVHitRateEvent` data every second to demonstrate event-based metrics
 
 Step 1: Launch a mock workers via the following command (if already built):
@@ -107,11 +112,11 @@ docker compose -f deploy/docker-compose.yml --profile metrics up -d
 
 ## Metrics Collection Modes
 
-The deprecated `metrics` component supports two modes for exposing metrics in a Prometheus format:
+The metrics component supports two modes for exposing metrics in a Prometheus format:
 
 ### Pull Mode (Default)
 
-When running in pull mode (the default), the deprecated `metrics` component will expose a
+When running in pull mode (the default), the metrics component will expose a
 Prometheus metrics endpoint on the specified host and port that a
 Prometheus server or curl client can pull from:
 
@@ -144,7 +149,7 @@ curl localhost:9091/metrics
 ### Push Mode
 
 For ephemeral or batch jobs, or when metrics need to be pushed through a firewall,
-you can use Push mode. In this mode, the deprecated `metrics` component will periodically push
+you can use Push mode. In this mode, the metrics component will periodically push
 metrics to an externally hosted
 [Prometheus PushGateway](https://prometheus.io/docs/instrumenting/pushing/):
 
@@ -153,7 +158,7 @@ Start a prometheus push gateway service via docker:
 docker run --rm -d -p 9091:9091 --name pushgateway prom/pushgateway
 ```
 
-Start the deprecated `metrics` component in `--push` mode, specifying the host and port of your PushGateway:
+Start the metrics component in `--push` mode, specifying the host and port of your PushGateway:
 ```bash
 # Push metrics to a Prometheus PushGateway every --push-interval seconds
 metrics \
@@ -181,7 +186,7 @@ curl 127.0.0.1:9091/metrics
 ```
 ## Building/Running from Source
 
-For easy iteration while making edits to the deprecated `metrics` component, you can use `cargo run`
+For easy iteration while making edits to the metrics component, you can use `cargo run`
 to build and run with your local changes:
 
 ```bash

--- a/components/planner/src/dynamo/planner/utils/prometheus.py
+++ b/components/planner/src/dynamo/planner/utils/prometheus.py
@@ -35,7 +35,7 @@ class PrometheusAPIClient:
         increase(metric_sum[interval])/increase(metric_count[interval])
 
         Args:
-            metric_name: Base metric name (e.g., 'nv_llm_http_service_inter_token_latency_seconds')
+            metric_name: Base metric name (e.g., 'dynamo_http_service_inter_token_latency_seconds')
             interval: Time interval for the query (e.g., '60s')
             operation_name: Human-readable name for error logging
 
@@ -43,7 +43,7 @@ class PrometheusAPIClient:
             Average metric value or 0 if no data/error
         """
         try:
-            query = f"increase({metric_name}_sum[{interval}])/increase({metric_name}_count[{interval}])"
+            query = f"increase(dynamo_frontend_{metric_name}_sum[{interval}])/increase({metric_name}_count[{interval}])"
             result = self.prom.custom_query(query=query)
             if not result:
                 # No data available yet (no requests made) - return 0 silently
@@ -55,21 +55,21 @@ class PrometheusAPIClient:
 
     def get_avg_inter_token_latency(self, interval: str):
         return self._get_average_metric(
-            "nv_llm_http_service_inter_token_latency_seconds",
+            "inter_token_latency_seconds",
             interval,
             "avg inter token latency",
         )
 
     def get_avg_time_to_first_token(self, interval: str):
         return self._get_average_metric(
-            "nv_llm_http_service_time_to_first_token_seconds",
+            "time_to_first_token_seconds",
             interval,
             "avg time to first token",
         )
 
     def get_avg_request_duration(self, interval: str):
         return self._get_average_metric(
-            "nv_llm_http_service_request_duration_seconds",
+            "request_duration_seconds",
             interval,
             "avg request duration",
         )
@@ -78,7 +78,7 @@ class PrometheusAPIClient:
         # This function follows a different query pattern than the other metrics
         try:
             raw_res = self.prom.custom_query(
-                query=f"increase(nv_llm_http_service_requests_total[{interval}])"
+                query=f"increase(dynamo_http_service_requests_total[{interval}])"
             )
             total_count = 0.0
             for res in raw_res:
@@ -91,14 +91,14 @@ class PrometheusAPIClient:
 
     def get_avg_input_sequence_tokens(self, interval: str):
         return self._get_average_metric(
-            "nv_llm_http_service_input_sequence_tokens",
+            "input_sequence_tokens",
             interval,
             "avg input sequence tokens",
         )
 
     def get_avg_output_sequence_tokens(self, interval: str):
         return self._get_average_metric(
-            "nv_llm_http_service_output_sequence_tokens",
+            "output_sequence_tokens",
             interval,
             "avg output sequence tokens",
         )

--- a/components/planner/src/dynamo/planner/utils/prometheus.py
+++ b/components/planner/src/dynamo/planner/utils/prometheus.py
@@ -35,7 +35,7 @@ class PrometheusAPIClient:
         increase(metric_sum[interval])/increase(metric_count[interval])
 
         Args:
-            metric_name: Base metric name (e.g., 'dynamo_http_service_inter_token_latency_seconds')
+            metric_name: Base metric name (e.g., 'dynamo_frontend_inter_token_latency_seconds')
             interval: Time interval for the query (e.g., '60s')
             operation_name: Human-readable name for error logging
 
@@ -43,7 +43,7 @@ class PrometheusAPIClient:
             Average metric value or 0 if no data/error
         """
         try:
-            query = f"increase(dynamo_frontend_{metric_name}_sum[{interval}])/increase({metric_name}_count[{interval}])"
+            query = f"increase(dynamo_frontend_{metric_name}_sum[{interval}])/increase(dynamo_frontend_{metric_name}_count[{interval}])"
             result = self.prom.custom_query(query=query)
             if not result:
                 # No data available yet (no requests made) - return 0 silently
@@ -78,7 +78,7 @@ class PrometheusAPIClient:
         # This function follows a different query pattern than the other metrics
         try:
             raw_res = self.prom.custom_query(
-                query=f"increase(dynamo_http_service_requests_total[{interval}])"
+                query=f"increase(dynamo_frontend_requests_total[{interval}])"
             )
             total_count = 0.0
             for res in raw_res:

--- a/components/planner/src/dynamo/planner/utils/prometheus.py
+++ b/components/planner/src/dynamo/planner/utils/prometheus.py
@@ -35,7 +35,7 @@ class PrometheusAPIClient:
         increase(metric_sum[interval])/increase(metric_count[interval])
 
         Args:
-            metric_name: Base metric name (e.g., 'dynamo_frontend_inter_token_latency_seconds')
+            metric_name: Base metric name (e.g., 'inter_token_latency_seconds')
             interval: Time interval for the query (e.g., '60s')
             operation_name: Human-readable name for error logging
 
@@ -43,7 +43,8 @@ class PrometheusAPIClient:
             Average metric value or 0 if no data/error
         """
         try:
-            query = f"increase(dynamo_frontend_{metric_name}_sum[{interval}])/increase(dynamo_frontend_{metric_name}_count[{interval}])"
+            full_metric_name = f"dynamo_frontend_{metric_name}"
+            query = f"increase({full_metric_name}_sum[{interval}])/increase({full_metric_name}_count[{interval}])"
             result = self.prom.custom_query(query=query)
             if not result:
                 # No data available yet (no requests made) - return 0 silently

--- a/deploy/metrics/README.md
+++ b/deploy/metrics/README.md
@@ -1,5 +1,24 @@
 # Metrics Visualization with Prometheus and Grafana
 
+⚠️ **DEPRECATION NOTICE** ⚠️
+
+**The `metrics-aggregation-service` (port 9091) is being deprecated and will be removed in a future release.**
+
+The metrics aggregation service is being replaced by the **`MetricsRegistry`** built-in functionality that is now available directly in the `DistributedRuntime` framework. The new system provides:
+
+- **Built-in Prometheus HTTP endpoint** accessible via `DYN_SYSTEM_ENABLED=true` and `DYN_SYSTEM_PORT=<port>` (default: 8081)
+- **Automatic metric registration** when creating metrics via endpoint factory methods
+- **Automatic labeling** with namespace, component, and endpoint information
+- **Simplified deployment** - no separate metrics component required
+
+**For new projects and existing deployments, please migrate to using `MetricsRegistry` instead of the metrics aggregation service.**
+
+The Prometheus configuration in this directory has been updated to scrape from the new `dynamo-backend` job (port 8081) instead of the deprecated `metrics-aggregation-service` (port 9091).
+
+See the [Dynamo MetricsRegistry Guide](../../docs/guides/metrics.md) for detailed information on using the new metrics system.
+
+---
+
 This directory contains configuration for visualizing metrics from the metrics aggregation service using Prometheus and Grafana.
 
 ## Components
@@ -99,14 +118,20 @@ The following configuration files should be present in this directory:
 
 IMPORTANT: This section is being phased out, and some metrics may not function as expected. A new solution is under development.
 
+⚠️ **DEPRECATED METRICS NOTICE** ⚠️
+
+**The following `llm_kv_*` metrics are deprecated and will be removed in a future release:**
+
 When you run the example [components/metrics](../../components/metrics/README.md) component, it exposes a Prometheus /metrics endpoint with the followings (defined in [../../components/metrics/src/lib.rs](../../components/metrics/src/lib.rs)):
 - `llm_requests_active_slots`: Number of currently active request slots per worker
 - `llm_requests_total_slots`: Total available request slots per worker
-- `llm_kv_blocks_active`: Number of active KV blocks per worker
-- `llm_kv_blocks_total`: Total KV blocks available per worker
-- `llm_kv_hit_rate_percent`: Cumulative KV Cache hit percent per worker
+- `llm_kv_blocks_active`: Number of active KV blocks per worker ⚠️ **DEPRECATED**
+- `llm_kv_blocks_total`: Total KV blocks available per worker ⚠️ **DEPRECATED**
+- `llm_kv_hit_rate_percent`: Cumulative KV Cache hit percent per worker ⚠️ **DEPRECATED**
 - `llm_load_avg`: Average load across workers
 - `llm_load_std`: Load standard deviation across workers
+
+**These `llm_kv_*` metrics are being replaced by the new `dynamo_*` metrics from the MetricsRegistry system. Please migrate to the new system.**
 
 ## Troubleshooting
 

--- a/deploy/metrics/README.md
+++ b/deploy/metrics/README.md
@@ -1,24 +1,5 @@
 # Metrics Visualization with Prometheus and Grafana
 
-⚠️ **DEPRECATION NOTICE** ⚠️
-
-**The `metrics-aggregation-service` (port 9091) is being deprecated and will be removed in a future release.**
-
-The metrics aggregation service is being replaced by the **`MetricsRegistry`** built-in functionality that is now available directly in the `DistributedRuntime` framework. The new system provides:
-
-- **Built-in Prometheus HTTP endpoint** accessible via `DYN_SYSTEM_ENABLED=true` and `DYN_SYSTEM_PORT=<port>` (default: 8081)
-- **Automatic metric registration** when creating metrics via endpoint factory methods
-- **Automatic labeling** with namespace, component, and endpoint information
-- **Simplified deployment** - no separate metrics component required
-
-**For new projects and existing deployments, please migrate to using `MetricsRegistry` instead of the metrics aggregation service.**
-
-The Prometheus configuration in this directory has been updated to scrape from the new `dynamo-backend` job (port 8081) instead of the deprecated `metrics-aggregation-service` (port 9091).
-
-
-
----
-
 This directory contains configuration for visualizing metrics from the metrics aggregation service using Prometheus and Grafana.
 
 ## Components
@@ -79,7 +60,7 @@ As of Q2 2025, Dynamo HTTP Frontend metrics are exposed when you build container
 
    - Start the [components/metrics](../../components/metrics/README.md) application to begin monitoring for metric events from dynamo workers and aggregating them on a Prometheus metrics endpoint: `http://localhost:9091/metrics`.
    - Uncomment the appropriate lines in prometheus.yml to poll port 9091.
-   - Start worker(s) that publishes KV Cache metrics: [examples/rust/service_metrics/bin/server](../../lib/runtime/examples/service_metrics/README.md)` can populate dummy KV Cache metrics.
+   - Start worker(s) that publishes KV Cache metrics: [lib/runtime/examples/service_metrics/README.md](../../lib/runtime/examples/service_metrics/README.md) can populate dummy KV Cache metrics.
 
 
 ## Configuration
@@ -114,24 +95,21 @@ The following configuration files should be present in this directory:
 - [grafana_dashboards/grafana-dcgm-metrics.json](./grafana_dashboards/grafana-dcgm-metrics.json): Contains Grafana dashboard configuration for DCGM GPU metrics
 - [grafana_dashboards/grafana-llm-metrics.json](./grafana_dashboards/grafana-llm-metrics.json): This file, which is being phased out, contains the Grafana dashboard configuration for LLM-specific metrics. It requires an additional `metrics` component to operate concurrently. A new version is under development.
 
-## Running the example `metrics` component
+## Running the deprecated `metrics` component
 
-IMPORTANT: This section is being phased out, and some metrics may not function as expected. A new solution is under development.
+⚠️ **DEPRECATION NOTICE** ⚠️
 
-⚠️ **DEPRECATED METRICS NOTICE** ⚠️
+When you run the example [components/metrics](../../components/metrics/README.md) component, it exposes a Prometheus /metrics endpoint with the following metrics (defined in [components/metrics/src/lib.rs](../../components/metrics/src/lib.rs)):
 
-**The following `llm_kv_*` metrics are deprecated and will be removed in a future release:**
+**⚠️ The following `llm_kv_*` metrics are deprecated:**
 
-When you run the example [components/metrics](../../components/metrics/README.md) component, it exposes a Prometheus /metrics endpoint with the followings (defined in [../../components/metrics/src/lib.rs](../../components/metrics/src/lib.rs)):
-- `llm_requests_active_slots`: Number of currently active request slots per worker
+- `llm_requests_active_slots`: Active request slots per worker
 - `llm_requests_total_slots`: Total available request slots per worker
-- `llm_kv_blocks_active`: Number of active KV blocks per worker ⚠️ **DEPRECATED**
-- `llm_kv_blocks_total`: Total KV blocks available per worker ⚠️ **DEPRECATED**
-- `llm_kv_hit_rate_percent`: Cumulative KV Cache hit percent per worker ⚠️ **DEPRECATED**
+- `llm_kv_blocks_active`: Active KV blocks per worker
+- `llm_kv_blocks_total`: Total KV blocks available per worker
+- `llm_kv_hit_rate_percent`: KV Cache hit percent per worker
 - `llm_load_avg`: Average load across workers
 - `llm_load_std`: Load standard deviation across workers
-
-**These `llm_kv_*` metrics are being replaced by the new `dynamo_*` metrics from the MetricsRegistry system. Please migrate to the new system.**
 
 ## Troubleshooting
 

--- a/deploy/metrics/README.md
+++ b/deploy/metrics/README.md
@@ -8,7 +8,7 @@ The metrics aggregation service is being replaced by the **`MetricsRegistry`** b
 
 - **Built-in Prometheus HTTP endpoint** accessible via `DYN_SYSTEM_ENABLED=true` and `DYN_SYSTEM_PORT=<port>` (default: 8081)
 - **Automatic metric registration** when creating metrics via endpoint factory methods
-- **Automatic prefix and labeling** with `dynamo_component_` name prefix, as well as auto labels: dynamo_namespace, dynamo_component, and dynamo_endpoint information. These labels are prefixed to avoid Kubernetes label collisions.
+- **Automatic labeling** with namespace, component, and endpoint information
 - **Simplified deployment** - no separate metrics component required
 
 **For new projects and existing deployments, please migrate to using `MetricsRegistry` instead of the metrics aggregation service.**

--- a/deploy/metrics/README.md
+++ b/deploy/metrics/README.md
@@ -8,7 +8,7 @@ The metrics aggregation service is being replaced by the **`MetricsRegistry`** b
 
 - **Built-in Prometheus HTTP endpoint** accessible via `DYN_SYSTEM_ENABLED=true` and `DYN_SYSTEM_PORT=<port>` (default: 8081)
 - **Automatic metric registration** when creating metrics via endpoint factory methods
-- **Automatic labeling** with namespace, component, and endpoint information
+- **Automatic prefix and labeling** with `dynamo_component_` name prefix, as well as auto labels: dynamo_namespace, dynamo_component, and dynamo_endpoint information. These labels are prefixed to avoid Kubernetes label collisions.
 - **Simplified deployment** - no separate metrics component required
 
 **For new projects and existing deployments, please migrate to using `MetricsRegistry` instead of the metrics aggregation service.**

--- a/deploy/metrics/README.md
+++ b/deploy/metrics/README.md
@@ -15,7 +15,7 @@ The metrics aggregation service is being replaced by the **`MetricsRegistry`** b
 
 The Prometheus configuration in this directory has been updated to scrape from the new `dynamo-backend` job (port 8081) instead of the deprecated `metrics-aggregation-service` (port 9091).
 
-See the [Dynamo MetricsRegistry Guide](../../docs/guides/metrics.md) for detailed information on using the new metrics system.
+
 
 ---
 

--- a/deploy/metrics/grafana_dashboards/grafana-dynamo-dashboard.json
+++ b/deploy/metrics/grafana_dashboards/grafana-dynamo-dashboard.json
@@ -27,7 +27,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "dynamo_http_service_requests_total (1m)",
+      "description": "dynamo_frontend_requests_total (1m)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -106,7 +106,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(dynamo_http_service_requests_total[30s])",
+          "expr": "rate(dynamo_frontend_requests_total[30s])",
           "legendFormat": "{{request_type}}, {{status}},",
           "range": true,
           "refId": "A"
@@ -120,7 +120,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "dynamo_http_service_time_to_first_token_seconds (sum/count)",
+      "description": "dynamo_frontend_time_to_first_token_seconds (sum/count)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -199,7 +199,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "1000*(dynamo_http_service_time_to_first_token_seconds_sum/dynamo_http_service_time_to_first_token_seconds_count)",
+          "expr": "1000*(dynamo_frontend_time_to_first_token_seconds_sum/dynamo_frontend_time_to_first_token_seconds_count)",
           "legendFormat": "{{model}}",
           "range": true,
           "refId": "A"
@@ -213,7 +213,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "dynamo_http_service_inter_token_latency_seconds (sum/count)",
+      "description": "dynamo_frontend_inter_token_latency_seconds (sum/count)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -292,7 +292,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "1000*(dynamo_http_service_inter_token_latency_seconds_sum/dynamo_http_service_inter_token_latency_seconds_count)",
+          "expr": "1000*(dynamo_frontend_inter_token_latency_seconds_sum/dynamo_frontend_inter_token_latency_seconds_count)",
           "legendFormat": "{{model}}",
           "range": true,
           "refId": "A"
@@ -306,7 +306,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "dynamo_http_service_request_duration (sum/count)",
+      "description": "dynamo_frontend_request_duration (sum/count)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -385,7 +385,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "1000*(dynamo_http_service_request_duration_seconds_sum / dynamo_http_service_request_duration_seconds_count)",
+          "expr": "1000*(dynamo_frontend_request_duration_seconds_sum / dynamo_frontend_request_duration_seconds_count)",
           "legendFormat": "{{model}}",
           "range": true,
           "refId": "A"
@@ -399,7 +399,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "The length is the number of tokens. dynamo_http_service_input_sequence_tokens",
+      "description": "The length is the number of tokens. dynamo_frontend_input_sequence_tokens",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -478,7 +478,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "dynamo_http_service_input_sequence_tokens_sum / dynamo_http_service_input_sequence_tokens_count",
+          "expr": "dynamo_frontend_input_sequence_tokens_sum / dynamo_frontend_input_sequence_tokens_count",
           "legendFormat": "ISL",
           "range": true,
           "refId": "A"
@@ -489,7 +489,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "dynamo_http_service_output_sequence_tokens_sum / dynamo_http_service_output_sequence_tokens_count",
+          "expr": "dynamo_frontend_output_sequence_tokens_sum / dynamo_frontend_output_sequence_tokens_count",
           "hide": false,
           "instant": false,
           "legendFormat": "OSL",

--- a/deploy/metrics/grafana_dashboards/grafana-dynamo-dashboard.json
+++ b/deploy/metrics/grafana_dashboards/grafana-dynamo-dashboard.json
@@ -27,7 +27,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "nv_llm_http_service_requests_total (1m)",
+      "description": "dynamo_http_service_requests_total (1m)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -106,7 +106,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(nv_llm_http_service_requests_total[30s])",
+          "expr": "rate(dynamo_http_service_requests_total[30s])",
           "legendFormat": "{{request_type}}, {{status}},",
           "range": true,
           "refId": "A"
@@ -120,7 +120,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "nv_llm_http_service_time_to_first_token_seconds (sum/count)",
+      "description": "dynamo_http_service_time_to_first_token_seconds (sum/count)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -199,7 +199,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "1000*(nv_llm_http_service_time_to_first_token_seconds_sum/nv_llm_http_service_time_to_first_token_seconds_count)",
+          "expr": "1000*(dynamo_http_service_time_to_first_token_seconds_sum/dynamo_http_service_time_to_first_token_seconds_count)",
           "legendFormat": "{{model}}",
           "range": true,
           "refId": "A"
@@ -213,7 +213,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "nv_llm_http_service_inter_token_latency_seconds (sum/count)",
+      "description": "dynamo_http_service_inter_token_latency_seconds (sum/count)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -292,7 +292,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "1000*(nv_llm_http_service_inter_token_latency_seconds_sum/nv_llm_http_service_inter_token_latency_seconds_count)",
+          "expr": "1000*(dynamo_http_service_inter_token_latency_seconds_sum/dynamo_http_service_inter_token_latency_seconds_count)",
           "legendFormat": "{{model}}",
           "range": true,
           "refId": "A"
@@ -306,7 +306,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "nv_llm_http_service_request_duration (sum/count)",
+      "description": "dynamo_http_service_request_duration (sum/count)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -385,7 +385,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "1000*(nv_llm_http_service_request_duration_seconds_sum / nv_llm_http_service_request_duration_seconds_count)",
+          "expr": "1000*(dynamo_http_service_request_duration_seconds_sum / dynamo_http_service_request_duration_seconds_count)",
           "legendFormat": "{{model}}",
           "range": true,
           "refId": "A"
@@ -399,7 +399,7 @@
         "type": "prometheus",
         "uid": "P1809F7CD0C75ACF3"
       },
-      "description": "The length is the number of tokens. nv_llm_http_service_input_sequence_tokens",
+      "description": "The length is the number of tokens. dynamo_http_service_input_sequence_tokens",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -478,7 +478,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "nv_llm_http_service_input_sequence_tokens_sum / nv_llm_http_service_input_sequence_tokens_count",
+          "expr": "dynamo_http_service_input_sequence_tokens_sum / dynamo_http_service_input_sequence_tokens_count",
           "legendFormat": "ISL",
           "range": true,
           "refId": "A"
@@ -489,7 +489,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "nv_llm_http_service_output_sequence_tokens_sum / nv_llm_http_service_output_sequence_tokens_count",
+          "expr": "dynamo_http_service_output_sequence_tokens_sum / dynamo_http_service_output_sequence_tokens_count",
           "hide": false,
           "instant": false,
           "legendFormat": "OSL",

--- a/deploy/metrics/grafana_dashboards/grafana-llm-metrics.json
+++ b/deploy/metrics/grafana_dashboards/grafana-llm-metrics.json
@@ -26,7 +26,13 @@
     "distributed under the License is distributed on an \"AS IS\" BASIS,",
     "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
     "See the License for the specific language governing permissions and",
-    "limitations under the License."
+    "limitations under the License.",
+    "",
+    "DEPRECATION NOTICE:",
+    "This dashboard uses deprecated llm_kv_* metrics (llm_kv_blocks_active, llm_kv_blocks_total, llm_kv_hit_rate_percent)",
+    "that are part of the deprecated metrics aggregation service. These metrics will be removed in a future release.",
+    "Please migrate to the new MetricsRegistry system which provides dynamo_* metrics instead.",
+    "See docs/guides/metrics.md for migration guidance."
   ],
   "editable": true,
   "fiscalYearStartMonth": 0,

--- a/deploy/metrics/prometheus.yml
+++ b/deploy/metrics/prometheus.yml
@@ -47,6 +47,8 @@ scrape_configs:
     static_configs:
       - targets: ['host.docker.internal:8081']
 
+  # DEPRECATED: This metrics aggregation service is being deprecated in favor of MetricsRegistry
+  # The new system uses the 'dynamo-backend' job above instead of this separate service
   # This is another demo aggregator that needs to be launched manually. See components/metrics/README.md
   # Note that you may need to disable the firewall on your host. On Ubuntu: sudo ufw allow 9091/tcp
   - job_name: 'metrics-aggregation-service'

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -94,7 +94,8 @@ pub struct ResponseMetricCollector {
 
 impl Default for Metrics {
     fn default() -> Self {
-        Self::new("nv_llm")
+        // do not make this dynamic, because it'll be difficult to update on Grafana
+        Self::new("dynamo")
     }
 }
 

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -94,25 +94,24 @@ pub struct ResponseMetricCollector {
 
 impl Default for Metrics {
     fn default() -> Self {
-        // do not make this dynamic, because it'll be difficult to update on Grafana
-        Self::new("dynamo")
+        Self::new()
     }
 }
 
 impl Metrics {
-    /// Create Metrics with the given prefix
+    /// Create Metrics with hardcoded "dynamo" prefix
     /// The following metrics will be created:
-    /// - `{prefix}_http_service_requests_total` - IntCounterVec for the total number of requests processed
-    /// - `{prefix}_http_service_inflight_requests` - IntGaugeVec for the number of inflight requests
-    /// - `{prefix}_http_service_request_duration_seconds` - HistogramVec for the duration of requests
-    /// - `{prefix}_http_service_input_sequence_tokens` - HistogramVec for input sequence length in tokens
-    /// - `{prefix}_http_service_output_sequence_tokens` - HistogramVec for output sequence length in tokens
-    /// - `{prefix}_http_service_time_to_first_token_seconds` - HistogramVec for time to first token in seconds
-    /// - `{prefix}_http_service_inter_token_latency_seconds` - HistogramVec for inter-token latency in seconds
-    pub fn new(prefix: &str) -> Self {
+    /// - `dynamo_frontend_requests_total` - IntCounterVec for the total number of requests processed
+    /// - `dynamo_frontend_inflight_requests` - IntGaugeVec for the number of inflight requests
+    /// - `dynamo_frontend_request_duration_seconds` - HistogramVec for the duration of requests
+    /// - `dynamo_frontend_input_sequence_tokens` - HistogramVec for input sequence length in tokens
+    /// - `dynamo_frontend_output_sequence_tokens` - HistogramVec for output sequence length in tokens
+    /// - `dynamo_frontend_time_to_first_token_seconds` - HistogramVec for time to first token in seconds
+    /// - `dynamo_frontend_inter_token_latency_seconds` - HistogramVec for inter-token latency in seconds
+    pub fn new() -> Self {
         let request_counter = IntCounterVec::new(
             Opts::new(
-                format!("{}_http_service_requests_total", prefix),
+                "dynamo_frontend_requests_total",
                 "Total number of LLM requests processed",
             ),
             &["model", "endpoint", "request_type", "status"],
@@ -121,7 +120,7 @@ impl Metrics {
 
         let inflight_gauge = IntGaugeVec::new(
             Opts::new(
-                format!("{}_http_service_inflight_requests", prefix),
+                "dynamo_frontend_inflight_requests",
                 "Number of inflight requests",
             ),
             &["model"],
@@ -132,7 +131,7 @@ impl Metrics {
 
         let request_duration = HistogramVec::new(
             HistogramOpts::new(
-                format!("{}_http_service_request_duration_seconds", prefix),
+                "dynamo_frontend_request_duration_seconds",
                 "Duration of LLM requests",
             )
             .buckets(buckets),
@@ -142,7 +141,7 @@ impl Metrics {
 
         let input_sequence_length = HistogramVec::new(
             HistogramOpts::new(
-                format!("{}_http_service_input_sequence_tokens", prefix),
+                "dynamo_frontend_input_sequence_tokens",
                 "Input sequence length in tokens",
             )
             .buckets(vec![
@@ -155,7 +154,7 @@ impl Metrics {
 
         let output_sequence_length = HistogramVec::new(
             HistogramOpts::new(
-                format!("{}_http_service_output_sequence_tokens", prefix),
+                "dynamo_frontend_output_sequence_tokens",
                 "Output sequence length in tokens",
             )
             .buckets(vec![
@@ -167,7 +166,7 @@ impl Metrics {
 
         let time_to_first_token = HistogramVec::new(
             HistogramOpts::new(
-                format!("{}_http_service_time_to_first_token_seconds", prefix),
+                "dynamo_frontend_time_to_first_token_seconds",
                 "Time to first token in seconds",
             )
             .buckets(vec![
@@ -180,7 +179,7 @@ impl Metrics {
 
         let inter_token_latency = HistogramVec::new(
             HistogramOpts::new(
-                format!("{}_http_service_inter_token_latency_seconds", prefix),
+                "dynamo_frontend_inter_token_latency_seconds",
                 "Inter-token latency in seconds",
             )
             .buckets(vec![

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -12,6 +12,9 @@ pub use prometheus::Registry;
 
 use super::RouteDoc;
 
+/// Metric prefix for all HTTP service metrics
+pub const FRONTEND_METRIC_PREFIX: &str = "dynamo_frontend";
+
 /// Value for the `status` label in the request counter for successful requests
 pub const REQUEST_STATUS_SUCCESS: &str = "success";
 
@@ -23,6 +26,11 @@ pub const REQUEST_TYPE_STREAM: &str = "stream";
 
 /// Partial value for the `type` label in the request counter for unary requests
 pub const REQUEST_TYPE_UNARY: &str = "unary";
+
+/// Helper function to construct metric names with the standard prefix
+fn frontend_metric_name(suffix: &str) -> String {
+    format!("{}_{}", FRONTEND_METRIC_PREFIX, suffix)
+}
 
 pub struct Metrics {
     request_counter: IntCounterVec,
@@ -99,7 +107,7 @@ impl Default for Metrics {
 }
 
 impl Metrics {
-    /// Create Metrics with hardcoded "dynamo" prefix
+    /// Create Metrics with the standard prefix defined by [`FRONTEND_METRIC_PREFIX`]
     /// The following metrics will be created:
     /// - `dynamo_frontend_requests_total` - IntCounterVec for the total number of requests processed
     /// - `dynamo_frontend_inflight_requests` - IntGaugeVec for the number of inflight requests
@@ -111,7 +119,7 @@ impl Metrics {
     pub fn new() -> Self {
         let request_counter = IntCounterVec::new(
             Opts::new(
-                "dynamo_frontend_requests_total",
+                frontend_metric_name("requests_total"),
                 "Total number of LLM requests processed",
             ),
             &["model", "endpoint", "request_type", "status"],
@@ -120,7 +128,7 @@ impl Metrics {
 
         let inflight_gauge = IntGaugeVec::new(
             Opts::new(
-                "dynamo_frontend_inflight_requests",
+                frontend_metric_name("inflight_requests"),
                 "Number of inflight requests",
             ),
             &["model"],
@@ -131,7 +139,7 @@ impl Metrics {
 
         let request_duration = HistogramVec::new(
             HistogramOpts::new(
-                "dynamo_frontend_request_duration_seconds",
+                frontend_metric_name("request_duration_seconds"),
                 "Duration of LLM requests",
             )
             .buckets(buckets),
@@ -141,7 +149,7 @@ impl Metrics {
 
         let input_sequence_length = HistogramVec::new(
             HistogramOpts::new(
-                "dynamo_frontend_input_sequence_tokens",
+                frontend_metric_name("input_sequence_tokens"),
                 "Input sequence length in tokens",
             )
             .buckets(vec![
@@ -154,7 +162,7 @@ impl Metrics {
 
         let output_sequence_length = HistogramVec::new(
             HistogramOpts::new(
-                "dynamo_frontend_output_sequence_tokens",
+                frontend_metric_name("output_sequence_tokens"),
                 "Output sequence length in tokens",
             )
             .buckets(vec![
@@ -166,7 +174,7 @@ impl Metrics {
 
         let time_to_first_token = HistogramVec::new(
             HistogramOpts::new(
-                "dynamo_frontend_time_to_first_token_seconds",
+                frontend_metric_name("time_to_first_token_seconds"),
                 "Time to first token in seconds",
             )
             .buckets(vec![
@@ -179,7 +187,7 @@ impl Metrics {
 
         let inter_token_latency = HistogramVec::new(
             HistogramOpts::new(
-                "dynamo_frontend_inter_token_latency_seconds",
+                frontend_metric_name("inter_token_latency_seconds"),
                 "Inter-token latency in seconds",
             )
             .buckets(vec![

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -22,7 +22,7 @@ use dynamo_llm::http::{
     },
     service::{
         error::HttpError,
-        metrics::{Endpoint, RequestType, Status},
+        metrics::{Endpoint, FRONTEND_METRIC_PREFIX, RequestType, Status},
         service_v2::HttpService,
         Metrics,
     },
@@ -357,7 +357,7 @@ async fn test_http_service() {
     let families = registry.gather();
     let histogram_metric_family = families
         .into_iter()
-        .find(|m| m.get_name() == "dynamo_frontend_request_duration_seconds")
+        .find(|m| m.get_name() == &format!("{}_request_duration_seconds", FRONTEND_METRIC_PREFIX))
         .expect("Histogram metric not found");
 
     assert_eq!(

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -357,7 +357,7 @@ async fn test_http_service() {
     let families = registry.gather();
     let histogram_metric_family = families
         .into_iter()
-        .find(|m| m.get_name() == "nv_llm_http_service_request_duration_seconds")
+        .find(|m| m.get_name() == "dynamo_http_service_request_duration_seconds")
         .expect("Histogram metric not found");
 
     assert_eq!(

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -22,7 +22,7 @@ use dynamo_llm::http::{
     },
     service::{
         error::HttpError,
-        metrics::{Endpoint, FRONTEND_METRIC_PREFIX, RequestType, Status},
+        metrics::{Endpoint, RequestType, Status, FRONTEND_METRIC_PREFIX},
         service_v2::HttpService,
         Metrics,
     },
@@ -357,7 +357,7 @@ async fn test_http_service() {
     let families = registry.gather();
     let histogram_metric_family = families
         .into_iter()
-        .find(|m| m.get_name() == &format!("{}_request_duration_seconds", FRONTEND_METRIC_PREFIX))
+        .find(|m| m.get_name() == format!("{}_request_duration_seconds", FRONTEND_METRIC_PREFIX))
         .expect("Histogram metric not found");
 
     assert_eq!(

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -357,7 +357,7 @@ async fn test_http_service() {
     let families = registry.gather();
     let histogram_metric_family = families
         .into_iter()
-        .find(|m| m.get_name() == "dynamo_http_service_request_duration_seconds")
+        .find(|m| m.get_name() == "dynamo_frontend_request_duration_seconds")
         .expect("Histogram metric not found");
 
     assert_eq!(

--- a/lib/runtime/examples/system_metrics/README.md
+++ b/lib/runtime/examples/system_metrics/README.md
@@ -29,7 +29,7 @@ let ingress = Ingress::for_engine(my_handler)?;
 ingress.add_metrics(&endpoint)?;
 ```
 
-The endpoint automatically provides prefix of `dynamo_component_*` in the name, and automatic labeling (dynamo_namespace, dynamo_component, dynamo_endpoint) for all metrics. These labels are prefixed with "dynamo_" to avoid collisions with Kubernetes and other monitoring system labels.
+The endpoint automatically provides proper labeling (namespace, component, endpoint) for all metrics.
 
 ## Available Methods
 
@@ -44,13 +44,13 @@ The `Ingress` struct provides methods for metrics:
 The following Prometheus metrics are automatically created for all work handlers:
 
 ### Counters
-- `dynamo_component_requests_total` - Total requests processed
-- `dynamo_component_request_bytes_total` - Total bytes received in requests
-- `dynamo_component_response_bytes_total` - Total bytes sent in responses
-- `dynamo_component_errors_total` - Total errors encountered (with error_type labels)
+- `requests_total` - Total requests processed
+- `request_bytes_total` - Total bytes received in requests
+- `response_bytes_total` - Total bytes sent in responses
+- `errors_total` - Total errors encountered (with error_type labels)
 
 ### Error Types
-The `dynamo_component_errors_total` metric includes the following error types:
+The `errors_total` metric includes the following error types:
 - `deserialization` - Errors parsing request messages
 - `invalid_message` - Unexpected message format
 - `response_stream` - Errors creating response streams
@@ -59,65 +59,65 @@ The `dynamo_component_errors_total` metric includes the following error types:
 - `publish_final` - Errors publishing final response
 
 ### Histograms
-- `dynamo_component_request_duration_seconds` - Request processing time
+- `request_duration_seconds` - Request processing time
 
 ### Gauges
-- `dynamo_component_concurrent_requests` - Number of requests currently being processed
+- `concurrent_requests` - Number of requests currently being processed
 
 ### Custom Metrics (Optional)
-- `dynamo_component_my_custom_bytes_processed_total` - Total data bytes processed by system handler (example)
+- `my_custom_bytes_processed_total` - Total data bytes processed by system handler (example)
 
 ### Labels
 All metrics automatically include these labels from the endpoint:
-- `dynamo_namespace` - The namespace name
-- `dynamo_component` - The component name
-- `dynamo_endpoint` - The endpoint name
+- `namespace` - The namespace name
+- `component` - The component name
+- `endpoint` - The endpoint name
 
 ## Example Metrics Output
 
 When the system is running, you'll see metrics from the /metrics HTTP path like this:
 
 ```prometheus
-# HELP dynamo_component_concurrent_requests Number of requests currently being processed by work handler
-# TYPE dynamo_component_concurrent_requests gauge
-dynamo_component_concurrent_requests{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 0
+# HELP concurrent_requests Number of requests currently being processed by work handler
+# TYPE concurrent_requests gauge
+concurrent_requests{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 0
 
-# HELP dynamo_component_my_custom_bytes_processed_total Example of a custom metric. Total number of data bytes processed by system handler
-# TYPE dynamo_component_my_custom_bytes_processed_total counter
-dynamo_component_my_custom_bytes_processed_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 42
+# HELP my_custom_bytes_processed_total Example of a custom metric. Total number of data bytes processed by system handler
+# TYPE my_custom_bytes_processed_total counter
+my_custom_bytes_processed_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 42
 
-# HELP dynamo_component_request_bytes_total Total number of bytes received in requests by work handler
-# TYPE dynamo_component_request_bytes_total counter
-dynamo_component_request_bytes_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 1098
+# HELP request_bytes_total Total number of bytes received in requests by work handler
+# TYPE request_bytes_total counter
+request_bytes_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 1098
 
-# HELP dynamo_component_request_duration_seconds Time spent processing requests by work handler
-# TYPE dynamo_component_request_duration_seconds histogram
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.005"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.01"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.025"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.05"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.1"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.25"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.5"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="1"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="2.5"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="5"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="10"} 3
-dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="+Inf"} 3
-dynamo_component_request_duration_seconds_sum{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 0.00048793700000000003
-dynamo_component_request_duration_seconds_count{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 3
+# HELP request_duration_seconds Time spent processing requests by work handler
+# TYPE request_duration_seconds histogram
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.005"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.01"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.025"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.05"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.1"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.25"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.5"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="1"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="2.5"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="5"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="10"} 3
+request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="+Inf"} 3
+request_duration_seconds_sum{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 0.00048793700000000003
+request_duration_seconds_count{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 3
 
-# HELP dynamo_component_requests_total Total number of requests processed by work handler
-# TYPE dynamo_component_requests_total counter
-dynamo_component_requests_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 3
+# HELP requests_total Total number of requests processed by work handler
+# TYPE requests_total counter
+requests_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 3
 
-# HELP dynamo_component_response_bytes_total Total number of bytes sent in responses by work handler
-# TYPE dynamo_component_response_bytes_total counter
-dynamo_component_response_bytes_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 1917
+# HELP response_bytes_total Total number of bytes sent in responses by work handler
+# TYPE response_bytes_total counter
+response_bytes_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 1917
 
-# HELP dynamo_component_uptime_seconds Total uptime of the DistributedRuntime in seconds
-# TYPE dynamo_component_uptime_seconds gauge
-dynamo_component_uptime_seconds{dynamo_namespace="http_server"} 1.8226759879999999
+# HELP uptime_seconds Total uptime of the DistributedRuntime in seconds
+# TYPE uptime_seconds gauge
+uptime_seconds{namespace="http_server"} 1.8226759879999999
 ```
 
 ## Examples
@@ -211,7 +211,7 @@ Once running, you can query the metrics:
 curl http://localhost:8081/metrics | grep -E "(requests_total|request_bytes_total|response_bytes_total|errors_total|request_duration_seconds|concurrent_requests)"
 
 # Get request count for specific endpoint
-curl http://localhost:8081/metrics | grep 'requests_total{endpoint="example_endpoint"}'
+curl http://localhost:8081/metrics | grep 'requests_total{endpoint="dyn_example_endpoint"}'
 
 # Get request duration histogram
 curl http://localhost:8081/metrics | grep 'request_duration_seconds'

--- a/lib/runtime/examples/system_metrics/README.md
+++ b/lib/runtime/examples/system_metrics/README.md
@@ -29,7 +29,7 @@ let ingress = Ingress::for_engine(my_handler)?;
 ingress.add_metrics(&endpoint)?;
 ```
 
-The endpoint automatically provides proper labeling (namespace, component, endpoint) for all metrics.
+The endpoint automatically provides prefix of `dynamo_component_*` in the name, and automatic labeling (dynamo_namespace, dynamo_component, dynamo_endpoint) for all metrics. These labels are prefixed with "dynamo_" to avoid collisions with Kubernetes and other monitoring system labels.
 
 ## Available Methods
 
@@ -44,13 +44,13 @@ The `Ingress` struct provides methods for metrics:
 The following Prometheus metrics are automatically created for all work handlers:
 
 ### Counters
-- `requests_total` - Total requests processed
-- `request_bytes_total` - Total bytes received in requests
-- `response_bytes_total` - Total bytes sent in responses
-- `errors_total` - Total errors encountered (with error_type labels)
+- `dynamo_component_requests_total` - Total requests processed
+- `dynamo_component_request_bytes_total` - Total bytes received in requests
+- `dynamo_component_response_bytes_total` - Total bytes sent in responses
+- `dynamo_component_errors_total` - Total errors encountered (with error_type labels)
 
 ### Error Types
-The `errors_total` metric includes the following error types:
+The `dynamo_component_errors_total` metric includes the following error types:
 - `deserialization` - Errors parsing request messages
 - `invalid_message` - Unexpected message format
 - `response_stream` - Errors creating response streams
@@ -59,65 +59,65 @@ The `errors_total` metric includes the following error types:
 - `publish_final` - Errors publishing final response
 
 ### Histograms
-- `request_duration_seconds` - Request processing time
+- `dynamo_component_request_duration_seconds` - Request processing time
 
 ### Gauges
-- `concurrent_requests` - Number of requests currently being processed
+- `dynamo_component_concurrent_requests` - Number of requests currently being processed
 
 ### Custom Metrics (Optional)
-- `my_custom_bytes_processed_total` - Total data bytes processed by system handler (example)
+- `dynamo_component_my_custom_bytes_processed_total` - Total data bytes processed by system handler (example)
 
 ### Labels
 All metrics automatically include these labels from the endpoint:
-- `namespace` - The namespace name
-- `component` - The component name
-- `endpoint` - The endpoint name
+- `dynamo_namespace` - The namespace name
+- `dynamo_component` - The component name
+- `dynamo_endpoint` - The endpoint name
 
 ## Example Metrics Output
 
 When the system is running, you'll see metrics from the /metrics HTTP path like this:
 
 ```prometheus
-# HELP concurrent_requests Number of requests currently being processed by work handler
-# TYPE concurrent_requests gauge
-concurrent_requests{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 0
+# HELP dynamo_component_concurrent_requests Number of requests currently being processed by work handler
+# TYPE dynamo_component_concurrent_requests gauge
+dynamo_component_concurrent_requests{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 0
 
-# HELP my_custom_bytes_processed_total Example of a custom metric. Total number of data bytes processed by system handler
-# TYPE my_custom_bytes_processed_total counter
-my_custom_bytes_processed_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 42
+# HELP dynamo_component_my_custom_bytes_processed_total Example of a custom metric. Total number of data bytes processed by system handler
+# TYPE dynamo_component_my_custom_bytes_processed_total counter
+dynamo_component_my_custom_bytes_processed_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 42
 
-# HELP request_bytes_total Total number of bytes received in requests by work handler
-# TYPE request_bytes_total counter
-request_bytes_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 1098
+# HELP dynamo_component_request_bytes_total Total number of bytes received in requests by work handler
+# TYPE dynamo_component_request_bytes_total counter
+dynamo_component_request_bytes_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 1098
 
-# HELP request_duration_seconds Time spent processing requests by work handler
-# TYPE request_duration_seconds histogram
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.005"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.01"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.025"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.05"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.1"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.25"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.5"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="1"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="2.5"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="5"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="10"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="+Inf"} 3
-request_duration_seconds_sum{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 0.00048793700000000003
-request_duration_seconds_count{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 3
+# HELP dynamo_component_request_duration_seconds Time spent processing requests by work handler
+# TYPE dynamo_component_request_duration_seconds histogram
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.005"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.01"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.025"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.05"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.1"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.25"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.5"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="1"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="2.5"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="5"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="10"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="+Inf"} 3
+dynamo_component_request_duration_seconds_sum{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 0.00048793700000000003
+dynamo_component_request_duration_seconds_count{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 3
 
-# HELP requests_total Total number of requests processed by work handler
-# TYPE requests_total counter
-requests_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 3
+# HELP dynamo_component_requests_total Total number of requests processed by work handler
+# TYPE dynamo_component_requests_total counter
+dynamo_component_requests_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 3
 
-# HELP response_bytes_total Total number of bytes sent in responses by work handler
-# TYPE response_bytes_total counter
-response_bytes_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 1917
+# HELP dynamo_component_response_bytes_total Total number of bytes sent in responses by work handler
+# TYPE dynamo_component_response_bytes_total counter
+dynamo_component_response_bytes_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 1917
 
-# HELP uptime_seconds Total uptime of the DistributedRuntime in seconds
-# TYPE uptime_seconds gauge
-uptime_seconds{namespace="http_server"} 1.8226759879999999
+# HELP dynamo_component_uptime_seconds Total uptime of the DistributedRuntime in seconds
+# TYPE dynamo_component_uptime_seconds gauge
+dynamo_component_uptime_seconds{dynamo_namespace="http_server"} 1.8226759879999999
 ```
 
 ## Examples
@@ -211,7 +211,7 @@ Once running, you can query the metrics:
 curl http://localhost:8081/metrics | grep -E "(requests_total|request_bytes_total|response_bytes_total|errors_total|request_duration_seconds|concurrent_requests)"
 
 # Get request count for specific endpoint
-curl http://localhost:8081/metrics | grep 'requests_total{endpoint="dyn_example_endpoint"}'
+curl http://localhost:8081/metrics | grep 'requests_total{endpoint="example_endpoint"}'
 
 # Get request duration histogram
 curl http://localhost:8081/metrics | grep 'request_duration_seconds'

--- a/lib/runtime/src/http_server.rs
+++ b/lib/runtime/src/http_server.rs
@@ -65,25 +65,8 @@ impl Clone for HttpServerInfo {
     }
 }
 
-pub struct HttpMetricsRegistry {
-    pub drt: Arc<crate::DistributedRuntime>,
-}
 
-impl crate::traits::DistributedRuntimeProvider for HttpMetricsRegistry {
-    fn drt(&self) -> &crate::DistributedRuntime {
-        &self.drt
-    }
-}
 
-impl MetricsRegistry for HttpMetricsRegistry {
-    fn basename(&self) -> String {
-        "dynamo".to_string()
-    }
-
-    fn parent_hierarchy(&self) -> Vec<String> {
-        [self.drt().parent_hierarchy(), vec![self.drt().basename()]].concat()
-    }
-}
 
 /// HTTP server state containing metrics and uptime tracking
 pub struct HttpServerState {
@@ -96,11 +79,10 @@ pub struct HttpServerState {
 impl HttpServerState {
     /// Create new HTTP server state with the provided metrics registry
     pub fn new(drt: Arc<crate::DistributedRuntime>) -> anyhow::Result<Self> {
-        let http_metrics_registry = Arc::new(HttpMetricsRegistry { drt: drt.clone() });
         // Note: This metric is created at the DRT level (no namespace), so we manually add "dynamo_" prefix
         // to maintain consistency with the project's metric naming convention
-        let uptime_gauge = http_metrics_registry.as_ref().create_gauge(
-            "system_uptime_seconds",
+        let uptime_gauge = drt.as_ref().create_gauge(
+            "dynamo_uptime_seconds",
             "Total uptime of the DistributedRuntime in seconds",
             &[],
         )?;
@@ -368,9 +350,9 @@ mod tests {
         println!("Full metrics response:\n{}", response);
 
         let expected = "\
-# HELP dynamo_system_uptime_seconds Total uptime of the DistributedRuntime in seconds
-# TYPE dynamo_system_uptime_seconds gauge
-dynamo_system_uptime_seconds{namespace=\"dynamo\"} 42
+# HELP dynamo_uptime_seconds Total uptime of the DistributedRuntime in seconds
+# TYPE dynamo_uptime_seconds gauge
+dynamo_uptime_seconds 42
 ";
         assert_eq!(response, expected);
     }
@@ -445,8 +427,8 @@ dynamo_system_uptime_seconds{namespace=\"dynamo\"} 42
                     let tracestate_value = "vendor1=opaqueValue1,vendor2=opaqueValue2";
                     let mut headers = reqwest::header::HeaderMap::new();
                     headers.insert(
-                        reqwest::header::HeaderName.from_static("traceparent"),
-                        reqwest::header::HeaderValue.from_str(traceparent_value)?,
+                        reqwest::header::HeaderName::from_static("traceparent"),
+                        reqwest::header::HeaderValue::from_str(traceparent_value).unwrap(),
                     );
                     let url = format!("http://{}{}", addr, path);
                     let response = client.get(&url).send().await.unwrap();

--- a/lib/runtime/src/http_server.rs
+++ b/lib/runtime/src/http_server.rs
@@ -66,8 +66,6 @@ impl Clone for HttpServerInfo {
 }
 
 
-
-
 /// HTTP server state containing metrics and uptime tracking
 pub struct HttpServerState {
     // global drt registry is for printing out the entire Prometheus format output

--- a/lib/runtime/src/http_server.rs
+++ b/lib/runtime/src/http_server.rs
@@ -65,7 +65,6 @@ impl Clone for HttpServerInfo {
     }
 }
 
-
 /// HTTP server state containing metrics and uptime tracking
 pub struct HttpServerState {
     // global drt registry is for printing out the entire Prometheus format output

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -645,6 +645,7 @@ mod tests {
 mod test_prefixes {
     use super::create_test_drt;
     use super::*;
+    use prometheus::core::Collector;
 
     #[test]
     fn test_hierarchical_prefixes_and_parent_hierarchies() {
@@ -810,16 +811,26 @@ mod test_prefixes {
         );
         println!("Invalid namespace prefix: '{}'", invalid_namespace.prefix());
 
-        // Try to create a metric - this should fail because "@@123" gets stripped to "" which is invalid
+        // Try to create a metric - this should succeed because the namespace name will be sanitized
         let result = invalid_namespace.create_counter("test_counter", "A test counter", &[]);
         println!("Result with invalid namespace '@@123':");
         println!("{:?}", result);
 
-        // The result should be an error from Prometheus
+        // The result should fail because even after sanitization, the name "123" doesn't follow Prometheus naming pattern
         assert!(
             result.is_err(),
-            "Creating metric with invalid namespace should fail"
+            "Creating metric with invalid namespace should fail even after sanitization"
         );
+
+        // Verify the error message indicates the sanitized name is still invalid
+        if let Err(e) = &result {
+            let error_msg = e.to_string();
+            assert!(
+                error_msg.contains("123"),
+                "Error message should mention the sanitized name '123', got: {}",
+                error_msg
+            );
+        }
 
         // For comparison, show a valid namespace works
         let valid_namespace = drt.namespace("test_namespace").unwrap();
@@ -926,15 +937,15 @@ testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 5
         println!("{}", namespace_output);
 
         let expected_namespace_output = format!(
-            r#"# HELP testintcounter A test int counter
-# TYPE testintcounter counter
-testintcounter{{namespace="testnamespace"}} 12345
-# HELP testnamespace_testcounter A test counter
+            r#"# HELP testnamespace_testcounter A test counter
 # TYPE testnamespace_testcounter counter
 testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",namespace="testnamespace"}} 123.456789
 # HELP testnamespace_testgauge A test gauge
 # TYPE testnamespace_testgauge gauge
 testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 50000
+# HELP testnamespace_testintcounter A test int counter
+# TYPE testnamespace_testintcounter counter
+testnamespace_testintcounter{{namespace="testnamespace"}} 12345
 "#
         );
 
@@ -1015,9 +1026,6 @@ testhistogram_bucket{{le="10"}} 3
 testhistogram_bucket{{le="+Inf"}} 3
 testhistogram_sum 7.5
 testhistogram_count 3
-# HELP testintcounter A test int counter
-# TYPE testintcounter counter
-testintcounter{{namespace="testnamespace"}} 12345
 # HELP testintgauge A test int gauge
 # TYPE testintgauge gauge
 testintgauge 42
@@ -1031,6 +1039,9 @@ testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",nam
 # HELP testnamespace_testgauge A test gauge
 # TYPE testnamespace_testgauge gauge
 testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 50000
+# HELP testnamespace_testintcounter A test int counter
+# TYPE testnamespace_testintcounter counter
+testnamespace_testintcounter{{namespace="testnamespace"}} 12345
 "#
         );
 

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -17,6 +17,11 @@
 //!
 //! This module provides registry classes for Prometheus metrics
 //! that auto populates the labels with the namespace-component-endpoint hierarchy.
+//!
+//! Note: Labels use "dynamo_" prefix (e.g., "dynamo_namespace", "dynamo_component", "dynamo_endpoint")
+//! to avoid collisions with Kubernetes labels. Kubernetes commonly uses labels like "namespace", "pod",
+//! "service", "app", "version", etc., and using plain names would cause conflicts in Prometheus queries,
+//! dashboards, and alerting rules. The "dynamo_" prefix ensures our metrics remain distinct and unambiguous.
 
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -30,12 +35,15 @@ pub const USE_AUTO_LABELS: bool = true;
 // Prometheus imports
 use prometheus::Encoder;
 
-fn build_metric_name(namespace: &str, metric_name: &str) -> String {
-    if !namespace.is_empty() {
-        format!("{}_{}", namespace, metric_name)
-    } else {
-        metric_name.to_string()
-    }
+/// Builds a metric name with the hardcoded "dynamo_component" prefix.
+///
+/// Note: The "dynamo_component" prefix is hardcoded instead of being dynamic because:
+/// - Consumers (Grafana dashboards, monitoring systems) expect static metric names
+/// - Dynamic prefixes would make Prometheus queries and alerting rules brittle
+/// - Metric name changes require updates to all dependent systems (dashboards, alerts, documentation)
+/// - Static names provide better discoverability and consistency across deployments
+fn build_metric_name(metric_name: &str) -> String {
+    format!("dynamo_component_{}", metric_name)
 }
 
 /// Lints a metric name component by stripping off invalid characters and validating Prometheus naming pattern
@@ -199,27 +207,6 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
 ) -> anyhow::Result<Arc<T>> {
     // Validate that user-provided labels don't have duplicate keys
     let mut seen_keys = std::collections::HashSet::new();
-
-    let basename = registry.basename();
-    let parent_hierarchy = registry.parent_hierarchy();
-
-    // Build hierarchy: parent_hierarchy + [basename]
-    let hierarchy = [parent_hierarchy.clone(), vec![basename.clone()]].concat();
-
-    let namespace = if hierarchy.len() >= 2 {
-        let potential_namespace = &hierarchy[1];
-        if !potential_namespace.is_empty() {
-            lint_prometheus_name(potential_namespace)?
-        } else {
-            "".to_string()
-        }
-    } else {
-        "".to_string()
-    };
-
-    let metric_name = build_metric_name(&namespace, metric_name);
-
-    // Validate that user-provided labels don't have duplicate keys
     for (key, _) in labels {
         if !seen_keys.insert(*key) {
             return Err(anyhow::anyhow!(
@@ -228,13 +215,26 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
             ));
         }
     }
+
+    let metric_name = build_metric_name(metric_name);
+
+    // Get hierarchy information (needed for both auto-labels and metric registration)
+    let basename = registry.basename();
+    let parent_hierarchy = registry.parent_hierarchy();
+    let hierarchy = [parent_hierarchy.clone(), vec![basename.clone()]].concat();
+
     // Build updated_labels: auto-labels first, then user labels
     let mut updated_labels: Vec<(String, String)> = Vec::new();
 
     if USE_AUTO_LABELS {
-        // Validate that user-provided labels don't conflict with auto-generated labels
+        // Validate that user-provided labels don't conflict with auto-generated labels.
+        // These labels are automatically added by the MetricsRegistry to provide consistent
+        // hierarchical context across all Dynamo metrics. The "dynamo_" prefix is critical to
+        // avoid collisions with Kubernetes labels, which commonly use plain names like "namespace",
+        // "pod", "service", "app", "version", etc.
         for (key, _) in labels {
-            if *key == "namespace" || *key == "component" || *key == "endpoint" {
+            if *key == "dynamo_namespace" || *key == "dynamo_component" || *key == "dynamo_endpoint"
+            {
                 return Err(anyhow::anyhow!(
                     "Label '{}' is automatically added by auto_label feature and cannot be manually set",
                     key
@@ -242,25 +242,42 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
             }
         }
 
-        // Add auto-generated labels with sanitized values
-        if !namespace.is_empty() {
-            updated_labels.push(("namespace".to_string(), namespace.to_string()));
-        }
-        if hierarchy.len() > 2 {
-            let component = &hierarchy[2];
-            if !component.is_empty() {
-                let valid_component = lint_prometheus_name(component)?;
-                if !valid_component.is_empty() {
-                    updated_labels.push(("component".to_string(), valid_component));
+        // Add auto-generated labels with sanitized values.
+        // CRITICAL: We use "dynamo_" prefixed labels to avoid collisions with Kubernetes labels.
+        // Kubernetes environments commonly use labels like "namespace", "pod", "service", "app",
+        // "version", "instance", "node", "deployment", etc. Using plain names would cause conflicts
+        // in Prometheus queries, dashboards, and alerting rules, making it impossible to distinguish
+        // between Kubernetes system labels and our application metrics.
+        //
+        // Namespace label (from hierarchy[1])
+        if hierarchy.len() > 1 {
+            let raw_namespace = &hierarchy[1];
+            if !raw_namespace.is_empty() {
+                let valid_namespace = lint_prometheus_name(raw_namespace)?;
+                if !valid_namespace.is_empty() {
+                    updated_labels.push(("dynamo_namespace".to_string(), valid_namespace));
                 }
             }
         }
+
+        // Component label (from hierarchy[2])
+        if hierarchy.len() > 2 {
+            let raw_component = &hierarchy[2];
+            if !raw_component.is_empty() {
+                let valid_component = lint_prometheus_name(raw_component)?;
+                if !valid_component.is_empty() {
+                    updated_labels.push(("dynamo_component".to_string(), valid_component));
+                }
+            }
+        }
+
+        // Endpoint label (from hierarchy[3])
         if hierarchy.len() > 3 {
-            let endpoint = &hierarchy[3];
-            if !endpoint.is_empty() {
-                let valid_endpoint = lint_prometheus_name(endpoint)?;
+            let raw_endpoint = &hierarchy[3];
+            if !raw_endpoint.is_empty() {
+                let valid_endpoint = lint_prometheus_name(raw_endpoint)?;
                 if !valid_endpoint.is_empty() {
-                    updated_labels.push(("endpoint".to_string(), valid_endpoint));
+                    updated_labels.push(("dynamo_endpoint".to_string(), valid_endpoint));
                 }
             }
         }
@@ -560,12 +577,12 @@ mod tests {
 
     #[test]
     fn test_build_metric_name_with_prefix() {
-        // Test that build_metric_name correctly prepends the namespace
-        let result = build_metric_name("", "requests");
-        assert_eq!(result, "requests");
+        // Test that build_metric_name correctly prepends the hardcoded "dynamo_component" prefix
+        let result = build_metric_name("requests");
+        assert_eq!(result, "dynamo_component_requests");
 
-        let result = build_metric_name("dynamo", "requests");
-        assert_eq!(result, "dynamo_requests");
+        let result = build_metric_name("total_count");
+        assert_eq!(result, "dynamo_component_total_count");
     }
 
     #[test]
@@ -815,10 +832,10 @@ mod test_prefixes {
         println!("Result with invalid namespace '@@123':");
         println!("{:?}", result);
 
-        // The result should be an error because empty metric names are invalid
+        // The result should succeed since hyphens are allowed in namespace names
         assert!(
-            result.is_err(),
-            "Creating metric with namespace '@@123' should fail because it gets stripped to empty string"
+            result.is_ok(),
+            "Creating metric with namespace containing hyphens should succeed"
         );
 
         // For comparison, show a valid namespace works
@@ -831,7 +848,7 @@ mod test_prefixes {
             "Creating metric with valid namespace should succeed"
         );
 
-        println!("✓ Invalid namespace behavior verified!");
+        println!("✓ Namespace with hyphens behavior verified!");
     }
 }
 
@@ -868,9 +885,9 @@ mod test_simple_metricsregistry_trait {
         println!("{}", endpoint_output);
 
         let expected_endpoint_output = format!(
-            r#"# HELP testnamespace_testcounter A test counter
-# TYPE testnamespace_testcounter counter
-testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",namespace="testnamespace"}} 123.456789
+            r#"# HELP dynamo_component_testcounter A test counter
+# TYPE dynamo_component_testcounter counter
+dynamo_component_testcounter{{dynamo_component="testcomponent",dynamo_endpoint="testendpoint",dynamo_namespace="testnamespace"}} 123.456789
 "#
         );
 
@@ -896,12 +913,12 @@ testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",nam
         println!("{}", component_output);
 
         let expected_component_output = format!(
-            r#"# HELP testnamespace_testcounter A test counter
-# TYPE testnamespace_testcounter counter
-testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",namespace="testnamespace"}} 123.456789
-# HELP testnamespace_testgauge A test gauge
-# TYPE testnamespace_testgauge gauge
-testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 50000
+            r#"# HELP dynamo_component_testcounter A test counter
+# TYPE dynamo_component_testcounter counter
+dynamo_component_testcounter{{dynamo_component="testcomponent",dynamo_endpoint="testendpoint",dynamo_namespace="testnamespace"}} 123.456789
+# HELP dynamo_component_testgauge A test gauge
+# TYPE dynamo_component_testgauge gauge
+dynamo_component_testgauge{{dynamo_component="testcomponent",dynamo_namespace="testnamespace"}} 50000
 "#
         );
 
@@ -926,15 +943,15 @@ testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 5
         println!("{}", namespace_output);
 
         let expected_namespace_output = format!(
-            r#"# HELP testnamespace_testcounter A test counter
-# TYPE testnamespace_testcounter counter
-testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",namespace="testnamespace"}} 123.456789
-# HELP testnamespace_testgauge A test gauge
-# TYPE testnamespace_testgauge gauge
-testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 50000
-# HELP testnamespace_testintcounter A test int counter
-# TYPE testnamespace_testintcounter counter
-testnamespace_testintcounter{{namespace="testnamespace"}} 12345
+            r#"# HELP dynamo_component_testcounter A test counter
+# TYPE dynamo_component_testcounter counter
+dynamo_component_testcounter{{dynamo_component="testcomponent",dynamo_endpoint="testendpoint",dynamo_namespace="testnamespace"}} 123.456789
+# HELP dynamo_component_testgauge A test gauge
+# TYPE dynamo_component_testgauge gauge
+dynamo_component_testgauge{{dynamo_component="testcomponent",dynamo_namespace="testnamespace"}} 50000
+# HELP dynamo_component_testintcounter A test int counter
+# TYPE dynamo_component_testintcounter counter
+dynamo_component_testintcounter{{dynamo_namespace="testnamespace"}} 12345
 "#
         );
 
@@ -1002,35 +1019,35 @@ testnamespace_testintcounter{{namespace="testnamespace"}} 12345
         println!("{}", drt_output);
 
         let expected_drt_output = format!(
-            r#"# HELP testcountervec A test counter vector
-# TYPE testcountervec counter
-testcountervec{{method="GET",service="api",status="200"}} 10
-testcountervec{{method="POST",service="api",status="201"}} 5
-# HELP testhistogram A test histogram
-# TYPE testhistogram histogram
-testhistogram_bucket{{le="1"}} 0
-testhistogram_bucket{{le="2.5"}} 2
-testhistogram_bucket{{le="5"}} 3
-testhistogram_bucket{{le="10"}} 3
-testhistogram_bucket{{le="+Inf"}} 3
-testhistogram_sum 7.5
-testhistogram_count 3
-# HELP testintgauge A test int gauge
-# TYPE testintgauge gauge
-testintgauge 42
-# HELP testintgaugevec A test int gauge vector
-# TYPE testintgaugevec gauge
-testintgaugevec{{instance="server1",service="api",status="active"}} 10
-testintgaugevec{{instance="server2",service="api",status="inactive"}} 0
-# HELP testnamespace_testcounter A test counter
-# TYPE testnamespace_testcounter counter
-testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",namespace="testnamespace"}} 123.456789
-# HELP testnamespace_testgauge A test gauge
-# TYPE testnamespace_testgauge gauge
-testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 50000
-# HELP testnamespace_testintcounter A test int counter
-# TYPE testnamespace_testintcounter counter
-testnamespace_testintcounter{{namespace="testnamespace"}} 12345
+            r#"# HELP dynamo_component_testcounter A test counter
+# TYPE dynamo_component_testcounter counter
+dynamo_component_testcounter{{dynamo_component="testcomponent",dynamo_endpoint="testendpoint",dynamo_namespace="testnamespace"}} 123.456789
+# HELP dynamo_component_testcountervec A test counter vector
+# TYPE dynamo_component_testcountervec counter
+dynamo_component_testcountervec{{method="GET",service="api",status="200"}} 10
+dynamo_component_testcountervec{{method="POST",service="api",status="201"}} 5
+# HELP dynamo_component_testgauge A test gauge
+# TYPE dynamo_component_testgauge gauge
+dynamo_component_testgauge{{dynamo_component="testcomponent",dynamo_namespace="testnamespace"}} 50000
+# HELP dynamo_component_testhistogram A test histogram
+# TYPE dynamo_component_testhistogram histogram
+dynamo_component_testhistogram_bucket{{le="1"}} 0
+dynamo_component_testhistogram_bucket{{le="2.5"}} 2
+dynamo_component_testhistogram_bucket{{le="5"}} 3
+dynamo_component_testhistogram_bucket{{le="10"}} 3
+dynamo_component_testhistogram_bucket{{le="+Inf"}} 3
+dynamo_component_testhistogram_sum 7.5
+dynamo_component_testhistogram_count 3
+# HELP dynamo_component_testintcounter A test int counter
+# TYPE dynamo_component_testintcounter counter
+dynamo_component_testintcounter{{dynamo_namespace="testnamespace"}} 12345
+# HELP dynamo_component_testintgauge A test int gauge
+# TYPE dynamo_component_testintgauge gauge
+dynamo_component_testintgauge 42
+# HELP dynamo_component_testintgaugevec A test int gauge vector
+# TYPE dynamo_component_testintgaugevec gauge
+dynamo_component_testintgaugevec{{instance="server1",service="api",status="active"}} 10
+dynamo_component_testintgaugevec{{instance="server2",service="api",status="inactive"}} 0
 "#
         );
 


### PR DESCRIPTION
#### Overview:

Renames frontend metrics from `nv_llm_http_service_*` to `dynamo_frontend_*` and hardcodes the "dynamo" prefix in the metrics system for consistency and simplified API.

#### Details:

- **Metric Renaming**: Updates all frontend metric names from `nv_llm_http_service_*` to `dynamo_frontend_*` across Rust code, Python utilities, and Grafana dashboards
- **Hardcoded Prefix**: Simplifies the Metrics API by removing the dynamic prefix parameter and hardcoding "dynamo" as the prefix
- **Deprecation Notices**: Adds prominent deprecation warnings for the old `components/metrics` component and `llm_kv_*` metrics
- **Documentation Updates**: Updates metrics documentation to reflect the new naming convention and simplified API

#### Where should the reviewer start?

- `lib/llm/src/http/service/metrics.rs` - Core metrics implementation changes
- `components/planner/src/dynamo/planner/utils/prometheus.py` - Python utility updates
- `deploy/metrics/grafana_dashboards/grafana-dynamo-dashboard.json` - Dashboard metric name updates
- `docs/guides/metrics.md` - Documentation updates

#### Related Issues:

Relates to DIS-337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notices to metrics-related documentation and Grafana dashboards, guiding users to migrate to the new MetricsRegistry system.
  * Updated instructions and references to reflect the new metrics system and changed metric prefixes from legacy names to "dynamo" or "dynamo_frontend".
  * Clarified migration steps and provided links to updated guides.

* **Refactor**
  * Standardized all Prometheus metric names and queries to use the "dynamo_frontend" prefix, replacing older naming conventions.

* **Tests**
  * Updated tests to check for the new metric names reflecting the "dynamo_frontend" prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->