### PR TITLE
docs: add instructions to install uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,11 +257,13 @@ source $HOME/.cargo/env
 
 Follow the instructions in [uv installation](https://docs.astral.sh/uv/#installation) guide to install uv if you don't have `uv` installed. Once uv is installed, create a virtual environment and activate it.
 
+- Install uv
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
-# Install uv
-url -LsSf https://astral.sh/uv/install.sh | sh
 
-# Create a virtual environment
+- Create a virtual environment
+```bash
 uv venv dynamo
 source dynamo/bin/activate
 ```

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ source $HOME/.cargo/env
 
 ## 3. Create a Python virtual env:
 
-Follow the instructions in [uv installation](https://docs.astral.sh/uv/#installation) guide to install uv.
+Follow the instructions in [uv installation](https://docs.astral.sh/uv/#installation) guide to install uv if you don't have `uv` installed. Once uv is installed, create a virtual environment and activate it.
 
 ```
 # Install uv

--- a/README.md
+++ b/README.md
@@ -255,7 +255,13 @@ source $HOME/.cargo/env
 
 ## 3. Create a Python virtual env:
 
+Follow the instructions in [uv installation](https://docs.astral.sh/uv/#installation) guide to install uv.
+
 ```
+# Install uv
+url -LsSf https://astral.sh/uv/install.sh | sh
+
+# Create a virtual environment
 uv venv dynamo
 source dynamo/bin/activate
 ```


### PR DESCRIPTION
#### Overview:

add instructions to install uv




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded setup instructions to include installing uv and creating/activating a “dynamo” Python virtual environment.
  - Added a clear link to the uv installation guide and copy‑pasteable commands for environment setup.
  - Standardized the virtual environment name (“dynamo”) for consistency across the README.
  - Updated both “Create a Python virtual env” sections to reflect the new steps and ensure parity between duplicated instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->