### PR TITLE
fix: Ensure Login to NGC step works

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to NGC
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         run: |
           echo "${{ secrets.NGC_CI_ACCESS_TOKEN }}" | docker login nvcr.io -u '$oauthtoken' --password-stdin
       - name: Define Image Tag

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ on:
   push:
     branches:
     - main
-    - "pull-request/[0-9]+"
+  pull_request:
 
 jobs:
   build-test:
@@ -35,6 +35,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to NGC
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         run: |
           echo "${{ secrets.NGC_CI_ACCESS_TOKEN }}" | docker login nvcr.io -u '$oauthtoken' --password-stdin
       - name: Define Image Tag

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ on:
   push:
     branches:
     - main
-  pull_request:
+    - "pull-request/[0-9]+"
 
 jobs:
   build-test:
@@ -35,7 +35,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to NGC
-        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         run: |
           echo "${{ secrets.NGC_CI_ACCESS_TOKEN }}" | docker login nvcr.io -u '$oauthtoken' --password-stdin
       - name: Define Image Tag


### PR DESCRIPTION
Overview:
Login to NGC is disabled for external contributors since by default secrets are [NOT accessible to forked repos](https://github.com/orgs/community/discussions/50161), which is why external PR's are unable to access this value (all external contributions are forked repos). This PR ensures that the job is only run for NVIDIAN contributors instead of external contributors since this step shouldn't be required for external contributors. 

Details:

Validated that this logic works for forked contributions: https://github.com/ai-dynamo/dynamo/actions/runs/16916123263/job/47930359224?pr=2411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated build-and-test workflow to conditionally perform NGC login only on pushes and same-repository pull requests, improving CI security for external contributions.
  - Ensures CI continues to run as expected for internal changes while avoiding credential use on forked PRs.
  - No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->