### PR TITLE
feat: update NIXL version in vLLM to use  nixl threadpool support

### DIFF
--- a/container/deps/trtllm/install_nixl.sh
+++ b/container/deps/trtllm/install_nixl.sh
@@ -23,11 +23,11 @@ set -ex
 
 GITHUB_URL="https://github.com"
 
-UCX_VERSION="v1.18.1"
+UCX_VERSION="v1.19.0"
 UCX_INSTALL_PATH="/usr/local/ucx/"
 CUDA_PATH="/usr/local/cuda"
 
-NIXL_COMMIT="16348080f5bdeb9fe6058a23be140cec020ef3f3"
+NIXL_COMMIT="623063c073cd3db4717cb03f891198fb4f728388"
 
 UCX_REPO="https://github.com/openucx/ucx.git"
 NIXL_REPO="https://github.com/ai-dynamo/nixl.git"

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -150,7 +150,7 @@ else
     uv pip install torch==2.7.1+cu128 torchaudio==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu128
     VLLM_TEMP_DIR=/tmp/vllm/wheel/$VLLM_REF
     mkdir -p $VLLM_TEMP_DIR
-    REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_COMMIT}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     curl -L $REMOTE_WHEEL_URL -o $VLLM_PRECOMPILED_WHEEL_LOCATION
     if [ "$EDITABLE" = "true" ]; then

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -152,7 +152,7 @@ else
     mkdir -p $VLLM_TEMP_DIR
     REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
-    curl -L $REMOTE_WHEEL_URL -o $VLLM_PRECOMPILED_WHEEL_LOCATION
+    curl -fS --retry 3 -L "$REMOTE_WHEEL_URL" -o "$VLLM_PRECOMPILED_WHEEL_LOCATION"
     if [ "$EDITABLE" = "true" ]; then
         VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND
     else

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -147,11 +147,18 @@ if [ "$ARCH" = "arm64" ]; then
     fi
 else
     echo "Installing vllm for AMD64 architecture"
+    uv pip install torch==2.7.1+cu128 torchaudio==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu128
+    VLLM_TEMP_DIR=/tmp/vllm/wheel/$VLLM_REF
+    mkdir -p $VLLM_TEMP_DIR
+    REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_COMMIT}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    curl -L $REMOTE_WHEEL_URL -o $VLLM_PRECOMPILED_WHEEL_LOCATION
     if [ "$EDITABLE" = "true" ]; then
         VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND
     else
         VLLM_USE_PRECOMPILED=1 uv pip install . --torch-backend=$TORCH_BACKEND
     fi
+    rm -rf $VLLM_PRECOMPILED_WHEEL_LOCATION
 fi
 
 # Install ep_kernels and DeepGEMM

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -152,6 +152,7 @@ else
     mkdir -p $VLLM_TEMP_DIR
     REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    rm -rf $VLLM_PRECOMPILED_WHEEL_LOCATION || true
     curl -fS --retry 3 -L "$REMOTE_WHEEL_URL" -o "$VLLM_PRECOMPILED_WHEEL_LOCATION"
     if [ "$EDITABLE" = "true" ]; then
         VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND


### PR DESCRIPTION
#### Overview:

Update vLLM to use to latest 
* NIXL version `623063c07`  with threadpool support
* Updated UCX to v1.19.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On AMD64, installation now uses a precompiled vLLM wheel, reducing build time and improving reliability.
  * Pins the PyTorch stack to torch 2.7.1+cu128, torchaudio 2.7.1, and torchvision 0.22.1 for consistency.

* **Chores**
  * Updated UCX to v1.19.0.
  * Refreshed internal dependency revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->