### PR TITLE
feat: register Kv router instance into etcd

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -3,6 +3,7 @@
 
 use dynamo_runtime::component::Component;
 use dynamo_runtime::prelude::DistributedRuntimeProvider;
+use dynamo_runtime::slug::Slug;
 
 use crate::discovery::ModelEntry;
 
@@ -217,7 +218,11 @@ impl ModelManager {
             .drt()
             .etcd_client()
             .ok_or_else(|| anyhow::anyhow!("KV routing requires etcd (dynamic mode)"))?;
-        let router_key = format!("kv_routers/{}/{}", model_name, uuid::Uuid::new_v4());
+        let router_key = format!(
+            "kv_routers/{}/{}",
+            Slug::from_string(model_name),
+            uuid::Uuid::new_v4()
+        );
         etcd_client
             .kv_create(
                 &router_key,

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -213,20 +213,6 @@ impl ModelManager {
         kv_cache_block_size: u32,
         kv_router_config: Option<KvRouterConfig>,
     ) -> anyhow::Result<Arc<KvRouter>> {
-        let selector = Box::new(DefaultWorkerSelector::new(kv_router_config));
-        let chooser = KvRouter::new(
-            component.clone(),
-            kv_cache_block_size,
-            Some(selector),
-            kv_router_config,
-        )
-        .await?;
-        let new_kv_chooser = Arc::new(chooser);
-        self.kv_choosers
-            .lock()
-            .unwrap()
-            .insert(model_name.to_string(), new_kv_chooser.clone());
-
         let etcd_client = component
             .drt()
             .etcd_client()
@@ -240,6 +226,19 @@ impl ModelManager {
             )
             .await?;
 
+        let selector = Box::new(DefaultWorkerSelector::new(kv_router_config));
+        let chooser = KvRouter::new(
+            component.clone(),
+            kv_cache_block_size,
+            Some(selector),
+            kv_router_config,
+        )
+        .await?;
+        let new_kv_chooser = Arc::new(chooser);
+        self.kv_choosers
+            .lock()
+            .unwrap()
+            .insert(model_name.to_string(), new_kv_chooser.clone());
         Ok(new_kv_chooser)
     }
 }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -16,6 +16,7 @@ use dynamo_runtime::{
     protocols::annotated::Annotated,
 };
 use futures::stream::{self, StreamExt};
+use serde::{Deserialize, Serialize};
 
 pub mod approx;
 pub mod indexer;
@@ -73,7 +74,7 @@ pub trait WorkerSelector {
 }
 
 /// KV Router configuration parameters
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct KvRouterConfig {
     pub overlap_score_weight: f64,
 

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -274,9 +274,6 @@ def test_mocker_kv_router(request, runtime_services):
         for mocker in mocker_processes:
             mocker.__enter__()
 
-        # Check etcd registration - expect 1 KV router
-        asyncio.run(check_registration_in_etcd(expected_count=1))
-
         # Use async to send requests concurrently for better performance
         asyncio.run(
             send_inflight_requests(
@@ -289,6 +286,9 @@ def test_mocker_kv_router(request, runtime_services):
         )
 
         logger.info(f"Successfully completed {NUM_REQUESTS} requests")
+
+        # Check etcd registration - expect 1 KV router
+        asyncio.run(check_registration_in_etcd(expected_count=1))
 
     finally:
         # Clean up
@@ -345,9 +345,6 @@ def test_mocker_two_kv_router(request, runtime_services):
         for mocker in mocker_processes:
             mocker.__enter__()
 
-        # Check etcd registration - expect 2 KV routers
-        asyncio.run(check_registration_in_etcd(expected_count=2))
-
         # Build URLs for both routers
         router_urls = [
             f"http://localhost:{port}/v1/chat/completions" for port in router_ports
@@ -365,6 +362,9 @@ def test_mocker_two_kv_router(request, runtime_services):
         logger.info(
             f"Successfully completed {NUM_REQUESTS} requests across {len(router_ports)} routers"
         )
+
+        # Check etcd registration - expect 2 KV routers
+        asyncio.run(check_registration_in_etcd(expected_count=2))
 
     finally:
         # Clean up routers

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -163,9 +163,6 @@ async def check_registration_in_etcd(expected_count: int):
     runtime = get_runtime()
     etcd = runtime.etcd_client()
 
-    # Wait a bit for registration to complete
-    await asyncio.sleep(2)
-
     # Check for kv_routers in etcd
     # The KV router registers itself with key format: kv_routers/{model_name}/{uuid}
     kv_routers = await etcd.kv_get_prefix("kv_routers/")


### PR DESCRIPTION
#### Motivation

The motivation for this is to prepare for router replica warm restarts. KV router needs to be aware of the existence (and healthiness) of other KV routers, so they can properly coordinate dumping their `RadixTree` states and loading them back.

#### Changes

Register an instance of KV router under the `kv_routers/` prefix upon successful creation of a `KvRouter` in `create_kv_chooser`

#### E2E tests

In pre-merge CI, verify that one Router gets you one key with prefix `kv_routers/` and two Router replicas get you two keys with prefix `kv_routers/` 😃 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * KV router configurations are now persisted to a cluster store in dynamic mode, improving continuity across restarts and deployments.
  * Creation of new KV routers now validates the availability of the cluster store upfront, providing immediate feedback if unavailable.
  * Added serialization support for KV router configuration, enabling safer persistence and potential future export/import flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->