### PR TITLE
fix: Fix docker-compose.yml Path in Example README

### DIFF
--- a/examples/basics/quickstart/README.md
+++ b/examples/basics/quickstart/README.md
@@ -12,7 +12,7 @@ Before running this example, ensure you have the following services running:
 You can start these services using Docker Compose:
 
 ```bash
-docker compose -f deploy/metrics/docker-compose.yml up -d
+docker compose -f deploy/docker-compose.yml up -d
 ```
 
 ## Components


### PR DESCRIPTION
#### Overview:

`deploy/metrics/docker-compose.yml` doesn't exist. I'm guessing it's supposed to be `deploy/docker-compose.yml`.

#### Details:

Fixed the path to `docker-compose.yml` (`deploy/metrics/docker-compose.yml` -> `deploy/docker-compose.yml`).

#### Where should the reviewer start?

Check the fixed path is correct.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Quickstart guide to reference the correct Docker Compose file for starting services, replacing an outdated path.
  * Clarifies setup steps and reduces confusion during local deployment by pointing to the primary compose configuration.
  * Improves onboarding accuracy with consistent instructions across the guide.
  * No changes to application features or runtime behavior; this update is documentation-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->