### PR TITLE
fix: small build warning fix

### DIFF
--- a/lib/runtime/src/pipeline/network/codec/two_part.rs
+++ b/lib/runtime/src/pipeline/network/codec/two_part.rs
@@ -65,7 +65,7 @@ impl Decoder for TwoPartCodec {
 
         let header_len = cursor.get_u64() as usize;
         let body_len = cursor.get_u64() as usize;
-        let checksum = cursor.get_u64();
+        let _checksum = cursor.get_u64();
 
         let total_len = 24 + header_len + body_len;
 
@@ -81,13 +81,13 @@ impl Decoder for TwoPartCodec {
             return Ok(None);
         }
 
-        // Advance the buffer past the lengths and checksum
+        // Advance the buffer past the lengths and _checksum
         src.advance(24);
 
         #[cfg(debug_assertions)]
         {
             // If the server sent a dummy checksum, skip it.
-            if checksum != 0 {
+            if _checksum != 0 {
                 let bytes_to_hash =
                     header_len
                         .checked_add(body_len)
@@ -100,7 +100,7 @@ impl Decoder for TwoPartCodec {
                 let computed_checksum = xxh3_64(data_to_hash);
 
                 // Compare checksums
-                if checksum != computed_checksum {
+                if _checksum != computed_checksum {
                     return Err(TwoPartCodecError::ChecksumMismatch);
                 }
             }

--- a/lib/runtime/src/pipeline/network/codec/two_part.rs
+++ b/lib/runtime/src/pipeline/network/codec/two_part.rs
@@ -81,7 +81,7 @@ impl Decoder for TwoPartCodec {
             return Ok(None);
         }
 
-        // Advance the buffer past the lengths and _checksum
+        // Advance the buffer past the lengths and checksum
         src.advance(24);
 
         #[cfg(debug_assertions)]


### PR DESCRIPTION
#### Overview:

small fix to the following build warning I got:

```
Compiling dynamo-runtime v0.4.0+post0 (/builds/dl/ai-services/microservices/nim-llm/dynamo/lib/runtime)
warning: unused variable: `checksum`
  --> /builds/dl/ai-services/microservices/nim-llm/dynamo/lib/runtime/src/pipeline/network/codec/two_part.rs:68:13
   |
68 |         let checksum = cursor.get_u64();
   |             ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_checksum`
   |
   = note: `#[warn(unused_variables)]` on by default
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Internal cleanup around checksum handling to improve code clarity and maintainability.
  - Ensures checksum verification logic remains consistent, with additional validation in debug builds.
  - No changes to public APIs or behavior; existing request/response processing remains the same.
  - No impact on performance or compatibility; this is a non-functional update focused on readability and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->