### PR TITLE
fix: add curl and jq for health checks

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -429,8 +429,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential python3-dev libnuma-dev \
-        # Curl for polling various endpoints.
+        # jq and curl for polling various endpoints and health checks
         curl \
+        jq \
         # For debugging
         vim \
         # Libraries required by UCX to find RDMA devices

--- a/container/Dockerfile.sglang-wideep
+++ b/container/Dockerfile.sglang-wideep
@@ -152,6 +152,9 @@ RUN cmake --version
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     rapidjson-dev \
+    # jq and curl for polling various endpoints and health checks
+    jq \
+    curl \
     zlib1g-dev
 
 RUN git clone --depth=1 https://github.com/triton-inference-server/perf_analyzer.git && \

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -380,7 +380,8 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         python3-dev \
-        # Curl for polling various endpoints.
+        # jq and curl for polling various endpoints and health checks
+        jq \
         curl \
         # For debugging
         vim \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -437,7 +437,8 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         python3-dev \
-        # Curl for polling various endpoints.
+        # jq and curl for polling various endpoints and health checks
+        jq \
         curl \
         # For debugging
         vim \


### PR DESCRIPTION
#### Overview:

- add `jq` for frontend health probes ([usage](https://github.com/ai-dynamo/dynamo/blob/57482dcf6a21fdb32b42cd05108a38a8111c1f0a/components/backends/vllm/deploy/agg.yaml#L24))

https://nvbugspro.nvidia.com/bug/5425651

closes: 
nvbug: 5425651 
linear ticket: DYN-792

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the `jq` utility to runtime images across multiple containers to enhance endpoint polling and health check capabilities.
  * Updated documentation comments to indicate that both `jq` and `curl` are now installed for these purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->