### PR TITLE
fix(k8s): sglang disagg now uses decode worker 

### DIFF
--- a/components/backends/sglang/deploy/disagg.yaml
+++ b/components/backends/sglang/deploy/disagg.yaml
@@ -83,7 +83,7 @@ spec:
           args:
             - "python3"
             - "-m"
-            - "dynamo.sglang.worker"
+            - "dynamo.sglang.decode_worker"
             - "--model-path"
             - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
             - "--served-model-name"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for the SGLangDecodeWorker service.  
  * Minor formatting improvement with a newline added to the configuration file (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->