### PR TITLE
fix(build): Pin cuda-python>=12,<13 to avoid trtllm breakage (#2379)

### DIFF
--- a/container/Dockerfile.tensorrt_llm
+++ b/container/Dockerfile.tensorrt_llm
@@ -481,8 +481,12 @@ COPY --from=dev /workspace/target/release/metrics /usr/local/bin/metrics
 # NOTE: If a package (tensorrt_llm) exists on both --index-url and --extra-index-url,
 # uv will prioritize the --extra-index-url, unless --index-strategy unsafe-best-match
 # is also specified. So set the configurable index as a --extra-index-url for prioritization.
-# locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc4
-RUN uv pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" && \
+# NOTE: locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc4
+# NOTE: locking cuda-python version to <13 to avoid breaks with tensorrt-llm 1.0.0rc4. This
+#       can be removed after https://github.com/NVIDIA/TensorRT-LLM/pull/6703 is merged
+#       we upgrade to a published pip wheel containing this change.
+RUN uv pip install "cuda-python>=12,<13" && \
+    uv pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" && \
     if [ "$ARCH" = "amd64" ]; then \
         pip install "triton==3.3.1"; \
     fi; \


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Cherry-pick TRTLLM cuda-python13 build fix back to main from release/0.4.0

Fixes this error at runtime when importing tensorrt_llm from cuda-python 13 getting pulled in:
```
cannot import name 'cuda' from 'cuda' (unknown location)
```

See #2379 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved container compatibility by pinning CUDA Python to the 12.x range during TensorRT-LLM installation.
  - Preserves platform-specific Triton installation for amd64.

- Chores
  - Reworked install sequence to staged pip steps for more reliable dependency resolution.
  - Added installation of local wheels from the workspace in both build and runtime flows.
  - Applied changes across both main build/runtime and runtime-only sections to ensure consistent packaging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->