### PR TITLE
feat: inject DGD id in planner env variables

### DIFF
--- a/deploy/cloud/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/cloud/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -260,3 +260,16 @@ func (s *DynamoComponentDeploymentSharedSpec) GetNumberOfNodes() int32 {
 	}
 	return 1
 }
+
+func (s *DynamoComponentDeployment) GetParentGraphDeploymentName() string {
+	for _, ownerRef := range s.ObjectMeta.OwnerReferences {
+		if ownerRef.Kind == "DynamoGraphDeployment" {
+			return ownerRef.Name
+		}
+	}
+	return ""
+}
+
+func (s *DynamoComponentDeployment) GetParentGraphDeploymentNamespace() string {
+	return s.GetNamespace()
+}

--- a/deploy/cloud/operator/api/v1alpha1/dynamocomponentdeployment_types_test.go
+++ b/deploy/cloud/operator/api/v1alpha1/dynamocomponentdeployment_types_test.go
@@ -210,3 +210,54 @@ func TestDynamoComponentDeployment_SetDynamoDeploymentConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestDynamoComponentDeployment_GetParentGraphDeploymentName(t *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Spec       DynamoComponentDeploymentSpec
+		Status     DynamoComponentDeploymentStatus
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "test",
+			fields: fields{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "DynamoGraphDeployment",
+							Name: "name",
+						},
+					},
+				},
+			},
+			want: "name",
+		},
+		{
+			name: "no owner reference",
+			fields: fields{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{},
+				},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DynamoComponentDeployment{
+				TypeMeta:   tt.fields.TypeMeta,
+				ObjectMeta: tt.fields.ObjectMeta,
+				Spec:       tt.fields.Spec,
+				Status:     tt.fields.Status,
+			}
+			if got := s.GetParentGraphDeploymentName(); got != tt.want {
+				t.Errorf("DynamoComponentDeployment.GetParentGraphDeploymentName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/cloud/operator/internal/dynamo/component_common.go
+++ b/deploy/cloud/operator/internal/dynamo/component_common.go
@@ -14,7 +14,7 @@ import (
 type ComponentDefaults interface {
 	// GetBaseContainer returns the base container configuration for this component type
 	// The numberOfNodes parameter indicates the total number of nodes in the deployment
-	GetBaseContainer(numberOfNodes int32) (corev1.Container, error)
+	GetBaseContainer(numberOfNodes int32, parentGraphDeploymentName, parentGraphDeploymentNamespace string) (corev1.Container, error)
 
 	// GetBasePodSpec returns the base pod spec configuration for this component type
 	// The numberOfNodes parameter indicates the total number of nodes in the deployment
@@ -38,7 +38,7 @@ func ComponentDefaultsFactory(componentType string, numberOfNodes int32) Compone
 // BaseComponentDefaults provides common defaults shared by all components
 type BaseComponentDefaults struct{}
 
-func (b *BaseComponentDefaults) GetBaseContainer(numberOfNodes int32) (corev1.Container, error) {
+func (b *BaseComponentDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeploymentName, parentGraphDeploymentNamespace string) (corev1.Container, error) {
 	return b.getCommonContainer(), nil
 }
 

--- a/deploy/cloud/operator/internal/dynamo/component_common.go
+++ b/deploy/cloud/operator/internal/dynamo/component_common.go
@@ -14,15 +14,15 @@ import (
 type ComponentDefaults interface {
 	// GetBaseContainer returns the base container configuration for this component type
 	// The numberOfNodes parameter indicates the total number of nodes in the deployment
-	GetBaseContainer(numberOfNodes int32, parentGraphDeploymentName, parentGraphDeploymentNamespace string) (corev1.Container, error)
+	GetBaseContainer(context ComponentContext) (corev1.Container, error)
 
 	// GetBasePodSpec returns the base pod spec configuration for this component type
 	// The numberOfNodes parameter indicates the total number of nodes in the deployment
-	GetBasePodSpec(numberOfNodes int32) (corev1.PodSpec, error)
+	GetBasePodSpec(context ComponentContext) (corev1.PodSpec, error)
 }
 
 // ComponentDefaultsFactory creates appropriate defaults based on component type and number of nodes
-func ComponentDefaultsFactory(componentType string, numberOfNodes int32) ComponentDefaults {
+func ComponentDefaultsFactory(componentType string) ComponentDefaults {
 	switch componentType {
 	case commonconsts.ComponentTypeFrontend:
 		return NewFrontendDefaults()
@@ -38,20 +38,41 @@ func ComponentDefaultsFactory(componentType string, numberOfNodes int32) Compone
 // BaseComponentDefaults provides common defaults shared by all components
 type BaseComponentDefaults struct{}
 
-func (b *BaseComponentDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeploymentName, parentGraphDeploymentNamespace string) (corev1.Container, error) {
-	return b.getCommonContainer(), nil
+type ComponentContext struct {
+	numberOfNodes                  int32
+	DynamoNamespace                string
+	ParentGraphDeploymentName      string
+	ParentGraphDeploymentNamespace string
 }
 
-func (b *BaseComponentDefaults) GetBasePodSpec(numberOfNodes int32) (corev1.PodSpec, error) {
+func (b *BaseComponentDefaults) GetBaseContainer(context ComponentContext) (corev1.Container, error) {
+	return b.getCommonContainer(context), nil
+}
+
+func (b *BaseComponentDefaults) GetBasePodSpec(context ComponentContext) (corev1.PodSpec, error) {
 	return corev1.PodSpec{}, nil
 }
 
-func (b *BaseComponentDefaults) getCommonContainer() corev1.Container {
+func (b *BaseComponentDefaults) getCommonContainer(context ComponentContext) corev1.Container {
 	container := corev1.Container{
 		Name: "main",
 		Command: []string{
 			"/bin/sh",
 			"-c",
+		},
+	}
+	container.Env = []corev1.EnvVar{
+		{
+			Name:  "DYN_NAMESPACE",
+			Value: context.DynamoNamespace,
+		},
+		{
+			Name:  "DYN_PARENT_DGD_K8S_NAME",
+			Value: context.ParentGraphDeploymentName,
+		},
+		{
+			Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+			Value: context.ParentGraphDeploymentNamespace,
 		},
 	}
 

--- a/deploy/cloud/operator/internal/dynamo/component_frontend.go
+++ b/deploy/cloud/operator/internal/dynamo/component_frontend.go
@@ -23,9 +23,9 @@ func NewFrontendDefaults() *FrontendDefaults {
 	return &FrontendDefaults{&BaseComponentDefaults{}}
 }
 
-func (f *FrontendDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeploymentName, parentGraphDeploymentNamespace string) (corev1.Container, error) {
+func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Container, error) {
 	// Frontend doesn't need backend-specific config
-	container := f.getCommonContainer()
+	container := f.getCommonContainer(context)
 
 	// Add HTTP port
 	container.Ports = []corev1.ContainerPort{
@@ -78,12 +78,12 @@ func (f *FrontendDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDepl
 	}
 
 	// Add standard environment variables
-	container.Env = []corev1.EnvVar{
+	container.Env = append(container.Env, []corev1.EnvVar{
 		{
 			Name:  commonconsts.EnvDynamoServicePort,
 			Value: fmt.Sprintf("%d", commonconsts.DynamoServicePort),
 		},
-	}
+	}...)
 
 	return container, nil
 }

--- a/deploy/cloud/operator/internal/dynamo/component_frontend.go
+++ b/deploy/cloud/operator/internal/dynamo/component_frontend.go
@@ -23,7 +23,7 @@ func NewFrontendDefaults() *FrontendDefaults {
 	return &FrontendDefaults{&BaseComponentDefaults{}}
 }
 
-func (f *FrontendDefaults) GetBaseContainer(numberOfNodes int32) (corev1.Container, error) {
+func (f *FrontendDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeploymentName, parentGraphDeploymentNamespace string) (corev1.Container, error) {
 	// Frontend doesn't need backend-specific config
 	container := f.getCommonContainer()
 

--- a/deploy/cloud/operator/internal/dynamo/component_planner.go
+++ b/deploy/cloud/operator/internal/dynamo/component_planner.go
@@ -20,8 +20,8 @@ func NewPlannerDefaults() *PlannerDefaults {
 	return &PlannerDefaults{&BaseComponentDefaults{}}
 }
 
-func (p *PlannerDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeploymentName, parentGraphDeploymentNamespace string) (corev1.Container, error) {
-	container := p.getCommonContainer()
+func (p *PlannerDefaults) GetBaseContainer(context ComponentContext) (corev1.Container, error) {
+	container := p.getCommonContainer(context)
 
 	// Add planner-specific defaults
 	container.Resources = corev1.ResourceRequirements{
@@ -35,21 +35,10 @@ func (p *PlannerDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeplo
 		},
 	}
 
-	container.Env = []corev1.EnvVar{
-		{
-			Name:  "K8S_PARENT_NAME",
-			Value: parentGraphDeploymentName,
-		},
-		{
-			Name:  "K8S_PARENT_NAMESPACE",
-			Value: parentGraphDeploymentNamespace,
-		},
-	}
-
 	return container, nil
 }
 
-func (p *PlannerDefaults) GetBasePodSpec(numberOfNodes int32) (corev1.PodSpec, error) {
+func (p *PlannerDefaults) GetBasePodSpec(context ComponentContext) (corev1.PodSpec, error) {
 	podSpec := corev1.PodSpec{
 		ServiceAccountName: commonconsts.PlannerServiceAccountName,
 	}

--- a/deploy/cloud/operator/internal/dynamo/component_planner.go
+++ b/deploy/cloud/operator/internal/dynamo/component_planner.go
@@ -20,7 +20,7 @@ func NewPlannerDefaults() *PlannerDefaults {
 	return &PlannerDefaults{&BaseComponentDefaults{}}
 }
 
-func (p *PlannerDefaults) GetBaseContainer(numberOfNodes int32) (corev1.Container, error) {
+func (p *PlannerDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeploymentName, parentGraphDeploymentNamespace string) (corev1.Container, error) {
 	container := p.getCommonContainer()
 
 	// Add planner-specific defaults
@@ -32,6 +32,17 @@ func (p *PlannerDefaults) GetBaseContainer(numberOfNodes int32) (corev1.Containe
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("2"),
 			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+	}
+
+	container.Env = []corev1.EnvVar{
+		{
+			Name:  "K8S_PARENT_NAME",
+			Value: parentGraphDeploymentName,
+		},
+		{
+			Name:  "K8S_PARENT_NAMESPACE",
+			Value: parentGraphDeploymentNamespace,
 		},
 	}
 

--- a/deploy/cloud/operator/internal/dynamo/component_planner_test.go
+++ b/deploy/cloud/operator/internal/dynamo/component_planner_test.go
@@ -21,6 +21,7 @@ func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
 		numberOfNodes                  int32
 		parentGraphDeploymentName      string
 		parentGraphDeploymentNamespace string
+		dynamoNamespace                string
 	}
 	tests := []struct {
 		name    string
@@ -38,6 +39,7 @@ func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
 				numberOfNodes:                  1,
 				parentGraphDeploymentName:      "name",
 				parentGraphDeploymentNamespace: "namespace",
+				dynamoNamespace:                "dynamo-namespace",
 			},
 			want: corev1.Container{
 				Name: "main",
@@ -56,8 +58,9 @@ func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
 					},
 				},
 				Env: []corev1.EnvVar{
-					{Name: "K8S_PARENT_NAME", Value: "name"},
-					{Name: "K8S_PARENT_NAMESPACE", Value: "namespace"},
+					{Name: "DYN_NAMESPACE", Value: "dynamo-namespace"},
+					{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "name"},
+					{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: "namespace"},
 				},
 			},
 		},
@@ -67,7 +70,12 @@ func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
 			p := &PlannerDefaults{
 				BaseComponentDefaults: tt.fields.BaseComponentDefaults,
 			}
-			got, err := p.GetBaseContainer(tt.args.numberOfNodes, tt.args.parentGraphDeploymentName, tt.args.parentGraphDeploymentNamespace)
+			got, err := p.GetBaseContainer(ComponentContext{
+				numberOfNodes:                  tt.args.numberOfNodes,
+				ParentGraphDeploymentName:      tt.args.parentGraphDeploymentName,
+				ParentGraphDeploymentNamespace: tt.args.parentGraphDeploymentNamespace,
+				DynamoNamespace:                tt.args.dynamoNamespace,
+			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("PlannerDefaults.GetBaseContainer() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/deploy/cloud/operator/internal/dynamo/component_planner_test.go
+++ b/deploy/cloud/operator/internal/dynamo/component_planner_test.go
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dynamo
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
+	type fields struct {
+		BaseComponentDefaults *BaseComponentDefaults
+	}
+	type args struct {
+		numberOfNodes                  int32
+		parentGraphDeploymentName      string
+		parentGraphDeploymentNamespace string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    corev1.Container
+		wantErr bool
+	}{
+		{
+			name: "test",
+			fields: fields{
+				BaseComponentDefaults: &BaseComponentDefaults{},
+			},
+			args: args{
+				numberOfNodes:                  1,
+				parentGraphDeploymentName:      "name",
+				parentGraphDeploymentNamespace: "namespace",
+			},
+			want: corev1.Container{
+				Name: "main",
+				Command: []string{
+					"/bin/sh",
+					"-c",
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+				Env: []corev1.EnvVar{
+					{Name: "K8S_PARENT_NAME", Value: "name"},
+					{Name: "K8S_PARENT_NAMESPACE", Value: "namespace"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PlannerDefaults{
+				BaseComponentDefaults: tt.fields.BaseComponentDefaults,
+			}
+			got, err := p.GetBaseContainer(tt.args.numberOfNodes, tt.args.parentGraphDeploymentName, tt.args.parentGraphDeploymentNamespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PlannerDefaults.GetBaseContainer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			diff := cmp.Diff(got, tt.want)
+			if diff != "" {
+				t.Errorf("PlannerDefaults.GetBaseContainer() = %v, want %v", diff, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/cloud/operator/internal/dynamo/component_worker.go
+++ b/deploy/cloud/operator/internal/dynamo/component_worker.go
@@ -23,7 +23,7 @@ func NewWorkerDefaults() *WorkerDefaults {
 	return &WorkerDefaults{&BaseComponentDefaults{}}
 }
 
-func (w *WorkerDefaults) GetBaseContainer(numberOfNodes int32) (corev1.Container, error) {
+func (w *WorkerDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeploymentName, parentGraphDeploymentNamespace string) (corev1.Container, error) {
 	container := w.getCommonContainer()
 
 	// Add system port

--- a/deploy/cloud/operator/internal/dynamo/component_worker.go
+++ b/deploy/cloud/operator/internal/dynamo/component_worker.go
@@ -23,8 +23,8 @@ func NewWorkerDefaults() *WorkerDefaults {
 	return &WorkerDefaults{&BaseComponentDefaults{}}
 }
 
-func (w *WorkerDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeploymentName, parentGraphDeploymentNamespace string) (corev1.Container, error) {
-	container := w.getCommonContainer()
+func (w *WorkerDefaults) GetBaseContainer(context ComponentContext) (corev1.Container, error) {
+	container := w.getCommonContainer(context)
 
 	// Add system port
 	container.Ports = []corev1.ContainerPort{
@@ -84,7 +84,7 @@ func (w *WorkerDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeploy
 		FailureThreshold: 60,
 	}
 
-	container.Env = []corev1.EnvVar{
+	container.Env = append(container.Env, []corev1.EnvVar{
 		{
 			Name:  "DYN_SYSTEM_ENABLED",
 			Value: "true",
@@ -97,7 +97,7 @@ func (w *WorkerDefaults) GetBaseContainer(numberOfNodes int32, parentGraphDeploy
 			Name:  "DYN_SYSTEM_PORT",
 			Value: fmt.Sprintf("%d", commonconsts.DynamoSystemPort),
 		},
-	}
+	}...)
 
 	return container, nil
 }

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -105,7 +105,7 @@ func (s ServiceConfig) GetNamespace() *string {
 	return &s.Config.Dynamo.Namespace
 }
 
-func GetDefaultDynamoNamespace(ctx context.Context, dynamoDeployment *v1alpha1.DynamoGraphDeployment) string {
+func GetDefaultDynamoNamespace(dynamoDeployment *v1alpha1.DynamoGraphDeployment) string {
 	return fmt.Sprintf("dynamo-%s", dynamoDeployment.Name)
 }
 
@@ -118,7 +118,10 @@ func ParseDynDeploymentConfig(ctx context.Context, jsonContent []byte) (DynDeplo
 // GenerateDynamoComponentsDeployments generates a map of DynamoComponentDeployments from a DynamoGraphConfig
 func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphDeployment *v1alpha1.DynamoGraphDeployment, defaultIngressSpec *v1alpha1.IngressSpec) (map[string]*v1alpha1.DynamoComponentDeployment, error) {
 	deployments := make(map[string]*v1alpha1.DynamoComponentDeployment)
-	graphDynamoNamespace := ""
+	graphDynamoNamespace, err := getDynamoNamespace(parentDynamoGraphDeployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the graph dynamo namespace: %w", err)
+	}
 	for componentName, component := range parentDynamoGraphDeployment.Spec.Services {
 		deployment := &v1alpha1.DynamoComponentDeployment{}
 		deployment.Spec.DynamoComponentDeploymentSharedSpec = component.DynamoComponentDeploymentSharedSpec
@@ -126,22 +129,14 @@ func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphD
 		deployment.Spec.BackendFramework = parentDynamoGraphDeployment.Spec.BackendFramework
 		deployment.Namespace = parentDynamoGraphDeployment.Namespace
 		deployment.Spec.ServiceName = componentName
-		dynamoNamespace := GetDefaultDynamoNamespace(ctx, parentDynamoGraphDeployment)
-		if component.DynamoNamespace != nil && *component.DynamoNamespace != "" {
-			dynamoNamespace = *component.DynamoNamespace
-		}
-		if graphDynamoNamespace != "" && graphDynamoNamespace != dynamoNamespace {
-			return nil, fmt.Errorf("namespace mismatch for component %s: graph uses namespace %s but component specifies %s", componentName, graphDynamoNamespace, dynamoNamespace)
-		}
-		graphDynamoNamespace = dynamoNamespace
-		deployment.Spec.DynamoNamespace = &dynamoNamespace
+		deployment.Spec.DynamoNamespace = &graphDynamoNamespace
 		labels := make(map[string]string)
 		// add the labels in the spec in order to label all sub-resources
 		deployment.Spec.Labels = labels
 		// and add the labels to the deployment itself
 		deployment.Labels = labels
 		labels[commonconsts.KubeLabelDynamoComponent] = componentName
-		labels[commonconsts.KubeLabelDynamoNamespace] = dynamoNamespace
+		labels[commonconsts.KubeLabelDynamoNamespace] = graphDynamoNamespace
 
 		// Propagate metrics annotation from parent deployment if present
 		if parentDynamoGraphDeployment.Annotations != nil {
@@ -188,6 +183,24 @@ func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphD
 		deployments[componentName] = deployment
 	}
 	return deployments, nil
+}
+
+func getDynamoNamespace(parentDynamoGraphDeployment *v1alpha1.DynamoGraphDeployment) (string, error) {
+	graphDynamoNamespace := ""
+	for componentName, component := range parentDynamoGraphDeployment.Spec.Services {
+		dynamoNamespace := ""
+		if component.DynamoNamespace != nil && *component.DynamoNamespace != "" {
+			dynamoNamespace = *component.DynamoNamespace
+		}
+		if graphDynamoNamespace != "" && graphDynamoNamespace != dynamoNamespace {
+			return "", fmt.Errorf("namespace mismatch for component %s: graph uses namespace %s but component specifies %s", componentName, graphDynamoNamespace, dynamoNamespace)
+		}
+		graphDynamoNamespace = dynamoNamespace
+	}
+	if graphDynamoNamespace == "" {
+		graphDynamoNamespace = GetDefaultDynamoNamespace(parentDynamoGraphDeployment)
+	}
+	return graphDynamoNamespace, nil
 }
 
 // updateDynDeploymentConfig updates the runtime config object for the given dynamoDeploymentComponent
@@ -676,8 +689,16 @@ func GenerateBasePodSpec(
 	serviceName string,
 ) (corev1.PodSpec, error) {
 	// Start with base container generated per component type
-	componentDefaults := ComponentDefaultsFactory(component.ComponentType, numberOfNodes)
-	container, err := componentDefaults.GetBaseContainer(numberOfNodes, parentGraphDeploymentName, namespace)
+	componentContext := ComponentContext{
+		numberOfNodes:                  numberOfNodes,
+		ParentGraphDeploymentName:      parentGraphDeploymentName,
+		ParentGraphDeploymentNamespace: namespace,
+	}
+	if component.DynamoNamespace != nil {
+		componentContext.DynamoNamespace = *component.DynamoNamespace
+	}
+	componentDefaults := ComponentDefaultsFactory(component.ComponentType)
+	container, err := componentDefaults.GetBaseContainer(componentContext)
 	if err != nil {
 		return corev1.PodSpec{}, fmt.Errorf("failed to get base container: %w", err)
 	}
@@ -779,7 +800,7 @@ func GenerateBasePodSpec(
 	backend.UpdateContainer(&container, numberOfNodes, role, component, serviceName, multinodeDeployer)
 
 	// get base podspec from component
-	podSpec, err := componentDefaults.GetBasePodSpec(numberOfNodes)
+	podSpec, err := componentDefaults.GetBasePodSpec(componentContext)
 	if err != nil {
 		return corev1.PodSpec{}, fmt.Errorf("failed to get base podspec: %w", err)
 	}
@@ -848,9 +869,13 @@ func GenerateGrovePodGangSet(
 	if controllerConfig.Grove.TerminationDelay > 0 {
 		gangSet.Spec.Template.TerminationDelay = &metav1.Duration{Duration: controllerConfig.Grove.TerminationDelay}
 	}
-
+	dynamoNamespace, err := getDynamoNamespace(dynamoDeployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the graph dynamo namespace: %w", err)
+	}
 	var scalingGroups []grovev1alpha1.PodCliqueScalingGroupConfig
 	for serviceName, component := range dynamoDeployment.Spec.Services {
+		component.DynamoNamespace = &dynamoNamespace
 		// Determine backend framework using hybrid approach
 		backendFramework, err := getBackendFrameworkFromComponent(component, dynamoDeployment)
 		if err != nil {

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -689,14 +689,7 @@ func GenerateBasePodSpec(
 	serviceName string,
 ) (corev1.PodSpec, error) {
 	// Start with base container generated per component type
-	componentContext := ComponentContext{
-		numberOfNodes:                  numberOfNodes,
-		ParentGraphDeploymentName:      parentGraphDeploymentName,
-		ParentGraphDeploymentNamespace: namespace,
-	}
-	if component.DynamoNamespace != nil {
-		componentContext.DynamoNamespace = *component.DynamoNamespace
-	}
+	componentContext := generateComponentContext(component, parentGraphDeploymentName, namespace, numberOfNodes)
 	componentDefaults := ComponentDefaultsFactory(component.ComponentType)
 	container, err := componentDefaults.GetBaseContainer(componentContext)
 	if err != nil {
@@ -828,6 +821,18 @@ func setMetricsLabels(labels map[string]string, dynamoGraphDeployment *v1alpha1.
 	}
 	// Any other value (including empty) enables metrics
 	labels[commonconsts.KubeLabelMetricsEnabled] = commonconsts.KubeLabelValueTrue
+}
+
+func generateComponentContext(component *v1alpha1.DynamoComponentDeploymentOverridesSpec, parentGraphDeploymentName string, namespace string, numberOfNodes int32) ComponentContext {
+	componentContext := ComponentContext{
+		numberOfNodes:                  numberOfNodes,
+		ParentGraphDeploymentName:      parentGraphDeploymentName,
+		ParentGraphDeploymentNamespace: namespace,
+	}
+	if component.DynamoNamespace != nil {
+		componentContext.DynamoNamespace = *component.DynamoNamespace
+	}
+	return componentContext
 }
 
 // GeneratePodSpecForComponent creates a PodSpec for Grove deployments (simplified wrapper)

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -4126,6 +4126,7 @@ func TestGenerateBasePodSpec_PlannerServiceAccount(t *testing.T) {
 				tt.component,
 				BackendFrameworkSGLang,
 				secretsRetriever,
+				"test-deployment",
 				"default",
 				RoleMain,
 				1,

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -1303,6 +1303,18 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
 													},
+													{
+														Name:  "DYN_NAMESPACE",
+														Value: "dynamo-test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAME",
+														Value: "test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+														Value: "test-namespace",
+													},
 												},
 												Resources: corev1.ResourceRequirements{
 													Requests: corev1.ResourceList{
@@ -1417,6 +1429,18 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 													{
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
+													},
+													{
+														Name:  "DYN_NAMESPACE",
+														Value: "dynamo-test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAME",
+														Value: "test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+														Value: "test-namespace",
 													},
 												},
 												Resources: corev1.ResourceRequirements{
@@ -1746,6 +1770,18 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
 													},
+													{
+														Name:  "DYN_NAMESPACE",
+														Value: "dynamo-test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAME",
+														Value: "test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+														Value: "test-namespace",
+													},
 												},
 												Resources: corev1.ResourceRequirements{
 													Requests: corev1.ResourceList{
@@ -1881,6 +1917,18 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
 													},
+													{
+														Name:  "DYN_NAMESPACE",
+														Value: "dynamo-test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAME",
+														Value: "test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+														Value: "test-namespace",
+													},
 												},
 												Resources: corev1.ResourceRequirements{
 													Requests: corev1.ResourceList{
@@ -1991,6 +2039,18 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 													{
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
+													},
+													{
+														Name:  "DYN_NAMESPACE",
+														Value: "dynamo-test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAME",
+														Value: "test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+														Value: "test-namespace",
 													},
 												},
 												Resources: corev1.ResourceRequirements{
@@ -2106,6 +2166,18 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 													{
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
+													},
+													{
+														Name:  "DYN_NAMESPACE",
+														Value: "dynamo-test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAME",
+														Value: "test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+														Value: "test-namespace",
 													},
 												},
 												Resources: corev1.ResourceRequirements{
@@ -2459,6 +2531,18 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
 													},
+													{
+														Name:  "DYN_NAMESPACE",
+														Value: "dynamo-test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAME",
+														Value: "test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+														Value: "test-namespace",
+													},
 												},
 												Resources: corev1.ResourceRequirements{
 													Requests: corev1.ResourceList{
@@ -2582,6 +2666,18 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
 													},
+													{
+														Name:  "DYN_NAMESPACE",
+														Value: "dynamo-test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAME",
+														Value: "test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+														Value: "test-namespace",
+													},
 												},
 												Resources: corev1.ResourceRequirements{
 													Requests: corev1.ResourceList{
@@ -2692,6 +2788,18 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 													{
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
+													},
+													{
+														Name:  "DYN_NAMESPACE",
+														Value: "dynamo-test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAME",
+														Value: "test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+														Value: "test-namespace",
 													},
 												},
 												Resources: corev1.ResourceRequirements{
@@ -2807,6 +2915,18 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 													{
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
+													},
+													{
+														Name:  "DYN_NAMESPACE",
+														Value: "dynamo-test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAME",
+														Value: "test-dynamo-graph-deployment",
+													},
+													{
+														Name:  "DYN_PARENT_DGD_K8S_NAMESPACE",
+														Value: "test-namespace",
 													},
 												},
 												Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
#### Overview:

 inject DGD id in planner env variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Planner pods now include environment variables exposing their parent deployment and namespace (K8S_PARENT_NAME, K8S_PARENT_NAMESPACE) for easier introspection and integration.

* **Tests**
  * Added unit tests validating planner container configuration.
  * Added tests for retrieving parent deployment metadata.
  * Updated existing tests to reflect parameter changes in pod spec generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->