### PR TITLE
fix: upgrade cudarc to 0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
  "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
- "cudarc",
+ "cudarc 0.16.6",
  "float8",
  "gemm 0.17.1",
  "half 2.6.0",
@@ -1397,6 +1397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cudarc"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "018e09f92e57618dbae5a3a0dcc2026547eed0e5b6a503a32c11ee1a94890830"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,7 +1865,7 @@ dependencies = [
  "candle-core 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
  "criterion",
- "cudarc",
+ "cudarc 0.17.1",
  "dashmap",
  "derive-getters",
  "derive_builder",
@@ -2346,7 +2355,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f498aec3b227cd892ce18967f4033d9d397d28a80a7ab67e9f6b0176a79654e"
 dependencies = [
- "cudarc",
+ "cudarc 0.16.6",
  "half 2.6.0",
  "num-traits",
 ]
@@ -7892,7 +7901,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14053653d0b7fa7b21015aa9a62edc8af2f60aa6f9c54e66386ecce55f22ed29"
 dependencies = [
- "cudarc",
+ "cudarc 0.16.6",
  "half 2.6.0",
  "serde",
  "thiserror 1.0.69",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.16.6"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17200eb07e7d85a243aa1bf4569a7aa998385ba98d14833973a817a63cc86e92"
+checksum = "018e09f92e57618dbae5a3a0dcc2026547eed0e5b6a503a32c11ee1a94890830"
 dependencies = [
  "libloading",
 ]

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -92,7 +92,7 @@ dialoguer = { version = "0.11", default-features = false, features = ["editor", 
 
 # block_manager
 nixl-sys = {version = "0.4.1", optional = true }
-cudarc = { version = "0.16.6", features = ["cuda-12020"], optional = true }
+cudarc = { version = "0.17.1", features = ["cuda-12020"], optional = true }
 ndarray = { version = "0.16", optional = true }
 nix = { version = "0.26", optional = true }
 


### PR DESCRIPTION
Fixes the build with `--features cuda,dynamo-llm/block-manager`.

cudarc failed over: "Both dynamic-loading and dynamic-linking features are active, this is a bug"

Explanation:

- Before dbe48a1d2b9, mistral linked to cudarc 0.13.9 with dynamic _linking_, while Dynamo linked to 0.16.2 with dynamic _loading_. So they didn't see each other in the build process and it somehow worked.

- With the consolidation to 0.16.6 a single cudarc is used, and therefore feature selection intersects with this conflict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to include additional features for improved compatibility and performance. No visible changes to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->