### PR TITLE
fix: remove kvmanager feature from python 3.12 ai-dynamo-runtime wheel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-engine-llamacpp"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "async-stream",
  "dynamo-llm",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-engine-mistralrs"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "ahash",
  "akin",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-run"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "bytemuck",
  "derive-getters",
@@ -3776,7 +3776,7 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libdynamo_llm"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "axum 0.8.3",
  "clap 4.5.40",
@@ -5899,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "clap 4.5.40",
  "dynamo-llm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.0+post0"
 edition = "2021"
 description = "Dynamo Inference Framework"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -228,7 +228,7 @@ COPY components/ /opt/dynamo/components/
 RUN uv build --wheel --out-dir /opt/dynamo/dist && \
     cd /opt/dynamo/lib/bindings/python && \
     uv pip install maturin[patchelf] && \
-    maturin build --release --features block-manager --out /opt/dynamo/dist && \
+    maturin build --release --out /opt/dynamo/dist && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
         # do not enable KVBM feature, ensure compatibility with lower glibc
         uv run --python 3.11 maturin build --release --out /opt/dynamo/dist && \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -8,6 +8,7 @@ ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 # can be updated to later versions.
 ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 ARG RELEASE_BUILD=false
+ARG ENABLE_KVBM=false
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
 #   ARCH: Used for package suffixes (e.g., amd64, arm64)
@@ -197,6 +198,8 @@ ARG CARGO_BUILD_JOBS
 ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-16}
 # Use build arg RELEASE_BUILD = true to generate wheels for Python 3.10, 3.11 and 3.12.
 ARG RELEASE_BUILD
+# Use arg ENABLE_KVBM = true to turn on the block-manager feature
+ARG ENABLE_KVBM
 
 WORKDIR /opt/dynamo
 
@@ -228,7 +231,11 @@ COPY components/ /opt/dynamo/components/
 RUN uv build --wheel --out-dir /opt/dynamo/dist && \
     cd /opt/dynamo/lib/bindings/python && \
     uv pip install maturin[patchelf] && \
-    maturin build --release --out /opt/dynamo/dist && \
+    if [ "$ENABLE_KVBM" = "true" ]; then \
+        maturin build --release --features block-manager --out /opt/dynamo/dist; \
+    else \
+        maturin build --release --out /opt/dynamo/dist; \
+    fi && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
         # do not enable KVBM feature, ensure compatibility with lower glibc
         uv run --python 3.11 maturin build --release --out /opt/dynamo/dist && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -8,6 +8,7 @@ ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 # can be updated to later versions.
 ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 ARG RELEASE_BUILD
+ARG ENABLE_KVBM=false
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
 
@@ -320,6 +321,8 @@ ARG CARGO_BUILD_JOBS
 ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-16}
 # Use build arg RELEASE_BUILD = true to generate wheels for Python 3.10, 3.11 and 3.12.
 ARG RELEASE_BUILD
+# Use arg ENABLE_KVBM = true to turn on the block-manager feature
+ARG ENABLE_KVBM
 
 # Keep in sync with the base image.
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl
@@ -368,7 +371,11 @@ RUN cargo build \
 RUN uv build --wheel --out-dir /workspace/dist && \
     cd /workspace/lib/bindings/python && \
     uv pip install maturin[patchelf] && \
-    maturin build --release --out /workspace/dist && \
+    if [ "$ENABLE_KVBM" = "true" ]; then \
+        maturin build --release --features block-manager --out /opt/dynamo/dist;\
+    else \
+        maturin build --release --out /opt/dynamo/dist; \
+    fi && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
         # do not enable KVBM feature, ensure compatibility with lower glibc
         uv run --python 3.11 maturin build --release --out /workspace/dist && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -372,9 +372,9 @@ RUN uv build --wheel --out-dir /workspace/dist && \
     cd /workspace/lib/bindings/python && \
     uv pip install maturin[patchelf] && \
     if [ "$ENABLE_KVBM" = "true" ]; then \
-        maturin build --release --features block-manager --out /opt/dynamo/dist;\
+        maturin build --release --features block-manager --out /workspace/dist; \
     else \
-        maturin build --release --out /opt/dynamo/dist; \
+        maturin build --release --out /workspace/dist; \
     fi && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
         # do not enable KVBM feature, ensure compatibility with lower glibc

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -368,7 +368,7 @@ RUN cargo build \
 RUN uv build --wheel --out-dir /workspace/dist && \
     cd /workspace/lib/bindings/python && \
     uv pip install maturin[patchelf] && \
-    maturin build --release --features block-manager --out /workspace/dist && \
+    maturin build --release --out /workspace/dist && \
     if [ "$RELEASE_BUILD" = "true" ]; then \
         # do not enable KVBM feature, ensure compatibility with lower glibc
         uv run --python 3.11 maturin build --release --out /workspace/dist && \

--- a/container/build.sh
+++ b/container/build.sh
@@ -274,6 +274,9 @@ get_options() {
         --release-build)
             RELEASE_BUILD=true
             ;;
+        --enable-kvbm)
+            ENABLE_KVBM=true
+            ;;
         --make-efa)
             NIXL_UCX_REF=$NIXL_UCX_EFA_REF
             ;;
@@ -528,6 +531,11 @@ fi
 if [  ! -z ${RELEASE_BUILD} ]; then
     echo "Performing a release build!"
     BUILD_ARGS+=" --build-arg RELEASE_BUILD=${RELEASE_BUILD} "
+fi
+
+if [  ! -z ${ENABLE_KVBM} ]; then
+    echo "Enabling the KVBM in the ai-dynamo-runtime"
+    BUILD_ARGS+=" --build-arg ENABLE_KVBM=${ENABLE_KVBM} "
 fi
 
 if [ -n "${NIXL_UCX_REF}" ]; then

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -19,7 +19,7 @@
 
 [package]
 name = "dynamo-py3"
-version = "0.4.0"
+version = "0.4.0+post0"
 edition = "2021"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "ai-dynamo-runtime"
-dynamic = ["version"]
+version = "0.4.0.post0"
 description = "Dynamo Inference Framework Runtime"
 readme = "README.md"
 authors = [

--- a/lib/bindings/python/tests/test_block_manager.py
+++ b/lib/bindings/python/tests/test_block_manager.py
@@ -19,7 +19,13 @@ import asyncio
 import pytest
 import torch
 
-from dynamo.llm import BlockManager
+# Attempt to import the optional module
+try:
+    from dynamo.llm import BlockManager
+except ImportError:
+    pytest.importorskip(
+        "optional_module", reason="block-manager feature is not enabled"
+    )
 
 pytestmark = pytest.mark.pre_merge
 

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.0+post0"
 edition = "2021"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
 
 [project]
 name = "ai-dynamo"
-version = "0.4.0"
+version = "0.4.0.post0"
 description = "Distributed Inference Framework"
 readme = "README.md"
 authors = [
@@ -25,7 +25,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "ai-dynamo-runtime==0.4.0",
+    "ai-dynamo-runtime==0.4.0.post0",
     "pytest>=8.3.4",
     "types-psutil>=7.0.0.20250218",
     "kubernetes>=32.0.1,<33.0.0",


### PR DESCRIPTION
#### Overview:

This removes the KVBM from the `ai-dynamo-runtime` wheel so that in environments where the glibc version is not 2.38 (such as AWS AL2023) we are able to run dynamo in environments for python 3.12.

#### Details:

Enabling the KVBM feature in the `ai-dynamo-runtime` wheel requires packaging `libnixl.so`. Unfortunately, due to lack of the publicly-available NVIDIA containers which contain both CUDA and a manylinux build environment there is not an easy way to build `libnixl.so` in such a way that the glibc version is kept equivalent to the 2.28 reported by the wheel.

By removing it the wheel no longer contains `libnixl.so` and has a glibc dependency of 2.28.

#### Where should the reviewer start?

After pulling this branch in the dynamo repo run the following to build the container and copy out the wheels into a folder called `./wheelhouse`:

```bash
container/build.sh --framework none --tag dynamo:base-aws
docker create --name aws dynamo:base-aws
docker cp aws:/opt/dynamo/wheelhouse .
docker rm aws
```

In the top-level of the dynamo directory add the following file named `Containerfile.al2023`

```Dockerfile
FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS base

COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

ENV VIRTUAL_ENV=/opt/dynamo/venv
RUN mkdir /opt/dynamo && \
    uv venv --python 3.12 ${VIRTUAL_ENV}
ENV PATH="$VIRTUAL_ENV/bin:$PATH"\
    UV_COMPILE_BYTECODE=1 \
    UV_LINK_MODE=copy

COPY wheelhouse /wheelhouse

RUN yum install -y clang

RUN --mount=type=cache,target=/root/.cache/uv \
    echo "oof4" >> /hi_there.txt && \
    uv pip install \
    /wheelhouse/ai_dynamo_runtime*cp312*.whl \
    /wheelhouse/ai_dynamo-0.4.0.post0-py3-none-any.whl[vllm]
```

We will now build this container

```bash
docker build -f Containerfile.al2023 --tag al2023:p312-vllm . 
```

To test the container we will bring up Dynamo in the normal way using Qwen3-0.6B

```bash
docker compose -f ~/ai-dynamo/dynamo/deploy/docker-compose.yml up -d
docker run --gpus all -d --name al2023_frontend --network host --ipc host al2023:p312-vllm python -m dynamo.frontend
docker run --gpus all -d --name al2023_worker -v ~/.cache/huggingface:/root/.cache/huggingface --network host --ipc host al2023:p312-vllm python -m dynamo.vllm --model Qwen/Qwen3-0.6B --enforce-eager --no-enable-prefix-caching
```

Wait for a moment while the model is downloaded and the service starts. If you issue the command too early just wait a second and try again.
```bash
curl localhost:8080/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "Qwen/Qwen3-0.6B",
    "messages": [
    {
        "role": "user",
        "content": "Hello, how are you?"
    }
    ],
    "stream":false,
    "max_tokens": 300
}' | jq
```

Once you have observed functionality you can clean up your running containers, delete the `./wheelhouse/` folder and `./Containerfile.al2023`
```bash
docker stop al2023_frontend al2023_worker
docker rm al2023_frontend al2023_worker
docker image rm al2023:p312-vllm dynamo:base-aws
rm -rf ./wheelhouse
rm ./Containerfile.al2023
```

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Fixes OPS-623


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.4.0.post0 and aligned dependency versions accordingly.
  * Switched Python bindings from dynamic (VCS-based) to a fixed static version.
  * Adjusted container build to produce Python wheels with default features; overall build workflow unchanged.
* **Notes**
  * No changes to public APIs or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->