### PR TITLE
chore: update wideep dockerfile for sgl to newest rel

### DIFF
--- a/components/backends/sglang/docs/dsr1-wideep-gb200.md
+++ b/components/backends/sglang/docs/dsr1-wideep-gb200.md
@@ -29,7 +29,7 @@ docker build \
   -f container/Dockerfile.sglang-wideep \
   -t dynamo-wideep-gb200 \
   --build-arg MODE=blackwell \
-  --build-arg SGLANG_IMAGE_TAG=v0.4.9.post6-cu128-gb200 \
+  --build-arg SGLANG_IMAGE_TAG=v0.5.0rc0-cu129-gb200 \
   --build-arg ARCH=arm64 \
   --build-arg ARCH_ALT=aarch64 \
   .

--- a/container/Dockerfile.sglang-wideep
+++ b/container/Dockerfile.sglang-wideep
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG SGLANG_IMAGE_TAG="v0.4.10-cu126"
+ARG SGLANG_IMAGE_TAG="v0.5.0rc0-cu126"
 
 FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG}
 
@@ -21,7 +21,7 @@ ARG MODE="hopper"
 ARG ARCH="amd64"
 ARG ARCH_ALT="x86_64"
 ARG NIXL_UCX_REF="v1.19.x"
-ARG NIXL_TAG="0.4.1"
+ARG NIXL_TAG="0.5.0"
 ARG CMAKE_VERSION="3.31.8"
 ARG RUST_VERSION="1.87.0"
 ARG CARGO_BUILD_JOBS="16"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Docker build example to reference a newer SGLANG image tag.

- Chores
  - Bumped container build dependencies to newer versions of SGLANG and NIXL.
  - Updated CUDA-targeted image variants used during builds (including examples with cu126 and cu129).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->