### PR TITLE
fix: remove add_labels in Component

### DIFF
--- a/components/backends/vllm/src/dynamo/vllm/main.py
+++ b/components/backends/vllm/src/dynamo/vllm/main.py
@@ -133,11 +133,7 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
     Instantiate and serve
     """
 
-    component = (
-        runtime.namespace(config.namespace)
-        .component(config.component)
-        .add_labels([("model", config.model)])
-    )
+    component = runtime.namespace(config.namespace).component(config.component)
     await component.create_service()
 
     generate_endpoint = component.endpoint(config.endpoint)
@@ -170,11 +166,7 @@ async def init(runtime: DistributedRuntime, config: Config):
     Instantiate and serve
     """
 
-    component = (
-        runtime.namespace(config.namespace)
-        .component(config.component)
-        .add_labels([("model", config.model)])
-    )
+    component = runtime.namespace(config.namespace).component(config.component)
     await component.create_service()
 
     generate_endpoint = component.endpoint(config.endpoint)


### PR DESCRIPTION
#### Overview:

I removed Component labels but forgot to remove in the Python caller, causing vLLM failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined initialization for the vLLM backend, removing redundant metadata labeling to simplify configuration. No changes to behavior, APIs, or performance.
* **Chores**
  * Internal cleanup to align component setup with current conventions. No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->