### PR TITLE
chore(sglang): Warn if --skip-tokenizer-init missing

### DIFF
--- a/components/backends/sglang/src/dynamo/sglang/common/sgl_utils.py
+++ b/components/backends/sglang/src/dynamo/sglang/common/sgl_utils.py
@@ -22,7 +22,19 @@ from argparse import Namespace
 from sglang.srt.server_args import ServerArgs
 
 
+class SkipTokenizerInitError(RuntimeError):
+    def __str__(self):
+        return "--skip-tokenizer-init flag is required"
+
+
 def parse_sglang_args_inc(args: list[str]) -> ServerArgs:
+    # Currently we only support Dynamo doing the tokenization, so we must give
+    # sglang the skip-tokenizer-init flag. We don't default it because this is temporary.
+    # Allow the --version and --help flags through.
+    temp_need_tok = ["--skip-tokenizer-init", "--version", "--help"]
+    if not any(w in args for w in temp_need_tok):
+        raise SkipTokenizerInitError()
+
     parser = argparse.ArgumentParser()
     bootstrap_port = _reserve_disaggregation_bootstrap_port()
     ServerArgs.add_cli_args(parser)

--- a/components/backends/sglang/src/dynamo/sglang/common/sgl_utils.py
+++ b/components/backends/sglang/src/dynamo/sglang/common/sgl_utils.py
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 import argparse
 import contextlib
@@ -23,15 +11,15 @@ from sglang.srt.server_args import ServerArgs
 
 
 class SkipTokenizerInitError(RuntimeError):
-    def __str__(self):
-        return "--skip-tokenizer-init flag is required"
+    def __init__(self):
+        super().__init__("--skip-tokenizer-init flag is required")
 
 
 def parse_sglang_args_inc(args: list[str]) -> ServerArgs:
     # Currently we only support Dynamo doing the tokenization, so we must give
     # sglang the skip-tokenizer-init flag. We don't default it because this is temporary.
     # Allow the --version and --help flags through.
-    temp_need_tok = ["--skip-tokenizer-init", "--version", "--help"]
+    temp_need_tok = ["--skip-tokenizer-init", "--version", "--help", "-h"]
     if not any(w in args for w in temp_need_tok):
         raise SkipTokenizerInitError()
 


### PR DESCRIPTION
Currently we only support Dynamo doing the tokenization, so we must give sglang the `--skip-tokenizer-init` flag. We don't default it because this is temporary.

In the near future we can use the presence of that flag do decide wether to `register_llm` as `ModelType.Backend` or `ModelType.Chat`, and whether to look for `output_ids` or `text` in sglang's response.