### PR TITLE
fix: re-enable deduplication

### DIFF
--- a/lib/llm/src/block_manager/pool/managed.rs
+++ b/lib/llm/src/block_manager/pool/managed.rs
@@ -77,7 +77,7 @@ pub struct ManagedBlockPoolArgs<S: Storage, L: LocalityProvider, M: BlockMetadat
     )]
     pool_metrics: Arc<PoolMetrics>,
 
-    #[builder(default = "BlockRegistrationDuplicationSetting::Allowed")]
+    #[builder(default = "BlockRegistrationDuplicationSetting::Disabled")]
     default_duplication_setting: BlockRegistrationDuplicationSetting,
 }
 


### PR DESCRIPTION
vLLM's block manager do not dedup. 

We allowed duplication when we were override the vLLM device block manager. 

Moving forward with the connector api, we want to dedup on host and disk.  In the future, we will revisit how we interact with the native, or replace the native, block manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a distributed key-value block manager (KVBM) for vLLM, enabling leader-worker block management, block transfer orchestration, and KV cache offloading across device, host, and disk.
  * Added Python and Rust APIs for KVBM integration, including cache manager, connector leader/worker, and block controller classes.
  * Provided comprehensive vLLM integration with support for external block transfers, slot/block lifecycle management, and connector metadata handling.

* **Documentation**
  * Added user guides for deploying Dynamo Cloud and running KVBM in vLLM.
  * Introduced detailed architecture and test plan documents for block manager and slot management systems.

* **Bug Fixes**
  * Improved error handling and validation for block allocation, transfer, and cache reset operations.

* **Chores**
  * Updated Dockerfiles and build scripts to support KVBM environments and dependencies.
  * Enhanced dependency management and feature flags for Rust and Python packages.

* **Tests**
  * Added extensive unit and integration tests for KVBM, vLLM integration, and block manager workflows.
  * Removed legacy block manager tests, replacing them with new tests targeting distributed and vLLM scenarios.

* **Refactor**
  * Refactored block manager internals to support locality-aware block data, async initialization, and distributed resource management.
  * Modularized codebase with clear separation between logical, local, and distributed block handling.

End-users can now leverage distributed KV cache management for large language models, with improved reliability, extensibility, and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->