### PR TITLE
feat: dynamo namespace isolation for backend component + vllm-fix

### DIFF
--- a/components/backends/mocker/src/dynamo/mocker/main.py
+++ b/components/backends/mocker/src/dynamo/mocker/main.py
@@ -4,6 +4,7 @@
 # Usage: `python -m dynamo.mocker --model-path /data/models/Qwen3-0.6B-Q8_0.gguf --extra-engine-args args.json`
 
 import argparse
+import os
 from pathlib import Path
 
 import uvloop
@@ -14,7 +15,8 @@ from dynamo.runtime.logging import configure_dynamo_logging
 
 from . import __version__
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
+DYNAMO_NAMESPACE = os.environ.get("DYN_NAMESPACE", "global")
+DEFAULT_ENDPOINT = f"dyn://{DYNAMO_NAMESPACE}.backend.generate"
 
 configure_dynamo_logging()
 

--- a/components/backends/mocker/src/dynamo/mocker/main.py
+++ b/components/backends/mocker/src/dynamo/mocker/main.py
@@ -15,8 +15,8 @@ from dynamo.runtime.logging import configure_dynamo_logging
 
 from . import __version__
 
-DYNAMO_NAMESPACE = os.environ.get("DYN_NAMESPACE", "global")
-DEFAULT_ENDPOINT = f"dyn://{DYNAMO_NAMESPACE}.backend.generate"
+DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "global")
+DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
 
 configure_dynamo_logging()
 

--- a/components/backends/sglang/deploy/agg.yaml
+++ b/components/backends/sglang/deploy/agg.yaml
@@ -24,7 +24,7 @@ spec:
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:
-            - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-agg && python3 -m dynamo.frontend --http-port=8000"
+            - "python3 -m dynamo.sglang.utils.clear_namespace && python3 -m dynamo.frontend --http-port=8000"
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg

--- a/components/backends/sglang/deploy/agg_router.yaml
+++ b/components/backends/sglang/deploy/agg_router.yaml
@@ -24,7 +24,7 @@ spec:
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:
-            - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-agg-router && python3 -m dynamo.frontend --http-port=8000  --router-mode kv"
+            - "python3 -m dynamo.sglang.utils.clear_namespace && python3 -m dynamo.frontend --http-port=8000  --router-mode kv"
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg-router

--- a/components/backends/sglang/deploy/disagg-multinode.yaml
+++ b/components/backends/sglang/deploy/disagg-multinode.yaml
@@ -26,7 +26,7 @@ spec:
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:
-            - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-disagg-multinode && python3 -m dynamo.frontend --http-port=8000"
+            - "python3 -m dynamo.sglang.utils.clear_namespace && python3 -m dynamo.frontend --http-port=8000"
     decode:
       multinode:
         nodeCount: 2

--- a/components/backends/sglang/deploy/disagg.yaml
+++ b/components/backends/sglang/deploy/disagg.yaml
@@ -24,7 +24,7 @@ spec:
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:
-            - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-disagg && python3 -m dynamo.frontend --http-port=8000"
+            - "python3 -m dynamo.sglang.utils.clear_namespace && python3 -m dynamo.frontend --http-port=8000"
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg

--- a/components/backends/sglang/deploy/disagg_planner.yaml
+++ b/components/backends/sglang/deploy/disagg_planner.yaml
@@ -31,7 +31,7 @@ spec:
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:
-            - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-disagg && python3 -m dynamo.frontend --http-port=8000"
+            - "python3 -m dynamo.sglang.utils.clear_namespace && python3 -m dynamo.frontend --http-port=8000"
     Planner:
       dynamoNamespace: dynamo
       envFromSecret: hf-token-secret

--- a/components/backends/sglang/src/dynamo/sglang/common/__init__.py
+++ b/components/backends/sglang/src/dynamo/sglang/common/__init__.py
@@ -15,6 +15,7 @@ from .protocol import (
 
 # Utilities
 from .sgl_utils import (
+    get_dynamo_namespace,
     graceful_shutdown,
     parse_sglang_args_inc,
     reserve_free_port,
@@ -33,6 +34,7 @@ __all__ = [
     "reserve_free_port",
     "graceful_shutdown",
     "setup_native_endpoints",
+    "get_dynamo_namespace",
     # Base handlers
     "BaseWorkerHandler",
 ]

--- a/components/backends/sglang/src/dynamo/sglang/common/sgl_utils.py
+++ b/components/backends/sglang/src/dynamo/sglang/common/sgl_utils.py
@@ -4,6 +4,7 @@
 import argparse
 import contextlib
 import logging
+import os
 import socket
 from argparse import Namespace
 
@@ -100,3 +101,7 @@ def setup_native_endpoints(server_args, component, handler):
         )
 
     return tasks
+
+
+def get_dynamo_namespace():
+    return os.environ.get("DYN_NAMESPACE", "global")

--- a/components/backends/sglang/src/dynamo/sglang/decode_worker/main.py
+++ b/components/backends/sglang/src/dynamo/sglang/decode_worker/main.py
@@ -17,6 +17,7 @@ from dynamo.runtime import DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sglang.common import (
     BaseWorkerHandler,
+    get_dynamo_namespace,
     graceful_shutdown,
     parse_sglang_args_inc,
     setup_native_endpoints,
@@ -68,10 +69,9 @@ async def worker(runtime: DistributedRuntime):
 
 async def init(runtime: DistributedRuntime, server_args: ServerArgs):
     """Initialize decode worker"""
-
     engine = sgl.Engine(server_args=server_args)
 
-    component = runtime.namespace("dynamo").component("decode")
+    component = runtime.namespace(get_dynamo_namespace()).component("decode")
     await component.create_service()
 
     handler = DecodeRequestHandler(engine, server_args, component)

--- a/components/backends/sglang/src/dynamo/sglang/utils/clear_namespace.py
+++ b/components/backends/sglang/src/dynamo/sglang/utils/clear_namespace.py
@@ -18,6 +18,7 @@
 import argparse
 import asyncio
 import logging
+import os
 
 from dynamo.runtime import DistributedRuntime, EtcdKvCache, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -39,6 +40,11 @@ async def clear_namespace(runtime: DistributedRuntime, namespace: str):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--namespace", type=str, required=True)
+    parser.add_argument("--namespace", type=str, required=False, default=None)
     args = parser.parse_args()
+    if not args.namespace:
+        args.namespace = os.environ.get("DYN_NAMESPACE")
+    assert (
+        args.namespace
+    ), "Missing namespace, either pass --namespace or set DYN_NAMESPACE"
     asyncio.run(clear_namespace(args.namespace))

--- a/components/backends/sglang/src/dynamo/sglang/worker/main.py
+++ b/components/backends/sglang/src/dynamo/sglang/worker/main.py
@@ -33,6 +33,7 @@ from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sglang.common import (
     BaseWorkerHandler,
     DisaggPreprocessedRequest,
+    get_dynamo_namespace,
     graceful_shutdown,
     parse_sglang_args_inc,
     setup_native_endpoints,
@@ -332,7 +333,9 @@ async def init(
 
     engine = sgl.Engine(server_args=server_args)
 
-    component = runtime.namespace("dynamo").component("worker")
+    dynamo_namespace = get_dynamo_namespace()
+
+    component = runtime.namespace(dynamo_namespace).component("worker")
     await component.create_service()
 
     endpoint = component.endpoint("generate")
@@ -342,7 +345,7 @@ async def init(
 
     if server_args.disaggregation_mode != "null":
         decode_client = (
-            await runtime.namespace("dynamo")
+            await runtime.namespace(dynamo_namespace)
             .component("decode")
             .endpoint("generate")
             .client()

--- a/components/backends/vllm/README.md
+++ b/components/backends/vllm/README.md
@@ -158,7 +158,6 @@ For complete Kubernetes deployment instructions, configurations, and troubleshoo
 
 vLLM workers are configured through command-line arguments. Key parameters include:
 
-- `--endpoint`: Dynamo endpoint in format `dyn://namespace.component.endpoint`
 - `--model`: Model to serve (e.g., `Qwen/Qwen3-0.6B`)
 - `--is-prefill-worker`: Enable prefill-only mode for disaggregated serving
 - `--metrics-endpoint-port`: Port for publishing KV metrics to Dynamo

--- a/components/backends/vllm/deploy/README.md
+++ b/components/backends/vllm/deploy/README.md
@@ -186,7 +186,6 @@ spec:
 
 vLLM workers are configured through command-line arguments. Key parameters include:
 
-- `--endpoint`: Dynamo endpoint in format `dyn://namespace.component.endpoint`
 - `--model`: Model to serve (e.g., `Qwen/Qwen3-0.6B`)
 - `--is-prefill-worker`: Enable prefill-only mode for disaggregated serving
 - `--metrics-endpoint-port`: Port for publishing KV metrics to Dynamo

--- a/components/backends/vllm/src/dynamo/vllm/args.py
+++ b/components/backends/vllm/src/dynamo/vllm/args.py
@@ -4,7 +4,6 @@
 
 import logging
 import os
-import sys
 from typing import Optional
 
 from vllm.config import KVTransferConfig
@@ -27,7 +26,6 @@ from .ports import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
 DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
 
 # Global LMCache configuration - initialize once on module import
@@ -61,12 +59,6 @@ def parse_args() -> Config:
     )
     parser.add_argument(
         "--version", action="version", version=f"Dynamo Backend VLLM {__version__}"
-    )
-    parser.add_argument(
-        "--endpoint",
-        type=str,
-        default=DEFAULT_ENDPOINT,
-        help=f"Dynamo endpoint string in 'dyn://namespace.component.endpoint' format. Default: {DEFAULT_ENDPOINT}",
     )
     parser.add_argument(
         "--is-prefill-worker",
@@ -113,27 +105,9 @@ def parse_args() -> Config:
         # This becomes an `Option` on the Rust side
         config.served_model_name = None
 
-    namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
-
-    if args.is_prefill_worker:
-        args.endpoint = f"dyn://{namespace}.prefill.generate"
-    else:
-        # For decode workers, also use the provided namespace instead of hardcoded "dynamo"
-        args.endpoint = f"dyn://{namespace}.backend.generate"
-
-    endpoint_str = args.endpoint.replace("dyn://", "", 1)
-    endpoint_parts = endpoint_str.split(".")
-    if len(endpoint_parts) != 3:
-        logger.error(
-            f"Invalid endpoint format: '{args.endpoint}'. Expected 'dyn://namespace.component.endpoint' or 'namespace.component.endpoint'."
-        )
-        sys.exit(1)
-
-    parsed_namespace, parsed_component_name, parsed_endpoint_name = endpoint_parts
-
-    config.namespace = parsed_namespace
-    config.component = parsed_component_name
-    config.endpoint = parsed_endpoint_name
+    config.namespace = os.environ.get("DYN_NAMESPACE", "global")
+    config.component = "prefill" if args.is_prefill_worker else "backend"
+    config.endpoint = "generate"
     config.engine_args = engine_args
     config.is_prefill_worker = args.is_prefill_worker
     config.migration_limit = args.migration_limit

--- a/components/backends/vllm/src/dynamo/vllm/args.py
+++ b/components/backends/vllm/src/dynamo/vllm/args.py
@@ -113,7 +113,7 @@ def parse_args() -> Config:
         # This becomes an `Option` on the Rust side
         config.served_model_name = None
 
-    namespace = os.environ.get("DYNAMO_NAMESPACE", "dynamo")
+    namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
 
     if args.is_prefill_worker:
         args.endpoint = f"dyn://{namespace}.prefill.generate"

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -150,7 +150,7 @@ else
     uv pip install torch==2.7.1+cu128 torchaudio==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu128
     VLLM_TEMP_DIR=/tmp/vllm/wheel/$VLLM_REF
     mkdir -p $VLLM_TEMP_DIR
-    REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_COMMIT}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     curl -L $REMOTE_WHEEL_URL -o $VLLM_PRECOMPILED_WHEEL_LOCATION
     if [ "$EDITABLE" = "true" ]; then

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -152,7 +152,7 @@ else
     mkdir -p $VLLM_TEMP_DIR
     REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
-    curl -L $REMOTE_WHEEL_URL -o $VLLM_PRECOMPILED_WHEEL_LOCATION
+    curl -fS --retry 3 -L "$REMOTE_WHEEL_URL" -o "$VLLM_PRECOMPILED_WHEEL_LOCATION"
     if [ "$EDITABLE" = "true" ]; then
         VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND
     else

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -147,11 +147,18 @@ if [ "$ARCH" = "arm64" ]; then
     fi
 else
     echo "Installing vllm for AMD64 architecture"
+    uv pip install torch==2.7.1+cu128 torchaudio==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cu128
+    VLLM_TEMP_DIR=/tmp/vllm/wheel/$VLLM_REF
+    mkdir -p $VLLM_TEMP_DIR
+    REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_COMMIT}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    curl -L $REMOTE_WHEEL_URL -o $VLLM_PRECOMPILED_WHEEL_LOCATION
     if [ "$EDITABLE" = "true" ]; then
         VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND
     else
         VLLM_USE_PRECOMPILED=1 uv pip install . --torch-backend=$TORCH_BACKEND
     fi
+    rm -rf $VLLM_PRECOMPILED_WHEEL_LOCATION
 fi
 
 # Install ep_kernels and DeepGEMM

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -152,6 +152,7 @@ else
     mkdir -p $VLLM_TEMP_DIR
     REMOTE_WHEEL_URL=https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
     export VLLM_PRECOMPILED_WHEEL_LOCATION=$VLLM_TEMP_DIR/vllm-1.0.0.dev-cp38-abi3-manylinux1_x86_64.whl
+    rm -rf $VLLM_PRECOMPILED_WHEEL_LOCATION || true
     curl -fS --retry 3 -L "$REMOTE_WHEEL_URL" -o "$VLLM_PRECOMPILED_WHEEL_LOCATION"
     if [ "$EDITABLE" = "true" ]; then
         VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=$TORCH_BACKEND

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -90,7 +90,7 @@ impl ModelWatcher {
 
     /// Common watch logic with optional namespace filtering
     pub async fn watch(&self, mut events_rx: Receiver<WatchEvent>, target_namespace: Option<&str>) {
-        let global_namespace = target_namespace.map_or(true, is_global_namespace);
+        let global_namespace = target_namespace.is_none_or(is_global_namespace);
 
         while let Some(event) = events_rx.recv().await {
             match event {

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -36,6 +36,7 @@ use crate::{
 };
 
 use super::{ModelEntry, ModelManager, MODEL_ROOT_PATH};
+use crate::namespace::is_global_namespace;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ModelUpdate {
@@ -87,8 +88,9 @@ impl ModelWatcher {
         }
     }
 
-    pub async fn watch(&self, mut events_rx: Receiver<WatchEvent>) {
-        tracing::debug!("model watcher started");
+    /// Common watch logic with optional namespace filtering
+    pub async fn watch(&self, mut events_rx: Receiver<WatchEvent>, target_namespace: Option<&str>) {
+        let global_namespace = target_namespace.map_or(true, is_global_namespace);
 
         while let Some(event) = events_rx.recv().await {
             match event {
@@ -107,6 +109,20 @@ impl ModelWatcher {
                             continue;
                         }
                     };
+
+                    // Filter by namespace if target_namespace is specified
+                    if let Some(target_ns) = target_namespace {
+                        if !global_namespace && model_entry.endpoint.namespace != target_ns {
+                            tracing::debug!(
+                                model_namespace = model_entry.endpoint.namespace,
+                                target_namespace = target_ns,
+                                model_name = model_entry.name,
+                                "Skipping model from different namespace"
+                            );
+                            continue;
+                        }
+                    }
+
                     let key = match kv.key_str() {
                         Ok(k) => k,
                         Err(err) => {
@@ -123,21 +139,30 @@ impl ModelWatcher {
                     }
 
                     if self.manager.has_model_any(&model_entry.name) {
-                        tracing::trace!(name = model_entry.name, "New endpoint for existing model");
+                        tracing::trace!(
+                            name = model_entry.name,
+                            namespace = model_entry.endpoint.namespace,
+                            "New endpoint for existing model"
+                        );
                         self.notify_on_model.notify_waiters();
                         continue;
                     }
 
                     match self.handle_put(&model_entry).await {
                         Ok(()) => {
-                            tracing::info!(model_name = model_entry.name, "added model");
+                            tracing::info!(
+                                model_name = model_entry.name,
+                                namespace = model_entry.endpoint.namespace,
+                                "added model"
+                            );
                             self.notify_on_model.notify_waiters();
                         }
                         Err(err) => {
                             tracing::error!(
                                 error = format!("{err:#}"),
-                                "error adding model {}",
-                                model_entry.name
+                                "error adding model {} from namespace {}",
+                                model_entry.name,
+                                model_entry.endpoint.namespace,
                             );
                         }
                     }

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -77,7 +77,7 @@ pub async fn prepare_engine(
 
             let inner_watch_obj = watch_obj.clone();
             let _watcher_task = tokio::spawn(async move {
-                inner_watch_obj.watch(receiver).await;
+                inner_watch_obj.watch(receiver, None).await;
             });
             tracing::info!("Waiting for remote model..");
 

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -27,6 +27,7 @@ pub mod migration;
 pub mod mocker;
 pub mod model_card;
 pub mod model_type;
+pub mod namespace;
 pub mod perf;
 pub mod postprocessor;
 pub mod preprocessor;

--- a/lib/llm/src/namespace.rs
+++ b/lib/llm/src/namespace.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// The global namespace for all models
+pub const GLOBAL_NAMESPACE: &str = "global";
+
+pub fn is_global_namespace(namespace: &str) -> bool {
+    namespace == GLOBAL_NAMESPACE || namespace.is_empty()
+}

--- a/lib/llm/tests/http_namespace_integration.rs
+++ b/lib/llm/tests/http_namespace_integration.rs
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for HTTP service namespace discovery functionality.
+//! These tests verify that the HTTP service correctly filters models based on namespace configuration.
+
+use dynamo_llm::{
+    discovery::ModelEntry,
+    model_type::ModelType,
+    namespace::{is_global_namespace, GLOBAL_NAMESPACE},
+};
+use dynamo_runtime::protocols::Endpoint;
+
+// Helper function to create a test ModelEntry
+fn create_test_model_entry(
+    name: &str,
+    namespace: &str,
+    component: &str,
+    endpoint_name: &str,
+    model_type: ModelType,
+) -> ModelEntry {
+    ModelEntry {
+        name: name.to_string(),
+        endpoint: Endpoint {
+            namespace: namespace.to_string(),
+            component: component.to_string(),
+            name: endpoint_name.to_string(),
+        },
+        model_type,
+        runtime_config: None,
+    }
+}
+
+#[test]
+fn test_namespace_filtering_behavior() {
+    // Test the core namespace filtering logic used in HTTP service
+    let test_models = vec![
+        create_test_model_entry(
+            "model-1",
+            "vllm-agg",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry(
+            "model-2",
+            "sglang-prod",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry(
+            "model-3",
+            "global",
+            "backend",
+            "generate",
+            ModelType::Completion,
+        ),
+        create_test_model_entry(
+            "model-4",
+            "tensorrt-llm",
+            "backend",
+            "generate",
+            ModelType::Embedding,
+        ),
+    ];
+
+    // Test filtering for specific namespace "vllm-agg"
+    let target_namespace = "vllm-agg";
+    let is_global = is_global_namespace(target_namespace);
+
+    let filtered_models: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_models.len(), 1);
+    assert_eq!(filtered_models[0].name, "model-1");
+    assert_eq!(filtered_models[0].endpoint.namespace, "vllm-agg");
+
+    // Test filtering for global namespace (should include all models)
+    let target_namespace = GLOBAL_NAMESPACE;
+    let is_global = is_global_namespace(target_namespace);
+
+    let filtered_models_global: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_models_global.len(), 4); // All models should be included
+
+    // Test filtering for empty namespace (treated as global)
+    let target_namespace = "";
+    let is_global = is_global_namespace(target_namespace);
+
+    let filtered_models_empty: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_models_empty.len(), 4); // All models should be included
+}
+
+#[test]
+fn test_endpoint_id_namespace_extraction() {
+    // Test endpoint ID parsing for different namespace formats
+    let test_cases = vec![
+        ("vllm-agg.frontend.http", "vllm-agg", "frontend", "http"),
+        (
+            "sglang-prod.backend.generate",
+            "sglang-prod",
+            "backend",
+            "generate",
+        ),
+        ("global.frontend.http", "global", "frontend", "http"),
+        (
+            "tensorrt-llm.backend.inference",
+            "tensorrt-llm",
+            "backend",
+            "inference",
+        ),
+        (
+            "test-namespace.component.endpoint",
+            "test-namespace",
+            "component",
+            "endpoint",
+        ),
+    ];
+
+    for (endpoint_str, expected_namespace, expected_component, expected_name) in test_cases {
+        let endpoint: Endpoint = endpoint_str.parse().expect("Failed to parse endpoint");
+
+        assert_eq!(endpoint.namespace, expected_namespace);
+        assert_eq!(endpoint.component, expected_component);
+        assert_eq!(endpoint.name, expected_name);
+
+        // Test namespace classification
+        let is_global = is_global_namespace(&endpoint.namespace);
+        if expected_namespace == GLOBAL_NAMESPACE {
+            assert!(
+                is_global,
+                "Namespace '{}' should be classified as global",
+                expected_namespace
+            );
+        } else {
+            assert!(
+                !is_global,
+                "Namespace '{}' should not be classified as global",
+                expected_namespace
+            );
+        }
+    }
+}
+
+#[test]
+fn test_model_discovery_scoping_scenarios() {
+    // Test various scenarios for model discovery scoping
+
+    // Scenario 1: Frontend configured for specific namespace should only see models from that namespace
+    let frontend_namespace = "vllm-agg";
+    let available_models = vec![
+        create_test_model_entry(
+            "llama-7b",
+            "vllm-agg",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry(
+            "mistral-7b",
+            "vllm-agg",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry(
+            "gpt-3.5",
+            "sglang-prod",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry("claude-3", "global", "backend", "generate", ModelType::Chat),
+    ];
+
+    let visible_models: Vec<&ModelEntry> = available_models
+        .iter()
+        .filter(|model| {
+            let is_global = is_global_namespace(frontend_namespace);
+            is_global || model.endpoint.namespace == frontend_namespace
+        })
+        .collect();
+
+    assert_eq!(visible_models.len(), 2);
+    assert!(visible_models
+        .iter()
+        .all(|m| m.endpoint.namespace == "vllm-agg"));
+
+    // Scenario 2: Frontend configured for global namespace should see all models
+    let frontend_namespace = GLOBAL_NAMESPACE;
+    let visible_models_global: Vec<&ModelEntry> = available_models
+        .iter()
+        .filter(|model| {
+            let is_global = is_global_namespace(frontend_namespace);
+            is_global || model.endpoint.namespace == frontend_namespace
+        })
+        .collect();
+
+    assert_eq!(visible_models_global.len(), 4); // Should see all models
+
+    // Scenario 3: Frontend configured for non-existent namespace should see no models
+    let frontend_namespace = "non-existent-namespace";
+    let visible_models_none: Vec<&ModelEntry> = available_models
+        .iter()
+        .filter(|model| {
+            let is_global = is_global_namespace(frontend_namespace);
+            is_global || model.endpoint.namespace == frontend_namespace
+        })
+        .collect();
+
+    assert_eq!(visible_models_none.len(), 0); // Should see no models
+}
+
+#[test]
+fn test_namespace_boundary_conditions() {
+    // Test edge cases and boundary conditions for namespace handling
+
+    let test_models = vec![
+        create_test_model_entry("model-1", "", "backend", "generate", ModelType::Chat), // Empty namespace
+        create_test_model_entry("model-2", "global", "backend", "generate", ModelType::Chat), // Global namespace
+        create_test_model_entry(
+            "model-3",
+            "ns-with-special-chars_123",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+    ];
+
+    // Test filtering with empty target namespace (should be treated as global)
+    let target_namespace = "";
+    let is_global = is_global_namespace(target_namespace);
+    assert!(is_global); // Empty namespace should be treated as global
+
+    let filtered_empty: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_empty.len(), 3); // All models should be visible
+
+    // Test filtering with exact "global" namespace
+    let target_namespace = "global";
+    let is_global = is_global_namespace(target_namespace);
+    assert!(is_global);
+
+    let filtered_global: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_global.len(), 3); // All models should be visible
+
+    // Test case sensitivity - "GLOBAL" should not be treated as global
+    let target_namespace = "GLOBAL";
+    let is_global = is_global_namespace(target_namespace);
+    assert!(!is_global); // Should be case-sensitive
+
+    let filtered_uppercase: Vec<&ModelEntry> = test_models
+        .iter()
+        .filter(|model| is_global || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_uppercase.len(), 0); // No models should be visible
+}

--- a/lib/llm/tests/namespace.rs
+++ b/lib/llm/tests/namespace.rs
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_llm::{
+    discovery::ModelEntry,
+    model_type::ModelType,
+    namespace::{is_global_namespace, GLOBAL_NAMESPACE},
+};
+use dynamo_runtime::protocols::Endpoint;
+
+#[test]
+fn test_is_global_namespace_with_global_string() {
+    assert!(is_global_namespace(GLOBAL_NAMESPACE));
+    assert!(is_global_namespace("global"));
+}
+
+#[test]
+fn test_is_global_namespace_with_empty_string() {
+    assert!(is_global_namespace(""));
+}
+
+#[test]
+fn test_is_global_namespace_with_specific_namespace() {
+    assert!(!is_global_namespace("test-namespace"));
+    assert!(!is_global_namespace("my-custom-namespace"));
+}
+
+#[test]
+fn test_is_global_namespace_with_whitespace() {
+    // Whitespace should not be considered global
+    assert!(!is_global_namespace(" "));
+    assert!(!is_global_namespace("  "));
+    assert!(!is_global_namespace("\t"));
+    assert!(!is_global_namespace("\n"));
+}
+
+#[test]
+fn test_is_global_namespace_case_sensitivity() {
+    // Should be case sensitive
+    assert!(!is_global_namespace("Global"));
+    assert!(!is_global_namespace("GLOBAL"));
+}
+
+#[test]
+fn test_global_namespace_constant() {
+    assert_eq!(GLOBAL_NAMESPACE, "global");
+}
+
+// Helper function to create a test ModelEntry
+fn create_test_model_entry(
+    name: &str,
+    namespace: &str,
+    component: &str,
+    endpoint_name: &str,
+    model_type: ModelType,
+) -> ModelEntry {
+    ModelEntry {
+        name: name.to_string(),
+        endpoint: Endpoint {
+            namespace: namespace.to_string(),
+            component: component.to_string(),
+            name: endpoint_name.to_string(),
+        },
+        model_type,
+        runtime_config: None,
+    }
+}
+
+#[test]
+fn test_model_entry_creation_with_different_namespaces() {
+    // Test creating ModelEntry with specific namespace
+    let model_vllm = create_test_model_entry(
+        "test-model-1",
+        "vllm-agg",
+        "backend",
+        "generate",
+        ModelType::Chat,
+    );
+
+    assert_eq!(model_vllm.name, "test-model-1");
+    assert_eq!(model_vllm.endpoint.namespace, "vllm-agg");
+    assert_eq!(model_vllm.endpoint.component, "backend");
+    assert_eq!(model_vllm.endpoint.name, "generate");
+    assert_eq!(model_vllm.model_type, ModelType::Chat);
+
+    // Test creating ModelEntry with global namespace
+    let model_global = create_test_model_entry(
+        "test-model-2",
+        "global",
+        "frontend",
+        "http",
+        ModelType::Completion,
+    );
+
+    assert_eq!(model_global.name, "test-model-2");
+    assert_eq!(model_global.endpoint.namespace, "global");
+    assert_eq!(model_global.endpoint.component, "frontend");
+    assert_eq!(model_global.endpoint.name, "http");
+    assert_eq!(model_global.model_type, ModelType::Completion);
+}
+
+#[test]
+fn test_namespace_filtering_logic() {
+    // Test the core logic that would be used in namespace filtering
+    let models = vec![
+        create_test_model_entry(
+            "model-1",
+            "vllm-agg",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry(
+            "model-2",
+            "sglang-prod",
+            "backend",
+            "generate",
+            ModelType::Chat,
+        ),
+        create_test_model_entry("model-3", "global", "backend", "generate", ModelType::Chat),
+        create_test_model_entry("model-4", "", "backend", "generate", ModelType::Chat),
+    ];
+
+    // Test filtering for specific namespace "vllm-agg"
+    let target_namespace = "vllm-agg";
+    let global_namespace = is_global_namespace(target_namespace);
+    let filtered_vllm: Vec<&ModelEntry> = models
+        .iter()
+        .filter(|model| global_namespace || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_vllm.len(), 1);
+    assert_eq!(filtered_vllm[0].name, "model-1");
+    assert_eq!(filtered_vllm[0].endpoint.namespace, "vllm-agg");
+
+    // Test filtering for global namespace (should include all)
+    let target_namespace = "global";
+    let global_namespace = is_global_namespace(target_namespace);
+    let filtered_global: Vec<&ModelEntry> = models
+        .iter()
+        .filter(|model| global_namespace || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_global.len(), 4); // All models should be included
+
+    // Test filtering for empty namespace (should include all, treated as global)
+    let target_namespace = "";
+    let global_namespace = is_global_namespace(target_namespace);
+    let filtered_empty: Vec<&ModelEntry> = models
+        .iter()
+        .filter(|model| global_namespace || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_empty.len(), 4); // All models should be included
+
+    // Test filtering for non-existent namespace
+    let target_namespace = "non-existent";
+    let global_namespace = is_global_namespace(target_namespace);
+    let filtered_none: Vec<&ModelEntry> = models
+        .iter()
+        .filter(|model| global_namespace || model.endpoint.namespace == target_namespace)
+        .collect();
+
+    assert_eq!(filtered_none.len(), 0); // No models should match
+}
+
+#[test]
+fn test_model_entry_serialization() {
+    // Test that ModelEntry can be serialized and deserialized (important for etcd storage)
+    let model = create_test_model_entry(
+        "test-model",
+        "vllm-agg",
+        "backend",
+        "generate",
+        ModelType::Chat,
+    );
+
+    // Serialize to JSON
+    let json = serde_json::to_string(&model).expect("Failed to serialize ModelEntry");
+    assert!(json.contains("test-model"));
+    assert!(json.contains("vllm-agg"));
+    assert!(json.contains("backend"));
+    assert!(json.contains("generate"));
+
+    // Deserialize from JSON
+    let deserialized: ModelEntry =
+        serde_json::from_str(&json).expect("Failed to deserialize ModelEntry");
+    assert_eq!(deserialized.name, model.name);
+    assert_eq!(deserialized.endpoint.namespace, model.endpoint.namespace);
+    assert_eq!(deserialized.endpoint.component, model.endpoint.component);
+    assert_eq!(deserialized.endpoint.name, model.endpoint.name);
+    assert_eq!(deserialized.model_type, model.model_type);
+}
+
+#[test]
+fn test_endpoint_namespace_parsing() {
+    // Test Endpoint creation from string with namespace
+    let endpoint1 = Endpoint::from("vllm-agg.backend.generate");
+    assert_eq!(endpoint1.namespace, "vllm-agg");
+    assert_eq!(endpoint1.component, "backend");
+    assert_eq!(endpoint1.name, "generate");
+
+    let endpoint2 = Endpoint::from("global.frontend.http");
+    assert_eq!(endpoint2.namespace, "global");
+    assert_eq!(endpoint2.component, "frontend");
+    assert_eq!(endpoint2.name, "http");
+
+    // Test with forward slash separator
+    let endpoint3 = Endpoint::from("sglang-prod/backend/generate");
+    assert_eq!(endpoint3.namespace, "sglang-prod");
+    assert_eq!(endpoint3.component, "backend");
+    assert_eq!(endpoint3.name, "generate");
+}


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Namespace-aware configuration via environment variable, enabling dynamic defaults across services.
  - Frontend now supports a --namespace flag (falls back to environment) with clearer startup logging.
  - Per-namespace model discovery/filtering in dynamic HTTP mode to scope visible models.

- Refactor
  - Simplified vLLM configuration; removed the --endpoint CLI option in favor of environment-driven defaults.

- Documentation
  - Updated vLLM docs to reflect removal of the --endpoint option.

- Chores
  - Faster vLLM installation on AMD64 using a precompiled wheel.

- Tests
  - Added integration tests covering namespace filtering and discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->