### PR TITLE
feat: multi tenancy - operator automatically injects dynamo_namespace

### DIFF
--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -36,10 +36,6 @@ spec:
         limits:
           cpu: "1"
           memory: "2Gi"
-      envs:
-        # TODO: this will be removed once operator is updated to set this env variable
-        - name: DYNAMO_NAMESPACE
-          value: "vllm-agg"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
@@ -86,9 +82,6 @@ spec:
           value: "[\"generate\"]"
         - name: DYN_SYSTEM_PORT
           value: "9090"
-        # TODO: this will be removed once operator is updated to set this env variable
-        - name: DYNAMO_NAMESPACE
-          value: "vllm-agg"
       extraPodSpec:
         mainContainer:
           startupProbe:

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -36,6 +36,10 @@ spec:
         limits:
           cpu: "1"
           memory: "2Gi"
+      envs:
+        # TODO: this will be removed once operator is updated to set this env variable
+        - name: DYNAMO_NAMESPACE
+          value: "vllm-agg"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
@@ -82,6 +86,9 @@ spec:
           value: "[\"generate\"]"
         - name: DYN_SYSTEM_PORT
           value: "9090"
+        # TODO: this will be removed once operator is updated to set this env variable
+        - name: DYNAMO_NAMESPACE
+          value: "vllm-agg"
       extraPodSpec:
         mainContainer:
           startupProbe:

--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -19,6 +19,7 @@
 
 import argparse
 import asyncio
+import logging
 import os
 import re
 
@@ -34,6 +35,12 @@ from dynamo.llm import (
     run_input,
 )
 from dynamo.runtime import DistributedRuntime
+
+GLOBAL_NAMESPACE = "global"
+DYNAMO_NAMESPACE_ENV_VAR = "DYNAMO_NAMESPACE"
+
+
+logger = logging.getLogger(__name__)
 
 
 def validate_static_endpoint(value):
@@ -111,6 +118,12 @@ def parse_args():
         dest="use_kv_events",
         help=" KV Router. Disable KV events.",
     )
+    parser.add_argument(
+        "--namespace",
+        type=str,
+        default=None,
+        help="Dynamo namespace for model discovery scoping. If specified, models will only be discovered from this namespace. If not specified, discovers models from all namespaces (global discovery).",
+    )
     parser.set_defaults(use_kv_events=True)
     parser.add_argument(
         "--router-replica-sync",
@@ -144,6 +157,9 @@ def parse_args():
 
     if flags.static_endpoint and (not flags.model_name or not flags.model_path):
         parser.error("--static-endpoint requires both --model-name and --model-path")
+
+    if not flags.namespace and os.environ.get(DYNAMO_NAMESPACE_ENV_VAR):
+        flags.namespace = os.environ.get(DYNAMO_NAMESPACE_ENV_VAR)
 
     return flags
 
@@ -183,6 +199,16 @@ async def async_main():
 
     if flags.static_endpoint:
         kwargs["endpoint_id"] = flags.static_endpoint
+    else:
+        # For dynamic discovery, create an endpoint_id with the specified namespace
+        # This will be used by the HTTP service to determine which namespace to filter on
+        if flags.namespace:
+            # Specific namespace provided - use namespace-scoped discovery
+            kwargs["endpoint_id"] = f"{flags.namespace}.frontend.http"
+        else:
+            # No namespace provided - use default namespace "global" for global discovery
+            kwargs["endpoint_id"] = f"{GLOBAL_NAMESPACE}.frontend.http"
+
     if flags.model_name:
         kwargs["model_name"] = flags.model_name
     if flags.model_path:
@@ -195,6 +221,20 @@ async def async_main():
         # out=auto, most common
         engine_type = EngineType.Dynamic
     e = EntrypointArgs(engine_type, **kwargs)
+
+    # Log the discovery configuration for debugging
+    if is_static:
+        logger.info(
+            f"Starting frontend in static mode with endpoint: {flags.static_endpoint}"
+        )
+    else:
+        if flags.namespace:
+            logger.info(
+                f"Starting frontend with dynamic discovery scoped to namespace: '{flags.namespace}'"
+            )
+        else:
+            logger.info("Starting frontend with global discovery")
+
     engine = await make_engine(runtime, e)
 
     try:

--- a/deploy/cloud/operator/internal/consts/consts.go
+++ b/deploy/cloud/operator/internal/consts/consts.go
@@ -18,6 +18,7 @@ const (
 	MpiRunSshPort = 2222
 
 	EnvDynamoServicePort = "DYNAMO_PORT"
+	EnvDynamoNamespace   = "DYNAMO_NAMESPACE"
 
 	KubeLabelDynamoSelector = "nvidia.com/selector"
 

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -420,7 +420,7 @@ impl ModelWatcher {
                     // We don't need to check namespace for deletion since we're removing by key
                     // But we log the namespace for debugging if we can parse the entry
                     if let Ok(model_entry) = serde_json::from_slice::<ModelEntry>(kv.value()) {
-                        if model_entry.endpoint.namespace == target_namespace {
+                        if global_namespace || model_entry.endpoint.namespace == target_namespace {
                             tracing::info!(
                                 model_name = model_entry.name,
                                 namespace = model_entry.endpoint.namespace,

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -45,12 +45,12 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
                     if !is_global_namespace(namespace) {
                         // Use namespace-specific discovery if a specific namespace is configured
                         tracing::info!(
-                            "frontend will discover models from namespace: '{}'",
+                            "http ingress will discover models from namespace: '{}'",
                             namespace
                         );
                     } else {
                         // Use global discovery when namespace is "global", empty, or null
-                        tracing::info!("frontend will discover models from all namespaces");
+                        tracing::info!("http ingress will discover models from all namespaces");
                     }
                     run_namespace_watcher(
                         distributed_runtime,

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -26,6 +26,7 @@ pub mod migration;
 pub mod mocker;
 pub mod model_card;
 pub mod model_type;
+pub mod namespace;
 pub mod perf;
 pub mod postprocessor;
 pub mod preprocessor;

--- a/lib/llm/src/namespace.rs
+++ b/lib/llm/src/namespace.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// The global namespace for all models
+pub const GLOBAL_NAMESPACE: &str = "global";
+
+pub fn is_global_namespace(namespace: &str) -> bool {
+    namespace == GLOBAL_NAMESPACE || namespace.is_empty()
+}

--- a/lib/llm/tests/http_namespace_integration.rs
+++ b/lib/llm/tests/http_namespace_integration.rs
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for HTTP service namespace discovery functionality.
+//! These tests verify that the HTTP service correctly filters models based on namespace configuration.
+
+use dynamo_llm::{
+    discovery::ModelEntry,
+    model_type::ModelType,
+    namespace::{is_global_namespace, GLOBAL_NAMESPACE},
+};
+use dynamo_runtime::protocols::Endpoint;
+
+// Helper function to create a test ModelEntry
+fn create_test_model_entry(
+    name: &str,
+    namespace: &str,
+    component: &str,
+    endpoint_name: &str,
+    model_type: ModelType,
+) -> ModelEntry {
+    ModelEntry {
+        name: name.to_string(),
+        endpoint: Endpoint {
+            namespace: namespace.to_string(),
+            component: component.to_string(),
+            name: endpoint_name.to_string(),
+        },
+        model_type,
+    }
+}
+
+#[test]
+fn test_namespace_filtering_behavior() {
+    // Test the core namespace filtering logic used in HTTP service
+    let test_models = vec![
+        create_test_model_entry(
+            "model-1",
+            "vllm-agg",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry(
+            "model-2",
+            "sglang-prod",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry(
+            "model-3",
+            "global",
+            "backend",
+            "generate",
+            ModelType::Completion,
+        ),
+        create_test_model_entry(
+            "model-4",
+            "tensorrt-llm",
+            "backend",
+            "generate",
+            ModelType::Embedding,
+        ),
+    ];
+
+    // Test filtering for specific namespace "vllm-agg"
+    let target_namespace = "vllm-agg";
+    let is_global = is_global_namespace(target_namespace);
+
+    let filtered_models: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| {
+            // This mirrors the logic in ModelWatcher::watch_namespace_filtered
+            is_global || model.endpoint.namespace == target_namespace
+        })
+        .collect();
+
+    assert_eq!(filtered_models.len(), 1);
+    assert_eq!(filtered_models[0].name, "model-1");
+    assert_eq!(filtered_models[0].endpoint.namespace, "vllm-agg");
+
+    // Test filtering for global namespace (should include all models)
+    let target_namespace = GLOBAL_NAMESPACE;
+    let is_global = is_global_namespace(target_namespace);
+
+    let filtered_models_global: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_models_global.len(), 4); // All models should be included
+
+    // Test filtering for empty namespace (treated as global)
+    let target_namespace = "";
+    let is_global = is_global_namespace(target_namespace);
+
+    let filtered_models_empty: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_models_empty.len(), 4); // All models should be included
+}
+
+#[test]
+fn test_endpoint_id_namespace_extraction() {
+    // Test endpoint ID parsing for different namespace formats
+    let test_cases = vec![
+        ("vllm-agg.frontend.http", "vllm-agg", "frontend", "http"),
+        (
+            "sglang-prod.backend.generate",
+            "sglang-prod",
+            "backend",
+            "generate",
+        ),
+        ("global.frontend.http", "global", "frontend", "http"),
+        (
+            "tensorrt-llm.backend.inference",
+            "tensorrt-llm",
+            "backend",
+            "inference",
+        ),
+        (
+            "test-namespace.component.endpoint",
+            "test-namespace",
+            "component",
+            "endpoint",
+        ),
+    ];
+
+    for (endpoint_str, expected_namespace, expected_component, expected_name) in test_cases {
+        let endpoint: Endpoint = endpoint_str.parse().expect("Failed to parse endpoint");
+
+        assert_eq!(endpoint.namespace, expected_namespace);
+        assert_eq!(endpoint.component, expected_component);
+        assert_eq!(endpoint.name, expected_name);
+
+        // Test namespace classification
+        let is_global = is_global_namespace(&endpoint.namespace);
+        if expected_namespace == GLOBAL_NAMESPACE {
+            assert!(
+                is_global,
+                "Namespace '{}' should be classified as global",
+                expected_namespace
+            );
+        } else {
+            assert!(
+                !is_global,
+                "Namespace '{}' should not be classified as global",
+                expected_namespace
+            );
+        }
+    }
+}
+
+#[test]
+fn test_model_discovery_scoping_scenarios() {
+    // Test various scenarios for model discovery scoping
+
+    // Scenario 1: Frontend configured for specific namespace should only see models from that namespace
+    let frontend_namespace = "vllm-agg";
+    let available_models = vec![
+        create_test_model_entry(
+            "llama-7b",
+            "vllm-agg",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry(
+            "mistral-7b",
+            "vllm-agg",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry(
+            "gpt-3.5",
+            "sglang-prod",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry("claude-3", "global", "backend", "generate", ModelType::Chat),
+    ];
+
+    let visible_models: Vec<&ModelEntry> = available_models
+        .iter()
+        .filter(|model| {
+            let is_global = is_global_namespace(frontend_namespace);
+            is_global || model.endpoint.namespace == frontend_namespace
+        })
+        .collect();
+
+    assert_eq!(visible_models.len(), 2);
+    assert!(visible_models
+        .iter()
+        .all(|m| m.endpoint.namespace == "vllm-agg"));
+
+    // Scenario 2: Frontend configured for global namespace should see all models
+    let frontend_namespace = GLOBAL_NAMESPACE;
+    let visible_models_global: Vec<&ModelEntry> = available_models
+        .iter()
+        .filter(|model| {
+            let is_global = is_global_namespace(frontend_namespace);
+            is_global || model.endpoint.namespace == frontend_namespace
+        })
+        .collect();
+
+    assert_eq!(visible_models_global.len(), 4); // Should see all models
+
+    // Scenario 3: Frontend configured for non-existent namespace should see no models
+    let frontend_namespace = "non-existent-namespace";
+    let visible_models_none: Vec<&ModelEntry> = available_models
+        .iter()
+        .filter(|model| {
+            let is_global = is_global_namespace(frontend_namespace);
+            is_global || model.endpoint.namespace == frontend_namespace
+        })
+        .collect();
+
+    assert_eq!(visible_models_none.len(), 0); // Should see no models
+}
+
+#[test]
+fn test_namespace_boundary_conditions() {
+    // Test edge cases and boundary conditions for namespace handling
+
+    let test_models = vec![
+        create_test_model_entry("model-1", "", "backend", "generate", ModelType::Chat), // Empty namespace
+        create_test_model_entry("model-2", "global", "backend", "generate", ModelType::Chat), // Global namespace
+        create_test_model_entry(
+            "model-3",
+            "ns-with-special-chars_123",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+    ];
+
+    // Test filtering with empty target namespace (should be treated as global)
+    let target_namespace = "";
+    let is_global = is_global_namespace(target_namespace);
+    assert!(is_global); // Empty namespace should be treated as global
+
+    let filtered_empty: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_empty.len(), 3); // All models should be visible
+
+    // Test filtering with exact "global" namespace
+    let target_namespace = "global";
+    let is_global = is_global_namespace(target_namespace);
+    assert!(is_global);
+
+    let filtered_global: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_global.len(), 3); // All models should be visible
+
+    // Test case sensitivity - "GLOBAL" should not be treated as global
+    let target_namespace = "GLOBAL";
+    let is_global = is_global_namespace(target_namespace);
+    assert!(!is_global); // Should be case-sensitive
+
+    let filtered_uppercase: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_uppercase.len(), 0); // No models should be visible
+}

--- a/lib/llm/tests/namespace.rs
+++ b/lib/llm/tests/namespace.rs
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_llm::{
+    discovery::ModelEntry,
+    model_type::ModelType,
+    namespace::{is_global_namespace, GLOBAL_NAMESPACE},
+};
+use dynamo_runtime::protocols::Endpoint;
+
+#[test]
+fn test_is_global_namespace_with_global_string() {
+    assert!(is_global_namespace(GLOBAL_NAMESPACE));
+    assert!(is_global_namespace("global"));
+}
+
+#[test]
+fn test_is_global_namespace_with_empty_string() {
+    assert!(is_global_namespace(""));
+}
+
+#[test]
+fn test_is_global_namespace_with_specific_namespace() {
+    assert!(!is_global_namespace("test-namespace"));
+    assert!(!is_global_namespace("my-custom-namespace"));
+}
+
+#[test]
+fn test_is_global_namespace_with_whitespace() {
+    // Whitespace should not be considered global
+    assert!(!is_global_namespace(" "));
+    assert!(!is_global_namespace("  "));
+    assert!(!is_global_namespace("\t"));
+    assert!(!is_global_namespace("\n"));
+}
+
+#[test]
+fn test_is_global_namespace_case_sensitivity() {
+    // Should be case sensitive
+    assert!(!is_global_namespace("Global"));
+    assert!(!is_global_namespace("GLOBAL"));
+}
+
+#[test]
+fn test_global_namespace_constant() {
+    assert_eq!(GLOBAL_NAMESPACE, "global");
+}
+
+// Helper function to create a test ModelEntry
+fn create_test_model_entry(
+    name: &str,
+    namespace: &str,
+    component: &str,
+    endpoint_name: &str,
+    model_type: ModelType,
+) -> ModelEntry {
+    ModelEntry {
+        name: name.to_string(),
+        endpoint: Endpoint {
+            namespace: namespace.to_string(),
+            component: component.to_string(),
+            name: endpoint_name.to_string(),
+        },
+        model_type,
+    }
+}
+
+#[test]
+fn test_model_entry_creation_with_different_namespaces() {
+    // Test creating ModelEntry with specific namespace
+    let model_vllm = create_test_model_entry(
+        "test-model-1",
+        "vllm-agg",
+        "backend",
+        "generate",
+        ModelType::Chat,
+    );
+
+    assert_eq!(model_vllm.name, "test-model-1");
+    assert_eq!(model_vllm.endpoint.namespace, "vllm-agg");
+    assert_eq!(model_vllm.endpoint.component, "backend");
+    assert_eq!(model_vllm.endpoint.name, "generate");
+    assert_eq!(model_vllm.model_type, ModelType::Chat);
+
+    // Test creating ModelEntry with global namespace
+    let model_global = create_test_model_entry(
+        "test-model-2",
+        "global",
+        "frontend",
+        "http",
+        ModelType::Completion,
+    );
+
+    assert_eq!(model_global.name, "test-model-2");
+    assert_eq!(model_global.endpoint.namespace, "global");
+    assert_eq!(model_global.endpoint.component, "frontend");
+    assert_eq!(model_global.endpoint.name, "http");
+    assert_eq!(model_global.model_type, ModelType::Completion);
+}
+
+#[test]
+fn test_namespace_filtering_logic() {
+    // Test the core logic that would be used in namespace filtering
+    let models = vec![
+        create_test_model_entry(
+            "model-1",
+            "vllm-agg",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry(
+            "model-2",
+            "sglang-prod",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry("model-3", "global", "backend", "generate", ModelType::Chat),
+        create_test_model_entry("model-4", "", "backend", "generate", ModelType::Chat),
+    ];
+
+    // Test filtering for specific namespace "vllm-agg"
+    let target_namespace = "vllm-agg";
+    let global_namespace = is_global_namespace(target_namespace);
+    let filtered_vllm: Vec<&ModelEntry> = models
+        .iter()
+        .filter(|model| global_namespace || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_vllm.len(), 1);
+    assert_eq!(filtered_vllm[0].name, "model-1");
+    assert_eq!(filtered_vllm[0].endpoint.namespace, "vllm-agg");
+
+    // Test filtering for global namespace (should include all)
+    let target_namespace = "global";
+    let global_namespace = is_global_namespace(target_namespace);
+    let filtered_global: Vec<&ModelEntry> = models
+        .iter()
+        .filter(|model| global_namespace || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_global.len(), 4); // All models should be included
+
+    // Test filtering for empty namespace (should include all, treated as global)
+    let target_namespace = "";
+    let global_namespace = is_global_namespace(target_namespace);
+    let filtered_empty: Vec<&ModelEntry> = models
+        .iter()
+        .filter(|model| global_namespace || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_empty.len(), 4); // All models should be included
+
+    // Test filtering for non-existent namespace
+    let target_namespace = "non-existent";
+    let global_namespace = is_global_namespace(target_namespace);
+    let filtered_none: Vec<&ModelEntry> = models
+        .iter()
+        .filter(|model| global_namespace || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_none.len(), 0); // No models should match
+}
+
+#[test]
+fn test_model_entry_serialization() {
+    // Test that ModelEntry can be serialized and deserialized (important for etcd storage)
+    let model = create_test_model_entry(
+        "test-model",
+        "vllm-agg",
+        "backend",
+        "generate",
+        ModelType::Chat,
+    );
+
+    // Serialize to JSON
+    let json = serde_json::to_string(&model).expect("Failed to serialize ModelEntry");
+    assert!(json.contains("test-model"));
+    assert!(json.contains("vllm-agg"));
+    assert!(json.contains("backend"));
+    assert!(json.contains("generate"));
+
+    // Deserialize from JSON
+    let deserialized: ModelEntry =
+        serde_json::from_str(&json).expect("Failed to deserialize ModelEntry");
+    assert_eq!(deserialized.name, model.name);
+    assert_eq!(deserialized.endpoint.namespace, model.endpoint.namespace);
+    assert_eq!(deserialized.endpoint.component, model.endpoint.component);
+    assert_eq!(deserialized.endpoint.name, model.endpoint.name);
+    assert_eq!(deserialized.model_type, model.model_type);
+}
+
+#[test]
+fn test_endpoint_namespace_parsing() {
+    // Test Endpoint creation from string with namespace
+    let endpoint1 = Endpoint::from("vllm-agg.backend.generate");
+    assert_eq!(endpoint1.namespace, "vllm-agg");
+    assert_eq!(endpoint1.component, "backend");
+    assert_eq!(endpoint1.name, "generate");
+
+    let endpoint2 = Endpoint::from("global.frontend.http");
+    assert_eq!(endpoint2.namespace, "global");
+    assert_eq!(endpoint2.component, "frontend");
+    assert_eq!(endpoint2.name, "http");
+
+    // Test with forward slash separator
+    let endpoint3 = Endpoint::from("sglang-prod/backend/generate");
+    assert_eq!(endpoint3.namespace, "sglang-prod");
+    assert_eq!(endpoint3.component, "backend");
+    assert_eq!(endpoint3.name, "generate");
+}


### PR DESCRIPTION
#### Overview:

Based on [multi-tenancy proposal](https://github.com/ai-dynamo/enhancements/blob/bis/multi-tenancy/deps/000N-mutlitenancy-support.md#dynamo-operator-changes)

Top level dynamoNamespace in DynamoGraphDeployment should automatically set `DYNAMO_NAMESPACE` environment variable in all component pods.

```yaml
apiVersion: dynamo.ai/v1alpha1
kind: DynamoGraphDeployment
metadata:
  name: dynamo-graph-deployment
spec:
  dynamoNamespace: default/model1
```

closes: DYN-839
