### PR TITLE
fix: doc links

### DIFF
--- a/docs/guides/dynamo_deploy/README.md
+++ b/docs/guides/dynamo_deploy/README.md
@@ -29,11 +29,11 @@ Dynamo Cloud acts as an orchestration layer between the end user and Kubernetes,
 
 We provide a Custom Resource YAML file for many examples under the components/backends/{engine}/deploy folders. Consult the examples below for the CRs for a specific inference backend.
 
-[View SGLang K8s](/components/backends/sglang/deploy/README.md)
+[View SGLang K8s](../../../components/backends/sglang/deploy/README.md)
 
-[View vLLM K8s](/components/backends/vllm/deploy/README.md)
+[View vLLM K8s](../../../components/backends/vllm/deploy/README.md)
 
-[View TRT-LLM K8s](/components/backends/trtllm/deploy/README.md)
+[View TRT-LLM K8s](../../../components/backends/trtllm/deploy/README.md)
 
 ### Deploying a particular example
 


### PR DESCRIPTION
#### Overview:

fix broken doc links for deployment of frameworks

fixes nvbug: https://nvbugspro.nvidia.com/bug/5424387
closes linear: [dyn-819](https://linear.app/nvidia-dynamo/issue/DYN-819)



#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links for example Custom Resource YAML files to use relative paths for backend components (SGLang, vLLM, TRT-LLM). No other content was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->