### PR TITLE
fix: Fix ETCD and NATS starvation under massive request concurrency

### DIFF
--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -51,16 +51,10 @@ impl DistributedRuntime {
         let etcd_client = if is_static {
             None
         } else {
-            Some(
-                Self::build_with_runtime(move || {
-                    etcd::Client::new(etcd_config.clone(), runtime_clone)
-                })
-                .await?,
-            )
+            Some(etcd::Client::new(etcd_config.clone(), runtime_clone).await?)
         };
 
-        // TODO(jthomson04): We may want to consider running the NATS client across multiple threads.
-        let nats_client = Self::build_with_runtime(move || nats_config.clone().connect()).await?;
+        let nats_client = nats_config.clone().connect().await?;
 
         // Start system status server for health and metrics if enabled in configuration
         let config = crate::config::RuntimeConfig::from_settings().unwrap_or_default();
@@ -137,30 +131,6 @@ impl DistributedRuntime {
         }
 
         Ok(distributed_runtime)
-    }
-
-    async fn build_with_runtime<T: Send + Sync + 'static>(
-        f: impl AsyncFnOnce() -> Result<T> + Send + Sync + 'static,
-    ) -> Result<T> {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        std::thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
-
-            runtime.block_on(async move {
-                let value = f().await;
-
-                tx.send(value)
-                    .unwrap_or_else(|_| panic!("This should never happen!"));
-
-                std::future::pending::<()>().await;
-            });
-        });
-
-        rx.await
-            .unwrap_or_else(|e| panic!("Failed to build with runtime: {:?}", e))
     }
 
     pub async fn from_settings(runtime: Runtime) -> Result<Self> {

--- a/lib/runtime/src/transports.rs
+++ b/lib/runtime/src/transports.rs
@@ -21,4 +21,5 @@
 pub mod etcd;
 pub mod nats;
 pub mod tcp;
+mod utils;
 pub mod zmq;

--- a/lib/runtime/src/transports/utils.rs
+++ b/lib/runtime/src/transports/utils.rs
@@ -1,0 +1,35 @@
+use std::{future::Future, sync::Arc};
+
+use anyhow::Result;
+
+pub async fn build_in_runtime<
+    T: Send + Sync + 'static,
+    F: Future<Output = Result<T>> + Send + 'static,
+>(
+    f: F,
+    num_threads: usize,
+) -> Result<(T, Arc<tokio::runtime::Runtime>)> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let runtime = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(num_threads)
+            .enable_all()
+            .build()?,
+    );
+
+    let runtime_clone = runtime.clone();
+    std::thread::spawn(move || {
+        runtime_clone.block_on(async move {
+            let result = f.await;
+            tx.send(result)
+                .unwrap_or_else(|_| panic!("This should never happen!"));
+
+            std::future::pending::<()>().await;
+        })
+    });
+
+    let result = rx.await??;
+
+    Ok((result, runtime))
+}

--- a/lib/runtime/src/transports/utils.rs
+++ b/lib/runtime/src/transports/utils.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{future::Future, sync::Arc};
 
 use anyhow::Result;


### PR DESCRIPTION
Was doing some Dynamo benchmarks across a dozen GB200 nodes. I found that the ETCD heartbeat in the frontend would sometimes fail, leading to it terminating. 

This was due to how we were running the heartbeat. At extremely high concurrencies (>20000), we have 10s of thousands of async tasks. This causes the gRPC/networking drivers in the gRPC client to starve. This involves a couple fixes:
- Moves the heartbeat task to it's own dedicated, high-priority thread, instead of running it as a secondary task on our main runtime.
- Instantiate a new etcd client within the dedicated thread. 

A similar issue also exists with NATS. Under high load, the NATS client gets starved, leading to heinous performance issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved etcd lease management by running lease creation and keep-alive tasks in a dedicated high-priority thread, enhancing reliability under high concurrency.

* **Refactor**
  * Unified and simplified etcd client and lease creation logic to use a configuration object, reducing complexity and improving maintainability.

* **Bug Fixes**
  * Improved error handling during etcd client connection and lease grant failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->