### PR TITLE
chore: update pyo3 version to 0.25

### DIFF
--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -608,7 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
 ]
 
 [[package]]
@@ -1105,12 +1105,14 @@ dependencies = [
 
 [[package]]
 name = "dlpark"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc178fc3bf4ce54c26ccffcf271ff574954ac4b940f15121be3d69f277194537"
+checksum = "66bdac5087071c9178f952a5bcc7a996ff667c1d0c256f23d6512b59fd3dc39d"
 dependencies = [
+ "bitflags 2.9.0",
  "half",
  "pyo3",
+ "snafu",
 ]
 
 [[package]]
@@ -3470,11 +3472,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
- "cfg-if 1.0.0",
  "indoc",
  "libc",
  "memoffset 0.9.1",
@@ -3488,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977dc837525cfd22919ba6a831413854beb7c99a256c03bf8624ad707e45810e"
+checksum = "d73cc6b1b7d8b3cef02101d37390dbdfe7e450dfea14921cae80a9534ba59ef2"
 dependencies = [
  "async-channel",
  "clap",
@@ -3505,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes-macros"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2df2884957d2476731f987673befac5d521dff10abb0a7cbe12015bc7702fe9"
+checksum = "ca31e43a0f205f2960208938135e37e579e61e10b36b4e7f49b0e8f60fab5b83"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3516,19 +3517,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
 dependencies = [
  "once_cell",
- "target-lexicon",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3536,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3548,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3561,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "pythonize"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a6ee7a084f913f98d70cdc3ebec07e852b735ae3059a1500db2661265da9ff"
+checksum = "597907139a488b22573158793aa7539df36ae863eba300c75f3a0d65fc475e27"
 dependencies = [
  "pyo3",
  "serde",
@@ -4315,6 +4316,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "snafu"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4512,6 +4534,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -59,7 +59,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
 # "abi3-py39" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.9
-pyo3 = { version = "0.23.4", default-features = false, features = [
+pyo3 = { version = "0.25.1", default-features = false, features = [
   "macros",
   "experimental-async",
   "experimental-inspect",
@@ -67,14 +67,14 @@ pyo3 = { version = "0.23.4", default-features = false, features = [
   "py-clone",
 ] }
 
-pyo3-async-runtimes = { version = "0.23.0", default-features = false, features = [
+pyo3-async-runtimes = { version = "0.25.0", default-features = false, features = [
   "attributes",
   "testing",
   "tokio-runtime",
   "unstable-streams",
 ] }
 
-pythonize = "0.23"
+pythonize = "0.25"
 
-dlpark = { version = "0.5", features = ["pyo3", "half"], optional = true }
+dlpark = { version = "0.6", features = ["pyo3", "half"], optional = true }
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -850,8 +850,7 @@ impl AsyncResponseStream {
 
                         if annotated {
                             let object = Annotated { inner: pyobj };
-                            #[allow(deprecated)]
-                            let object = Python::with_gil(|py| object.into_py(py));
+                            let object = Python::with_gil(|py| Py::new(py, object).unwrap().into());
                             return Ok(object);
                         } else {
                             match pyobj.data {

--- a/lib/bindings/python/rust/llm/block_manager/dlpack.rs
+++ b/lib/bindings/python/rust/llm/block_manager/dlpack.rs
@@ -19,7 +19,7 @@
 
 use super::*;
 use dlpark::ffi::{DataType, Device, ManagerCtx, ShapeAndStrides, ToTensor};
-use pyo3::{ffi::c_str, types::PyTuple, PyObject, PyResult, Python, IntoPyObjectExt};
+use pyo3::{ffi::c_str, types::PyTuple, IntoPyObjectExt, PyObject, PyResult, Python};
 use std::sync::{Arc, Mutex};
 
 struct DlPackTensor {

--- a/lib/bindings/python/rust/llm/block_manager/dlpack.rs
+++ b/lib/bindings/python/rust/llm/block_manager/dlpack.rs
@@ -18,8 +18,8 @@
 #![allow(deprecated)]
 
 use super::*;
-use dlpark::prelude::{DataType, Device, ManagerCtx, ShapeAndStrides, ToTensor};
-use pyo3::{ffi::c_str, prelude::IntoPy, types::PyTuple, PyObject, PyResult, Python};
+use dlpark::ffi::{DataType, Device, ManagerCtx, ShapeAndStrides, ToTensor};
+use pyo3::{ffi::c_str, types::PyTuple, PyObject, PyResult, Python, IntoPyObjectExt};
 use std::sync::{Arc, Mutex};
 
 struct DlPackTensor {
@@ -102,7 +102,7 @@ pub fn dlpack<'py>(
         dtype: dtype,
         device_id: device_id,
     });
-    let py_capsule = manager_ctx.into_py(py);
+    let py_capsule = manager_ctx.into_pyobject(py).unwrap();
     Ok(py_capsule)
 }
 
@@ -123,7 +123,7 @@ pub fn dlpack_device<'py>(
         block::BlockType::Pinned(_) => dev_type_enum.getattr("CPU_PINNED").unwrap(),
         block::BlockType::Device(_) => dev_type_enum.getattr("CUDA").unwrap(),
     };
-    let dev_id = device_id.into_py(py).into_bound(py);
+    let dev_id = device_id.into_pyobject(py).unwrap().into_bound(py);
     let dev = vec![dev_type, dev_id];
     PyTuple::new(py, dev)
 }


### PR DESCRIPTION
#### Overview:

Update py03 version to latest.

Fix compile error as part of upgrade
```
error[E0599]: no method named `into_py` found for struct `Annotated` in the current scope
   --> rust/lib.rs:854:71
    |
854 |                             let object = Python::with_gil(|py| object.into_py(py));
    |                                                                       ^^^^^^^
...
871 | struct Annotated {
    | ---------------- method `into_py` not found for this struct
    |
help: there is a method `into` with a similar name, but with different arguments
   --> /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/convert/mod.rs:451:5

For more information about this error, try `rustc --explain E0599`.
```

closes: OPS-652