### PR TITLE
fix(build): Pin cuda-python>=12,<13 to avoid trtllm breakage

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -501,8 +501,12 @@ COPY --from=dev /workspace/target/release/metrics /usr/local/bin/metrics
 # NOTE: If a package (tensorrt_llm) exists on both --index-url and --extra-index-url,
 # uv will prioritize the --extra-index-url, unless --index-strategy unsafe-best-match
 # is also specified. So set the configurable index as a --extra-index-url for prioritization.
-# locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc4
-RUN uv pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" && \
+# NOTE: locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc4
+# NOTE: locking cuda-python version to <13 to avoid breaks with tensorrt-llm 1.0.0rc4. This
+#       can be removed after https://github.com/NVIDIA/TensorRT-LLM/pull/6703 is merged
+#       we upgrade to a published pip wheel containing this change.
+RUN uv pip install "cuda-python>=12,<13" && \
+    uv pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" && \
     if [ "$ARCH" = "amd64" ]; then \
         pip install "triton==3.3.1"; \
     fi; \


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Fixes this error when importing TRTLLM:
```
>>> import tensorrt_llm
Traceback (most recent call last):
...
  File "/opt/dynamo/venv/lib/python3.12/site-packages/tensorrt_llm/_ipc_utils.py", line 20, in <module>
    from cuda import cuda, cudart
ImportError: cannot import name 'cuda' from 'cuda' (unknown location)
```

Root cause: cuda-python published package for cuda 13, and trtllm was installing cuda-python with an loose version restriction, so it picked up latest cuda 13 and isn't compatible yet with the published 1.0.0rc4 trtllm wheel we're installing alongside it.

Fix: Pin cuda-python>=12,<13, same as this PR on TRTLLM side: https://github.com/NVIDIA/TensorRT-LLM/pull/6703

Once the TRTLLM PR is merged and a new trtllm python package is published with this dependency constraint, we can remove this workaround and update our trtllm package version.
