### PR TITLE
feat: pre-built wheel for vllm image build

### DIFF
--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -150,7 +150,7 @@ else
     uv pip install torch==2.7.1+cu128 torchaudio==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu128
     VLLM_TEMP_DIR=/tmp/vllm/wheel/$VLLM_REF
     mkdir -p $VLLM_TEMP_DIR
-    REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_COMMIT}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     curl -L $REMOTE_WHEEL_URL -o $VLLM_PRECOMPILED_WHEEL_LOCATION
     if [ "$EDITABLE" = "true" ]; then

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -152,7 +152,7 @@ else
     mkdir -p $VLLM_TEMP_DIR
     REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
-    curl -L $REMOTE_WHEEL_URL -o $VLLM_PRECOMPILED_WHEEL_LOCATION
+    curl -fS --retry 3 -L "$REMOTE_WHEEL_URL" -o "$VLLM_PRECOMPILED_WHEEL_LOCATION"
     if [ "$EDITABLE" = "true" ]; then
         VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND
     else

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -147,7 +147,6 @@ if [ "$ARCH" = "arm64" ]; then
     fi
 else
     echo "Installing vllm for AMD64 architecture"
-    uv pip install torch==2.7.1+cu128 torchaudio==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu128
     VLLM_TEMP_DIR=/tmp/vllm/wheel/$VLLM_REF
     mkdir -p $VLLM_TEMP_DIR
     REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
@@ -155,9 +154,9 @@ else
     rm -rf $VLLM_PRECOMPILED_WHEEL_LOCATION || true
     curl -fS --retry 3 -L "$REMOTE_WHEEL_URL" -o "$VLLM_PRECOMPILED_WHEEL_LOCATION"
     if [ "$EDITABLE" = "true" ]; then
-        VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND
+        uv pip install -e . --torch-backend=$TORCH_BACKEND
     else
-        VLLM_USE_PRECOMPILED=1 uv pip install . --torch-backend=$TORCH_BACKEND
+       uv pip install . --torch-backend=$TORCH_BACKEND
     fi
     rm -rf $VLLM_PRECOMPILED_WHEEL_LOCATION
 fi

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -147,11 +147,18 @@ if [ "$ARCH" = "arm64" ]; then
     fi
 else
     echo "Installing vllm for AMD64 architecture"
+    uv pip install torch==2.7.1+cu128 torchaudio==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu128
+    VLLM_TEMP_DIR=/tmp/vllm/wheel/$VLLM_REF
+    mkdir -p $VLLM_TEMP_DIR
+    REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_COMMIT}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    curl -L $REMOTE_WHEEL_URL -o $VLLM_PRECOMPILED_WHEEL_LOCATION
     if [ "$EDITABLE" = "true" ]; then
         VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND
     else
         VLLM_USE_PRECOMPILED=1 uv pip install . --torch-backend=$TORCH_BACKEND
     fi
+    rm -rf $VLLM_PRECOMPILED_WHEEL_LOCATION
 fi
 
 # Install ep_kernels and DeepGEMM

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -152,6 +152,7 @@ else
     mkdir -p $VLLM_TEMP_DIR
     REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    rm -rf $VLLM_PRECOMPILED_WHEEL_LOCATION || true
     curl -fS --retry 3 -L "$REMOTE_WHEEL_URL" -o "$VLLM_PRECOMPILED_WHEEL_LOCATION"
     if [ "$EDITABLE" = "true" ]; then
         VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND


### PR DESCRIPTION
#### Overview:

use commit specific `VLLM_PRECOMPILED_WHEEL_LOCATION` along with `VLLM_PRECOMPILED` 

Successful pipeline: [33422439](https://gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/-/pipelines/33422439)


<img width="1398" height="386" alt="Screenshot 2025-08-17 at 11 00 32 PM" src="https://github.com/user-attachments/assets/de17ecfe-812d-41c9-a248-6f8670200dce" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Use a precompiled vLLM wheel for AMD64 (x86_64) installs for faster setup.
  * Automatically installs compatible PyTorch (CUDA 12.8) on AMD64.
  * Introduces an environment variable to point to a custom precompiled wheel.
* Chores
  * Reduces build time and lowers dependency requirements by avoiding source builds.
  * Cleans up the downloaded wheel after installation.
  * ARM64 installation path remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->