### PR TITLE
feat: skip downloading model weights if using mocker (only tokenizer)

### DIFF
--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -40,7 +40,8 @@ pub async fn run(
         .http_port(Some(flags.http_port))
         .router_config(Some(flags.router_config()))
         .request_template(flags.request_template.clone())
-        .migration_limit(flags.migration_limit);
+        .migration_limit(flags.migration_limit)
+        .is_mocker(matches!(out_opt, Some(Output::Mocker)));
 
     // TODO: old, address this later:
     // If `in=dyn` we want the trtllm/sglang/vllm subprocess to listen on that endpoint.

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -156,7 +156,8 @@ pub fn make_engine<'p>(
         .request_template(args.template_file.clone())
         .kv_cache_block_size(args.kv_cache_block_size)
         .router_config(args.router_config.clone().map(|rc| rc.into()))
-        .http_port(args.http_port);
+        .http_port(args.http_port)
+        .is_mocker(matches!(args.engine_type, EngineType::Mocker));
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let local_model = builder.build().await.map_err(to_pyerr)?;
         let inner = select_engine(distributed_runtime, args, local_model)

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -47,6 +47,7 @@ pub struct LocalModelBuilder {
     kv_cache_block_size: u32,
     http_port: u16,
     migration_limit: u32,
+    is_mocker: bool,
 }
 
 impl Default for LocalModelBuilder {
@@ -62,6 +63,7 @@ impl Default for LocalModelBuilder {
             template_file: Default::default(),
             router_config: Default::default(),
             migration_limit: Default::default(),
+            is_mocker: Default::default(),
         }
     }
 }
@@ -119,6 +121,11 @@ impl LocalModelBuilder {
         self
     }
 
+    pub fn is_mocker(&mut self, is_mocker: bool) -> &mut Self {
+        self.is_mocker = is_mocker;
+        self
+    }
+
     /// Make an LLM ready for use:
     /// - Download it from Hugging Face (and NGC in future) if necessary
     /// - Resolve the path
@@ -169,7 +176,7 @@ impl LocalModelBuilder {
         let relative_path = model_path.trim_start_matches(HF_SCHEME);
         let full_path = if is_hf_repo {
             // HF download if necessary
-            super::hub::from_hf(relative_path).await?
+            super::hub::from_hf(relative_path, self.is_mocker).await?
         } else {
             fs::canonicalize(relative_path)?
         };

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -5,11 +5,11 @@ import asyncio
 import json
 import logging
 import os
+import time
 
 import aiohttp
 import pytest
 
-from tests.conftest import download_models
 from tests.utils.managed_process import ManagedProcess
 
 pytestmark = pytest.mark.pre_merge
@@ -96,9 +96,6 @@ def test_mocker_kv_router(request, runtime_services):
     This test doesn't require GPUs and runs quickly for pre-merge validation.
     """
 
-    # Download only the Qwen model for this test
-    download_models([MODEL_NAME])
-
     # runtime_services starts etcd and nats
     logger.info("Starting mocker KV router test")
 
@@ -131,6 +128,9 @@ def test_mocker_kv_router(request, runtime_services):
         # Start all mockers
         for mocker in mocker_processes:
             mocker.__enter__()
+
+        # Give 2 seconds for setups (download tokenizer)
+        time.sleep(2)
 
         # Send test requests
         test_payload = {

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -5,7 +5,6 @@ import asyncio
 import json
 import logging
 import os
-import time
 
 import aiohttp
 import pytest
@@ -128,9 +127,6 @@ def test_mocker_kv_router(request, runtime_services):
         # Start all mockers
         for mocker in mocker_processes:
             mocker.__enter__()
-
-        # Give 2 seconds for setups (download tokenizer)
-        time.sleep(2)
 
         # Send test requests
         test_payload = {


### PR DESCRIPTION
#### Overview:

closes #2088 

Add `is_mocker` to `LocalModelBuilder`. If true, then ignore downloading weight files (matching common patterns such as `.bin`, `.safetensors`, `.h5`, etc). Only applies to hf paths for now.

Tests:
- Verified that the per-merge CI tests with mockers only download the tokenizer
- Verified other engine types still download model weights and run as normal (e.g. vllm, trtllm)