### PR TITLE
fix(ci): Reduce the free gpu memory fraction

### DIFF
--- a/components/backends/trtllm/engine_configs/agg.yaml
+++ b/components/backends/trtllm/engine_configs/agg.yaml
@@ -22,7 +22,7 @@ backend: pytorch
 enable_chunked_prefill: true
 
 kv_cache_config:
-  free_gpu_memory_fraction: 0.95
+  free_gpu_memory_fraction: 0.85
 
 # NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
 # NOTE: overlap_scheduler enabled by default since this commit and changed

--- a/components/backends/trtllm/engine_configs/decode.yaml
+++ b/components/backends/trtllm/engine_configs/decode.yaml
@@ -25,7 +25,7 @@ cuda_graph_config:
   max_batch_size: 16
 
 kv_cache_config:
-  free_gpu_memory_fraction: 0.95
+  free_gpu_memory_fraction: 0.85
 
 cache_transceiver_config:
   backend: default

--- a/components/backends/trtllm/engine_configs/prefill.yaml
+++ b/components/backends/trtllm/engine_configs/prefill.yaml
@@ -24,7 +24,7 @@ disable_overlap_scheduler: true
 cuda_graph_config:
   max_batch_size: 16
 kv_cache_config:
-  free_gpu_memory_fraction: 0.95
+  free_gpu_memory_fraction: 0.85
 
 cache_transceiver_config:
   backend: default


### PR DESCRIPTION
#### Overview:

With the new cache_transceiver config, this high free_gpu_memory_fraction can lead to OOM issues on A100 machines.
Updating to reasonable defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated default GPU memory allocation for inference, reducing reserved space for the key-value cache from 95% to 85%.
  - Applied consistently across prefill, decode, and aggregation stages for uniform behavior.
  - Adjusts runtime memory distribution and may affect concurrency and throughput depending on hardware. No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->