### PR TITLE
fix: use wheel files for installation in trtllm build

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -486,7 +486,7 @@ RUN uv pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_P
     if [ "$ARCH" = "amd64" ]; then \
         pip install "triton==3.3.1"; \
     fi; \
-    uv pip install ai-dynamo nixl --find-links /workspace/wheelhouse
+    uv pip install /workspace/wheelhouse/ai_dynamo_runtime*cp312*.whl /workspace/wheelhouse/ai_dynamo*any.whl /workspace/wheelhouse/nixl*.whl
 
 # Copy benchmarks, backends and tests for CI
 # TODO: Remove this once we have a functional CI image built on top of the runtime image


### PR DESCRIPTION
#### Overview:

Use wheel files to install dynamo and nixl packages.

Using --find-links brings in newer version of nixl from pypi repo. from pip docs - https://pip.pypa.io/en/latest/cli/pip_install/#finding-packages
>pip looks for packages in a number of places: on PyPI (or the index given as --index-url, if not disabled via --no-index), in the local filesystem, and in any additional repositories specified via --find-links or --extra-index-url. There is no priority in the locations that are searched. Rather they are all checked, and the “best” match for the requirements (in terms of version number - see the [specification](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers) for details) is selected.


Tested in build,
```
#102 32.55 Installed 11 packages in 3ms
#102 32.55  + ai-dynamo==0.4.0 (from file:///workspace/wheelhouse/ai_dynamo-0.4.0-py3-none-any.whl)
#102 32.55  + ai-dynamo-runtime==0.4.0 (from file:///workspace/wheelhouse/ai_dynamo_runtime-0.4.0-cp312-cp312-manylinux_2_28_x86_64.whl)
#102 32.55  + circus==0.19.0
#102 32.55  - click==8.2.1
#102 32.55  + click==8.1.8
#102 32.55  + nixl==0.4.1 (from file:///workspace/wheelhouse/nixl-0.4.1-cp312-cp312-linux_x86_64.whl)
#102 32.55  - pydantic==2.11.7
#102 32.55  + pydantic==2.10.6
```