### PR TITLE
feat: DIS-373 dynamo KVBM connector API integration with TRTLLM

### DIFF
--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -66,7 +66,7 @@ jobs:
           docker run -v ${{ github.workspace }}:/workspace -w /workspace \
             --name ${{ env.CONTAINER_ID }}_pytest \
             ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m \"${{ env.PYTEST_MARKS }}\""
+            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m \"${{ env.PYTEST_MARKS }}\" --ignore /workspace/lib/bindings/python/src/dynamo/llm/trtllm_integration/connector "
       - name: Copy test report from test Container
         if: always()
         run: |

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # For pull_request events, use the PR head (commit from the contributor's branch/repo)
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       # Cache lychee results (e.g. to avoid hitting rate limits)
       # https://lychee.cli.rs/github_action_recipes/caching/

--- a/docs/guides/run_kvbm_in_trtllm.md
+++ b/docs/guides/run_kvbm_in_trtllm.md
@@ -22,9 +22,11 @@ This guide explains how to leverage KVBM (KV Block Manager) to mange KV cache an
 To learn what KVBM is, please check [here](https://docs.nvidia.com/dynamo/latest/architecture/kvbm_intro.html)
 
 > [!Note]
-> - Ensure that `etcd` and 'nats' are running before starting.
+> - Ensure that `etcd` and `nats` are running before starting.
 > - KVBM does not currently support CUDA graphs in TensorRT-LLM.
 > - KVBM only supports TensorRT-LLM’s PyTorch backend.
+> - To enable disk cache offloading, you must first enable a CPU memory cache offloading.
+> - Disable partial reuse `enable_partial_reuse: false` in the LLM API config’s `kv_connector_config` to increase offloading cache hits.
 > - KVBM requires TensorRT-LLM at commit ce580ce4f52af3ad0043a800b3f9469e1f1109f6 or newer.
 
 ## Quick Start
@@ -45,7 +47,7 @@ docker compose -f deploy/docker-compose.yml up -d
 # 60 means 60GB of pinned CPU memory would be used
 export DYN_KVBM_CPU_CACHE_GB=60
 
-# enable kv offloading to disk
+# enable kv offloading to disk. Note: To enable disk cache offloading, you must first enable a CPU memory cache offloading.
 # 20 means 20GB of disk would be used
 export DYN_KVBM_DISK_CACHE_GB=20
 
@@ -57,6 +59,7 @@ export DYN_KVBM_LEADER_WORKER_INIT_TIMEOUT_SECS=1200
 
 ```bash
 # write an example LLM API config
+# Note: Disable partial reuse "enable_partial_reuse: false" in the LLM API config’s "kv_connector_config" to increase offloading cache hits.
 cat > "/tmp/kvbm_llm_api_config.yaml" <<EOF
 backend: pytorch
 cuda_graph_config: null

--- a/docs/guides/run_kvbm_in_trtllm.md
+++ b/docs/guides/run_kvbm_in_trtllm.md
@@ -22,7 +22,7 @@ This guide explains how to leverage KVBM (KV Block Manager) to mange KV cache an
 To learn what KVBM is, please check [here](https://docs.nvidia.com/dynamo/latest/architecture/kvbm_intro.html)
 
 > [!Note]
-> - Ensure that `etcd` is running before starting.
+> - Ensure that `etcd` and 'nats' are running before starting.
 > - KVBM does not currently support CUDA graphs in TensorRT-LLM.
 > - KVBM only supports TensorRT-LLM’s PyTorch backend.
 > - KVBM requires TensorRT-LLM at commit ce580ce4f52af3ad0043a800b3f9469e1f1109f6 or newer.

--- a/docs/guides/run_kvbm_in_trtllm.md
+++ b/docs/guides/run_kvbm_in_trtllm.md
@@ -35,7 +35,7 @@ To use KVBM in TensorRT-LLM, you can follow the steps below:
 # start up etcd for KVBM leader/worker registration and discovery
 docker compose -f deploy/docker-compose.yml up -d
 
-# Build a container that includes TensorRT-LLM and KVBM. Note: KVBM integration is only available in TensorRT-LLM commit ce580ce4f52af3ad0043a800b3f9469e1f1109f6.
+# Build a container that includes TensorRT-LLM and KVBM. Note: KVBM integration is only available in TensorRT-LLM commit ce580ce4f52af3ad0043a800b3f9469e1f1109f6 or newer.
 ./container/build.sh --framework trtllm --tensorrtllm-commit ce580ce4f52af3ad0043a800b3f9469e1f1109f6 --enable-kvbm
 
 # launch the container

--- a/docs/guides/run_kvbm_in_trtllm.md
+++ b/docs/guides/run_kvbm_in_trtllm.md
@@ -73,8 +73,14 @@ kv_connector_config:
   connector_worker_class: DynamoKVBMConnectorWorker
 EOF
 
-# serve an example LLM model
-trtllm-serve deepseek-ai/DeepSeek-R1-Distill-Llama-8B --host localhost --port 8000 --backend pytorch --extra_llm_api_options /tmp/kvbm_llm_api_config.yaml
+# start dynamo frontend
+python3 -m dynamo.frontend --http-port 8000 &
+
+# To serve an LLM model with dynamo
+python3 -m dynamo.trtllm \
+  --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
+  --served-model-name deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
+  --extra-engine-args /tmp/kvbm_llm_api_config.yaml &
 
 # make a call to LLM
 curl localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
@@ -88,4 +94,8 @@ curl localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   
     "stream":false,
     "max_tokens": 30
   }'
+
+# Optionally, we could also serve an LLM with trtllm-serve to utilize the KVBM feature.
+trtllm-serve deepseek-ai/DeepSeek-R1-Distill-Llama-8B --host localhost --port 8001 --backend pytorch --extra_llm_api_options /tmp/kvbm_llm_api_config.yaml
+
 ```

--- a/lib/bindings/python/rust/llm/block_manager.rs
+++ b/lib/bindings/python/rust/llm/block_manager.rs
@@ -233,7 +233,7 @@ pub struct BlockManagerBuilder {
 impl BlockManagerBuilder {
     pub fn new() -> Self {
         Self {
-            page_size: 0,
+            page_size: 32, // default consistent with BlockManager::new
             ..Default::default()
         }
     }

--- a/lib/bindings/python/rust/llm/block_manager.rs
+++ b/lib/bindings/python/rust/llm/block_manager.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use super::*;
+use anyhow::Result;
 use dynamo_llm::block_manager::block::{
     data::logical::distributed_leader_worker::DistributedLeaderWorkerResources, locality::Logical,
 };
@@ -218,5 +219,115 @@ impl BlockManager {
     #[inline(always)]
     pub fn get_block_manager(&self) -> &VllmBlockManager {
         &self.inner
+    }
+}
+
+#[derive(Default)]
+pub struct BlockManagerBuilder {
+    worker_id: u64,
+    leader: Option<distributed::KvbmLeader>,
+    page_size: usize,
+    disable_device_pool: bool,
+}
+
+impl BlockManagerBuilder {
+    pub fn new() -> Self {
+        Self {
+            page_size: 0,
+            ..Default::default()
+        }
+    }
+
+    pub fn worker_id(mut self, id: u64) -> Self {
+        self.worker_id = id;
+        self
+    }
+    pub fn page_size(mut self, ps: usize) -> Self {
+        self.page_size = ps;
+        self
+    }
+    pub fn leader(mut self, l: distributed::KvbmLeader) -> Self {
+        self.leader = Some(l);
+        self
+    }
+    pub fn disable_device_pool(mut self, yes: bool) -> Self {
+        self.disable_device_pool = yes;
+        self
+    }
+
+    /// Async build (call from an async context).
+    pub async fn build(self) -> Result<BlockManager> {
+        let worker_id = self.worker_id;
+        let leader = self.leader.ok_or_else(|| {
+            anyhow::anyhow!("leader is required (runtime is always taken from leader)")
+        })?;
+
+        // Get (inner leader handle, runtime) from the provided leader.
+        let (leader_inner, drt) = leader.dissolve();
+
+        let cancel_token = CancellationToken::new();
+
+        // Runtime & model config
+        let runtime_config = dynamo_llm::block_manager::KvManagerRuntimeConfig::builder()
+            .worker_id(worker_id)
+            .cancellation_token(cancel_token.clone())
+            .build()?;
+
+        let mut config =
+            dynamo_llm::block_manager::KvBlockManagerConfig::builder().runtime(runtime_config);
+
+        let model_config = dynamo_llm::block_manager::KvManagerModelConfig::builder()
+            .num_layers(1)
+            .outer_dim(1)
+            .page_size(self.page_size)
+            .inner_dim(1)
+            .build()?;
+
+        config = config.model(model_config);
+
+        // Layouts derived from leader’s counts
+        if !self.disable_device_pool {
+            config = config.device_layout(
+                dynamo_llm::block_manager::KvManagerLayoutConfig::builder()
+                    .num_blocks(leader_inner.num_device_blocks())
+                    .logical(Some(BlockParallelismStrategy::LeaderWorkerSharded))
+                    .build()?,
+            );
+        }
+
+        if leader_inner.num_host_blocks() > 0 {
+            config = config.host_layout(
+                dynamo_llm::block_manager::KvManagerLayoutConfig::builder()
+                    .num_blocks(leader_inner.num_host_blocks())
+                    .logical(Some(BlockParallelismStrategy::LeaderWorkerSharded))
+                    .build()?,
+            );
+        }
+
+        if leader_inner.num_disk_blocks() > 0 {
+            config = config.disk_layout(
+                dynamo_llm::block_manager::KvManagerLayoutConfig::builder()
+                    .num_blocks(leader_inner.num_disk_blocks())
+                    .logical(Some(BlockParallelismStrategy::LeaderWorkerSharded))
+                    .build()?,
+            );
+        }
+
+        let config = config.build()?;
+
+        let resources =
+            DistributedLeaderWorkerResources::new(Some(leader_inner), cancel_token.child_token())?;
+
+        let inner = dynamo_llm::block_manager::KvBlockManager::<
+            Logical<DistributedLeaderWorkerResources>,
+            BasicMetadata,
+        >::new(config, resources)
+        .await?;
+
+        Ok(BlockManager {
+            inner,
+            drt,
+            _controller: None,
+        })
     }
 }

--- a/lib/bindings/python/rust/llm/block_manager/distributed.rs
+++ b/lib/bindings/python/rust/llm/block_manager/distributed.rs
@@ -8,5 +8,5 @@ mod utils;
 mod worker;
 
 pub use leader::KvbmLeader;
-pub use utils::get_barrier_id;
+pub use utils::get_barrier_id_prefix;
 pub use worker::{KvbmWorker, VllmTensor};

--- a/lib/bindings/python/rust/llm/block_manager/distributed/leader.rs
+++ b/lib/bindings/python/rust/llm/block_manager/distributed/leader.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use utils::get_barrier_id;
+use utils::get_barrier_id_prefix;
 
 use derive_getters::Dissolve;
-use llm_rs::block_manager::distributed::{KvbmLeader as KvbmLeaderImpl, KvbmLeaderConfig};
+use llm_rs::block_manager::distributed::{
+    KvbmLeader as KvbmLeaderImpl, KvbmLeaderConfig, KvbmLeaderNumBlocksConfig,
+};
 
 const CPU_CACHE: &str = "DYN_KVBM_CPU_CACHE_GB";
 const CPU_CACHE_OVERRIDE: &str = "DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS";
@@ -16,15 +18,32 @@ const DISK_CACHE_OVERRIDE: &str = "DYN_KVBM_DISK_CACHE_OVERRIDE_NUM_BLOCKS";
 const LEADER_WORKER_INIT_TIMEOUT_SECS: &str = "DYN_KVBM_LEADER_WORKER_INIT_TIMEOUT_SECS";
 const DEFAULT_INIT_TIMEOUT_SECS: u64 = 120;
 
-fn compute_num_blocks(cache_size_key: &str, override_key: &str, bytes_per_block: usize) -> usize {
-    if let Ok(override_num_blocks) = std::env::var(override_key) {
-        override_num_blocks.parse::<usize>().unwrap_or(0)
-    } else {
-        let cache_size_gb = std::env::var(cache_size_key)
-            .unwrap_or_default()
-            .parse::<f64>()
-            .unwrap_or(0.0);
-        ((cache_size_gb * 1_000_000_000.0) / bytes_per_block as f64) as usize
+fn read_env_usize(key: &str) -> Option<usize> {
+    std::env::var(key).ok()?.trim().parse::<usize>().ok()
+}
+
+fn read_cache_size_float(key: &str) -> f64 {
+    std::env::var(key)
+        .unwrap_or_default()
+        .parse::<f64>()
+        .unwrap_or(0.0)
+}
+
+fn get_blocks_config(cache_size_key: &str, override_key: &str) -> KvbmLeaderNumBlocksConfig {
+    if let Some(nblocks) = read_env_usize(override_key) {
+        // Optional: still read cache size for observability, but override takes precedence.
+        let cache_gb: f64 = read_cache_size_float(cache_size_key);
+        return KvbmLeaderNumBlocksConfig {
+            cache_size_in_gb: cache_gb,
+            num_blocks_overriden: nblocks,
+        };
+    }
+
+    // No override -> compute from cache size (in GB)
+    let cache_gb: f64 = read_cache_size_float(cache_size_key);
+    KvbmLeaderNumBlocksConfig {
+        cache_size_in_gb: cache_gb,
+        num_blocks_overriden: 0,
     }
 }
 
@@ -51,22 +70,19 @@ impl KvbmLeader {
 #[pymethods]
 impl KvbmLeader {
     #[new]
-    #[pyo3(signature = (bytes_per_block, world_size, drt))]
-    fn new(bytes_per_block: usize, world_size: usize, drt: DistributedRuntime) -> PyResult<Self> {
-        let num_host_blocks = compute_num_blocks(CPU_CACHE, CPU_CACHE_OVERRIDE, bytes_per_block);
-        let num_disk_blocks = compute_num_blocks(DISK_CACHE, DISK_CACHE_OVERRIDE, bytes_per_block);
-
-        let barrier_id = get_barrier_id();
+    #[pyo3(signature = (world_size, drt))]
+    fn new(world_size: usize, drt: DistributedRuntime) -> PyResult<Self> {
+        let barrier_id_prefix = get_barrier_id_prefix();
         let leader_init_timeout_sec: u64 =
             get_leader_init_timeout_secs(LEADER_WORKER_INIT_TIMEOUT_SECS);
 
         let config = KvbmLeaderConfig::builder()
-            .barrier_id(barrier_id)
-            .num_host_blocks(num_host_blocks)
-            .num_disk_blocks(num_disk_blocks)
+            .barrier_id_prefix(barrier_id_prefix)
             .world_size(world_size)
             .leader_init_timeout_secs(leader_init_timeout_sec)
             .drt(drt.inner().clone())
+            .host_blocks_config(get_blocks_config(CPU_CACHE, CPU_CACHE_OVERRIDE))
+            .disk_blocks_config(get_blocks_config(DISK_CACHE, DISK_CACHE_OVERRIDE))
             .build()
             .map_err(to_pyerr)?;
 

--- a/lib/bindings/python/rust/llm/block_manager/distributed/utils.rs
+++ b/lib/bindings/python/rust/llm/block_manager/distributed/utils.rs
@@ -2,5 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub fn get_barrier_id_prefix() -> String {
-    std::env::var("DYN_KVBM_BARRIER_ID_PREFIX").unwrap_or("kvbm".to_string())
+    std::env::var("DYN_KVBM_BARRIER_ID_PREFIX")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "kvbm".to_string())
 }

--- a/lib/bindings/python/rust/llm/block_manager/distributed/utils.rs
+++ b/lib/bindings/python/rust/llm/block_manager/distributed/utils.rs
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-pub fn get_barrier_id() -> String {
-    std::env::var("DYN_KVBM_BARRIER_ID").unwrap_or("kvbm".to_string())
+pub fn get_barrier_id_prefix() -> String {
+    std::env::var("DYN_KVBM_BARRIER_ID_PREFIX").unwrap_or("kvbm".to_string())
 }

--- a/lib/bindings/python/rust/llm/block_manager/distributed/worker.rs
+++ b/lib/bindings/python/rust/llm/block_manager/distributed/worker.rs
@@ -107,7 +107,7 @@ impl KvbmWorker {
 #[pymethods]
 impl KvbmWorker {
     #[new]
-    #[pyo3(signature = (num_device_blocks, page_size, tensors, device_id=0, dtype_width_bytes=2, drt=None))]
+    #[pyo3(signature = (num_device_blocks, page_size, tensors, device_id=0, dtype_width_bytes=2, drt=None, layout_blocking=false))]
     fn new(
         num_device_blocks: usize,
         page_size: usize,
@@ -115,6 +115,7 @@ impl KvbmWorker {
         device_id: usize,
         dtype_width_bytes: usize,
         drt: Option<DistributedRuntime>,
+        layout_blocking: bool,
     ) -> PyResult<Self> {
         let py_drt = drt.ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err("DistributedRuntime (drt) must be provided")
@@ -146,7 +147,7 @@ impl KvbmWorker {
 
         let worker = rt
             .block_on(async move {
-                let kvbm_worker = KvbmWorkerImpl::new(config).await?;
+                let kvbm_worker = KvbmWorkerImpl::new(config, layout_blocking).await?;
                 anyhow::Ok(kvbm_worker)
             })
             .map_err(to_pyerr)?;

--- a/lib/bindings/python/rust/llm/block_manager/distributed/worker.rs
+++ b/lib/bindings/python/rust/llm/block_manager/distributed/worker.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 use std::sync::Arc;
-use utils::get_barrier_id;
+use utils::get_barrier_id_prefix;
 
 use llm_rs::block_manager::distributed::{
     BlockTransferHandler as RustBlockTransferHandler, KvbmWorker as KvbmWorkerImpl,
@@ -131,7 +131,7 @@ impl KvbmWorker {
             vllm_tensors.push(Arc::new(vllm_tensor));
         }
 
-        let barrier_id = get_barrier_id();
+        let barrier_id_prefix = get_barrier_id_prefix();
 
         let config = KvbmWorkerConfig::builder()
             .drt(drt)
@@ -140,7 +140,7 @@ impl KvbmWorker {
             .tensors(vllm_tensors)
             .device_id(device_id)
             .dtype_width_bytes(dtype_width_bytes)
-            .barrier_id(barrier_id)
+            .barrier_id_prefix(barrier_id_prefix)
             .build()
             .map_err(to_pyerr)?;
 

--- a/lib/bindings/python/rust/llm/block_manager/vllm.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm.rs
@@ -50,6 +50,9 @@ fn _vllm_integration(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<connector::worker::PyKvConnectorWorker>()?;
     m.add_class::<connector::leader::PyKvConnectorLeader>()?;
     m.add_class::<connector::SchedulerOutput>()?;
+    // TODO: use TRTLLM own integration module
+    m.add_class::<connector::trtllm_worker::PyTrtllmKvConnectorWorker>()?;
+    m.add_class::<connector::trtllm_leader::PyTrtllmKvConnectorLeader>()?;
     Ok(())
 }
 

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector.rs
@@ -7,6 +7,8 @@ use dynamo_llm::block_manager::{
 };
 
 pub mod leader;
+pub mod trtllm_leader;
+pub mod trtllm_worker;
 pub mod worker;
 
 use pyo3::prelude::*;

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader.rs
@@ -9,7 +9,7 @@ use dynamo_llm::block_manager::metrics_kvbm::KvbmMetrics;
 use dynamo_runtime::DistributedRuntime;
 use slot::{ConnectorSlotManager, SlotError, SlotManager, SlotState};
 
-use crate::llm::block_manager::BlockManager as PyBlockManager;
+use crate::llm::block_manager::BlockManagerBuilder;
 use crate::llm::block_manager::{
     distributed::KvbmLeader as PyKvbmLeader, vllm::connector::leader::slot::VllmConnectorSlot,
     vllm::KvbmRequest, VllmBlockManager,
@@ -26,10 +26,12 @@ use dynamo_llm::block_manager::{
     BasicMetadata, DiskStorage, ImmutableBlock, PinnedStorage,
 };
 use dynamo_llm::tokens::{SaltHash, TokenBlockSequence, Tokens};
-
+use std::sync::{Arc, OnceLock};
 use std::{collections::HashSet, sync::Mutex};
 use tokio;
+use tokio::runtime::Handle;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 
 type VllmLocality = Logical<DistributedLeaderWorkerResources>;
 
@@ -71,11 +73,13 @@ pub trait Leader: Send + Sync + std::fmt::Debug {
     fn has_slot(&self, request_id: String) -> bool;
 
     fn create_slot(&mut self, request: KvbmRequest, tokens: Vec<u32>) -> anyhow::Result<()>;
+
+    fn slot_manager(&self) -> &ConnectorSlotManager<String>;
 }
 
 #[derive(Debug)]
 pub struct KvConnectorLeader {
-    slot_manager: ConnectorSlotManager<String>,
+    slot_manager: Arc<OnceLock<ConnectorSlotManager<String>>>,
     block_size: usize,
     inflight_requests: HashSet<String>,
     onboarding_slots: HashSet<String>,
@@ -87,37 +91,86 @@ impl KvConnectorLeader {
     fn new(
         worker_id: String,
         drt: PyDistributedRuntime,
-        block_manager: PyBlockManager,
-        leader: PyKvbmLeader,
+        page_size: usize,
+        leader_py: PyKvbmLeader,
     ) -> Self {
         tracing::info!(
             "KvConnectorLeader initialized with worker_id: {}",
             worker_id
         );
 
-        // if drt is none, then we must construct a runtime and distributed runtime
-        let block_manager = block_manager.get_block_manager().clone();
-        let block_size = block_manager.block_size();
-
-        let leader = leader.get_inner();
-
-        // if we need a drt, get it from here
+        let leader = leader_py.get_inner().clone();
         let drt = drt.inner().clone();
+        let handle: Handle = drt.runtime().primary();
 
         let ns = drt
             .namespace(kvbm_connector::KVBM_CONNECTOR_LEADER)
             .unwrap();
 
         let kvbm_metrics = KvbmMetrics::new(&ns);
+        let kvbm_metrics_clone = kvbm_metrics.clone();
+
+        let slot_manager_cell = Arc::new(OnceLock::new());
+        let (leader_ready_tx, leader_ready_rx) = oneshot::channel::<String>();
+
+        {
+            let slot_manager_cell = slot_manager_cell.clone();
+
+            handle.spawn(async move {
+                let ready = leader.wait_worker_sync_ready().await;
+                if !ready {
+                    tracing::error!(
+                        "KvConnectorLeader init aborted: leader worker barrier not ready!",
+                    );
+                    return;
+                }
+
+                let block_manager = match BlockManagerBuilder::new()
+                    .worker_id(0)
+                    .leader(leader_py)
+                    .page_size(page_size)
+                    .disable_device_pool(false)
+                    .build()
+                    .await
+                {
+                    Ok(bm) => bm,
+                    Err(e) => {
+                        tracing::error!("Failed to build BlockManager: {}", e);
+                        return;
+                    }
+                };
+
+                // Create the slot manager now that everything is ready
+                let sm = ConnectorSlotManager::new(
+                    block_manager.get_block_manager().clone(),
+                    leader.clone(),
+                    drt.clone(),
+                    kvbm_metrics_clone.clone(),
+                );
+
+                let _ = slot_manager_cell.set(sm);
+
+                // another barrier sync to make sure worker init won't return before leader is ready
+                let _ = leader.run_leader_readiness_barrier_blocking(drt);
+
+                if leader_ready_tx.send("finished".to_string()).is_err() {
+                    tracing::error!("main routine receiver dropped before result was sent");
+                }
+            });
+        }
+
+        tokio::task::block_in_place(|| {
+            handle.block_on(async {
+                match leader_ready_rx.await {
+                    Ok(_) => tracing::info!("KvConnectorLeader init complete."),
+                    Err(_) => tracing::warn!("KvConnectorLeader init channel dropped"),
+                }
+            });
+        });
 
         Self {
-            slot_manager: ConnectorSlotManager::new(
-                block_manager.clone(),
-                leader,
-                drt.clone(),
-                kvbm_metrics.clone(),
-            ),
-            block_size,
+            slot_manager: slot_manager_cell,
+            block_size: page_size,
             inflight_requests: HashSet::new(),
             onboarding_slots: HashSet::new(),
             iteration_counter: 0,
@@ -127,6 +180,13 @@ impl KvConnectorLeader {
 }
 
 impl Leader for KvConnectorLeader {
+    #[inline]
+    fn slot_manager(&self) -> &ConnectorSlotManager<String> {
+        self.slot_manager
+            .get()
+            .expect("slot_manager not initialized")
+    }
+
     /// Match the tokens in the request with the available block pools.
     /// Note: the necessary details of the request are captured prior to this call. For vllm,
     /// we make a create slot call prior to this call, so a slot is guaranteed to exist.
@@ -147,7 +207,7 @@ impl Leader for KvConnectorLeader {
         // the number of device matched tokens should be less than or equal to the number of tokens in the request
         debug_assert!(num_computed_tokens % self.block_size == 0);
 
-        let shared_slot = self.slot_manager.get_slot(&request_id)?;
+        let shared_slot = self.slot_manager().get_slot(&request_id)?;
         let mut slot = shared_slot
             .lock()
             .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
@@ -215,7 +275,7 @@ impl Leader for KvConnectorLeader {
             num_external_tokens
         );
 
-        let shared_slot = self.slot_manager.get_slot(&request_id)?;
+        let shared_slot = self.slot_manager().get_slot(&request_id)?;
         let mut slot = shared_slot
             .lock()
             .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
@@ -271,7 +331,7 @@ impl Leader for KvConnectorLeader {
         // This is kind of a nice abstraction as it keeps the events simplier; however, we now create the request-slot
         // once for onboarding (this loop), then again for prefill/decode (new_requests loop).
         for request_id in onboarding_slots.iter() {
-            let shared_slot = self.slot_manager.get_slot(request_id)?;
+            let shared_slot = self.slot_manager().get_slot(request_id)?;
             let mut slot = shared_slot
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
@@ -300,7 +360,7 @@ impl Leader for KvConnectorLeader {
                 "request_id {request_id} not found in inflight_requests: "
             );
 
-            let shared_slot = self.slot_manager.get_slot(request_id)?;
+            let shared_slot = self.slot_manager().get_slot(request_id)?;
             let mut slot = shared_slot
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
@@ -343,7 +403,7 @@ impl Leader for KvConnectorLeader {
                 // we really do not know what to expect here:
                 // first let's try to get the slot, it might fail because maybe preemption put us thru
                 // a finished cycle -- who knows
-                let shared_slot = self.slot_manager.get_slot(request_id);
+                let shared_slot = self.slot_manager().get_slot(request_id);
                 match &shared_slot {
                     Ok(_) => {
                         tracing::info!("after preemption, slot is still alive");
@@ -371,7 +431,7 @@ impl Leader for KvConnectorLeader {
                 "request_id {request_id} not found in inflight_requests: "
             );
 
-            let shared_slot = self.slot_manager.get_slot(request_id)?;
+            let shared_slot = self.slot_manager().get_slot(request_id)?;
             let mut slot = shared_slot
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
@@ -399,7 +459,7 @@ impl Leader for KvConnectorLeader {
         }
 
         for unscheduled_req in inflight_requests.iter() {
-            let shared_slot = self.slot_manager.get_slot(unscheduled_req)?;
+            let shared_slot = self.slot_manager().get_slot(unscheduled_req)?;
             let mut slot_guard = shared_slot
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
@@ -424,7 +484,7 @@ impl Leader for KvConnectorLeader {
     ) -> anyhow::Result<bool> {
         tracing::debug!("Request finished: {request_id}; block_ids: {block_ids:?}");
 
-        if !self.slot_manager.has_slot(&request_id) {
+        if !self.slot_manager().has_slot(&request_id) {
             tracing::warn!(
                 "request_finished called for request_id: {request_id} but slot is not found"
             );
@@ -433,7 +493,7 @@ impl Leader for KvConnectorLeader {
         }
 
         // grab the slot
-        let shared_slot = self.slot_manager.get_slot(&request_id)?;
+        let shared_slot = self.slot_manager().get_slot(&request_id)?;
 
         // mark the slot as finished
         let mut slot = shared_slot
@@ -450,7 +510,7 @@ impl Leader for KvConnectorLeader {
         self.inflight_requests.remove(&request_id);
 
         // remove it from the manager as we will never use it again
-        self.slot_manager.remove_slot(&request_id)?;
+        self.slot_manager().remove_slot(&request_id)?;
 
         // if the slot has finished, we can return false to vllm, indicating all gpu blocks are free to be reused
         // otherwise, we return true, which means there are still outstanding operations on gpu blocks which
@@ -465,13 +525,13 @@ impl Leader for KvConnectorLeader {
     }
 
     fn has_slot(&self, request_id: String) -> bool {
-        self.slot_manager.has_slot(&request_id)
+        self.slot_manager().has_slot(&request_id)
     }
 
     /// Create a new slot for the given request ID.
     /// This is used to create a new slot for the request.
     fn create_slot(&mut self, request: KvbmRequest, tokens: Vec<u32>) -> anyhow::Result<()> {
-        self.slot_manager
+        self.slot_manager()
             .create_slot(&request.request_id, tokens, request.salt_hash)?;
 
         self.inflight_requests.insert(request.request_id);
@@ -488,11 +548,11 @@ pub struct PyKvConnectorLeader {
 #[pymethods]
 impl PyKvConnectorLeader {
     #[new]
-    #[pyo3(signature = (worker_id, drt, block_manager, leader))]
+    #[pyo3(signature = (worker_id, drt, page_size, leader))]
     pub fn new(
         worker_id: String,
         drt: PyDistributedRuntime,
-        block_manager: PyBlockManager,
+        page_size: usize,
         leader: PyKvbmLeader,
     ) -> Self {
         let enable_kvbm_record = std::env::var("ENABLE_KVBM_RECORD")
@@ -501,18 +561,10 @@ impl PyKvConnectorLeader {
 
         let connector_leader: Box<dyn Leader> = if enable_kvbm_record {
             Box::new(recorder::KvConnectorLeaderRecorder::new(
-                worker_id,
-                drt,
-                block_manager,
-                leader,
+                worker_id, drt, page_size, leader,
             ))
         } else {
-            Box::new(KvConnectorLeader::new(
-                worker_id,
-                drt,
-                block_manager,
-                leader,
-            ))
+            Box::new(KvConnectorLeader::new(worker_id, drt, page_size, leader))
         };
         Self { connector_leader }
     }

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader/slot.rs
@@ -106,6 +106,17 @@ pub trait Slot: std::fmt::Debug {
         num_scheduled_tokens: usize,
     ) -> Result<(), SlotError>;
 
+    // TRT-LLM does not include scheduled tokens in the scheduler output.
+    // Ideally, we should have a dedicated implementation for the TRT-LLM slot.
+    // However, since only this single function needs to be rewritten for now,
+    // we keep it as a separate function in Slot.
+    fn apply_scheduler_output_with_computed_position(
+        &mut self,
+        tokens: &[u32],
+        block_ids: &[usize],
+        computed_position: usize,
+    ) -> Result<(), SlotError>;
+
     fn record_start_iteration(&mut self, iteration: u64) -> Result<(), SlotError>;
 
     fn mark_as_prefilling(&mut self, iteration: u64) -> Result<(), SlotError>;
@@ -228,6 +239,11 @@ impl<R: RequestKey> SlotManager<R> for ConnectorSlotManager<R> {
         tokens: Vec<u32>,
         salt_hash: SaltHash,
     ) -> Result<(), SlotError> {
+        tracing::debug!(
+            "creating slot with request_id: {}, num_tokens: {}",
+            request_id,
+            tokens.len()
+        );
         let slot = VllmConnectorSlot::new(
             request_id.to_string(),
             tokens.into(),
@@ -566,6 +582,93 @@ impl Slot for VllmConnectorSlot {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all, fields(request_id = self.request_id.as_str()))]
+    fn apply_scheduler_output_with_computed_position(
+        &mut self,
+        tokens: &[u32],
+        block_ids: &[usize],
+        computed_position: usize,
+    ) -> Result<(), SlotError> {
+        // TRTLLM's KV Connector Manager will have (computed_position - external matches)
+        // in onborading case
+        if computed_position < self.current_position {
+            tracing::debug!(
+                "computed_position={} <= current_position={}, so we are onboarding during prefilling phase",
+                computed_position, self.current_position
+            );
+            return Ok(());
+        }
+
+        // now we decide what we should do for the new computed tokens
+
+        if computed_position < self.sequence.total_tokens() {
+            // no need to apply new tokens, since it's applied when created the slot during prefilling
+            self.state = SlotState::Prefilling;
+        } else {
+            tracing::debug!(
+                "appending {} newly decoded tokens to sequence",
+                tokens.len()
+            );
+            self.sequence.extend(tokens.into()).unwrap();
+            self.state = SlotState::Decoding;
+        }
+
+        // apply new block_ids, this should be applied for both prefilling and decoding
+        // because this is unknown when creating the slot
+        if !block_ids.is_empty() {
+            tracing::debug!("assigning {} new device blocks slot", block_ids.len());
+            self.device_blocks.extend(block_ids);
+        }
+
+        let num_candidate_blocks =
+            ((computed_position + 1) / self.block_size) - self.evaluated_blocks;
+
+        if num_candidate_blocks != 0 {
+            // do we have a mechanism for skipping gpu cache hit blocks?  not sure yet.
+            // for now, offload all the blocks to the host
+            let offload_block_ids: Vec<usize> = self
+                .device_blocks
+                .iter()
+                .skip(self.evaluated_blocks)
+                .take(num_candidate_blocks)
+                .copied()
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                offload_block_ids.len(),
+                num_candidate_blocks,
+                "device block overflow - candidate blocks exceed block count at offset {}",
+                self.evaluated_blocks
+            );
+
+            let offload_token_blocks: Vec<TokenBlock> = self
+                .sequence
+                .blocks()
+                .iter()
+                .skip(self.evaluated_blocks)
+                .take(num_candidate_blocks)
+                .cloned()
+                .collect::<Vec<_>>();
+
+            self.offload_blocks(&offload_block_ids, &offload_token_blocks)
+                .expect("failed to offload blocks");
+
+            self.evaluated_blocks += num_candidate_blocks;
+        }
+
+        // done applying policy
+        tracing::debug!(
+            "done applying kv cache policy at current_position: {}; computed_position: {}",
+            self.current_position,
+            computed_position,
+        );
+
+        // advance current position to computed position
+        self.current_position = computed_position;
+
+        Ok(())
+    }
+
     fn record_start_iteration(&mut self, iteration: u64) -> Result<(), SlotError> {
         if self.iteration_first_scheduled.is_none() {
             self.iteration_first_scheduled = Some(iteration);
@@ -676,7 +779,7 @@ impl Slot for VllmConnectorSlot {
         let num_matched_blocks = num_matched_host_blocks + num_matched_disk_blocks;
 
         tracing::debug!(
-            "matched {} host blocks and {} disk blocks; {} total blocks",
+            "successfully matched {} host blocks and {} disk blocks; {} total blocks",
             num_matched_host_blocks,
             num_matched_disk_blocks,
             num_matched_blocks
@@ -925,7 +1028,7 @@ impl VllmConnectorSlot {
         tracing::debug!(
             request_id = self.request_id,
             operation_id = %operation_id,
-            "onboarding {} blocks from {:?} to device",
+            "start onboarding {} blocks from {:?} to device",
             num_blocks,
             src_storage_pool,
         );

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader/slot.rs
@@ -593,13 +593,17 @@ impl Slot for VllmConnectorSlot {
         // in onborading case
         if computed_position < self.current_position {
             tracing::debug!(
-                "computed_position={} <= current_position={}, so we are onboarding during prefilling phase",
+                "computed_position={} < current_position={}, so we are onboarding during prefilling phase",
                 computed_position, self.current_position
             );
             return Ok(());
         }
 
         // now we decide what we should do for the new computed tokens
+        tracing::debug!(
+                "applying scheduler output, computed_position={}, sequence_total_tokens={}",
+                computed_position, self.sequence.total_tokens()
+            );
 
         if computed_position < self.sequence.total_tokens() {
             // no need to apply new tokens, since it's applied when created the slot during prefilling
@@ -621,7 +625,7 @@ impl Slot for VllmConnectorSlot {
         }
 
         let num_candidate_blocks =
-            ((computed_position + 1) / self.block_size) - self.evaluated_blocks;
+            (computed_position / self.block_size) - self.evaluated_blocks;
 
         if num_candidate_blocks != 0 {
             // do we have a mechanism for skipping gpu cache hit blocks?  not sure yet.

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader/slot.rs
@@ -601,9 +601,10 @@ impl Slot for VllmConnectorSlot {
 
         // now we decide what we should do for the new computed tokens
         tracing::debug!(
-                "applying scheduler output, computed_position={}, sequence_total_tokens={}",
-                computed_position, self.sequence.total_tokens()
-            );
+            "applying scheduler output, computed_position={}, sequence_total_tokens={}",
+            computed_position,
+            self.sequence.total_tokens()
+        );
 
         if computed_position < self.sequence.total_tokens() {
             // no need to apply new tokens, since it's applied when created the slot during prefilling
@@ -1337,7 +1338,9 @@ async fn process_offload_request(
             tracing::debug!("Offloading transfer completed successfully");
         }
         Err(_) => {
-            return Err(anyhow::anyhow!("Offloading transfer completion notification failed"));
+            return Err(anyhow::anyhow!(
+                "Offloading transfer completion notification failed"
+            ));
         }
     }
     tracing::debug!(
@@ -1411,7 +1414,9 @@ async fn process_onboard_request(
             tracing::debug!("Onboarding transfer completed successfully");
         }
         Err(_) => {
-            return Err(anyhow::anyhow!("Onboarding transfer completion notification failed"));
+            return Err(anyhow::anyhow!(
+                "Onboarding transfer completion notification failed"
+            ));
         }
     }
 

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader/slot.rs
@@ -625,7 +625,7 @@ impl Slot for VllmConnectorSlot {
         }
 
         let num_candidate_blocks =
-            (computed_position / self.block_size) - self.evaluated_blocks;
+            ((computed_position + 1) / self.block_size) - self.evaluated_blocks;
 
         if num_candidate_blocks != 0 {
             // do we have a mechanism for skipping gpu cache hit blocks?  not sure yet.
@@ -1334,10 +1334,10 @@ async fn process_offload_request(
     // 4. Wait for the offload request to complete
     match notify_receiver.await {
         Ok(_) => {
-            tracing::debug!("Transfer completed successfully");
+            tracing::debug!("Offloading transfer completed successfully");
         }
         Err(_) => {
-            return Err(anyhow::anyhow!("Transfer completion notification failed"));
+            return Err(anyhow::anyhow!("Offloading transfer completion notification failed"));
         }
     }
     tracing::debug!(
@@ -1408,10 +1408,10 @@ async fn process_onboard_request(
 
     match notify_receiver.await {
         Ok(_) => {
-            tracing::debug!("Transfer completed successfully");
+            tracing::debug!("Onboarding transfer completed successfully");
         }
         Err(_) => {
-            return Err(anyhow::anyhow!("Transfer completion notification failed"));
+            return Err(anyhow::anyhow!("Onboarding transfer completion notification failed"));
         }
     }
 

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_leader.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_leader.rs
@@ -98,7 +98,7 @@ impl KvConnectorLeader {
                 }
 
                 let block_manager = match BlockManagerBuilder::new()
-                    .worker_id(worker_id)
+                    .worker_id(0)
                     .leader(leader_py)
                     .page_size(page_size)
                     .disable_device_pool(false)

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_leader.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_leader.rs
@@ -1,0 +1,484 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+use crate::llm::block_manager::vllm::connector::leader::slot::{
+    ConnectorSlotManager, SlotManager, SlotState,
+};
+use crate::llm::block_manager::BlockManagerBuilder;
+use crate::llm::block_manager::{distributed::KvbmLeader as PyKvbmLeader, vllm::KvbmRequest};
+use crate::DistributedRuntime as PyDistributedRuntime;
+use anyhow;
+use std::collections::HashSet;
+use std::sync::{Arc, OnceLock};
+use tokio::runtime::Handle;
+
+pub trait Leader: Send + Sync + std::fmt::Debug {
+    fn get_num_new_matched_tokens(
+        &mut self,
+        request_id: String,
+        request_num_tokens: usize,
+        num_computed_tokens: usize,
+    ) -> anyhow::Result<(usize, bool)>;
+
+    fn update_state_after_alloc(
+        &mut self,
+        request_id: String,
+        block_ids: Vec<BlockId>,
+        context_current_position: usize,
+    ) -> anyhow::Result<()>;
+
+    fn build_connector_metadata(
+        &mut self,
+        scheduler_output: SchedulerOutput,
+    ) -> anyhow::Result<Vec<u8>>;
+
+    fn request_finished(
+        &mut self,
+        request_id: String,
+        block_ids: Vec<BlockId>,
+    ) -> anyhow::Result<bool>;
+
+    fn has_slot(&self, request_id: String) -> bool;
+
+    fn create_slot(&mut self, request: KvbmRequest, tokens: Vec<u32>) -> anyhow::Result<()>;
+
+    fn slot_manager(&self) -> &ConnectorSlotManager<String>;
+}
+
+#[derive(Debug)]
+pub struct KvConnectorLeader {
+    slot_manager: Arc<OnceLock<ConnectorSlotManager<String>>>,
+    block_size: usize,
+    inflight_requests: HashSet<String>,
+    onboarding_slots: HashSet<String>,
+    iteration_counter: u64,
+    inflight_request_to_num_external_tokens: HashMap<String, usize>,
+}
+
+impl KvConnectorLeader {
+    fn new(
+        worker_id: u64,
+        drt: PyDistributedRuntime,
+        page_size: usize,
+        leader_py: PyKvbmLeader,
+    ) -> Self {
+        tracing::info!(
+            "KvConnectorLeader initialized with worker_id: {}",
+            worker_id
+        );
+
+        let leader = leader_py.get_inner().clone();
+        let drt = drt.inner().clone();
+        let handle: Handle = drt.runtime().primary();
+
+        let slot_manager_cell = Arc::new(OnceLock::new());
+
+        {
+            let slot_manager_cell = slot_manager_cell.clone();
+
+            handle.spawn(async move {
+                let ready = leader.wait_worker_sync_ready().await;
+                if !ready {
+                    tracing::error!(
+                        "KvConnectorLeader init aborted: leader worker barrier not ready!",
+                    );
+                    return;
+                }
+
+                let block_manager = match BlockManagerBuilder::new()
+                    .worker_id(worker_id)
+                    .leader(leader_py) // your distributed::KvbmLeader
+                    .page_size(page_size)
+                    .disable_device_pool(false)
+                    .build()
+                    .await
+                {
+                    Ok(bm) => bm,
+                    Err(e) => {
+                        tracing::error!("Failed to build BlockManager: {}", e);
+                        return;
+                    }
+                };
+
+                // Create the slot manager now that everything is ready
+                let sm = ConnectorSlotManager::new(
+                    block_manager.get_block_manager().clone(),
+                    leader.clone(),
+                    drt.clone(),
+                );
+
+                let _ = slot_manager_cell.set(sm);
+
+                // another barrier sync to make sure worker init won't return before leader is ready
+                leader.spawn_leader_readiness_barrier(drt);
+
+                tracing::info!("KvConnectorLeader init complete.");
+            });
+        }
+
+        Self {
+            slot_manager: slot_manager_cell,
+            block_size: page_size,
+            inflight_requests: HashSet::new(),
+            onboarding_slots: HashSet::new(),
+            iteration_counter: 0,
+            inflight_request_to_num_external_tokens: HashMap::new(),
+        }
+    }
+}
+
+impl Leader for KvConnectorLeader {
+    #[inline]
+    fn slot_manager(&self) -> &ConnectorSlotManager<String> {
+        self.slot_manager
+            .get()
+            .expect("slot_manager not initialized")
+    }
+
+    /// Match the tokens in the request with the available block pools.
+    /// Note: the necessary details of the request are captured prior to this call. For trtllm,
+    /// we make a create slot call prior to this call, so a slot is guaranteed to exist.
+    ///
+    /// To align with the connector interface, we must ensure that if no blocks are matched, we return (0, false).
+    /// In our implementation, if we match any block, we return (num_matched_tokens, true).
+    #[tracing::instrument(level = "debug", skip(self, request_num_tokens, num_computed_tokens))]
+    fn get_num_new_matched_tokens(
+        &mut self,
+        request_id: String,
+        request_num_tokens: usize,
+        num_computed_tokens: usize,
+    ) -> anyhow::Result<(usize, bool)> {
+        tracing::debug!(
+            "request_num_tokens: {request_num_tokens}; num_computed_tokens: {num_computed_tokens}"
+        );
+
+        // TRTLLM could match partial blocks if enable_partial_reuse = True,
+        // immediately return 0 to simplify things.
+        if num_computed_tokens % self.block_size != 0 {
+            return Ok((0, false));
+        }
+
+        let shared_slot = self.slot_manager().get_slot(&request_id)?;
+        let mut slot = shared_slot
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
+
+        if slot.state() == SlotState::Prefilling {
+            tracing::warn!("slot is in the Prefilled state; this seems like we need to reset the slot and start over");
+            slot.reset();
+        }
+
+        // early exit if we cannot match full block
+        if (slot.sequence().total_tokens() - num_computed_tokens) < self.block_size {
+            let total_tokens = slot.sequence().total_tokens();
+            tracing::debug!(
+                "total_tokens in sequence: {total_tokens}; num_computed_tokens: {num_computed_tokens}; can not match full block."
+            );
+            return Ok((0, false));
+        }
+
+        // find matches for any remaining tokens
+        // this will advance the computed position and hold any newly matched blocks in the slot
+        slot.acquire_local_matches(num_computed_tokens)?;
+
+        // return the number of external tokens that are ready for onboarding
+        // we always return true here as we always asynchronously onboard matched blocks
+        if let SlotState::OnboardStaged(num_external_tokens) = slot.state() {
+            debug_assert!((num_computed_tokens + num_external_tokens) % self.block_size == 0);
+            tracing::debug!(
+                request_id = request_id,
+                "scheduling onboarding for {} external tokens",
+                num_external_tokens
+            );
+            // Add to the map so that onboarding can be triggered in update_state_after_alloc.
+            self.inflight_request_to_num_external_tokens
+                .insert(request_id, num_external_tokens);
+            Ok((num_external_tokens, true))
+        } else {
+            Ok((0, false))
+        }
+    }
+
+    /// Note: TRTLLM will not provide any scheduler output data for requests that are onboarding. it is entirely
+    /// on the connector's implementation to handle this case.
+    #[tracing::instrument(level = "debug", skip_all, fields(request_id))]
+    fn update_state_after_alloc(
+        &mut self,
+        request_id: String,
+        block_ids: Vec<BlockId>,
+        context_current_position: usize,
+    ) -> anyhow::Result<()> {
+        tracing::debug!(request_id, "num_device_blocks: {}", block_ids.len(),);
+
+        let shared_slot = self.slot_manager().get_slot(&request_id)?;
+        let mut slot = shared_slot
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
+
+        // we have not yet advanced the computed position, but now we can, since we have an indication that we have
+        // necessary gpu blocks into which we will load the external tokens.
+
+        slot.append_mutable_device_blocks(&block_ids)?;
+
+        if let Some(&num_external_tokens) = self
+            .inflight_request_to_num_external_tokens
+            .get(&request_id)
+        {
+            if num_external_tokens > 0 {
+                let num_computed_tokens = (context_current_position + 1) - num_external_tokens;
+                slot.record_cached_device_tokens(num_computed_tokens);
+                slot.advance_computed_position(num_computed_tokens)?;
+
+                tracing::debug!(
+                    request_id = request_id,
+                    "triggering onboarding for {} external tokens",
+                    num_external_tokens
+                );
+                slot.trigger_onboarding(num_external_tokens)?;
+                self.onboarding_slots.insert(request_id.clone());
+            }
+
+            self.inflight_request_to_num_external_tokens
+                .remove(&request_id);
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(iteration = self.iteration_counter + 1))]
+    fn build_connector_metadata(
+        &mut self,
+        scheduler_output: SchedulerOutput,
+    ) -> anyhow::Result<Vec<u8>> {
+        // the iteration counter is used to track the number of times we have built the connector metadata
+        // all connetor operations have the iteration counter at which they were issued.
+        // this allows operations to be lazily enqueued to the transfer engine
+        // the worker side of the connector will track all operations for completion before the request is
+        // allowed to be marked as finished.
+        self.iteration_counter += 1;
+        let iteration = self.iteration_counter;
+
+        tracing::debug!("Building connector metadata");
+        tracing::debug!("SchedulerOutput: {scheduler_output:#?}");
+
+        let mut inflight_requests = self.inflight_requests.clone();
+        let mut md = ConnectorMetadata::new(iteration);
+
+        let onboarding_slots = std::mem::take(&mut self.onboarding_slots);
+
+        // Worker-side - we create a request slot for onboarding, then delete it when onboarding is finished, then
+        // recreate it again when we start the prefill/decode phase.
+        //
+        // This is kind of a nice abstraction as it keeps the events simplier; however, we now create the request-slot
+        // once for onboarding (this loop), then again for prefill/decode (new_requests loop).
+        for request_id in onboarding_slots.iter() {
+            let shared_slot = self.slot_manager().get_slot(request_id)?;
+            let mut slot = shared_slot
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
+
+            md.create_slot(request_id.clone());
+
+            if let Some(pending_ops) = slot.take_pending_operations() {
+                tracing::debug!("adding {} pending onboarding operations", pending_ops.len());
+                md.add_operations(pending_ops);
+            }
+        }
+
+        // todo: update the code and abstraction to account for this two-phase lifecycle.
+        for new_req in &scheduler_output.new_requests {
+            let request_id = &new_req.request_id;
+            assert!(
+                inflight_requests.remove(request_id),
+                "request_id {request_id} not found in inflight_requests: "
+            );
+
+            let shared_slot = self.slot_manager().get_slot(request_id)?;
+            let mut slot = shared_slot
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
+
+            // inform the worker that a new request-slot should be created
+            md.create_slot(new_req.request_id.clone());
+
+            slot.record_start_iteration(iteration)?;
+
+            debug_assert!(
+                matches!(
+                    slot.state(),
+                    SlotState::Initialized | SlotState::Onboarding(_)
+                ),
+                "current slot state: {:?}",
+                slot.state()
+            );
+
+            slot.apply_scheduler_output_with_computed_position(
+                &new_req.prompt_token_ids,
+                &new_req.block_ids,
+                new_req.num_computed_tokens - 1,
+            )?;
+
+            if let Some(pending_ops) = slot.take_pending_operations() {
+                tracing::debug!(
+                    "adding {} pending operations for slot {}",
+                    pending_ops.len(),
+                    new_req.request_id
+                );
+                md.add_operations(pending_ops);
+            }
+        }
+
+        for cached_req in &scheduler_output.cached_requests {
+            let request_id = &cached_req.request_id;
+
+            // note: evicition might trigger this assert
+            assert!(
+                inflight_requests.remove(request_id),
+                "request_id {request_id} not found in inflight_requests: "
+            );
+
+            let shared_slot = self.slot_manager().get_slot(request_id)?;
+            let mut slot = shared_slot
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
+
+            slot.apply_scheduler_output_with_computed_position(
+                &cached_req.new_token_ids,
+                &cached_req.new_block_ids,
+                cached_req.num_computed_tokens - 1,
+            )?;
+
+            if let Some(pending_ops) = slot.take_pending_operations() {
+                tracing::debug!(
+                    "adding {} pending operations for slot {}",
+                    pending_ops.len(),
+                    request_id
+                );
+                md.add_operations(pending_ops);
+            }
+        }
+
+        tracing::debug!("metadata: {md:#?}");
+        serde_json::to_vec(&md)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize connector metadata: {}", e))
+    }
+
+    fn request_finished(
+        &mut self,
+        request_id: String,
+        block_ids: Vec<BlockId>,
+    ) -> anyhow::Result<bool> {
+        tracing::debug!("Request finished: {request_id}; block_ids: {block_ids:?}");
+        // grab the slot
+        let shared_slot = self.slot_manager().get_slot(&request_id)?;
+
+        // mark the slot as finished
+        let mut slot = shared_slot
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
+        slot.mark_as_finished(self.iteration_counter)?;
+
+        // todo: allow the request to resolve when it should exit
+        // the request may have some outstanding operations
+        // we would like to inform it to shutdown, then have it signal to the work that is officially gone,
+        // then we can remove the slot and trigger the worker to clean up as well.
+
+        // remove it from the manager as we will never use it again
+        self.slot_manager().remove_slot(&request_id)?;
+        self.inflight_request_to_num_external_tokens
+            .remove(&request_id);
+
+        // if the slot has finished, we can return false to trtllm, indicating all gpu blocks are free to be reused
+        // otherwise, we return false, which means there are still outstanding operations on gpu blocks which
+        // must be awaited before the gpu blocks can be reused. if we return true, then it is the worker side
+        // of the connector api which will be used to inform trtllm that the request is finished.
+        if let SlotState::Finished = slot.state() {
+            Ok(false)
+        } else {
+            debug_assert!(matches!(slot.state(), SlotState::Finishing));
+            Ok(true)
+        }
+    }
+
+    fn has_slot(&self, request_id: String) -> bool {
+        self.slot_manager().has_slot(&request_id)
+    }
+
+    /// Create a new slot for the given request ID.
+    /// This is used to create a new slot for the request.
+    fn create_slot(&mut self, request: KvbmRequest, tokens: Vec<u32>) -> anyhow::Result<()> {
+        self.slot_manager()
+            .create_slot(&request.request_id, tokens, request.salt_hash)?;
+
+        self.inflight_requests.insert(request.request_id);
+
+        Ok(())
+    }
+}
+
+#[pyclass]
+pub struct PyTrtllmKvConnectorLeader {
+    connector_leader: Box<dyn Leader>,
+}
+
+#[pymethods]
+impl PyTrtllmKvConnectorLeader {
+    #[new]
+    #[pyo3(signature = (worker_id, drt, page_size, leader))]
+    pub fn new(
+        worker_id: u64,
+        drt: PyDistributedRuntime,
+        page_size: usize,
+        leader: PyKvbmLeader,
+    ) -> Self {
+        let connector_leader: Box<dyn Leader> =
+            Box::new(KvConnectorLeader::new(worker_id, drt, page_size, leader));
+        Self { connector_leader }
+    }
+
+    fn get_num_new_matched_tokens(
+        &mut self,
+        request_id: String,
+        request_num_tokens: usize,
+        num_computed_tokens: usize,
+    ) -> PyResult<(usize, bool)> {
+        self.connector_leader
+            .get_num_new_matched_tokens(request_id, request_num_tokens, num_computed_tokens)
+            .map_err(to_pyerr)
+    }
+
+    fn update_state_after_alloc(
+        &mut self,
+        request_id: String,
+        block_ids: Vec<BlockId>,
+        context_current_position: usize,
+    ) -> PyResult<()> {
+        self.connector_leader
+            .update_state_after_alloc(request_id, block_ids, context_current_position)
+            .map_err(to_pyerr)
+    }
+
+    fn build_connector_metadata(&mut self, scheduler_output: SchedulerOutput) -> PyResult<Vec<u8>> {
+        self.connector_leader
+            .build_connector_metadata(scheduler_output)
+            .map_err(to_pyerr)
+    }
+
+    fn request_finished(&mut self, request_id: &str, block_ids: Vec<BlockId>) -> PyResult<bool> {
+        self.connector_leader
+            .request_finished(request_id.to_string(), block_ids)
+            .map_err(to_pyerr)
+    }
+
+    fn has_slot(&self, request_id: &str) -> bool {
+        self.connector_leader.has_slot(request_id.to_string())
+    }
+
+    fn create_slot(&mut self, request: KvbmRequest, tokens: Vec<u32>) -> PyResult<()> {
+        self.connector_leader
+            .create_slot(request, tokens)
+            .map_err(to_pyerr)
+    }
+}

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_leader.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_leader.rs
@@ -210,7 +210,7 @@ impl Leader for KvConnectorLeader {
         block_ids: Vec<BlockId>,
         context_current_position: usize,
     ) -> anyhow::Result<()> {
-        tracing::debug!(request_id, "num_device_blocks: {}", block_ids.len(),);
+        tracing::debug!(request_id, "num_device_blocks: {}, context_current_position: {}", block_ids.len(), context_current_position);
 
         let shared_slot = self.slot_manager().get_slot(&request_id)?;
         let mut slot = shared_slot
@@ -227,7 +227,7 @@ impl Leader for KvConnectorLeader {
             .get(&request_id)
         {
             if num_external_tokens > 0 {
-                let num_computed_tokens = (context_current_position + 1) - num_external_tokens;
+                let num_computed_tokens = context_current_position - num_external_tokens;
                 slot.record_cached_device_tokens(num_computed_tokens);
                 slot.advance_computed_position(num_computed_tokens)?;
 
@@ -317,7 +317,7 @@ impl Leader for KvConnectorLeader {
             slot.apply_scheduler_output_with_computed_position(
                 &new_req.prompt_token_ids,
                 &new_req.block_ids,
-                new_req.num_computed_tokens - 1,
+                new_req.num_computed_tokens,
             )?;
 
             if let Some(pending_ops) = slot.take_pending_operations() {
@@ -347,7 +347,7 @@ impl Leader for KvConnectorLeader {
             slot.apply_scheduler_output_with_computed_position(
                 &cached_req.new_token_ids,
                 &cached_req.new_block_ids,
-                cached_req.num_computed_tokens - 1,
+                cached_req.num_computed_tokens,
             )?;
 
             if let Some(pending_ops) = slot.take_pending_operations() {

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_worker.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_worker.rs
@@ -5,18 +5,17 @@ use dynamo_llm::block_manager::connector::protocol::TransferType;
 use dynamo_llm::block_manager::connector::scheduler::{
     Scheduler, TransferSchedulerClient, WorkerSchedulerClient,
 };
-use dynamo_llm::block_manager::metrics_kvbm::KvbmMetrics;
 
 use std::collections::HashSet;
 use std::sync::{Arc, OnceLock};
 
 use super::*;
 use crate::llm::block_manager::distributed::get_barrier_id_prefix;
+use crate::llm::block_manager::vllm::connector::worker::event_sync_blocking;
 use crate::{
     llm::block_manager::distributed::VllmTensor, to_pyerr,
     DistributedRuntime as PyDistributedRuntime,
 };
-use dynamo_runtime::metrics::prometheus_names::kvbm_connector;
 
 use anyhow;
 use dynamo_llm::block_manager::distributed::{KvbmWorker, KvbmWorkerConfig};
@@ -31,20 +30,21 @@ pub trait Worker: Send + Sync {
         page_size: usize,
         device_id: usize,
         dtype_width_bytes: usize,
-        kv_caches: Vec<(String, Arc<VllmTensor>)>,
+        kv_cache_tensor: Arc<VllmTensor>,
         raw_event_handles: Vec<u64>,
     ) -> anyhow::Result<()>;
 
-    fn bind_connector_metadata(&mut self, metadata: Vec<u8>) -> anyhow::Result<()>;
+    fn bind_connector_meta(&mut self, metadata: Vec<u8>) -> anyhow::Result<()>;
 
-    fn clear_connector_metadata(&mut self);
+    fn start_load_kv(&mut self) -> anyhow::Result<()>;
 
-    fn save_kv_layer(&mut self, layer_name: String) -> anyhow::Result<()>;
+    fn save_kv_layer(&mut self, layer_idx: usize) -> anyhow::Result<()>;
 
     fn get_finished(
         &mut self,
-        finished_requests: HashSet<String>,
-    ) -> (HashSet<String>, HashSet<String>);
+        finished_gen_req_ids: Vec<u64>,
+        started_loading_req_ids: Vec<u64>,
+    ) -> (Vec<u64>, Vec<u64>);
 }
 
 pub struct KvConnectorWorker {
@@ -53,15 +53,13 @@ pub struct KvConnectorWorker {
     connector: WorkerSchedulerClient,
     transfer_client: TransferSchedulerClient,
 
-    kv_cache_layers: Vec<(String, Arc<VllmTensor>)>,
-
     /// Map of request id to inflight load requests
     maybe_finished_onboarding: HashSet<String>,
 
     /// Map of request id to inflight finished requests
     maybe_finished_offloading: HashSet<String>,
 
-    /// For now, offloading operations will be enqueued at the end of the forward pass
+    onboarding_operations: Vec<WorkerTransferRequest>,
     offloading_operations: Vec<WorkerTransferRequest>,
 
     bound: bool,
@@ -70,12 +68,10 @@ pub struct KvConnectorWorker {
 
     /// cuda events created by the python side
     layer_events: Vec<u64>,
-
-    kvbm_metrics: KvbmMetrics,
 }
 
 impl KvConnectorWorker {
-    fn new(py_drt: PyDistributedRuntime, vllm_worker_id: String) -> anyhow::Result<Self> {
+    fn new(py_drt: PyDistributedRuntime, trtllm_rank: String) -> anyhow::Result<Self> {
         let drt = py_drt.inner.clone();
         let runtime = drt.runtime().primary();
 
@@ -92,14 +88,9 @@ impl KvConnectorWorker {
         )?
         .detach();
 
-        let kvbm_metrics = KvbmMetrics::new(
-            &drt.namespace(kvbm_connector::KVBM_CONNECTOR_WORKER)
-                .unwrap(),
-        );
-
         tracing::info!(
-            "KvConnectorWorker initialized with worker_id: {}",
-            vllm_worker_id
+            "KvConnectorWorker initialized with worker_rank: {}",
+            trtllm_rank
         );
 
         Ok(Self {
@@ -109,29 +100,24 @@ impl KvConnectorWorker {
             transfer_client,
             maybe_finished_onboarding: HashSet::new(),
             maybe_finished_offloading: HashSet::new(),
+            onboarding_operations: Vec::new(),
             offloading_operations: Vec::new(),
             bound: false,
             iteration: 0,
             layers_complete: 0,
-            kv_cache_layers: Vec::new(),
             layer_events: Vec::new(),
-            kvbm_metrics,
         })
     }
 }
 
 impl Worker for KvConnectorWorker {
-    /// Registers the KV caches with the KVBM worker.
-    ///
-    /// The Dynamo KVBM worker is lazily initialized when the first KV cache is registered.
-    /// This process establishes a connection between all KVBM workers and the leader.
     fn register_kv_caches(
         &mut self,
         num_device_blocks: usize,
         page_size: usize,
         device_id: usize,
         dtype_width_bytes: usize,
-        kv_caches: Vec<(String, Arc<VllmTensor>)>,
+        kv_cache_tensor: Arc<VllmTensor>,
         raw_event_handles: Vec<u64>,
     ) -> anyhow::Result<()> {
         if self.kvbm_worker.get().is_some() {
@@ -139,36 +125,21 @@ impl Worker for KvConnectorWorker {
             return Err(anyhow::anyhow!("kvbm worker already registered"));
         }
 
-        assert_eq!(
-            kv_caches.len(),
-            raw_event_handles.len(),
-            "kv_caches and raw_event_handles must have the same length"
-        );
-
-        // Process kv_caches in layer execution order (already sorted by layer index)
-        let mut vllm_tensors = Vec::new();
-        for (layer_name, vllm_tensor) in kv_caches {
-            tracing::trace!("Registering KV cache layer: {layer_name}, tensor: {vllm_tensor:?}");
-
-            // Store for later lookup by name
-            self.kv_cache_layers.push((layer_name, vllm_tensor.clone()));
-
-            // Build ordered tensor list for worker config
-            vllm_tensors.push(vllm_tensor as Arc<dyn TorchTensor>);
-        }
-
-        self.layer_events = raw_event_handles;
+        let kv_cache_tensors = vec![kv_cache_tensor as Arc<dyn TorchTensor>];
 
         let config = KvbmWorkerConfig::builder()
             .drt(self.drt.clone())
             .num_device_blocks(num_device_blocks)
             .page_size(page_size)
-            .tensors(vllm_tensors)
+            .tensors(kv_cache_tensors)
             .device_id(device_id)
             .dtype_width_bytes(dtype_width_bytes)
+            .is_fully_contiguous_layout(true)
             .barrier_id_prefix(get_barrier_id_prefix())
             .scheduler_client(Some(self.transfer_client.clone()))
             .build()?;
+
+        self.layer_events = raw_event_handles;
 
         let worker = self.drt.runtime().primary().block_on(async move {
             let worker = KvbmWorker::new(config).await?;
@@ -182,11 +153,7 @@ impl Worker for KvConnectorWorker {
         Ok(())
     }
 
-    /// Loads the metadata from the leader.
-    /// This action translates the metadata into a set of actions that the worker will perform.
-    /// All actions much be assigned to a slot before [`KvConnectorWorker::clear_metadata`] is called.
-    fn bind_connector_metadata(&mut self, metadata: Vec<u8>) -> anyhow::Result<()> {
-        // debug_assert!(!self.bound, "connector metadata already bound");
+    fn bind_connector_meta(&mut self, metadata: Vec<u8>) -> anyhow::Result<()> {
         let metadata: ConnectorMetadata = serde_json::from_slice(&metadata)?;
         self.bound = true;
         self.iteration = metadata.iteration;
@@ -203,10 +170,6 @@ impl Worker for KvConnectorWorker {
             metadata.iteration,
             "iteration mismatch"
         );
-
-        // self.engine_tx
-        //     .send(EngineMessage::UpdateIteration(self.iteration))
-        //     .map_err(to_pyerr)?;
 
         // local actions
         // - create a request slot for each new request
@@ -233,14 +196,12 @@ impl Worker for KvConnectorWorker {
             }
         }
 
-        // immediately enqueue the onboarding operations
-        for operation in onboarding_operations {
-            let request_id = operation.request_id.clone();
-            self.connector.enqueue_request(operation);
-            self.maybe_finished_onboarding.insert(request_id);
-        }
+        debug_assert!(
+            self.onboarding_operations.is_empty(),
+            "onboarding operations should be empty"
+        );
+        self.onboarding_operations = onboarding_operations;
 
-        // delay offloading operations until the end of the forward pass
         debug_assert!(
             self.offloading_operations.is_empty(),
             "offloading operations should be empty"
@@ -250,25 +211,10 @@ impl Worker for KvConnectorWorker {
         Ok(())
     }
 
-    /// Clears the connector metadata and marks the iteration as complete.
-    fn clear_connector_metadata(&mut self) {
-        tracing::debug!(iteration = self.iteration, "clearing connector metadata");
-        debug_assert!(self.bound, "connector metadata not bound");
-        self.bound = false;
-        self.iteration = 0; // always reset; leader drives the counter
-        self.layers_complete = 0;
-        self.connector
-            .mark_iteration_complete()
-            .expect("failed to mark iteration complete");
-    }
-
-    /// Trigger layer-wise completion signals.
-    /// Trigger block-wise completion signals afer last layer.
-    fn save_kv_layer(&mut self, _layer_name: String) -> anyhow::Result<()> {
+    fn save_kv_layer(&mut self, _layer_idx: usize) -> anyhow::Result<()> {
         self.layers_complete += 1;
-        if self.layers_complete == self.kv_cache_layers.len() {
+        if self.layers_complete == self.layer_events.len() {
             let offloading_operations = std::mem::take(&mut self.offloading_operations);
-
             // block on the the completion of the last layer
             // todo(ryan): capture the context, pass this to the scheduler to do the await on another thread
             // or put the event on a stream and use stream waits to keep it all on device.
@@ -277,19 +223,24 @@ impl Worker for KvConnectorWorker {
                 self.connector.enqueue_request(operation);
             }
         }
-        self.kvbm_metrics.save_kv_layer_requests.inc();
+        Ok(())
+    }
+
+    fn start_load_kv(&mut self) -> anyhow::Result<()> {
+        let onboarding_operations = self.onboarding_operations.clone();
+        for operation in onboarding_operations {
+            let request_id = operation.request_id.clone();
+            self.connector.enqueue_request(operation);
+            self.maybe_finished_onboarding.insert(request_id);
+        }
         Ok(())
     }
 
     fn get_finished(
         &mut self,
-        finished_requests: HashSet<String>,
-    ) -> (HashSet<String>, HashSet<String>) {
-        tracing::debug!(
-            iteration = self.iteration,
-            "Getting finished requests: {finished_requests:?}"
-        );
-
+        finished_gen_req_ids: Vec<u64>,
+        started_loading_req_ids: Vec<u64>,
+    ) -> (Vec<u64>, Vec<u64>) {
         // we do not have to visit every slot on every pass, just slots we are waiting on
         //
         // there are two conditions where we would be waiting:
@@ -299,20 +250,19 @@ impl Worker for KvConnectorWorker {
         //    operations to complete -- either by finishing or being cancelled
         //    - the finish request is triggered by this function, it is not seen in the metadata
         //
-        // under each scenario, we mark the `maybe_loading_finished` and `maybe_finished_offloading` hashsets with
+        // under each scenario, we mark the `maybe_finished_onboarding` and `maybe_finished_offloading` hashsets with
         // the request id
         //
         // on each forward pass we visit the maybe slots to see if they are finished
-
         let mut is_finished_offloading = HashSet::new();
         let mut is_finished_onboarding = HashSet::new();
 
         // before we process the maybes, add any newly annotated finished requests
         // to the maybe finished set
-        for request_id in finished_requests {
+        for request_id in finished_gen_req_ids {
             tracing::debug!(request_id, "marking request as finished");
 
-            if !self.connector.has_slot(&request_id) {
+            if !self.connector.has_slot(&request_id.to_string()) {
                 tracing::warn!(
                     request_id,
                     "finished request received for unknown request_id; assuming never started"
@@ -320,19 +270,37 @@ impl Worker for KvConnectorWorker {
                 continue;
             }
 
-            if self.maybe_finished_onboarding.contains(&request_id) {
-                tracing::info!(
-                    request_id,
-                    "got a finished warning for a request that is onboarding"
-                );
-            } else if self.maybe_finished_offloading.contains(&request_id) {
+            if self
+                .maybe_finished_offloading
+                .contains(&request_id.to_string())
+            {
                 tracing::warn!(request_id, "possibly got a duplicate finished request; request_id already in the maybe_finished_offloading set");
             } else {
                 tracing::debug!(
                     request_id,
                     "received finished request; adding to maybe_finished_offloading set"
                 );
-                self.maybe_finished_offloading.insert(request_id.clone());
+                self.maybe_finished_offloading
+                    .insert(request_id.to_string());
+            }
+        }
+
+        for request_id in started_loading_req_ids {
+            tracing::debug!(request_id, "marking request as finished");
+
+            if !self.connector.has_slot(&request_id.to_string()) {
+                tracing::warn!(
+                    request_id,
+                    "finished request received for unknown request_id; assuming never started"
+                );
+                continue;
+            }
+
+            if self
+                .maybe_finished_onboarding
+                .contains(&request_id.to_string())
+            {
+                tracing::warn!(request_id, "possibly got a duplicate finished request; request_id already in the maybe_finished_onboarding set");
             }
         }
 
@@ -340,10 +308,10 @@ impl Worker for KvConnectorWorker {
         for request_id in self.maybe_finished_offloading.iter() {
             if self.connector.has_slot(request_id) {
                 if self.connector.is_complete(request_id) {
-                    tracing::debug!(request_id, "request slot is finished");
-                    is_finished_offloading.insert(request_id.clone());
+                    tracing::debug!(request_id, "request slot is finished offloading");
+                    is_finished_offloading.insert(request_id.to_string());
                 } else {
-                    tracing::debug!(request_id, "request slot is not finished");
+                    tracing::debug!(request_id, "request slot is not finished offloading");
                 }
             } else {
                 // made this condition more strict slot existence checks were added as a prerequesite
@@ -369,10 +337,10 @@ impl Worker for KvConnectorWorker {
         for request_id in self.maybe_finished_onboarding.iter() {
             if self.connector.has_slot(request_id) {
                 if self.connector.is_complete(request_id) {
-                    tracing::debug!(request_id, "request slot is finished");
+                    tracing::debug!(request_id, "request slot is finished onboarding");
                     is_finished_onboarding.insert(request_id.clone());
                 } else {
-                    tracing::debug!(request_id, "request slot is not finished");
+                    tracing::debug!(request_id, "request slot is not finished onboarding");
                 }
             } else {
                 panic!("request slot missing for {request_id}; however, it was present when added to the maybe finished onboarding set");
@@ -387,22 +355,32 @@ impl Worker for KvConnectorWorker {
             }
         }
 
-        (is_finished_offloading, is_finished_onboarding)
+        let finished_offloading: Vec<u64> = is_finished_offloading
+            .iter()
+            .filter_map(|s| s.parse::<u64>().ok()) // parse String -> u64
+            .collect();
+
+        let finished_onboarding: Vec<u64> = is_finished_onboarding
+            .iter()
+            .filter_map(|s| s.parse::<u64>().ok()) // parse String -> u64
+            .collect();
+
+        (finished_offloading, finished_onboarding)
     }
 }
 
 #[pyclass]
-pub struct PyKvConnectorWorker {
+pub struct PyTrtllmKvConnectorWorker {
     connector_worker: Box<dyn Worker>,
 }
 
 #[pymethods]
-impl PyKvConnectorWorker {
+impl PyTrtllmKvConnectorWorker {
     #[new]
-    #[pyo3(signature = (py_drt, vllm_worker_id))]
-    pub fn new(py_drt: PyDistributedRuntime, vllm_worker_id: String) -> PyResult<Self> {
+    #[pyo3(signature = (py_drt, trtllm_rank))]
+    pub fn new(py_drt: PyDistributedRuntime, trtllm_rank: String) -> PyResult<Self> {
         let connector_worker: Box<dyn Worker> =
-            Box::new(KvConnectorWorker::new(py_drt, vllm_worker_id).map_err(to_pyerr)?);
+            Box::new(KvConnectorWorker::new(py_drt, trtllm_rank).map_err(to_pyerr)?);
         Ok(Self { connector_worker })
     }
 
@@ -412,15 +390,11 @@ impl PyKvConnectorWorker {
         page_size: usize,
         device_id: usize,
         dtype_width_bytes: usize,
-        kv_caches: Vec<(String, Py<PyAny>)>,
+        kv_cache_tensor: Py<PyAny>,
         raw_event_handles: Vec<u64>,
     ) -> PyResult<()> {
-        // Convert Python tensors to Rust VllmTensor objects
-        let mut rust_kv_caches = Vec::new();
-        for (layer_name, py_tensor) in kv_caches {
-            let vllm_tensor = Arc::new(VllmTensor::new(py_tensor).map_err(to_pyerr)?);
-            rust_kv_caches.push((layer_name, vllm_tensor));
-        }
+        // Convert Python tensor to Rust VllmTensor objects
+        let rust_kv_cache_tensor = Arc::new(VllmTensor::new(kv_cache_tensor).map_err(to_pyerr)?);
 
         self.connector_worker
             .register_kv_caches(
@@ -428,60 +402,34 @@ impl PyKvConnectorWorker {
                 page_size,
                 device_id,
                 dtype_width_bytes,
-                rust_kv_caches,
+                rust_kv_cache_tensor,
                 raw_event_handles,
             )
             .map_err(to_pyerr)
     }
 
-    pub fn bind_connector_metadata(&mut self, metadata: Vec<u8>) -> PyResult<()> {
+    pub fn bind_connector_meta(&mut self, metadata: Vec<u8>) -> PyResult<()> {
         self.connector_worker
-            .bind_connector_metadata(metadata)
+            .bind_connector_meta(metadata)
             .map_err(to_pyerr)
     }
 
-    pub fn clear_connector_metadata(&mut self) {
-        self.connector_worker.clear_connector_metadata()
+    pub fn save_kv_layer(&mut self, layer_idx: usize) -> PyResult<()> {
+        self.connector_worker
+            .save_kv_layer(layer_idx)
+            .map_err(to_pyerr)
     }
 
-    pub fn save_kv_layer(&mut self, layer_name: String, _kv_layer: Py<PyAny>) -> PyResult<()> {
-        // Note: kv_layer is not used in the current implementation
-        self.connector_worker
-            .save_kv_layer(layer_name)
-            .map_err(to_pyerr)
+    pub fn start_load_kv(&mut self) -> PyResult<()> {
+        self.connector_worker.start_load_kv().map_err(to_pyerr)
     }
 
     pub fn get_finished(
         &mut self,
-        finished_requests: HashSet<String>,
-    ) -> (HashSet<String>, HashSet<String>) {
-        self.connector_worker.get_finished(finished_requests)
+        finished_gen_req_ids: Vec<u64>,
+        started_loading_req_ids: Vec<u64>,
+    ) -> (Vec<u64>, Vec<u64>) {
+        self.connector_worker
+            .get_finished(finished_gen_req_ids, started_loading_req_ids)
     }
-}
-
-use cudarc::driver::sys::{
-    cuCtxGetCurrent, cuEventSynchronize, cudaError_enum, CUcontext, CUevent,
-};
-use std::ptr;
-
-// todo(ryan): we will need this if we farm off the cuEventSynchronize to another thread
-fn _get_current_context() -> CUcontext {
-    let mut ctx: CUcontext = ptr::null_mut();
-    let status = unsafe { cuCtxGetCurrent(&mut ctx) };
-    assert_eq!(
-        status,
-        cudaError_enum::CUDA_SUCCESS,
-        "cuCtxGetCurrent failed"
-    );
-    assert!(!ctx.is_null(), "Torch has not set a CUDA context");
-    ctx
-}
-
-pub fn event_sync_blocking(event: u64) {
-    let status = unsafe { cuEventSynchronize(event as CUevent) };
-    assert_eq!(
-        status,
-        cudaError_enum::CUDA_SUCCESS,
-        "cuEventSynchronize failed"
-    );
 }

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_worker.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_worker.rs
@@ -142,7 +142,7 @@ impl Worker for KvConnectorWorker {
         self.layer_events = raw_event_handles;
 
         let worker = self.drt.runtime().primary().block_on(async move {
-            let worker = KvbmWorker::new(config).await?;
+            let worker = KvbmWorker::new(config, true).await?;
             anyhow::Ok(worker)
         })?;
 

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/worker.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/worker.rs
@@ -171,7 +171,7 @@ impl Worker for KvConnectorWorker {
             .build()?;
 
         let worker = self.drt.runtime().primary().block_on(async move {
-            let worker = KvbmWorker::new(config).await?;
+            let worker = KvbmWorker::new(config, false).await?;
             anyhow::Ok(worker)
         })?;
 

--- a/lib/bindings/python/src/dynamo/llm/trtllm_integration/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/trtllm_integration/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/lib/bindings/python/src/dynamo/llm/trtllm_integration/connector/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/trtllm_integration/connector/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .kvbm_connector_leader import DynamoKVBMConnectorLeader
+from .kvbm_connector_worker import DynamoKVBMConnectorWorker
+
+__all__ = ["DynamoKVBMConnectorLeader", "DynamoKVBMConnectorWorker"]

--- a/lib/bindings/python/src/dynamo/llm/trtllm_integration/connector/kvbm_connector_leader.py
+++ b/lib/bindings/python/src/dynamo/llm/trtllm_integration/connector/kvbm_connector_leader.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+from typing import List
+
+from tensorrt_llm._torch.pyexecutor.kv_cache_connector import (
+    KvCacheConnectorScheduler,
+    SchedulerOutput,
+)
+from tensorrt_llm.bindings.executor import ExecutorConfig
+from tensorrt_llm.bindings.internal.batch_manager import LlmRequest
+
+from dynamo.llm import KvbmLeader
+from dynamo.llm.trtllm_integration.rust import KvbmRequest
+from dynamo.llm.trtllm_integration.rust import (
+    KvConnectorLeader as RustKvConnectorLeader,
+)
+from dynamo.llm.trtllm_integration.rust import SchedulerOutput as RustSchedulerOutput
+from dynamo.runtime import DistributedRuntime
+
+
+class DynamoKVBMConnectorLeader(KvCacheConnectorScheduler):
+    def __init__(self, executor_config: ExecutorConfig):
+        super().__init__(executor_config)
+        self.drt = DistributedRuntime.detached()
+
+        world_size = self._config.mapping.world_size
+        self.block_size = self._config.tokens_per_block
+
+        # Set bytes_per_block to 0, because we will retrieve the actual value from the worker side.
+        leader = KvbmLeader(world_size, drt=self.drt)
+
+        print(
+            f"KvConnectorLeader initialized with rank: {executor_config.mapping.rank}"
+        )
+        self._connector = RustKvConnectorLeader(
+            executor_config.mapping.rank, self.drt, self.block_size, leader
+        )
+
+    def build_connector_meta(self, scheduler_output: SchedulerOutput) -> bytes:
+        """
+        Build the metadata for the worker.
+        This is called by the KV Cache Manager when adding a sequence.
+        Args:
+            scheduler_output: The data for all inflight requests.
+        Returns:
+            The metadata for the workers.
+        """
+        output = RustSchedulerOutput()
+
+        for req in scheduler_output.new_requests:
+            output.add_new_request(
+                str(req.request_id),
+                req.new_tokens,
+                req.new_block_ids,
+                req.computed_position + 1,
+            )
+
+        resumed_from_preemption = False
+        for req in scheduler_output.cached_requests:
+            output.add_cached_request(
+                str(req.request_id),
+                resumed_from_preemption,
+                req.new_tokens,
+                req.new_block_ids,
+                req.computed_position + 1,
+            )
+
+        return self._connector.build_connector_metadata(output)
+
+    def get_num_new_matched_tokens(
+        self, request: LlmRequest, num_computed_tokens: int
+    ) -> tuple[int, bool]:
+        """
+        Get the number of tokens that can be loaded from remote KV cache.
+        This does not include the tokens already matched on device (indicated by `num_computed_tokens`).
+        Args:
+            request: The request to get the number of tokens for.
+            num_computed_tokens: The number of tokens already matched on device.
+        Returns:
+            The number of tokens that can be loaded from remote KV cache.
+            Whether the tokens will be loaded asynchronously.
+        """
+        self._create_slot(request)
+        return self._connector.get_num_new_matched_tokens(
+            str(request.request_id),
+            len(request.get_tokens(0)),
+            num_computed_tokens,
+        )
+
+    def update_state_after_alloc(self, request: LlmRequest, block_ids: List[int]):
+        """
+        Called after get_num_new_matched_tokens is called to provide the block ids to the scheduler.
+        Args:
+            request: The request that was allocated resources.
+            block_ids: The KV cacheblock IDs that were allocated.
+        """
+        self._connector.update_state_after_alloc(
+            str(request.request_id), block_ids, request.context_current_position
+        )
+
+    def request_finished(self, request: LlmRequest, cache_block_ids: list[int]) -> bool:
+        """
+        Called when a request is finished generating tokens.
+        Args:
+            request: The request that finished generating tokens.
+        Returns:
+            Whether the request is performing asynchronous saving operations.
+            If true, this indicates that the kv cache manager should wait to deallocate the blocks until the saving has completed (determined by `get_finished` on the workers).
+        """
+        is_async_saving = self._connector.request_finished(
+            str(request.request_id), cache_block_ids
+        )
+        return is_async_saving
+
+    def _create_slot(self, request: LlmRequest) -> None:
+        """Create a slot for the request"""
+
+        if self._connector.has_slot(str(request.request_id)):
+            return None
+
+        if bool(request.multimodal_positions):
+            raise ValueError("Unsupported request - requires mm extra keys")
+
+        all_token_ids = request.get_tokens(0)
+
+        # extract the critial aspects of the request that effect how the tokens are hashed
+        request = KvbmRequest(
+            request_id=str(request.request_id), lora_name=None, salt_hash=None
+        )
+
+        self._connector.create_slot(request, all_token_ids)

--- a/lib/bindings/python/src/dynamo/llm/trtllm_integration/connector/kvbm_connector_leader.py
+++ b/lib/bindings/python/src/dynamo/llm/trtllm_integration/connector/kvbm_connector_leader.py
@@ -54,7 +54,7 @@ class DynamoKVBMConnectorLeader(KvCacheConnectorScheduler):
                 str(req.request_id),
                 req.new_tokens,
                 req.new_block_ids,
-                req.computed_position + 1,
+                req.computed_position,
             )
 
         resumed_from_preemption = False
@@ -64,7 +64,7 @@ class DynamoKVBMConnectorLeader(KvCacheConnectorScheduler):
                 resumed_from_preemption,
                 req.new_tokens,
                 req.new_block_ids,
-                req.computed_position + 1,
+                req.computed_position,
             )
 
         return self._connector.build_connector_metadata(output)

--- a/lib/bindings/python/src/dynamo/llm/trtllm_integration/connector/kvbm_connector_worker.py
+++ b/lib/bindings/python/src/dynamo/llm/trtllm_integration/connector/kvbm_connector_worker.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from tensorrt_llm import logger
+from tensorrt_llm._torch.pyexecutor.kv_cache_connector import KvCacheConnectorWorker
+from tensorrt_llm.bindings.executor import ExecutorConfig
+
+from dynamo.llm.trtllm_integration.rust import (
+    KvConnectorWorker as RustKvConnectorWorker,
+)
+from dynamo.runtime import DistributedRuntime
+
+
+class DynamoKVBMConnectorWorker(KvCacheConnectorWorker):
+    def __init__(self, executor_config: ExecutorConfig):
+        super().__init__(executor_config)
+
+        self.drt = DistributedRuntime.detached()
+
+        self.rank = executor_config.mapping.rank
+
+        self._connector = RustKvConnectorWorker(
+            self.drt, str(executor_config.mapping.rank)
+        )
+
+    def register_kv_caches(self, kv_cache_tensor: torch.Tensor):
+        """
+        Register the KV cache tensors to the worker.
+        This can be used for something like NIXL registration.
+        Args:
+            kv_cache_tensor: The contiguous KV cache tensor.
+        """
+        print(f"Register KV Caches on rank {self.rank}")
+        logger.info(
+            f"KvConnectorWorker started registering the kv caches on rank {self._config.mapping.rank}"
+        )
+
+        num_device_blocks = kv_cache_tensor.shape[0]
+        page_size = self._config.tokens_per_block
+        device_id = kv_cache_tensor.device.index
+        kv_cache_dtype = kv_cache_tensor.dtype
+
+        num_cache_layers = kv_cache_tensor.shape[1]
+        self.events = [
+            torch.cuda.Event(enable_timing=False, interprocess=False)
+            for _ in range(num_cache_layers)
+        ]
+
+        for event in self.events:
+            event.record(torch.cuda.current_stream(device_id))
+
+        raw_event_handles = [event.cuda_event for event in self.events]
+
+        self._connector.register_kv_caches(
+            num_device_blocks,
+            page_size,
+            device_id,
+            kv_cache_dtype.itemsize,
+            kv_cache_tensor,
+            raw_event_handles,
+        )
+
+    def bind_connector_meta(self, metadata: object):
+        """Set the connector metadata from the scheduler.
+
+        This function should be called by the model runner every time
+        before the model execution. The metadata will be used for runtime
+        KV cache loading and saving.
+
+        Args:
+            metadata (bytes): the connector metadata.
+        """
+        super().bind_connector_meta(metadata)
+        self._connector.bind_connector_meta(metadata)
+
+    def start_load_kv(self, stream: torch.cuda.Stream):
+        """
+        Begin loading the KV cache in preparation for the next forward pass.
+        Specific blocks to transfer are indicated by the scheduler's metadata.
+        """
+        self._connector.start_load_kv()
+
+    def wait_for_save(self, stream: torch.cuda.Stream):
+        """
+        Block until all synchronous saving operations are complete. Called at the end of the forward pass.
+        """
+        pass
+
+    def wait_for_layer_load(self, layer_idx: int, stream: torch.cuda.Stream):
+        """
+        Wait for a layer to finish being loaded before proceeding with the forward pass on the layer.
+        Note: This function is called immediately before the layer's work is enqueued into the stream.
+        Args:
+            layer_idx: The index of the layer to wait for.
+            stream: The stream the forward pass is being executed on.
+        """
+        pass
+
+    def save_kv_layer(self, layer_idx: int, stream: torch.cuda.Stream):
+        """
+        Begin saving the KV cache for a layer.
+        Note: This function is called immediately after the layer's work is enqueued into the stream.
+        Args:
+            layer_idx: The index of the layer to save.
+            stream: The stream the forward pass is being executed on.
+        """
+        self.events[layer_idx].record(stream)
+        self._connector.save_kv_layer(layer_idx)
+
+    def get_finished(
+        self, finished_gen_req_ids: list[int], started_loading_req_ids: list[int]
+    ) -> tuple[list[int], list[int]]:
+        """
+        Get the requests that have finished loading and saving.
+        Args:
+            finished_gen_req_ids: The IDs of the requests that have finished generating tokens, and are now asynchronously saving.
+            started_loading_req_ids: The IDs of the requests that have started asynchronously loading.
+        Returns:
+            The IDs of the requests that have finished saving.
+            The IDs of the requests that have finished loading.
+        Note: IDs may only be returned from this call after they've been provided in the `finished_gen_req_ids` and `started_loading_req_ids` arguments.
+        Additionally, the runtime will only take action based on these returned IDs once they've been returned by ALL workers. This allows some workers to take longer than others to complete the operations.
+        """
+        return self._connector.get_finished(
+            finished_gen_req_ids, started_loading_req_ids
+        )

--- a/lib/bindings/python/src/dynamo/llm/trtllm_integration/rust.py
+++ b/lib/bindings/python/src/dynamo/llm/trtllm_integration/rust.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Loader for the Rust-based TensorRT-LLM integration objects, using objects from _vllm_integration for now
+"""
+
+try:
+    # TODO: use TRTLLM own integration module
+    from dynamo._core import _vllm_integration
+
+    # Runtime - dynamically loaded classes from Rust extension
+    KvbmRequest = getattr(_vllm_integration, "KvbmRequest")
+    KvbmBlockList = getattr(_vllm_integration, "KvbmBlockList")
+    BlockState = getattr(_vllm_integration, "BlockState")
+    BlockStates = getattr(_vllm_integration, "BlockStates")
+    SlotUpdate = getattr(_vllm_integration, "SlotUpdate")
+
+    KvConnectorWorker = getattr(_vllm_integration, "PyTrtllmKvConnectorWorker")
+    KvConnectorLeader = getattr(_vllm_integration, "PyTrtllmKvConnectorLeader")
+    SchedulerOutput = getattr(_vllm_integration, "SchedulerOutput")
+
+except ImportError:
+    print(
+        "Failed to import Dynamo KVBM. TensorRT-LLM integration will not be available."
+    )
+    KvbmRequest = None
+    KvbmBlockList = None
+    BlockState = None
+    BlockStates = None
+    SlotUpdate = None
+    KvConnectorWorker = None
+    KvConnectorLeader = None
+    SchedulerOutput = None
+
+__all__ = [
+    "KvbmRequest",
+    "KvbmBlockList",
+    "BlockState",
+    "BlockStates",
+    "SlotUpdate",
+    "KvConnectorWorker",
+    "KvConnectorLeader",
+    "SchedulerOutput",
+]

--- a/lib/bindings/python/src/dynamo/llm/vllm_integration/connector_leader.py
+++ b/lib/bindings/python/src/dynamo/llm/vllm_integration/connector_leader.py
@@ -14,7 +14,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadat
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.request import Request
-from vllm.worker.cache_engine import CacheEngine
 
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -29,7 +28,7 @@ if TYPE_CHECKING:
 # )
 # from dynamo.llm.vllm_integration.rust import SchedulerOutput as RustSchedulerOutput
 
-from dynamo.llm import BlockManager, KvbmLeader
+from dynamo.llm import KvbmLeader
 from dynamo.llm.vllm_integration.kv_cache_utils import (
     find_and_set_available_port_from_env,
 )
@@ -64,25 +63,12 @@ class KvConnectorLeader:
 
         self.vllm_config = vllm_config
         world_size = vllm_config.parallel_config.world_size
-        bytes_per_block = CacheEngine.get_cache_block_size(
-            vllm_config.cache_config,
-            vllm_config.model_config,
-            vllm_config.parallel_config,
-        )
-        total_bytes = bytes_per_block * world_size
 
-        leader = KvbmLeader(total_bytes, world_size, drt=self.drt)
-
-        block_manager = BlockManager(
-            0,
-            leader,
-            vllm_config.cache_config.block_size,
-            disable_device_pool=True,
-        )
+        leader = KvbmLeader(world_size, drt=self.drt)
 
         print(f"KvConnectorLeader initialized with engine_id: {engine_id}")
         self._connector = RustKvConnectorLeader(
-            engine_id, self.drt, block_manager, leader
+            engine_id, self.drt, vllm_config.cache_config.block_size, leader
         )
 
     # KV Connector

--- a/lib/llm/src/block_manager/distributed.rs
+++ b/lib/llm/src/block_manager/distributed.rs
@@ -136,7 +136,7 @@ mod tests {
                 .device_id(i)
                 .build()?;
 
-            let worker = KvbmWorker::new(config).await?;
+            let worker = KvbmWorker::new(config, false).await?;
             workers.push(worker);
         }
 

--- a/lib/llm/src/block_manager/distributed.rs
+++ b/lib/llm/src/block_manager/distributed.rs
@@ -8,7 +8,7 @@ mod zmq;
 mod leader;
 mod worker;
 
-pub use leader::{KvbmLeader, KvbmLeaderConfig};
+pub use leader::{KvbmLeader, KvbmLeaderConfig, KvbmLeaderNumBlocksConfig};
 pub use transfer::BlockTransferHandler;
 pub use utils::{
     BlockTransferPool, BlockTransferRequest, ConnectorRequestLeader, ConnectorTransferType,
@@ -130,21 +130,31 @@ mod tests {
                 vec![Arc::new(MockTensor::new(vec![2, NUM_BLOCKS, 4096]))];
 
             let config = KvbmWorkerConfig::builder()
-                .barrier_id(barrier_id.clone())
+                .barrier_id_prefix(barrier_id.clone())
                 .num_device_blocks(NUM_BLOCKS)
                 .tensors(tensors)
-                .worker_id(i)
+                .device_id(i)
                 .build()?;
 
             let worker = KvbmWorker::new(config).await?;
             workers.push(worker);
         }
 
+        let host_blocks = KvbmLeaderNumBlocksConfig {
+            cache_size_in_gb: 1.0,
+            num_blocks_overriden: NUM_BLOCKS,
+        };
+
+        let disk_blocks = KvbmLeaderNumBlocksConfig {
+            cache_size_in_gb: 1.0,
+            num_blocks_overriden: NUM_BLOCKS,
+        };
+
         let leader_config = KvbmLeaderConfig::builder()
-            .barrier_id(barrier_id)
+            .barrier_id_prefix(barrier_id)
             .world_size(num_workers)
-            .num_host_blocks(NUM_BLOCKS)
-            .num_disk_blocks(NUM_BLOCKS)
+            .host_blocks_config(host_blocks)
+            .disk_blocks_config(disk_blocks)
             .build()?;
 
         // When/if this returns, we know that all the workers were also successful.

--- a/lib/llm/src/block_manager/distributed/leader.rs
+++ b/lib/llm/src/block_manager/distributed/leader.rs
@@ -11,10 +11,13 @@ use dynamo_runtime::utils::leader_worker_barrier::LeaderBarrier;
 
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot;
-use tokio_util::sync::CancellationToken;
+use tokio::sync::Notify;
+use tokio::sync::OnceCell;
+use tokio::time::sleep;
 
 /// Data that is sent to workers over ETCD to establish a ZMQ connection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -25,17 +28,31 @@ pub struct KvbmLeaderData {
     pub num_disk_blocks: usize,
 }
 
+#[derive(Builder, Clone, Debug, Default)]
+pub struct KvbmLeaderNumBlocksConfig {
+    #[builder(default = "0.0")]
+    pub cache_size_in_gb: f64,
+
+    #[builder(default = "0")]
+    pub num_blocks_overriden: usize,
+}
+
+fn compute_num_blocks(
+    num_blocks_config: &KvbmLeaderNumBlocksConfig,
+    bytes_per_block: usize,
+) -> usize {
+    if num_blocks_config.num_blocks_overriden > 0 {
+        num_blocks_config.num_blocks_overriden
+    } else {
+        ((num_blocks_config.cache_size_in_gb * 1_000_000_000.0) / bytes_per_block as f64) as usize
+    }
+}
+
 #[derive(Builder, Clone, Debug)]
 pub struct KvbmLeaderConfig {
-    #[builder(default = "0")]
-    num_host_blocks: usize,
-
-    #[builder(default = "0")]
-    num_disk_blocks: usize,
-
     /// The barrier id to use for syncing with workers.
     #[builder(default = "String::from(\"kvbm\")")]
-    barrier_id: String,
+    barrier_id_prefix: String,
 
     /// The world size.
     #[builder(default = "1")]
@@ -47,12 +64,26 @@ pub struct KvbmLeaderConfig {
 
     #[builder(setter(strip_option))]
     drt: Option<DistributedRuntime>,
+
+    #[builder(default = "KvbmLeaderNumBlocksConfig::default()")]
+    host_blocks_config: KvbmLeaderNumBlocksConfig,
+
+    #[builder(default = "KvbmLeaderNumBlocksConfig::default()")]
+    disk_blocks_config: KvbmLeaderNumBlocksConfig,
 }
 
 impl KvbmLeaderConfig {
     pub fn builder() -> KvbmLeaderConfigBuilder {
         KvbmLeaderConfigBuilder::default()
     }
+}
+
+#[derive(Debug, Default)]
+pub struct KvbmLeaderState {
+    pub num_device_blocks: Arc<AtomicUsize>,
+    pub num_host_blocks: Arc<AtomicUsize>,
+    pub num_disk_blocks: Arc<AtomicUsize>,
+    pub workers_allocation_ready: Arc<AtomicBool>,
 }
 
 /// The leader of the KVBM.
@@ -62,9 +93,13 @@ impl KvbmLeaderConfig {
 /// - Syncing the leader barrier with workers.
 /// - Sending messages to workers.
 pub struct KvbmLeader {
-    num_device_blocks: usize,
-    zmq_leader: ZmqActiveMessageLeader,
+    state: Arc<KvbmLeaderState>,
+    zmq_leader: Arc<OnceCell<ZmqActiveMessageLeader>>,
     config: KvbmLeaderConfig,
+    //readiness flags
+    workers_sync_ready: Arc<AtomicBool>,
+    workers_sync_ready_notify: Arc<Notify>,
+    workers_sync_done: Arc<AtomicBool>,
 }
 
 impl KvbmLeader {
@@ -76,34 +111,106 @@ impl KvbmLeader {
             }
         };
 
-        tracing::info!(
-            "Syncing leader barrier with {} workers on barrier id {}",
-            config.world_size,
-            config.barrier_id
-        );
-
         let leader_sockets = new_leader_sockets("tcp://127.0.0.1")?;
 
-        let zmq_data = Arc::new(KvbmLeaderData {
-            pub_url: leader_sockets.pub_url.clone(),
-            ack_url: leader_sockets.ack_url.clone(),
-            num_host_blocks: config.num_host_blocks,
-            num_disk_blocks: config.num_disk_blocks,
+        let leader = Self {
+            state: Arc::new(KvbmLeaderState::default()),
+            zmq_leader: Arc::new(tokio::sync::OnceCell::new()),
+            config,
+            workers_sync_ready: Arc::new(AtomicBool::new(false)),
+            workers_sync_ready_notify: Arc::new(Notify::new()),
+            workers_sync_done: Arc::new(AtomicBool::new(false)),
+        };
+
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        leader.spawn_barrier_task(
+            drt,
+            leader_sockets.pub_url.clone(),
+            leader_sockets.ack_url.clone(),
+        );
+        leader.spawn_zmq_task(leader_sockets, cancel_token);
+
+        Ok(leader)
+    }
+
+    fn spawn_barrier_task(
+        &self,
+        drt: DistributedRuntime,
+        leader_sockets_pub_url: String,
+        leader_sockets_ack_url: String,
+    ) {
+        let state = self.state.clone();
+        let leader_config = self.config.clone();
+        let ready = Arc::clone(&self.workers_sync_ready);
+        let notify = Arc::clone(&self.workers_sync_ready_notify);
+        let done = Arc::clone(&self.workers_sync_done);
+
+        tokio::spawn(async move {
+            match KvbmLeader::run_barrier_sync(
+                drt,
+                leader_sockets_pub_url,
+                leader_sockets_ack_url,
+                leader_config,
+            )
+            .await
+            {
+                Ok((num_device_blocks, num_host_blocks, num_disk_blocks)) => {
+                    // write back results
+                    state
+                        .num_device_blocks
+                        .store(num_device_blocks, Ordering::Release);
+                    state
+                        .num_host_blocks
+                        .store(num_host_blocks, Ordering::Release);
+                    state
+                        .num_disk_blocks
+                        .store(num_disk_blocks, Ordering::Release);
+                    ready.store(true, Ordering::Release);
+                    done.store(true, Ordering::Release);
+                    notify.notify_waiters();
+                }
+                Err(e) => {
+                    tracing::error!("Barrier sync failed: {e:?}");
+                    done.store(true, Ordering::Release);
+                    notify.notify_waiters();
+                }
+            }
+        });
+    }
+
+    async fn run_barrier_sync(
+        drt: DistributedRuntime,
+        leader_sockets_pub_url: String,
+        leader_sockets_ack_url: String,
+        leader_config: KvbmLeaderConfig,
+    ) -> anyhow::Result<(usize, usize, usize)> {
+        let barrier_id_worker_to_leader =
+            format!("{}{}", leader_config.barrier_id_prefix, "-worker-to-leader");
+        tracing::info!(
+            "Syncing leader barrier with {} workers on barrier id {}",
+            leader_config.world_size,
+            barrier_id_worker_to_leader
+        );
+        let zmq_data_worker_to_leader: Arc<KvbmLeaderData> = Arc::new(KvbmLeaderData {
+            pub_url: leader_sockets_pub_url.clone(),
+            ack_url: leader_sockets_ack_url.clone(),
+            num_host_blocks: 0, // doesn't matter for worker to leader sync
+            num_disk_blocks: 0, // doesn't matter for worker to leader sync
         });
 
         // Build our leader barrier and publish the data.
         // TODO: Use a separate timeout parameter from the ZMQ connection timeout
-        let leader_barrier: LeaderBarrier<KvbmLeaderData, worker::KvbmWorkerData> =
+        let worker_to_leader_barrier: LeaderBarrier<KvbmLeaderData, worker::KvbmWorkerData> =
             LeaderBarrier::new(
-                config.barrier_id.clone(),
-                config.world_size,
-                Some(Duration::from_secs(config.leader_init_timeout_secs)),
+                barrier_id_worker_to_leader.clone(),
+                leader_config.world_size,
+                Some(Duration::from_secs(leader_config.leader_init_timeout_secs)),
             );
 
-        let worker_data = leader_barrier
-            .sync(&drt, zmq_data.as_ref())
+        let worker_data = worker_to_leader_barrier
+            .sync(&drt, zmq_data_worker_to_leader.as_ref())
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to sync leader barrier: {:?}", e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to sync worker to leader barrier: {:?}", e))?;
 
         let num_device_blocks = worker_data
             .values()
@@ -111,46 +218,190 @@ impl KvbmLeader {
             .min()
             .unwrap();
 
-        tracing::info!("Leader barrier synced with {} workers", config.world_size);
+        let bytes_per_block: usize = worker_data.values().map(|d| d.bytes_per_block).sum();
+
+        assert!(
+            bytes_per_block > 0,
+            "bytes_per_block must be greater than 0"
+        );
+
+        tracing::info!(
+            "Worker to leader barrier synced with {} workers",
+            leader_config.world_size
+        );
         tracing::debug!("Worker data: {:?}", worker_data);
 
-        // Now, create our active message leader.
-        // This also blocks until a ZMQ connection has been established.
-        let cancel_token = CancellationToken::new();
-        let zmq_leader = ZmqActiveMessageLeader::new(
-            leader_sockets,
-            config.world_size,
-            Duration::from_secs(config.leader_init_timeout_secs),
-            cancel_token.clone(),
-        )
-        .await?;
+        let num_host_blocks =
+            compute_num_blocks(&leader_config.host_blocks_config, bytes_per_block);
+        let num_disk_blocks =
+            compute_num_blocks(&leader_config.disk_blocks_config, bytes_per_block);
 
-        Ok(Self {
-            num_device_blocks,
-            zmq_leader,
-            config,
-        })
+        // Start the second sync to transfer num_host_blocks and num_disk_blocks to worker
+        let barrier_id_leader_to_worker =
+            format!("{}{}", leader_config.barrier_id_prefix, "-leader-to-worker");
+        tracing::info!(
+            "Syncing leader barrier with {} workers on barrier id {}",
+            leader_config.world_size,
+            barrier_id_leader_to_worker
+        );
+
+        let zmq_data_leader_to_worker = Arc::new(KvbmLeaderData {
+            pub_url: leader_sockets_pub_url.clone(),
+            ack_url: leader_sockets_ack_url.clone(),
+            num_host_blocks,
+            num_disk_blocks,
+        });
+
+        let leader_to_worker_barrier: LeaderBarrier<KvbmLeaderData, worker::KvbmWorkerData> =
+            LeaderBarrier::new(
+                barrier_id_leader_to_worker.clone(),
+                leader_config.world_size,
+                Some(Duration::from_secs(leader_config.leader_init_timeout_secs)),
+            );
+
+        let _worker_data = leader_to_worker_barrier
+            .sync(&drt, zmq_data_leader_to_worker.as_ref())
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to sync leader to worker barrier: {:?}", e))?;
+
+        tracing::info!(
+            "Worker to leader barrier synced with {} workers",
+            leader_config.world_size
+        );
+        Ok((num_device_blocks, num_host_blocks, num_disk_blocks))
+    }
+
+    fn spawn_zmq_task(
+        &self,
+        leader_sockets: LeaderSockets,
+        cancel: tokio_util::sync::CancellationToken,
+    ) {
+        let cell = self.zmq_leader.clone();
+        let state = self.state.clone();
+        let world_size = self.config.world_size;
+        let timeout = self.config.leader_init_timeout_secs;
+
+        tokio::spawn(async move {
+            let res = ZmqActiveMessageLeader::new(
+                leader_sockets,
+                world_size,
+                std::time::Duration::from_secs(timeout),
+                cancel,
+            )
+            .await;
+
+            match res {
+                Ok(zmq) => {
+                    let _ = cell.set(zmq);
+                    // mark ready
+                    state
+                        .workers_allocation_ready
+                        .store(true, Ordering::Release);
+                }
+                Err(e) => {
+                    tracing::error!("ZMQ init failed: {e:?}");
+                }
+            }
+        });
+    }
+
+    pub fn spawn_leader_readiness_barrier(&self, drt: DistributedRuntime) {
+        let leader_config = self.config.clone();
+        let handle = drt.runtime().primary();
+        handle.spawn(async move {
+            match KvbmLeader::run_leader_readiness(drt, leader_config).await {
+                Ok(()) => {
+                    tracing::info!("leader readiness barrier synced!");
+                }
+                Err(e) => {
+                    tracing::error!("leader readiness barrier failed: {e:?}");
+                }
+            }
+        });
+    }
+
+    async fn run_leader_readiness(
+        drt: DistributedRuntime,
+        leader_config: KvbmLeaderConfig,
+    ) -> anyhow::Result<()> {
+        let barrier_id_leader_ready =
+            format!("{}{}", leader_config.barrier_id_prefix, "-leader-ready");
+        tracing::info!(
+            "Syncing leader readiness barrier with {} workers on barrier id {}",
+            leader_config.world_size,
+            barrier_id_leader_ready
+        );
+
+        let leader_readiness_barrier: LeaderBarrier<(), ()> = LeaderBarrier::new(
+            barrier_id_leader_ready.clone(),
+            leader_config.world_size,
+            Some(Duration::from_secs(leader_config.leader_init_timeout_secs)),
+        );
+
+        let _ = leader_readiness_barrier
+            .sync(&drt, &())
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to sync leader readiness barrier on leader: {:?}", e)
+            })?;
+
+        Ok(())
     }
 
     pub async fn transfer_blocks_request(
         &self,
         request: BlockTransferRequest,
     ) -> anyhow::Result<oneshot::Receiver<()>> {
+        let zmq = self
+            .zmq_leader
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("ZMQ leader not ready"))?;
         let data = vec![serde_json::to_vec(&request)?];
-        self.zmq_leader
-            .broadcast(ZMQ_TRANSFER_BLOCKS_MESSAGE, data)
-            .await
+        zmq.broadcast(ZMQ_TRANSFER_BLOCKS_MESSAGE, data).await
+    }
+
+    pub fn is_worker_sync_ready(&self) -> bool {
+        self.workers_sync_ready.load(Ordering::Acquire)
+    }
+
+    pub fn is_worker_sync_done(&self) -> bool {
+        self.workers_sync_done.load(Ordering::Acquire)
     }
 
     pub fn num_device_blocks(&self) -> usize {
-        self.num_device_blocks
+        self.state.num_device_blocks.load(Ordering::Acquire)
     }
 
     pub fn num_host_blocks(&self) -> usize {
-        self.config.num_host_blocks
+        self.state.num_host_blocks.load(Ordering::Acquire)
     }
 
     pub fn num_disk_blocks(&self) -> usize {
-        self.config.num_disk_blocks
+        self.state.num_disk_blocks.load(Ordering::Acquire)
+    }
+
+    pub async fn wait_worker_sync_ready(&self) -> bool {
+        if self.is_worker_sync_ready() {
+            return true;
+        }
+        if self.is_worker_sync_done() {
+            return false;
+        }
+
+        let notified = self.workers_sync_ready_notify.notified();
+        if self.is_worker_sync_ready() {
+            return true;
+        }
+        if self.is_worker_sync_done() {
+            return false;
+        }
+
+        // bounded wait
+        tokio::select! {
+            _ = notified => {
+                self.is_worker_sync_ready()
+            }
+            _ = sleep(Duration::from_secs(self.config.leader_init_timeout_secs)) => false,
+        }
     }
 }

--- a/lib/llm/src/block_manager/distributed/leader.rs
+++ b/lib/llm/src/block_manager/distributed/leader.rs
@@ -11,12 +11,12 @@ use dynamo_runtime::utils::leader_worker_barrier::LeaderBarrier;
 
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
-use tokio::sync::oneshot;
 use tokio::sync::Notify;
 use tokio::sync::OnceCell;
+use tokio::sync::oneshot;
 use tokio::time::sleep;
 
 /// Data that is sent to workers over ETCD to establish a ZMQ connection.

--- a/lib/llm/src/block_manager/distributed/worker.rs
+++ b/lib/llm/src/block_manager/distributed/worker.rs
@@ -431,6 +431,7 @@ impl KvbmWorker {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn worker_task(
         device_layout: Box<dyn NixlLayout<StorageType = DeviceStorage>>,
         mut layout_builder: LayoutConfigBuilder,

--- a/lib/llm/src/block_manager/layout.rs
+++ b/lib/llm/src/block_manager/layout.rs
@@ -334,7 +334,8 @@ impl FullyContiguousConfig {
         config.validate()?;
 
         let alignment = config.alignment;
-        let outer_dim_stride_in_bytes = config.page_size * config.inner_dim * config.dtype_width_bytes;
+        let outer_dim_stride_in_bytes =
+            config.page_size * config.inner_dim * config.dtype_width_bytes;
         let layer_stride_in_bytes = outer_dim_stride_in_bytes * config.outer_dim;
         let memory_region_size = layer_stride_in_bytes;
         let natural_block_stride = config.num_layers * layer_stride_in_bytes;

--- a/lib/llm/src/block_manager/layout.rs
+++ b/lib/llm/src/block_manager/layout.rs
@@ -334,9 +334,9 @@ impl FullyContiguousConfig {
         config.validate()?;
 
         let alignment = config.alignment;
-        let memory_region_size = config.page_size * config.inner_dim * config.dtype_width_bytes;
-        let outer_dim_stride_in_bytes = memory_region_size;
+        let outer_dim_stride_in_bytes = config.page_size * config.inner_dim * config.dtype_width_bytes;
         let layer_stride_in_bytes = outer_dim_stride_in_bytes * config.outer_dim;
+        let memory_region_size = layer_stride_in_bytes;
         let natural_block_stride = config.num_layers * layer_stride_in_bytes;
 
         let block_stride_in_bytes = if alignment > 1 {

--- a/lib/llm/src/block_manager/pool/managed.rs
+++ b/lib/llm/src/block_manager/pool/managed.rs
@@ -456,6 +456,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> BlockPool<S, L, M>
         &self,
         sequence_hashes: &[SequenceHash],
     ) -> BlockPoolResult<ImmutableBlocks<S, L, M>> {
+        tracing::debug!("find matching for sequence_hashes: {:?}", sequence_hashes);
         self._match_sequence_hashes(sequence_hashes)?
             .blocking_recv()
             .map_err(|_| BlockPoolError::ProgressEngineShutdown)?

--- a/tests/kvbm/README.md
+++ b/tests/kvbm/README.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-This suite validates determinism properties of the API-backed LLM under fixed sampling parameters and optionally across prefix cache resets. The tests can automatically start a local vLLM server, warm it up, and compare responses for identical prompts over multiple iterations.
+This suite validates the determinism properties of the API-backed LLM under fixed sampling parameters and, optionally, across prefix cache resets. The tests can automatically start a local LLM server—either a vLLM server or a TensorRT-LLM server—warm it up, and compare responses for identical prompts over multiple iterations. The suite also automatically detects whether the vLLM or TensorRT-LLM wheel is installed and starts the corresponding server.
 
 ## Files
 
-- `test_determinism.py` — comprehensive determinism tests with automatic vLLM server lifecycle and warmup.
+- `test_determinism.py` — comprehensive determinism tests with automatic LLM server lifecycle and warmup.
   - `test_determinism_with_cache_reset` — run test with warmup, reset cache, then run again without warmup to test determinism across cache reset boundary
   - `test_concurrent_determinism_with_ifeval` — send parametrized number of IFEval prompts (default: 120) with controlled concurrency, with warmup, then reset cache and test again without warmup to validate determinism across cache reset
 
@@ -19,7 +19,7 @@ This suite validates determinism properties of the API-backed LLM under fixed sa
 
 ## How It Works
 
-- A `VLLMServerManager` fixture (`vllm_server`) launches `vllm serve` with the Dynamo connector and optional cache block overrides.
+- A `LLMServerManager` fixture (`llm_server`) launches `vllm serve` or `trtllm-serve` with the Dynamo connector and optional cache block overrides.
 - A `tester` fixture binds the test client to the running server's base URL.
 - The test performs a comprehensive warmup across prompts, then executes repeated requests and checks that responses are identical (deterministic). An optional cache reset phase re-validates determinism across the reset boundary.
 
@@ -43,8 +43,8 @@ Environment variables control server settings and test load:
 
 - Server/model
   - `KVBM_MODEL_ID` (default: `deepseek-ai/DeepSeek-R1-Distill-Llama-8B`)
-  - `KVBM_VLLM_PORT` (default: `8000`)
-  - `KVBM_VLLM_START_TIMEOUT` (default: `300` seconds)
+  - `KVBM_SERVER_PORT` (default: `8000`)
+  - `KVBM_SERVER_START_TIMEOUT` (default: `300` seconds)
 
 - Cache size overrides
   - `KVBM_CPU_BLOCKS` (used via test parametrization; default: `10000`)
@@ -90,5 +90,5 @@ pytest -v -m "kvbm" -s
 
 - Warmup is critical to avoid initialization effects impacting determinism.
 - For faster local iteration, reduce `KVBM_MAX_ITERATIONS` and/or increase intervals.
-- Logs are written under the per-test directory created by `tests/conftest.py` and include the vLLM server stdout/stderr.
-- Tests use the static port defined by `KVBM_VLLM_PORT` for vLLM server communication.
+- Logs are written under the per-test directory created by `tests/conftest.py` and include the LLM server stdout/stderr.
+- Tests use the static port defined by `KVBM_SERVER_PORT` for LLM server communication.

--- a/tests/kvbm/test_determinism.py
+++ b/tests/kvbm/test_determinism.py
@@ -24,7 +24,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, TextIO, Tuple
+from typing import Any, Dict, List, Optional, TextIO, Tuple
 
 import pytest
 import requests
@@ -128,7 +128,7 @@ class LLMServerManager:
         config_path = os.environ.get(
             "KVBM_TRTLLM_LLMAPI_CONFIG_PATH", "/tmp/kvbm_llm_api_config.yaml"
         )
-        llm_api_config = {}
+        llm_api_config: dict[str, Any] = {}
         llm_api_config[
             "cuda_graph_config"
         ] = None  # explicitly disable CUDA graph since Connector API doesn't support CUDA graph yet in TRTLLM
@@ -146,7 +146,7 @@ class LLMServerManager:
         if gpu_cache_blocks is not None:
             del llm_api_config["kv_cache_config"]["free_gpu_memory_fraction"]
             llm_api_config["kv_cache_config"]["max_tokens"] = (
-                gpu_cache_blocks * 32
+                int(gpu_cache_blocks) * 32
             )  # TRTLLM defaults 32 tokens per block
 
         # Construct serve command

--- a/tests/kvbm/test_determinism.py
+++ b/tests/kvbm/test_determinism.py
@@ -13,6 +13,7 @@ before validation) to avoid server initialization effects that could
 impact determinism measurements.
 """
 
+import importlib.util
 import logging
 import os
 import signal
@@ -21,6 +22,7 @@ import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, TextIO, Tuple
 
@@ -38,8 +40,13 @@ pytestmark = [
 ]
 
 
-class VLLMServerManager:
-    """Manages vLLM server lifecycle for determinism testing."""
+class ServerType(str, Enum):
+    vllm = "vllm"
+    trtllm = "trtllm"
+
+
+class LLMServerManager:
+    """Manages LLM server lifecycle for determinism testing."""
 
     def __init__(
         self,
@@ -48,8 +55,10 @@ class VLLMServerManager:
         cpu_cache_blocks: Optional[int] = None,
         gpu_cache_blocks: Optional[int] = None,
         log_dir: Optional[Path] = None,
+        server_type: Optional[str] = ServerType.vllm,
     ):
-        self.port = port or int(os.environ.get("KVBM_VLLM_PORT", "8000"))
+        self.server_type = server_type
+        self.port = port or int(os.environ.get("KVBM_SERVER_PORT", "8000"))
         self.base_url = base_url or f"http://localhost:{self.port}"
         self.process: Optional[subprocess.Popen] = None
         self.cpu_cache_blocks = cpu_cache_blocks
@@ -63,10 +72,40 @@ class VLLMServerManager:
             f"cpu{cpu_cache_blocks or 'default'}_gpu{gpu_cache_blocks or 'default'}"
         )
         self.server_log_file = (
-            self.log_dir / f"vllm_server_{config_str}_{timestamp}.log"
+            self.log_dir / f"{self.server_type}_server_{config_str}_{timestamp}.log"
         )
         self.server_stdout_file: Optional[TextIO] = None
         self.server_stderr_file: Optional[TextIO] = None
+
+        # Environment for the process
+        self.env = os.environ.copy()
+        self.env.update(
+            {
+                "RUST_BACKTRACE": "1",
+                "DYN_LOG": os.environ.get(
+                    "DYN_LOG", "debug,dynamo_llm::block_manager::layout=error"
+                ),
+                # DynamoConnector connection settings
+                "NATS_SERVER": "nats://localhost:4222",
+                "ETCD_ENDPOINTS": "http://localhost:2379",
+            }
+        )
+
+        # CPU cache blocks override via env
+        if cpu_cache_blocks is not None:
+            self.env["DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS"] = str(cpu_cache_blocks)
+
+        if self.server_type == ServerType.vllm:
+            self._set_up_vllm_config(gpu_cache_blocks)
+        elif self.server_type == ServerType.trtllm:
+            self._set_up_trtllm_config(gpu_cache_blocks)
+        else:
+            raise ValueError(
+                f"{self.server_type} is not supported yet in the KVBM test suite"
+            )
+
+    def _set_up_vllm_config(self, gpu_cache_blocks):
+        self.env["VLLM_SERVER_DEV_MODE"] = "1"
 
         # Construct serve command
         self.server_cmd = [
@@ -85,27 +124,52 @@ class VLLMServerManager:
         if gpu_cache_blocks is not None:
             self.server_cmd.extend(["--num-gpu-blocks-override", str(gpu_cache_blocks)])
 
-        # Environment for the process
-        self.env = os.environ.copy()
-        self.env.update(
-            {
-                "RUST_BACKTRACE": "1",
-                "DYN_LOG": os.environ.get(
-                    "DYN_LOG", "debug,dynamo_llm::block_manager::layout=error"
-                ),
-                "VLLM_SERVER_DEV_MODE": "1",
-                # DynamoConnector connection settings
-                "NATS_SERVER": "nats://localhost:4222",
-                "ETCD_ENDPOINTS": "http://localhost:2379",
-            }
+    def _set_up_trtllm_config(self, gpu_cache_blocks):
+        config_path = os.environ.get(
+            "KVBM_TRTLLM_LLMAPI_CONFIG_PATH", "/tmp/kvbm_llm_api_config.yaml"
         )
+        llm_api_config = {}
+        llm_api_config[
+            "cuda_graph_config"
+        ] = None  # explicitly disable CUDA graph since Connector API doesn't support CUDA graph yet in TRTLLM
+        llm_api_config["kv_cache_config"] = {
+            "enable_partial_reuse": False,
+            "free_gpu_memory_fraction": 0.10,  # Set a small GPU fraction so that we can evict/reset the on-device kv cache faster
+        }
+        llm_api_config["kv_connector_config"] = {
+            "connector_module": "dynamo.llm.trtllm_integration.connector",
+            "connector_scheduler_class": "DynamoKVBMConnectorLeader",
+            "connector_worker_class": "DynamoKVBMConnectorWorker",
+        }
 
-        # CPU cache blocks override via env
-        if cpu_cache_blocks is not None:
-            self.env["DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS"] = str(cpu_cache_blocks)
+        # GPU blocks override
+        if gpu_cache_blocks is not None:
+            del llm_api_config["kv_cache_config"]["free_gpu_memory_fraction"]
+            llm_api_config["kv_cache_config"]["max_tokens"] = (
+                gpu_cache_blocks * 32
+            )  # TRTLLM defaults 32 tokens per block
+
+        # Construct serve command
+        self.server_cmd = [
+            "trtllm-serve",
+            os.environ.get("KVBM_MODEL_ID", "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"),
+            "--host",
+            "localhost",
+            "--port",
+            str(self.port),
+            "--backend",
+            "pytorch",
+            "--extra_llm_api_options",
+            config_path,
+        ]
+
+        import yaml
+
+        with open(config_path, "w") as f:
+            yaml.dump(llm_api_config, f, default_flow_style=False, sort_keys=False)
 
     def start_server(self, timeout: int = 300) -> bool:
-        """Start vLLM server and wait for readiness."""
+        """Start LLM server and wait for readiness."""
         if self.is_server_running():
             self.stop_server()
             time.sleep(2)
@@ -119,7 +183,7 @@ class VLLMServerManager:
         )
         if self.server_stdout_file is not None:
             self.server_stdout_file.write(
-                f"=== vLLM Server Started at {datetime.now()} ===\nCommand: {' '.join(self.server_cmd)}\n"
+                f"=== {self.server_type} Server Started at {datetime.now()} ===\nCommand: {' '.join(self.server_cmd)}\n"
             )
             self.server_stdout_file.flush()
 
@@ -147,7 +211,7 @@ class VLLMServerManager:
         return False
 
     def stop_server(self):
-        """Stop vLLM server and close logs."""
+        """Stop LLM server and close logs."""
         if self.process:
             try:
                 os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
@@ -205,7 +269,12 @@ class VLLMServerManager:
 class DeterminismTester:
     """Test class for model determinism validation."""
 
-    def __init__(self, base_url: Optional[str] = None, model_id: Optional[str] = None):
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        model_id: Optional[str] = None,
+        server_type: Optional[str] = ServerType.vllm,
+    ):
         # Allow environment override for flexibility in CI/local runs
         self.base_url = (
             base_url or os.environ.get("DYNAMO_API_BASE_URL") or "http://localhost:8000"
@@ -215,6 +284,7 @@ class DeterminismTester:
             or os.environ.get("KVBM_MODEL_ID")
             or "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
         )
+        self.server_type = server_type
 
         self.shakespeare_file = Path("t8.shakespeare.txt")
         self.max_iterations = int(os.environ.get("KVBM_MAX_ITERATIONS", "500"))
@@ -298,11 +368,28 @@ class DeterminismTester:
     def reset_prefix_cache(self):
         """Reset the prefix cache."""
         print("Resetting prefix cache...")
-        response = requests.post(
-            f"{self.base_url}/reset_prefix_cache",
-            timeout=int(os.environ.get("KVBM_HTTP_TIMEOUT", "30")),
-        )
-        response.raise_for_status()
+        if self.server_type == ServerType.trtllm:
+            # TRTLLM doesn't support reset_prefix_cache endpoint API
+            # 300 shakespeare content could evict the 0.1 x 80G (~1700 blocks) on-device cache
+            shakespeare_count = 300
+            for seq_idx in range(1, shakespeare_count + 1):
+                start_word = (seq_idx - 1) * self.word_count
+                content = self.get_shakespeare_content(start_word)
+
+                if content:
+                    print(
+                        f"Resetting Shakespeare sequence {seq_idx} (words {start_word}-{start_word + self.word_count - 1})..."
+                    )
+                    try:
+                        self.make_request(content)
+                    except Exception as e:
+                        print(f"Resetting request failed: {e}")
+        else:
+            response = requests.post(
+                f"{self.base_url}/reset_prefix_cache",
+                timeout=int(os.environ.get("KVBM_HTTP_TIMEOUT", "30")),
+            )
+            response.raise_for_status()
         print("Cache reset done")
 
     def warmup_server(self):
@@ -623,11 +710,11 @@ class DeterminismTester:
 
 
 @pytest.fixture(scope="function")
-def vllm_server(request, runtime_services):
-    """Start and stop vLLM server for each test with optional cache block overrides.
+def llm_server(request, runtime_services):
+    """Start and stop a LLM server for each test with optional cache block overrides.
 
     To parametrize, use:
-      @pytest.mark.parametrize("vllm_server", [{"cpu_blocks": 10000, "gpu_blocks": 2048}], indirect=True)
+      @pytest.mark.parametrize("llm_server", [{"cpu_blocks": 10000, "gpu_blocks": 2048}], indirect=True)
     """
     logger = logging.getLogger("pytest")
     logger.setLevel(logging.INFO)
@@ -639,17 +726,27 @@ def vllm_server(request, runtime_services):
     # Put logs in the per-test directory set up by tests/conftest.py
     log_dir = Path(request.node.name)
 
-    server_manager = VLLMServerManager(
+    if importlib.util.find_spec("vllm") is not None:
+        server_type = ServerType.vllm
+    elif importlib.util.find_spec("tensorrt_llm") is not None:
+        server_type = ServerType.trtllm
+    else:
+        raise Exception(
+            "Neither the vllm nor the tensorrt_llm module is available in the current environment."
+        )
+
+    server_manager = LLMServerManager(
         port=port,
         cpu_cache_blocks=cpu_blocks,
         gpu_cache_blocks=gpu_blocks,
         log_dir=log_dir,
+        server_type=server_type,
     )
 
-    start_timeout = int(os.environ.get("KVBM_VLLM_START_TIMEOUT", "300"))
+    start_timeout = int(os.environ.get("KVBM_SERVER_START_TIMEOUT", "300"))
     if not server_manager.start_server(timeout=start_timeout):
         pytest.fail(
-            f"Failed to start vLLM server (cpu_blocks={cpu_blocks}, gpu_blocks={gpu_blocks}, port={server_manager.port})"
+            f"Failed to start {server_type} server (cpu_blocks={cpu_blocks}, gpu_blocks={gpu_blocks}, port={server_manager.port})"
         )
 
     yield server_manager
@@ -658,9 +755,11 @@ def vllm_server(request, runtime_services):
 
 
 @pytest.fixture(scope="function")
-def tester(vllm_server):
+def tester(llm_server):
     """Create determinism tester bound to the running server's base URL."""
-    t = DeterminismTester(base_url=vllm_server.base_url)
+    t = DeterminismTester(
+        base_url=llm_server.base_url, server_type=llm_server.server_type
+    )
     t.download_shakespeare_text()
     return t
 
@@ -669,13 +768,13 @@ class TestDeterminism:
     """Test class for determinism validation."""
 
     @pytest.mark.parametrize(
-        "vllm_server",
+        "llm_server",
         [
             {"cpu_blocks": int(os.environ.get("KVBM_CPU_BLOCKS", "10000"))},
         ],
         indirect=True,
     )
-    def test_determinism_with_cache_reset(self, tester, vllm_server, runtime_services):
+    def test_determinism_with_cache_reset(self, tester, llm_server, runtime_services):
         """Test determinism across cache reset: run test with warmup, reset cache, run again without warmup."""
         print("\n" + "=" * 70)
         print("STARTING DETERMINISM TEST (WITH CACHE RESET)")
@@ -797,7 +896,7 @@ class TestDeterminism:
         ), f"Model is not deterministic across cache reset: {total_failed} comparisons failed"
 
     @pytest.mark.parametrize(
-        "vllm_server",
+        "llm_server",
         [
             {"cpu_blocks": int(os.environ.get("KVBM_CPU_BLOCKS", "20000"))},
         ],
@@ -818,7 +917,7 @@ class TestDeterminism:
     def test_concurrent_determinism_with_ifeval(
         self,
         tester,
-        vllm_server,
+        llm_server,
         runtime_services,
         num_concurrent,
         max_tokens,


### PR DESCRIPTION
#### Overview:

Dynamo KVBM connector API integration with TRTLLM, including fixes after merging the connector API vLLM integration and addressing comments from https://github.com/ai-dynamo/dynamo/pull/2440

#### Details:
The PR is based on the ongoing changes from https://github.com/NVIDIA/TensorRT-LLM/pull/7228, which added TRT-LLM connector API compatibility.

Changes in this PR:
1. Added support for an external KV cache layout that is fully contiguous, since TRT-LLM’s cache layout is fully contiguous.
2. Instead of providing bytes_per_block from the KVBM leader bindings, the KVBM leader now reads bytes_per_block from the worker for a more accurate estimation. This is necessary because there is no straightforward or reliable way to extract bytes_per_block directly from the TRT-LLM KV cache.
3. Introduced additional complexity to the leader–worker barrier, requiring two synchronization steps:
Worker → Leader: send bytes_per_block.
Leader → Worker: send num_host_blocks and num_disk_blocks.
5. Added the basic Rust-based leader–worker integration for TRT-LLM, with some compatibility changes:
1). When the leader calls update_state_after_alloc, no num_external_tokens is passed. For now, a HashMap is used to track each request’s num_external_tokens when calling get_num_new_matched_tokens.
2). build_connector_metadata now uses a new implementation of apply_scheduler_output, namely apply_scheduler_output_with_computed_position, to trigger offloading. This change is required because TRT-LLM’s scheduler output does not include the number of scheduled tokens, so offloading decisions must be based on the computed position.

Issues:
A separate Python module and Rust crate will need to be built specifically for TRT-LLM. For now, TRT-LLM is included in vllm_integration to reuse some core KVBM integration code.

**New changes after last review:**
1. Updated the vLLM integration to read the "bytes_per_block" from the worker, instead of getting from the scheduler. 
2. KVBM worker can either initialize in a blocking or non-blocking mode. 
    in vLLM, the engine core will register kv cache in workers first and then initialize the leader, the engine's readiness depends on the scheduler's readiness, so the worker initialization need to be non-blocking, and the scheduler's initialization need to be blocking.
    in TRTLLM, the engine core will initialize the leader and register kv cache in workers at the same time and in the same process, he engine's readiness depends on the worker's readiness, so the worker initialization need to be blocking, and the scheduler's initialization need to be non-blocking.

#### Where should the reviewer start?

The reviewer could start with kvbm_connector_leader.py and kvbm_connector_worker.py. And then look into the rust bindings inside the trtllm_leader.rs and trtllm_worker.rs implementation.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
