### PR TITLE
fix: add --enable-kvbm doc to build.sh help

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -382,6 +382,7 @@ show_help() {
     echo "  [--build-context name=path to add build context]"
     echo "  [--release-build perform a release build]"
     echo "  [--make-efa Enables EFA support for NIXL]"
+    echo "  [--enable-kvbm Enables KVBM support in Python 3.12]"
     echo "  [--trtllm-use-nixl-kvcache-experimental Enables NIXL KVCACHE experimental support for TensorRT-LLM]"
     exit 0
 }

--- a/container/build.sh
+++ b/container/build.sh
@@ -363,9 +363,8 @@ show_image_options() {
 
 show_help() {
     echo "usage: build.sh"
-    echo "  [--base base image]"
     echo "  [--base-image-tag base image tag]"
-    echo "  [--platform platform for docker build"
+    echo "  [--platform platform for docker build]"
     echo "  [--framework framework one of ${!FRAMEWORKS[*]}]"
     echo "  [--tensorrtllm-pip-wheel-dir path to tensorrtllm pip wheel directory]"
     echo "  [--tensorrtllm-commit tensorrtllm commit to use for building the trtllm wheel if the wheel is not provided]"

--- a/container/build.sh
+++ b/container/build.sh
@@ -363,6 +363,7 @@ show_image_options() {
 
 show_help() {
     echo "usage: build.sh"
+    echo "  [--base-image base image]"
     echo "  [--base-image-tag base image tag]"
     echo "  [--platform platform for docker build]"
     echo "  [--framework framework one of ${!FRAMEWORKS[*]}]"


### PR DESCRIPTION
#### Overview:

Adds documentation to `container/build.sh --help` for `--enable-kvbm` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help to include the --enable-kvbm flag, clarifying how to enable KVBM support for Python 3.12 builds.
  * Improves discoverability and transparency of available build options in the help output.
  * No changes to behavior or error handling; this is a help text addition only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->