### PR TITLE
fix: Locked triton==3.3.1 since triton 3.4.0 breaks tensorrt-llm 1.0.0rc4

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -158,7 +158,9 @@ RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
         WHEEL_FILE=$(find /trtllm_wheel -name "*.whl" | head -n 1); \
         if [ -n "$WHEEL_FILE" ]; then \
             pip install "$WHEEL_FILE"; \
-            pip install "triton==3.3.1"; \
+            if [ "$ARCH" = "amd64" ]; then \
+                pip install "triton==3.3.1"; \
+            fi; \
         else \
             echo "No wheel file found in /trtllm_wheel directory."; \
             exit 1; \
@@ -166,7 +168,9 @@ RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
     else \
         # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
         pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}"; \
-        pip install "triton==3.3.1"; \
+        if [ "$ARCH" = "amd64" ]; then \
+            pip install "triton==3.3.1"; \
+        fi; \
     fi
 
 # Install test dependencies
@@ -501,7 +505,9 @@ COPY --from=dev /workspace/target/release/metrics /usr/local/bin/metrics
 # is also specified. So set the configurable index as a --extra-index-url for prioritization.
 # locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc4
 RUN uv pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" && \
-    uv pip install "triton==3.3.1" && \
+    if [ "$ARCH" = "amd64" ]; then \
+        pip install "triton==3.3.1"; \
+    fi; \
     uv pip install ai-dynamo nixl --find-links wheelhouse
 
 # Setup TRTLLM environment variables, same as in dev image

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -150,13 +150,14 @@ COPY --from=trtllm_wheel . /trtllm_wheel/
 # Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel
 # because there might be mismatched versions of TensorRT between the NGC PyTorch
 # and the TRTLLM wheel.
+# Locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc4
 RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
     pip uninstall -y tensorrt && \
     if [ "$HAS_TRTLLM_CONTEXT" = "1" ]; then \
         # Install from local wheel directory in build context
         WHEEL_FILE=$(find /trtllm_wheel -name "*.whl" | head -n 1); \
         if [ -n "$WHEEL_FILE" ]; then \
-            pip install "$WHEEL_FILE"; \
+            pip install "$WHEEL_FILE triton==3.3.1"; \
         else \
             echo "No wheel file found in /trtllm_wheel directory."; \
             exit 1; \
@@ -164,7 +165,7 @@ RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
     else \
          # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
          pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" \
-         "${TENSORRTLLM_PIP_WHEEL}" ; \
+         "${TENSORRTLLM_PIP_WHEEL} triton==3.3.1" ; \
     fi
 
 # Install test dependencies
@@ -497,8 +498,9 @@ COPY --from=dev /workspace/target/release/metrics /usr/local/bin/metrics
 # NOTE: If a package (tensorrt_llm) exists on both --index-url and --extra-index-url,
 # uv will prioritize the --extra-index-url, unless --index-strategy unsafe-best-match
 # is also specified. So set the configurable index as a --extra-index-url for prioritization.
+# locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc4
 RUN uv pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" \
-    "${TENSORRTLLM_PIP_WHEEL}" && \
+    "${TENSORRTLLM_PIP_WHEEL} triton==3.3.1" && \
     uv pip install ai-dynamo nixl --find-links wheelhouse
 
 # Setup TRTLLM environment variables, same as in dev image

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -157,7 +157,7 @@ RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
         # Install from local wheel directory in build context
         WHEEL_FILE=$(find /trtllm_wheel -name "*.whl" | head -n 1); \
         if [ -n "$WHEEL_FILE" ]; then \
-            pip install "$WHEEL_FILE triton==3.3.1"; \
+            pip install "$WHEEL_FILE" "triton==3.3.1"; \
         else \
             echo "No wheel file found in /trtllm_wheel directory."; \
             exit 1; \
@@ -165,7 +165,7 @@ RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
     else \
          # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
          pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" \
-         "${TENSORRTLLM_PIP_WHEEL} triton==3.3.1" ; \
+         "${TENSORRTLLM_PIP_WHEEL}" "triton==3.3.1" ; \
     fi
 
 # Install test dependencies
@@ -500,7 +500,7 @@ COPY --from=dev /workspace/target/release/metrics /usr/local/bin/metrics
 # is also specified. So set the configurable index as a --extra-index-url for prioritization.
 # locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc4
 RUN uv pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" \
-    "${TENSORRTLLM_PIP_WHEEL} triton==3.3.1" && \
+    "${TENSORRTLLM_PIP_WHEEL}" "triton==3.3.1" && \
     uv pip install ai-dynamo nixl --find-links wheelhouse
 
 # Setup TRTLLM environment variables, same as in dev image

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -157,15 +157,16 @@ RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
         # Install from local wheel directory in build context
         WHEEL_FILE=$(find /trtllm_wheel -name "*.whl" | head -n 1); \
         if [ -n "$WHEEL_FILE" ]; then \
-            pip install "$WHEEL_FILE" "triton==3.3.1"; \
+            pip install "$WHEEL_FILE"; \
+            pip install "triton==3.3.1"; \
         else \
             echo "No wheel file found in /trtllm_wheel directory."; \
             exit 1; \
         fi; \
     else \
-         # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
-         pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" \
-         "${TENSORRTLLM_PIP_WHEEL}" "triton==3.3.1" ; \
+        # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
+        pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}"; \
+        pip install "triton==3.3.1"; \
     fi
 
 # Install test dependencies
@@ -499,8 +500,8 @@ COPY --from=dev /workspace/target/release/metrics /usr/local/bin/metrics
 # uv will prioritize the --extra-index-url, unless --index-strategy unsafe-best-match
 # is also specified. So set the configurable index as a --extra-index-url for prioritization.
 # locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc4
-RUN uv pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" \
-    "${TENSORRTLLM_PIP_WHEEL}" "triton==3.3.1" && \
+RUN uv pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" && \
+    uv pip install "triton==3.3.1" && \
     uv pip install ai-dynamo nixl --find-links wheelhouse
 
 # Setup TRTLLM environment variables, same as in dev image

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -46,6 +46,7 @@ sentencepiece
 tensorboard==2.19.0
 tensorboardX==2.6.2.2
 transformers
+triton==3.3.1. # 3.4.0 breaks tensorrt-llm 1.0.0rc4
 types-aiofiles
 types-PyYAML
 uvicorn

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -46,7 +46,6 @@ sentencepiece
 tensorboard==2.19.0
 tensorboardX==2.6.2.2
 transformers
-triton==3.3.1. # 3.4.0 breaks tensorrt-llm 1.0.0rc4
 types-aiofiles
 types-PyYAML
 uvicorn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 [project.optional-dependencies]
 trtllm =[
     "uvloop",
-    "tensorrt-llm==1.0.0rc4"
+    "tensorrt-llm==1.0.0rc4",
+    "triton==3.3.1",  # locking triton as version 3.4.0 breaks tensorrt-llm 1.0.0rc4
 ]
 
 vllm = [


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
