### PR TITLE
fix: use tokio spawn / interval.tick(), make nats metric names clearer, fix tests sharing environment variables (temp_env)

### DIFF
--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -48,7 +48,7 @@ use super::{
 
 use crate::pipeline::network::{ingress::push_endpoint::PushEndpoint, PushWorkHandler};
 use crate::protocols::Endpoint as EndpointId;
-use crate::service::ComponentNatsPrometheusMetrics;
+use crate::service::ComponentNatsServerPrometheusMetrics;
 use async_nats::{
     rustls::quic,
     service::{Service, ServiceExt},
@@ -223,6 +223,10 @@ impl Component {
         self.name.clone()
     }
 
+    pub fn labels(&self) -> &[(String, String)] {
+        &self.labels
+    }
+
     pub fn endpoint(&self, endpoint: impl Into<String>) -> Endpoint {
         Endpoint {
             component: self.clone(),
@@ -267,18 +271,19 @@ impl Component {
             .await
     }
 
-    /// Add Prometheus metrics for this component's service stats.
+    /// Add Prometheus metrics for this component's NATS service stats.
     ///
-    /// Starts a background task that scrapes stats every ~4.7s and updates metrics.
-    /// The thinking was that it should be a little bit shorter than the Prometheus polling interval.
-    /// Currently Prometheus polls every 6 seconds, and I wanted every poll to be fresh, so this is set
-    /// as an arbitrary 4.7 seconds plus 0.3 seconds if it times out. It's a bit of a hand-wavey decision.
-    pub fn start_scraping_metrics(&self) -> Result<()> {
+    /// Starts a background task that periodically requests service statistics from NATS
+    /// and updates the corresponding Prometheus metrics. The scraping interval is set to
+    /// approximately 4.7 seconds to ensure fresh data is available for each Prometheus
+    /// polling cycle (which occurs every 6 seconds by default).
+    pub fn start_scraping_nats_service_component_metrics(&self) -> Result<()> {
         const NATS_TIMEOUT_AND_INITIAL_DELAY_MS: std::time::Duration =
             std::time::Duration::from_millis(300);
-        const MAX_DELAY_MS: std::time::Duration = std::time::Duration::from_millis(4700);
+        const MAX_DELAY_MS: std::time::Duration = std::time::Duration::from_millis(777);
 
-        let component_metrics = ComponentNatsPrometheusMetrics::new(self)?;
+        // If there is another component with the same service name, this will fail.
+        let component_metrics = ComponentNatsServerPrometheusMetrics::new(self)?;
 
         let component_clone = self.clone();
         let mut hierarchies = self.parent_hierarchy();
@@ -292,35 +297,35 @@ impl Component {
         let m = component_metrics.clone();
         let c = component_clone.clone();
 
-        // Use std::thread for the background task to avoid runtime context issues
-        std::thread::spawn(move || {
-            // Use the existing secondary runtime from drt for background metrics scraping
-            let rt = c.drt().runtime().secondary();
+        // Use the DRT's runtime handle to spawn the background task.
+        // We cannot use regular `tokio::spawn` here because:
+        // 1. This method may be called from contexts without an active Tokio runtime
+        //    (e.g., tests that create a DRT in a blocking context)
+        // 2. Tests often create a temporary runtime just to build the DRT, then drop it
+        // 3. `tokio::spawn` requires being called from within a runtime context
+        // By using the DRT's own runtime handle, we ensure the task runs in the
+        // correct runtime that will persist for the lifetime of the component.
+        c.drt().runtime().secondary().spawn(async move {
+            let timeout = NATS_TIMEOUT_AND_INITIAL_DELAY_MS;
+            let mut interval = tokio::time::interval(MAX_DELAY_MS);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-            // Run the background scraping loop
-            rt.block_on(async {
-                let timeout = NATS_TIMEOUT_AND_INITIAL_DELAY_MS;
-                let mut delay = NATS_TIMEOUT_AND_INITIAL_DELAY_MS;
-
-                loop {
-                    match c.scrape_stats(timeout).await {
-                        Ok(service_set) => {
-                            m.update_from_service_set(&service_set);
-                        }
-                        Err(err) => {
-                            tracing::error!(
-                                "Background scrape failed for {}: {}",
-                                c.service_name(),
-                                err
-                            );
-                            m.reset_to_zeros();
-                            // Double delay on failure, capped at MAX_DELAY
-                            delay = std::cmp::min(delay * 2, MAX_DELAY_MS);
-                        }
+            loop {
+                match c.scrape_stats(timeout).await {
+                    Ok(service_set) => {
+                        m.update_from_service_set(&service_set);
                     }
-                    tokio::time::sleep(delay).await;
+                    Err(err) => {
+                        tracing::error!(
+                            "Background scrape failed for {}: {}",
+                            c.service_name(),
+                            err
+                        );
+                        m.reset_to_zeros();
+                    }
                 }
-            });
+                interval.tick().await;
+            }
         });
 
         Ok(())
@@ -575,12 +580,27 @@ impl Namespace {
         // Register the metrics callback for this component.
         // If registration fails, log a warning but do not propagate the error,
         // as metrics are not mission critical and should not block component creation.
-        if let Err(err) = component.start_scraping_metrics() {
-            tracing::warn!(
-                "Failed to add metrics callback for component '{}': {}",
-                component.service_name(),
-                err
-            );
+        if let Err(err) = component.start_scraping_nats_service_component_metrics() {
+            let error_str = err.to_string();
+
+            // Check if this is a duplicate metrics registration (expected in some cases)
+            // or a different error (unexpected)
+            if error_str.contains("Duplicate metrics") {
+                // This is not a critical error because it's possible for multiple Components
+                // with the same service_name to register metrics callbacks.
+                tracing::debug!(
+                    "Duplicate metrics registration for component '{}' (expected when multiple components share the same service_name): {}",
+                    component.service_name(),
+                    error_str
+                );
+            } else {
+                // This is unexpected and should be more visible
+                tracing::warn!(
+                    "Failed to start scraping metrics for component '{}': {}",
+                    component.service_name(),
+                    err
+                );
+            }
         }
 
         Ok(component)

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -275,12 +275,12 @@ impl Component {
     ///
     /// Starts a background task that periodically requests service statistics from NATS
     /// and updates the corresponding Prometheus metrics. The scraping interval is set to
-    /// approximately 4.7 seconds to ensure fresh data is available for each Prometheus
-    /// polling cycle (which occurs every 6 seconds by default).
+    /// approximately 873ms (MAX_DELAY_MS), which is arbitrary but any value less than a second
+    /// is fair game. This frequent scraping provides real-time service statistics updates.
     pub fn start_scraping_nats_service_component_metrics(&self) -> Result<()> {
         const NATS_TIMEOUT_AND_INITIAL_DELAY_MS: std::time::Duration =
             std::time::Duration::from_millis(300);
-        const MAX_DELAY_MS: std::time::Duration = std::time::Duration::from_millis(777);
+        const MAX_DELAY_MS: std::time::Duration = std::time::Duration::from_millis(873);
 
         // If there is another component with the same service name, this will fail.
         let component_metrics = ComponentNatsServerPrometheusMetrics::new(self)?;

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 pub use crate::component::Component;
-use crate::transports::nats::DRTNatsPrometheusMetrics;
+use crate::transports::nats::DRTNatsClientPrometheusMetrics;
 use crate::{
     component::{self, ComponentBuilder, Endpoint, InstanceSource, Namespace},
     discovery::DiscoveryClient,
@@ -95,28 +95,29 @@ impl DistributedRuntime {
             system_health,
         };
 
-        let sys_nats_metrics = DRTNatsPrometheusMetrics::new(
+        let nats_client_metrics = DRTNatsClientPrometheusMetrics::new(
             &distributed_runtime,
             nats_client_for_metrics.client().clone(),
         )?;
         let mut drt_hierarchies = distributed_runtime.parent_hierarchy();
         drt_hierarchies.push(distributed_runtime.hierarchy());
         // Register a callback to update NATS client metrics
-        let nats_metrics_callback = Arc::new({
-            let sys_nats_metrics_clone = sys_nats_metrics.clone();
+        let nats_client_callback = Arc::new({
+            let nats_client_clone = nats_client_metrics.clone();
             move || {
-                sys_nats_metrics_clone.set_from_client_stats();
+                nats_client_clone.set_from_client_stats();
                 Ok(())
             }
         });
-        distributed_runtime.register_metrics_callback(drt_hierarchies, nats_metrics_callback);
+        distributed_runtime.register_metrics_callback(drt_hierarchies, nats_client_callback);
 
-        // Start system status server if enabled
+        // Handle system status server initialization
         if let Some(cancel_token) = cancel_token {
+            // System server is enabled - start both the state and HTTP server
             let host = config.system_host.clone();
             let port = config.system_port;
 
-            // Start system status server (it spawns its own task internally)
+            // Start system status server (it creates SystemStatusState internally)
             match crate::system_status_server::spawn_system_status_server(
                 &host,
                 port,
@@ -146,7 +147,18 @@ impl DistributedRuntime {
                 }
             }
         } else {
-            tracing::debug!("Health and system status server is disabled via DYN_SYSTEM_ENABLED");
+            // System server HTTP is disabled, but still create the state for metrics
+            // This ensures uptime_seconds metric is always registered
+            let system_status_state = crate::system_status_server::SystemStatusState::new(
+                Arc::new(distributed_runtime.clone()),
+            )?;
+
+            // Initialize the start time for uptime tracking
+            system_status_state
+                .initialize_start_time()
+                .map_err(|e| error!("Failed to initialize system status start time: {}", e))?;
+
+            tracing::debug!("System status server HTTP endpoints disabled, but uptime metrics are being tracked");
         }
 
         Ok(distributed_runtime)

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -154,9 +154,9 @@ impl DistributedRuntime {
             )?;
 
             // Initialize the start time for uptime tracking
-            system_status_state
-                .initialize_start_time()
-                .map_err(|e| error!("Failed to initialize system status start time: {}", e))?;
+            if let Err(e) = system_status_state.initialize_start_time() {
+                tracing::warn!("Failed to initialize system status start time: {}", e);
+            }
 
             tracing::debug!("System status server HTTP endpoints disabled, but uptime metrics are being tracked");
         }

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -578,20 +578,6 @@ mod test_helpers {
     use super::prometheus_names::{nats_client, nats_service};
     use super::*;
 
-    /// Creates a test DistributedRuntime for integration tests.
-    /// Uses NATS; requires #[cfg(feature = "integration")].
-    #[cfg(feature = "integration")]
-    pub fn create_test_drt() -> crate::DistributedRuntime {
-        // Create a single-threaded runtime for test isolation
-        // This avoids conflicts when tests run in parallel
-        let rt = crate::Runtime::from_current().unwrap();
-        tokio::runtime::Runtime::new().unwrap().block_on(async {
-            crate::DistributedRuntime::from_settings_without_discovery(rt)
-                .await
-                .unwrap()
-        })
-    }
-
     /// Helper function to create a DRT instance for testing in async contexts
     #[cfg(feature = "integration")]
     pub async fn create_test_drt_async() -> crate::DistributedRuntime {

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -584,7 +584,7 @@ mod test_helpers {
     pub fn create_test_drt() -> crate::DistributedRuntime {
         // Create a single-threaded runtime for test isolation
         // This avoids conflicts when tests run in parallel
-        let rt = crate::Runtime::single_threaded().unwrap();
+        let rt = crate::Runtime::from_current().unwrap();
         tokio::runtime::Runtime::new().unwrap().block_on(async {
             crate::DistributedRuntime::from_settings_without_discovery(rt)
                 .await
@@ -939,9 +939,9 @@ mod test_metricsregistry_prefixes {
     use super::*;
     use prometheus::core::Collector;
 
-    #[test]
-    fn test_hierarchical_prefixes_and_parent_hierarchies() {
-        let drt = super::test_helpers::create_test_drt();
+    #[tokio::test]
+    async fn test_hierarchical_prefixes_and_parent_hierarchies() {
+        let drt = super::test_helpers::create_test_drt_async().await;
 
         const DRT_NAME: &str = "";
         const NAMESPACE_NAME: &str = "ns901";
@@ -1013,10 +1013,10 @@ mod test_metricsregistry_prefixes {
             .is_ok());
     }
 
-    #[test]
-    fn test_recursive_namespace() {
+    #[tokio::test]
+    async fn test_recursive_namespace() {
         // Create a distributed runtime for testing
-        let drt = super::test_helpers::create_test_drt();
+        let drt = super::test_helpers::create_test_drt_async().await;
 
         // Create a deeply chained namespace: ns1.ns2.ns3
         let ns1 = drt.namespace("ns1").unwrap();
@@ -1071,10 +1071,10 @@ mod test_metricsregistry_prometheus_fmt_outputs {
     use prometheus::Counter;
     use std::sync::Arc;
 
-    #[test]
-    fn test_prometheusfactory_using_metrics_registry_trait() {
+    #[tokio::test]
+    async fn test_prometheusfactory_using_metrics_registry_trait() {
         // Setup real DRT and registry using the test-friendly constructor
-        let drt = super::test_helpers::create_test_drt();
+        let drt = super::test_helpers::create_test_drt_async().await;
 
         // Use a simple constant namespace name
         let namespace_name = "ns345";
@@ -1329,10 +1329,10 @@ mod test_metricsregistry_nats {
     use crate::pipeline::PushRouter;
     use crate::{DistributedRuntime, Runtime};
     use tokio::time::{sleep, Duration};
-    #[test]
-    fn test_drt_nats_metrics() {
+    #[tokio::test]
+    async fn test_drt_nats_metrics() {
         // Setup real DRT and registry using the test-friendly constructor
-        let drt = super::test_helpers::create_test_drt();
+        let drt = super::test_helpers::create_test_drt_async().await;
 
         // Get DRT output which should include NATS client metrics
         let drt_output = drt.prometheus_metrics_fmt().unwrap();
@@ -1390,13 +1390,13 @@ mod test_metricsregistry_nats {
         println!("✓ DistributedRuntime NATS metrics integration test passed!");
     }
 
-    #[test]
-    fn test_nats_metric_names() {
+    #[tokio::test]
+    async fn test_nats_metric_names() {
         // This test only tests the existence of the NATS metrics. It does not check
         // the values of the metrics.
 
         // Setup real DRT and registry using the test-friendly constructor
-        let drt = super::test_helpers::create_test_drt();
+        let drt = super::test_helpers::create_test_drt_async().await;
 
         // Create a namespace and components from the DRT
         let namespace = drt.namespace("ns789").unwrap();

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -34,64 +34,64 @@ pub mod labels {
 
 /// NATS client metrics. DistributedRuntime contains a NATS client shared by all children)
 pub mod nats_client {
-    /// Prefix for all NATS client metrics
-    pub const PREFIX: &str = "nats_client_";
-
     /// Macro to generate NATS client metric names with the prefix
-    macro_rules! nats_client_prefix {
+    macro_rules! nats_client_name {
         ($name:expr) => {
             concat!("nats_client_", $name)
         };
     }
 
+    /// Prefix for all NATS client metrics
+    pub const PREFIX: &str = nats_client_name!("");
+
     /// Total number of bytes received by NATS client
-    pub const IN_TOTAL_BYTES: &str = nats_client_prefix!("in_total_bytes");
+    pub const IN_TOTAL_BYTES: &str = nats_client_name!("in_total_bytes");
 
     /// Total number of bytes sent by NATS client
-    pub const OUT_OVERHEAD_BYTES: &str = nats_client_prefix!("out_overhead_bytes");
+    pub const OUT_OVERHEAD_BYTES: &str = nats_client_name!("out_overhead_bytes");
 
     /// Total number of messages received by NATS client
-    pub const IN_MESSAGES: &str = nats_client_prefix!("in_messages");
+    pub const IN_MESSAGES: &str = nats_client_name!("in_messages");
 
     /// Total number of messages sent by NATS client
-    pub const OUT_MESSAGES: &str = nats_client_prefix!("out_messages");
+    pub const OUT_MESSAGES: &str = nats_client_name!("out_messages");
 
     /// Total number of connections established by NATS client
-    pub const CONNECTS: &str = nats_client_prefix!("connects");
+    pub const CONNECTS: &str = nats_client_name!("connects");
 
     /// Current connection state of NATS client (0=disconnected, 1=connected, 2=reconnecting)
-    pub const CONNECTION_STATE: &str = nats_client_prefix!("connection_state");
+    pub const CONNECTION_STATE: &str = nats_client_name!("connection_state");
 }
 
 /// NATS service metrics, from the $SRV.STATS.<service_name> requests on NATS server
 pub mod nats_service {
-    /// Prefix for all NATS service metrics
-    pub const PREFIX: &str = "nats_service_";
-
     /// Macro to generate NATS service metric names with the prefix
-    macro_rules! nats_service_prefix {
+    macro_rules! nats_service_name {
         ($name:expr) => {
             concat!("nats_service_", $name)
         };
     }
 
+    /// Prefix for all NATS service metrics
+    pub const PREFIX: &str = nats_service_name!("");
+
     /// Average processing time in milliseconds (maps to: average_processing_time in ms)
-    pub const AVG_PROCESSING_MS: &str = nats_service_prefix!("avg_processing_time_ms");
+    pub const AVG_PROCESSING_MS: &str = nats_service_name!("avg_processing_time_ms");
 
     /// Total errors across all endpoints (maps to: num_errors)
-    pub const TOTAL_ERRORS: &str = nats_service_prefix!("total_errors");
+    pub const TOTAL_ERRORS: &str = nats_service_name!("total_errors");
 
     /// Total requests across all endpoints (maps to: num_requests)
-    pub const TOTAL_REQUESTS: &str = nats_service_prefix!("total_requests");
+    pub const TOTAL_REQUESTS: &str = nats_service_name!("total_requests");
 
     /// Total processing time in milliseconds (maps to: processing_time in ms)
-    pub const TOTAL_PROCESSING_MS: &str = nats_service_prefix!("total_processing_time_ms");
+    pub const TOTAL_PROCESSING_MS: &str = nats_service_name!("total_processing_time_ms");
 
     /// Number of active services (derived from ServiceSet.services)
-    pub const ACTIVE_SERVICES: &str = nats_service_prefix!("active_services");
+    pub const ACTIVE_SERVICES: &str = nats_service_name!("active_services");
 
     /// Number of active endpoints (derived from ServiceInfo.endpoints)
-    pub const ACTIVE_ENDPOINTS: &str = nats_service_prefix!("active_endpoints");
+    pub const ACTIVE_ENDPOINTS: &str = nats_service_name!("active_endpoints");
 }
 
 /// All NATS client Prometheus metric names as an array for iteration/validation

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -32,69 +32,73 @@ pub mod labels {
     pub const ENDPOINT: &str = "dynamo_endpoint";
 }
 
-/// NATS Prometheus metric names
-pub mod nats {
+/// NATS client metrics. DistributedRuntime contains a NATS client shared by all children)
+pub mod nats_client {
     /// Prefix for all NATS client metrics
-    pub const PREFIX: &str = "nats_";
+    pub const PREFIX: &str = "nats_client_";
 
-    /// ===== DistributedRuntime metrics =====
     /// Total number of bytes received by NATS client
-    pub const IN_TOTAL_BYTES: &str = "nats_in_total_bytes";
+    pub const IN_TOTAL_BYTES: &str = "nats_client_in_total_bytes";
 
     /// Total number of bytes sent by NATS client
-    pub const OUT_OVERHEAD_BYTES: &str = "nats_out_overhead_bytes";
+    pub const OUT_OVERHEAD_BYTES: &str = "nats_client_out_overhead_bytes";
 
     /// Total number of messages received by NATS client
-    pub const IN_MESSAGES: &str = "nats_in_messages";
+    pub const IN_MESSAGES: &str = "nats_client_in_messages";
 
     /// Total number of messages sent by NATS client
-    pub const OUT_MESSAGES: &str = "nats_out_messages";
+    pub const OUT_MESSAGES: &str = "nats_client_out_messages";
 
     /// Total number of connections established by NATS client
-    pub const CONNECTS: &str = "nats_connects";
+    pub const CONNECTS: &str = "nats_client_connects";
 
     /// Current connection state of NATS client (0=disconnected, 1=connected, 2=reconnecting)
-    pub const CONNECTION_STATE: &str = "nats_connection_state";
+    pub const CONNECTION_STATE: &str = "nats_client_connection_state";
+}
 
-    /// ===== Component metrics (ordered to match NatsStatsMetrics fields) =====
+/// NATS service metrics, from the $SRV.STATS.<service_name> requests on NATS server
+pub mod nats_service {
+    /// Prefix for all NATS service metrics
+    pub const PREFIX: &str = "nats_service_";
+
     /// Average processing time in milliseconds (maps to: average_processing_time in ms)
-    pub const AVG_PROCESSING_MS: &str = "nats_avg_processing_time_ms";
+    pub const AVG_PROCESSING_MS: &str = "nats_service_avg_processing_time_ms";
 
     /// Total errors across all endpoints (maps to: num_errors)
-    pub const TOTAL_ERRORS: &str = "nats_total_errors";
+    pub const TOTAL_ERRORS: &str = "nats_service_total_errors";
 
     /// Total requests across all endpoints (maps to: num_requests)
-    pub const TOTAL_REQUESTS: &str = "nats_total_requests";
+    pub const TOTAL_REQUESTS: &str = "nats_service_total_requests";
 
     /// Total processing time in milliseconds (maps to: processing_time in ms)
-    pub const TOTAL_PROCESSING_MS: &str = "nats_total_processing_time_ms";
+    pub const TOTAL_PROCESSING_MS: &str = "nats_service_total_processing_time_ms";
 
     /// Number of active services (derived from ServiceSet.services)
-    pub const ACTIVE_SERVICES: &str = "nats_active_services";
+    pub const ACTIVE_SERVICES: &str = "nats_service_active_services";
 
     /// Number of active endpoints (derived from ServiceInfo.endpoints)
-    pub const ACTIVE_ENDPOINTS: &str = "nats_active_endpoints";
+    pub const ACTIVE_ENDPOINTS: &str = "nats_service_active_endpoints";
 }
 
 /// All NATS client Prometheus metric names as an array for iteration/validation
 pub const DRT_NATS_METRICS: &[&str] = &[
-    nats::CONNECTION_STATE,
-    nats::CONNECTS,
-    nats::IN_TOTAL_BYTES,
-    nats::IN_MESSAGES,
-    nats::OUT_OVERHEAD_BYTES,
-    nats::OUT_MESSAGES,
+    nats_client::CONNECTION_STATE,
+    nats_client::CONNECTS,
+    nats_client::IN_TOTAL_BYTES,
+    nats_client::IN_MESSAGES,
+    nats_client::OUT_OVERHEAD_BYTES,
+    nats_client::OUT_MESSAGES,
 ];
 
 /// All component service Prometheus metric names as an array for iteration/validation
 /// (ordered to match NatsStatsMetrics fields)
 pub const COMPONENT_NATS_METRICS: &[&str] = &[
-    nats::AVG_PROCESSING_MS,   // maps to: average_processing_time (nanoseconds)
-    nats::TOTAL_ERRORS,        // maps to: num_errors
-    nats::TOTAL_REQUESTS,      // maps to: num_requests
-    nats::TOTAL_PROCESSING_MS, // maps to: processing_time (nanoseconds)
-    nats::ACTIVE_SERVICES,     // derived from ServiceSet.services
-    nats::ACTIVE_ENDPOINTS,    // derived from ServiceInfo.endpoints
+    nats_service::AVG_PROCESSING_MS, // maps to: average_processing_time (nanoseconds)
+    nats_service::TOTAL_ERRORS,      // maps to: num_errors
+    nats_service::TOTAL_REQUESTS,    // maps to: num_requests
+    nats_service::TOTAL_PROCESSING_MS, // maps to: processing_time (nanoseconds)
+    nats_service::ACTIVE_SERVICES,   // derived from ServiceSet.services
+    nats_service::ACTIVE_ENDPOINTS,  // derived from ServiceInfo.endpoints
 ];
 
 /// Work handler Prometheus metric names

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -37,23 +37,30 @@ pub mod nats_client {
     /// Prefix for all NATS client metrics
     pub const PREFIX: &str = "nats_client_";
 
+    /// Macro to generate NATS client metric names with the prefix
+    macro_rules! nats_client_prefix {
+        ($name:expr) => {
+            concat!("nats_client_", $name)
+        };
+    }
+
     /// Total number of bytes received by NATS client
-    pub const IN_TOTAL_BYTES: &str = "nats_client_in_total_bytes";
+    pub const IN_TOTAL_BYTES: &str = nats_client_prefix!("in_total_bytes");
 
     /// Total number of bytes sent by NATS client
-    pub const OUT_OVERHEAD_BYTES: &str = "nats_client_out_overhead_bytes";
+    pub const OUT_OVERHEAD_BYTES: &str = nats_client_prefix!("out_overhead_bytes");
 
     /// Total number of messages received by NATS client
-    pub const IN_MESSAGES: &str = "nats_client_in_messages";
+    pub const IN_MESSAGES: &str = nats_client_prefix!("in_messages");
 
     /// Total number of messages sent by NATS client
-    pub const OUT_MESSAGES: &str = "nats_client_out_messages";
+    pub const OUT_MESSAGES: &str = nats_client_prefix!("out_messages");
 
     /// Total number of connections established by NATS client
-    pub const CONNECTS: &str = "nats_client_connects";
+    pub const CONNECTS: &str = nats_client_prefix!("connects");
 
     /// Current connection state of NATS client (0=disconnected, 1=connected, 2=reconnecting)
-    pub const CONNECTION_STATE: &str = "nats_client_connection_state";
+    pub const CONNECTION_STATE: &str = nats_client_prefix!("connection_state");
 }
 
 /// NATS service metrics, from the $SRV.STATS.<service_name> requests on NATS server
@@ -61,23 +68,30 @@ pub mod nats_service {
     /// Prefix for all NATS service metrics
     pub const PREFIX: &str = "nats_service_";
 
+    /// Macro to generate NATS service metric names with the prefix
+    macro_rules! nats_service_prefix {
+        ($name:expr) => {
+            concat!("nats_service_", $name)
+        };
+    }
+
     /// Average processing time in milliseconds (maps to: average_processing_time in ms)
-    pub const AVG_PROCESSING_MS: &str = "nats_service_avg_processing_time_ms";
+    pub const AVG_PROCESSING_MS: &str = nats_service_prefix!("avg_processing_time_ms");
 
     /// Total errors across all endpoints (maps to: num_errors)
-    pub const TOTAL_ERRORS: &str = "nats_service_total_errors";
+    pub const TOTAL_ERRORS: &str = nats_service_prefix!("total_errors");
 
     /// Total requests across all endpoints (maps to: num_requests)
-    pub const TOTAL_REQUESTS: &str = "nats_service_total_requests";
+    pub const TOTAL_REQUESTS: &str = nats_service_prefix!("total_requests");
 
     /// Total processing time in milliseconds (maps to: processing_time in ms)
-    pub const TOTAL_PROCESSING_MS: &str = "nats_service_total_processing_time_ms";
+    pub const TOTAL_PROCESSING_MS: &str = nats_service_prefix!("total_processing_time_ms");
 
     /// Number of active services (derived from ServiceSet.services)
-    pub const ACTIVE_SERVICES: &str = "nats_service_active_services";
+    pub const ACTIVE_SERVICES: &str = nats_service_prefix!("active_services");
 
     /// Number of active endpoints (derived from ServiceInfo.endpoints)
-    pub const ACTIVE_ENDPOINTS: &str = "nats_service_active_endpoints";
+    pub const ACTIVE_ENDPOINTS: &str = nats_service_prefix!("active_endpoints");
 }
 
 /// All NATS client Prometheus metric names as an array for iteration/validation

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -78,11 +78,28 @@ impl SystemStatusState {
     /// Create new system status server state with the provided metrics registry
     pub fn new(drt: Arc<crate::DistributedRuntime>) -> anyhow::Result<Self> {
         // Note: This metric is created at the DRT level (no namespace), so it will be prefixed with "dynamo_component_"
-        let uptime_gauge = drt.as_ref().create_gauge(
+        let uptime_gauge = match drt.as_ref().create_gauge(
             "uptime_seconds",
             "Total uptime of the DistributedRuntime in seconds",
             &[],
-        )?;
+        ) {
+            Ok(gauge) => gauge,
+            Err(e) if e.to_string().contains("Duplicate metrics") => {
+                // If the metric already exists, get it from the registry
+                // This can happen when SystemStatusState is created multiple times in tests
+                tracing::debug!(
+                    "uptime_seconds metric already registered, retrieving existing metric"
+                );
+                // Create a dummy gauge since we can't retrieve the existing one easily
+                // The important thing is that the metric is registered in the registry
+                prometheus::Gauge::new(
+                    "uptime_seconds",
+                    "Total uptime of the DistributedRuntime in seconds",
+                )
+                .map_err(|e| anyhow::anyhow!("Failed to create dummy gauge: {}", e))?
+            }
+            Err(e) => return Err(e),
+        };
         let state = Self {
             root_drt: drt,
             start_time: OnceLock::new(),
@@ -387,30 +404,37 @@ mod tests {
         // Test that metrics have correct namespace
         temp_env::async_with_vars([("DYN_SYSTEM_ENABLED", Some("false"))], async {
             let drt = create_test_drt_async().await;
-            let system_status = SystemStatusState::new(Arc::new(drt)).unwrap();
+            // SystemStatusState is already created in distributed.rs when DYN_SYSTEM_ENABLED=false
+            // so we don't need to create it again here
 
-            // Initialize start time
-            system_status.initialize_start_time().unwrap();
-
-            system_status.uptime_gauge.set(42.0);
-
-            let response = system_status.drt().prometheus_metrics_fmt().unwrap();
+            // The uptime_seconds metric should already be registered and available
+            let response = drt.prometheus_metrics_fmt().unwrap();
             println!("Full metrics response:\n{}", response);
 
             // Filter out NATS client metrics for comparison
-            use crate::metrics::prometheus_names::nats as nats_metrics;
+            use crate::metrics::prometheus_names::{nats_client, nats_service};
 
             let filtered_response: String = response
                 .lines()
-                .filter(|line| !line.contains(nats_metrics::PREFIX))
+                .filter(|line| {
+                    !line.contains(nats_client::PREFIX) && !line.contains(nats_service::PREFIX)
+                })
                 .collect::<Vec<_>>()
                 .join("\n");
 
-            let expected = "\
-# HELP dynamo_component_uptime_seconds Total uptime of the DistributedRuntime in seconds
-# TYPE dynamo_component_uptime_seconds gauge
-dynamo_component_uptime_seconds 42";
-            assert_eq!(filtered_response, expected);
+            // Check that uptime_seconds metric is present with correct namespace
+            assert!(
+                filtered_response.contains("# HELP dynamo_component_uptime_seconds"),
+                "Should contain uptime_seconds help text"
+            );
+            assert!(
+                filtered_response.contains("# TYPE dynamo_component_uptime_seconds gauge"),
+                "Should contain uptime_seconds type"
+            );
+            assert!(
+                filtered_response.contains("dynamo_component_uptime_seconds"),
+                "Should contain uptime_seconds metric with correct namespace"
+            );
         })
         .await;
     }

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -90,7 +90,7 @@ impl SystemStatusState {
                 tracing::debug!(
                     "uptime_seconds metric already registered, retrieving existing metric"
                 );
-                // Create a dummy gauge since we can't retrieve the existing one easily
+                // Create a non-http gauge since we can't retrieve the existing one easily
                 // The important thing is that the metric is registered in the registry
                 prometheus::Gauge::new(
                     "uptime_seconds",

--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -44,7 +44,7 @@ use tokio::time;
 use url::Url;
 use validator::{Validate, ValidationError};
 
-use crate::metrics::prometheus_names::nats as nats_metrics;
+use crate::metrics::prometheus_names::nats_client as nats_metrics;
 pub use crate::slug::Slug;
 use tracing as log;
 
@@ -520,7 +520,7 @@ impl NatsQueue {
 /// Flow: NATS Client → Client Statistics → set_from_client_stats() → Prometheus Gauge
 /// Note: These are snapshots updated when set_from_client_stats() is called.
 #[derive(Debug, Clone)]
-pub struct DRTNatsPrometheusMetrics {
+pub struct DRTNatsClientPrometheusMetrics {
     nats_client: client::Client,
     /// Number of bytes received (excluding protocol overhead)
     pub in_bytes: IntGauge,
@@ -536,7 +536,7 @@ pub struct DRTNatsPrometheusMetrics {
     pub connection_state: IntGauge,
 }
 
-impl DRTNatsPrometheusMetrics {
+impl DRTNatsClientPrometheusMetrics {
     /// Create a new instance of NATS client metrics using a DistributedRuntime's Prometheus constructors
     pub fn new(drt: &crate::DistributedRuntime, nats_client: client::Client) -> Result<Self> {
         let in_bytes = drt.create_intgauge(


### PR DESCRIPTION
#### Overview:

Follow-up to https://github.com/ai-dynamo/dynamo/pull/2480 with improvements and feedback

drt runtime::spawn, interval.tick(), refactored NATS metrics organization, and fixed test parallelization issues

#### Details:

- Use drt runtime::spawn instead of thread::spawn, and interval.tick() instead of sleep(...). Note that the blocking problem was lready fixed in PR 2480 where I removed std::thread::spawn, used tokio::runtime::Handle::try_current()). Graham and Olson said to use tokio spawn/interval.tick, which I'm doing here. 
- Split NATS metrics into separate `nats_client` and `nats_service` modules for clearer separation of concerns
- Enhanced NATS service metrics with `service_name` and component-specific labels for better observability
- Fixed test parallelization failures by ensuring `uptime_seconds` metric is consistently registered
- Improved duplicate metric registration handling with intelligent error categorization
- Updated test helpers to use `temp_env` for proper environment variable isolation

#### Where should the reviewer start?

- `lib/runtime/src/component.rs` - Check the improved error handling for duplicate metrics
- `lib/runtime/src/metrics/prometheus_names.rs` - See the new module structure for NATS metrics
- `lib/runtime/src/distributed.rs` - Review the uptime_seconds metric registration logic

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Fixes DIS-445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded NATS client metrics (bytes, messages, connects, connection state).
  - Introduced NATS service metrics (avg processing time, totals, active services/endpoints) with consistent labels (including service name).
  - Uptime metrics now tracked even when system HTTP endpoints are disabled.

- Refactor
  - Split metrics into two namespaces: nats_client_* and nats_service_* (old nats_* renamed).
  - Streamlined background metrics scraping with fixed-interval runtime tasks and a shorter polling interval.

- Bug Fixes
  - More robust handling of duplicate Prometheus metric registrations to prevent startup conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->