### PR TITLE
fix(model_card): Serialize the cached slug to etcd

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -92,7 +92,9 @@ pub struct ModelDeploymentCard {
     pub display_name: String,
 
     // Cache the Slugified display_name so we can share references to it
-    slug: Slug,
+    // This is `pub` so that it gets serialized to etcd, which is simpler than
+    // having the frontend re-calcuate it (which would be fine too).
+    pub slug: Slug,
 
     /// Model information
     pub model_info: Option<ModelInfoType>,


### PR DESCRIPTION
The `slug` field is a cache of the `Slug` of the display_name. Storing it allows us to share references to it, and avoids re-computing it.

A "slug" (newspaper term) is a URL friendly string: "Qwen3 0.6B" ->
"qwen3-0-6b". We use it as the model name in HTTP, as an etcd/nats key, etc.

When the ModelDeploymentCard gets serialized to etcd we don't need to send that field. However when we de-serialize, we need the field. We could either not send it, and have frontend allow it being empty and re-compute it immediately after de-serialize, OR we can just send it to etcd. It's small, it's cheap, and it's easy, so we send it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved comments to clarify the visibility of certain fields for easier frontend integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->