### PR TITLE
  fix: Standardize namespace environment variable to DYN_NAMESPACE

### DIFF
--- a/components/backends/sglang/deploy/disagg_planner.yaml
+++ b/components/backends/sglang/deploy/disagg_planner.yaml
@@ -11,7 +11,7 @@ spec:
   envs:
     - name: DYNAMO_SERVICE_CONFIG
       value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:9090"]}]},{"job_name":"frontend","static_configs":[{"targets":["sglang-disagg-planner-frontend:8000"]}]}]}}'
-    - name: DYNAMO_NAMESPACE
+    - name: DYN_NAMESPACE
       value: "dynamo"
   services:
     Frontend:

--- a/components/backends/sglang/deploy/disagg_planner.yaml
+++ b/components/backends/sglang/deploy/disagg_planner.yaml
@@ -9,7 +9,7 @@ metadata:
     nvidia.com/enable-grove: "false" # temporarily disable grove because current k8s connector does not work with grove
 spec:
   envs:
-    - name: DYNAMO_SERVICE_CONFIG
+    - name: DYN_SERVICE_CONFIG
       value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:9090"]}]},{"job_name":"frontend","static_configs":[{"targets":["sglang-disagg-planner-frontend:8000"]}]}]}}'
     - name: DYN_NAMESPACE
       value: "dynamo"

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -9,9 +9,9 @@ metadata:
     nvidia.com/enable-grove: "false" # temporarily disable grove because current k8s connector does not work with grove
 spec:
   envs:
-    - name: DYNAMO_SERVICE_CONFIG
+    - name: DYN_SERVICE_CONFIG
       value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:9090"]}]},{"job_name":"frontend","static_configs":[{"targets":["vllm-disagg-planner-frontend:8000"]}]}]}}'
-    - name: DYNAMO_PORT
+    - name: DYN_PORT
       value: "8000"
     - name: DYN_NAMESPACE
       value: "vllm-disagg-planner"

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -13,7 +13,7 @@ spec:
       value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:9090"]}]},{"job_name":"frontend","static_configs":[{"targets":["vllm-disagg-planner-frontend:8000"]}]}]}}'
     - name: DYNAMO_PORT
       value: "8000"
-    - name: DYNAMO_NAMESPACE
+    - name: DYN_NAMESPACE
       value: "vllm-disagg-planner"
   services:
     Frontend:

--- a/components/backends/vllm/src/dynamo/vllm/args.py
+++ b/components/backends/vllm/src/dynamo/vllm/args.py
@@ -113,7 +113,7 @@ def parse_args() -> Config:
         # This becomes an `Option` on the Rust side
         config.served_model_name = None
 
-    namespace = os.environ.get("DYNAMO_NAMESPACE", "dynamo")
+    namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
 
     if args.is_prefill_worker:
         args.endpoint = f"dyn://{namespace}.prefill.generate"

--- a/components/planner/src/dynamo/planner/config.py
+++ b/components/planner/src/dynamo/planner/config.py
@@ -25,12 +25,12 @@ class ServiceConfig(dict):
     def _load_from_env(cls):
         """Load config from environment variable"""
         configs = {}
-        env_config = os.environ.get("DYNAMO_SERVICE_CONFIG")
+        env_config = os.environ.get("DYN_SERVICE_CONFIG")
         if env_config:
             try:
                 configs = json.loads(env_config)
             except json.JSONDecodeError:
-                print("Failed to parse DYNAMO_SERVICE_CONFIG")
+                print("Failed to parse DYN_SERVICE_CONFIG")
         return cls(configs)  # Initialize dict subclass with configs
 
     def require(self, service_name, key):

--- a/components/planner/src/dynamo/planner/defaults.py
+++ b/components/planner/src/dynamo/planner/defaults.py
@@ -71,7 +71,7 @@ def _get_default_prometheus_endpoint(port: str, namespace: str):
 
 class SLAPlannerDefaults(BasePlannerDefaults):
     port = os.environ.get("DYNAMO_PORT", "8000")
-    namespace = os.environ.get("DYNAMO_NAMESPACE", "vllm-disagg-planner")
+    namespace = os.environ.get("DYN_NAMESPACE", "vllm-disagg-planner")
     prometheus_endpoint = _get_default_prometheus_endpoint(port, namespace)
     profile_results_dir = "profiling_results"
     isl = 3000  # in number of tokens

--- a/components/planner/src/dynamo/planner/defaults.py
+++ b/components/planner/src/dynamo/planner/defaults.py
@@ -70,7 +70,7 @@ def _get_default_prometheus_endpoint(port: str, namespace: str):
 
 
 class SLAPlannerDefaults(BasePlannerDefaults):
-    port = os.environ.get("DYNAMO_PORT", "8000")
+    port = os.environ.get("DYN_PORT", "8000")
     namespace = os.environ.get("DYN_NAMESPACE", "vllm-disagg-planner")
     prometheus_endpoint = _get_default_prometheus_endpoint(port, namespace)
     profile_results_dir = "profiling_results"

--- a/deploy/cloud/operator/internal/consts/consts.go
+++ b/deploy/cloud/operator/internal/consts/consts.go
@@ -17,7 +17,7 @@ const (
 
 	MpiRunSshPort = 2222
 
-	EnvDynamoServicePort = "DYNAMO_PORT"
+	EnvDynamoServicePort = "DYN_PORT"
 
 	KubeLabelDynamoSelector = "nvidia.com/selector"
 

--- a/deploy/cloud/operator/internal/dynamo/component_frontend.go
+++ b/deploy/cloud/operator/internal/dynamo/component_frontend.go
@@ -56,7 +56,7 @@ func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Co
 				Command: []string{
 					"/bin/sh",
 					"-c",
-					"curl -s http://localhost:${DYNAMO_PORT}/health | jq -e \".status == \\\"healthy\\\"\"",
+					"curl -s http://localhost:${DYN_PORT}/health | jq -e \".status == \\\"healthy\\\"\"",
 				},
 			},
 		},

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -674,7 +674,7 @@ func addStandardEnvVars(container *corev1.Container, controllerConfig controller
 }
 
 // GenerateBasePodSpec creates a basic PodSpec with common logic shared between controller and grove
-// Includes standard environment variables (DYNAMO_PORT, NATS_SERVER, ETCD_ENDPOINTS)
+// Includes standard environment variables (DYN_PORT, NATS_SERVER, ETCD_ENDPOINTS)
 // Deployment-specific environment merging should be handled by the caller
 func GenerateBasePodSpec(
 	component *v1alpha1.DynamoComponentDeploymentOverridesSpec,

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -1059,7 +1059,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 					Spec: v1alpha1.DynamoGraphDeploymentSpec{
 						Envs: []corev1.EnvVar{
 							{
-								Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+								Name:  "DYN_POD_GANG_SET_REPLICAS",
 								Value: "1",
 							},
 						},
@@ -1284,7 +1284,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+														Name:  "DYN_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
 													{
@@ -1292,7 +1292,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 														Value: "1",
 													},
 													{
-														Name:  "DYNAMO_PORT",
+														Name:  "DYN_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoServicePort),
 													},
 													{
@@ -1415,7 +1415,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+														Name:  "DYN_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
 													{
@@ -1494,7 +1494,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 					Spec: v1alpha1.DynamoGraphDeploymentSpec{
 						Envs: []corev1.EnvVar{
 							{
-								Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+								Name:  "DYN_POD_GANG_SET_REPLICAS",
 								Value: "1",
 							},
 						},
@@ -1743,7 +1743,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+														Name:  "DYN_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
 													{
@@ -1890,7 +1890,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+														Name:  "DYN_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
 													{
@@ -2021,7 +2021,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+														Name:  "DYN_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
 													{
@@ -2029,7 +2029,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 														Value: "1",
 													},
 													{
-														Name:  "DYNAMO_PORT",
+														Name:  "DYN_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoServicePort),
 													},
 													{
@@ -2152,7 +2152,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+														Name:  "DYN_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
 													{
@@ -2231,7 +2231,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 					Spec: v1alpha1.DynamoGraphDeploymentSpec{
 						Envs: []corev1.EnvVar{
 							{
-								Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+								Name:  "DYN_POD_GANG_SET_REPLICAS",
 								Value: "1",
 							},
 						},
@@ -2504,7 +2504,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+														Name:  "DYN_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
 													{
@@ -2639,7 +2639,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+														Name:  "DYN_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
 													{
@@ -2770,7 +2770,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+														Name:  "DYN_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
 													{
@@ -2778,7 +2778,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 														Value: "1",
 													},
 													{
-														Name:  "DYNAMO_PORT",
+														Name:  "DYN_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoServicePort),
 													},
 													{
@@ -2901,7 +2901,7 @@ func TestGenerateGrovePodGangSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
+														Name:  "DYN_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
 													{

--- a/deploy/helm/chart/templates/deployment.yaml
+++ b/deploy/helm/chart/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             name: {{ $serviceSpec.envFromSecret }}
         {{- end }}
         env:
-        - name: DYNAMO_PORT
+        - name: DYN_PORT
           value: "{{ $.Values.dynamoPort | default 8000 }}"
         {{- if $.Values.etcdAddr }}
         - name: ETCD_ENDPOINTS

--- a/deploy/helm/chart/templates/grove-podgangset.yaml
+++ b/deploy/helm/chart/templates/grove-podgangset.yaml
@@ -70,7 +70,7 @@ spec:
             {{- $serviceSpec.extraPodSpec.mainContainer.args | toYaml | nindent 14 }}
             {{- end }}
             env:
-            - name: DYNAMO_PORT
+            - name: DYN_PORT
               value: "{{ $.Values.dynamoPort | default 8000 }}"
             {{- if $.Values.etcdAddr }}
             - name: ETCD_ENDPOINTS

--- a/docs/guides/dynamo_deploy/dynamo_operator.md
+++ b/docs/guides/dynamo_deploy/dynamo_operator.md
@@ -178,7 +178,7 @@ kubectl get dynamographdeployment llm-agg -n $NAMESPACE
 | Name                                               | Description                          | Default                                                |
 |----------------------------------------------------|--------------------------------------|--------------------------------------------------------|
 | `LOG_LEVEL`                                        | Logging verbosity level              | `info`                                                 |
-| `DYNAMO_SYSTEM_NAMESPACE`                          | System namespace                     | `dynamo`                                               |
+| `DYN_SYSTEM_NAMESPACE`                          | System namespace                     | `dynamo`                                               |
 
 - **Flags:**
   | Flag                  | Description                                | Default |


### PR DESCRIPTION
#### Overview:

Fixes inconsistency in namespace environment variable usage across components. The K8s operator injects DYN_NAMESPACE for all containers, but some components were still expecting DYNAMO_NAMESPACE.

#### Details:

  - Updated vLLM backend to use DYN_NAMESPACE instead of DYNAMO_NAMESPACE
  - Updated SLA planner defaults to use DYN_NAMESPACE instead of DYNAMO_NAMESPACE
  - Updated deployment YAML files to consistently use DYN_NAMESPACE environment variable

#### Where should the reviewer start?

`components/backends/vllm/src/dynamo/vllm/args.py`
`components/planner/src/dynamo/planner/defaults.py `
`deploy/cloud/operator/internal/dynamo/component_common.go `

#### Related Issues: 

- Addresses GitHub issue: #2477 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized environment variable for namespace from DYNAMO_NAMESPACE to DYN_NAMESPACE across planner and backend deployments.
  - Preserved default values; no behavioral changes for users relying on defaults.
  - Planner and vLLM components now derive endpoints and metrics configuration from the updated variable.

- Migration Notes
  - If you set DYNAMO_NAMESPACE previously, update your environment/configuration to use DYN_NAMESPACE instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->