### PR TITLE
feat(http): TLS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +501,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1788,6 +1833,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +1909,7 @@ dependencies = [
  "async-trait",
  "async_zmq",
  "axum 0.8.3",
+ "axum-server",
  "blake3",
  "bs62",
  "bytemuck",
@@ -1899,6 +1951,7 @@ dependencies = [
  "rmp-serde",
  "rstest 0.18.2",
  "rstest_reuse",
+ "rustls",
  "serde",
  "serde_json",
  "serial_test",
@@ -2417,6 +2470,22 @@ dependencies = [
  "lazy_static",
  "num",
 ]
+
+[[package]]
+name = "fs-err"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -6086,6 +6155,7 @@ version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -6154,6 +6224,7 @@ version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ Dynamo provides a simple way to spin up a local set of inference components incl
 - **Workers** – Set of pre-configured LLM serving engines.
 
 ```
-# Start an OpenAI compatible HTTP server, a pre-processor (prompt templating and tokenization) and a router:
-python -m dynamo.frontend --http-port 8080
+# Start an OpenAI compatible HTTP server, a pre-processor (prompt templating and tokenization) and a router.
+# Pass the TLS certificate and key paths to use HTTPS instead of HTTP.
+python -m dynamo.frontend --http-port 8080 [--tls-cert-path cert.pem] [--tls-key-path key.pem]
 
 # Start the SGLang engine, connecting to NATS and etcd to receive requests. You can run several of these,
 # both for the same model and for multiple models. The frontend node will discover them.

--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -16,10 +16,15 @@
 # Worker example:
 # - cd lib/bindings/python/examples/hello_world
 # - python server_sglang_static.py
+#
+# For TLS:
+# - python -m dynamo.frontend --http-port 8443 --tls-cert-path cert.pem --tls-key-path key.pem
+#
 
 import argparse
 import asyncio
 import os
+import pathlib
 import re
 
 import uvloop
@@ -84,6 +89,18 @@ def parse_args():
     )
     parser.add_argument(
         "--http-port", type=int, default=8080, help="HTTP port for the engine (u16)."
+    )
+    parser.add_argument(
+        "--tls-cert-path",
+        type=pathlib.Path,
+        default=None,
+        help="TLS certificate path, PEM format.",
+    )
+    parser.add_argument(
+        "--tls-key-path",
+        type=pathlib.Path,
+        default=None,
+        help="TLS certificate key path, PEM format.",
     )
     parser.add_argument(
         "--router-mode",
@@ -192,6 +209,10 @@ async def async_main():
         kwargs["model_name"] = flags.model_name
     if flags.model_path:
         kwargs["model_path"] = flags.model_path
+    if flags.tls_cert_path:
+        kwargs["tls_cert_path"] = flags.tls_cert_path
+    if flags.tls_key_path:
+        kwargs["tls_key_path"] = flags.tls_key_path
 
     if is_static:
         # out=dyn://<static_endpoint>

--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -166,6 +166,8 @@ def parse_args():
 
     if flags.static_endpoint and (not flags.model_name or not flags.model_path):
         parser.error("--static-endpoint requires both --model-name and --model-path")
+    if bool(flags.tls_cert_path) ^ bool(flags.tls_key_path):  # ^ is XOR
+        parser.error("--tls-cert-path and --tls-key-path must be provided together")
 
     return flags
 

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -50,11 +50,11 @@ pub struct Flags {
     pub http_port: u16,
 
     /// TLS certificate file
-    #[arg(long)]
+    #[arg(long, requires = "tls_key_path")]
     pub tls_cert_path: Option<PathBuf>,
 
     /// TLS certificate key file
-    #[arg(long)]
+    #[arg(long, requires = "tls_cert_path")]
     pub tls_key_path: Option<PathBuf>,
 
     /// The name of the model we are serving

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -45,8 +45,17 @@ pub struct Flags {
     pub model_path_flag: Option<PathBuf>,
 
     /// HTTP port. `in=http` only
+    /// If tls_cert_path and tls_key_path are provided, this will be TLS/HTTPS.
     #[arg(long, default_value = "8080")]
     pub http_port: u16,
+
+    /// TLS certificate file
+    #[arg(long)]
+    pub tls_cert_path: Option<PathBuf>,
+
+    /// TLS certificate key file
+    #[arg(long)]
+    pub tls_key_path: Option<PathBuf>,
 
     /// The name of the model we are serving
     #[arg(long)]

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -20,7 +20,7 @@ pub async fn run(
     runtime: Runtime,
     in_opt: Input,
     out_opt: Option<Output>,
-    flags: Flags,
+    mut flags: Flags,
 ) -> anyhow::Result<()> {
     //
     // Configure
@@ -39,7 +39,9 @@ pub async fn run(
         .kv_cache_block_size(flags.kv_cache_block_size)
         // Only set if user provides. Usually loaded from tokenizer_config.json
         .context_length(flags.context_length)
-        .http_port(Some(flags.http_port))
+        .http_port(flags.http_port)
+        .tls_cert_path(flags.tls_cert_path.take())
+        .tls_key_path(flags.tls_key_path.take())
         .router_config(Some(flags.router_config()))
         .request_template(flags.request_template.clone())
         .migration_limit(flags.migration_limit)

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -317,6 +317,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +406,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +476,29 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.100",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -444,7 +512,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.100",
 ]
@@ -679,6 +747,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1114,6 +1191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-stack"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1228,7 @@ dependencies = [
  "async-trait",
  "async_zmq",
  "axum",
+ "axum-server",
  "blake3",
  "bs62",
  "bytemuck",
@@ -1179,6 +1263,7 @@ dependencies = [
  "rayon",
  "regex",
  "rmp-serde",
+ "rustls",
  "serde",
  "serde_json",
  "strum",
@@ -1518,6 +1603,22 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -2031,6 +2132,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2537,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2496,6 +2615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,6 +2651,12 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2862,7 +2993,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743ed1038b386b75451f9e0bba37cb2e3eea75873635268337d6531be99c9303"
 dependencies = [
- "bindgen",
+ "bindgen 0.71.1",
  "cc",
  "libc",
  "os_info",
@@ -3580,7 +3711,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.12",
@@ -3599,7 +3730,7 @@ dependencies = [
  "getrandom 0.3.2",
  "rand 0.9.1",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3938,6 +4069,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -3953,6 +4090,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
@@ -3960,7 +4110,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3970,6 +4120,7 @@ version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4038,6 +4189,7 @@ version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4522,7 +4674,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -5373,6 +5525,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "ahash",
  "akin",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-py3"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.4.0"
+version = "0.4.0+post0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -10,6 +10,7 @@ use dynamo_llm::entrypoint::input::Input;
 use dynamo_llm::entrypoint::EngineConfig as RsEngineConfig;
 use dynamo_llm::entrypoint::RouterConfig as RsRouterConfig;
 use dynamo_llm::kv_router::KvRouterConfig as RsKvRouterConfig;
+use dynamo_llm::local_model::DEFAULT_HTTP_PORT;
 use dynamo_llm::local_model::{LocalModel, LocalModelBuilder};
 use dynamo_llm::mocker::protocols::MockEngineArgs;
 use dynamo_runtime::protocols::Endpoint as EndpointId;
@@ -128,6 +129,13 @@ impl EntrypointArgs {
             })?),
             None => None,
         };
+        if (tls_cert_path.is_some() && tls_key_path.is_none())
+            || (tls_cert_path.is_none() && tls_key_path.is_some())
+        {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "tls_cert_path and tls_key_path must be provided together",
+            ));
+        }
         Ok(EntrypointArgs {
             engine_type,
             model_path,
@@ -138,7 +146,7 @@ impl EntrypointArgs {
             template_file,
             router_config,
             kv_cache_block_size,
-            http_port: http_port.unwrap_or(0),
+            http_port: http_port.unwrap_or(DEFAULT_HTTP_PORT),
             tls_cert_path,
             tls_key_path,
             extra_engine_args,

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -94,7 +94,9 @@ pub(crate) struct EntrypointArgs {
     template_file: Option<PathBuf>,
     router_config: Option<RouterConfig>,
     kv_cache_block_size: Option<u32>,
-    http_port: Option<u16>,
+    http_port: u16,
+    tls_cert_path: Option<PathBuf>,
+    tls_key_path: Option<PathBuf>,
     extra_engine_args: Option<PathBuf>,
 }
 
@@ -102,7 +104,7 @@ pub(crate) struct EntrypointArgs {
 impl EntrypointArgs {
     #[allow(clippy::too_many_arguments)]
     #[new]
-    #[pyo3(signature = (engine_type, model_path=None, model_name=None, model_config=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_port=None, extra_engine_args=None))]
+    #[pyo3(signature = (engine_type, model_path=None, model_name=None, model_config=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None))]
     pub fn new(
         engine_type: EngineType,
         model_path: Option<PathBuf>,
@@ -114,6 +116,8 @@ impl EntrypointArgs {
         router_config: Option<RouterConfig>,
         kv_cache_block_size: Option<u32>,
         http_port: Option<u16>,
+        tls_cert_path: Option<PathBuf>,
+        tls_key_path: Option<PathBuf>,
         extra_engine_args: Option<PathBuf>,
     ) -> PyResult<Self> {
         let endpoint_id_obj: Option<EndpointId> = match endpoint_id {
@@ -134,7 +138,9 @@ impl EntrypointArgs {
             template_file,
             router_config,
             kv_cache_block_size,
-            http_port,
+            http_port: http_port.unwrap_or(0),
+            tls_cert_path,
+            tls_key_path,
             extra_engine_args,
         })
     }
@@ -164,6 +170,8 @@ pub fn make_engine<'p>(
         .kv_cache_block_size(args.kv_cache_block_size)
         .router_config(args.router_config.clone().map(|rc| rc.into()))
         .http_port(args.http_port)
+        .tls_cert_path(args.tls_cert_path.clone())
+        .tls_key_path(args.tls_key_path.clone())
         .is_mocker(matches!(args.engine_type, EngineType::Mocker))
         .extra_engine_args(args.extra_engine_args.clone());
     pyo3_async_runtimes::tokio::future_into_py(py, async move {

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -101,7 +101,9 @@ unicode-segmentation = "1.12"
 
 # http-service
 axum = { workspace = true }
+axum-server = { version = "0.7", features = ["tls-rustls"] }
 tower-http = {workspace = true}
+rustls = { version = "0.23" }
 
 
 # tokenizers

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -37,7 +37,13 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
                 .tls_key_path(Some(tls_key_path.to_path_buf()))
                 .port(local_model.http_port())
         }
-        (_, _) => service_v2::HttpService::builder().port(local_model.http_port()),
+        (None, None) => service_v2::HttpService::builder().port(local_model.http_port()),
+        (_, _) => {
+            // CLI should prevent us ever getting here
+            anyhow::bail!(
+                "Both --tls-cert-path and --tls-key-path must be provided together to enable TLS"
+            );
+        }
     };
     http_service_builder =
         http_service_builder.with_request_template(engine_config.local_model().request_template());

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -22,9 +22,25 @@ use dynamo_runtime::{DistributedRuntime, Runtime};
 
 /// Build and run an HTTP service
 pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Result<()> {
-    let mut http_service_builder = service_v2::HttpService::builder()
-        .port(engine_config.local_model().http_port())
-        .with_request_template(engine_config.local_model().request_template());
+    let local_model = engine_config.local_model();
+    let mut http_service_builder = match (local_model.tls_cert_path(), local_model.tls_key_path()) {
+        (Some(tls_cert_path), Some(tls_key_path)) => {
+            if !tls_cert_path.exists() {
+                anyhow::bail!("TLS certificate not found: {}", tls_cert_path.display());
+            }
+            if !tls_key_path.exists() {
+                anyhow::bail!("TLS key not found: {}", tls_key_path.display());
+            }
+            service_v2::HttpService::builder()
+                .enable_tls(true)
+                .tls_cert_path(Some(tls_cert_path.to_path_buf()))
+                .tls_key_path(Some(tls_key_path.to_path_buf()))
+                .port(local_model.http_port())
+        }
+        (_, _) => service_v2::HttpService::builder().port(local_model.http_port()),
+    };
+    http_service_builder =
+        http_service_builder.with_request_template(engine_config.local_model().request_template());
 
     let http_service = match engine_config {
         EngineConfig::Dynamic(_) => {

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::env::var;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -15,9 +16,11 @@ use crate::discovery::ModelManager;
 use crate::endpoint_type::EndpointType;
 use crate::request_template::RequestTemplate;
 use anyhow::Result;
+use axum_server::tls_rustls::RustlsConfig;
 use derive_builder::Builder;
 use dynamo_runtime::logging::make_request_span;
 use dynamo_runtime::transports::etcd;
+use std::net::SocketAddr;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tower_http::trace::TraceLayer;
@@ -126,6 +129,9 @@ pub struct HttpService {
     router: axum::Router,
     port: u16,
     host: String,
+    enable_tls: bool,
+    tls_cert_path: Option<PathBuf>,
+    tls_key_path: Option<PathBuf>,
     route_docs: Vec<RouteDoc>,
 }
 
@@ -137,6 +143,15 @@ pub struct HttpServiceConfig {
 
     #[builder(setter(into), default = "String::from(\"0.0.0.0\")")]
     host: String,
+
+    #[builder(default = "false")]
+    enable_tls: bool,
+
+    #[builder(default = "None")]
+    tls_cert_path: Option<PathBuf>,
+
+    #[builder(default = "None")]
+    tls_key_path: Option<PathBuf>,
 
     // #[builder(default)]
     // custom: Vec<axum::Router>
@@ -183,19 +198,60 @@ impl HttpService {
 
     pub async fn run(&self, cancel_token: CancellationToken) -> Result<()> {
         let address = format!("{}:{}", self.host, self.port);
-        tracing::info!(address, "Starting HTTP service on: {address}");
-
-        let listener = tokio::net::TcpListener::bind(address.as_str())
-            .await
-            .unwrap_or_else(|_| panic!("could not bind to address: {address}"));
+        let protocol = if self.enable_tls { "HTTPS" } else { "HTTP" };
+        tracing::info!(address, "Starting {protocol} service on: {address}");
 
         let router = self.router.clone();
         let observer = cancel_token.child_token();
 
-        axum::serve(listener, router)
-            .with_graceful_shutdown(observer.cancelled_owned())
-            .await
-            .inspect_err(|_| cancel_token.cancel())?;
+        let addr: SocketAddr = address
+            .parse()
+            .map_err(|e| anyhow::anyhow!("Invalid address '{}': {}", address, e))?;
+
+        if self.enable_tls {
+            let cert_path = self
+                .tls_cert_path
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("TLS certificate path not provided"))?;
+            let key_path = self
+                .tls_key_path
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("TLS private key path not provided"))?;
+
+            // aws_lc_rs is the default but other crates pull in `ring` also,
+            // so rustls doesn't know which one to use. Tell it.
+            let rustls_out = rustls::crypto::aws_lc_rs::default_provider().install_default();
+            // The Err type is `Arc<Self>`. Very strange.
+            if rustls_out.is_err() {
+                anyhow::bail!(
+                    "Failed installing AWS-LC-RS as the TLS crypto provider. Cannot start web server."
+                );
+            }
+
+            let config = RustlsConfig::from_pem_file(cert_path, key_path)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to create TLS config: {}", e))?;
+
+            let server = axum_server::bind_rustls(addr, config).serve(router.into_make_service());
+
+            tokio::select! {
+                result = server => {
+                    result.map_err(|e| anyhow::anyhow!("HTTPS server error: {}", e))?;
+                }
+                _ = observer.cancelled() => {
+                    tracing::info!("HTTPS server shutdown requested");
+                }
+            }
+        } else {
+            let listener = tokio::net::TcpListener::bind(addr)
+                .await
+                .unwrap_or_else(|_| panic!("could not bind to address: {address}"));
+
+            axum::serve(listener, router)
+                .with_graceful_shutdown(observer.cancelled_owned())
+                .await
+                .inspect_err(|_| cancel_token.cancel())?;
+        }
 
         Ok(())
     }
@@ -283,6 +339,9 @@ impl HttpServiceConfigBuilder {
             router,
             port: config.port,
             host: config.host,
+            enable_tls: config.enable_tls,
+            tls_cert_path: config.tls_cert_path,
+            tls_key_path: config.tls_key_path,
             route_docs: all_docs,
         })
     }

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -38,7 +38,8 @@ const DEFAULT_NAME: &str = "dynamo";
 const DEFAULT_KV_CACHE_BLOCK_SIZE: u32 = 16;
 
 /// We can't have it default to 0, so pick something
-const DEFAULT_HTTP_PORT: u16 = 8080;
+/// 'pub' because the bindings use it for consistency.
+pub const DEFAULT_HTTP_PORT: u16 = 8080;
 
 pub struct LocalModelBuilder {
     model_path: Option<PathBuf>,

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -50,6 +50,8 @@ pub struct LocalModelBuilder {
     router_config: Option<RouterConfig>,
     kv_cache_block_size: u32,
     http_port: u16,
+    tls_cert_path: Option<PathBuf>,
+    tls_key_path: Option<PathBuf>,
     migration_limit: u32,
     is_mocker: bool,
     extra_engine_args: Option<PathBuf>,
@@ -62,6 +64,8 @@ impl Default for LocalModelBuilder {
         LocalModelBuilder {
             kv_cache_block_size: DEFAULT_KV_CACHE_BLOCK_SIZE,
             http_port: DEFAULT_HTTP_PORT,
+            tls_cert_path: Default::default(),
+            tls_key_path: Default::default(),
             model_path: Default::default(),
             model_name: Default::default(),
             model_config: Default::default(),
@@ -110,9 +114,18 @@ impl LocalModelBuilder {
         self
     }
 
-    /// Passing None resets it to default
-    pub fn http_port(&mut self, port: Option<u16>) -> &mut Self {
-        self.http_port = port.unwrap_or(DEFAULT_HTTP_PORT);
+    pub fn http_port(&mut self, port: u16) -> &mut Self {
+        self.http_port = port;
+        self
+    }
+
+    pub fn tls_cert_path(&mut self, p: Option<PathBuf>) -> &mut Self {
+        self.tls_cert_path = p;
+        self
+    }
+
+    pub fn tls_key_path(&mut self, p: Option<PathBuf>) -> &mut Self {
+        self.tls_key_path = p;
         self
     }
 
@@ -187,6 +200,8 @@ impl LocalModelBuilder {
                 endpoint_id,
                 template,
                 http_port: self.http_port,
+                tls_cert_path: self.tls_cert_path.take(),
+                tls_key_path: self.tls_key_path.take(),
                 router_config: self.router_config.take().unwrap_or_default(),
                 runtime_config: self.runtime_config.clone(),
             });
@@ -260,6 +275,8 @@ impl LocalModelBuilder {
             endpoint_id,
             template,
             http_port: self.http_port,
+            tls_cert_path: self.tls_cert_path.take(),
+            tls_key_path: self.tls_key_path.take(),
             router_config: self.router_config.take().unwrap_or_default(),
             runtime_config: self.runtime_config.clone(),
         })
@@ -272,7 +289,9 @@ pub struct LocalModel {
     card: ModelDeploymentCard,
     endpoint_id: EndpointId,
     template: Option<RequestTemplate>,
-    http_port: u16, // Only used if input is HTTP server
+    http_port: u16,
+    tls_cert_path: Option<PathBuf>,
+    tls_key_path: Option<PathBuf>,
     router_config: RouterConfig,
     runtime_config: ModelRuntimeConfig,
 }
@@ -303,6 +322,14 @@ impl LocalModel {
 
     pub fn http_port(&self) -> u16 {
         self.http_port
+    }
+
+    pub fn tls_cert_path(&self) -> Option<&Path> {
+        self.tls_cert_path.as_deref()
+    }
+
+    pub fn tls_key_path(&self) -> Option<&Path> {
+        self.tls_key_path.as_deref()
     }
 
     pub fn router_config(&self) -> &RouterConfig {

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -277,8 +277,12 @@ impl Component {
         let mut hierarchies = self.parent_hierarchy();
         hierarchies.push(self.hierarchy());
         debug_assert_eq!(
-            hierarchies.last().cloned().unwrap_or_default(),
-            self.service_name()
+            hierarchies
+                .last()
+                .cloned()
+                .unwrap_or_default()
+                .to_lowercase(),
+            self.service_name().to_lowercase()
         ); // it happens that in component, hierarchy and service name are the same
 
         // Register a metrics callback that scrapes component statistics

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -276,14 +276,11 @@ impl Component {
         let component_clone = self.clone();
         let mut hierarchies = self.parent_hierarchy();
         hierarchies.push(self.hierarchy());
-        debug_assert_eq!(
-            hierarchies
-                .last()
-                .cloned()
-                .unwrap_or_default()
-                .to_lowercase(),
-            self.service_name().to_lowercase()
-        ); // it happens that in component, hierarchy and service name are the same
+        debug_assert!(hierarchies
+            .last()
+            .map(|x| x.as_str())
+            .unwrap_or_default()
+            .eq_ignore_ascii_case(&self.service_name())); // it happens that in component, hierarchy and service name are the same
 
         // Register a metrics callback that scrapes component statistics
         let metrics_callback = Arc::new(move || {


### PR DESCRIPTION
While we expect the frontend to be deployed behind a web layer, we still want to support TLS:
- The data center might require all internal communications to be encrypted.
- For some deployments such as NIM a web layer is not practical.

Make a self-signed certificate:

```
openssl genpkey -algorithm Ed25519 -out key.pem
openssl req -new -x509 -key key.pem -days 1460 -out cert.pem -subj "/C=US/ST=CA/L=Santa Clara/O=LocalDev/OU=Dynamo/CN=example.com"
```

Start the frontend:

```
python -m dynamo.frontend --http-port 8443 --tls-cert-path /data/certs/cert.pem --tls-key-path /data/certs/key.pem
```

Remember to add `--insecure` to your curl request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional TLS/HTTPS support for the OpenAI-compatible HTTP server.
  - New CLI flags: --tls-cert-path and --tls-key-path. When both are provided, the server starts in HTTPS mode; otherwise it runs over HTTP.
  - Validates certificate and key files with clear error messages; startup logs now indicate HTTP vs HTTPS.

- Documentation
  - Updated README with TLS/HTTPS usage and revised startup command example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->