### PR TITLE
fix: revert wideep sgl to 0.4.8.post1

### DIFF
--- a/components/backends/sglang/docs/dsr1-wideep-h100.md
+++ b/components/backends/sglang/docs/dsr1-wideep-h100.md
@@ -9,10 +9,10 @@ Dynamo supports SGLang's implementation of wide expert parallelism and large sca
 
 ## Instructions
 
-1. Pull the SGLang container.
+1. Pull the SGLang release `v0.4.8.post1` container. We are actively working on validating newer releases.
 
 ```bash
-docker pull lmsysorg/sglang:latest
+docker pull docker pull lmsysorg/sglang:v0.4.8.post1-cu126
 ```
 
 You can also pull a specific tag from the [lmsys dockerhub](https://hub.docker.com/r/lmsysorg/sglang/tags)

--- a/components/backends/sglang/docs/dsr1-wideep-h100.md
+++ b/components/backends/sglang/docs/dsr1-wideep-h100.md
@@ -12,7 +12,7 @@ Dynamo supports SGLang's implementation of wide expert parallelism and large sca
 1. Pull the SGLang release `v0.4.8.post1` container. We are actively working on validating newer releases.
 
 ```bash
-docker pull docker pull lmsysorg/sglang:v0.4.8.post1-cu126
+docker pull lmsysorg/sglang:v0.4.8.post1-cu126
 ```
 
 You can also pull a specific tag from the [lmsys dockerhub](https://hub.docker.com/r/lmsysorg/sglang/tags)

--- a/container/Dockerfile.sglang-wideep
+++ b/container/Dockerfile.sglang-wideep
@@ -15,7 +15,7 @@
 
 # This should be pinned to the sglang version that is installed with Dynamo
 # in the pyproject.toml
-FROM lmsysorg/sglang:v0.4.9.post6-cu126
+FROM lmsysorg/sglang:v0.4.8.post1-cu126
 
 # Add NIXL build dependencies
 RUN apt-get update -y && \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions to specify pulling a particular SGLang container image version and added a note about ongoing validation of newer releases.

* **Chores**
  * Changed the Docker base image for the SGLang component to an earlier version for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->