### PR TITLE
fix: Change FrontEnd Health thresholds

### DIFF
--- a/components/backends/sglang/deploy/agg.yaml
+++ b/components/backends/sglang/deploy/agg.yaml
@@ -12,9 +12,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health

--- a/components/backends/sglang/deploy/agg.yaml
+++ b/components/backends/sglang/deploy/agg.yaml
@@ -8,29 +8,6 @@ metadata:
 spec:
   services:
     Frontend:
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       dynamoNamespace: sglang-agg
       componentType: main
       replicas: 1
@@ -48,6 +25,29 @@ spec:
           command: ["sh", "-c"]
           args:
             - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-agg && python3 -m dynamo.frontend --http-port=8000"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       livenessProbe:

--- a/components/backends/sglang/deploy/agg.yaml
+++ b/components/backends/sglang/deploy/agg.yaml
@@ -8,12 +8,18 @@ metadata:
 spec:
   services:
     Frontend:
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health
           port: 8000
-        initialDelaySeconds: 20
-        periodSeconds: 5
+        periodSeconds: 10
         timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
@@ -22,10 +28,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 30
-        failureThreshold: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       dynamoNamespace: sglang-agg
       componentType: main
       replicas: 1

--- a/components/backends/sglang/deploy/agg_router.yaml
+++ b/components/backends/sglang/deploy/agg_router.yaml
@@ -12,9 +12,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health

--- a/components/backends/sglang/deploy/agg_router.yaml
+++ b/components/backends/sglang/deploy/agg_router.yaml
@@ -8,12 +8,18 @@ metadata:
 spec:
   services:
     Frontend:
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health
           port: 8000
-        initialDelaySeconds: 20
-        periodSeconds: 5
+        periodSeconds: 10
         timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
@@ -22,10 +28,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 30
-        failureThreshold: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       dynamoNamespace: sglang-agg-router
       componentType: main
       replicas: 1

--- a/components/backends/sglang/deploy/agg_router.yaml
+++ b/components/backends/sglang/deploy/agg_router.yaml
@@ -8,29 +8,6 @@ metadata:
 spec:
   services:
     Frontend:
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       dynamoNamespace: sglang-agg-router
       componentType: main
       replicas: 1
@@ -48,6 +25,29 @@ spec:
           command: ["sh", "-c"]
           args:
             - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-agg-router && python3 -m dynamo.frontend --http-port=8000  --router-mode kv"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       livenessProbe:

--- a/components/backends/sglang/deploy/disagg.yaml
+++ b/components/backends/sglang/deploy/disagg.yaml
@@ -8,12 +8,18 @@ metadata:
 spec:
   services:
     Frontend:
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health
           port: 8000
-        initialDelaySeconds: 20
-        periodSeconds: 5
+        periodSeconds: 10
         timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
@@ -22,10 +28,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 30
-        failureThreshold: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       dynamoNamespace: sglang-disagg
       componentType: main
       replicas: 1

--- a/components/backends/sglang/deploy/disagg.yaml
+++ b/components/backends/sglang/deploy/disagg.yaml
@@ -12,9 +12,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health

--- a/components/backends/sglang/deploy/disagg.yaml
+++ b/components/backends/sglang/deploy/disagg.yaml
@@ -8,29 +8,6 @@ metadata:
 spec:
   services:
     Frontend:
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       dynamoNamespace: sglang-disagg
       componentType: main
       replicas: 1
@@ -48,6 +25,29 @@ spec:
           command: ["sh", "-c"]
           args:
             - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-disagg && python3 -m dynamo.frontend --http-port=8000"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       livenessProbe:

--- a/components/backends/trtllm/deploy/agg.yaml
+++ b/components/backends/trtllm/deploy/agg.yaml
@@ -8,33 +8,6 @@ metadata:
 spec:
   services:
     Frontend:
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 60
-      dynamoNamespace: trtllm-agg
-      componentType: main
-      livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       replicas: 1
       resources:
         requests:
@@ -52,6 +25,33 @@ spec:
             - -c
           args:
             - "python3 -m dynamo.frontend --http-port 8000"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          dynamoNamespace: trtllm-agg
+          componentType: main
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       livenessProbe:

--- a/components/backends/trtllm/deploy/agg.yaml
+++ b/components/backends/trtllm/deploy/agg.yaml
@@ -8,6 +8,13 @@ metadata:
 spec:
   services:
     Frontend:
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       dynamoNamespace: trtllm-agg
       componentType: main
       livenessProbe:
@@ -16,8 +23,8 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 5
-        timeoutSeconds: 3
+        periodSeconds: 10
+        timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
         exec:
@@ -25,10 +32,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 3
-        failureThreshold: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       replicas: 1
       resources:
         requests:

--- a/components/backends/trtllm/deploy/agg.yaml
+++ b/components/backends/trtllm/deploy/agg.yaml
@@ -12,9 +12,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
       dynamoNamespace: trtllm-agg
       componentType: main
       livenessProbe:

--- a/components/backends/trtllm/deploy/agg_router.yaml
+++ b/components/backends/trtllm/deploy/agg_router.yaml
@@ -8,14 +8,21 @@ metadata:
 spec:
   services:
     Frontend:
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         exec:
           command:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 5
-        timeoutSeconds: 3
+        periodSeconds: 10
+        timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
         exec:
@@ -23,10 +30,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 3
-        failureThreshold: 5
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       dynamoNamespace: trtllm-agg-router
       componentType: main
       replicas: 1

--- a/components/backends/trtllm/deploy/agg_router.yaml
+++ b/components/backends/trtllm/deploy/agg_router.yaml
@@ -12,9 +12,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
       livenessProbe:
         exec:
           command:

--- a/components/backends/trtllm/deploy/agg_router.yaml
+++ b/components/backends/trtllm/deploy/agg_router.yaml
@@ -8,31 +8,6 @@ metadata:
 spec:
   services:
     Frontend:
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       dynamoNamespace: trtllm-agg-router
       componentType: main
       replicas: 1
@@ -52,6 +27,31 @@ spec:
             - -c
           args:
             - "python3 -m dynamo.frontend --http-port 8000 --router-mode kv"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       livenessProbe:

--- a/components/backends/trtllm/deploy/disagg.yaml
+++ b/components/backends/trtllm/deploy/disagg.yaml
@@ -14,9 +14,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
       livenessProbe:
         exec:
           command:

--- a/components/backends/trtllm/deploy/disagg.yaml
+++ b/components/backends/trtllm/deploy/disagg.yaml
@@ -10,14 +10,21 @@ spec:
     Frontend:
       dynamoNamespace: trtllm-disagg
       componentType: main
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         exec:
           command:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 5
-        timeoutSeconds: 3
+        periodSeconds: 10
+        timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
         exec:
@@ -25,10 +32,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 3
-        failureThreshold: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       replicas: 1
       resources:
         requests:

--- a/components/backends/trtllm/deploy/disagg.yaml
+++ b/components/backends/trtllm/deploy/disagg.yaml
@@ -10,31 +10,6 @@ spec:
     Frontend:
       dynamoNamespace: trtllm-disagg
       componentType: main
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       replicas: 1
       resources:
         requests:
@@ -52,6 +27,31 @@ spec:
             - -c
           args:
             - "python3 -m dynamo.frontend --http-port 8000"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     TRTLLMPrefillWorker:
       dynamoNamespace: trtllm-disagg
       envFromSecret: hf-token-secret

--- a/components/backends/trtllm/deploy/disagg_router.yaml
+++ b/components/backends/trtllm/deploy/disagg_router.yaml
@@ -10,31 +10,6 @@ spec:
     Frontend:
       dynamoNamespace: trtllm-v1-disagg-router
       componentType: main
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
-      livenessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       replicas: 1
       resources:
         requests:
@@ -52,6 +27,31 @@ spec:
             - -c
           args:
             - "python3 -m dynamo.frontend --http-port 8000 --router-mode kv"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              periodSeconds: 5
+              timeoutSeconds: 5
+              failureThreshold: 60
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     TRTLLMPrefillWorker:
       dynamoNamespace: trtllm-v1-disagg-router
       envFromSecret: hf-token-secret

--- a/components/backends/trtllm/deploy/disagg_router.yaml
+++ b/components/backends/trtllm/deploy/disagg_router.yaml
@@ -10,14 +10,21 @@ spec:
     Frontend:
       dynamoNamespace: trtllm-v1-disagg-router
       componentType: main
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         exec:
           command:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 5
-        timeoutSeconds: 3
+        periodSeconds: 10
+        timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
         exec:
@@ -25,10 +32,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 3
-        failureThreshold: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       replicas: 1
       resources:
         requests:

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -8,12 +8,18 @@ metadata:
 spec:
   services:
     Frontend:
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health
           port: 8000
-        initialDelaySeconds: 20
-        periodSeconds: 5
+        periodSeconds: 10
         timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
@@ -22,8 +28,7 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 10
-        periodSeconds: 5
+        periodSeconds: 15
         timeoutSeconds: 5
         failureThreshold: 3
       dynamoNamespace: vllm-agg

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -19,9 +19,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
       readinessProbe:
         exec:
           command:

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -8,29 +8,6 @@ metadata:
 spec:
   services:
     Frontend:
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
-      livenessProbe:
-        httpGet:
-          path: /health
-          port: 8000
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       dynamoNamespace: vllm-agg
       componentType: main
       replicas: 1
@@ -50,6 +27,29 @@ spec:
             - -c
           args:
             - "python3 -m dynamo.frontend --http-port 8000"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       livenessProbe:

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -8,29 +8,6 @@ metadata:
 spec:
   services:
     Frontend:
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       dynamoNamespace: vllm-agg-router
       componentType: main
       replicas: 1
@@ -50,6 +27,29 @@ spec:
             - -c
           args:
             - "python3 -m dynamo.frontend --http-port 8000 --router-mode kv"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       livenessProbe:

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -12,9 +12,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -8,12 +8,18 @@ metadata:
 spec:
   services:
     Frontend:
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health
           port: 8000
-        initialDelaySeconds: 20
-        periodSeconds: 5
+        periodSeconds: 10
         timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
@@ -22,10 +28,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 30
-        failureThreshold: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       dynamoNamespace: vllm-agg-router
       componentType: main
       replicas: 1

--- a/components/backends/vllm/deploy/disagg.yaml
+++ b/components/backends/vllm/deploy/disagg.yaml
@@ -11,6 +11,13 @@ spec:
       dynamoNamespace: vllm-disagg
       componentType: main
       replicas: 1
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health
@@ -25,10 +32,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 30
-        failureThreshold: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       resources:
         requests:
           cpu: "32"

--- a/components/backends/vllm/deploy/disagg.yaml
+++ b/components/backends/vllm/deploy/disagg.yaml
@@ -11,30 +11,6 @@ spec:
       dynamoNamespace: vllm-disagg
       componentType: main
       replicas: 1
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        initialDelaySeconds: 20
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       resources:
         requests:
           cpu: "32"
@@ -51,6 +27,30 @@ spec:
             - -c
           args:
             - "python3 -m dynamo.frontend --http-port 8000"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret

--- a/components/backends/vllm/deploy/disagg.yaml
+++ b/components/backends/vllm/deploy/disagg.yaml
@@ -15,9 +15,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -18,29 +18,6 @@ spec:
       dynamoNamespace: vllm-disagg-planner
       componentType: main
       replicas: 1
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       resources:
         requests:
           cpu: "32"
@@ -57,6 +34,29 @@ spec:
             - -c
           args:
             - "python3 -m dynamo.frontend --http-port 8000"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     Planner:
       dynamoNamespace: vllm-disagg-planner
       envFromSecret: hf-token-secret

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -18,12 +18,18 @@ spec:
       dynamoNamespace: vllm-disagg-planner
       componentType: main
       replicas: 1
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health
           port: 8000
-        initialDelaySeconds: 20
-        periodSeconds: 5
+        periodSeconds: 10
         timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
@@ -32,10 +38,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 30
-        failureThreshold: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       resources:
         requests:
           cpu: "32"

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -22,9 +22,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health

--- a/components/backends/vllm/deploy/disagg_router.yaml
+++ b/components/backends/vllm/deploy/disagg_router.yaml
@@ -15,9 +15,9 @@ spec:
         httpGet:
           path: /health
           port: 8000
-          periodSeconds: 5
-          timeoutSeconds: 5
-          failureThreshold: 60
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health

--- a/components/backends/vllm/deploy/disagg_router.yaml
+++ b/components/backends/vllm/deploy/disagg_router.yaml
@@ -11,12 +11,18 @@ spec:
       dynamoNamespace: vllm-v1-disagg-router
       componentType: main
       replicas: 1
+      startupProbe:
+        httpGet:
+          path: /health
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
       livenessProbe:
         httpGet:
           path: /health
           port: 8000
-        initialDelaySeconds: 20
-        periodSeconds: 5
+        periodSeconds: 10
         timeoutSeconds: 5
         failureThreshold: 3
       readinessProbe:
@@ -25,10 +31,9 @@ spec:
             - /bin/sh
             - -c
             - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        initialDelaySeconds: 60
-        periodSeconds: 60
-        timeoutSeconds: 30
-        failureThreshold: 10
+        periodSeconds: 15
+        timeoutSeconds: 5
+        failureThreshold: 3
       resources:
         requests:
           cpu: "1"

--- a/components/backends/vllm/deploy/disagg_router.yaml
+++ b/components/backends/vllm/deploy/disagg_router.yaml
@@ -11,29 +11,6 @@ spec:
       dynamoNamespace: vllm-v1-disagg-router
       componentType: main
       replicas: 1
-      startupProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 5
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 3
-      readinessProbe:
-        exec:
-          command:
-            - /bin/sh
-            - -c
-            - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
-        periodSeconds: 15
-        timeoutSeconds: 5
-        failureThreshold: 3
       resources:
         requests:
           cpu: "1"
@@ -50,6 +27,29 @@ spec:
             - -c
           args:
             - "python3 -m dynamo.frontend --http-port 8000 --router-mode kv"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl -s http://localhost:8000/health | jq -e ".status == \"healthy\""'
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
     VllmDecodeWorker:
       dynamoNamespace: vllm-v1-disagg-router
       envFromSecret: hf-token-secret


### PR DESCRIPTION
#### Overview:

Move probes from the backward-compatible to new locations and add the StartupProbe.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added startup health checks to the Frontend service across multiple deployment configurations.
  * Adjusted liveness and readiness health check intervals and thresholds to improve monitoring and responsiveness during startup and operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->