### PR TITLE
fix: Add common and test dependencies to sglang runtime build

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -449,6 +449,16 @@ COPY --from=wheel_builder /workspace/dist/*.whl wheelhouse/
 COPY --from=base /workspace/wheels/nixl/*.whl wheelhouse/
 RUN uv pip install "ai-dynamo[sglang]" --pre --find-links wheelhouse
 
+# Common dependencies
+# TODO: Remove extra install and use pyproject.toml to define all dependencies
+RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
+    uv pip install --requirement /tmp/requirements.txt
+
+# Install test dependencies
+# TODO: Remove this once we have a functional CI image built on top of the runtime image
+RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.txt \
+    uv pip install --requirement /tmp/requirements.txt
+
 # Copy launch banner
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \
     sed '/^#\s/d' /workspace/launch_message.txt > ~/.launch_screen && \


### PR DESCRIPTION
#### Overview:

Add common, test dependencies to the sglang runtime container so that it follows suite with other backend images. 

#### Details:

- Add test/common deps to the sglang runtime image. 

#### Where should the reviewer start?

- dockerfile.sglang

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image to install additional Python dependencies for runtime and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->