### PR TITLE
chore: Upgrade volcano dependency version

### DIFF
--- a/deploy/cloud/operator/go.mod
+++ b/deploy/cloud/operator/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/lws v0.6.1
-	volcano.sh/apis v1.11.0
+	volcano.sh/apis v1.12.2
 )
 
 require (

--- a/deploy/cloud/operator/go.sum
+++ b/deploy/cloud/operator/go.sum
@@ -242,5 +242,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.7.0 h1:qPeWmscJcXP0snki5IYF79Z8xrl8ETFxg
 sigs.k8s.io/structured-merge-diff/v4 v4.7.0/go.mod h1:dDy58f92j70zLsuZVuUX5Wp9vtxXpaZnkPGWeqDfCps=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
-volcano.sh/apis v1.11.0 h1:Z5ZXxxgUNfXv1OhfVXXfGPN7StoSsozQM+8CAPoNWY8=
-volcano.sh/apis v1.11.0/go.mod h1:FOdmG++9+8lgENJ9XXDh+O3Jcb9YVRnlMSpgIh3NSVI=
+volcano.sh/apis v1.12.2 h1:KvNyM/kMizFVlALiH/uFHPwYFHRtxuVnBL0upbFbDss=
+volcano.sh/apis v1.12.2/go.mod h1:0XNNnIOevJSYNiXRmwhXUrYCcCcWcBeTY0nxrlkk03A=


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Currently, the latest dependency version of volcano is v1.12.2, which is adapted to k8s version 1.33, therefore needs to be upgraded

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded external dependency volcano.sh/apis to v1.12.2.
  * No changes to features, workflows, or UI.
  * No configuration updates or data migrations required.
  * Existing behavior remains consistent across environments.
  * Build and deployment processes remain unaffected.
  * Compatibility with existing components verified; no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->