### PR TITLE
fix: Move register_llm_block down

### DIFF
--- a/components/backends/vllm/src/dynamo/vllm/main.py
+++ b/components/backends/vllm/src/dynamo/vllm/main.py
@@ -141,16 +141,6 @@ async def init(runtime: DistributedRuntime, config: Config):
         .client()
     )
 
-    if not config.engine_args.data_parallel_rank:  # if rank is 0 or None then register
-        await register_llm(
-            ModelType.Backend,
-            generate_endpoint,
-            config.model,
-            config.served_model_name,
-            kv_cache_block_size=config.engine_args.block_size,
-            migration_limit=config.migration_limit,
-        )
-
     factory = StatLoggerFactory(component, config.engine_args.data_parallel_rank or 0)
     engine_client, vllm_config, default_sampling_params = setup_vllm_engine(
         config, factory
@@ -185,6 +175,16 @@ async def init(runtime: DistributedRuntime, config: Config):
         logger.info(f"Reading Events from {zmq_endpoint}")
 
         handler.kv_publisher = kv_publisher
+
+    if not config.engine_args.data_parallel_rank:  # if rank is 0 or None then register
+        await register_llm(
+            ModelType.Backend,
+            generate_endpoint,
+            config.model,
+            config.served_model_name,
+            kv_cache_block_size=config.engine_args.block_size,
+            migration_limit=config.migration_limit,
+        )
 
     try:
         await asyncio.gather(


### PR DESCRIPTION
#### Overview:

Fixes timing issue where models appear in `/v1/models` endpoint before they're ready for inference in the vLLM backend.

#### Details:

Moved the `register_llm` call in the vLLM backend from early in the initialization process to just before the `serve_endpoint` calls, eliminating the ~20-60 second gap where requests would fail with "no instances found for endpoint" errors.

#### Where should the reviewer start?

- `components/backends/vllm/src/dynamo/vllm/main.py` - The main fix moving `register_llm` timing

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #2296 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the initialization sequence to register the LLM service later in the startup process. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->