### PR TITLE
fix: revert registering runtime config for trtllm backend (deadlock)

### DIFF
--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -229,9 +229,6 @@ async def init(runtime: DistributedRuntime, config: Config):
         endpoint = component.endpoint(config.endpoint)
 
         if is_first_worker(config):
-            # Get runtime configuration from the engine
-            runtime_config = await get_engine_runtime_config(engine, config)
-
             # Register the model with runtime config
             await register_llm(
                 modelType,
@@ -240,7 +237,6 @@ async def init(runtime: DistributedRuntime, config: Config):
                 config.served_model_name,
                 kv_cache_block_size=config.kv_block_size,
                 migration_limit=config.migration_limit,
-                runtime_config=runtime_config,  # Add runtime config here
             )
         # publisher will be set later if publishing is enabled.
         handler_config = RequestHandlerConfig(


### PR DESCRIPTION
#### Overview:

...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the first-worker initialization flow by removing dependency on engine-derived runtime configuration during registration.
  * Maintains existing behavior for endpoint resolution, model path handling, cache settings, and subsequent setup steps.
  * No changes to public interfaces or user-facing functionality.
  * Aims to reduce complexity in startup logic without impacting performance or stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->