### PR TITLE
ci: run gitlab triggers on runner group

### DIFF
--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -25,7 +25,7 @@ jobs:
   mirror_repo:
     name: Mirror Repository to GitLab
     environment: GITLAB
-    runs-on: self-hosted
+    runs-on: gitlab_ci_runners
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
     name: Trigger CI Pipeline
     environment: GITLAB
     needs: mirror_repo
-    runs-on: self-hosted
+    runs-on: gitlab_ci_runners
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -25,7 +25,8 @@ jobs:
   mirror_repo:
     name: Mirror Repository to GitLab
     environment: GITLAB
-    runs-on: gitlab_ci_runners
+    runs-on: 
+      group: gitlab_ci_runners
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -36,7 +37,8 @@ jobs:
     name: Trigger CI Pipeline
     environment: GITLAB
     needs: mirror_repo
-    runs-on: gitlab_ci_runners
+    runs-on:
+      group: gitlab_ci_runners
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -25,7 +25,7 @@ jobs:
   mirror_repo:
     name: Mirror Repository to GitLab
     environment: GITLAB
-    runs-on: 
+    runs-on:
       group: gitlab_ci_runners
     steps:
     - name: Checkout repository


### PR DESCRIPTION
#### Overview:

Limit trigger ci workflows to run on runner group.

closes: OPS-712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI workflows to run on a new runner label for multiple jobs. All workflow steps remain unchanged; only the execution environment label is updated. Builds, tests, and pipeline triggers should behave identically, with no changes to artifacts or release outputs. No user-facing functionality changes are expected. This maintenance ensures consistent execution across pipelines without altering features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->