### PR TITLE
fix: nil pointer deref in dynamo controller

### DIFF
--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -166,12 +166,16 @@ func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphD
 		labels[commonconsts.KubeLabelDynamoComponent] = componentName
 		labels[commonconsts.KubeLabelDynamoNamespace] = dynamoNamespace
 		if component.ComponentType == commonconsts.ComponentTypePlanner {
+			// ensure that the extraPodSpec is not nil
 			if deployment.Spec.ExtraPodSpec == nil {
-				deployment.Spec.ExtraPodSpec = &common.ExtraPodSpec{
-					PodSpec: &corev1.PodSpec{},
-				}
+				deployment.Spec.ExtraPodSpec = &common.ExtraPodSpec{}
 			}
-			deployment.Spec.ExtraPodSpec.ServiceAccountName = commonconsts.PlannerServiceAccountName
+			// ensure that the embedded PodSpec struct is not nil
+			if deployment.Spec.ExtraPodSpec.PodSpec == nil {
+				deployment.Spec.ExtraPodSpec.PodSpec = &corev1.PodSpec{}
+			}
+			// finally set the service account name
+			deployment.Spec.ExtraPodSpec.PodSpec.ServiceAccountName = commonconsts.PlannerServiceAccountName
 		}
 		if deployment.IsMainComponent() && defaultIngressSpec != nil && deployment.Spec.Ingress == nil {
 			deployment.Spec.Ingress = defaultIngressSpec


### PR DESCRIPTION
#### Overview:

The controller was experiencing a nil pointer dereference. The issue occurred when trying to set the service account name on potentially nil nested structs.

## Changes
- Added proper nil checks for `ExtraPodSpec` and its embedded `PodSpec`
- Fixed the path for setting `ServiceAccountName` to use `PodSpec.ServiceAccountName` instead of directly on `ExtraPodSpec`
- Improved code structure with clear comments for each initialization step


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when configuring Planner components by ensuring service account settings are correctly applied, preventing potential issues with missing or uninitialized configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->