### PR TITLE
feat: LLM metrics for non-streaming requests in frontend

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -290,11 +290,9 @@ async fn completions(
 
         Ok(sse_stream.into_response())
     } else {
-        // Process the stream to collect metrics for non-streaming requests
-        let stream = stream.map(move |response| {
-            // Process metrics but return the original response for aggregation
-            process_metrics_only(&response, &mut response_collector);
-            response
+        // Tap the stream to collect metrics for non-streaming requests without altering items
+        let stream = stream.inspect(move |response| {
+            process_metrics_only(response, &mut response_collector);
         });
 
         let response = NvCreateCompletionResponse::from_annotated_stream(stream)
@@ -521,11 +519,8 @@ async fn chat_completions(
 
         Ok(sse_stream.into_response())
     } else {
-        // Process the stream to collect metrics for non-streaming requests
-        let stream = stream.map(move |response| {
-            // Process metrics but return the original response for aggregation
-            process_metrics_only(&response, &mut response_collector);
-            response
+        let stream = stream.inspect(move |response| {
+            process_metrics_only(response, &mut response_collector);
         });
 
         let response = NvCreateChatCompletionResponse::from_annotated_stream(stream)

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -290,7 +290,13 @@ async fn completions(
 
         Ok(sse_stream.into_response())
     } else {
-        // TODO: report ISL/OSL for non-streaming requests
+        // Process the stream to collect metrics for non-streaming requests
+        let stream = stream.map(move |response| {
+            // Process metrics but return the original response for aggregation
+            process_metrics_only(&response, &mut response_collector);
+            response
+        });
+
         let response = NvCreateCompletionResponse::from_annotated_stream(stream)
             .await
             .map_err(|e| {
@@ -515,7 +521,13 @@ async fn chat_completions(
 
         Ok(sse_stream.into_response())
     } else {
-        // TODO: report ISL/OSL for non-streaming requests
+        // Process the stream to collect metrics for non-streaming requests
+        let stream = stream.map(move |response| {
+            // Process metrics but return the original response for aggregation
+            process_metrics_only(&response, &mut response_collector);
+            response
+        });
+
         let response = NvCreateChatCompletionResponse::from_annotated_stream(stream)
             .await
             .map_err(|e| {
@@ -908,6 +920,17 @@ struct EventConverter<T>(Annotated<T>);
 impl<T> From<Annotated<T>> for EventConverter<T> {
     fn from(annotated: Annotated<T>) -> Self {
         EventConverter(annotated)
+    }
+}
+
+fn process_metrics_only<T>(
+    annotated: &Annotated<T>,
+    response_collector: &mut ResponseMetricCollector,
+) {
+    // update metrics
+    if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(annotated) {
+        response_collector.observe_current_osl(metrics.output_tokens);
+        response_collector.observe_response(metrics.input_tokens, metrics.chunk_tokens);
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enhanced internal observability for non-streaming completions and chat completions by recording response and token metrics.
  - Improves monitoring and analytics without changing outputs, error handling, or the public API.
  - Streaming behavior remains unchanged; only non-streaming paths gain telemetry.
  - Aids capacity planning, usage reporting, and troubleshooting through more accurate metric collection.
  - No user-facing changes; functionality and performance remain consistent while backend insights increase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->