### PR TITLE
feat: Support `python -m dynamo.frontend --version`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ __pycache__/
 *.so
 *.egg-info
 
+# Hatch build artifact
+_version.py
+
 ### Helm ###
 *.tgz
 Chart.lock

--- a/.gitignore
+++ b/.gitignore
@@ -80,16 +80,14 @@ __pycache__/
 *.egg-info
 
 # Hatch build artifact
-_version.py
+components/**/_version.py
 
 ### Helm ###
 *.tgz
 Chart.lock
 generated-values.yaml
 
+# Local build artifacts for devcontainer
 .build/
 **/.devcontainer/.env
 TensorRT-LLM
-
-# Local build artifacts for devcontainer
-.build/

--- a/components/backends/llama_cpp/src/dynamo/llama_cpp/__init__.py
+++ b/components/backends/llama_cpp/src/dynamo/llama_cpp/__init__.py
@@ -1,6 +1,12 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except Exception:
+    try:
+        from importlib.metadata import version as _pkg_version
 
-__version__ = __version__
+        __version__ = _pkg_version("ai-dynamo")
+    except Exception:
+        __version__ = "0.0.0+unknown"

--- a/components/backends/llama_cpp/src/dynamo/llama_cpp/__init__.py
+++ b/components/backends/llama_cpp/src/dynamo/llama_cpp/__init__.py
@@ -1,0 +1,6 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from ._version import __version__
+
+__version__ = __version__

--- a/components/backends/llama_cpp/src/dynamo/llama_cpp/main.py
+++ b/components/backends/llama_cpp/src/dynamo/llama_cpp/main.py
@@ -11,6 +11,7 @@ from typing import Optional
 import uvloop
 from llama_cpp import Llama
 
+from dynamo.llama_cpp import __version__
 from dynamo.llm import ModelType, register_llm
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -82,6 +83,9 @@ class RequestHandler:
 def cmd_line_args():
     parser = argparse.ArgumentParser(
         description="llama.cpp server integrated with Dynamo LLM."
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"Dynamo Backend llama.cpp {__version__}"
     )
     parser.add_argument(
         "--model-path",

--- a/components/backends/llama_cpp/src/dynamo/llama_cpp/main.py
+++ b/components/backends/llama_cpp/src/dynamo/llama_cpp/main.py
@@ -11,10 +11,11 @@ from typing import Optional
 import uvloop
 from llama_cpp import Llama
 
-from dynamo.llama_cpp import __version__
 from dynamo.llm import ModelType, register_llm
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
+
+from . import __version__
 
 DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
 

--- a/components/backends/mocker/src/dynamo/mocker/__init__.py
+++ b/components/backends/mocker/src/dynamo/mocker/__init__.py
@@ -1,6 +1,12 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except Exception:
+    try:
+        from importlib.metadata import version as _pkg_version
 
-__version__ = __version__
+        __version__ = _pkg_version("ai-dynamo")
+    except Exception:
+        __version__ = "0.0.0+unknown"

--- a/components/backends/mocker/src/dynamo/mocker/__init__.py
+++ b/components/backends/mocker/src/dynamo/mocker/__init__.py
@@ -1,0 +1,6 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from ._version import __version__
+
+__version__ = __version__

--- a/components/backends/mocker/src/dynamo/mocker/main.py
+++ b/components/backends/mocker/src/dynamo/mocker/main.py
@@ -9,9 +9,10 @@ from pathlib import Path
 import uvloop
 
 from dynamo.llm import EngineType, EntrypointArgs, make_engine, run_input
-from dynamo.mocker import __version__
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
+
+from . import __version__
 
 DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
 

--- a/components/backends/mocker/src/dynamo/mocker/main.py
+++ b/components/backends/mocker/src/dynamo/mocker/main.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import uvloop
 
 from dynamo.llm import EngineType, EntrypointArgs, make_engine, run_input
+from dynamo.mocker import __version__
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -40,6 +41,9 @@ def cmd_line_args():
     parser = argparse.ArgumentParser(
         description="Mocker engine for testing Dynamo LLM infrastructure.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"Dynamo Mocker {__version__}"
     )
     parser.add_argument(
         "--model-path",

--- a/components/backends/sglang/src/dynamo/sglang/__init__.py
+++ b/components/backends/sglang/src/dynamo/sglang/__init__.py
@@ -1,6 +1,12 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except Exception:
+    try:
+        from importlib.metadata import version as _pkg_version
 
-__version__ = __version__
+        __version__ = _pkg_version("ai-dynamo")
+    except Exception:
+        __version__ = "0.0.0+unknown"

--- a/components/backends/sglang/src/dynamo/sglang/__init__.py
+++ b/components/backends/sglang/src/dynamo/sglang/__init__.py
@@ -1,0 +1,6 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from ._version import __version__
+
+__version__ = __version__

--- a/components/backends/trtllm/src/dynamo/trtllm/__init__.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/__init__.py
@@ -1,6 +1,12 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except Exception:
+    try:
+        from importlib.metadata import version as _pkg_version
 
-__version__ = __version__
+        __version__ = _pkg_version("ai-dynamo")
+    except Exception:
+        __version__ = "0.0.0+unknown"

--- a/components/backends/trtllm/src/dynamo/trtllm/__init__.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/__init__.py
@@ -1,2 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from ._version import __version__
+
+__version__ = __version__

--- a/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from tensorrt_llm.llmapi import BuildConfig
 
+from dynamo.trtllm import __version__
 from dynamo.trtllm.request_handlers.handler_base import (
     DisaggregationMode,
     DisaggregationStrategy,
@@ -108,6 +109,9 @@ def parse_endpoint(endpoint: str) -> tuple[str, str, str]:
 def cmd_line_args():
     parser = argparse.ArgumentParser(
         description="TensorRT-LLM server integrated with Dynamo LLM."
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"Dynamo Backend TRTLLM {__version__}"
     )
     parser.add_argument(
         "--endpoint",

--- a/components/backends/vllm/src/dynamo/vllm/__init__.py
+++ b/components/backends/vllm/src/dynamo/vllm/__init__.py
@@ -1,6 +1,12 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except Exception:
+    try:
+        from importlib.metadata import version as _pkg_version
 
-__version__ = __version__
+        __version__ = _pkg_version("ai-dynamo")
+    except Exception:
+        __version__ = "0.0.0+unknown"

--- a/components/backends/vllm/src/dynamo/vllm/__init__.py
+++ b/components/backends/vllm/src/dynamo/vllm/__init__.py
@@ -1,0 +1,6 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from ._version import __version__
+
+__version__ = __version__

--- a/components/backends/vllm/src/dynamo/vllm/args.py
+++ b/components/backends/vllm/src/dynamo/vllm/args.py
@@ -12,6 +12,8 @@ from vllm.distributed.kv_events import KVEventsConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.utils import FlexibleArgumentParser
 
+from dynamo.vllm import __version__
+
 from .ports import (
     DEFAULT_DYNAMO_PORT_MAX,
     DEFAULT_DYNAMO_PORT_MIN,
@@ -57,6 +59,9 @@ class Config:
 def parse_args() -> Config:
     parser = FlexibleArgumentParser(
         description="vLLM server integrated with Dynamo LLM."
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"Dynamo Backend VLLM {__version__}"
     )
     parser.add_argument(
         "--endpoint",

--- a/components/backends/vllm/src/dynamo/vllm/args.py
+++ b/components/backends/vllm/src/dynamo/vllm/args.py
@@ -12,8 +12,7 @@ from vllm.distributed.kv_events import KVEventsConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.utils import FlexibleArgumentParser
 
-from dynamo.vllm import __version__
-
+from . import __version__
 from .ports import (
     DEFAULT_DYNAMO_PORT_MAX,
     DEFAULT_DYNAMO_PORT_MIN,

--- a/components/frontend/src/dynamo/frontend/__init__.py
+++ b/components/frontend/src/dynamo/frontend/__init__.py
@@ -1,6 +1,12 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except Exception:
+    try:
+        from importlib.metadata import version as _pkg_version
 
-__version__ = __version__
+        __version__ = _pkg_version("ai-dynamo")
+    except Exception:
+        __version__ = "0.0.0+unknown"

--- a/components/frontend/src/dynamo/frontend/__init__.py
+++ b/components/frontend/src/dynamo/frontend/__init__.py
@@ -1,0 +1,6 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from ._version import __version__
+
+__version__ = __version__

--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -24,6 +24,7 @@ import re
 
 import uvloop
 
+from dynamo.frontend import __version__
 from dynamo.llm import (
     EngineType,
     EntrypointArgs,
@@ -70,6 +71,9 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Dynamo Frontend: HTTP+Pre-processor+Router",
         formatter_class=argparse.RawTextHelpFormatter,  # To preserve multi-line help formatting
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"Dynamo Frontend {__version__}"
     )
     parser.add_argument(
         "-i", "--interactive", action="store_true", help="Interactive text chat"

--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -24,7 +24,6 @@ import re
 
 import uvloop
 
-from dynamo.frontend import __version__
 from dynamo.llm import (
     EngineType,
     EntrypointArgs,
@@ -35,6 +34,8 @@ from dynamo.llm import (
     run_input,
 )
 from dynamo.runtime import DistributedRuntime
+
+from . import __version__
 
 
 def validate_static_endpoint(value):

--- a/components/planner/src/dynamo/planner/__init__.py
+++ b/components/planner/src/dynamo/planner/__init__.py
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 __all__ = [
     "CircusController",
@@ -21,10 +9,13 @@ __all__ = [
     "SLAPlannerDefaults",
     "ServiceConfig",
 ]
-
 # Import the classes
 from dynamo.planner.circusd import CircusController
 from dynamo.planner.config import ServiceConfig
 from dynamo.planner.defaults import LoadPlannerDefaults, SLAPlannerDefaults
 from dynamo.planner.kubernetes_connector import KubernetesConnector
 from dynamo.planner.planner_connector import PlannerConnector
+
+from ._version import __version__
+
+__version__ = __version__

--- a/components/planner/src/dynamo/planner/__init__.py
+++ b/components/planner/src/dynamo/planner/__init__.py
@@ -16,6 +16,12 @@ from dynamo.planner.defaults import LoadPlannerDefaults, SLAPlannerDefaults
 from dynamo.planner.kubernetes_connector import KubernetesConnector
 from dynamo.planner.planner_connector import PlannerConnector
 
-from ._version import __version__
+try:
+    from ._version import __version__
+except Exception:
+    try:
+        from importlib.metadata import version as _pkg_version
 
-__version__ = __version__
+        __version__ = _pkg_version("ai-dynamo")
+    except Exception:
+        __version__ = "0.0.0+unknown"

--- a/components/planner/src/dynamo/planner/config.py
+++ b/components/planner/src/dynamo/planner/config.py
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 import json
 import logging

--- a/components/planner/src/dynamo/planner/utils/planner_core.py
+++ b/components/planner/src/dynamo/planner/utils/planner_core.py
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 import argparse
 import asyncio
@@ -21,7 +9,7 @@ import time
 from dataclasses import dataclass
 from typing import Optional
 
-from dynamo.planner import KubernetesConnector
+from dynamo.planner import KubernetesConnector, __version__
 from dynamo.planner.defaults import WORKER_COMPONENT_NAMES, SLAPlannerDefaults
 from dynamo.planner.utils.load_predictor import LOAD_PREDICTORS
 from dynamo.planner.utils.perf_interpolation import (
@@ -346,6 +334,9 @@ async def start_sla_planner(runtime: DistributedRuntime, args: argparse.Namespac
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     # Common planner arguments
+    parser.add_argument(
+        "--version", action="version", version=f"Dynamo Planner {__version__}"
+    )
     parser.add_argument(
         "--environment",
         type=str,

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -218,7 +218,7 @@ COPY --from=base $VIRTUAL_ENV $VIRTUAL_ENV
 ENV PATH=$CARGO_HOME/bin:$VIRTUAL_ENV/bin:$PATH
 
 # Copy configuration files first for better layer caching
-COPY pyproject.toml README.md LICENSE Cargo.toml Cargo.lock rust-toolchain.toml /opt/dynamo/
+COPY pyproject.toml README.md LICENSE Cargo.toml Cargo.lock rust-toolchain.toml hatch_build.py /opt/dynamo/
 
 # Copy source code
 COPY lib/ /opt/dynamo/lib/

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -337,6 +337,7 @@ COPY LICENSE /workspace/
 COPY Cargo.toml /workspace/
 COPY Cargo.lock /workspace/
 COPY rust-toolchain.toml /workspace/
+COPY hatch_build.py /workspace/
 
 # Copy source code
 COPY lib/ /workspace/lib/

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 ARG BASE_IMAGE="nvcr.io/nvidia/pytorch"
 ARG BASE_IMAGE_TAG="25.05-py3"
@@ -285,6 +273,7 @@ COPY LICENSE /workspace/
 COPY Cargo.toml /workspace/
 COPY Cargo.lock /workspace/
 COPY rust-toolchain.toml /workspace/
+COPY hatch_build.py /workspace/
 
 # Copy source code
 COPY lib/ /workspace/lib/

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -352,6 +352,7 @@ COPY LICENSE /workspace/
 COPY Cargo.toml /workspace/
 COPY Cargo.lock /workspace/
 COPY rust-toolchain.toml /workspace/
+COPY hatch_build.py /workspace/
 
 # Copy source code
 COPY lib/ /workspace/lib/

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,52 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+COMPONENTS = [
+    "frontend/src/dynamo/frontend",
+    "backends/vllm/src/dynamo/vllm",
+    "backends/sglang/src/dynamo/sglang",
+    "backends/trtllm/src/dynamo/trtllm",
+    "backends/mocker/src/dynamo/mocker",
+    "backends/llama_cpp/src/dynamo/llama_cpp",
+    "planner/src/dynamo/planner",
+]
+
+
+class VersionWriterHook(BuildHookInterface):
+    """
+    A Hatch build hook to write the project version to a file.
+    """
+
+    def initialize(self, version, build_data):
+        """
+        This method is called before the build process begins.
+        """
+
+        full_version = self.metadata.version
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=self.root,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            git_version = result.stdout.strip()
+            if git_version:
+                full_version += f"+{git_version}"
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+
+        version_content = f'#  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n#  SPDX-License-Identifier: Apache-2.0\n\n# This file is auto-generated at build time\n__version__ = "{full_version}"\n'
+
+        for component in COMPONENTS:
+            version_file_path = os.path.join(
+                self.root, f"components/{component}/_version.py"
+            )
+            with open(version_file_path, "w") as f:
+                f.write(version_content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 [project]
 name = "ai-dynamo"
@@ -85,6 +73,9 @@ llama_cpp = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
 
 [tool.hatch.build.targets.wheel]
 packages = [


### PR DESCRIPTION
Version looks like this `0.4.0+3a3f5bf2` if you have git, `0.4.0` otherwise.

The `--version` flag should work on all components except sglang, because that handles arguments differently.

All components (including sglang) have the expected `__version__` attribute at the top level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a --version flag to frontend, planner, and multiple backends (vLLM, TRT-LLM, sglang, llama.cpp, mocker) to display component versions via the CLI.

- Chores
  - Enhanced build process to auto-generate per-component version metadata used by the CLI.
  - Updated ignore rules to exclude generated version artifacts.
  - Minor formatting cleanups with no impact on behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->