### PR TITLE
fix: Pinned PyTorch version for vLLM container

### DIFF
--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -148,12 +148,7 @@ fi
 # Install ep_kernels and DeepGEMM
 echo "Installing ep_kernels and DeepGEMM"
 cd tools/ep_kernels
-
-# These libraries lack version pinning and would download the latest PyTorch version,
-# which can cause compatibility issues with torchvision. The actual PyTorch version pinning
-# to 2.7.1 is implemented later in this script.
-bash install_python_libraries.sh
-
+bash install_python_libraries.sh # These libraries aren't pinned.
 cd ep_kernels_workspace
 git clone https://github.com/deepseek-ai/DeepGEMM.git
 cd DeepGEMM

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -24,7 +24,7 @@ VLLM_REF="f4135232b9a8c4845f8961fb1cd17581c56ae2ce"
 MAX_JOBS=16
 INSTALLATION_DIR=/tmp
 ARCH=$(uname -m)
-DEEPGEMM_REF="1876566"
+DEEPGEMM_REF="03d0be3"
 FLASHINF_REF="v0.2.8rc1"
 TORCH_BACKEND="cu128"
 
@@ -179,14 +179,7 @@ else
     git clone https://github.com/flashinfer-ai/flashinfer.git --recursive
     cd flashinfer
     git checkout $FLASHINF_REF
-    python -m pip install -v .
-fi
-
-if [ "$ARCH" = "amd64" ]; then
-    # NOTE: PyTorch 2.8.0 compatibility issue
-    # PyTorch 2.8.0 causes "RuntimeError: operator torchvision::nms does not exist" error.
-    # Temporarily pinning to PyTorch 2.7.1 until this compatibility issue is resolved.
-    uv pip install torch==2.7.1 --index-url https://download.pytorch.org/whl/cu128
+    uv pip install -v --no-build-isolation .
 fi
 
 echo "vllm installation completed successfully"

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -148,7 +148,12 @@ fi
 # Install ep_kernels and DeepGEMM
 echo "Installing ep_kernels and DeepGEMM"
 cd tools/ep_kernels
-bash install_python_libraries.sh # These libraries aren't pinned.
+
+# These libraries lack version pinning and would download the latest PyTorch version,
+# which can cause compatibility issues with torchvision. The actual PyTorch version pinning
+# to 2.7.1 is implemented later in this script.
+bash install_python_libraries.sh
+
 cd ep_kernels_workspace
 git clone https://github.com/deepseek-ai/DeepGEMM.git
 cd DeepGEMM
@@ -175,6 +180,13 @@ else
     cd flashinfer
     git checkout $FLASHINF_REF
     python -m pip install -v .
+fi
+
+if [ "$ARCH" = "amd64" ]; then
+    # NOTE: PyTorch 2.8.0 compatibility issue
+    # PyTorch 2.8.0 causes "RuntimeError: operator torchvision::nms does not exist" error.
+    # Temporarily pinning to PyTorch 2.7.1 until this compatibility issue is resolved.
+    uv pip install torch==2.7.1 --index-url https://download.pytorch.org/whl/cu128
 fi
 
 echo "vllm installation completed successfully"


### PR DESCRIPTION
#### Overview:

The container comes with PyTorch 2.7.1, matching vLLM v0.10.0. During the FlashInfer installation, however, PyTorch 2.8.0 gets installed, which leads to compatibility issues between Torch and TorchVision, such as:
```
"RuntimeError: operator torchvision::nms does not exist"
```

I couldn’t find any reference to torch==2.8.* or similar in the FlashInfer repository. Adding the `--no-build-isolation` flag ensures that the installation respects the PyTorch version already present in the environment.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added comments to clarify Python library installation and version compatibility.
  * Updated installation process to ensure PyTorch 2.7.1 is installed on amd64 systems to prevent runtime errors with torchvision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->