### PR TITLE
chore: updating to use pinned precompiled version

### DIFF
--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -147,10 +147,13 @@ if [ "$ARCH" = "arm64" ]; then
     fi
 else
     echo "Installing vllm for AMD64 architecture"
+
+    export VLLM_PRECOMPILED_WHEEL_LOCATION=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+
     if [ "$EDITABLE" = "true" ]; then
-        VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND
+	uv pip install -e . --torch-backend=$TORCH_BACKEND
     else
-        VLLM_USE_PRECOMPILED=1 uv pip install . --torch-backend=$TORCH_BACKEND
+        uv pip install . --torch-backend=$TORCH_BACKEND
     fi
 fi
 

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -149,7 +149,7 @@ else
     echo "Installing vllm for AMD64 architecture"
 
     echo "Attempting to install pinned OpenAI version..."
-    if ! uv pip install  openai==1.99.9 then
+    if ! uv pip install  openai==1.99.9; then
         echo "Pinned versions failed"
         exit 1
     fi

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -148,6 +148,12 @@ if [ "$ARCH" = "arm64" ]; then
 else
     echo "Installing vllm for AMD64 architecture"
 
+    echo "Attempting to install pinned OpenAI version..."
+    if ! uv pip install  openai==1.99.9 then
+        echo "Pinned versions failed"
+        exit 1
+    fi
+
     export VLLM_PRECOMPILED_WHEEL_LOCATION=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
 
     if [ "$EDITABLE" = "true" ]; then


### PR DESCRIPTION
#### Overview:

Pins the precompile version for vllm to the same as used for source installation.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Simplified the AMD64 installation flow by removing conditional branches and using direct install commands for both editable and standard setups.
  - Reduced complexity in dependency installation, leading to more predictable and consistent installs on AMD64.
  - No changes to the ARM64 installation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->