### PR TITLE
chore: add deprecation warning for nvext

### DIFF
--- a/lib/llm/src/entrypoint/input/batch.rs
+++ b/lib/llm/src/entrypoint/input/batch.rs
@@ -222,6 +222,7 @@ async fn evaluate(
         )
         .temperature(template.as_ref().map_or(0.7, |t| t.temperature))
         .build()?;
+    #[allow(deprecated)] // TODO: remove this once nvext is removed
     let req = NvCreateChatCompletionRequest {
         inner,
         common: Default::default(),

--- a/lib/llm/src/entrypoint/input/text.rs
+++ b/lib/llm/src/entrypoint/input/text.rs
@@ -115,7 +115,7 @@ async fn main_loop(
         //     // This makes the pre-processor ignore stop tokens
         //     req_builder.min_tokens(8192);
         // }
-
+        #[allow(deprecated)]
         let req = NvCreateChatCompletionRequest {
             inner,
             common: Default::default(),

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1030,6 +1030,7 @@ pub fn responses_router(
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // TODO: remove this once nvext is removed
 mod tests {
     use std::collections::HashMap;
 

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(deprecated)] // TODO: remove this once nvext is removed
+
 use derive_builder::Builder;
 use dynamo_runtime::protocols::annotated::AnnotationsProvider;
 use serde::{Deserialize, Serialize};
@@ -41,6 +43,7 @@ pub struct NvCreateCompletionRequest {
     #[serde(flatten)]
     pub common: CommonExt,
 
+    #[deprecated(note = "The `nvext` field is deprecated and may be removed in a future release.")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nvext: Option<NvExt>,
 }
@@ -80,6 +83,7 @@ pub fn prompt_to_string(prompt: &async_openai::types::Prompt) -> String {
     }
 }
 
+#[allow(deprecated)]
 impl NvExtProvider for NvCreateCompletionRequest {
     fn nvext(&self) -> Option<&NvExt> {
         self.nvext.as_ref()
@@ -113,6 +117,7 @@ impl AnnotationsProvider for NvCreateCompletionRequest {
     }
 }
 
+#[allow(deprecated)]
 impl OpenAISamplingOptionsProvider for NvCreateCompletionRequest {
     fn get_temperature(&self) -> Option<f32> {
         self.inner.temperature
@@ -178,6 +183,7 @@ impl CommonExtProvider for NvCreateCompletionRequest {
     }
 }
 
+#[allow(deprecated)]
 impl OpenAIStopConditionsProvider for NvCreateCompletionRequest {
     fn get_max_tokens(&self) -> Option<u32> {
         self.inner.max_tokens
@@ -353,5 +359,24 @@ impl ValidateRequest for NvCreateCompletionRequest {
         // none for seed
 
         Ok(())
+    }
+}
+
+#[test]
+fn test_deprecated_nvext_json_deserialization() {
+    let json_with_nvext = serde_json::json!({
+        "model": "test-model",
+        "prompt": "Hello",
+        "nvext": {
+            "ignore_eos": true
+        }
+    });
+
+    let request: NvCreateCompletionRequest = serde_json::from_value(json_with_nvext).unwrap();
+
+    #[allow(deprecated)]
+    {
+        assert!(request.nvext.is_some());
+        assert_eq!(request.nvext.as_ref().unwrap().ignore_eos, Some(true));
     }
 }

--- a/lib/llm/src/protocols/openai/responses.rs
+++ b/lib/llm/src/protocols/openai/responses.rs
@@ -174,6 +174,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
         let top_logprobs = convert_top_logprobs(resp.inner.top_logprobs);
 
         // The below should encompass all of the allowed configurable parameters
+        #[allow(deprecated)] // TODO: remove this once nvext is removed
         Ok(NvCreateChatCompletionRequest {
             inner: CreateChatCompletionRequest {
                 messages,

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(deprecated)] // TODO: remove this once nvext is removed
 use anyhow::Error;
 use async_openai::config::OpenAIConfig;
 use async_stream::stream;

--- a/lib/llm/tests/openai_completions.rs
+++ b/lib/llm/tests/openai_completions.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(deprecated)] // TODO: remove this once nvext is removed
+
 use async_openai::types::CreateCompletionRequestArgs;
 use dynamo_llm::protocols::openai::{completions::NvCreateCompletionRequest, validate};
 use serde::{Deserialize, Serialize};

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-
+#![allow(deprecated)] // TODO: remove this once nvext is removed
 use anyhow::{Ok, Result};
 
 use dynamo_llm::model_card::{ModelDeploymentCard, PromptContextMixin};

--- a/lib/llm/tests/test_common_ext.rs
+++ b/lib/llm/tests/test_common_ext.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+#![allow(deprecated)] // TODO: remove this once nvext is removed
 
 use dynamo_llm::protocols::{
     common::StopConditionsProvider,


### PR DESCRIPTION
#### Overview:

nvext should be deprecated soon. This PR adds a deprecation warning for using nvext API. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #2412 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Deprecations
  - Marked the nvext field in OpenAI chat and completions requests as deprecated. Existing payloads remain supported for now.
- Compatibility
  - No behavior changes; existing integrations continue to work. Deserialization and handling of the deprecated field are preserved.
- Tests
  - Added tests to verify deprecated field deserialization and access. Suppressed deprecation warnings in test suites.
- Chores
  - Suppressed compile-time deprecation warnings in targeted areas to reduce noise during builds, with plans to remove once the deprecated field is retired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->