### PR TITLE
feat: dynamo namespace isolation for backend component

### DIFF
--- a/components/backends/mocker/src/dynamo/mocker/main.py
+++ b/components/backends/mocker/src/dynamo/mocker/main.py
@@ -4,6 +4,7 @@
 # Usage: `python -m dynamo.mocker --model-path /data/models/Qwen3-0.6B-Q8_0.gguf --extra-engine-args args.json`
 
 import argparse
+import os
 from pathlib import Path
 
 import uvloop
@@ -14,7 +15,8 @@ from dynamo.runtime.logging import configure_dynamo_logging
 
 from . import __version__
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
+DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
 
 configure_dynamo_logging()
 

--- a/components/backends/sglang/src/dynamo/sglang/args.py
+++ b/components/backends/sglang/src/dynamo/sglang/args.py
@@ -115,7 +115,7 @@ def parse_args(args: list[str]) -> Config:
     # Dynamo argument processing
     # If an endpoint is provided, validate and use it
     # otherwise fall back to default endpoints
-    namespace = os.environ.get("DYNAMO_NAMESPACE", "dynamo")
+    namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
 
     endpoint = parsed_args.endpoint
     if endpoint is None:

--- a/components/backends/sglang/src/dynamo/sglang/utils/clear_namespace.py
+++ b/components/backends/sglang/src/dynamo/sglang/utils/clear_namespace.py
@@ -4,6 +4,7 @@
 import argparse
 import asyncio
 import logging
+import os
 
 from dynamo.runtime import DistributedRuntime, EtcdKvCache, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -24,6 +25,11 @@ async def clear_namespace(runtime: DistributedRuntime, namespace: str):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--namespace", type=str, required=True)
+    parser.add_argument(
+        "--namespace", type=str, required=False, default=os.environ.get("DYN_NAMESPACE")
+    )
     args = parser.parse_args()
+    assert (
+        args.namespace
+    ), "Missing namespace, either pass --namespace or set DYN_NAMESPACE"
     asyncio.run(clear_namespace(args.namespace))

--- a/components/backends/vllm/README.md
+++ b/components/backends/vllm/README.md
@@ -159,7 +159,6 @@ For complete Kubernetes deployment instructions, configurations, and troubleshoo
 
 vLLM workers are configured through command-line arguments. Key parameters include:
 
-- `--endpoint`: Dynamo endpoint in format `dyn://namespace.component.endpoint`
 - `--model`: Model to serve (e.g., `Qwen/Qwen3-0.6B`)
 - `--is-prefill-worker`: Enable prefill-only mode for disaggregated serving
 - `--metrics-endpoint-port`: Port for publishing KV metrics to Dynamo

--- a/components/backends/vllm/deploy/README.md
+++ b/components/backends/vllm/deploy/README.md
@@ -186,7 +186,6 @@ spec:
 
 vLLM workers are configured through command-line arguments. Key parameters include:
 
-- `--endpoint`: Dynamo endpoint in format `dyn://namespace.component.endpoint`
 - `--model`: Model to serve (e.g., `Qwen/Qwen3-0.6B`)
 - `--is-prefill-worker`: Enable prefill-only mode for disaggregated serving
 - `--metrics-endpoint-port`: Port for publishing KV metrics to Dynamo

--- a/components/backends/vllm/src/dynamo/vllm/args.py
+++ b/components/backends/vllm/src/dynamo/vllm/args.py
@@ -4,7 +4,6 @@
 
 import logging
 import os
-import sys
 from typing import Optional
 
 from vllm.config import KVTransferConfig
@@ -29,7 +28,6 @@ from .ports import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
 DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
 
 VALID_CONNECTORS = {"nixl", "lmcache", "kvbm", "null", "none"}
@@ -71,12 +69,6 @@ def parse_args() -> Config:
     )
     parser.add_argument(
         "--version", action="version", version=f"Dynamo Backend VLLM {__version__}"
-    )
-    parser.add_argument(
-        "--endpoint",
-        type=str,
-        default=DEFAULT_ENDPOINT,
-        help=f"Dynamo endpoint string in 'dyn://namespace.component.endpoint' format. Default: {DEFAULT_ENDPOINT}",
     )
     parser.add_argument(
         "--is-prefill-worker",
@@ -145,27 +137,9 @@ def parse_args() -> Config:
         # This becomes an `Option` on the Rust side
         config.served_model_name = None
 
-    namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
-
-    if args.is_prefill_worker:
-        args.endpoint = f"dyn://{namespace}.prefill.generate"
-    else:
-        # For decode workers, also use the provided namespace instead of hardcoded "dynamo"
-        args.endpoint = f"dyn://{namespace}.backend.generate"
-
-    endpoint_str = args.endpoint.replace("dyn://", "", 1)
-    endpoint_parts = endpoint_str.split(".")
-    if len(endpoint_parts) != 3:
-        logger.error(
-            f"Invalid endpoint format: '{args.endpoint}'. Expected 'dyn://namespace.component.endpoint' or 'namespace.component.endpoint'."
-        )
-        sys.exit(1)
-
-    parsed_namespace, parsed_component_name, parsed_endpoint_name = endpoint_parts
-
-    config.namespace = parsed_namespace
-    config.component = parsed_component_name
-    config.endpoint = parsed_endpoint_name
+    config.namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
+    config.component = "prefill" if args.is_prefill_worker else "backend"
+    config.endpoint = "generate"
     config.engine_args = engine_args
     config.is_prefill_worker = args.is_prefill_worker
     config.migration_limit = args.migration_limit


### PR DESCRIPTION
#### Overview:
dynamo namespace scoping for backend components

closes: [DYN-838](https://linear.app/nvidia-dynamo/issue/DYN-838)

Supports scoping backend to a specific dynamo namespace based on env variable  `DYN_NAMESPACE`
- Now [operator auto-injects this env var ](https://github.com/ai-dynamo/dynamo/pull/2460/files#diff-e8978ea112461ffbdbb5bf4a4f5c5a11d8f4056d7c5f14049813d3b327e07cb5R66)as part of https://github.com/ai-dynamo/dynamo/pull/2460


[NOTE] Merge after related PR for frontend: https://github.com/ai-dynamo/dynamo/pull/2394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Namespace-aware model discovery: filter models by a specific namespace or use global discovery.
  - Frontend now supports setting a namespace via CLI option or environment variable, with clear startup logging indicating discovery mode.

- Documentation
  - Updated vLLM worker documentation to remove an obsolete endpoint flag and clarify remaining CLI options.

- Tests
  - Added integration and unit tests covering namespace filtering, endpoint parsing, and discovery scoping to ensure reliable behavior across scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->