### PR TITLE
fix: Cherry pick pr 2186 release 0.4.0 to fix docs/runtime/README.md link

### DIFF
--- a/docs/runtime/README.md
+++ b/docs/runtime/README.md
@@ -110,7 +110,7 @@ Annotated { data: Some("d"), id: None, event: None, comment: None }
 
 #### Python
 
-See the [README.md](../API/python_bindings.md) for details
+See the [README.md](../../lib/runtime/lib/bindings/python/README.md) for details
 
 The Python and Rust `hello_world` client and server examples are interchangeable,
 so you can start the Python `server.py` and talk to it from the Rust `client`.


### PR DESCRIPTION
#### Overview:

Cherry-pick PR #2186 onto release/0.4.0 branch to fix broken documentation link in runtime README.

#### Details:

- Cherry-picked commit `ee09de0b3` from main branch
- Fixed broken link in `docs/runtime/README.md` 

#### Where should the reviewer start?

- `docs/runtime/README.md` - Verify the link points to the correct Python bindings documentation

#### Related Issues:

- Relates to DIS-2186 (original PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added Kubernetes deployment manifests for TensorRT-LLM with detailed configurations for aggregated, disaggregated, and router-based setups.
- Expanded documentation with a new "Kubernetes Deployment" section for TensorRT-LLM, including deployment instructions and manifest usage.

**Bug Fixes**
- Corrected and improved numerous documentation links and references throughout the project for better navigation and accuracy.
- Fixed package installation instructions and system dependency names in SGLang documentation and Dockerfiles.

**Refactor**
- Restructured and consolidated configuration files for CUDA graph and key-value cache settings, improving clarity and extensibility.
- Centralized and modularized port allocation logic for vLLM, introducing explicit port range configuration and atomic ETCD-based reservation.

**Chores**
- Updated dependency versions, including nixl, tensorrt-llm, and related build arguments across Dockerfiles and build scripts.
- Improved Dockerfiles to include necessary utilities (jq, curl) for health checks and endpoint polling.

**Documentation**
- Reorganized and enhanced framework support and deployment instructions for better visibility and usability.
- Removed outdated or redundant documentation files and sections, including multimodal and operator deployment guides.
- Clarified Kubernetes and cloud deployment workflows, and updated example guides for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->