### PR TITLE
docs: Add pinned install for cuda-python in pip install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,10 @@ It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/
 ### Install prerequisites
 ```
 # Optional step: Only required for Blackwell and Grace Hopper
-pip3 install torch==2.7.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
+uv pip install torch==2.7.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
+
+# Required until the trtllm version is bumped to include this pinned dependency itself
+uv pip install "cuda-python>=12,<13"
 
 sudo apt-get -y install libopenmpi-dev
 ```


### PR DESCRIPTION


#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Apply same fix for cuda-python dependency on pip install path that is already covered in container build here: https://github.com/ai-dynamo/dynamo/blob/f73d35d50c389926a934de131751796ce5050766/container/Dockerfile.trtllm#L481C20-L481C41

Related: https://github.com/ai-dynamo/dynamo/pull/2379

Fixes:
```
>>> import tensorrt_llm
Traceback (most recent call last):
...
  File "/opt/dynamo/venv/lib/python3.12/site-packages/tensorrt_llm/_ipc_utils.py", line 20, in <module>
    from cuda import cuda, cudart
ImportError: cannot import name 'cuda' from 'cuda' (unknown location)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated installation instructions to use uv for Python package management.
  - Revised optional PyTorch install command to align with uv workflows.
  - Added guidance to install cuda-python (>=12,<13) to ensure compatibility.
  - Improved formatting for readability in the setup section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->