### PR TITLE
docs: CLOSE ME

### DIFF
--- a/.cursor/rules/docs-rules.mdc
+++ b/.cursor/rules/docs-rules.mdc
@@ -1,0 +1,48 @@
+---
+globs: *.md
+alwaysApply: false
+---
+Spell out numbers under 10 unless you are talking about a specific value or a parameter.
+Correct: This uses four nodes.
+Incorrect: This uses 4 nodes
+Avoid using "please" and "see."
+Please is used in marketing documents rather than technical documentation.
+"Refer to" is more sensitive to users with visual disabilities than "see."
+Refer to the following rather than see the following.
+Use "can" instead of "may" whenever possible.
+Use: The installation can take up to 20 minutes.
+Avoid: The installation may take up to 20 minutes.
+For parenthetical statements, ensure your punctuation is in the correct location when using quotation marks.
+Correct: A key and familiar paradigm in Biology exists that "Structure determines Function."
+Incorrect: A key and familiar paradigm in Biology exists that "Structure determines Function". (I know this looks odd to most people educated outside of the U.S.)
+Avoid using Latin terms (e.g., etc., i.e., and via).
+e.g. = for example, etc. = and so on, i.e. = that is, and via = using, by, or through.
+Avoid excessive hyphenation.
+For example, if using command line as a noun, you don't need a hyphen, but you need one when it's an adjective.
+Example: The command line is very easy to use, but command-line output can be hard to understand.
+Ensure commas are used correctly.
+Use a comma before the conjunction in a list of three or more items. (The comma that comes before the conjunction is known as the Oxford or serial comma.)
+Google includes Mail, Calendar, People, and Tasks.
+Save your file to a hard drive, an external drive, or OneDrive.
+               Note: If a series contains more than three items or the items are long, consider a bulleted list to improve readability.
+Commas also follow an introductory phrase.
+With WhatsApp, you can call any phone.
+To join independent clauses with a conjunction, such as and, or, but, yet or so.
+This tool is used to parse incoming parameters, and it can also be used to parse the outgoing results.
+               Note: If the sentence is long or complex, consider rewriting it as two sentences.
+Case headings​ consistently throughout the document (we currently use title casing).
+NVIDIA is not cased "Nvidia" (when referring to the company or products). You will see this casing in marketing docs and blogs, but it shouldn't be used in our tech docs.
+Use “after” instead of “once” because they have a subtle difference.
+What Is Their Main Difference?
+The main difference between "once" and "after" is that "once" expresses a sense of urgency while "after" simply points out what follows an action or event.
+     Example: 
+     Call me once you get home. Means as soon as you step in the door.
+     Call me after you get home. Means call me sometime after you arrive. 
+Once is also meant to illustrate something is done one time only.
+Make ​sure you use "which" and "that”  (relative pronouns) correctly.
+Relative Pronouns
+What are they?
+
+Relative pronouns such as "which" and "that" are words that begin adjective clauses. Often, relative pronouns can be removed from a sentence without changing its meaning. In fact, at times, the omission of these clauses results in cleaner, tighter sentences. If required for clarity, it is important to know which one to use and when.
+
+Clauses can be essential because they can provide the reader with more information about the noun they follow. Clauses that start with "which" are nonrestrictive or nonessential clauses. A nonrestrictive/nonessential clause is a clause that does not limit the essential meaning of the element it modifies, and if it were removed from the sentence, the implied meaning behind it would remain the same. Nonrestrictive/nonessential clauses should always be set off from the rest of the sentence with commas.

--- a/components/README.md
+++ b/components/README.md
@@ -29,7 +29,7 @@ Dynamo supports multiple inference engines (with a focus on SGLang, vLLM, and Te
 
 Each engine provides launch scripts for different deployment patterns in their respective `/launch` & `/deploy` directories.
 
-## Core Components
+## Core Services
 
 ### [Backends](backends/)
 

--- a/components/backends/sglang/README.md
+++ b/components/backends/sglang/README.md
@@ -50,7 +50,7 @@ git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 | **GB200 Support**   | ✅     |                                                              |
 
 
-## Quick Start
+## SGLang Quick Start
 
 Below we provide a guide that lets you run all of our the common deployment patterns on a single node. See our different [architectures](../llm/README.md#deployment-architectures) for a high level overview of each pattern and the architecture diagram for each.
 

--- a/components/backends/sglang/deploy/agg.yaml.bak
+++ b/components/backends/sglang/deploy/agg.yaml.bak
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-agg
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: sglang-agg
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "10Gi"
+        limits:
+          cpu: "32"
+          memory: "40Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          command: ["sh", "-c"]
+          args:
+            - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-agg && python3 -m dynamo.frontend --http-port=8000"
+    SGLangDecodeWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: sglang-agg
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "32"
+          memory: "80Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3"
+            - "-m"
+            - "dynamo.sglang.worker"
+            - "--model-path"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--served-model-name"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--page-size"
+            - "16"
+            - "--tp"
+            - "1"
+            - "--trust-remote-code"
+            - "--skip-tokenizer-init"

--- a/components/backends/sglang/deploy/agg_router.yaml.bak
+++ b/components/backends/sglang/deploy/agg_router.yaml.bak
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-agg-router
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: sglang-agg-router
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "10Gi"
+        limits:
+          cpu: "32"
+          memory: "40Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          command: ["sh", "-c"]
+          args:
+            - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-agg-router && python3 -m dynamo.frontend --http-port=8000  --router-mode kv"
+    SGLangDecodeWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: sglang-agg-router
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "32"
+          memory: "80Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3"
+            - "-m"
+            - "dynamo.sglang.worker"
+            - "--model-path"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--served-model-name"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--page-size"
+            - "16"
+            - "--tp"
+            - "1"
+            - "--trust-remote-code"
+            - "--skip-tokenizer-init"

--- a/components/backends/sglang/deploy/disagg.yaml.bak
+++ b/components/backends/sglang/deploy/disagg.yaml.bak
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-disagg
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: sglang-disagg
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "10Gi"
+        limits:
+          cpu: "32"
+          memory: "40Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          command: ["sh", "-c"]
+          args:
+            - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-disagg && python3 -m dynamo.frontend --http-port=8000"
+    SGLangDecodeWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: sglang-disagg
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "32"
+          memory: "80Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3"
+            - "-m"
+            - "dynamo.sglang.decode_worker"
+            - "--model-path"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--served-model-name"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--page-size"
+            - "16"
+            - "--tp"
+            - "1"
+            - "--trust-remote-code"
+            - "--skip-tokenizer-init"
+            - "--disaggregation-mode"
+            - "decode"
+            - "--disaggregation-transfer-backend"
+            - "nixl"
+    SGLangPrefillWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: sglang-disagg
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "32"
+          memory: "80Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3"
+            - "-m"
+            - "dynamo.sglang.worker"
+            - "--model-path"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--served-model-name"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--page-size"
+            - "16"
+            - "--tp"
+            - "1"
+            - "--trust-remote-code"
+            - "--skip-tokenizer-init"
+            - "--disaggregation-mode"
+            - "prefill"
+            - "--disaggregation-transfer-backend"
+            - "nixl"

--- a/components/backends/sglang/deploy/disagg_planner.yaml.bak
+++ b/components/backends/sglang/deploy/disagg_planner.yaml.bak
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-disagg-planner
+  annotations:
+    nvidia.com/enable-grove: "false"
+spec:
+  envs:
+    - name: DYNAMO_SERVICE_CONFIG
+      value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:9090"]}]},{"job_name":"frontend","static_configs":[{"targets":["sglang-disagg-planner-frontend:8000"]}]}]}}'
+    - name: DYNAMO_NAMESPACE
+      value: "dynamo"
+  services:
+    Frontend:
+      dynamoNamespace: dynamo
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "10Gi"
+        limits:
+          cpu: "32"
+          memory: "40Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          command: ["sh", "-c"]
+          args:
+            - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-disagg && python3 -m dynamo.frontend --http-port=8000"
+    Planner:
+      dynamoNamespace: dynamo
+      envFromSecret: hf-token-secret
+      componentType: planner
+      replicas: 1
+      livenessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      readinessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        initialDelaySeconds: 60
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      resources:
+        requests:
+          cpu: "2"
+          memory: "2Gi"
+        limits:
+          cpu: "8"
+          memory: "16Gi"
+      pvc:
+        create: false
+        name: profiling-pvc # Must be pre-created before deployment and SLA profiler must have been run
+        mountPoint: /workspace/profiling_results
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/planner/src/dynamo/planner
+          args:
+            - python
+            - -m
+            - planner_sla
+            - --environment=kubernetes
+            - --backend=sglang
+            - --adjustment-interval=60
+            - --profile-results-dir=/workspace/profiling_results
+    Prometheus: # NOTE: this is set on Prometheus to ensure a service is created for the Prometheus component. This is a workaround and should be managed differently.
+      dynamoNamespace: dynamo
+      componentType: frontend
+      replicas: 1
+      envs:
+        - name: PYTHONPATH
+          value: "/workspace/components/planner/src"
+      livenessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      readinessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        initialDelaySeconds: 30
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      resources:
+        requests:
+          cpu: "2"
+          memory: "2Gi"
+        limits:
+          cpu: "8"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.planner.prometheus"
+    SGLangDecodeWorker:
+      dynamoNamespace: dynamo
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 2
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "32"
+          memory: "80Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          args:
+            - "python3"
+            - "-m"
+            - "dynamo.sglang.decode_worker"
+            - "--model-path"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--served-model-name"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--page-size"
+            - "16"
+            - "--tp"
+            - "1"
+            - "--trust-remote-code"
+            - "--skip-tokenizer-init"
+            - "--disaggregation-mode"
+            - "decode"
+            - "--disaggregation-transfer-backend"
+            - "nixl"
+    SGLangPrefillWorker:
+      dynamoNamespace: dynamo
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 2
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "32"
+          memory: "80Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.4.0
+          workingDir: /workspace/components/backends/sglang
+          args:
+            - "python3"
+            - "-m"
+            - "dynamo.sglang.worker"
+            - "--model-path"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--served-model-name"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--page-size"
+            - "16"
+            - "--tp"
+            - "1"
+            - "--trust-remote-code"
+            - "--skip-tokenizer-init"
+            - "--disaggregation-mode"
+            - "prefill"
+            - "--disaggregation-transfer-backend"
+            - "nixl"

--- a/components/backends/sglang/docs/dsr1-wideep.md
+++ b/components/backends/sglang/docs/dsr1-wideep.md
@@ -1,0 +1,1 @@
+../../../../docs/components/backends/sglang/docs/dsr1-wideep.md

--- a/components/backends/sglang/docs/multinode-examples.md
+++ b/components/backends/sglang/docs/multinode-examples.md
@@ -5,8 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 
 # Multinode Examples
 
-## Multi-node sized models
-
 SGLang allows you to deploy multi-node sized models by adding in the `dist-init-addr`, `nnodes`, and `node-rank` arguments. Below we demonstrate and example of deploying DeepSeek R1 for disaggregated serving across 4 nodes. This example requires 4 nodes of 8xH100 GPUs.
 
 **Step 1**: Use the provided helper script to generate commands to start NATS/ETCD on your head prefill node. This script will also give you environment variables to export on each other node. You will need the IP addresses of your head prefill and head decode node to run this script.

--- a/components/backends/sglang/docs/sgl-http-server.md
+++ b/components/backends/sglang/docs/sgl-http-server.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Supporting SGLang's native endpoints via HTTP Server
 
-# Introduction
+## Introduction
 
 The SGLang HTTP server provides a REST API interface for managing and monitoring SGLang components running in a dynamo distributed environment. It leverages dynamo's service discovery mechanism to automatically find and communicate with SGLang workers across the cluster.
 

--- a/components/backends/trtllm/README.md
+++ b/components/backends/trtllm/README.md
@@ -66,7 +66,7 @@ git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 | **DP Rank Routing**| ✅           |                                                                 |
 | **GB200 Support**  | ✅           |                                                                 |
 
-## Quick Start
+## TensorRT-LLM Quick Start
 
 Below we provide a guide that lets you run all of our the common deployment patterns on a single node.
 

--- a/components/backends/trtllm/deploy/agg.yaml.bak
+++ b/components/backends/trtllm/deploy/agg.yaml.bak
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: trtllm-agg
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: trtllm-agg
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests:
+          cpu: "5"
+          memory: "10Gi"
+        limits:
+          cpu: "5"
+          memory: "10Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidian/nim-llm-dev/trtllm-runtime:dep-233.17
+          workingDir: /workspace/components/backends/trtllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.frontend --http-port 8000"
+    TRTLLMWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: trtllm-agg
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidian/nim-llm-dev/trtllm-runtime:dep-233.17
+          workingDir: /workspace/components/backends/trtllm
+          args:
+            - "python3"
+            - "-m"
+            - "dynamo.trtllm"
+            - "--model-path"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--served-model-name"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--extra-engine-args"
+            - "engine_configs/agg.yaml"

--- a/components/backends/trtllm/deploy/agg_router.yaml.bak
+++ b/components/backends/trtllm/deploy/agg_router.yaml.bak
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: trtllm-agg-router
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: trtllm-agg-router
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidian/nim-llm-dev/trtllm-runtime:dep-233.17
+          workingDir: /workspace/components/backends/trtllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.frontend --http-port 8000 --router-mode kv"
+    TRTLLMWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: trtllm-agg-router
+      componentType: worker
+      replicas: 2
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidian/nim-llm-dev/trtllm-runtime:dep-233.17
+          workingDir: /workspace/components/backends/trtllm
+          args:
+            - "python3"
+            - "-m"
+            - "dynamo.trtllm"
+            - "--model-path"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--served-model-name"
+            - "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+            - "--extra-engine-args"
+            - "engine_configs/agg.yaml"
+            - "--publish-events-and-metrics"

--- a/components/backends/trtllm/deploy/disagg.yaml.bak
+++ b/components/backends/trtllm/deploy/disagg.yaml.bak
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: trtllm-disagg
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: trtllm-disagg
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests:
+          cpu: "5"
+          memory: "10Gi"
+        limits:
+          cpu: "5"
+          memory: "10Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidian/nim-llm-dev/trtllm-runtime:dep-233.17
+          workingDir: /workspace/components/backends/trtllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.frontend --http-port 8000"
+    TRTLLMPrefillWorker:
+      dynamoNamespace: trtllm-disagg
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidian/nim-llm-dev/trtllm-runtime:dep-233.17
+          workingDir: /workspace/components/backends/trtllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.trtllm --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B --served-model-name deepseek-ai/DeepSeek-R1-Distill-Llama-8B --extra-engine-args engine_configs/prefill.yaml --disaggregation-mode prefill --disaggregation-strategy decode_first"
+    TRTLLMDecodeWorker:
+      dynamoNamespace: trtllm-disagg
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidian/nim-llm-dev/trtllm-runtime:dep-233.17
+          workingDir: /workspace/components/backends/trtllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.trtllm --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B --served-model-name deepseek-ai/DeepSeek-R1-Distill-Llama-8B --extra-engine-args engine_configs/decode.yaml --disaggregation-mode decode --disaggregation-strategy decode_first"

--- a/components/backends/trtllm/deploy/disagg_router.yaml.bak
+++ b/components/backends/trtllm/deploy/disagg_router.yaml.bak
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: trtllm-v1-disagg-router
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: trtllm-v1-disagg-router
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests:
+          cpu: "5"
+          memory: "10Gi"
+        limits:
+          cpu: "5"
+          memory: "10Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidian/nim-llm-dev/trtllm-runtime:dep-233.17
+          workingDir: /workspace/components/backends/trtllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.frontend --http-port 8000 --router-mode kv"
+    TRTLLMPrefillWorker:
+      dynamoNamespace: trtllm-v1-disagg-router
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 2
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidian/nim-llm-dev/trtllm-runtime:dep-233.17
+          workingDir: /workspace/components/backends/trtllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.trtllm --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B --served-model-name deepseek-ai/DeepSeek-R1-Distill-Llama-8B --extra-engine-args engine_configs/prefill.yaml --disaggregation-mode prefill --disaggregation-strategy prefill_first --publish-events-and-metrics"
+    TRTLLMDecodeWorker:
+      dynamoNamespace: trtllm-v1-disagg-router
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+        limits:
+          cpu: "10"
+          memory: "20Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidian/nim-llm-dev/trtllm-runtime:dep-233.17
+          workingDir: /workspace/components/backends/trtllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.trtllm --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B --served-model-name deepseek-ai/DeepSeek-R1-Distill-Llama-8B --extra-engine-args engine_configs/decode.yaml --disaggregation-mode decode --disaggregation-strategy prefill_first"

--- a/components/backends/trtllm/engine_configs/agg.yaml.bak
+++ b/components/backends/trtllm/engine_configs/agg.yaml.bak
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 1
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+max_batch_size: 16
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.85
+
+# NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
+# NOTE: overlap_scheduler enabled by default since this commit and changed
+# config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+# https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
+
+
+cuda_graph_config:
+  max_batch_size: 16

--- a/components/backends/trtllm/engine_configs/decode.yaml.bak
+++ b/components/backends/trtllm/engine_configs/decode.yaml.bak
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 1
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+disable_overlap_scheduler: false
+
+cuda_graph_config:
+  max_batch_size: 16
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.85
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/deepseek_r1/mtp/mtp_agg.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/mtp/mtp_agg.yaml.bak
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: FP4 only supported starting with Blackwell GPUs.
+# https://huggingface.co/nvidia/DeepSeek-R1-FP4
+# You can also specify the full path to locally downloaded weights
+# instead of a HuggingFace ID here.
+
+backend: pytorch
+tensor_parallel_size: 4
+moe_expert_parallel_size: 4
+enable_attention_dp: true
+max_batch_size: 256
+# 8448 = 8192 ISL + 256 OSL
+max_num_tokens: 8448
+max_seq_len: 8448
+kv_cache_config:
+  free_gpu_memory_fraction: 0.30
+  dtype: fp8
+
+# Enable the MTP(Multi-Token Prediction) in the model engine
+speculative_config:
+  decoding_type: MTP
+  num_nextn_predict_layers: 1
+
+cuda_graph_config:
+  enable_padding: true
+  batch_sizes:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+
+print_iter_log: true

--- a/components/backends/trtllm/engine_configs/deepseek_r1/mtp/mtp_decode.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/mtp/mtp_decode.yaml.bak
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: FP4 only supported starting with Blackwell GPUs.
+# https://huggingface.co/nvidia/DeepSeek-R1-FP4
+# You can also specify the full path to locally downloaded weights
+# instead of a HuggingFace ID here.
+
+backend: pytorch
+tensor_parallel_size: 4
+moe_expert_parallel_size: 4
+enable_attention_dp: false
+max_batch_size: 256
+# Note: When MPT is enabled and `cuda_graph_batch_sizes` is specified, `max_num_tokens` must satisfy the following formula:
+# max_num_tokens >= max(cuda_graph_batch_sizes) * (num_nextn_predict_layers + 1)
+# This is a known issue in TensorRT-LLM and will be resolved in the next release.
+max_num_tokens: 512
+# 8704 = 8192 ISL + 512 OSL
+max_seq_len: 8704
+kv_cache_config:
+  free_gpu_memory_fraction: 0.85
+  dtype: fp8
+
+# Enable the MTP(Multi-Token Prediction) in decode model engine
+speculative_config:
+  decoding_type: MTP
+  num_nextn_predict_layers: 1
+
+cuda_graph_config:
+  enable_padding: true
+  batch_sizes:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+
+print_iter_log: true
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/deepseek_r1/mtp/mtp_prefill.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/mtp/mtp_prefill.yaml.bak
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: FP4 only supported starting with Blackwell GPUs.
+# https://huggingface.co/nvidia/DeepSeek-R1-FP4
+# You can also specify the full path to locally downloaded weights
+# instead of a HuggingFace ID here.
+
+backend: pytorch
+tensor_parallel_size: 4
+moe_expert_parallel_size: 4
+enable_attention_dp: true
+max_batch_size: 1
+max_num_tokens: 8192
+max_seq_len: 8192
+kv_cache_config:
+  free_gpu_memory_fraction: 0.75
+  dtype: fp8
+
+print_iter_log: true
+disable_overlap_scheduler: true
+
+# Enable the MTP(Multi-Token Prediction) in the prefill model engine
+speculative_config:
+  decoding_type: MTP
+  num_nextn_predict_layers: 1
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/deepseek_r1/simple/agg.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/simple/agg.yaml.bak
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+backend: pytorch
+
+# TP/EP/PP/DP
+tensor_parallel_size: 4
+moe_expert_parallel_size: 4
+pipeline_parallel_size: 1
+enable_attention_dp: false
+
+max_batch_size: 256
+# 8448 = 8192 ISL + 256 OSL
+max_num_tokens: 8448
+max_seq_len: 8448
+
+kv_cache_config:
+  # With dp attention disabled: high free_gpu_memory_fraction is fine.
+  free_gpu_memory_fraction: 0.85
+  # With dp attention enabled: large ISL at high concurrency may need
+  # free_gpu_memory_fraction low to have enough available memory.
+  # free_gpu_memory_fraction: 0.30
+  dtype: fp8
+
+
+# NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
+# NOTE: overlap_scheduler enabled by default since this commit and changed
+# config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+# https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
+cuda_graph_config:
+  enable_padding: true
+# NOTE: For larger max batch size, you may want to add larger cuda graph
+# batch sizes below to match.
+  batch_sizes:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+
+print_iter_log: true

--- a/components/backends/trtllm/engine_configs/deepseek_r1/simple/decode.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/simple/decode.yaml.bak
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+backend: pytorch
+
+# TP/EP/PP/DP
+tensor_parallel_size: 4
+moe_expert_parallel_size: 4
+pipeline_parallel_size: 1
+enable_attention_dp: false
+
+max_batch_size: 256
+max_num_tokens: 256
+# 8448 = 8192 ISL + 256 OSL
+max_seq_len: 8448
+
+kv_cache_config:
+  # With dp attention disabled: high free_gpu_memory_fraction is fine.
+  free_gpu_memory_fraction: 0.85
+  # With dp attention enabled: large ISL at high concurrency may need
+  # free_gpu_memory_fraction low to have enough available memory.
+  # free_gpu_memory_fraction: 0.30
+  dtype: fp8
+
+# NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
+# NOTE: overlap_scheduler enabled by default since this commit and changed
+# config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+# https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
+disable_overlap_scheduler: false
+
+cuda_graph_config:
+  enable_padding: true
+  # NOTE: For larger max batch size, you may want to
+  # add larger cuda graph batch sizes below to match.
+  batch_sizes:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+
+print_iter_log: true
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/deepseek_r1/simple/prefill.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/simple/prefill.yaml.bak
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+backend: pytorch
+
+# TP/EP/PP/DP
+tensor_parallel_size: 4
+moe_expert_parallel_size: 4
+pipeline_parallel_size: 1
+enable_attention_dp: true
+
+max_batch_size: 1
+max_num_tokens: 8192
+max_seq_len: 8192
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.75
+  dtype: fp8 # NOTE: This dtype must match in both prefill/decode configs
+
+# NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
+# NOTE: overlap_scheduler enabled by default since this commit and changed
+# config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+# https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
+disable_overlap_scheduler: true
+print_iter_log: true
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/dep16_agg.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/dep16_agg.yaml.bak
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Example of a Multi-node worker, but no WideEP or EPLB.
+# See wide_ep*.yaml for WideEP example configs.
+backend: pytorch
+tensor_parallel_size: 16
+moe_expert_parallel_size: 16
+enable_attention_dp: true
+max_batch_size: 256
+max_num_tokens: 256
+max_seq_len: 8448
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.7
+  dtype: fp8
+
+cuda_graph_config:
+  enable_padding: true
+  batch_sizes:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256

--- a/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/eplb.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/eplb.yaml.bak
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# moe_load_balancer settings for TRTLLM based on:
+# https://github.com/NVIDIA/TensorRT-LLM/blob/main/examples/ep_load_balancer/README.md#online-ep-load-balancer
+num_slots: 288
+layer_updates_per_iter: 2

--- a/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/wide_ep_agg.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/wide_ep_agg.yaml.bak
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+backend: pytorch
+
+# WideEP related settings
+moe_config:
+  backend: WIDEEP
+  # moe_max_num_tokens will default to max_num_tokens if left unspecified.
+  #
+  # If you want to set this value explicitly, one recommendation is below:
+  #   moe_max_num_tokens = max_batch_size * moe_expert_parallel_size
+  #   4096 = 256 * 16
+  # moe_max_num_tokens: 4096
+  load_balancer: /mnt/engine_configs/deepseek_r1/wide_ep/eplb.yaml
+
+tensor_parallel_size: 16
+moe_expert_parallel_size: 16
+
+enable_attention_dp: true
+max_batch_size: 256
+max_num_tokens: 256
+max_seq_len: 8448
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.3
+  dtype: fp8
+
+cuda_graph_config:
+  enable_padding: true
+  batch_sizes:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256

--- a/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/wide_ep_decode.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/wide_ep_decode.yaml.bak
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+backend: pytorch
+
+# WideEP related settings
+moe_config:
+  backend: WIDEEP
+  load_balancer: /mnt/engine_configs/deepseek_r1/wide_ep/eplb.yaml
+
+# TP/EP/PP/DP
+tensor_parallel_size: 16
+moe_expert_parallel_size: 16
+pipeline_parallel_size: 1
+enable_attention_dp: true
+
+max_batch_size: 256
+max_num_tokens: 256
+# 8448 = 8192 ISL + 256 OSL
+max_seq_len: 8448
+
+kv_cache_config:
+  # With dp attention disabled: high free_gpu_memory_fraction is fine.
+  # free_gpu_memory_fraction: 0.85
+  # With dp attention enabled: large ISL at high concurrency may need
+  # free_gpu_memory_fraction low to have enough available memory.
+  free_gpu_memory_fraction: 0.30
+  dtype: fp8
+
+
+# NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
+# NOTE: overlap_scheduler enabled by default since this commit and changed
+# config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+# https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
+disable_overlap_scheduler: false
+cuda_graph_config:
+  enable_padding: true
+  # NOTE: For larger max batch size, you may want to
+  # add larger cuda graph batch sizes below to match.
+  batch_sizes:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+
+
+print_iter_log: true
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/wide_ep_prefill.yaml.bak
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/wide_ep_prefill.yaml.bak
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+backend: pytorch
+
+# WideEP related settings
+moe_config:
+  backend: WIDEEP
+  load_balancer: /mnt/engine_configs/deepseek_r1/wide_ep/eplb.yaml
+
+# TP/EP/PP/DP
+tensor_parallel_size: 16
+moe_expert_parallel_size: 16
+pipeline_parallel_size: 1
+enable_attention_dp: true
+
+max_batch_size: 1
+max_num_tokens: 8192
+max_seq_len: 8192
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.3
+  dtype: fp8 # NOTE: This dtype must match in both prefill/decode configs
+
+# NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
+# NOTE: overlap_scheduler enabled by default since this commit and changed
+# config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+# https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428
+disable_overlap_scheduler: true
+print_iter_log: true
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/gemma3/vswa_agg.yaml.bak
+++ b/components/backends/trtllm/engine_configs/gemma3/vswa_agg.yaml.bak
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tensor_parallel_size: 1
+backend: pytorch
+
+kv_cache_config:
+  max_attention_window:
+    - 512
+    - 512
+    - 512
+    - 512
+    - 512
+    - 32768

--- a/components/backends/trtllm/engine_configs/gemma3/vswa_decode.yaml.bak
+++ b/components/backends/trtllm/engine_configs/gemma3/vswa_decode.yaml.bak
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tensor_parallel_size: 1
+backend: pytorch
+
+kv_cache_config:
+  max_attention_window:
+    - 512
+    - 512
+    - 512
+    - 512
+    - 512
+    - 32768
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/gemma3/vswa_prefill.yaml.bak
+++ b/components/backends/trtllm/engine_configs/gemma3/vswa_prefill.yaml.bak
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tensor_parallel_size: 1
+backend: pytorch
+disable_overlap_scheduler: true
+
+kv_cache_config:
+  max_attention_window:
+    - 512
+    - 512
+    - 512
+    - 512
+    - 512
+    - 32768
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/gpt_oss/decode.yaml.bak
+++ b/components/backends/trtllm/engine_configs/gpt_oss/decode.yaml.bak
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+enable_attention_dp: true
+disable_overlap_scheduler: false
+moe_config:
+    backend: CUTLASS
+cuda_graph_config:
+    enable_padding: true
+cache_transceiver_config:
+  backend: ucx
+  max_tokens_in_buffer: 65536
+print_iter_log: false
+stream_interval: 10

--- a/components/backends/trtllm/engine_configs/gpt_oss/prefill.yaml.bak
+++ b/components/backends/trtllm/engine_configs/gpt_oss/prefill.yaml.bak
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+enable_attention_dp: false
+disable_overlap_scheduler: true
+moe_config:
+    backend: CUTLASS
+enable_chunked_prefill: true
+cuda_graph_config:
+    max_batch_size: 32
+    enable_padding: true
+cache_transceiver_config:
+  backend: ucx
+  max_tokens_in_buffer: 65536
+print_iter_log: false
+stream_interval: 10

--- a/components/backends/trtllm/engine_configs/llama4/eagle/eagle_agg.yaml.bak
+++ b/components/backends/trtllm/engine_configs/llama4/eagle/eagle_agg.yaml.bak
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+backend: pytorch
+tensor_parallel_size: 4
+moe_expert_parallel_size: 4
+max_batch_size: 256
+# When max_num_tokens set to higher values, can cause OOM issues.
+# Will be investigated in the future with TRTLLM team.
+max_num_tokens: 1024
+max_seq_len: 8448
+enable_autotuner: false
+disable_overlap_scheduler: true
+
+# Enable Speculative Decoding in the model engine
+speculative_config:
+  decoding_type: Eagle
+  max_draft_len: 1
+  speculative_model_dir: nvidia/Llama-4-Maverick-17B-128E-Eagle3
+  eagle3_one_model: false
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.5
+  enable_block_reuse: false
+
+
+cuda_graph_config:
+  max_batch_size: 8
+

--- a/components/backends/trtllm/engine_configs/llama4/eagle/eagle_decode.yaml.bak
+++ b/components/backends/trtllm/engine_configs/llama4/eagle/eagle_decode.yaml.bak
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+backend: pytorch
+tensor_parallel_size: 4
+moe_expert_parallel_size: 4
+max_batch_size: 256
+max_num_tokens: 512
+# 8704 = 8192 ISL + 512 OSL
+max_seq_len: 8704
+disable_overlap_scheduler: true
+enable_autotuner: false
+
+# Enable Speculative Decoding in the model engine
+speculative_config:
+  decoding_type: Eagle
+  max_draft_len: 1
+  speculative_model_dir: nvidia/Llama-4-Maverick-17B-128E-Eagle3
+  eagle3_one_model: false
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.5
+  enable_block_reuse: false
+  dtype: fp8
+
+cuda_graph_config:
+  enable_padding: true
+  batch_sizes:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+
+print_iter_log: true
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/llama4/eagle/eagle_prefill.yaml.bak
+++ b/components/backends/trtllm/engine_configs/llama4/eagle/eagle_prefill.yaml.bak
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+backend: pytorch
+tensor_parallel_size: 4
+moe_expert_parallel_size: 4
+max_batch_size: 1
+max_num_tokens: 8192
+max_seq_len: 8192
+print_iter_log: true
+disable_overlap_scheduler: true
+enable_autotuner: false
+
+# Enable Speculative Decoding in the model engine
+speculative_config:
+  decoding_type: Eagle
+  max_draft_len: 1
+  speculative_model_dir: nvidia/Llama-4-Maverick-17B-128E-Eagle3
+  eagle3_one_model: false
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.5
+  enable_block_reuse: false
+  dtype: fp8
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/llama4/eagle_one_model/eagle_decode.yaml.bak
+++ b/components/backends/trtllm/engine_configs/llama4/eagle_one_model/eagle_decode.yaml.bak
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+backend: pytorch
+tensor_parallel_size: 8
+moe_expert_parallel_size: 8
+max_batch_size: 256
+max_num_tokens: 1024
+# 8704 = 8192 ISL + 512 OSL
+max_seq_len: 8704
+disable_overlap_scheduler: true
+
+# Enable Speculative Decoding in the model engine
+speculative_config:
+  decoding_type: Eagle
+  max_draft_len: 3
+  speculative_model_dir: nvidia/Llama-4-Maverick-17B-128E-Eagle3
+  eagle3_one_model: True
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.5
+  enable_block_reuse: false
+
+cuda_graph_config:
+  padding_enabled: true
+  max_batch_size: 256
+
+print_iter_log: true
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/llama4/eagle_one_model/eagle_prefill.yaml.bak
+++ b/components/backends/trtllm/engine_configs/llama4/eagle_one_model/eagle_prefill.yaml.bak
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+backend: pytorch
+tensor_parallel_size: 8
+moe_expert_parallel_size: 8
+max_batch_size: 1
+max_num_tokens: 8192
+max_seq_len: 8192
+print_iter_log: true
+disable_overlap_scheduler: true
+
+# Enable Speculative Decoding in the model engine
+speculative_config:
+  decoding_type: Eagle
+  max_draft_len: 3
+  speculative_model_dir: nvidia/Llama-4-Maverick-17B-128E-Eagle3
+  eagle3_one_model: True
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.5
+  enable_block_reuse: false
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/multimodal/agg.yaml.bak
+++ b/components/backends/trtllm/engine_configs/multimodal/agg.yaml.bak
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 8
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 4096
+max_batch_size: 8
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.3
+  enable_block_reuse: false
+
+cache_transceiver_config:
+  backend: default
+# NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
+# NOTE: overlap_scheduler enabled by default since this commit and changed
+# config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':
+# https://github.com/NVIDIA/TensorRT-LLM/commit/b4e5df0ee0024eda3eeb83a6ba822245a30ab428

--- a/components/backends/trtllm/engine_configs/multimodal/decode.yaml.bak
+++ b/components/backends/trtllm/engine_configs/multimodal/decode.yaml.bak
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 1
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+max_batch_size: 16
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+disable_overlap_scheduler: false
+kv_cache_config:
+  free_gpu_memory_fraction: 0.30
+  enable_block_reuse: false
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/multimodal/llama4/decode.yaml.bak
+++ b/components/backends/trtllm/engine_configs/multimodal/llama4/decode.yaml.bak
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 8
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+max_batch_size: 16
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+disable_overlap_scheduler: false
+kv_cache_config:
+  free_gpu_memory_fraction: 0.30
+  enable_block_reuse: false
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/multimodal/llama4/prefill.yaml.bak
+++ b/components/backends/trtllm/engine_configs/multimodal/llama4/prefill.yaml.bak
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 8
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+max_batch_size: 16
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+# Overlap scheduler not currently supported in prefill only workers.
+disable_overlap_scheduler: true
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.30
+  enable_block_reuse: false
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/multimodal/prefill.yaml.bak
+++ b/components/backends/trtllm/engine_configs/multimodal/prefill.yaml.bak
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 1
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+max_batch_size: 16
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+# Overlap scheduler not currently supported in prefill only workers.
+disable_overlap_scheduler: true
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.30
+  enable_block_reuse: false
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/trtllm/engine_configs/prefill.yaml.bak
+++ b/components/backends/trtllm/engine_configs/prefill.yaml.bak
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 1
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+# Overlap scheduler not currently supported in prefill only workers.
+disable_overlap_scheduler: true
+cuda_graph_config:
+  max_batch_size: 16
+kv_cache_config:
+  free_gpu_memory_fraction: 0.85
+
+cache_transceiver_config:
+  backend: default

--- a/components/backends/vllm/README.md
+++ b/components/backends/vllm/README.md
@@ -51,7 +51,7 @@ git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 | **DP Rank Routing**| ✅   | Supported via external control of DP ranks |
 | **GB200 Support**  | 🚧   | Container functional on main |
 
-## Quick Start
+## vLLM Quick Start
 
 Below we provide a guide that lets you run all of our the common deployment patterns on a single node.
 

--- a/components/backends/vllm/deepseek-r1.md
+++ b/components/backends/vllm/deepseek-r1.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 
 Dynamo supports running Deepseek R1 with data parallel attention and wide expert parallelism. Each data parallel attention rank is a seperate dynamo component that will emit its own KV Events and Metrics. vLLM controls the expert parallelism using the flag `--enable-expert-parallel`
 
-# Instructions
+## Instructions
 
 The following script can be adapted to run Deepseek R1 with a variety of different configuration. The current configuration uses 2 nodes, 16 GPUs, and a dp of 16. Follow the [ReadMe](README.md) Getting Started section on each node, and then run these two commands.
 

--- a/components/backends/vllm/deploy/agg.yaml.bak
+++ b/components/backends/vllm/deploy/agg.yaml.bak
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-agg
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: vllm-agg
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.frontend --http-port 8000"
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-agg
+      componentType: worker
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B

--- a/components/backends/vllm/deploy/agg_router.yaml.bak
+++ b/components/backends/vllm/deploy/agg_router.yaml.bak
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-agg-router
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: vllm-agg-router
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.frontend --http-port 8000 --router-mode kv"
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-agg-router
+      componentType: worker
+      replicas: 2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B

--- a/components/backends/vllm/deploy/disagg.yaml.bak
+++ b/components/backends/vllm/deploy/disagg.yaml.bak
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: vllm-disagg
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests:
+          cpu: "32"
+          memory: "10Gi"
+        limits:
+          cpu: "32"
+          memory: "10Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.frontend --http-port 8000"
+    VllmDecodeWorker:
+      dynamoNamespace: vllm-disagg
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "32"
+          memory: "40Gi"
+          gpu: "1"
+        limits:
+          cpu: "32"
+          memory: "40Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B"
+    VllmPrefillWorker:
+      dynamoNamespace: vllm-disagg
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "32"
+          memory: "40Gi"
+          gpu: "1"
+        limits:
+          cpu: "32"
+          memory: "40Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --is-prefill-worker"

--- a/components/backends/vllm/deploy/disagg_planner.yaml.bak
+++ b/components/backends/vllm/deploy/disagg_planner.yaml.bak
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg-planner
+spec:
+  envs:
+    - name: DYNAMO_SERVICE_CONFIG
+      value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:9090"]}]},{"job_name":"frontend","static_configs":[{"targets":["vllm-disagg-planner-frontend:8000"]}]}]}}'
+    - name: DYNAMO_PORT
+      value: "8000"
+    - name: DYNAMO_NAMESPACE
+      value: "vllm-disagg-planner"
+  services:
+    Frontend:
+      dynamoNamespace: vllm-disagg-planner
+      componentType: frontend
+      replicas: 1
+      resources:
+        requests:
+          cpu: "32"
+          memory: "10Gi"
+        limits:
+          cpu: "32"
+          memory: "10Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.frontend --http-port 8000"
+    Planner:
+      dynamoNamespace: vllm-disagg-planner
+      envFromSecret: hf-token-secret
+      componentType: planner
+      replicas: 1
+      livenessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      readinessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        initialDelaySeconds: 60
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      resources:
+        requests:
+          cpu: "2"
+          memory: "2Gi"
+        limits:
+          cpu: "2"
+          memory: "2Gi"
+      pvc:
+        create: false
+        name: dynamo-pvc # Must be pre-created before deployment and SLA profiler must have been run
+        mountPoint: /workspace/profiling_results
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/planner/src/dynamo/planner
+          args:
+            - python
+            - -m
+            - planner_sla
+            - --environment=kubernetes
+            - --backend=vllm
+            - --adjustment-interval=60
+            - --profile-results-dir=/workspace/profiling_results
+    Prometheus: # NOTE: this is set on Prometheus to ensure a service is created for the Prometheus component. This is a workaround and should be managed differently.
+      dynamoNamespace: vllm-disagg-planner
+      componentType: frontend
+      replicas: 1
+      envs:
+        - name: PYTHONPATH
+          value: "/workspace/components/planner/src"
+      livenessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      readinessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        initialDelaySeconds: 30
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      resources:
+        requests:
+          cpu: "2"
+          memory: "2Gi"
+        limits:
+          cpu: "2"
+          memory: "2Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.planner.prometheus"
+    VllmDecodeWorker:
+      dynamoNamespace: vllm-disagg-planner
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 2
+      resources:
+        requests:
+          cpu: "8"
+          memory: "16Gi"
+          gpu: "1"
+        limits:
+          cpu: "8"
+          memory: "16Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --migration-limit=3"
+    VllmPrefillWorker:
+      dynamoNamespace: vllm-disagg-planner
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 2
+      resources:
+        requests:
+          cpu: "8"
+          memory: "16Gi"
+          gpu: "1"
+        limits:
+          cpu: "8"
+          memory: "16Gi"
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --is-prefill-worker --migration-limit=3

--- a/components/backends/vllm/deploy/disagg_router.yaml.bak
+++ b/components/backends/vllm/deploy/disagg_router.yaml.bak
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-v1-disagg-router
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: vllm-v1-disagg-router
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.frontend --http-port 8000 --router-mode kv"
+    VllmDecodeWorker:
+      dynamoNamespace: vllm-v1-disagg-router
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B
+    VllmPrefillWorker:
+      dynamoNamespace: vllm-v1-disagg-router
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --is-prefill-worker

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -48,7 +48,7 @@ There are multi-faceted challenges:
 
 To address the growing demands of distributed inference serving, NVIDIA introduces Dynamo. This innovative product tackles key challenges in scheduling, memory management, and data transfer. Dynamo employs KV-aware routing for optimized decoding, leveraging existing KV caches. For efficient global memory management at scale, it strategically stores and evicts KV caches across multiple memory tiers—GPU, CPU, SSD, and object storage—enhancing both time-to-first-token and overall throughput. Dynamo features NIXL (NVIDIA Inference tranXfer Library), a new data transfer engine designed for dynamic scaling and low-latency storage access.
 
-## High level architecture and key benefits
+## Key benefits
 
 The following diagram outlines Dynamo's high-level architecture. To enable large-scale distributed and disaggregated inference serving, Dynamo includes five key features:
 

--- a/docs/architecture/sla_planner.md
+++ b/docs/architecture/sla_planner.md
@@ -17,7 +17,7 @@ The SLA (Service Level Agreement)-based planner is an intelligent autoscaling sy
 * **Performance interpolation**: Leverages profiling results data from pre-deployment profiling for accurate scaling decisions
 * **Correction factors**: Adapts to real-world performance deviations from profiled data
 
-## Architecture
+## Design
 
 The SLA planner consists of several key components:
 
@@ -108,7 +108,7 @@ Finally, SLA planner applies the change by scaling up/down the number of prefill
 
 For detailed deployment instructions including setup, configuration, troubleshooting, and architecture overview, see the [SLA Planner Deployment Guide](../guides/dynamo_deploy/sla_planner_deployment.md).
 
-**Quick Start:**
+**To deploy SLA Planner:**
 ```bash
 cd components/backends/vllm/deploy
 kubectl apply -f disagg_planner.yaml -n {$NAMESPACE}

--- a/docs/components/backends/sglang/docs/multinode-examples.md
+++ b/docs/components/backends/sglang/docs/multinode-examples.md
@@ -1,1 +1,0 @@
-../../../../../components/backends/sglang/docs/multinode-examples.md

--- a/docs/components/backends/trtllm/README.md
+++ b/docs/components/backends/trtllm/README.md
@@ -1,1 +1,0 @@
-../../../../components/backends/trtllm/README.md

--- a/docs/components/backends/vllm/README.md
+++ b/docs/components/backends/vllm/README.md
@@ -1,1 +1,0 @@
-../../../../components/backends/vllm/README.md

--- a/docs/components/router/README.md
+++ b/docs/components/router/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 
 The Dynamo KV Router intelligently routes requests by evaluating their computational costs across different workers. It considers both decoding costs (from active blocks) and prefill costs (from newly computed blocks). Optimizing the KV Router is critical for achieving maximum throughput and minimum latency in distributed inference setups.
 
-## Quick Start
+## KV Router Quick Start
 
 To launch the Dynamo frontend with the KV Router:
 

--- a/docs/guides/dynamo_deploy/README.md
+++ b/docs/guides/dynamo_deploy/README.md
@@ -17,85 +17,66 @@ limitations under the License.
 
 # Deploying Inference Graphs to Kubernetes
 
- We expect users to deploy their inference graphs using CRDs or helm charts.
+High-level guide to Dynamo Kubernetes deployments. Start here, then dive into specific guides.
 
-# 1. Install Dynamo Cloud.
+## 1. Install Platform First
+**[Dynamo Kubernetes Platform](dynamo_cloud.md)** - Main installation guide with 3 paths
 
-Prior to deploying an inference graph the user should deploy the Dynamo Cloud Platform. Reference the [Quickstart Guide](quickstart.md) for steps to install Dynamo Cloud with Helm.
+## 2. Choose Your Backend
 
-Dynamo Cloud acts as an orchestration layer between the end user and Kubernetes, handling the complexity of deploying your graphs for you. This is a one-time action, only necessary the first time you deploy a DynamoGraph.
+Each backend has deployment examples and configuration options:
 
-# 2. Deploy your inference graph.
+| Backend | Available Configurations |
+|---------|--------------------------|
+| **[vLLM](../../components/backends/vllm/deploy/README.md)** | Aggregated, Aggregated + Router, Disaggregated, Disaggregated + Router, Disaggregated + Planner |
+| **[SGLang](../../components/backends/sglang/deploy/README.md)** | Aggregated, Aggregated + Router, Disaggregated, Disaggregated + Planner, Disaggregated Multi-node |
+| **[TensorRT-LLM](../../components/backends/trtllm/deploy/README.md)** | Aggregated, Aggregated + Router, Disaggregated, Disaggregated + Router | 
 
-We provide a Custom Resource YAML file for many examples under the components/backends/{engine}/deploy folders. Consult the examples below for the CRs for a specific inference backend.
-
-[View SGLang K8s](../../../components/backends/sglang/deploy/README.md)
-
-[View vLLM K8s](../../../components/backends/vllm/deploy/README.md)
-
-[View TRT-LLM K8s](../../../components/backends/trtllm/deploy/README.md)
-
-### Deploying a particular example
+## 3. Deploy Your First Model
 
 ```bash
-# Set your dynamo root directory
-cd <root-dynamo-folder>
-export PROJECT_ROOT=$(pwd)
-export NAMESPACE=<your-namespace> # the namespace you used to deploy Dynamo cloud to.
-```
+# Set same namespace from platform install
+export NAMESPACE=dynamo-cloud
 
-Deploying an example consists of the simple `kubectl apply -f ... -n ${NAMESPACE}` command. For example:
-
-```bash
+# Deploy any example (this uses vLLM with Qwen model using aggregated serving)
 kubectl apply -f components/backends/vllm/deploy/agg.yaml -n ${NAMESPACE}
+
+# Check status
+kubectl get dynamoGraphDeployment -n ${NAMESPACE}
+
+# Test it
+kubectl port-forward svc/agg-vllm-frontend 8000:8000 -n ${NAMESPACE}
+curl http://localhost:8000/v1/models
 ```
 
-You can use `kubectl get dynamoGraphDeployment -n ${NAMESPACE}` to view your deployment.
-You can use `kubectl delete dynamoGraphDeployment <your-dep-name> -n ${NAMESPACE}` to delete the deployment.
+## What's a DynamoGraphDeployment?
 
-We provide a Custom Resource YAML file for many examples under the `deploy/` folder.
-Use [VLLM YAML](../../components/backends/vllm/deploy/agg.yaml) for an example.
+It's a Kubernetes Custom Resource that defines your inference pipeline:
+- Model configuration
+- Resource allocation (GPUs, memory)
+- Scaling policies
+- Frontend/backend connections
 
-**Note 1** Example Image
-
-The examples use a prebuilt image from the `nvcr.io` registry.
-You can utilize public images from [Dynamo NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo) or build your own image and update the image location in your CR file prior to applying. Either way, you will need to overwrite the image in the example YAML.
-
-To build your own image:
-
-```bash
-./container/build.sh --framework <your-inference-framework>
+Example structure:
+```yaml
+apiVersion: dynamo.ai.nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: my-llm
+spec:
+  frontends:
+    - type: http
+      port: 8000
+  backends:
+    - type: vllm
+      model: "Qwen/Qwen2-0.5B"
+      gpus: 1
 ```
 
-For example for the `sglang` run
-```bash
-./container/build.sh --framework sglang
-```
+## Additional Resources
 
-To overwrite the image in the example:
-
-```bash
-extraPodSpec:
-        mainContainer:
-          image: <image-in-your-$DYNAMO_IMAGE>
-```
-
-**Note 2**
-Setup port forward if needed when deploying to Kubernetes.
-
-List the services in your namespace:
-
-```bash
-kubectl get svc -n ${NAMESPACE}
-```
-Look for one that ends in `-frontend` and use it for port forward.
-
-```bash
-SERVICE_NAME=$(kubectl get svc -n ${NAMESPACE} -o name | grep frontend | sed 's|.*/||' | sed 's|-frontend||' | head -n1)
-kubectl port-forward svc/${SERVICE_NAME}-frontend 8080:8080 -n ${NAMESPACE}
-```
-
-Additional Resources:
-- [Port Forward Documentation](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
-- [Examples Deployment Guide](../../examples/README.md#deploying-a-particular-example)
+- **[Examples](../../examples/README.md)** - Complete working examples
+- **[Create Custom Deployments](create_deployment.md)** - Build your own CRDs
+- **[Operator Documentation](dynamo_operator.md)** - How the platform works
+- **[Helm Charts](../../deploy/helm/README.md)** - For advanced users
 

--- a/docs/guides/dynamo_deploy/dynamo_cloud.md
+++ b/docs/guides/dynamo_deploy/dynamo_cloud.md
@@ -15,102 +15,167 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Dynamo Cloud Kubernetes Platform
+# Dynamo Kubernetes Platform
 
-The Dynamo Cloud platform is a comprehensive solution for deploying and managing Dynamo inference graphs (also referred to as pipelines) in Kubernetes environments. It provides a streamlined experience for deploying, scaling, and monitoring your inference services.
+Deploy and manage Dynamo inference graphs on Kubernetes with automated orchestration and scaling, using the Dynamo Kubernetes Platform.
 
-## Overview
+## Quick Start Paths
 
-The Dynamo cloud platform consists of several key components:
+**Path A: Production Install**  
+Install from published artifacts on your existing cluster → [Jump to Path A](#path-a-production-install)
 
-- **Dynamo Operator**: A Kubernetes operator that manages the lifecycle of Dynamo inference graphs from build ➡️ deploy. For more information on the operator, see [Dynamo Kubernetes Operator Documentation](../dynamo_deploy/dynamo_operator.md)
-- **Custom Resources**: Kubernetes custom resources for defining and managing Dynamo services
+**Path B: Local Development**  
+Set up Minikube first → [Minikube Setup](minikube.md) → Then follow Path A
 
-
-## Deployment Prerequisites
-
-Before getting started with the Dynamo cloud platform, ensure you have:
-
-- A Kubernetes cluster (version 1.24 or later)
-- [Earthly](https://earthly.dev/) installed for building components
-- Docker installed and running
-- Access to a container registry (e.g., Docker Hub, NVIDIA NGC, etc.)
-- `kubectl` configured to access your cluster
-- Helm installed (version 3.0 or later)
-
-
-> [!TIP]
-> Don't have a Kubernetes cluster? Check out our [Minikube setup guide](../../../docs/guides/dynamo_deploy/minikube.md) to set up a local environment! 🏠
-
-#### 🏗️ Build Dynamo inference runtime.
-
-[One-time Action]
-Before you could use Dynamo make sure you have setup the Inference Runtime Image.
-For basic cases you could use the prebuilt image for the Dynamo Inference Runtime.
-Just export the environment variable. This will be the image used by your individual components. You pick whatever dynamo version you want or use the latest (default)
-
-```bash
-export DYNAMO_IMAGE=nvcr.io/nvidia/dynamo:latest-vllm
-```
-
-For a custom setup build and push to your registry Dynamo Base Image for Dynamo inference runtime. This is a one-time operation.
-
-```bash
-# Run the script to build the default dynamo:latest-vllm image.
-./container/build.sh
-export IMAGE_TAG=<TAG>
-# Tag the image
-docker tag dynamo:latest-vllm <your-registry>/dynamo:${IMAGE_TAG}
-docker push <your-registry>/dynamo:${IMAGE_TAG}
-```
-
-## 🚀 Deploying the Dynamo Cloud Platform
+**Path C: Custom Development**  
+Build from source for customization → [Jump to Path C](#path-c-custom-development)
 
 ## Prerequisites
 
-Before deploying Dynamo Cloud, ensure your Kubernetes cluster meets the following requirements:
-
-#### 1. 🛡️ Istio Installation
-Dynamo Cloud requires Istio for service mesh capabilities. Verify Istio is installed and running:
-
 ```bash
-# Check if Istio is installed
-kubectl get pods -n istio-system
+# Required tools
+kubectl version --client  # v1.24+
+helm version             # v3.0+
+docker version           # Running daemon
 
-# Expected output should show running Istio pods
-# istiod-* pods should be in Running state
+# Set your inference runtime image
+export DYNAMO_IMAGE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+# Also available: sglang-runtime, tensorrtllm-runtime
 ```
 
-#### 2. 💾 PVC Support with Default Storage Class
-Dynamo Cloud requires Persistent Volume Claim (PVC) support with a default storage class. Verify your cluster configuration:
+> [!TIP]
+> No cluster? See [Minikube Setup](minikube.md) for local development.
+
+## Path A: Production Install
+
+Install from [NGC published artifacts](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo/artifacts) in 3 steps.
 
 ```bash
-# Check if default storage class exists
-kubectl get storageclass
+# 1. Set environment
+export NAMESPACE=dynamo-kubernetes
+export RELEASE_VERSION=0.4.0 # any version of Dynamo 0.3.2+
 
-# Expected output should show at least one storage class marked as (default)
-# Example:
-# NAME                 PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
-# standard (default)   kubernetes.io/gce-pd    Delete          Immediate              true                   1d
+# 2. Install CRDs
+helm fetch https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-crds-${RELEASE_VERSION}.tgz
+helm install dynamo-crds dynamo-crds-${RELEASE_VERSION}.tgz --namespace default
+
+# 3. Install Platform
+kubectl create namespace ${NAMESPACE}
+helm fetch https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-${RELEASE_VERSION}.tgz
+helm install dynamo-platform dynamo-platform-${RELEASE_VERSION}.tgz --namespace ${NAMESPACE}
 ```
 
-## Installation
+→ [Verify Installation](#verify-installation)
 
-Follow [Quickstart Guide](./quickstart.md) to install the Dynamo Cloud
+## Path C: Custom Development
 
-⚠️ **Note:** that omitting `--crds` will skip the CRDs installation/upgrade. This is useful when installing on a shared cluster as CRDs are cluster-scoped resources.
+Build and deploy from source for customization.
 
-⚠️ **Note:** If you'd like to only generate the generated-values.yaml file without deploying to Kubernetes (e.g., for inspection, CI workflows, or dry-run testing), use:
+### Quick Deploy Script
 
 ```bash
-./deploy_dynamo_cloud.py --yaml-only
+# 1. Set environment
+export NAMESPACE=dynamo-cloud
+export DOCKER_SERVER=nvcr.io/nvidia/ai-dynamo/  # or your registry
+export DOCKER_USERNAME='$oauthtoken'
+export DOCKER_PASSWORD=<YOUR_NGC_CLI_API_KEY>
+export IMAGE_TAG=0.4.0
+
+# 2. Build operator
+cd deploy/cloud/operator
+earthly --push +docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
+cd -
+
+# 3. Create namespace and secrets
+kubectl create namespace ${NAMESPACE}
+kubectl create secret docker-registry docker-imagepullsecret \
+  --docker-server=${DOCKER_SERVER} \
+  --docker-username=${DOCKER_USERNAME} \
+  --docker-password=${DOCKER_PASSWORD} \
+  --namespace=${NAMESPACE}
+
+# 4. Deploy
+helm repo add bitnami https://charts.bitnami.com/bitnami
+./deploy.sh --crds
 ```
 
+### Manual Steps (Alternative)
 
+<details>
+<summary>Click to expand manual installation steps</summary>
 
-### Cloud Provider-Specific deployment
+**Step 1: Install CRDs**
+```bash
+helm install dynamo-crds ./crds/ --namespace default
+```
 
-#### Google Kubernetes Engine (GKE) deployment
+```bash
+helm dep build ./platform/
+helm install dynamo-platform ./platform/ \
+  --namespace ${NAMESPACE} \
+  --set "dynamo-operator.controllerManager.manager.image.repository=${DOCKER_SERVER}/dynamo-operator" \
+  --set "dynamo-operator.controllerManager.manager.image.tag=${IMAGE_TAG}" \
+  --set "dynamo-operator.imagePullSecrets[0].name=docker-imagepullsecret"
+```
+</details>
 
-You can find detailed instructions for deployment in GKE [here](../dynamo_deploy/gke_setup.md)
+→ [Verify Installation](#verify-installation)
+
+## Verify Installation
+
+```bash
+# Check CRDs
+kubectl get crd | grep dynamo
+
+# Check operator and platform pods
+kubectl get pods -n ${NAMESPACE}
+# Expected: dynamo-operator-* and etcd-* pods Running
+```
+
+## Next Steps
+
+1. **Deploy Model/Workflow**
+   ```bash
+   # Example: Deploy a vLLM workflow with Qwen3-0.6B using aggregated serving
+   kubectl apply -f components/backends/vllm/deploy/agg.yaml -n ${NAMESPACE}
+   
+   # Port forward and test
+   kubectl port-forward svc/agg-vllm-frontend 8000:8000 -n ${NAMESPACE}
+   curl http://localhost:8000/v1/models
+   ```
+
+2. **Explore Backend Guides**
+   - [vLLM Deployments](../../components/backends/vllm/deploy/README.md)
+   - [SGLang Deployments](../../components/backends/sglang/deploy/README.md)
+   - [TensorRT-LLM Deployments](../../components/backends/trtllm/deploy/README.md)
+
+3. **Optional:**
+   - [Set up Prometheus & Grafana](k8s_metrics.md)
+   - [SLA Planner Deployment Guide](sla_planner_deployment.md) (for advanced SLA-aware scheduling and autoscaling)
+
+## Troubleshooting
+
+**Pods not starting?**
+```bash
+kubectl describe pod <pod-name> -n ${NAMESPACE}
+kubectl logs <pod-name> -n ${NAMESPACE}
+```
+
+**HuggingFace model access?**
+```bash
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN=${HF_TOKEN} \
+  -n ${NAMESPACE}
+```
+
+**Clean uninstall?**
+```bash
+./uninstall.sh  # Removes all CRDs and platform
+```
+
+## Advanced Options
+
+- [GKE-specific setup](gke_setup.md)
+- [Create custom deployments](create_deployment.md)
+- [Dynamo Operator details](dynamo_operator.md)
 

--- a/docs/guides/dynamo_deploy/dynamo_operator.md
+++ b/docs/guides/dynamo_deploy/dynamo_operator.md
@@ -70,16 +70,16 @@ spec:
 
 ## Installation
 
-[See installation steps](dynamo_cloud.md#overview)
+[See installation steps](dynamo_cloud.md)
 
 
 ## GitOps Deployment with FluxCD
 
-This section describes how to use FluxCD for GitOps-based deployment of Dynamo inference graphs. GitOps enables you to manage your Dynamo deployments declaratively using Git as the source of truth. We'll use the [aggregated vLLM example](../../../components/backends/vllm/README.md) to demonstrate the workflow.
+This section describes how to use FluxCD for GitOps-based deployment of Dynamo inference graphs. GitOps enables you to manage your Dynamo deployments declaratively using Git as the source of truth. We'll use the [aggregated vLLM example](../../components/backends/vllm/README.md) to demonstrate the workflow.
 
 ### Prerequisites
 
-- A Kubernetes cluster with [Dynamo Cloud](dynamo_cloud.md) installed
+- A Kubernetes cluster with [Dynamo Kubernetes Platform](dynamo_cloud.md) installed
 - [FluxCD](https://fluxcd.io/flux/installation/) installed in your cluster
 - A Git repository to store your deployment configurations
 
@@ -91,9 +91,9 @@ The GitOps workflow for Dynamo deployments consists of three main steps:
 2. Create and commit a DynamoGraphDeployment custom resource for initial deployment
 3. Update the graph by building a new version and updating the CR for subsequent updates
 
-### Step 1: Build and Push Dynamo Cloud Operator
+### Step 1: Build and Push Dynamo Operator
 
-First, follow to [See Install Dynamo Cloud](quickstart.md#install-dynamo-cloud).
+First, refer to [Install Dynamo Kubernetes Platform](dynamo_cloud.md).
 
 ### Step 2: Create Initial Deployment
 

--- a/docs/guides/dynamo_deploy/gke_setup.md
+++ b/docs/guides/dynamo_deploy/gke_setup.md
@@ -123,7 +123,7 @@ gcloud projects add-iam-policy-binding ${PROJECT} \
 
 ## Adding annotations to enable Workload Identity
 
-This is an example of values.yaml used to deploy Dynamo Cloud using custom GCP annotations to enable Workload Identity.
+This is an example of values.yaml used to deploy Dynamo Kubernetes Platform using custom GCP annotations to enable Workload Identity.
 
 ```yaml
 

--- a/docs/guides/dynamo_deploy/grove.md
+++ b/docs/guides/dynamo_deploy/grove.md
@@ -1,0 +1,94 @@
+# Grove Deployment Guide
+
+Grove is a Kubernetes API specifically designed to address the orchestration challenges of modern AI workloads, particularly disaggregated inference systems. Grove provides seamless integration with NVIDIA Dynamo for comprehensive AI infrastructure management.
+
+## Overview
+
+Grove was originally motivated by the challenges of orchestrating multinode, disaggregated inference systems. It provides a consistent and unified API that allows users to define, configure, and scale prefill, decode, and any other components like routing within a single custom resource.
+
+### How Grove Works for Disaggregated Serving
+
+Grove enables disaggregated serving by breaking down large language model inference into separate, specialized components that can be independently scaled and managed. This architecture provides several advantages:
+
+- **Component Specialization**: Separate prefill, decode, and routing components optimized for their specific tasks
+- **Independent Scaling**: Each component can scale based on its individual resource requirements and workload patterns
+- **Resource Optimization**: Better utilization of hardware resources through specialized workload placement
+- **Fault Isolation**: Issues in one component don't necessarily affect others
+
+## Core Components and API Resources
+
+Grove implements disaggregated serving through several custom Kubernetes resources that provide declarative composition of role-based pod groups:
+
+### PodGangSet
+The top-level Grove object that defines a group of components managed and colocated together. Key features include:
+- Support for autoscaling
+- Topology-aware spread of replicas for availability
+- Unified management of multiple disaggregated components
+
+### PodClique
+Represents a group of pods with a specific role (e.g., leader, worker, frontend). Each clique features:
+- Independent configuration options
+- Custom scaling logic support
+- Role-specific resource allocation
+
+### PodCliqueScalingGroup
+A set of PodCliques that scale and are scheduled together, ideal for tightly coupled roles like prefill leader and worker components that need coordinated scaling behavior.
+
+## Key Capabilities for Disaggregated Serving
+
+Grove provides several specialized features that make it particularly well-suited for disaggregated serving:
+
+### Flexible Gang Scheduling
+PodCliques and PodCliqueScalingGroups allow users to specify flexible gang-scheduling requirements at multiple levels within a PodGangSet to prevent resource deadlocks and ensure all components of a disaggregated system start together.
+
+### Multi-level Horizontal Auto-Scaling
+Supports pluggable horizontal auto-scaling solutions to scale PodGangSet, PodClique, and PodCliqueScalingGroup custom resources independently based on their specific metrics and requirements.
+
+### Network Topology-Aware Scheduling
+Allows specifying network topology pack and spread constraints to optimize for both network performance and service availability, crucial for disaggregated systems where components need efficient inter-node communication.
+
+### Custom Startup Dependencies
+Prescribes the order in which PodCliques must start in a declarative specification, with pod startup decoupled from pod creation or scheduling. This ensures proper initialization order for disaggregated components.
+
+## Use Cases and Examples
+
+Grove specifically supports:
+
+- **Multi-node disaggregated inference** for large models such as DeepSeek-R1 and Llama-4-Maverick
+- **Single-node disaggregated inference** for optimized resource utilization
+- **Agentic pipelines of models** for complex AI workflows
+- **Standard aggregated serving** patterns for single node or single GPU inference
+
+## Integration with NVIDIA Dynamo
+
+Grove is strategically aligned with NVIDIA Dynamo for seamless integration within the AI infrastructure stack:
+
+### Complementary Roles
+- **Grove**: Handles the Kubernetes orchestration layer for disaggregated AI workloads
+- **Dynamo**: Provides comprehensive AI infrastructure capabilities including serving backends, routing, and resource management
+
+### Release Coordination
+Grove is aligning its release schedule with NVIDIA Dynamo to ensure seamless integration, with the finalized release cadence reflected in the project roadmap.
+
+### Unified AI Platform
+The integration creates a comprehensive platform where:
+- Grove manages complex orchestration of disaggregated components
+- Dynamo provides the serving infrastructure, routing capabilities, and backend integrations
+- Together they enable sophisticated AI serving architectures with simplified management
+
+## Architecture Benefits
+
+Grove represents a significant advancement in Kubernetes-based orchestration for AI workloads by:
+
+1. **Simplifying Complex Deployments**: Provides a unified API that can manage multiple components (prefill, decode, routing) within a single resource definition
+2. **Enabling Sophisticated Architectures**: Supports advanced disaggregated inference patterns that were previously difficult to orchestrate
+3. **Reducing Operational Complexity**: Abstracts away the complexity of coordinating multiple interdependent AI components
+4. **Optimizing Resource Utilization**: Enables fine-grained control over component placement and scaling
+
+## Getting Started
+
+> **Note**: Grove is currently in development and aligning with NVIDIA Dynamo's release schedule. Documentation for installation, configuration, and detailed usage examples will be provided as the project approaches its v0.1.0 release.
+
+For practical examples of Grove-based multinode deployments in action, see the [Multinode Deployment Guide](multinode-deployment.md), which demonstrates multi-node disaggregated serving scenarios.
+
+For the latest updates on Grove, refer to the [official project on GitHub](https://github.com/NVIDIA/grove).

--- a/docs/guides/dynamo_deploy/k8s_metrics.md
+++ b/docs/guides/dynamo_deploy/k8s_metrics.md
@@ -1,0 +1,203 @@
+# Dynamo Metrics Collection on Kubernetes
+
+## Overview
+
+This guide provides a walkthrough for collecting and visualizing metrics from Dynamo components using the Prometheus Operator stack. The Prometheus Operator provides a powerful and flexible way to configure monitoring for Kubernetes applications through custom resources like PodMonitors, making it easy to automatically discover and scrape metrics from Dynamo components.
+
+## Prerequisites
+
+### Install Dynamo Operator
+Before setting up metrics collection, you'll need to have the Dynamo operator installed in your cluster. Follow our [Installation Guide](../dynamo_deploy/dynamo_cloud.md) for detailed instructions on deploying the Dynamo operator.
+
+### Install Prometheus Operator
+If you don't have an existing Prometheus setup, you'll need to install the Prometheus Operator. The Prometheus Operator introduces custom resources that make it easy to deploy and manage Prometheus monitoring in Kubernetes:
+
+- `PodMonitor`: Automatically discovers and scrapes metrics from pods based on label selectors
+- `ServiceMonitor`: Similar to PodMonitor but works with Services
+- `PrometheusRule`: Defines alerting and recording rules
+
+For a basic installation:
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+helm install prometheus prometheus-community/kube-prometheus-stack
+```
+
+## Deploy a DynamoGraphDeployment
+
+Let's start by deploying a simple vLLM aggregated deployment:
+
+```bash
+export NAMESPACE=dynamo # namespace where dynamo operator is installed
+pushd components/backends/vllm/deploy
+kubectl apply -f agg.yaml -n $NAMESPACE
+popd
+```
+
+This will create two components:
+- A Frontend component exposing metrics on its HTTP port
+- A Worker component exposing metrics on its system port
+
+Both components expose a `/metrics` endpoint following the OpenMetrics format, but with different metrics appropriate to their roles. For details about:
+- Deployment configuration: See the [vLLM README](../../components/backends/vllm/README.md)
+- Available metrics: See the [metrics guide](../metrics.md)
+
+### Validate the Deployment
+
+Let's send some test requests to populate metrics:
+
+```bash
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [
+    {
+        "role": "user",
+        "content": "In the heart of Eldoria, an ancient land of boundless magic and mysterious creatures, lies the long-forgotten city of Aeloria. Once a beacon of knowledge and power, Aeloria was buried beneath the shifting sands of time, lost to the world for centuries. You are an intrepid explorer, known for your unparalleled curiosity and courage, who has stumbled upon an ancient map hinting at ests that Aeloria holds a secret so profound that it has the potential to reshape the very fabric of reality. Your journey will take you through treacherous deserts, enchanted forests, and across perilous mountain ranges. Your Task: Character Background: Develop a detailed background for your character. Describe their motivations for seeking out Aeloria, their skills and weaknesses, and any personal connections to the ancient city or its legends. Are they driven by a quest for knowledge, a search for lost familt clue is hidden."
+    }
+    ],
+    "stream": true,
+    "max_tokens": 30
+  }'
+```
+
+For more information about validating the deployment, see the [vLLM README](../../components/backends/vllm/README.md).
+
+## Set Up Metrics Collection
+
+### Create PodMonitors
+
+The Prometheus Operator uses PodMonitor resources to automatically discover and scrape metrics from pods. To enable this discovery, the Dynamo operator automatically adds these labels to all pods:
+- `nvidia.com/metrics-enabled: "true"` - Enables metrics collection
+- `nvidia.com/dynamo-component-type: "frontend|worker"` - Identifies the component type
+
+> **Note**: You can opt-out specific deployments from metrics collection by adding this annotation to your DynamoGraphDeployment:
+```yaml
+apiVersion: nvidia.com/v1
+kind: DynamoGraphDeployment
+metadata:
+  name: my-deployment
+  annotations:
+    nvidia.com/enable-metrics: "false"
+spec:
+  # …
+```
+
+Let's create two monitors - one for each component type:
+
+First, create the frontend PodMonitor:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dynamo-frontend-metrics
+  namespace: $NAMESPACE
+spec:
+  selector:
+    matchLabels:
+      nvidia.com/metrics-enabled: "true"
+      nvidia.com/dynamo-component-type: "frontend"
+  podMetricsEndpoints:
+    - port: http
+      path: /metrics
+      interval: 2s
+  namespaceSelector:
+    matchNames:
+      - $NAMESPACE
+```
+
+Then, create the worker PodMonitor:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dynamo-worker-metrics
+  namespace: $NAMESPACE
+spec:
+  selector:
+    matchLabels:
+      nvidia.com/metrics-enabled: "true"
+      nvidia.com/dynamo-component-type: "worker"
+  podMetricsEndpoints:
+    - port: system
+      path: /metrics
+      interval: 2s
+  namespaceSelector:
+    matchNames:
+      - $NAMESPACE
+```
+
+If you are using planner, you can also create a PodMonitor for the planner:
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dynamo-planner-metrics
+  namespace: $NAMESPACE
+spec:
+  selector:
+    matchLabels:
+      nvidia.com/metrics-enabled: "true"
+      nvidia.com/dynamo-component-type: "planner"
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 2s
+  namespaceSelector:
+    matchNames:
+      - $NAMESPACE
+```
+
+Apply the PodMonitors:
+```bash
+pushd deploy/metrics/k8s
+# envsubst replaces ${NAMESPACE} with the actual namespace value
+envsubst < frontend-podmonitor.yaml | kubectl apply -n $NAMESPACE -f -
+envsubst < worker-podmonitor.yaml | kubectl apply -n $NAMESPACE -f -
+envsubst < planner-podmonitor.yaml | kubectl apply -n $NAMESPACE -f -
+popd
+```
+
+This will cause Prometheus to be re-configured to scrape metrics from the pods of your DynamoGraphDeployment.
+
+### Configure Grafana Dashboard
+
+Apply the Dynamo dashboard configuration to populate Grafana with the Dynamo dashboard:
+```bash
+pushd deploy/metrics/k8s
+kubectl apply -n monitoring -f grafana-dynamo-dashboard-configmap.yaml
+popd
+```
+
+The dashboard is embedded in the ConfigMap. Since it is labeled with `grafana_dashboard: "1"`, the Grafana will discover and populate it to its list of available dashboards. The dashboard includes panels for:
+- Frontend request rates
+- Time to first token
+- Inter-token latency
+- Request duration
+- Input/Output sequence lengths
+- GPU utilization
+
+## Viewing the Metrics
+
+### In Prometheus
+```bash
+kubectl port-forward svc/prometheus-operated 9090:9090 -n monitoring
+```
+
+Visit http://localhost:9090 and try these example queries:
+- `dynamo_frontend_requests_total`
+- `dynamo_frontend_time_to_first_token_seconds_bucket`
+
+![Prometheus UI showing Dynamo metrics](../../images/prometheus-k8s.png)
+
+### In Grafana
+```bash
+kubectl port-forward svc/grafana 3000:80 -n monitoring
+```
+
+Visit http://localhost:3000 and find the Dynamo dashboard under General.
+
+![Grafana dashboard showing Dynamo metrics](../../images/grafana-k8s.png)

--- a/docs/guides/dynamo_deploy/minikube.md
+++ b/docs/guides/dynamo_deploy/minikube.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Minikube Setup Guide
 
-Don't have a Kubernetes cluster? No problem! You can set up a local development environment using Minikube. This guide walks through the set up of everything you need to run Dynamo Cloud locally.
+Don't have a Kubernetes cluster? No problem! You can set up a local development environment using Minikube. This guide walks through the set up of everything you need to run Dynamo Kubernetes Platform locally.
 
 ## Setting Up Minikube
 
@@ -60,5 +60,5 @@ kubectl get storageclass
 
 ## Next Steps
 
-Once your local environment is set up, you can proceed with the [Dynamo Cloud deployment guide](./dynamo_cloud.md) to deploy the platform to your local cluster.
+Once your local environment is set up, you can proceed with the [Dynamo Kubernetes Platform deployment guide](./dynamo_cloud.md) to deploy the platform to your local cluster.
 

--- a/docs/guides/dynamo_deploy/minikube.md
+++ b/docs/guides/dynamo_deploy/minikube.md
@@ -19,19 +19,17 @@ limitations under the License.
 
 Don't have a Kubernetes cluster? No problem! You can set up a local development environment using Minikube. This guide walks through the set up of everything you need to run Dynamo Kubernetes Platform locally.
 
-## Setting Up Minikube
-
-### 1. Install Minikube
+## 1. Install Minikube
 First things first! Start by installing Minikube. Follow the official [Minikube installation guide](https://minikube.sigs.k8s.io/docs/start/) for your operating system.
 
-### 2. Configure GPU Support (Optional)
+## 2. Configure GPU Support (Optional)
 Planning to use GPU-accelerated workloads? You'll need to configure GPU support in Minikube. Follow the [Minikube GPU guide](https://minikube.sigs.k8s.io/docs/tutorials/nvidia/) to set up NVIDIA GPU support before proceeding.
 
 ```{tip}
 Make sure to configure GPU support before starting Minikube if you plan to use GPU workloads!
 ```
 
-### 3. Start Minikube
+## 3. Start Minikube
 Time to launch your local cluster!
 
 ```bash
@@ -44,7 +42,7 @@ minikube addons enable istio
 minikube addons enable storage-provisioner-rancher
 ```
 
-### 4. Verify Installation
+## 4. Verify Installation
 Let's make sure everything is working correctly!
 
 ```bash

--- a/docs/guides/dynamo_deploy/model_caching_with_fluid.md
+++ b/docs/guides/dynamo_deploy/model_caching_with_fluid.md
@@ -27,7 +27,7 @@ helm install fluid fluid/fluid -n fluid-system
 ```
 For advanced configuration, see the [Fluid Installation Guide](https://fluid-cloudnative.github.io/docs/get-started/installation).
 
-## Quick Start
+## Pre-deployment Steps
 
 1. Install Fluid (see [Installation](#installation)).
 2. Create a Dataset and Runtime (see [the following example](#webufs-example)).

--- a/docs/guides/dynamo_deploy/multinode-deployment.md
+++ b/docs/guides/dynamo_deploy/multinode-deployment.md
@@ -35,6 +35,8 @@ These systems provide enhanced scheduling capabilities including topology-aware 
 - Custom startup ordering for components
 - Resource-aware rolling updates
 
+For more information about Grove and its capabilities, see [Grove documentation](grove.md).
+
 
 [KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler) is an optional enhancement that provides a Kubernetes native scheduler optimized for AI workloads at large scale.
 
@@ -45,6 +47,7 @@ These systems provide enhanced scheduling capabilities including topology-aware 
 - Support for complex scheduling constraints
 - Integration with Grove for enhanced capabilities
 - Performance optimizations for large-scale deployments
+
 
 #### Using LWS and Volcano
 
@@ -110,8 +113,8 @@ args:
 
 For additional support and examples, see the working multinode configurations in:
 
-- **SGLang**: [components/backends/sglang/deploy/](../../components/backends/sglang/deploy/)
-- **TensorRT-LLM**: [components/backends/trtllm/deploy/](../../components/backends/trtllm/deploy/)
-- **vLLM**: [components/backends/vllm/deploy/](../../components/backends/vllm/deploy/)
+- **SGLang**: [SGLang Deployment Guide](../../components/backends/sglang/README.md#deployment)
+- **TensorRT-LLM**: [TensorRT-LLM Deployment Guide](../../components/backends/trtllm/README.md#kubernetes-deployment)
+- **vLLM**: [vLLM Deployment Guide](../../components/backends/vllm/README.md#kubernetes-deployment)
 
 These examples demonstrate proper usage of the `multinode` section with corresponding `gpu` limits and correct `tp-size` configuration.

--- a/docs/guides/dynamo_deploy/quickstart.md
+++ b/docs/guides/dynamo_deploy/quickstart.md
@@ -1,12 +1,12 @@
 # Quickstart
 
 Your onboarding includes 2 steps.
-1. Before deploying your inference graphs you need to install the Dynamo Inference Platform and the Dynamo Cloud.
-Dynamo Cloud acts as an orchestration layer between the end user and Kubernetes, handling the complexity of deploying your graphs for you.
+1. Before deploying your inference graphs you need to install the Dynamo Inference Platform and the Dynamo Kubernetes Platform.
+Dynamo Kubernetes Platform acts as an orchestration layer between the end user and Kubernetes, handling the complexity of deploying your graphs for you.
 You could install from [Published Artifacts](#1-installing-dynamo-cloud-from-published-artifacts) or [Source](#2-installing-dynamo-cloud-from-source)
-2. Once you install the Dynamo Cloud, proceed to the [Examples](../../examples/README.md) to deploy an inference graph.
+2. Once you install the Dynamo Kubernetes Platform, proceed to the [Examples](../../examples/README.md) to deploy an inference graph.
 
-## 1. Installing Dynamo Cloud from Published Artifacts
+## 1. Installing Dynamo Kubernetes Platform from Published Artifacts
 
 Use this approach when installing from pre-built helm charts and docker images published to NGC.
 
@@ -37,7 +37,7 @@ helm fetch https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-crds-${REL
 helm fetch https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-${RELEASE_VERSION}.tgz
 ```
 
-### Install Dynamo Cloud
+### Install Dynamo Kubernetes Platform
 
 **Step 1: Install Custom Resource Definitions (CRDs)**
 
@@ -56,7 +56,7 @@ kubectl create namespace ${NAMESPACE}
 helm install dynamo-platform dynamo-platform-${RELEASE_VERSION}.tgz --namespace ${NAMESPACE}
 ```
 
-## 2. Installing Dynamo Cloud from Source
+## 2. Installing Dynamo Kubernetes Platform from Source
 
 Use this approach when developing or customizing Dynamo as a contributor, or using local helm charts from the source repository.
 
@@ -95,9 +95,9 @@ docker login <your-registry>
 docker push <your-registry>/dynamo-base:latest-vllm
 ```
 
-### Install Dynamo Cloud
+### Install Dynamo Kubernetes Platform
 
-You need to build and push the Dynamo Cloud Operator Image by running
+You need to build and push the Dynamo Operator Image by running
 
 ```bash
 cd deploy/cloud/operator
@@ -170,7 +170,7 @@ helm install dynamo-platform ./platform/ \
   --set "dynamo-operator.imagePullSecrets[0].name=docker-imagepullsecret"
 ```
 
-[More on Deploying to Dynamo Cloud](./dynamo_cloud.md)
+[More on Deploying to Dynamo Kubernetes Platform](./dynamo_cloud.md)
 
 ## Uninstall CRDs for a clean start
 

--- a/examples/multimodal
+++ b/examples/multimodal
@@ -1,0 +1,1 @@
+multimodal_v1


### PR DESCRIPTION
This PR consolidates Dynamo's Kubernetes documentation and addresses tech writer feedback to improve clarity and navigation.

  📚 Documentation Consolidation

  - Added Grove documentation - New guide for advanced Kubernetes scheduling with PodGangSet/PodClique support
  - Added K8s metrics guide - Complete Prometheus/Grafana setup documentation
  - Streamlined deployment guides - Reorganized dynamo_deploy docs with clearer structure
  - Consistent naming - Standardized all references to "Dynamo Kubernetes Platform"
  - Removed duplicate docs - Cleaned up redundant symlinked component documentation

  🏷️ Fixed Heading Issues (Tech Writer Feedback)

  Redundant Headings:
  - docs/architecture/architecture.md: "High level architecture and key benefits" → "Key benefits"
  - docs/guides/dynamo_deploy/minikube.md: Removed redundant "Setting Up Minikube" H2, promoted subsections
  - components/backends/sglang/docs/sgl-http-server.md: Demoted duplicate H1 "Introduction" → H2
  - components/backends/vllm/deepseek-r1.md: Demoted duplicate H1 "Instructions" → H2
  - docs/architecture/sla_planner.md: "Architecture" → "Design"
  - components/README.md: "Core Components" → "Core Services"
  - components/backends/sglang/docs/multinode-examples.md: Removed redundant "Multi-node sized models" H2

  Ambiguous Quick Start Headings:
  - docs/architecture/sla_planner.md: "Quick Start:" → "To deploy SLA Planner:"
  - components/backends/sglang/README.md: "Quick Start" → "SGLang Quick Start"
  - components/backends/trtllm/README.md: "Quick Start" → "TensorRT-LLM Quick Start"
  - components/backends/vllm/README.md: "Quick Start" → "vLLM Quick Start"
  - docs/components/router/README.md: "Quick Start" → "KV Router Quick Start"
  - docs/guides/dynamo_deploy/model_caching_with_fluid.md: "Quick Start" → "Pre-deployment Steps"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added sample Kubernetes deployment manifests for vLLM, SGLang, and TensorRT-LLM (aggregated, disaggregated, and router/planner variants).
  - Introduced extensive TRT-LLM engine configuration examples (DeepSeek R1, Llama 4 Eagle, Gemma3, Multimodal).
  - Added a basic multimodal example placeholder.

- Documentation
  - Rebranded to “Dynamo Kubernetes Platform” and unified the deployment guide around DynamoGraphDeployment.
  - Added guides for Grove, metrics with Prometheus/Grafana, Minikube setup, and updated GKE notes.
  - Improved architecture and backend docs; refined headings for clarity.
  - Introduced a Markdown documentation style guide.

- Chores
  - Removed/cleaned redundant link-only docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->