### PR TITLE
fix: Reduce disk space usage in pre-merge-rust action (removes unnecessary sccache artifacts)

### DIFF
--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -36,13 +36,14 @@ on:
 
 jobs:
   pre-merge-rust:
-    runs-on: ubuntu-latest
+    runs-on:
+        group: Fastchecker
     strategy:
       matrix: { dir: ['.', 'lib/bindings/python', 'lib/runtime/examples'] }
     permissions:
       contents: read
-    env:
-      RUSTC_WRAPPER: "sccache"
+    #env:
+    #   RUSTC_WRAPPER: "sccache"
     steps:
     - uses: actions/checkout@v4
     - name: Set up system dependencies
@@ -50,12 +51,15 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y protobuf-compiler
 
-    - name: Cache sccache artifacts
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/sccache/
-        key: ${{ runner.os }}-sccache-${{ matrix.dir }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: ${{ runner.os }}-sccache-${{ matrix.dir }}-
+    # TODO: Caching target/ dir handles most of the build caching improvements
+    #       currently, so sccache artifacts are mostly duplicates wasting disk space.
+    #       Revisit this to see if overall caching flow can be improved.
+    #- name: Cache sccache artifacts
+    #  uses: actions/cache@v4
+    #  with:
+    #    path: ~/.cache/sccache/
+    #    key: ${{ runner.os }}-sccache-${{ matrix.dir }}-${{ hashFiles('**/Cargo.lock') }}
+    #    restore-keys: ${{ runner.os }}-sccache-${{ matrix.dir }}-
 
     # TODO: Consider single target/ directory for all subdirectories/crates instead.
     - name: Cache cargo artifacts
@@ -70,14 +74,14 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ matrix.dir }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-${{ matrix.dir }}-
 
-    - name: Install sccache
-      run: |
-        SCCACHE_VERSION="0.10.0"
-        SCCACHE_FILE="sccache-v${SCCACHE_VERSION}-$(uname -m)-unknown-linux-musl"
-        SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_FILE}.tar.gz"
-        curl -L "${SCCACHE_URL}" | tar xz
-        mv ${SCCACHE_FILE}/sccache /usr/local/bin/sccache
-        chmod +x /usr/local/bin/sccache
+    #- name: Install sccache
+    #  run: |
+    #    SCCACHE_VERSION="0.10.0"
+    #    SCCACHE_FILE="sccache-v${SCCACHE_VERSION}-$(uname -m)-unknown-linux-musl"
+    #    SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_FILE}.tar.gz"
+    #    curl -L "${SCCACHE_URL}" | tar xz
+    #    mv ${SCCACHE_FILE}/sccache /usr/local/bin/sccache
+    #    chmod +x /usr/local/bin/sccache
 
     - name: Install Rust in dev environment
       # Install Rust only to run GitHub Local Actions in (dev environment) using the `ACT` environment variable.
@@ -113,6 +117,6 @@ jobs:
       # NOTE: --all-targets doesn't run doc tests
       run: cargo test --locked --all-targets
 
-    - name: Run sccache stat for check
-      shell: bash
-      run: sccache --show-stats
+    #- name: Run sccache stat for check
+    #  shell: bash
+    #  run: sccache --show-stats

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -36,8 +36,7 @@ on:
 
 jobs:
   pre-merge-rust:
-    runs-on:
-        group: Fastchecker
+    runs-on: ubuntu-latest
     strategy:
       matrix: { dir: ['.', 'lib/bindings/python', 'lib/runtime/examples'] }
     permissions:
@@ -50,6 +49,17 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y protobuf-compiler
+
+    - name: Free runner disk space
+      run: |
+        echo "Disk space before:"
+        df -h
+        rm -rf \
+          /host_usr/share/dotnet /host_usr/local/lib/android /opt/ghc \
+          /host_usr/local/share/powershell /host_usr/share/swift /host_usr/local/.ghcup \
+          /host_usr/lib/jvm /opt/hostedtoolcache
+        echo "Disk space after:"
+        df -h
 
     # TODO: Caching target/ dir handles most of the build caching improvements
     #       currently, so sccache artifacts are mostly duplicates wasting disk space.

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -41,8 +41,6 @@ jobs:
       matrix: { dir: ['.', 'lib/bindings/python', 'lib/runtime/examples'] }
     permissions:
       contents: read
-    #env:
-    #   RUSTC_WRAPPER: "sccache"
     steps:
     - uses: actions/checkout@v4
     - name: Set up system dependencies
@@ -63,14 +61,7 @@ jobs:
 
     # TODO: Caching target/ dir handles most of the build caching improvements
     #       currently, so sccache artifacts are mostly duplicates wasting disk space.
-    #       Revisit this to see if overall caching flow can be improved.
-    #- name: Cache sccache artifacts
-    #  uses: actions/cache@v4
-    #  with:
-    #    path: ~/.cache/sccache/
-    #    key: ${{ runner.os }}-sccache-${{ matrix.dir }}-${{ hashFiles('**/Cargo.lock') }}
-    #    restore-keys: ${{ runner.os }}-sccache-${{ matrix.dir }}-
-
+    #       Revisit this to see if sccache can improve current caching behavior.
     # TODO: Consider single target/ directory for all subdirectories/crates instead.
     - name: Cache cargo artifacts
       uses: actions/cache@v4
@@ -83,15 +74,6 @@ jobs:
           ${{ matrix.dir }}/target/
         key: ${{ runner.os }}-cargo-${{ matrix.dir }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-${{ matrix.dir }}-
-
-    #- name: Install sccache
-    #  run: |
-    #    SCCACHE_VERSION="0.10.0"
-    #    SCCACHE_FILE="sccache-v${SCCACHE_VERSION}-$(uname -m)-unknown-linux-musl"
-    #    SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_FILE}.tar.gz"
-    #    curl -L "${SCCACHE_URL}" | tar xz
-    #    mv ${SCCACHE_FILE}/sccache /usr/local/bin/sccache
-    #    chmod +x /usr/local/bin/sccache
 
     - name: Install Rust in dev environment
       # Install Rust only to run GitHub Local Actions in (dev environment) using the `ACT` environment variable.
@@ -126,7 +108,3 @@ jobs:
       working-directory: ${{ matrix.dir }}
       # NOTE: --all-targets doesn't run doc tests
       run: cargo test --locked --all-targets
-
-    #- name: Run sccache stat for check
-    #  shell: bash
-    #  run: sccache --show-stats


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Various PRs are getting a pre-merge-rust check failure due to runner running out of disk space.

- ~1 GB of disk space is used from sccache artifacts
- ~3 GB of disk space is used from cargo (ex: `target/` dir) artifacts
- The `target/` dir caching is doing most of the heavy lifting so far
- We can revisit `sccache` in an improvement, so left a TODO

#### Details

This PR:
- removes the `sccache` part as it seems to be mostly redundant disk space usage for now, and we need to avoid running out of disk space.
- tries to clean up some additional disk space on the worker just in case
    - https://carlosbecker.com/posts/github-actions-disk-space/
    - https://github.com/ai-dynamo/dynamo/pull/2317#issuecomment-3161178348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed use of build caching tool to optimize workflow resource usage.
  * Added a step to free up disk space on the runner, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->