### PR TITLE
fix: Revert the commit for DeepGEMM to fix vLLM WideEP

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -17,7 +17,9 @@ ARG TORCH_BACKEND="cu128"
 
 # Match 0.10.0 vLLM release
 # https://github.com/vllm-project/vllm/releases/tag/v0.10.0
-ARG DEEPGEMM_REF="1876566"
+# Pinned to commit before https://github.com/deepseek-ai/DeepGEMM/pull/112 for DeepGEMM which seems to break on H100:
+# "RuntimeError: Failed: CUDA runtime error csrc/jit/kernel_runtime.hpp:108 '98'"
+ARG DEEPGEMM_REF="03d0be3"
 ARG FLASHINF_REF="v0.2.8rc1"
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.


### PR DESCRIPTION
#### Overview:

We're seeing an error when running vLLM WideEP after updating DeepGEMM commit:
```
RuntimeError: Failed: CUDA runtime error csrc/jit/kernel_runtime.hpp:108 '98'
```

Commit was updated [here](https://github.com/ai-dynamo/dynamo/commit/e82bc4ec960111b369260e1758072c93227b66bf).

Same error was reported [here](https://github.com/vllm-project/vllm/issues/19653). Fall back to the previous commit resolved the issue.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to improve compatibility and prevent runtime errors on H100 GPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->