### PR TITLE
feat: Pass CancelledError into Python asynchronous generator object upon stream cancellation 

### DIFF
--- a/components/backends/vllm/src/dynamo/vllm/handlers.py
+++ b/components/backends/vllm/src/dynamo/vllm/handlers.py
@@ -50,34 +50,28 @@ class BaseWorkerHandler(ABC):
         gen = self.engine_client.generate(prompt, sampling_params, request_id)
 
         num_output_tokens_so_far = 0
-        try:
-            async for res in gen:
-                # res is vllm's RequestOutput
+        async for res in gen:
+            # res is vllm's RequestOutput
 
-                # This is the expected way for a request to end.
-                # The new token ID will be eos, don't forward it.
-                if res.finished:
-                    yield {"finish_reason": "stop", "token_ids": []}
-                    break
+            # This is the expected way for a request to end.
+            # The new token ID will be eos, don't forward it.
+            if res.finished:
+                yield {"finish_reason": "stop", "token_ids": []}
+                break
 
-                if not res.outputs:
-                    yield {"finish_reason": "error", "token_ids": []}
-                    break
+            if not res.outputs:
+                yield {"finish_reason": "error", "token_ids": []}
+                break
 
-                output = res.outputs[0]
-                next_total_toks = len(output.token_ids)
-                out = {"token_ids": output.token_ids[num_output_tokens_so_far:]}
-                if output.finish_reason:
-                    out["finish_reason"] = output.finish_reason
-                if output.stop_reason:
-                    out["stop_reason"] = output.stop_reason
-                yield out
-                num_output_tokens_so_far = next_total_toks
-        except asyncio.CancelledError:
-            # raise EngineShGeneratorExit when engine exits so that frontend can migrate the request
-            raise GeneratorExit(
-                "Decode engine was shut down during token generation"
-            ) from None
+            output = res.outputs[0]
+            next_total_toks = len(output.token_ids)
+            out = {"token_ids": output.token_ids[num_output_tokens_so_far:]}
+            if output.finish_reason:
+                out["finish_reason"] = output.finish_reason
+            if output.stop_reason:
+                out["stop_reason"] = output.stop_reason
+            yield out
+            num_output_tokens_so_far = next_total_toks
 
 
 class DecodeWorkerHandler(BaseWorkerHandler):
@@ -161,8 +155,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     "kv_transfer_params"
                 ] = prefill_response.kv_transfer_params
 
-        async for tok in self.generate_tokens(prompt, sampling_params, request_id):
-            yield tok
+        try:
+            async for tok in self.generate_tokens(prompt, sampling_params, request_id):
+                yield tok
+        except asyncio.CancelledError:
+            await self.engine_client.abort(request_id)
+            logger.debug(f"Request ID {request_id} was cancelled")
+            raise
 
 
 class PrefillWorkerHandler(BaseWorkerHandler):
@@ -193,7 +192,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                     kv_transfer_params=res.kv_transfer_params,
                 ).model_dump_json()
         except asyncio.CancelledError:
-            # raise the error because we cannot migrate prefill requests
-            raise GeneratorExit(
-                "Prefill engine was shut down during token generation"
-            ) from None
+            await self.engine_client.abort(request_id)
+            logger.debug(f"Prefill Request ID {request_id} was cancelled")
+            raise

--- a/docs/guides/backend.md
+++ b/docs/guides/backend.md
@@ -113,10 +113,10 @@ In the P/D disaggregated setup you would have `deepseek-distill-llama8b.prefill.
 
 A Python worker may need to be shut down promptly, for example when the node running the worker is to be reclaimed and there isn't enough time to complete all ongoing requests before the shutdown deadline.
 
-In such cases, you can signal incomplete responses by raising a `GeneratorExit` exception in your generate loop. This will immediately close the response stream, signaling to the frontend that the stream is incomplete. With request migration enabled (see the [`migration_limit`](../architecture/request_migration.md) parameter), the frontend will automatically migrate the partially completed request to another worker instance, if available, to be completed.
+In such cases, you can signal incomplete responses by raising a `asyncio.CancelledError` exception in your generate loop. This will immediately close the response stream, signaling to the frontend that the stream is incomplete. With request migration enabled (see the [`migration_limit`](../architecture/request_migration.md) parameter), the frontend will automatically migrate the partially completed request to another worker instance, if available, to be completed.
 
 > [!WARNING]
-> We will update the `GeneratorExit` exception to a new Dynamo exception. Please expect minor code breaking change in the near future.
+> We may replace the `asyncio.CancelledError` exception to a new Dynamo exception. Please expect minor code breaking change in the near future.
 
 Here's an example of how to implement this in your `RequestHandler`:
 
@@ -128,12 +128,12 @@ class RequestHandler:
         for result in self.engine.generate_streaming(request):
             # Check if we need to migrate before yielding each token
             if is_shutting_down():
-                # Raising GeneratorExit closes the stream and triggers migration
-                raise GeneratorExit("Worker shutting down, migrating request")
+                # Raising asyncio.CancelledError closes the stream and triggers migration
+                raise asyncio.CancelledError
 
             yield result
 ```
 
-When `GeneratorExit` is raised, the frontend receives the incomplete response and can seamlessly continue generation on another available worker instance, preserving the user experience even during worker shutdowns.
+When `asyncio.CancelledError` is raised, the frontend receives the incomplete response and can seamlessly continue generation on another available worker instance, preserving the user experience even during worker shutdowns.
 
 For more information about how request migration works, see the [Request Migration Architecture](../architecture/request_migration.md) documentation.

--- a/lib/bindings/python/rust/async_stream.rs
+++ b/lib/bindings/python/rust/async_stream.rs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::Stream;
+use pyo3::prelude::*;
+use pyo3_async_runtimes::{into_future_with_locals, TaskLocals};
+use tokio::sync::mpsc;
+
+pub fn into_stream(
+    locals: TaskLocals,
+    gen_: Bound<'_, PyAny>,
+) -> PyResult<impl Stream<Item = PyResult<PyObject>> + 'static> {
+    let (tx, rx) = mpsc::channel(1);
+    let anext = PyObject::from(gen_.getattr("__anext__")?);
+    let py_gen = PyObject::from(gen_); // Store the generator for athrow call
+
+    tokio::spawn(async move {
+        loop {
+            let fut = Python::with_gil(|py| -> PyResult<_> {
+                into_future_with_locals(&locals, anext.bind(py).call0()?)
+            });
+            let item = match fut {
+                Ok(fut) => match fut.await {
+                    Ok(item) => Ok(item),
+                    Err(e) => {
+                        let stop_iter = Python::with_gil(|py| {
+                            e.is_instance_of::<pyo3::exceptions::PyStopAsyncIteration>(py)
+                        });
+
+                        if stop_iter {
+                            // end the iteration
+                            break;
+                        } else {
+                            Err(e)
+                        }
+                    }
+                },
+                Err(e) => Err(e),
+            };
+
+            if tx.send(item).await.is_err() {
+                tracing::debug!("Stream receiver dropped");
+
+                // Cancel the Python async generator object
+                // https://peps.python.org/pep-0525/#asynchronous-generator-object
+                let athrow = Python::with_gil(|py| -> PyResult<_> {
+                    let cancelled_error = pyo3::exceptions::asyncio::CancelledError::new_err(());
+                    let athrow_coro = py_gen.call_method1(py, "athrow", (cancelled_error,))?;
+                    into_future_with_locals(&locals, athrow_coro.into_bound(py))
+                });
+                match athrow {
+                    Ok(fut) => match fut.await {
+                        Ok(_) => {
+                            tracing::debug!("Generator cancelled: no further exception raised")
+                        }
+                        Err(err) => tracing::debug!("Generator cancelled: {}", err),
+                    },
+                    Err(err) => tracing::error!("Failed to call athrow on the generator: {}", err),
+                }
+
+                break;
+            }
+        }
+    });
+
+    Ok(tokio_stream::wrappers::ReceiverStream::new(rx))
+}

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -43,6 +43,7 @@ impl From<RouterMode> for RsRouterMode {
     }
 }
 
+mod async_stream;
 mod engine;
 mod http;
 mod llm;

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -29,6 +29,11 @@ pub struct Migration {
 
 impl Migration {
     pub async fn from_mdc(mdc: ModelDeploymentCard) -> Result<Arc<Self>> {
+        tracing::debug!(
+            "model {} migration limit {}",
+            mdc.display_name,
+            mdc.migration_limit
+        );
         Ok(Arc::new(Self {
             migration_limit: mdc.migration_limit,
         }))

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use dynamo_runtime::{
     pipeline::{
-        async_trait, AsyncEngineContextProvider, ManyOut, Operator, ResponseStream,
+        async_trait, AsyncEngineContextProvider, Context, ManyOut, Operator, ResponseStream,
         ServerStreamingEngine, SingleIn,
     },
     protocols::{annotated::Annotated, maybe_error::MaybeError},
@@ -55,10 +55,12 @@ impl
         next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>,
     ) -> Result<ManyOut<Annotated<LLMEngineOutput>>> {
         let (preprocessed_request, context) = request.transfer(());
+        let context_id = context.id().to_string();
         let engine_ctx = context.context();
         let engine_ctx_ = engine_ctx.clone();
         let retry_manager =
-            RetryManager::build(preprocessed_request, next, self.migration_limit).await?;
+            RetryManager::build(context_id, preprocessed_request, next, self.migration_limit)
+                .await?;
         let response_stream = stream::unfold(retry_manager, move |mut retry_manager| {
             let engine_ctx = engine_ctx_.clone();
             async move {
@@ -76,6 +78,7 @@ impl
 }
 
 struct RetryManager {
+    context_id: String,
     request: PreprocessedRequest,
     next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>,
     next_stream: Option<ManyOut<Annotated<LLMEngineOutput>>>,
@@ -84,11 +87,13 @@ struct RetryManager {
 
 impl RetryManager {
     pub async fn build(
+        context_id: String,
         preprocessed_request: PreprocessedRequest,
         next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>,
         retries_left: u32,
     ) -> Result<Self> {
         let mut slf = Self {
+            context_id,
             request: preprocessed_request,
             next_generate: next,
             next_stream: None,
@@ -132,8 +137,7 @@ impl RetryManager {
         let mut response_stream: Option<Result<ManyOut<Annotated<LLMEngineOutput>>>> = None;
         while self.retries_left > 0 {
             self.retries_left -= 1;
-            // TODO: Is there anything needed to pass between context?
-            let request = SingleIn::new(self.request.clone());
+            let request = Context::with_id(self.request.clone(), self.context_id.clone());
             response_stream = Some(self.next_generate.generate(request).await);
             if let Some(err) = response_stream.as_ref().unwrap().as_ref().err() {
                 if let Some(req_err) = err.downcast_ref::<NatsRequestError>() {
@@ -237,15 +241,22 @@ mod tests {
         num_responses: usize,
         token_offset: u32,
         call_count: Arc<AtomicU32>,
+        context_id: String,
     }
 
     impl MockEngine {
-        fn new(behavior: MockBehavior, num_responses: usize, token_offset: u32) -> Self {
+        fn new(
+            behavior: MockBehavior,
+            num_responses: usize,
+            token_offset: u32,
+            context_id: String,
+        ) -> Self {
             Self {
                 behavior,
                 num_responses,
                 token_offset,
                 call_count: Arc::new(AtomicU32::new(0)),
+                context_id,
             }
         }
     }
@@ -263,7 +274,14 @@ mod tests {
             request: SingleIn<PreprocessedRequest>,
         ) -> Result<ManyOut<Annotated<LLMEngineOutput>>> {
             let call_num = self.call_count.fetch_add(1, Ordering::SeqCst);
-            let (preprocessed_request, _) = request.transfer(());
+            let (preprocessed_request, context) = request.transfer(());
+
+            // Assert that the context_id matches the expected one
+            assert_eq!(
+                context.id().to_string(),
+                self.context_id,
+                "Context ID mismatch"
+            );
 
             // Calculate how many responses we've already generated based on request token_ids
             // Initial request has [1, 2, 3], so anything beyond that are generated responses
@@ -338,7 +356,7 @@ mod tests {
                     }
 
                     let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-                    let ctx = Arc::new(Controller::default());
+                    let ctx = Arc::new(Controller::new(self.context_id.clone()));
                     Ok(dynamo_runtime::pipeline::ResponseStream::new(
                         Box::pin(stream),
                         ctx,
@@ -369,7 +387,7 @@ mod tests {
                         });
 
                         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-                        let ctx = Arc::new(Controller::default());
+                        let ctx = Arc::new(Controller::new(self.context_id.clone()));
                         Ok(dynamo_runtime::pipeline::ResponseStream::new(
                             Box::pin(stream),
                             ctx,
@@ -405,7 +423,7 @@ mod tests {
                         });
 
                         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-                        let ctx = Arc::new(Controller::default());
+                        let ctx = Arc::new(Controller::new(self.context_id.clone()));
                         Ok(dynamo_runtime::pipeline::ResponseStream::new(
                             Box::pin(stream),
                             ctx,
@@ -422,7 +440,7 @@ mod tests {
                         });
 
                         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-                        let ctx = Arc::new(Controller::default());
+                        let ctx = Arc::new(Controller::new(self.context_id.clone()));
                         Ok(dynamo_runtime::pipeline::ResponseStream::new(
                             Box::pin(stream),
                             ctx,
@@ -457,7 +475,7 @@ mod tests {
             });
 
             let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-            let ctx = Arc::new(Controller::default());
+            let ctx = Arc::new(Controller::new(self.context_id.clone()));
             Ok(dynamo_runtime::pipeline::ResponseStream::new(
                 Box::pin(stream),
                 ctx,
@@ -471,12 +489,18 @@ mod tests {
     /// Expected behavior: All 10 responses should be received successfully.
     #[tokio::test]
     async fn test_retry_manager_no_migration() {
+        let context_id = uuid::Uuid::new_v4().to_string();
         let request = create_mock_request(10);
-        let mock_engine = Arc::new(MockEngine::new(MockBehavior::Success, 10, 100));
+        let mock_engine = Arc::new(MockEngine::new(
+            MockBehavior::Success,
+            10,
+            100,
+            context_id.clone(),
+        ));
         let next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
             mock_engine;
 
-        let mut retry_manager = RetryManager::build(request, next_generate, 0)
+        let mut retry_manager = RetryManager::build(context_id, request, next_generate, 0)
             .await
             .expect("Failed to build RetryManager");
 
@@ -502,12 +526,18 @@ mod tests {
     /// Expected behavior: All 10 responses should be received successfully after retry.
     #[tokio::test]
     async fn test_retry_manager_new_request_migration() {
+        let context_id = uuid::Uuid::new_v4().to_string();
         let request = create_mock_request(10);
-        let mock_engine = Arc::new(MockEngine::new(MockBehavior::FailThenSuccess, 10, 100));
+        let mock_engine = Arc::new(MockEngine::new(
+            MockBehavior::FailThenSuccess,
+            10,
+            100,
+            context_id.clone(),
+        ));
         let next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
             mock_engine;
 
-        let mut retry_manager = RetryManager::build(request, next_generate, 3)
+        let mut retry_manager = RetryManager::build(context_id, request, next_generate, 3)
             .await
             .expect("Failed to build RetryManager");
 
@@ -533,16 +563,18 @@ mod tests {
     /// Expected behavior: 5 responses from first stream + 5 responses from retry stream = 10 total.
     #[tokio::test]
     async fn test_retry_manager_ongoing_request_migration() {
+        let context_id = uuid::Uuid::new_v4().to_string();
         let request = create_mock_request(10);
         let mock_engine = Arc::new(MockEngine::new(
             MockBehavior::MidStreamFail { fail_after: 5 },
             10,
             100,
+            context_id.clone(),
         ));
         let next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
             mock_engine;
 
-        let mut retry_manager = RetryManager::build(request, next_generate, 3)
+        let mut retry_manager = RetryManager::build(context_id, request, next_generate, 3)
             .await
             .expect("Failed to build RetryManager");
 
@@ -569,13 +601,19 @@ mod tests {
     /// Expected behavior: Should receive an error after all retries are exhausted, with the original error.
     #[tokio::test]
     async fn test_retry_manager_new_request_migration_indefinite_failure() {
+        let context_id = uuid::Uuid::new_v4().to_string();
         let request = create_mock_request(0);
-        let mock_engine = Arc::new(MockEngine::new(MockBehavior::AlwaysFail, 0, 100));
+        let mock_engine = Arc::new(MockEngine::new(
+            MockBehavior::AlwaysFail,
+            0,
+            100,
+            context_id.clone(),
+        ));
         let next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
             mock_engine;
 
         // Should fail to build due to initial stream creation failure after exhausting all 3 retries
-        let retry_manager_result = RetryManager::build(request, next_generate, 3).await;
+        let retry_manager_result = RetryManager::build(context_id, request, next_generate, 3).await;
 
         assert!(retry_manager_result.is_err());
         if let Err(error) = retry_manager_result {
@@ -589,16 +627,18 @@ mod tests {
     /// Expected behavior: Should receive some responses from first stream, then error after retries exhausted.
     #[tokio::test]
     async fn test_retry_manager_ongoing_request_migration_indefinite_failure() {
+        let context_id = uuid::Uuid::new_v4().to_string();
         let request = create_mock_request(10);
         let mock_engine = Arc::new(MockEngine::new(
             MockBehavior::MidStreamFailAlways { fail_after: 3 },
             10,
             100,
+            context_id.clone(),
         ));
         let next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
             mock_engine;
 
-        let mut retry_manager = RetryManager::build(request, next_generate, 3) // 3 retries
+        let mut retry_manager = RetryManager::build(context_id, request, next_generate, 3) // 3 retries
             .await
             .expect("Failed to build RetryManager");
 
@@ -636,16 +676,18 @@ mod tests {
     /// Expected behavior: Should receive some responses from first stream, then error after retries exhausted.
     #[tokio::test]
     async fn test_retry_manager_ongoing_request_migration_indefinite_failure_stream_error() {
+        let context_id = uuid::Uuid::new_v4().to_string();
         let request = create_mock_request(10);
         let mock_engine = Arc::new(MockEngine::new(
             MockBehavior::MidStreamFailAlwaysStreamError { fail_after: 3 },
             10,
             100,
+            context_id.clone(),
         ));
         let next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
             mock_engine;
 
-        let mut retry_manager = RetryManager::build(request, next_generate, 3) // 3 retries
+        let mut retry_manager = RetryManager::build(context_id, request, next_generate, 3) // 3 retries
             .await
             .expect("Failed to build RetryManager");
 

--- a/tests/fault_tolerance/test_request_cancellation.py
+++ b/tests/fault_tolerance/test_request_cancellation.py
@@ -1,0 +1,357 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+import shutil
+import time
+
+import pytest
+import requests
+from huggingface_hub import snapshot_download
+
+from tests.utils.managed_process import ManagedProcess
+
+logger = logging.getLogger(__name__)
+
+
+class DynamoFrontendProcess(ManagedProcess):
+    """Process manager for Dynamo frontend"""
+
+    def __init__(self, request):
+        command = ["python", "-m", "dynamo.frontend"]
+
+        # Set debug logging environment
+        env = os.environ.copy()
+        env["DYN_LOG"] = "debug"
+
+        log_dir = f"{request.node.name}_frontend"
+
+        # Clean up any existing log directory from previous runs
+        try:
+            shutil.rmtree(log_dir)
+            logger.info(f"Cleaned up existing log directory: {log_dir}")
+        except FileNotFoundError:
+            # Directory doesn't exist, which is fine
+            pass
+
+        super().__init__(
+            command=command,
+            env=env,
+            display_output=True,
+            terminate_existing=True,
+            log_dir=log_dir,
+        )
+
+
+class DynamoWorkerProcess(ManagedProcess):
+    """Process manager for Dynamo worker with vLLM backend"""
+
+    def __init__(self, request):
+        command = [
+            "python3",
+            "-m",
+            "dynamo.vllm",
+            "--model",
+            "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+            "--enforce-eager",
+            "--max-model-len",
+            "16384",
+            "--migration-limit",
+            "3",
+        ]
+
+        # Set debug logging environment
+        env = os.environ.copy()
+        env["DYN_LOG"] = "debug"
+        env["DYN_SYSTEM_ENABLED"] = "true"
+        env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
+        env["DYN_SYSTEM_PORT"] = "8081"
+
+        log_dir = f"{request.node.name}_worker"
+
+        # Clean up any existing log directory from previous runs
+        try:
+            shutil.rmtree(log_dir)
+            logger.info(f"Cleaned up existing log directory: {log_dir}")
+        except FileNotFoundError:
+            # Directory doesn't exist, which is fine
+            pass
+
+        super().__init__(
+            command=command,
+            env=env,
+            health_check_urls=[("http://localhost:8081/health", self.is_ready)],
+            timeout=300,
+            display_output=True,
+            terminate_existing=True,
+            log_dir=log_dir,
+        )
+
+    def get_pid(self):
+        """Get the PID of the worker process"""
+        return self.proc.pid if self.proc else None
+
+    def is_ready(self, response) -> bool:
+        """Check the health of the worker process"""
+        try:
+            data = response.json()
+            if data.get("status") == "ready":
+                logger.info("Worker status is ready")
+                return True
+            logger.warning(f"Worker status is not ready: {data.get('status')}")
+        except ValueError:
+            logger.warning("Worker health response is not valid JSON")
+        return False
+
+
+def download_model() -> None:
+    """
+    Download the DeepSeek-R1-Distill-Llama-8B model from HuggingFace Hub if not already cached.
+    """
+    model_id = "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+    logger.info(f"Caching model {model_id}...")
+
+    max_retries = 5
+    retry_delay = 30  # seconds
+
+    for attempt in range(max_retries):
+        try:
+            # Download the model to the default cache directory
+            # This will skip download if the model is already cached
+            snapshot_download(
+                repo_id="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+                repo_type="model",
+                local_files_only=False,
+            )
+            logger.info(f"Model {model_id} is ready for use")
+            return  # Success, exit the function
+        except Exception as e:
+            if attempt < max_retries - 1:  # Not the last attempt
+                logger.warning(
+                    f"Failed to download model {model_id} (attempt {attempt + 1}/{max_retries}): {e}"
+                )
+                logger.info(f"Retrying in {retry_delay} seconds...")
+                time.sleep(retry_delay)
+            else:  # Last attempt failed
+                logger.error(
+                    f"Failed to download model {model_id} after {max_retries} attempts: {e}"
+                )
+                raise
+
+
+def send_completion_request(
+    prompt: str, max_tokens: int, timeout: int = 120
+) -> requests.Response:
+    """Send a completion request to the frontend"""
+    payload = {
+        "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+    }
+
+    headers = {"Content-Type": "application/json"}
+
+    logger.info(
+        f"Sending completion request with prompt: '{prompt[:50]}...' and max_tokens: {max_tokens}"
+    )
+
+    session = requests.Session()
+    try:
+        response = session.post(
+            "http://localhost:8080/v1/completions",
+            headers=headers,
+            json=payload,
+            timeout=timeout,
+        )
+        logger.info(f"Received response with status code: {response.status_code}")
+        return response
+    except requests.exceptions.Timeout:
+        logger.error(f"Request timed out after {timeout} seconds")
+        raise
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Request failed with error: {e}")
+        raise
+
+
+def send_chat_completion_request(
+    prompt: str, max_tokens: int, timeout: int = 120, stream: bool = False
+) -> requests.Response:
+    """Send a chat completion request to the frontend"""
+    payload = {
+        "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "stream": stream,
+    }
+
+    headers = {"Content-Type": "application/json"}
+
+    logger.info(
+        f"Sending chat completion request (stream={stream}) with prompt: '{prompt[:50]}...' and max_tokens: {max_tokens}"
+    )
+
+    session = requests.Session()
+    try:
+        response = session.post(
+            "http://localhost:8080/v1/chat/completions",
+            headers=headers,
+            json=payload,
+            timeout=timeout,
+            stream=stream,
+        )
+        logger.info(f"Received response with status code: {response.status_code}")
+        return response
+    except requests.exceptions.Timeout:
+        logger.error(f"Request timed out after {timeout} seconds")
+        raise
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Request failed with error: {e}")
+        raise
+
+
+def send_request_and_cancel(request_type: str = "completion"):
+    """Send a request with short timeout to trigger cancellation"""
+    logger.info(f"Sending {request_type} request to be cancelled...")
+
+    prompt = "Tell me a very long and detailed story about the history of artificial intelligence, including all major milestones, researchers, and breakthroughs?"
+    timeout = 1  # Short timeout to trigger cancellation
+    try:
+        if request_type == "completion":
+            response = send_completion_request(prompt, 16000, timeout)
+        elif request_type == "chat_completion":
+            response = send_chat_completion_request(prompt, 16000, timeout, False)
+        elif request_type == "chat_completion_stream":
+            response = send_chat_completion_request(prompt, 16000, timeout, True)
+            # Read a few responses and then disconnect
+            if response.status_code == 200:
+                itr_count, max_itr = 0, 5
+                try:
+                    for res in response.iter_lines():
+                        logger.info(f"Received response {itr_count + 1}: {res[:50]}...")
+                        itr_count += 1
+                        if itr_count >= max_itr:
+                            break
+                        time.sleep(0.1)
+                except Exception as e:
+                    pytest.fail(f"Stream reading failed: {e}")
+
+            response.close()
+            raise Exception("Closed response")
+        else:
+            pytest.fail(f"Unknown request type: {request_type}")
+
+        pytest.fail(
+            f"{request_type} request completed unexpectedly - should have been cancelled"
+        )
+    except Exception as e:
+        logger.info(f"{request_type} request was cancelled: {e}")
+
+
+def read_log_content(log_path: str | None) -> str:
+    """Read log content from a file"""
+    if log_path is None:
+        pytest.fail("Log path is None - cannot read log content")
+
+    try:
+        with open(log_path, "r") as f:
+            return f.read()
+    except Exception as e:
+        pytest.fail(f"Could not read log file {log_path}: {e}")
+
+
+def verify_request_cancelled(
+    worker_process: DynamoWorkerProcess,
+    frontend_process: DynamoFrontendProcess,
+    worker_log_offset: int = 0,
+    frontend_log_offset: int = 0,
+) -> tuple[int, int]:
+    """Verify that the worker and frontend logs contain cancellation messages
+
+    Returns:
+        tuple: (new_worker_log_length, new_frontend_log_length)
+    """
+
+    # Check worker log for cancellation pattern
+    worker_log_content = read_log_content(worker_process._log_path)
+    new_worker_content = worker_log_content[worker_log_offset:]
+    has_worker_cancellation = (
+        "finished processing python async generator stream" in new_worker_content
+    )
+
+    # Check frontend log for "issued control message Kill to sender" message
+    frontend_log_content = read_log_content(frontend_process._log_path)
+    new_frontend_content = frontend_log_content[frontend_log_offset:]
+    has_kill_message = "issued control message Kill to sender" in new_frontend_content
+
+    logger.info(f"Kill message found in frontend log: {has_kill_message}")
+    logger.info(f"Worker cancellation pattern found: {has_worker_cancellation}")
+
+    if not (has_kill_message and has_worker_cancellation):
+        pytest.fail("Request cancellation was not detected in worker and frontend logs")
+
+    return len(worker_log_content), len(frontend_log_content)
+
+
+@pytest.mark.vllm
+@pytest.mark.gpu_1
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_request_cancellation_vllm(request, runtime_services):
+    """
+    End-to-end test for request cancellation functionality.
+
+    This test verifies that when a request is cancelled by the client,
+    the system properly handles the cancellation and cleans up resources
+    on the worker side. Tests three scenarios:
+    1. Completion request
+    2. Chat completion request (non-streaming)
+    3. Chat completion request (streaming)
+    """
+    # Step 0: Download the model from HuggingFace if not already cached
+    download_model()
+
+    # Step 1: Start the frontend
+    with DynamoFrontendProcess(request) as frontend:
+        logger.info("Frontend started successfully")
+
+        # Step 2: Start a single worker
+        logger.info("Starting worker...")
+        worker = DynamoWorkerProcess(request)
+
+        with worker:
+            logger.info(f"Worker PID: {worker.get_pid()}")
+
+            # TODO: Why the model is not immediately available at the frontend after health check
+            #       returns success.
+            time.sleep(2)
+
+            # Step 3: Test request cancellation
+            worker_log_offset, frontend_log_offset = 0, 0
+
+            test_scenarios = [
+                ("completion", "Completion request cancellation"),
+                ("chat_completion", "Chat completion request cancellation"),
+                (
+                    "chat_completion_stream",
+                    "Chat completion stream request cancellation",
+                ),
+            ]
+
+            for i, (request_type, description) in enumerate(test_scenarios, 1):
+                logger.info(f"Testing {description.lower()}...")
+                send_request_and_cancel(request_type)
+
+                logger.info(
+                    "Checking for cancellation messages in worker and frontend logs..."
+                )
+                time.sleep(0.5)  # Make sure logs are written before proceeding
+                worker_log_offset, frontend_log_offset = verify_request_cancelled(
+                    worker, frontend, worker_log_offset, frontend_log_offset
+                )
+
+                logger.info(f"{description} detected successfully")
+
+            logger.info(
+                "All request cancellation tests completed successfully - request cancellation is working correctly"
+            )


### PR DESCRIPTION
#### Overview:

Raise `asyncio.CancelledError` into Python asynchronous generator object if the Rust stream ended before the Python generator has finished sending responses.

#### Details:

Enhanced the current [pyo3_async_runtimes `into_stream_with_locals_v1`](https://github.com/PyO3/pyo3-async-runtimes/blob/74cd232b0606cd9e0dcab291bd10a8cadf69a1ed/src/generic.rs#L1343) implementation to additionally raise the `asyncio.CancelledError` exception into the async generator object per [PEP 525](https://peps.python.org/pep-0525/#asynchronous-generator-object) when the Rust stream receiving side is dropped.

Also enhanced the vLLM worker to abort requests on cancel, and add to E2E test.

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A
