### PR TITLE
fix: Use `/usr` dir prefix when freeing disk space

### DIFF
--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -53,9 +53,9 @@ jobs:
         echo "Disk space before:"
         df -h
         rm -rf \
-          /host_usr/share/dotnet /host_usr/local/lib/android /opt/ghc \
-          /host_usr/local/share/powershell /host_usr/share/swift /host_usr/local/.ghcup \
-          /host_usr/lib/jvm /opt/hostedtoolcache
+          /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+          /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+          /usr/lib/jvm /opt/hostedtoolcache
         echo "Disk space after:"
         df -h
 

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         echo "Disk space before:"
         df -h
-        rm -rf \
+        sudo rm -rf \
           /usr/share/dotnet /usr/local/lib/android /opt/ghc \
           /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
           /usr/lib/jvm /opt/hostedtoolcache


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Aiming to resolve disk space issues on pre-merge-rust github action like this: https://github.com/ai-dynamo/dynamo/actions/runs/17055769950/job/48353017453?pr=2465

**Before this PR (32GB disk space available):**

```
...
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   41G   32G  57% /
...
```

**After this PR (53GB disk space available):**

```
...
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   20G   53G  28% /
...
```

#### Details:

<!-- Describe the changes made in this PR. -->

`/host_usr` dirs didn't exist from original change, this updates them to existing `/usr` dirs. This was a silly oversight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pre-merge CI workflow to perform runner disk cleanup with elevated permissions, targeting system directories for more reliable space recovery.
  * Reduces intermittent CI failures caused by low disk space, improving stability and predictability of Rust pre-merge checks.
  * Speeds up CI by minimizing reruns due to storage issues.
  * No changes to application behavior; impact is limited to build/release reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->