### PR TITLE
fix: Fixes OPS-618 Add Access Token for accessing containers on NGC

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,6 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
         run: |
+          docker login nvcr.io -u '$oauthtoken' -p ${{ secrets.NGC_CI_ACCESS_TOKEN }}
           ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target dev --framework none
       - name: Start services with docker-compose
         working-directory: ./deploy

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Login to NGC
         run: |
-          docker login nvcr.io -u '$oauthtoken' -p ${{ secrets.NGC_CI_ACCESS_TOKEN }}
+          echo "${{ secrets.NGC_CI_ACCESS_TOKEN }}" | docker login nvcr.io -u '$oauthtoken' --password-stdin
       - name: Define Image Tag
         id: define_image_tag
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Login to NGC
+        run: |
+          docker login nvcr.io -u '$oauthtoken' -p ${{ secrets.NGC_CI_ACCESS_TOKEN }}
       - name: Define Image Tag
         id: define_image_tag
         run: |
@@ -42,7 +45,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
         run: |
-          docker login nvcr.io -u '$oauthtoken' -p ${{ secrets.NGC_CI_ACCESS_TOKEN }}
           ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target dev --framework none
       - name: Start services with docker-compose
         working-directory: ./deploy


### PR DESCRIPTION
#### Overview:

Add NGC access token to prevent Github runners from hitting unauthorized access when pulling NGC containers and creating unnecessary noise:

````
ERROR: failed to build: failed to solve: nvcr.io/nvidia/cuda-dl-base:25.01-cuda12.8-devel-ubuntu24.04: failed to resolve source metadata for nvcr.io/nvidia/cuda-dl-base:25.01-cuda12.8-devel-ubuntu24.04: unexpected status from HEAD request to https://nvcr.io/v2/nvidia/cuda-dl-base/manifests/25.01-cuda12.8-devel-ubuntu24.04: 401 Unauthorized
````

#### Details:

- Add new secret NGC_CI_ACCESS_TOKEN as a service key for Github runners.
- Login to NGC registry before pulling container. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI build pipeline to authenticate with the NVIDIA container registry during image builds, ensuring reliable access to required container artifacts.
  * Improves build stability by reducing failures related to registry permissions or rate limits.
  * No impact on application features, behavior, or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->