### PR TITLE
fix: use default batch_size for decode

### DIFF
--- a/components/backends/trtllm/engine_configs/gpt_oss/decode.yaml
+++ b/components/backends/trtllm/engine_configs/gpt_oss/decode.yaml
@@ -17,7 +17,6 @@ disable_overlap_scheduler: false
 moe_config:
     backend: CUTLASS
 cuda_graph_config:
-    max_batch_size: 128
     enable_padding: true
 cache_transceiver_config:
   backend: ucx

--- a/components/backends/trtllm/gpt-oss.md
+++ b/components/backends/trtllm/gpt-oss.md
@@ -203,7 +203,6 @@ CUDA_VISIBLE_DEVICES=4,5,6,7 python3 -m dynamo.trtllm \
   --disaggregation-mode decode \
   --disaggregation-strategy prefill_first \
   --max-num-tokens 16384 \
-  --max-batch-size 128 \
   --free-gpu-memory-fraction 0.9 \
   --tensor-parallel-size 4 \
   --expert-parallel-size 4

--- a/components/backends/trtllm/launch/gpt_oss_disagg.sh
+++ b/components/backends/trtllm/launch/gpt_oss_disagg.sh
@@ -40,7 +40,6 @@ CUDA_VISIBLE_DEVICES=4,5,6,7 python3 -m dynamo.trtllm \
   --disaggregation-mode decode \
   --disaggregation-strategy "$DISAGGREGATION_STRATEGY" \
   --max-num-tokens 16384 \
-  --max-batch-size 128 \
   --free-gpu-memory-fraction 0.9 \
   --tensor-parallel-size 4 \
   --expert-parallel-size 4


### PR DESCRIPTION
#### Overview:

Removes specified batch size for decode worker in gpt-oss deployment guide based on feedback from @jthomson04 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed explicit maximum batch size setting for the decode worker in configuration and launch scripts.
  * Updated documentation to reflect the removal of the max batch size argument from the decode worker launch command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->