### PR TITLE
fix: show raw sglang logs given env var

### DIFF
--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -192,6 +192,7 @@ def configure_vllm_logging(dyn_level: int):
         json.dump(vllm_config, f)
         os.environ["VLLM_LOGGING_CONFIG_PATH"] = f.name
 
+
 def get_bool_env_var(name: str, default: str = "false") -> bool:
     value = os.getenv(name, default)
     value = value.lower()

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -94,7 +94,8 @@ def configure_dynamo_logging(
 
     # configure inference engine loggers
     configure_vllm_logging(dyn_level)
-    configure_sglang_logging(dyn_level)
+    if not os.environ.get("DYN_SKIP_SGLANG_LOG_FORMATTING"):
+        configure_sglang_logging(dyn_level)
 
     # loggers that should be configured to ERROR
     error_loggers = ["tag"]

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -94,7 +94,7 @@ def configure_dynamo_logging(
 
     # configure inference engine loggers
     configure_vllm_logging(dyn_level)
-    if not os.environ.get("DYN_SKIP_SGLANG_LOG_FORMATTING"):
+    if "DYN_SKIP_SGLANG_LOG_FORMATTING" not in os.environ:
         configure_sglang_logging(dyn_level)
 
     # loggers that should be configured to ERROR

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -202,7 +202,7 @@ def get_bool_env_var(name: str, default: str = "false") -> bool:
 
     if (value not in truthy_values) and (value not in falsy_values):
         logging.warning(
-            f"The environment variable {name} has an unrecognized value={value!r}, treating as false"
+            f"The environment variable {name} has an unrecognized value={value}, treating as false"
         )
 
     return value in truthy_values

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -93,8 +93,9 @@ def configure_dynamo_logging(
     dyn_level = log_level_mapping(dyn_var)
 
     # configure inference engine loggers
-    configure_vllm_logging(dyn_level)
-    if "DYN_SKIP_SGLANG_LOG_FORMATTING" not in os.environ:
+    if not get_bool_env_var("DYN_SKIP_VLLM_LOG_FORMATTING"):
+        configure_vllm_logging(dyn_level)
+    if not get_bool_env_var("DYN_SKIP_SGLANG_LOG_FORMATTING"):
         configure_sglang_logging(dyn_level)
 
     # loggers that should be configured to ERROR
@@ -190,3 +191,17 @@ def configure_vllm_logging(dyn_level: int):
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
         json.dump(vllm_config, f)
         os.environ["VLLM_LOGGING_CONFIG_PATH"] = f.name
+
+def get_bool_env_var(name: str, default: str = "false") -> bool:
+    value = os.getenv(name, default)
+    value = value.lower()
+
+    truthy_values = ("true", "1")
+    falsy_values = ("false", "0")
+
+    if (value not in truthy_values) and (value not in falsy_values):
+        logging.warning(
+            f"The environment variable {name} has an unrecognized value={value!r}, treating as false"
+        )
+
+    return value in truthy_values


### PR DESCRIPTION
SGL in their logger adds a prefix that allows you to see DP/TP/EP rank attached to their logs. However, if you pass a custom formatter in, you cannot see them anymore. Since this prefix is added at the SGL scheduler level, I cannot really bypass it. 

Since we only need this for benchmarking purposes, I've added a bypass in the logging.py that will show the raw sglang prefill/decode server logs. By default this will not be set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for skipping SGLang log formatting by setting an environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->