### PR TITLE
ci: Try to use github actions services for nats/etcd to run integration tests

### DIFF
--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -174,4 +174,5 @@ jobs:
         else
           echo "No integration tests found in ${{ matrix.dir }}, skipping"
         fi
-      timeout-minutes: 10
+      # FIXME: Improve build/test time and lower this timeout
+      timeout-minutes: 20

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -35,7 +35,8 @@ on:
     - 'Cargo.lock'
 
 jobs:
-  pre-merge-rust:
+  # Fast checks that don't require external services - provides quick feedback
+  fast-checks:
     runs-on: ubuntu-latest
     strategy:
       matrix: { dir: ['.', 'lib/bindings/python', 'lib/runtime/examples'] }
@@ -90,3 +91,87 @@ jobs:
       working-directory: ${{ matrix.dir }}
       # NOTE: --all-targets doesn't run doc tests
       run: cargo test --locked --all-targets
+
+  # Integration tests that require external services (nats, etcd)
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: { dir: ['.', 'lib/bindings/python', 'lib/runtime/examples'] }
+    permissions:
+      contents: read
+    # nats/etcd services needed in background for integration tests
+    services:
+      nats-server:
+        image: nats:2.11.4
+        options: --name nats-server
+        ports:
+          - 4222:4222
+          - 6222:6222
+          - 8222:8222
+        env:
+          NATS_ARGS: "-js --trace -m 8222"
+      etcd-server:
+        image: bitnami/etcd:3.6.1
+        ports:
+          - 2379:2379
+          - 2380:2380
+        env:
+          ALLOW_NONE_AUTHENTICATION: yes
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up system dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y protobuf-compiler
+    - name: Cache Cargo Registry
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ github.head_ref || github.ref_name }}-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install Rust in dev environment
+      # Install Rust only to run GitHub Local Actions in (dev environment) using the `ACT` environment variable.
+      # See act usage: https://nektosact.com/introduction.html
+      # https://nektosact.com/usage/index.html?highlight=env.Act#skipping-steps
+      if: ${{ env.ACT }}
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        rustup toolchain install 1.86.0-x86_64-unknown-linux-gnu
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+    - name: Wait for Services to be Ready
+      run: |
+        echo "Waiting for services to be ready..."
+        # Wait for NATS server to be ready
+        for i in {1..30}; do
+          if curl -f http://localhost:8222/varz >/dev/null 2>&1; then
+            echo "NATS server is ready"
+            break
+          fi
+          if [ $i -eq 30 ]; then
+            echo "NATS server failed to start"
+            exit 1
+          fi
+          sleep 2
+        done
+        # Wait for etcd server to be ready
+        for i in {1..30}; do
+          if curl -f http://localhost:2379/health >/dev/null 2>&1; then
+            echo "etcd server is ready"
+            break
+          fi
+          if [ $i -eq 30 ]; then
+            echo "etcd server failed to start"
+            exit 1
+          fi
+          sleep 2
+        done
+    - name: Run Integration Tests
+      working-directory: ${{ matrix.dir }}
+      run: |
+        # Only run integration tests if the integration feature exists
+        if cargo test --locked --features integration --no-run 2>/dev/null; then
+          echo "Running integration tests in ${{ matrix.dir }}"
+          cargo test --locked --features integration
+        else
+          echo "No integration tests found in ${{ matrix.dir }}, skipping"
+        fi
+      timeout-minutes: 10

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -50,14 +50,47 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y protobuf-compiler
 
-    # Advanced Rust caching - replaces manual registry/tools caching
-    - name: Set up Rust cache
-      uses: swatinem/rust-cache@v2
+    # Enhanced multi-layer Rust caching strategy using actions/cache@v4
+    - name: Cache Cargo registry index
+      uses: actions/cache@v4
       with:
-        # Cache key based on working directory to avoid conflicts between matrix jobs
-        workspaces: ${{ matrix.dir }}
-        # Additional cache key components for better invalidation
-        key: ${{ matrix.dir }}
+        path: ~/.cargo/registry/index
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-index-
+
+    - name: Cache Cargo registry cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/registry/cache
+        key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-cache-
+
+    - name: Cache Cargo git database
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/git/db
+        key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-git-
+
+    - name: Cache Cargo tools
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin
+        key: ${{ runner.os }}-cargo-tools-${{ hashFiles('**/Cargo.lock') }}-v1
+        restore-keys: |
+          ${{ runner.os }}-cargo-tools-
+
+    - name: Cache target directory
+      uses: actions/cache@v4
+      with:
+        path: ${{ matrix.dir }}/target
+        key: ${{ runner.os }}-target-${{ matrix.dir }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/*.rs') }}
+        restore-keys: |
+          ${{ runner.os }}-target-${{ matrix.dir }}-${{ hashFiles('**/Cargo.lock') }}-
+          ${{ runner.os }}-target-${{ matrix.dir }}-
 
     - name: Install Rust in dev environment
       # Install Rust only to run GitHub Local Actions in (dev environment) using the `ACT` environment variable.
@@ -73,6 +106,16 @@ jobs:
       run: |
         rustup toolchain install 1.86.0 --profile minimal --component rustfmt,clippy
         rustup default 1.86.0
+
+    - name: Optimize Cargo cache
+      run: |
+        # Clean up old build artifacts to optimize cache size
+        if [ -d "${{ matrix.dir }}/target" ]; then
+          # Remove incremental compilation artifacts (they don't cache well)
+          find "${{ matrix.dir }}/target" -name incremental -type d -exec rm -rf {} + 2>/dev/null || true
+          # Remove old fingerprints to force rebuild verification
+          find "${{ matrix.dir }}/target" -name .fingerprint -type d -mtime +1 -exec rm -rf {} + 2>/dev/null || true
+        fi
 
     - name: Check code formatting and run Clippy
       working-directory: ${{ matrix.dir }}
@@ -139,11 +182,41 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y protobuf-compiler
 
-    - name: Set up Rust cache
-      uses: swatinem/rust-cache@v2
+    # Enhanced multi-layer Rust caching strategy for integration tests
+    - name: Cache Cargo registry index
+      uses: actions/cache@v4
       with:
-        workspaces: ${{ matrix.dir }}
-        key: ${{ matrix.dir }}-integration
+        path: ~/.cargo/registry/index
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-index-
+
+    - name: Cache Cargo registry cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/registry/cache
+        key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-cache-
+
+    - name: Cache Cargo git database
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/git/db
+        key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-git-
+
+    - name: Cache target directory for integration tests
+      uses: actions/cache@v4
+      with:
+        path: ${{ matrix.dir }}/target
+        key: ${{ runner.os }}-target-integration-${{ matrix.dir }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/*.rs') }}
+        restore-keys: |
+          ${{ runner.os }}-target-integration-${{ matrix.dir }}-${{ hashFiles('**/Cargo.lock') }}-
+          ${{ runner.os }}-target-integration-${{ matrix.dir }}-
+          ${{ runner.os }}-target-${{ matrix.dir }}-${{ hashFiles('**/Cargo.lock') }}-
+          ${{ runner.os }}-target-${{ matrix.dir }}-
 
     - name: Install Rust in dev environment
       if: ${{ env.ACT }}
@@ -156,6 +229,16 @@ jobs:
       run: |
         rustup toolchain install 1.86.0 --profile minimal
         rustup default 1.86.0
+
+    - name: Optimize Cargo cache for integration tests
+      run: |
+        # Clean up old build artifacts to optimize cache size
+        if [ -d "${{ matrix.dir }}/target" ]; then
+          # Remove incremental compilation artifacts (they don't cache well)
+          find "${{ matrix.dir }}/target" -name incremental -type d -exec rm -rf {} + 2>/dev/null || true
+          # Remove old fingerprints to force rebuild verification
+          find "${{ matrix.dir }}/target" -name .fingerprint -type d -mtime +1 -exec rm -rf {} + 2>/dev/null || true
+        fi
 
     - name: Wait for services to be ready
       run: |

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -35,13 +35,30 @@ on:
     - 'Cargo.lock'
 
 jobs:
-  # Fast checks that don't require external services - provides quick feedback
-  fast-checks:
+  pre-merge-rust:
     runs-on: ubuntu-latest
     strategy:
       matrix: { dir: ['.', 'lib/bindings/python', 'lib/runtime/examples'] }
     permissions:
       contents: read
+    # nats/etcd services needed in background for integration tests
+    services:
+      nats-server:
+        image: nats:2.11.4
+        options: --name nats-server
+        ports:
+          - 4222:4222
+          - 6222:6222
+          - 8222:8222
+        env:
+          NATS_ARGS: "-js --trace -m 8222"
+      etcd-server:
+        image: bitnami/etcd:3.6.1
+        ports:
+          - 2379:2379
+          - 2380:2380
+        env:
+          ALLOW_NONE_AUTHENTICATION: yes
     steps:
     - uses: actions/checkout@v4
     - name: Set up system dependencies
@@ -91,52 +108,6 @@ jobs:
       working-directory: ${{ matrix.dir }}
       # NOTE: --all-targets doesn't run doc tests
       run: cargo test --locked --all-targets
-
-  # Integration tests that require external services (nats, etcd)
-  integration-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: { dir: ['.', 'lib/bindings/python', 'lib/runtime/examples'] }
-    permissions:
-      contents: read
-    # nats/etcd services needed in background for integration tests
-    services:
-      nats-server:
-        image: nats:2.11.4
-        options: --name nats-server
-        ports:
-          - 4222:4222
-          - 6222:6222
-          - 8222:8222
-        env:
-          NATS_ARGS: "-js --trace -m 8222"
-      etcd-server:
-        image: bitnami/etcd:3.6.1
-        ports:
-          - 2379:2379
-          - 2380:2380
-        env:
-          ALLOW_NONE_AUTHENTICATION: yes
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up system dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y protobuf-compiler
-    - name: Cache Cargo Registry
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ github.head_ref || github.ref_name }}-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install Rust in dev environment
-      # Install Rust only to run GitHub Local Actions in (dev environment) using the `ACT` environment variable.
-      # See act usage: https://nektosact.com/introduction.html
-      # https://nektosact.com/usage/index.html?highlight=env.Act#skipping-steps
-      if: ${{ env.ACT }}
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        rustup toolchain install 1.86.0-x86_64-unknown-linux-gnu
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
     - name: Wait for Services to be Ready
       run: |
         echo "Waiting for services to be ready..."

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -104,7 +104,7 @@ jobs:
 
     - name: Set up Rust toolchain with pinned version
       run: |
-        rustup toolchain install 1.86.0 --profile minimal --component rustfmt,clippy
+        rustup toolchain install 1.86.0 --component rustfmt,clippy
         rustup default 1.86.0
 
     - name: Optimize Cargo cache
@@ -227,7 +227,7 @@ jobs:
 
     - name: Set up Rust toolchain
       run: |
-        rustup toolchain install 1.86.0 --profile minimal
+        rustup toolchain install 1.86.0
         rustup default 1.86.0
 
     - name: Optimize Cargo cache for integration tests

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -86,10 +86,6 @@ jobs:
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
     - name: Set up Rust Toolchain Components
       run: rustup component add rustfmt clippy
-    - name: Run Cargo Check
-      working-directory: ${{ matrix.dir }}
-      run: cargo check --locked
-      timeout-minutes: 5
     - name: Verify Code Formatting
       working-directory: ${{ matrix.dir }}
       run: cargo fmt -- --check

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -101,6 +101,11 @@ jobs:
       run: |
         cargo-deny --version || cargo install cargo-deny@0.16.4
         cargo-deny --no-default-features check --hide-inclusion-graph licenses bans --config ${{ github.workspace }}/deny.toml
+    - name: Build Project
+      working-directory: ${{ matrix.dir }}
+      run: cargo build --locked
+      # FIXME: Improve build time and lower this timeout (ex: caching)
+      timeout-minutes: 15
     - name: Run Doc Tests
       working-directory: ${{ matrix.dir }}
       run: cargo doc --no-deps && cargo test --locked --doc
@@ -145,5 +150,3 @@ jobs:
         else
           echo "No integration tests found in ${{ matrix.dir }}, skipping"
         fi
-      # FIXME: Improve build/test time and lower this timeout
-      timeout-minutes: 20

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -99,13 +99,14 @@ jobs:
       if: ${{ env.ACT }}
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        rustup toolchain install 1.86.0-x86_64-unknown-linux-gnu
+        rustup toolchain install 1.87.0-x86_64-unknown-linux-gnu
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     - name: Set up Rust toolchain with pinned version
       run: |
-        rustup toolchain install 1.86.0 --component rustfmt,clippy
-        rustup default 1.86.0
+        rustup toolchain install 1.87.0
+        rustup default 1.87.0
+        rustup component add rustfmt clippy
 
     - name: Optimize Cargo cache
       run: |
@@ -225,10 +226,11 @@ jobs:
         rustup toolchain install 1.86.0-x86_64-unknown-linux-gnu
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-    - name: Set up Rust toolchain
+    - name: Set up Rust toolchain with pinned version
       run: |
-        rustup toolchain install 1.86.0
-        rustup default 1.86.0
+        rustup toolchain install 1.87.0
+        rustup default 1.87.0
+        rustup component add rustfmt clippy
 
     - name: Optimize Cargo cache for integration tests
       run: |

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -135,14 +135,14 @@ jobs:
     - name: Build project
       working-directory: ${{ matrix.dir }}
       run: cargo build --locked
-      timeout-minutes: 10
+      timeout-minutes: 15
 
     - name: Run documentation tests
       working-directory: ${{ matrix.dir }}
       run: |
         cargo doc --locked --no-deps
         cargo test --locked --doc
-      timeout-minutes: 5
+      timeout-minutes: 10
 
     - name: Run unit tests
       working-directory: ${{ matrix.dir }}
@@ -280,4 +280,4 @@ jobs:
         else
           echo "No integration tests found in ${{ matrix.dir }}, skipping"
         fi
-      timeout-minutes: 10
+      timeout-minutes: 15

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -35,13 +35,85 @@ on:
     - 'Cargo.lock'
 
 jobs:
-  pre-merge-rust:
+  # Fast checks without services - formatting, linting, building, unit tests
+  rust-checks:
     runs-on: ubuntu-latest
     strategy:
       matrix: { dir: ['.', 'lib/bindings/python', 'lib/runtime/examples'] }
     permissions:
       contents: read
-    # nats/etcd services needed in background for integration tests
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up system dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y protobuf-compiler
+
+    # Advanced Rust caching - replaces manual registry/tools caching
+    - name: Set up Rust cache
+      uses: swatinem/rust-cache@v2
+      with:
+        # Cache key based on working directory to avoid conflicts between matrix jobs
+        workspaces: ${{ matrix.dir }}
+        # Additional cache key components for better invalidation
+        key: ${{ matrix.dir }}
+
+    - name: Install Rust in dev environment
+      # Install Rust only to run GitHub Local Actions in (dev environment) using the `ACT` environment variable.
+      # See act usage: https://nektosact.com/introduction.html
+      # https://nektosact.com/usage/index.html?highlight=env.Act#skipping-steps
+      if: ${{ env.ACT }}
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        rustup toolchain install 1.86.0-x86_64-unknown-linux-gnu
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Set up Rust toolchain with pinned version
+      run: |
+        rustup toolchain install 1.86.0 --profile minimal --component rustfmt,clippy
+        rustup default 1.86.0
+
+    - name: Check code formatting and run Clippy
+      working-directory: ${{ matrix.dir }}
+      run: |
+        echo "Checking code formatting..."
+        cargo fmt -- --check
+        echo "Running Clippy checks..."
+        cargo clippy --no-deps --all-targets -- -D warnings
+
+    - name: Install and run cargo-deny
+      working-directory: ${{ matrix.dir }}
+      run: |
+        cargo-deny --version || cargo install cargo-deny@0.16.4 --locked
+        cargo-deny --no-default-features check --hide-inclusion-graph licenses bans --config ${{ github.workspace }}/deny.toml
+
+    - name: Build project
+      working-directory: ${{ matrix.dir }}
+      run: cargo build --locked
+      timeout-minutes: 10
+
+    - name: Run documentation tests
+      working-directory: ${{ matrix.dir }}
+      run: |
+        cargo doc --locked --no-deps
+        cargo test --locked --doc
+      timeout-minutes: 5
+
+    - name: Run unit tests
+      working-directory: ${{ matrix.dir }}
+      run: cargo test --locked --all-targets
+      timeout-minutes: 10
+
+  # Integration tests with services - only run when needed
+  rust-integration-tests:
+    runs-on: ubuntu-latest
+    needs: rust-checks  # Only run if basic checks pass
+    strategy:
+      matrix: { dir: ['.', 'lib/bindings/python', 'lib/runtime/examples'] }
+    permissions:
+      contents: read
+    # Services only started for integration tests
     services:
       nats-server:
         image: nats:2.11.4
@@ -61,55 +133,31 @@ jobs:
           ALLOW_NONE_AUTHENTICATION: yes
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up system dependencies
       run: |
         sudo apt-get update -y
         sudo apt-get install -y protobuf-compiler
-    - name: Cache Cargo Registry
-      uses: actions/cache@v3
+
+    - name: Set up Rust cache
+      uses: swatinem/rust-cache@v2
       with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ github.head_ref || github.ref_name }}-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache Cargo Tools
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/bin
-        key: ${{ runner.os }}-cargo-tools-${{ github.head_ref || github.ref_name }}-${{ hashFiles('**/Cargo.lock') }}
+        workspaces: ${{ matrix.dir }}
+        key: ${{ matrix.dir }}-integration
+
     - name: Install Rust in dev environment
-      # Install Rust only to run GitHub Local Actions in (dev environment) using the `ACT` environment variable.
-      # See act usage: https://nektosact.com/introduction.html
-      # https://nektosact.com/usage/index.html?highlight=env.Act#skipping-steps
       if: ${{ env.ACT }}
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         rustup toolchain install 1.86.0-x86_64-unknown-linux-gnu
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-    - name: Set up Rust Toolchain Components
-      run: rustup component add rustfmt clippy
-    - name: Verify Code Formatting
-      working-directory: ${{ matrix.dir }}
-      run: cargo fmt -- --check
-    - name: Run Clippy Checks
-      working-directory: ${{ matrix.dir }}
-      run: cargo clippy --no-deps --all-targets -- -D warnings
-    - name: Install and Run cargo-deny
-      working-directory: ${{ matrix.dir }}
+
+    - name: Set up Rust toolchain
       run: |
-        cargo-deny --version || cargo install cargo-deny@0.16.4
-        cargo-deny --no-default-features check --hide-inclusion-graph licenses bans --config ${{ github.workspace }}/deny.toml
-    - name: Build Project
-      working-directory: ${{ matrix.dir }}
-      run: cargo build --locked
-      # FIXME: Improve build time and lower this timeout (ex: caching)
-      timeout-minutes: 15
-    - name: Run Doc Tests
-      working-directory: ${{ matrix.dir }}
-      run: cargo doc --no-deps && cargo test --locked --doc
-    - name: Run Unit Tests
-      working-directory: ${{ matrix.dir }}
-      # NOTE: --all-targets doesn't run doc tests
-      run: cargo test --locked --all-targets
-    - name: Wait for Services to be Ready
+        rustup toolchain install 1.86.0 --profile minimal
+        rustup default 1.86.0
+
+    - name: Wait for services to be ready
       run: |
         echo "Waiting for services to be ready..."
         # Wait for NATS server to be ready
@@ -136,7 +184,8 @@ jobs:
           fi
           sleep 2
         done
-    - name: Run Integration Tests
+
+    - name: Run integration tests
       working-directory: ${{ matrix.dir }}
       run: |
         # Only run integration tests if the integration feature exists
@@ -146,3 +195,4 @@ jobs:
         else
           echo "No integration tests found in ${{ matrix.dir }}, skipping"
         fi
+      timeout-minutes: 10

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -168,9 +168,9 @@ jobs:
       working-directory: ${{ matrix.dir }}
       run: |
         # Only run integration tests if the integration feature exists
-        if cargo test --locked --features integration --no-run 2>/dev/null; then
+        if cargo test --locked --features integration --no-default-features --no-run; then
           echo "Running integration tests in ${{ matrix.dir }}"
-          cargo test --locked --features integration
+          cargo test --locked --features integration --no-default-features
         else
           echo "No integration tests found in ${{ matrix.dir }}, skipping"
         fi


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Add parallel steps for integration tests and dependent nats/etcd services running using built-in github actions `services` feature

Notes: 
- There are currently no integration tests under `lib/bindings/python` - so this is a short check, and is redundant until we add some. If we do add some, they'll automatically be picked up. We can also just exclude it to save resources until integration tests are added there.