### PR TITLE
chore: enable tool call array parsing

### DIFF
--- a/lib/llm/src/postprocessor/tool_calling/json_parser.rs
+++ b/lib/llm/src/postprocessor/tool_calling/json_parser.rs
@@ -95,7 +95,7 @@ fn extract_tool_call_content<'a>(
 pub fn try_tool_call_parse_json(
     message: &str,
     config: &JsonParserConfig,
-) -> anyhow::Result<Option<ToolCallResponse>> {
+) -> anyhow::Result<Vec<ToolCallResponse>> {
     // Log the config we are using
     tracing::debug!("Using JSON parser config: {:?}", config);
     let trimmed = message.trim();
@@ -147,19 +147,20 @@ pub fn try_tool_call_parse_json(
     //   }
     // }
     if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(json) {
-        return parse(single.name, single.parameters).map(Some);
+        return Ok(vec![parse(single.name, single.parameters)?]);
+        //parse(single.name, single.parameters).map(Some);
 
-    // CalledFunctionArguments: Single { name, arguments }
-    // Example:
-    // {
-    //   "name": "summarize",
-    //   "arguments": {
-    //     "text": "Rust is a systems programming language.",
-    //     "length": "short"
-    //   }
-    // }
+        // CalledFunctionArguments: Single { name, arguments }
+        // Example:
+        // {
+        //   "name": "summarize",
+        //   "arguments": {
+        //     "text": "Rust is a systems programming language.",
+        //     "length": "short"
+        //   }
+        // }
     } else if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(json) {
-        return parse(single.name, single.arguments).map(Some);
+        return Ok(vec![parse(single.name, single.arguments)?]);
 
     // Vec<CalledFunctionParameters>: List of { name, parameters }
     // Example:
@@ -168,9 +169,13 @@ pub fn try_tool_call_parse_json(
     //   { "name": "send_email", "parameters": { "to": "user@example.com", "subject": "Welcome!" } }
     // ]
     // We pop the last item in the list to use.
-    } else if let Ok(mut list) = serde_json::from_str::<Vec<CalledFunctionParameters>>(json) {
-        if let Some(item) = list.pop() {
-            return parse(item.name, item.parameters).map(Some);
+    } else if let Ok(list) = serde_json::from_str::<Vec<CalledFunctionParameters>>(json) {
+        let mut results = Vec::new();
+        for item in list {
+            results.push(parse(item.name, item.parameters)?);
+        }
+        if !results.is_empty() {
+            return Ok(results);
         }
 
     // Vec<CalledFunctionArguments>: List of { name, arguments }
@@ -185,11 +190,15 @@ pub fn try_tool_call_parse_json(
     //   }
     // ]
     // Again, we take the last item for processing.
-    } else if let Ok(mut list) = serde_json::from_str::<Vec<CalledFunctionArguments>>(json) {
-        if let Some(item) = list.pop() {
-            return parse(item.name, item.arguments).map(Some);
+    } else if let Ok(list) = serde_json::from_str::<Vec<CalledFunctionArguments>>(json) {
+        let mut results = Vec::new();
+        for item in list {
+            results.push(parse(item.name, item.arguments)?);
+        }
+        if !results.is_empty() {
+            return Ok(results);
         }
     }
 
-    Ok(None)
+    Ok(vec![])
 }

--- a/lib/llm/src/postprocessor/tool_calling/json_parser.rs
+++ b/lib/llm/src/postprocessor/tool_calling/json_parser.rs
@@ -174,9 +174,7 @@ pub fn try_tool_call_parse_json(
         for item in list {
             results.push(parse(item.name, item.parameters)?);
         }
-        if !results.is_empty() {
-            return Ok(results);
-        }
+        return Ok(results);
 
     // Vec<CalledFunctionArguments>: List of { name, arguments }
     // Example:
@@ -195,9 +193,7 @@ pub fn try_tool_call_parse_json(
         for item in list {
             results.push(parse(item.name, item.arguments)?);
         }
-        if !results.is_empty() {
-            return Ok(results);
-        }
+        return Ok(results);
     }
 
     Ok(vec![])

--- a/lib/llm/src/postprocessor/tool_calling/tools.rs
+++ b/lib/llm/src/postprocessor/tool_calling/tools.rs
@@ -16,11 +16,13 @@ pub fn try_tool_call_parse_aggregate(
     parser_str: Option<&str>,
 ) -> anyhow::Result<Vec<async_openai::types::ChatCompletionMessageToolCall>> {
     let parsed = detect_and_parse_tool_call(message, parser_str)?;
-    if !parsed.is_empty() {
-        Ok(parsed
-            .into_iter()
-            .map(
-                |parsed| async_openai::types::ChatCompletionMessageToolCall {
+    if parsed.is_empty() {
+        return Ok(vec![]);
+    }
+    Ok(parsed
+        .into_iter()
+        .map(
+            |parsed| async_openai::types::ChatCompletionMessageToolCall {
                     id: parsed.id,
                     r#type: async_openai::types::ChatCompletionToolType::Function,
                     function: async_openai::types::FunctionCall {
@@ -30,9 +32,6 @@ pub fn try_tool_call_parse_aggregate(
                 },
             )
             .collect())
-    } else {
-        Ok(vec![])
-    }
 }
 
 /// Try parsing a string as a structured tool call, for streaming (delta) usage.
@@ -43,8 +42,10 @@ pub fn try_tool_call_parse_stream(
     parser_str: Option<&str>,
 ) -> anyhow::Result<Vec<async_openai::types::ChatCompletionMessageToolCallChunk>> {
     let parsed = detect_and_parse_tool_call(message, parser_str)?;
-    if !parsed.is_empty() {
-        Ok(parsed
+    if parsed.is_empty() {
+        return Ok(vec![]);
+    }
+    Ok(parsed
             .into_iter()
             .enumerate()
             .map(
@@ -58,9 +59,7 @@ pub fn try_tool_call_parse_stream(
                     }),
                     // Add other fields as needed if required by the struct definition
                 },
-            )
-            .collect())
-    } else {
-        Ok(vec![])
-    }
+        )
+        .collect(),
+    )
 }

--- a/lib/llm/src/postprocessor/tool_calling/tools.rs
+++ b/lib/llm/src/postprocessor/tool_calling/tools.rs
@@ -23,15 +23,15 @@ pub fn try_tool_call_parse_aggregate(
         .into_iter()
         .map(
             |parsed| async_openai::types::ChatCompletionMessageToolCall {
-                    id: parsed.id,
-                    r#type: async_openai::types::ChatCompletionToolType::Function,
-                    function: async_openai::types::FunctionCall {
-                        name: parsed.function.name,
-                        arguments: parsed.function.arguments,
-                    },
+                id: parsed.id,
+                r#type: async_openai::types::ChatCompletionToolType::Function,
+                function: async_openai::types::FunctionCall {
+                    name: parsed.function.name,
+                    arguments: parsed.function.arguments,
                 },
-            )
-            .collect())
+            },
+        )
+        .collect())
 }
 
 /// Try parsing a string as a structured tool call, for streaming (delta) usage.
@@ -46,20 +46,19 @@ pub fn try_tool_call_parse_stream(
         return Ok(vec![]);
     }
     Ok(parsed
-            .into_iter()
-            .enumerate()
-            .map(
-                |(idx, parsed)| async_openai::types::ChatCompletionMessageToolCallChunk {
-                    index: idx as u32,
-                    id: Some(parsed.id),
-                    r#type: Some(async_openai::types::ChatCompletionToolType::Function),
-                    function: Some(async_openai::types::FunctionCallStream {
-                        name: Some(parsed.function.name),
-                        arguments: Some(parsed.function.arguments),
-                    }),
-                    // Add other fields as needed if required by the struct definition
-                },
+        .into_iter()
+        .enumerate()
+        .map(
+            |(idx, parsed)| async_openai::types::ChatCompletionMessageToolCallChunk {
+                index: idx as u32,
+                id: Some(parsed.id),
+                r#type: Some(async_openai::types::ChatCompletionToolType::Function),
+                function: Some(async_openai::types::FunctionCallStream {
+                    name: Some(parsed.function.name),
+                    arguments: Some(parsed.function.arguments),
+                }),
+                // Add other fields as needed if required by the struct definition
+            },
         )
-        .collect(),
-    )
+        .collect())
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -169,19 +169,20 @@ impl DeltaAggregator {
                         None,
                     )
                 {
-                    if !tool_calls.is_empty() {
-                        for tool_call in &tool_calls {
-                            tracing::debug!(
-                                tool_call_id = %tool_call.id,
-                                function_name = %tool_call.function.name,
-                                arguments = %tool_call.function.arguments,
-                                "Parsed structured tool call from aggregated content"
-                            );
-                        }
-                        choice.tool_calls = Some(tool_calls);
-                        choice.text.clear();
-                        choice.finish_reason = Some(async_openai::types::FinishReason::ToolCalls);
+                    if tool_calls.is_empty() {
+                        continue;
                     }
+                    for tool_call in &tool_calls {
+                        tracing::debug!(
+                            tool_call_id = %tool_call.id,
+                            function_name = %tool_call.function.name,
+                            arguments = %tool_call.function.arguments,
+                            "Parsed structured tool call from aggregated content"
+                        );
+                    }
+                    choice.tool_calls = Some(tool_calls);
+                    choice.text.clear();
+                    choice.finish_reason = Some(async_openai::types::FinishReason::ToolCalls);
                 }
             }
         }
@@ -490,5 +491,68 @@ mod tests {
             Some(async_openai::types::FinishReason::Stop)
         );
         assert_eq!(choice1.message.role, async_openai::types::Role::Assistant);
+    }
+
+    #[tokio::test]
+    async fn test_tool_calling_output() {
+
+        // Simulate a delta with a tool call in the content
+        let tool_call_json = r#"{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}"#;
+
+        // Use create_test_delta to generate the annotated delta, then extract the inner delta for the test
+        let annotated_delta = create_test_delta(
+            0,
+            tool_call_json,
+            Some(async_openai::types::Role::Assistant),
+            Some(async_openai::types::FinishReason::ToolCalls),
+        );
+        let delta = annotated_delta.data.unwrap().inner;
+
+        let data = NvCreateChatCompletionStreamResponse { inner: delta };
+
+        // Wrap it in Annotated and create a stream
+        let annotated_delta = Annotated {
+            data: Some(data),
+            id: Some("test_id".to_string()),
+            event: None,
+            comment: None,
+        };
+        let stream = Box::pin(stream::iter(vec![annotated_delta]));
+
+        // Call DeltaAggregator::apply
+        let result = DeltaAggregator::apply(stream).await;
+
+        // Check the result
+        assert!(result.is_ok());
+        let response = result.unwrap();
+
+        // There should be one choice
+        assert_eq!(response.inner.choices.len(), 1);
+        let choice = &response.inner.choices[0];
+
+        // The tool_calls field should be present and parsed
+        assert!(choice.message.tool_calls.is_some());
+        let tool_calls = choice.message.tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+
+        let tool_call = &tool_calls[0];
+        assert_eq!(tool_call.function.name, "get_weather");
+        // The arguments should be a JSON string containing the expected keys
+        let args: serde_json::Value = serde_json::from_str(&tool_call.function.arguments).unwrap();
+        assert_eq!(args["location"], "San Francisco, CA");
+        assert_eq!(args["unit"], "fahrenheit");
+
+        // The content should be cleared (None) after tool call parsing
+        assert!(choice.message.content.is_none());
+
+        // The finish_reason should be ToolCalls
+        assert_eq!(
+            choice.finish_reason,
+            Some(async_openai::types::FinishReason::ToolCalls)
+        );
+        assert_eq!(
+            choice.message.role,
+            async_openai::types::Role::Assistant
+        );
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -495,7 +495,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_tool_calling_output() {
-
         // Simulate a delta with a tool call in the content
         let tool_call_json = r#"{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}"#;
 
@@ -550,9 +549,6 @@ mod tests {
             choice.finish_reason,
             Some(async_openai::types::FinishReason::ToolCalls)
         );
-        assert_eq!(
-            choice.message.role,
-            async_openai::types::Role::Assistant
-        );
+        assert_eq!(choice.message.role, async_openai::types::Role::Assistant);
     }
 }


### PR DESCRIPTION
#### Overview:

This PR enables parsing of multiple tool calls present inside an array structure. 

#### Details:

```
r#"<think>
Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me check the tools available.
</think>

<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}, {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}]</TOOLCALL>"#;
```

Currently for these kind of tool calls only last one was considered. This PR enables parsing of multiple tool calls present in an array structure and enables end to end.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
