### PR TITLE
test: lychee offline in pre-merge CI (full check only on push to main)

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -50,7 +50,6 @@ jobs:
           # Set GITHUB_TOKEN to avoid github rate limits on URL checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd docs
           set -euo pipefail
 
           # Set offline mode for pull requests, full check for pushes to main

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -52,6 +52,16 @@ jobs:
         run: |
           cd docs
           set -euo pipefail
+
+          # Set offline mode for pull requests, full check for pushes to main
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Running lychee in offline mode (internal links only) for PR check"
+            OFFLINE_FLAG="--offline"
+          else
+            echo "Running lychee in full mode (all links) for main branch"
+            OFFLINE_FLAG=""
+          fi
+
           # Run lychee against all files in repo
           lychee \
             --cache \
@@ -59,4 +69,5 @@ jobs:
             --exclude-path "ATTRIBUTIONS.*" \
             --accept "200..=299, 403, 429" \
             --exclude-all-private --exclude 0.0.0.0 \
+            $OFFLINE_FLAG \
             .

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -65,7 +65,8 @@ jobs:
           lychee \
             --cache \
             --no-progress \
-            --exclude-path "ATTRIBUTIONS.*" \
+            --root-dir "${{ github.workspace }}" \
+            --exclude-path ".*ATTRIBUTIONS.*" \
             --accept "200..=299, 403, 429" \
             --exclude-all-private --exclude 0.0.0.0 \
             $OFFLINE_FLAG \


### PR DESCRIPTION
#### Overview:

As titled. Doing a full lychee check on every commit runs into a rate-limiting problem, particularly the link https://sdk.operatorframework.io/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized documentation link checks in CI: pull requests now run in offline mode to validate internal links only, reducing external flakiness and speeding up feedback.
  * Pushes to the main branch run the full link validation to ensure comprehensive coverage.
  * Added clear status messages indicating whether checks are running in offline or full mode for better visibility in workflow logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->