### PR TITLE
fix: dynamo_component to be added in metric names

### DIFF
--- a/lib/runtime/examples/system_metrics/README.md
+++ b/lib/runtime/examples/system_metrics/README.md
@@ -1,10 +1,10 @@
-# Generic Profiling for Work Handlers
+# Generic Profiling for Request Handlers
 
-This example demonstrates how to add automatic Prometheus metrics profiling to any work handler without modifying the handler code itself.
+This example demonstrates how to add automatic Prometheus metrics profiling to any request handler without modifying the handler code itself.
 
 ## Overview
 
-The `WorkHandlerMetrics` system provides automatic profiling capabilities that are applied to all work handlers automatically. It automatically tracks:
+The `RequestHandlerMetrics` system provides automatic profiling capabilities that are applied to all request handlers automatically. It automatically tracks:
 
 - **Request Count**: Total number of requests processed
 - **Request Duration**: Time spent processing each request
@@ -15,7 +15,7 @@ Additionally, the example demonstrates how to add custom metrics with data bytes
 
 ## How It Works
 
-**Automatic Metrics**: All work handlers automatically get profiling metrics without any code changes.
+**Automatic Metrics**: All request handlers automatically get profiling metrics without any code changes.
 
 **Custom Metrics**: If you want to add custom metrics IN ADDITION to the automatic ones, you can use the `add_metrics` method:
 
@@ -29,28 +29,28 @@ let ingress = Ingress::for_engine(my_handler)?;
 ingress.add_metrics(&endpoint)?;
 ```
 
-The endpoint automatically provides proper labeling (namespace, component, endpoint) for all metrics.
+The endpoint automatically provides proper labeling (dynamo_namespace, dynamo_component, dynamo_endpoint) for all metrics. These labels are prefixed with "dynamo_" to avoid collisions with Kubernetes and other monitoring system labels.
 
 ## Available Methods
 
 The `Ingress` struct provides methods for metrics:
 
-- **Automatic**: All handlers get profiling metrics automatically
+- **Automatic**: All request handlers get profiling metrics automatically
 - `Ingress::add_metrics(&endpoint)` - Add custom metrics IN ADDITION to automatic ones (optional)
 
 ## Metrics Generated
 
 ### Automatic Metrics (No Code Changes Required)
-The following Prometheus metrics are automatically created for all work handlers:
+The following Prometheus metrics are automatically created for all request handlers:
 
 ### Counters
-- `requests_total` - Total requests processed
-- `request_bytes_total` - Total bytes received in requests
-- `response_bytes_total` - Total bytes sent in responses
-- `errors_total` - Total errors encountered (with error_type labels)
+- `dynamo_component_requests_total` - Total requests processed
+- `dynamo_component_request_bytes_total` - Total bytes received in requests
+- `dynamo_component_response_bytes_total` - Total bytes sent in responses
+- `dynamo_component_errors_total` - Total errors encountered (with error_type labels)
 
 ### Error Types
-The `errors_total` metric includes the following error types:
+The `dynamo_component_errors_total` metric includes the following error types:
 - `deserialization` - Errors parsing request messages
 - `invalid_message` - Unexpected message format
 - `response_stream` - Errors creating response streams
@@ -59,65 +59,67 @@ The `errors_total` metric includes the following error types:
 - `publish_final` - Errors publishing final response
 
 ### Histograms
-- `request_duration_seconds` - Request processing time
+- `dynamo_component_request_duration_seconds` - Request processing time
 
 ### Gauges
-- `concurrent_requests` - Number of requests currently being processed
+- `dynamo_component_concurrent_requests` - Number of requests currently being processed
 
 ### Custom Metrics (Optional)
-- `my_custom_bytes_processed_total` - Total data bytes processed by system handler (example)
+- `dynamo_component_my_custom_bytes_processed_total` - Total data bytes processed by system handler (example)
 
 ### Labels
 All metrics automatically include these labels from the endpoint:
-- `namespace` - The namespace name
-- `component` - The component name
-- `endpoint` - The endpoint name
+- `dynamo_namespace` - The namespace name
+- `dynamo_component` - The component name
+- `dynamo_endpoint` - The endpoint name
+
+These labels are prefixed with "dynamo_" to avoid collisions with Kubernetes and other monitoring system labels.
 
 ## Example Metrics Output
 
 When the system is running, you'll see metrics from the /metrics HTTP path like this:
 
 ```prometheus
-# HELP concurrent_requests Number of requests currently being processed by work handler
-# TYPE concurrent_requests gauge
-concurrent_requests{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 0
+# HELP dynamo_component_concurrent_requests Number of requests currently being processed by request handler
+# TYPE dynamo_component_concurrent_requests gauge
+dynamo_component_concurrent_requests{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 0
 
-# HELP my_custom_bytes_processed_total Example of a custom metric. Total number of data bytes processed by system handler
-# TYPE my_custom_bytes_processed_total counter
-my_custom_bytes_processed_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 42
+# HELP dynamo_component_my_custom_bytes_processed_total Example of a custom metric. Total number of data bytes processed by system handler
+# TYPE dynamo_component_my_custom_bytes_processed_total counter
+dynamo_component_my_custom_bytes_processed_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 42
 
-# HELP request_bytes_total Total number of bytes received in requests by work handler
-# TYPE request_bytes_total counter
-request_bytes_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 1098
+# HELP dynamo_component_request_bytes_total Total number of bytes received in requests by request handler
+# TYPE dynamo_component_request_bytes_total counter
+dynamo_component_request_bytes_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 1098
 
-# HELP request_duration_seconds Time spent processing requests by work handler
-# TYPE request_duration_seconds histogram
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.005"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.01"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.025"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.05"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.1"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.25"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="0.5"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="1"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="2.5"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="5"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="10"} 3
-request_duration_seconds_bucket{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace",le="+Inf"} 3
-request_duration_seconds_sum{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 0.00048793700000000003
-request_duration_seconds_count{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 3
+# HELP dynamo_component_request_duration_seconds Time spent processing requests by request handler
+# TYPE dynamo_component_request_duration_seconds histogram
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.005"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.01"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.025"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.05"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.1"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.25"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.5"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="1"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="2.5"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="5"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="10"} 3
+dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="+Inf"} 3
+dynamo_component_request_duration_seconds_sum{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 0.00048793700000000003
+dynamo_component_request_duration_seconds_count{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 3
 
-# HELP requests_total Total number of requests processed by work handler
-# TYPE requests_total counter
-requests_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 3
+# HELP dynamo_component_requests_total Total number of requests processed by request handler
+# TYPE dynamo_component_requests_total counter
+dynamo_component_requests_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 3
 
-# HELP response_bytes_total Total number of bytes sent in responses by work handler
-# TYPE response_bytes_total counter
-response_bytes_total{component="dyn_example_component",endpoint="dyn_example_endpoint9881",namespace="dyn_example_namespace"} 1917
+# HELP dynamo_component_response_bytes_total Total number of bytes sent in responses by request handler
+# TYPE dynamo_component_response_bytes_total counter
+dynamo_component_response_bytes_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 1917
 
 # HELP uptime_seconds Total uptime of the DistributedRuntime in seconds
 # TYPE uptime_seconds gauge
-uptime_seconds{namespace="http_server"} 1.8226759879999999
+uptime_seconds{dynamo_namespace="http_server"} 1.8226759879999999
 ```
 
 ## Examples
@@ -169,8 +171,8 @@ let handler = RequestHandler::with_metrics(system_metrics);
 let ingress = Ingress::for_engine(handler)?;
 
 // Add custom metrics IN ADDITION to automatic ones
-// You'll get both: automatic metrics (requests_total, request_duration_seconds, etc.)
-// AND custom metrics (my_custom_bytes_processed_total)
+// You'll get both: automatic metrics (dynamo_component_requests_total, dynamo_component_request_duration_seconds, etc.)
+// AND custom metrics (dynamo_component_my_custom_bytes_processed_total)
 ingress.add_metrics(&endpoint)?;
 ```
 
@@ -207,15 +209,9 @@ Then make curl requests to the frontend (see the [main README](../../../../READM
 Once running, you can query the metrics:
 
 ```bash
-# Get all work handler metrics
-curl http://localhost:8081/metrics | grep -E "(requests_total|request_bytes_total|response_bytes_total|errors_total|request_duration_seconds|concurrent_requests)"
+# Get all request handler metrics for components
+curl http://localhost:8081/metrics | grep -E "dynamo_component"
 
-# Get request count for specific endpoint
-curl http://localhost:8081/metrics | grep 'requests_total{endpoint="dyn_example_endpoint"}'
-
-# Get request duration histogram
-curl http://localhost:8081/metrics | grep 'request_duration_seconds'
-
-# Get custom system metrics
-curl http://localhost:8081/metrics | grep 'my_custom_bytes_processed_total'
+# Get all frontend metrics
+curl http://localhost:8080/metrics | grep -E "dynamo_frontend"
 ```

--- a/lib/runtime/examples/system_metrics/README.md
+++ b/lib/runtime/examples/system_metrics/README.md
@@ -1,10 +1,10 @@
-# Generic Profiling for Request Handlers
+# Generic Metrics for Component Endpoints
 
-This example demonstrates how to add automatic Prometheus metrics profiling to any request handler without modifying the handler code itself.
+This example demonstrates the automatic metrics provided to component endpoints by default.
 
 ## Overview
 
-Request handlers are measured automatically when using the DistributedRuntime code. The DistributedRuntime uses the `MetricsRegistry` trait which provides automatic profiling capabilities that are applied to all request handlers automatically. It automatically tracks:
+Component endpoints are measured automatically when using the DistributedRuntime code. The DistributedRuntime uses the `MetricsRegistry` trait which provides automatic measurement capabilities that are applied to all component endpoints automatically. It automatically tracks:
 
 - **Request Count**: Total number of requests processed
 - **Request Duration**: Time spent processing each request
@@ -15,14 +15,14 @@ Additionally, the example demonstrates how to add custom metrics with data bytes
 
 ## How It Works
 
-**Automatic Metrics**: All request handlers automatically get profiling metrics without any code changes.
+**Automatic Metrics**: All component endpoints automatically get measurement metrics without any code changes.
 
 **Custom Metrics**: If you want to add custom metrics IN ADDITION to the automatic ones, you can use the `add_metrics` method:
 
 ```rust
 use dynamo_runtime::pipeline::network::Ingress;
 
-// Automatic profiling - no code changes needed!
+// Automatic measurements - no code changes needed!
 let ingress = Ingress::for_engine(my_handler)?;
 
 // Optional: Add custom metrics IN ADDITION to automatic ones
@@ -35,13 +35,13 @@ The endpoint automatically provides proper labeling (dynamo_namespace, dynamo_co
 
 The `Ingress` struct provides methods for metrics:
 
-- **Automatic**: All request handlers get profiling metrics automatically
+- **Automatic**: All component endpoints get measurement metrics automatically
 - `Ingress::add_metrics(&endpoint)` - Add custom metrics IN ADDITION to automatic ones (optional)
 
 ## Metrics Generated
 
 ### Automatic Metrics (No Code Changes Required)
-The following Prometheus metrics are automatically created for all request handlers:
+The following Prometheus metrics are automatically created for all component endpoints:
 
 ### Counters
 - `dynamo_component_requests_total` - Total requests processed
@@ -80,7 +80,7 @@ These labels are prefixed with "dynamo_" to avoid collisions with Kubernetes and
 When the system is running, you'll see metrics from the /metrics HTTP path like this:
 
 ```prometheus
-# HELP dynamo_component_concurrent_requests Number of requests currently being processed by request handler
+# HELP dynamo_component_concurrent_requests Number of requests currently being processed by component endpoint
 # TYPE dynamo_component_concurrent_requests gauge
 dynamo_component_concurrent_requests{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 0
 
@@ -88,11 +88,11 @@ dynamo_component_concurrent_requests{dynamo_component="example_component",dynamo
 # TYPE dynamo_component_bytes_processed_total counter
 dynamo_component_bytes_processed_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 42
 
-# HELP dynamo_component_request_bytes_total Total number of bytes received in requests by request handler
+# HELP dynamo_component_request_bytes_total Total number of bytes received in requests by component endpoint
 # TYPE dynamo_component_request_bytes_total counter
 dynamo_component_request_bytes_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 1098
 
-# HELP dynamo_component_request_duration_seconds Time spent processing requests by request handler
+# HELP dynamo_component_request_duration_seconds Time spent processing requests by component endpoint
 # TYPE dynamo_component_request_duration_seconds histogram
 dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.005"} 3
 dynamo_component_request_duration_seconds_bucket{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace",le="0.01"} 3
@@ -109,11 +109,11 @@ dynamo_component_request_duration_seconds_bucket{dynamo_component="example_compo
 dynamo_component_request_duration_seconds_sum{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 0.00048793700000000003
 dynamo_component_request_duration_seconds_count{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 3
 
-# HELP dynamo_component_requests_total Total number of requests processed by request handler
+# HELP dynamo_component_requests_total Total number of requests processed by component endpoint
 # TYPE dynamo_component_requests_total counter
 dynamo_component_requests_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 3
 
-# HELP dynamo_component_response_bytes_total Total number of bytes sent in responses by request handler
+# HELP dynamo_component_response_bytes_total Total number of bytes sent in responses by component endpoint
 # TYPE dynamo_component_response_bytes_total counter
 dynamo_component_response_bytes_total{dynamo_component="example_component",dynamo_endpoint="example_endpoint9881",dynamo_namespace="example_namespace"} 1917
 
@@ -124,7 +124,7 @@ uptime_seconds{dynamo_namespace="http_server"} 1.8226759879999999
 
 ## Example
 
-### Request Handler with Automatic Profiling and Optional Custom Metrics
+### Component Endpoint with Automatic Measurements and Optional Custom Metrics
 
 ```rust
 struct RequestHandler {
@@ -142,7 +142,7 @@ impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, Error> for Reques
         }
 
         // Your business logic here...
-        // No need to add any automatic metrics code!
+        // No need to add any automatic measurement code!
 
         Ok(ResponseStream::new(Box::pin(stream), ctx.context()))
     }
@@ -156,7 +156,7 @@ let handler = if enable_custom_metrics {
     RequestHandler::new()
 };
 
-// Automatic profiling - no additional code needed!
+// Automatic measurements - no additional code needed!
 let ingress = Ingress::for_engine(handler)?;
 
 // Optional: Add custom metrics IN ADDITION to automatic ones
@@ -169,9 +169,9 @@ if enable_custom_metrics {
 
 ## Benefits
 
-1. **Little/No Code Changes**: Existing handlers automatically get profiling metrics, and easy to add custom metrics for your particular application.
+1. **Little/No Code Changes**: Existing handlers automatically get measurement metrics, and easy to add custom metrics for your particular application.
 2. **Simple API**: Simply swap out Prometheus constructors with one of the endpoint's factory methods.
-3. **Automatic Profiling**: Request count, duration, and error tracking out of the box for request handlers.
+3. **Automatic Measurements**: Request count, duration, and error tracking out of the box for component endpoints.
 4. **Automatic Labeling**: Endpoint provides proper namespace/component/endpoint labels
 
 ## Running the Example
@@ -198,7 +198,7 @@ Then make curl requests to the frontend (see the [main README](../../../../READM
 Once running, you can query the metrics:
 
 ```bash
-# Get all request handler metrics for components
+# Get all component endpoint metrics for components
 curl http://localhost:8081/metrics | grep -E "dynamo_component"
 
 # Get all frontend metrics

--- a/lib/runtime/src/http_server.rs
+++ b/lib/runtime/src/http_server.rs
@@ -65,6 +65,7 @@ impl Clone for HttpServerInfo {
     }
 }
 
+
 /// HTTP server state containing metrics and uptime tracking
 pub struct HttpServerState {
     // global drt registry is for printing out the entire Prometheus format output
@@ -347,9 +348,9 @@ mod tests {
         println!("Full metrics response:\n{}", response);
 
         let expected = "\
-# HELP dynamo_uptime_seconds Total uptime of the DistributedRuntime in seconds
-# TYPE dynamo_uptime_seconds gauge
-dynamo_uptime_seconds 42
+# HELP dynamo_component_dynamo_uptime_seconds Total uptime of the DistributedRuntime in seconds
+# TYPE dynamo_component_dynamo_uptime_seconds gauge
+dynamo_component_dynamo_uptime_seconds 42
 ";
         assert_eq!(response, expected);
     }

--- a/lib/runtime/src/http_server.rs
+++ b/lib/runtime/src/http_server.rs
@@ -65,7 +65,6 @@ impl Clone for HttpServerInfo {
     }
 }
 
-
 /// HTTP server state containing metrics and uptime tracking
 pub struct HttpServerState {
     // global drt registry is for printing out the entire Prometheus format output

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -16,7 +16,8 @@
 //! Metric Registry Framework for Dynamo.
 //!
 //! This module provides registry classes for Prometheus metrics
-//! that auto populates the labels with the namespace-component-endpoint hierarchy.
+//! that auto populates the labels with the component-endpoint hierarchy.
+//! All metrics are prefixed with "dynamo_component_" to avoid collisions with Kubernetes and other monitoring system labels.
 
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -24,18 +25,15 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-// If set to true, then metrics will be labeled with the namespace, component, and endpoint.
+// If set to true, then metrics will be labeled with the dynamo_namespace, dynamo_component, and dynamo_endpoint.
+// These labels are prefixed with "dynamo_" to avoid collisions with Kubernetes and other monitoring system labels.
 pub const USE_AUTO_LABELS: bool = true;
 
 // Prometheus imports
 use prometheus::Encoder;
 
-fn build_metric_name(namespace: &str, metric_name: &str) -> String {
-    if !namespace.is_empty() {
-        format!("{}_{}", namespace, metric_name)
-    } else {
-        metric_name.to_string()
-    }
+fn build_metric_name(metric_name: &str) -> String {
+    format!("dynamo_component_{}", metric_name)
 }
 
 /// Lints a metric name component by stripping off invalid characters and validating Prometheus naming pattern
@@ -206,18 +204,7 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
     // Build hierarchy: parent_hierarchy + [basename]
     let hierarchy = [parent_hierarchy.clone(), vec![basename.clone()]].concat();
 
-    let namespace = if hierarchy.len() >= 2 {
-        let potential_namespace = &hierarchy[1];
-        if !potential_namespace.is_empty() {
-            lint_prometheus_name(potential_namespace)?
-        } else {
-            "".to_string()
-        }
-    } else {
-        "".to_string()
-    };
-
-    let metric_name = build_metric_name(&namespace, metric_name);
+    let metric_name = build_metric_name(metric_name);
 
     // Validate that user-provided labels don't have duplicate keys
     for (key, _) in labels {
@@ -234,7 +221,7 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
     if USE_AUTO_LABELS {
         // Validate that user-provided labels don't conflict with auto-generated labels
         for (key, _) in labels {
-            if *key == "namespace" || *key == "component" || *key == "endpoint" {
+            if *key == "dynamo_namespace" || *key == "dynamo_component" || *key == "dynamo_endpoint" {
                 return Err(anyhow::anyhow!(
                     "Label '{}' is automatically added by auto_label feature and cannot be manually set",
                     key
@@ -243,15 +230,21 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
         }
 
         // Add auto-generated labels with sanitized values
-        if !namespace.is_empty() {
-            updated_labels.push(("namespace".to_string(), namespace.to_string()));
+        if hierarchy.len() >= 2 {
+            let namespace = &hierarchy[1];
+            if !namespace.is_empty() {
+                let valid_namespace = lint_prometheus_name(namespace)?;
+                if !valid_namespace.is_empty() {
+                    updated_labels.push(("dynamo_namespace".to_string(), valid_namespace));
+                }
+            }
         }
         if hierarchy.len() > 2 {
             let component = &hierarchy[2];
             if !component.is_empty() {
                 let valid_component = lint_prometheus_name(component)?;
                 if !valid_component.is_empty() {
-                    updated_labels.push(("component".to_string(), valid_component));
+                    updated_labels.push(("dynamo_component".to_string(), valid_component));
                 }
             }
         }
@@ -260,7 +253,7 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
             if !endpoint.is_empty() {
                 let valid_endpoint = lint_prometheus_name(endpoint)?;
                 if !valid_endpoint.is_empty() {
-                    updated_labels.push(("endpoint".to_string(), valid_endpoint));
+                    updated_labels.push(("dynamo_endpoint".to_string(), valid_endpoint));
                 }
             }
         }
@@ -560,12 +553,12 @@ mod tests {
 
     #[test]
     fn test_build_metric_name_with_prefix() {
-        // Test that build_metric_name correctly prepends the namespace
-        let result = build_metric_name("", "requests");
-        assert_eq!(result, "requests");
+        // Test that build_metric_name correctly prepends the dynamo_component prefix
+        let result = build_metric_name("requests");
+        assert_eq!(result, "dynamo_component_requests");
 
-        let result = build_metric_name("dynamo", "requests");
-        assert_eq!(result, "dynamo_requests");
+        let result = build_metric_name("counter");
+        assert_eq!(result, "dynamo_component_counter");
     }
 
     #[test]
@@ -816,10 +809,10 @@ mod test_prefixes {
         println!("Result with invalid namespace '@@123':");
         println!("{:?}", result);
 
-        // The result should fail because even after sanitization, the name "123" doesn't follow Prometheus naming pattern
+        // The result should be an error because '@@123' gets sanitized to '123' which is invalid
         assert!(
             result.is_err(),
-            "Creating metric with invalid namespace should fail even after sanitization"
+            "Creating metric with namespace '@@123' should fail because it gets sanitized to '123' which is invalid"
         );
 
         // Verify the error message indicates the sanitized name is still invalid
@@ -879,9 +872,9 @@ mod test_simple_metricsregistry_trait {
         println!("{}", endpoint_output);
 
         let expected_endpoint_output = format!(
-            r#"# HELP testnamespace_testcounter A test counter
-# TYPE testnamespace_testcounter counter
-testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",namespace="testnamespace"}} 123.456789
+            r#"# HELP dynamo_component_testcounter A test counter
+# TYPE dynamo_component_testcounter counter
+dynamo_component_testcounter{{dynamo_component="testcomponent",dynamo_endpoint="testendpoint",dynamo_namespace="testnamespace"}} 123.456789
 "#
         );
 
@@ -907,12 +900,12 @@ testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",nam
         println!("{}", component_output);
 
         let expected_component_output = format!(
-            r#"# HELP testnamespace_testcounter A test counter
-# TYPE testnamespace_testcounter counter
-testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",namespace="testnamespace"}} 123.456789
-# HELP testnamespace_testgauge A test gauge
-# TYPE testnamespace_testgauge gauge
-testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 50000
+            r#"# HELP dynamo_component_testcounter A test counter
+# TYPE dynamo_component_testcounter counter
+dynamo_component_testcounter{{dynamo_component="testcomponent",dynamo_endpoint="testendpoint",dynamo_namespace="testnamespace"}} 123.456789
+# HELP dynamo_component_testgauge A test gauge
+# TYPE dynamo_component_testgauge gauge
+dynamo_component_testgauge{{dynamo_component="testcomponent",dynamo_namespace="testnamespace"}} 50000
 "#
         );
 
@@ -937,15 +930,15 @@ testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 5
         println!("{}", namespace_output);
 
         let expected_namespace_output = format!(
-            r#"# HELP testnamespace_testcounter A test counter
-# TYPE testnamespace_testcounter counter
-testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",namespace="testnamespace"}} 123.456789
-# HELP testnamespace_testgauge A test gauge
-# TYPE testnamespace_testgauge gauge
-testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 50000
-# HELP testnamespace_testintcounter A test int counter
-# TYPE testnamespace_testintcounter counter
-testnamespace_testintcounter{{namespace="testnamespace"}} 12345
+            r#"# HELP dynamo_component_testcounter A test counter
+# TYPE dynamo_component_testcounter counter
+dynamo_component_testcounter{{dynamo_component="testcomponent",dynamo_endpoint="testendpoint",dynamo_namespace="testnamespace"}} 123.456789
+# HELP dynamo_component_testgauge A test gauge
+# TYPE dynamo_component_testgauge gauge
+dynamo_component_testgauge{{dynamo_component="testcomponent",dynamo_namespace="testnamespace"}} 50000
+# HELP dynamo_component_testintcounter A test int counter
+# TYPE dynamo_component_testintcounter counter
+dynamo_component_testintcounter{{dynamo_namespace="testnamespace"}} 12345
 "#
         );
 
@@ -1013,35 +1006,35 @@ testnamespace_testintcounter{{namespace="testnamespace"}} 12345
         println!("{}", drt_output);
 
         let expected_drt_output = format!(
-            r#"# HELP testcountervec A test counter vector
-# TYPE testcountervec counter
-testcountervec{{method="GET",service="api",status="200"}} 10
-testcountervec{{method="POST",service="api",status="201"}} 5
-# HELP testhistogram A test histogram
-# TYPE testhistogram histogram
-testhistogram_bucket{{le="1"}} 0
-testhistogram_bucket{{le="2.5"}} 2
-testhistogram_bucket{{le="5"}} 3
-testhistogram_bucket{{le="10"}} 3
-testhistogram_bucket{{le="+Inf"}} 3
-testhistogram_sum 7.5
-testhistogram_count 3
-# HELP testintgauge A test int gauge
-# TYPE testintgauge gauge
-testintgauge 42
-# HELP testintgaugevec A test int gauge vector
-# TYPE testintgaugevec gauge
-testintgaugevec{{instance="server1",service="api",status="active"}} 10
-testintgaugevec{{instance="server2",service="api",status="inactive"}} 0
-# HELP testnamespace_testcounter A test counter
-# TYPE testnamespace_testcounter counter
-testnamespace_testcounter{{component="testcomponent",endpoint="testendpoint",namespace="testnamespace"}} 123.456789
-# HELP testnamespace_testgauge A test gauge
-# TYPE testnamespace_testgauge gauge
-testnamespace_testgauge{{component="testcomponent",namespace="testnamespace"}} 50000
-# HELP testnamespace_testintcounter A test int counter
-# TYPE testnamespace_testintcounter counter
-testnamespace_testintcounter{{namespace="testnamespace"}} 12345
+            r#"# HELP dynamo_component_testcounter A test counter
+# TYPE dynamo_component_testcounter counter
+dynamo_component_testcounter{{dynamo_component="testcomponent",dynamo_endpoint="testendpoint",dynamo_namespace="testnamespace"}} 123.456789
+# HELP dynamo_component_testcountervec A test counter vector
+# TYPE dynamo_component_testcountervec counter
+dynamo_component_testcountervec{{method="GET",service="api",status="200"}} 10
+dynamo_component_testcountervec{{method="POST",service="api",status="201"}} 5
+# HELP dynamo_component_testgauge A test gauge
+# TYPE dynamo_component_testgauge gauge
+dynamo_component_testgauge{{dynamo_component="testcomponent",dynamo_namespace="testnamespace"}} 50000
+# HELP dynamo_component_testhistogram A test histogram
+# TYPE dynamo_component_testhistogram histogram
+dynamo_component_testhistogram_bucket{{le="1"}} 0
+dynamo_component_testhistogram_bucket{{le="2.5"}} 2
+dynamo_component_testhistogram_bucket{{le="5"}} 3
+dynamo_component_testhistogram_bucket{{le="10"}} 3
+dynamo_component_testhistogram_bucket{{le="+Inf"}} 3
+dynamo_component_testhistogram_sum 7.5
+dynamo_component_testhistogram_count 3
+# HELP dynamo_component_testintcounter A test int counter
+# TYPE dynamo_component_testintcounter counter
+dynamo_component_testintcounter{{dynamo_namespace="testnamespace"}} 12345
+# HELP dynamo_component_testintgauge A test int gauge
+# TYPE dynamo_component_testintgauge gauge
+dynamo_component_testintgauge 42
+# HELP dynamo_component_testintgaugevec A test int gauge vector
+# TYPE dynamo_component_testintgaugevec gauge
+dynamo_component_testintgaugevec{{instance="server1",service="api",status="active"}} 10
+dynamo_component_testintgaugevec{{instance="server2",service="api",status="inactive"}} 0
 "#
         );
 

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -221,7 +221,8 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
     if USE_AUTO_LABELS {
         // Validate that user-provided labels don't conflict with auto-generated labels
         for (key, _) in labels {
-            if *key == "dynamo_namespace" || *key == "dynamo_component" || *key == "dynamo_endpoint" {
+            if *key == "dynamo_namespace" || *key == "dynamo_component" || *key == "dynamo_endpoint"
+            {
                 return Err(anyhow::anyhow!(
                     "Label '{}' is automatically added by auto_label feature and cannot be manually set",
                     key

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -231,7 +231,7 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
         }
 
         // Add auto-generated labels with sanitized values
-        if hierarchy.len() > 3 {
+        if hierarchy.len() > 1 {
             let namespace = &hierarchy[1];
             if !namespace.is_empty() {
                 let valid_namespace = lint_prometheus_name(namespace)?;

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -231,7 +231,7 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
         }
 
         // Add auto-generated labels with sanitized values
-        if hierarchy.len() >= 2 {
+        if hierarchy.len() > 3 {
             let namespace = &hierarchy[1];
             if !namespace.is_empty() {
                 let valid_namespace = lint_prometheus_name(namespace)?;


### PR DESCRIPTION
#### Overview:

Standardizes metric naming convention by adding `dynamo_component_` prefix to all metric names and updating labels to use `dynamo_` prefixed versions to avoid Kubernetes collisions.

#### Details:

- **Metric Naming**: All metrics now consistently use `dynamo_component_` prefix (e.g., `dynamo_component_uptime_seconds`)
- **Label Standardization**: Updated labels from `namespace`, `component`, `endpoint` to `dynamo_namespace`, `dynamo_component`, `dynamo_endpoint` to avoid Kubernetes label collisions
- **Documentation Updates**: Updated system_metrics README to reflect new naming convention and changed "Work Handlers" to "Request Handlers" terminology
- **Test Fixes**: Updated test expectations to match new metric format and fixed HTTP server test assertions
- **Code Simplification**: Simplified `build_metric_name` function to always use `dynamo_component_` prefix

#### Where should the reviewer start?

- `lib/runtime/src/metrics.rs` - Core metric naming logic and label handling
- `lib/runtime/src/http_server.rs` - HTTP server metric test updates
- `lib/runtime/examples/system_metrics/README.md` - Documentation updates and terminology changes

#### Related Issues:

Relates to DIS-339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation and examples to reflect new naming conventions for metrics and labels, including prefixing with "dynamo_" and terminology changes from "work handlers" to "request handlers".

* **Refactor**
  * Standardized all metric names and labels to use the "dynamo_component_" and "dynamo_" prefixes for consistency and to avoid conflicts with other monitoring systems.
  * Updated internal logic for metric name and label construction to enforce the new prefixing scheme.

* **Bug Fixes**
  * Corrected test header construction and error handling in integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->