### PR TITLE
chore(metrics): Remove the Arc

### DIFF
--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -177,38 +177,11 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "axum-core 0.5.2",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -218,7 +191,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -230,30 +203,10 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -692,7 +645,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "async_zmq",
- "axum 0.8.4",
+ "axum",
  "blake3",
  "bytes",
  "chrono",
@@ -809,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.14.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0452bcc559431b16f472b7ab86e2f9ccd5f3c2da3795afbd6b773665e047fe"
+checksum = "88365f1a5671eb2f7fc240adb216786bc6494b38ce15f1d26ad6eaa303d5e822"
 dependencies = [
  "http",
  "prost",
@@ -819,7 +772,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
- "tower 0.4.13",
+ "tower",
  "tower-service",
 ]
 
@@ -1033,18 +986,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.9.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1363,22 +1310,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1533,12 +1470,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -1827,7 +1758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -2272,7 +2203,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -2726,6 +2657,7 @@ dependencies = [
 name = "system_metrics"
 version = "0.4.0"
 dependencies = [
+ "anyhow",
  "dynamo-runtime",
  "futures",
  "prometheus",
@@ -2988,7 +2920,7 @@ version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3004,13 +2936,12 @@ checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64",
  "bytes",
  "h2",
@@ -3023,12 +2954,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-pemfile",
  "socket2",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3036,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3050,35 +2980,18 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3097,7 +3010,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]

--- a/lib/runtime/examples/system_metrics/Cargo.toml
+++ b/lib/runtime/examples/system_metrics/Cargo.toml
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 [package]
 name = "system_metrics"
@@ -27,6 +15,7 @@ default = []
 integration = [] # Integration tests that require NATS
 
 [dependencies]
+anyhow = "*"
 dynamo-runtime = { workspace = true }
 
 # third-party

--- a/lib/runtime/examples/system_metrics/src/lib.rs
+++ b/lib/runtime/examples/system_metrics/src/lib.rs
@@ -1,17 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use dynamo_runtime::{
     metrics::MetricsRegistry,
@@ -39,13 +27,11 @@ pub struct MyStats {
 /// Custom metrics for system stats with data bytes tracking
 #[derive(Clone, Debug)]
 pub struct MySystemStatsMetrics {
-    pub data_bytes_processed: Arc<IntCounter>,
+    pub data_bytes_processed: IntCounter,
 }
 
 impl MySystemStatsMetrics {
-    pub fn from_endpoint(
-        endpoint: &dynamo_runtime::component::Endpoint,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    pub fn from_endpoint(endpoint: &dynamo_runtime::component::Endpoint) -> anyhow::Result<Self> {
         let data_bytes_processed = endpoint.create_intcounter(
             "my_custom_bytes_processed_total",
             "Example of a custom metric. Total number of data bytes processed by system handler",
@@ -60,7 +46,7 @@ impl MySystemStatsMetrics {
 
 #[derive(Clone)]
 pub struct RequestHandler {
-    metrics: Option<Arc<MySystemStatsMetrics>>,
+    metrics: Option<MySystemStatsMetrics>,
 }
 
 impl RequestHandler {
@@ -70,7 +56,7 @@ impl RequestHandler {
 
     pub fn with_metrics(metrics: MySystemStatsMetrics) -> Arc<Self> {
         Arc::new(Self {
-            metrics: Some(Arc::new(metrics)),
+            metrics: Some(metrics),
         })
     }
 }

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -194,7 +194,7 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
     labels: &[(&str, &str)],
     buckets: Option<Vec<f64>>,
     const_labels: Option<&[&str]>,
-) -> anyhow::Result<Arc<T>> {
+) -> anyhow::Result<T> {
     // Validate that user-provided labels don't have duplicate keys
     let mut seen_keys = std::collections::HashSet::new();
 
@@ -376,7 +376,7 @@ fn create_metric<T: PrometheusMetric, R: MetricsRegistry + ?Sized>(
             .register(collector);
     }
 
-    Ok(Arc::new(metric))
+    Ok(metric)
 }
 
 /// This trait should be implemented by all metric registries, including Prometheus, Envy, OpenTelemetry, and others.
@@ -423,7 +423,7 @@ pub trait MetricsRegistry: Send + Sync + crate::traits::DistributedRuntimeProvid
         name: &str,
         description: &str,
         labels: &[(&str, &str)],
-    ) -> anyhow::Result<Arc<prometheus::Counter>> {
+    ) -> anyhow::Result<prometheus::Counter> {
         create_metric(self, name, description, labels, None, None)
     }
 
@@ -434,7 +434,7 @@ pub trait MetricsRegistry: Send + Sync + crate::traits::DistributedRuntimeProvid
         description: &str,
         const_labels: &[&str],
         const_label_values: &[(&str, &str)],
-    ) -> anyhow::Result<Arc<prometheus::CounterVec>> {
+    ) -> anyhow::Result<prometheus::CounterVec> {
         create_metric(
             self,
             name,
@@ -451,7 +451,7 @@ pub trait MetricsRegistry: Send + Sync + crate::traits::DistributedRuntimeProvid
         name: &str,
         description: &str,
         labels: &[(&str, &str)],
-    ) -> anyhow::Result<Arc<prometheus::Gauge>> {
+    ) -> anyhow::Result<prometheus::Gauge> {
         create_metric(self, name, description, labels, None, None)
     }
 
@@ -462,7 +462,7 @@ pub trait MetricsRegistry: Send + Sync + crate::traits::DistributedRuntimeProvid
         description: &str,
         labels: &[(&str, &str)],
         buckets: Option<Vec<f64>>,
-    ) -> anyhow::Result<Arc<prometheus::Histogram>> {
+    ) -> anyhow::Result<prometheus::Histogram> {
         create_metric(self, name, description, labels, buckets, None)
     }
 
@@ -472,7 +472,7 @@ pub trait MetricsRegistry: Send + Sync + crate::traits::DistributedRuntimeProvid
         name: &str,
         description: &str,
         labels: &[(&str, &str)],
-    ) -> anyhow::Result<Arc<prometheus::IntCounter>> {
+    ) -> anyhow::Result<prometheus::IntCounter> {
         create_metric(self, name, description, labels, None, None)
     }
 
@@ -483,7 +483,7 @@ pub trait MetricsRegistry: Send + Sync + crate::traits::DistributedRuntimeProvid
         description: &str,
         const_labels: &[&str],
         const_label_values: &[(&str, &str)],
-    ) -> anyhow::Result<Arc<prometheus::IntCounterVec>> {
+    ) -> anyhow::Result<prometheus::IntCounterVec> {
         create_metric(
             self,
             name,
@@ -500,7 +500,7 @@ pub trait MetricsRegistry: Send + Sync + crate::traits::DistributedRuntimeProvid
         name: &str,
         description: &str,
         labels: &[(&str, &str)],
-    ) -> anyhow::Result<Arc<prometheus::IntGauge>> {
+    ) -> anyhow::Result<prometheus::IntGauge> {
         create_metric(self, name, description, labels, None, None)
     }
 
@@ -511,7 +511,7 @@ pub trait MetricsRegistry: Send + Sync + crate::traits::DistributedRuntimeProvid
         description: &str,
         const_labels: &[&str],
         const_label_values: &[(&str, &str)],
-    ) -> anyhow::Result<Arc<prometheus::IntGaugeVec>> {
+    ) -> anyhow::Result<prometheus::IntGaugeVec> {
         create_metric(
             self,
             name,

--- a/lib/runtime/src/metrics_server.rs
+++ b/lib/runtime/src/metrics_server.rs
@@ -70,7 +70,7 @@ pub struct MetricsServerState {
     // global drt registry is for printing out the entire Prometheus format output
     root_drt: Arc<crate::DistributedRuntime>,
     start_time: OnceLock<Instant>,
-    uptime_gauge: Arc<prometheus::Gauge>,
+    uptime_gauge: prometheus::Gauge,
 }
 
 impl MetricsServerState {

--- a/lib/runtime/src/pipeline/network/ingress/push_handler.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_handler.rs
@@ -22,22 +22,22 @@ use std::sync::Arc;
 /// Metrics configuration for profiling work handlers
 #[derive(Clone, Debug)]
 pub struct WorkHandlerMetrics {
-    pub request_counter: Arc<IntCounter>,
-    pub request_duration: Arc<Histogram>,
-    pub concurrent_requests: Arc<IntGauge>,
-    pub request_bytes: Arc<IntCounter>,
-    pub response_bytes: Arc<IntCounter>,
-    pub error_counter: Arc<IntCounterVec>,
+    pub request_counter: IntCounter,
+    pub request_duration: Histogram,
+    pub concurrent_requests: IntGauge,
+    pub request_bytes: IntCounter,
+    pub response_bytes: IntCounter,
+    pub error_counter: IntCounterVec,
 }
 
 impl WorkHandlerMetrics {
     pub fn new(
-        request_counter: Arc<IntCounter>,
-        request_duration: Arc<Histogram>,
-        concurrent_requests: Arc<IntGauge>,
-        request_bytes: Arc<IntCounter>,
-        response_bytes: Arc<IntCounter>,
-        error_counter: Arc<IntCounterVec>,
+        request_counter: IntCounter,
+        request_duration: Histogram,
+        concurrent_requests: IntGauge,
+        request_bytes: IntCounter,
+        response_bytes: IntCounter,
+        error_counter: IntCounterVec,
     ) -> Self {
         Self {
             request_counter,


### PR DESCRIPTION
An `Arc` is a heap allocation, so ideally we do as few as possible. The Prometheus metric types are already `Clone`, and internally they [contain an Arc - e.g.](https://docs.rs/prometheus/latest/src/prometheus/gauge.rs.html#15-19), so we don't need the one we were adding.

Thanks Claude Code for doing the typing for me.

This will simplify #2330 a little.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated metric-related fields and method signatures to use direct metric types instead of shared pointers, simplifying their usage throughout the application. This affects metric creation, server state, and handler metrics. No changes to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->