### PR TITLE
fix: Disable NGC login for external contributors

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to NGC
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         run: |
           echo "${{ secrets.NGC_CI_ACCESS_TOKEN }}" | docker login nvcr.io -u '$oauthtoken' --password-stdin
       - name: Define Image Tag


### PR DESCRIPTION
#### Overview:

Testing if Login to NGC is disabled for external contributors since by default secrets are [NOT accessible to forked repos](https://github.com/orgs/community/discussions/50161), which is why external PR's are unable to access this value (all external contributions are forked repos). There are ways to workaround this but this could introduce complexities into the CI process. I am going to disable this job for forked repos.

#### Details:

- Disable `Login to NGC` for forked repos/external contributors. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Build & Test CI workflow to conditionally perform container registry login. Forked pull requests now skip the login step, reducing permission errors and avoiding unnecessary failures. Pushes and pull requests from the same repository continue to authenticate as before. This improves security, streamlines external contributions, and maintains existing behavior for internal workflows with no other pipeline changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->