### PR TITLE
fix: remove existing /workspace from CUDA base image before COPY oper…

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -361,6 +361,9 @@ COPY --from=wheel_builder $NIXL_PREFIX $NIXL_PREFIX
 # Copy Cargo cache to avoid re-downloading dependencies
 COPY --from=wheel_builder $CARGO_HOME $CARGO_HOME
 
+# This path exists from the base image, maintained by the CUDA team. Don't need it, so remove it.
+RUN rm -f /workspace && mkdir -p /workspace
+
 # Copy rest of the code
 COPY . /workspace
 

--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -318,6 +318,9 @@ COPY --from=wheel_builder /workspace /workspace
 # Copy Cargo cache to avoid re-downloading dependencies
 COPY --from=wheel_builder $CARGO_HOME $CARGO_HOME
 
+# This path exists from the base image, maintained by the CUDA team. Don't need it, so remove it.
+RUN rm -f /workspace && mkdir -p /workspace
+
 # Copy rest of the code
 COPY . /workspace
 

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -390,6 +390,9 @@ COPY --from=wheel_builder $NIXL_PREFIX $NIXL_PREFIX
 # Copy Cargo cache to avoid re-downloading dependencies
 COPY --from=wheel_builder $CARGO_HOME $CARGO_HOME
 
+# This path exists from the base image, maintained by the CUDA team. Don't need it, so remove it.
+RUN rm -f /workspace && mkdir -p /workspace
+
 # Copy rest of the code
 COPY . /workspace
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build files to properly handle `/workspace` directory initialization across multiple container configurations.
  * Ensured consistent directory setup in base CUDA image build stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->