### PR TITLE
build: add zmq lib to support trtllm's UCX connection establishment with zmq

### DIFF
--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -57,6 +57,8 @@ RUN apt update -y && \
     meson \
     ninja-build \
     pybind11-dev \
+    ## support UCX to establish connections with zmq
+    libzmq3-dev \
     # These headers are missing with the hpcx installer, required
     # by UCX to find RDMA devices
     libibverbs-dev rdma-core ibverbs-utils libibumad-dev \
@@ -373,6 +375,8 @@ RUN apt-get update && \
         curl \
         # For debugging
         vim \
+        # support UCX to establish connections with zmq
+        libzmq3-dev \
         # Libraries required by UCX to find RDMA devices
         libibverbs1 rdma-core ibverbs-utils libibumad3 \
         libnuma1 librdmacm1 ibverbs-providers \


### PR DESCRIPTION
#### Overview:

add zmq dev lib to docker image to support trtllm's UCX connection establishment with zmq

#### Details:

TRTLLM recently made a change(https://github.com/NVIDIA/TensorRT-LLM/pull/6090) to use the zmq to help UCX establish connection. An extra dependency is introduced. Or this error will appear when doing disagg:

```
 RuntimeError: [TensorRT-LLM][ERROR] Assertion failed: UCX wrapper library is not open correctly. error : libzmq.so.5: cannot open shared object file: No such file or directory (/src/tensorrt_llm/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp:162)
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies in the Docker image to include support for ZeroMQ connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->