### PR TITLE
feat: add vllm aggregated multinode deployment example

### DIFF
--- a/components/backends/vllm/deploy/agg-multinode.yaml
+++ b/components/backends/vllm/deploy/agg-multinode.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-mul
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: vllm-mul
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.frontend --http-port 8000"
+    VllmDecodeWorker:
+      multinode:
+        nodeCount: 2
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-mul
+      componentType: worker
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.0
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --tensor-parallel-size 2 --no-kv-transfer-config


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces a multi-node inference deployment with a user-facing HTTP frontend and distributed decode workers.
  * Enables serving the Qwen/Qwen3-0.6B model with 2-way tensor parallelism for improved scalability.
  * Frontend exposes an HTTP server on port 8000 for requests.
  * Worker nodes load credentials from a configured secret for model access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->