### PR TITLE
fix: dynamo operator lws worker not serving

### DIFF
--- a/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -580,6 +580,7 @@ func (r *DynamoComponentDeploymentReconciler) generateWorkerPodTemplateSpec(ctx 
 		return nil, errors.New("generateWorkerPodTemplateSpec: container Args cannot be empty for Ray worker pod")
 	}
 
+	currentArgs := workerPodTemplateSpec.Spec.Containers[0].Args[0]
 	if opt.dynamoComponentDeployment.Spec.Resources == nil || opt.dynamoComponentDeployment.Spec.Resources.Limits == nil || opt.dynamoComponentDeployment.Spec.Resources.Limits.GPU == "" {
 		return nil, fmt.Errorf("generateWorkerPodTemplateSpec: GPU limit is not set for Ray worker pod")
 	}
@@ -590,7 +591,7 @@ func (r *DynamoComponentDeploymentReconciler) generateWorkerPodTemplateSpec(ctx 
 	workerPodTemplateSpec.Spec.Containers[0].LivenessProbe = nil
 	workerPodTemplateSpec.Spec.Containers[0].ReadinessProbe = nil
 
-	workerPodTemplateSpec.Spec.Containers[0].Args[0] = "ray start --address=$(LWS_LEADER_ADDRESS):6379 --block"
+	workerPodTemplateSpec.Spec.Containers[0].Args[0] = fmt.Sprintf("ray start --address=$(LWS_LEADER_ADDRESS):6379 --block & %s && wait", currentArgs)
 
 	return workerPodTemplateSpec, nil
 }


### PR DESCRIPTION
#### Overview:
If we enable LWS in operator, the LWS worker can be assign GPUs but it actually block here without any activity. 
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
In generateWorkerPodTemplateSpec, it start a ray worker node by: ray start --address=$(LWS_LEADER_ADDRESS):6379 --block. However, it seems block here without any job.
<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?
deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller.go - generateWorkerPodTemplateSpec functions seems miss ray currentArgs while generateLeaderPodTemplateSpec have currentArgs
<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
#2214

- closes GitHub issue: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated worker container startup behavior to run the Ray service in the background alongside the main process, enabling concurrent execution with improved synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->