### PR TITLE
fix: K8s Operator to Start Pods in DGD if resources/limits is not set

### DIFF
--- a/deploy/cloud/operator/internal/controller_common/resource.go
+++ b/deploy/cloud/operator/internal/controller_common/resource.go
@@ -357,13 +357,11 @@ func firstKey(m map[string]interface{}) string {
 }
 
 func GetResourcesConfig(resources *common.Resources) (*corev1.ResourceRequirements, error) {
-
 	if resources == nil {
-		return nil, nil
+		return &corev1.ResourceRequirements{}, nil
 	}
 
 	currentResources := &corev1.ResourceRequirements{}
-
 	if resources.Limits != nil {
 		if resources.Limits.CPU != "" {
 			q, err := resource.ParseQuantity(resources.Limits.CPU)


### PR DESCRIPTION
#### Overview:

This PR fixes K8s Operator to Start Pods in DGD if resources/limits is not set

- closes GitHub issue: https://github.com/ai-dynamo/dynamo/issues/2227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing resource configurations to ensure consistent behavior when no resource requirements are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->