### PR TITLE
docs: use prebuilt gpt-oss container

### DIFF
--- a/components/backends/trtllm/gpt-oss.md
+++ b/components/backends/trtllm/gpt-oss.md
@@ -37,7 +37,7 @@ docker compose -f deploy/docker-compose.yml up
 ### 1. Pull the Container
 
 ```bash
-export DYNAMO_CONTAINER_IMAGE="nvcr.io/nvidia/ai-dynamo/tensorrtllm-gpt-oss:0.4.0"
+export DYNAMO_CONTAINER_IMAGE="nvcr.io/nvidia/ai-dynamo/tensorrtllm-gpt-oss:latest"
 
 docker pull $DYNAMO_CONTAINER_IMAGE
 ```

--- a/components/backends/trtllm/gpt-oss.md
+++ b/components/backends/trtllm/gpt-oss.md
@@ -34,7 +34,18 @@ docker compose -f deploy/docker-compose.yml up
 
 ## Instructions
 
-### 1. Build the Container
+### 1. Pull the Container
+
+```bash
+export DYNAMO_CONTAINER_IMAGE="nvcr.io/nvidia/ai-dynamo/tensorrtllm-gpt-oss:0.4.0"
+
+docker pull $DYNAMO_CONTAINER_IMAGE
+```
+
+<details>
+<summary> Building your own container </summary>
+
+If you'd like to build your own Dynamo container, use the following instructions
 
 **For ARM64 (GB200):**
 ```bash
@@ -64,6 +75,8 @@ docker build -f container/Dockerfile.tensorrt_llm_prebuilt . \
   --build-arg BASE_IMAGE_TAG=gpt-oss-dev \
   -t $DYNAMO_CONTAINER_IMAGE
 ```
+
+</details>
 
 ### 2. Download the Model
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to use a prebuilt container image by default.
  * Introduced a new environment variable for specifying the container image.
  * Added a collapsible section with manual build instructions for advanced users, including commands for different architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->