### PR TITLE
[DO NOT MERGE] example: add fluent label chaining API to MetricsRegistry

### DIFF
--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -182,6 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
+ "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -227,6 +228,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -673,6 +685,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3013,6 +3026,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/lib/runtime/examples/hello_world/src/bin/server.rs
+++ b/lib/runtime/examples/hello_world/src/bin/server.rs
@@ -15,6 +15,7 @@
 
 use dynamo_runtime::{
     logging,
+    metrics::MetricsRegistry,
     pipeline::{
         async_trait, network::Ingress, AsyncEngine, AsyncEngineContextProvider, Error, ManyOut,
         ResponseStream, SingleIn,
@@ -66,13 +67,18 @@ async fn backend(runtime: DistributedRuntime) -> Result<()> {
 
     // // make the ingress discoverable via a component service
     // // we must first create a service, then we can attach one more more endpoints
+    // Test the new add_labels functionality!
     runtime
+        .add_labels(&[("environment", "development"), ("version", "1.0")])
         .namespace(DEFAULT_NAMESPACE)?
+        .add_labels(&[("namespace_type", "hello_world")])
         .component("backend")?
+        .add_labels(&[("component_type", "backend_service")])
         .service_builder()
         .create()
         .await?
         .endpoint("generate")
+        .add_labels(&[("endpoint_type", "string_splitter")])
         .endpoint_builder()
         .handler(ingress)
         .start()

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -133,6 +133,10 @@ pub struct Component {
     // A static component's endpoints cannot be discovered via etcd, they are
     // fixed at startup time.
     is_static: bool,
+
+    /// Additional labels for metrics
+    #[builder(default = "Vec::new()")]
+    labels: Vec<(String, String)>,
 }
 
 impl Hash for Component {
@@ -183,6 +187,18 @@ impl MetricsRegistry for Component {
         ]
         .concat()
     }
+
+    fn stored_labels(&self) -> Vec<(&str, &str)> {
+        // Convert Vec<(String, String)> to Vec<(&str, &str)>
+        self.labels
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect()
+    }
+
+    fn labels_mut(&mut self) -> &mut Vec<(String, String)> {
+        &mut self.labels
+    }
 }
 
 impl Component {
@@ -220,6 +236,7 @@ impl Component {
             component: self.clone(),
             name: endpoint.into(),
             is_static: self.is_static,
+            labels: Vec::new(),
         }
     }
 
@@ -285,6 +302,9 @@ pub struct Endpoint {
     name: String,
 
     is_static: bool,
+
+    /// Additional labels for metrics
+    labels: Vec<(String, String)>,
 }
 
 impl Hash for Endpoint {
@@ -328,6 +348,18 @@ impl MetricsRegistry for Endpoint {
             vec![self.component.basename()],
         ]
         .concat()
+    }
+
+    fn stored_labels(&self) -> Vec<(&str, &str)> {
+        // Convert Vec<(String, String)> to Vec<(&str, &str)>
+        self.labels
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect()
+    }
+
+    fn labels_mut(&mut self) -> &mut Vec<(String, String)> {
+        &mut self.labels
     }
 }
 
@@ -447,6 +479,10 @@ pub struct Namespace {
 
     #[builder(default = "None")]
     parent: Option<Arc<Namespace>>,
+
+    /// Additional labels for metrics
+    #[builder(default = "Vec::new()")]
+    labels: Vec<(String, String)>,
 }
 
 impl DistributedRuntimeProvider for Namespace {

--- a/lib/runtime/src/component/namespace.rs
+++ b/lib/runtime/src/component/namespace.rs
@@ -86,6 +86,18 @@ impl MetricsRegistry for Namespace {
     fn parent_hierarchy(&self) -> Vec<String> {
         vec![self.drt().basename()]
     }
+
+    fn stored_labels(&self) -> Vec<(&str, &str)> {
+        // Convert Vec<(String, String)> to Vec<(&str, &str)>
+        self.labels
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect()
+    }
+
+    fn labels_mut(&mut self) -> &mut Vec<(String, String)> {
+        &mut self.labels
+    }
 }
 
 #[cfg(feature = "integration")]

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -40,6 +40,18 @@ impl MetricsRegistry for DistributedRuntime {
     fn parent_hierarchy(&self) -> Vec<String> {
         vec![] // drt is the root, so no parent hierarchy
     }
+
+    fn stored_labels(&self) -> Vec<(&str, &str)> {
+        // Convert Vec<(String, String)> to Vec<(&str, &str)>
+        self.labels
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect()
+    }
+
+    fn labels_mut(&mut self) -> &mut Vec<(String, String)> {
+        &mut self.labels
+    }
 }
 
 impl DistributedRuntime {
@@ -111,6 +123,7 @@ impl DistributedRuntime {
                 prometheus::Registry,
             >::new())),
             system_health,
+            labels: Vec::new(),
         };
 
         // Start metrics server if enabled

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -176,6 +176,9 @@ pub struct DistributedRuntime {
     // Health Status
     system_health: Arc<std::sync::Mutex<SystemHealth>>,
 
+    // Additional labels for metrics
+    labels: Vec<(String, String)>,
+
     // This map associates metric prefixes with their corresponding Prometheus registries.
     prometheus_registries_by_prefix: Arc<std::sync::Mutex<HashMap<String, prometheus::Registry>>>,
 }


### PR DESCRIPTION
This is just an example commit for @tzulingk, DO NOT MERGE!!!!!!

- Add add_labels() method to MetricsRegistry trait with default implementation
- Add labels field to DistributedRuntime, Namespace, Component, and Endpoint structs
- Update all metric creation methods to automatically combine stored labels with provided labels
- Enable method chaining: runtime.namespace(...).add_labels(...).component(...)?
- Refactor to eliminate code duplication using labels_mut() helper method
- Add example usage in hello_world server demonstrating label inheritance hierarchy



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching custom labels to metrics at various levels, including runtime, namespace, component, and endpoint.
  * Labels are now automatically included when creating metrics, allowing for more detailed and flexible metric categorization.

* **Improvements**
  * Enhanced metric management by enabling label modification and retrieval throughout the service hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->