### PR TITLE
feat(frontend): support setting HTTP host via CLI (--http-host)

### DIFF
--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -88,6 +88,12 @@ def parse_args():
         "--kv-cache-block-size", type=int, help="KV cache block size (u32)."
     )
     parser.add_argument(
+        "--http-host",
+        type=str,
+        default=os.environ.get("DYN_HTTP_HOST", "0.0.0.0"),
+        help="HTTP host for the engine (str). Can be set via DYN_HTTP_HOST env var.",
+    )
+    parser.add_argument(
         "--http-port",
         type=int,
         default=int(os.environ.get("DYN_HTTP_PORT", "8080")),
@@ -209,6 +215,7 @@ async def async_main():
         kv_router_config = None
 
     kwargs = {
+        "http_host": flags.http_host,
         "http_port": flags.http_port,
         "kv_cache_block_size": flags.kv_cache_block_size,
         "router_config": RouterConfig(

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -102,6 +102,7 @@ pub(crate) struct EntrypointArgs {
     template_file: Option<PathBuf>,
     router_config: Option<RouterConfig>,
     kv_cache_block_size: Option<u32>,
+    http_host: Option<String>,
     http_port: u16,
     tls_cert_path: Option<PathBuf>,
     tls_key_path: Option<PathBuf>,
@@ -112,7 +113,7 @@ pub(crate) struct EntrypointArgs {
 impl EntrypointArgs {
     #[allow(clippy::too_many_arguments)]
     #[new]
-    #[pyo3(signature = (engine_type, model_path=None, model_name=None, model_config=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None))]
+    #[pyo3(signature = (engine_type, model_path=None, model_name=None, model_config=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None))]
     pub fn new(
         engine_type: EngineType,
         model_path: Option<PathBuf>,
@@ -123,6 +124,7 @@ impl EntrypointArgs {
         template_file: Option<PathBuf>,
         router_config: Option<RouterConfig>,
         kv_cache_block_size: Option<u32>,
+        http_host: Option<String>,
         http_port: Option<u16>,
         tls_cert_path: Option<PathBuf>,
         tls_key_path: Option<PathBuf>,
@@ -153,6 +155,7 @@ impl EntrypointArgs {
             template_file,
             router_config,
             kv_cache_block_size,
+            http_host,
             http_port: http_port.unwrap_or(DEFAULT_HTTP_PORT),
             tls_cert_path,
             tls_key_path,
@@ -184,6 +187,7 @@ pub fn make_engine<'p>(
         .request_template(args.template_file.clone())
         .kv_cache_block_size(args.kv_cache_block_size)
         .router_config(args.router_config.clone().map(|rc| rc.into()))
+        .http_host(args.http_host.clone())
         .http_port(args.http_port)
         .tls_cert_path(args.tls_cert_path.clone())
         .tls_key_path(args.tls_key_path.clone())

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -45,6 +45,9 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
             );
         }
     };
+    if let Some(http_host) = local_model.http_host() {
+        http_service_builder = http_service_builder.host(http_host);
+    }
     http_service_builder =
         http_service_builder.with_request_template(engine_config.local_model().request_template());
 

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -50,6 +50,7 @@ pub struct LocalModelBuilder {
     template_file: Option<PathBuf>,
     router_config: Option<RouterConfig>,
     kv_cache_block_size: u32,
+    http_host: Option<String>,
     http_port: u16,
     tls_cert_path: Option<PathBuf>,
     tls_key_path: Option<PathBuf>,
@@ -64,6 +65,7 @@ impl Default for LocalModelBuilder {
     fn default() -> Self {
         LocalModelBuilder {
             kv_cache_block_size: DEFAULT_KV_CACHE_BLOCK_SIZE,
+            http_host: Default::default(),
             http_port: DEFAULT_HTTP_PORT,
             tls_cert_path: Default::default(),
             tls_key_path: Default::default(),
@@ -112,6 +114,11 @@ impl LocalModelBuilder {
     /// Passing None resets it to default
     pub fn kv_cache_block_size(&mut self, kv_cache_block_size: Option<u32>) -> &mut Self {
         self.kv_cache_block_size = kv_cache_block_size.unwrap_or(DEFAULT_KV_CACHE_BLOCK_SIZE);
+        self
+    }
+
+    pub fn http_host(&mut self, host: Option<String>) -> &mut Self {
+        self.http_host = host;
         self
     }
 
@@ -200,6 +207,7 @@ impl LocalModelBuilder {
                 full_path: PathBuf::new(),
                 endpoint_id,
                 template,
+                http_host: self.http_host.take(),
                 http_port: self.http_port,
                 tls_cert_path: self.tls_cert_path.take(),
                 tls_key_path: self.tls_key_path.take(),
@@ -275,6 +283,7 @@ impl LocalModelBuilder {
             full_path,
             endpoint_id,
             template,
+            http_host: self.http_host.take(),
             http_port: self.http_port,
             tls_cert_path: self.tls_cert_path.take(),
             tls_key_path: self.tls_key_path.take(),
@@ -290,6 +299,7 @@ pub struct LocalModel {
     card: ModelDeploymentCard,
     endpoint_id: EndpointId,
     template: Option<RequestTemplate>,
+    http_host: Option<String>,
     http_port: u16,
     tls_cert_path: Option<PathBuf>,
     tls_key_path: Option<PathBuf>,
@@ -319,6 +329,10 @@ impl LocalModel {
 
     pub fn request_template(&self) -> Option<RequestTemplate> {
         self.template.clone()
+    }
+
+    pub fn http_host(&self) -> Option<String> {
+        self.http_host.clone()
     }
 
     pub fn http_port(&self) -> u16 {


### PR DESCRIPTION
#### Overview:

This PR introduces a new --http-host option for the dynamo.frontend command line interface, allowing users to configure the HTTP server host address.

#### Details:

- Added `--http-host` argument to dynamo.frontend entrypoint.
- Example usage:

```bash
python -m dynamo.frontend --http-host 127.0.0.1
```

#### Where should the reviewer start?

The `--http-host` argument has been added to the Python dynamo.frontend execution:
- `components/frontend/src/dynamo/frontend/main.py`

Then, the `--http-host` value provided in Python is propagated through Rust:
- `lib/bindings/python/rust/llm/entrypoint.rs`
- `lib/llm/src/entrypoint/input/http.rs`
- `lib/llm/src/local_model.rs`


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

No related GitHub issue, since this is a minor change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now set the HTTP bind host for the engine.
    - Use the CLI flag --http-host or the DYN_HTTP_HOST environment variable.
    - Defaults to 0.0.0.0 if not provided.
    - Enables binding to localhost or a specific network interface as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->