### PR TITLE
fix: fix nil pointer deref in dynamo controller

### DIFF
--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -167,7 +167,9 @@ func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphD
 		labels[commonconsts.KubeLabelDynamoNamespace] = dynamoNamespace
 		if component.ComponentType == commonconsts.ComponentTypePlanner {
 			if deployment.Spec.ExtraPodSpec == nil {
-				deployment.Spec.ExtraPodSpec = &common.ExtraPodSpec{}
+				deployment.Spec.ExtraPodSpec = &common.ExtraPodSpec{
+					PodSpec: &corev1.PodSpec{},
+				}
 			}
 			deployment.Spec.ExtraPodSpec.ServiceAccountName = commonconsts.PlannerServiceAccountName
 		}


### PR DESCRIPTION
#### Overview:

Fixed a nil pointer dereference that occurred when setting `ServiceAccountName` for planner components. The issue was caused by accessing fields through an uninitialized embedded `*corev1.PodSpec` in `ExtraPodSpec`.

## Changes
- Properly initialize the embedded `*PodSpec` when creating a new `ExtraPodSpec` for planner components
- This ensures the `ServiceAccountName` field can be safely accessed and modified



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization of deployment specifications for Planner components to ensure correct configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->