### PR TITLE
fix: link to point to bindings/python/README.md

### DIFF
--- a/docs/runtime/README.md
+++ b/docs/runtime/README.md
@@ -110,7 +110,7 @@ Annotated { data: Some("d"), id: None, event: None, comment: None }
 
 #### Python
 
-See the [README.md](../API/python_bindings.md) for details
+See the [README.md](../../lib/runtime/lib/bindings/python/README.md) for details
 
 The Python and Rust `hello_world` client and server examples are interchangeable,
 so you can start the Python `server.py` and talk to it from the Rust `client`.


### PR DESCRIPTION
#### Overview:

Fix broken README link in runtime documentation to properly point to the Python bindings README.

#### Details:

Fixed relative path in docs/runtime/README.md to correctly link to lib/runtime/lib/bindings/python/README.md

#### Where should the reviewer start?

docs/runtime/README.md (line 113) - verify the link path is correct

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

NVBugs-5424387 https://nvbugspro.nvidia.com/bug/5424387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the link to Python bindings in the runtime README to direct users to the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->