### PR TITLE
feat: enable basic reasoning parsing of <think> </think> tokens

### DIFF
--- a/lib/llm/src/engines.rs
+++ b/lib/llm/src/engines.rs
@@ -183,7 +183,7 @@ impl
         incoming_request: SingleIn<NvCreateChatCompletionRequest>,
     ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
         let (request, context) = incoming_request.transfer(());
-        let deltas = request.response_generator();
+        let mut deltas = request.response_generator();
         let ctx = context.context();
         let req = request.inner.messages.into_iter().next_back().unwrap();
 

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -149,13 +149,9 @@ impl DeltaAggregator {
                         }
 
                         if let Some(reasoning_content) = &choice.delta.reasoning_content {
-                            if state_choice.reasoning_content.is_none() {
-                                state_choice.reasoning_content = Some("".to_string());
-                            }
                             state_choice
                                 .reasoning_content
-                                .as_mut()
-                                .unwrap()
+                                .get_or_insert_with(String::new)
                                 .push_str(reasoning_content);
                         }
 

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -243,7 +243,7 @@ impl From<DeltaChoice> for dynamo_async_openai::types::ChatChoice {
                 refusal: None,
                 function_call: None,
                 audio: None,
-                reasoning_content: None,
+                reasoning_content: delta.reasoning_content,
             },
             index: delta.index,
             finish_reason: delta.finish_reason,

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -155,7 +155,7 @@ impl DeltaAggregator {
                             state_choice
                                 .reasoning_content
                                 .as_mut()
-                                .expect("Reason Content")
+                                .unwrap()
                                 .push_str(reasoning_content);
                         }
 

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -61,6 +61,9 @@ struct DeltaChoice {
     logprobs: Option<dynamo_async_openai::types::ChatChoiceLogprobs>,
     // Optional tool calls for the chat choice.
     tool_calls: Option<Vec<dynamo_async_openai::types::ChatCompletionMessageToolCall>>,
+
+    /// Optional reasoning content for the chat choice.
+    reasoning_content: Option<String>,
 }
 
 impl Default for DeltaAggregator {
@@ -137,11 +140,23 @@ impl DeltaAggregator {
                                     finish_reason: None,
                                     logprobs: choice.logprobs,
                                     tool_calls: None,
+                                    reasoning_content: None,
                                 });
 
                         // Append content if available.
                         if let Some(content) = &choice.delta.content {
                             state_choice.text.push_str(content);
+                        }
+
+                        if let Some(reasoning_content) = &choice.delta.reasoning_content {
+                            if state_choice.reasoning_content.is_none() {
+                                state_choice.reasoning_content = Some("".to_string());
+                            }
+                            state_choice
+                                .reasoning_content
+                                .as_mut()
+                                .expect("Reason Content")
+                                .push_str(reasoning_content);
                         }
 
                         // Update finish reason if provided.

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_parsers::{reasoning, ReasoningParser, ReasoningParserType};
+use dynamo_parsers::{reasoning, ReasoningParserType};
 
 use super::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse};
 use crate::{
@@ -186,7 +186,8 @@ impl DeltaGenerator {
         if text.is_none() {
             return (None, None);
         }
-        let mut reasoning_parser = ReasoningParserType::get_reasoning_parser(self.reasoning_parser_type);
+        let mut reasoning_parser =
+            ReasoningParserType::get_reasoning_parser(self.reasoning_parser_type);
         let parser_result = reasoning_parser.parse_reasoning_streaming_incremental(
             text.as_deref().expect("Text should not be None"),
         );

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -181,14 +181,12 @@ impl DeltaGenerator {
     }
 
     fn create_reasoning_content(&mut self, text: Option<String>) -> Option<ParserResult> {
-        if text.is_none() {
-            return None;
-        }
+        text.as_ref()?;
         let parser_result = self
             .reasoning_parser
             .parse_reasoning_streaming_incremental(text.as_deref().unwrap());
 
-        return Some(parser_result);
+        Some(parser_result)
     }
 
     /// Creates a choice within a chat completion response.

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -88,9 +88,12 @@ impl DeltaGenerator {
             completion_tokens_details: None,
         };
 
-        // Reasoning parser
+        // Reasoning parser type
+        // This is hardcoded for now, but can be made configurable later.
+        // TODO: Make parser type configurable once front-end integration is determined
         let reasoning_parser_type = ReasoningParserType::Basic;
 
+        // Reasoning parser wrapper
         let reasoning_parser = reasoning_parser_type.get_reasoning_parser();
 
         Self {
@@ -181,10 +184,10 @@ impl DeltaGenerator {
     }
 
     fn create_reasoning_content(&mut self, text: Option<String>) -> Option<ParserResult> {
-        text.as_ref()?;
+        let text = text?;
         let parser_result = self
             .reasoning_parser
-            .parse_reasoning_streaming_incremental(text.as_deref().unwrap());
+            .parse_reasoning_streaming_incremental(&text);
 
         Some(parser_result)
     }

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -95,7 +95,7 @@ impl
         let max_tokens = request.inner.max_tokens.unwrap_or(0) as u64;
 
         // let generator = NvCreateChatCompletionStreamResponse::generator(request.model.clone());
-        let generator = request.response_generator();
+        let mut generator = request.response_generator();
 
         let stream = stream! {
             tokio::time::sleep(std::time::Duration::from_millis(max_tokens)).await;

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -33,7 +33,7 @@ impl BasicReasoningParser {
 }
 
 impl ReasoningParser for BasicReasoningParser {
-    fn detect_and_parse_reasoning(&mut self, text: &str) -> ParserResult {
+    fn detect_and_parse_reasoning(&self, text: &str) -> ParserResult {
         log::debug!("detect_and_parse_reasoning called with text: {:?}", text);
 
         let in_reasoning = self._in_reasoning || text.contains(&self.think_start_token);
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_detect_and_parse_reasoning_reasoning() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result =
             parser.detect_and_parse_reasoning("<think>with reasoning</think> and more text.");
@@ -189,7 +189,7 @@ mod tests {
     }
     #[test]
     fn test_detect_and_parse_reasoning_reasoning_no_reasoning() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning("This is a test without reasoning.");
         assert_eq!(result.normal_text, "This is a test without reasoning.");
@@ -197,7 +197,7 @@ mod tests {
     }
     #[test]
     fn test_detect_and_parse_reasoning_reasoning_truncated_reasoning() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning("<think>with truncated reasoning");
         assert_eq!(result.normal_text, "");
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_detect_and_parse_reasoning_multiple_reasoning_blocks() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning(
             "<think>first reasoning</think> middle <think>second reasoning</think> end",
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn test_nested_reasoning_blocks() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning(
             "<think>outer <think>inner</think> reasoning</think> normal",
@@ -355,7 +355,7 @@ mod tests {
 
     #[test]
     fn test_malformed_missing_closing_tag() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning("<think>reasoning without closing tag");
         assert_eq!(result.normal_text, "");
@@ -364,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_malformed_stray_closing_tag() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning("normal text</think> more normal");
         assert_eq!(result.normal_text, "normal text</think> more normal");
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_malformed_multiple_opening_tags() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser
             .detect_and_parse_reasoning("<think>first <think>second reasoning</think> normal");
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn test_empty_reasoning_block() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning("<think></think> normal text");
         assert_eq!(result.normal_text, "normal text");
@@ -393,7 +393,7 @@ mod tests {
 
     #[test]
     fn test_whitespace_only_reasoning_block() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning("<think>   \n\t  </think> normal text");
         assert_eq!(result.normal_text, "normal text");
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_force_reasoning_mode() {
-        let mut parser =
+        let parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
         let result = parser.detect_and_parse_reasoning("no think tags here");
         assert_eq!(result.normal_text, "");

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -4,7 +4,7 @@ use tracing as log;
 
 use crate::{ParserResult, ReasoningParser};
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 pub struct BasicReasoningParser {
     think_start_token: String,
     think_end_token: String,

--- a/lib/parsers/src/reasoning/deepseek_r1_parser.rs
+++ b/lib/parsers/src/reasoning/deepseek_r1_parser.rs
@@ -5,7 +5,7 @@ use super::base_parser::BasicReasoningParser;
 use crate::ParserResult;
 use crate::ReasoningParser;
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 pub struct DeepseekR1ReasoningParser {
     base: BasicReasoningParser,
 }

--- a/lib/parsers/src/reasoning/deepseek_r1_parser.rs
+++ b/lib/parsers/src/reasoning/deepseek_r1_parser.rs
@@ -1,19 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::base_parser::BaseReasoningParser;
-use super::base_parser::ParserResult;
-use super::base_parser::ReasoningParser;
+use super::base_parser::BasicReasoningParser;
+use crate::ParserResult;
+use crate::ReasoningParser;
 
 #[derive(Default)]
 pub struct DeepseekR1ReasoningParser {
-    base: BaseReasoningParser,
+    base: BasicReasoningParser,
 }
 
 impl DeepseekR1ReasoningParser {
     pub fn new() -> Self {
         Self {
-            base: BaseReasoningParser::new(
+            base: BasicReasoningParser::new(
                 "<think>".to_string(),
                 "</think>".to_string(),
                 true,

--- a/lib/parsers/src/reasoning/deepseek_r1_parser.rs
+++ b/lib/parsers/src/reasoning/deepseek_r1_parser.rs
@@ -28,7 +28,7 @@ impl ReasoningParser for DeepseekR1ReasoningParser {
         self.base.parse_reasoning_streaming_incremental(text)
     }
 
-    fn detect_and_parse_reasoning(&mut self, text: &str) -> ParserResult {
+    fn detect_and_parse_reasoning(&self, text: &str) -> ParserResult {
         self.base.detect_and_parse_reasoning(text)
     }
 }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -4,8 +4,6 @@
 mod base_parser;
 mod deepseek_r1_parser;
 
-use std::sync::{Arc, Mutex};
-
 // Re-export main types and functions for convenience
 pub use base_parser::BasicReasoningParser;
 pub use deepseek_r1_parser::DeepseekR1ReasoningParser;
@@ -41,7 +39,7 @@ pub trait ReasoningParser: Send + std::fmt::Debug {
     /// Parses a standalone, non-streaming input chunk. Implementations may reset or ignore
     /// internal streaming state and should return the split of normal vs reasoning text for
     /// this complete input. Marker tokens must not be included in either output.
-    fn detect_and_parse_reasoning(&mut self, text: &str) -> ParserResult;
+    fn detect_and_parse_reasoning(&self, text: &str) -> ParserResult;
 
     /// Parses a streaming chunk and updates internal state. The return value should be the
     /// delta: only the newly discovered normal and reasoning text attributable to this chunk
@@ -56,21 +54,18 @@ pub enum ReasoningParserType {
     Basic,
 }
 
-#[derive(std::fmt::Debug, Clone)]
+#[derive(std::fmt::Debug)]
 pub struct ReasoningParserWrapper {
-    parser: Arc<Mutex<dyn ReasoningParser>>,
+    parser: Box<dyn ReasoningParser>,
 }
 
 impl ReasoningParser for ReasoningParserWrapper {
-    fn detect_and_parse_reasoning(&mut self, text: &str) -> ParserResult {
-        self.parser.lock().unwrap().detect_and_parse_reasoning(text)
+    fn detect_and_parse_reasoning(&self, text: &str) -> ParserResult {
+        self.parser.detect_and_parse_reasoning(text)
     }
 
     fn parse_reasoning_streaming_incremental(&mut self, text: &str) -> ParserResult {
-        self.parser
-            .lock()
-            .unwrap()
-            .parse_reasoning_streaming_incremental(text)
+        self.parser.parse_reasoning_streaming_incremental(text)
     }
 }
 
@@ -78,15 +73,15 @@ impl ReasoningParserType {
     pub fn get_reasoning_parser(self) -> ReasoningParserWrapper {
         match self {
             ReasoningParserType::DeepseekR1 => ReasoningParserWrapper {
-                parser: Arc::new(Mutex::new(DeepseekR1ReasoningParser::new())),
+                parser: Box::new(DeepseekR1ReasoningParser::new()),
             },
             ReasoningParserType::Basic => ReasoningParserWrapper {
-                parser: Arc::new(Mutex::new(BasicReasoningParser::new(
+                parser: Box::new(BasicReasoningParser::new(
                     "<think>".into(),
                     "</think>".into(),
                     false,
                     true,
-                ))),
+                )),
             },
         }
     }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -24,14 +24,15 @@ pub trait ReasoningParser {
     fn parse_reasoning_streaming_incremental(&mut self, text: &str) -> ParserResult;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReasoningParserType {
     DeepseekR1,
     Basic,
 }
 
 impl ReasoningParserType {
-    pub fn get_reasoning_parser() -> Box<dyn ReasoningParser> {
-        match ReasoningParserType::Basic {
+    pub fn get_reasoning_parser(self) -> Box<dyn ReasoningParser> {
+        match self {
             ReasoningParserType::DeepseekR1 => Box::new(DeepseekR1ReasoningParser::new()),
             ReasoningParserType::Basic => Box::new(BasicReasoningParser::new(
                 "<think>".to_string(),

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -1,9 +1,44 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod base_parser;
-pub mod deepseek_r1_parser;
+mod base_parser;
+mod deepseek_r1_parser;
 
 // Re-export main types and functions for convenience
-pub use base_parser::ReasoningParser;
+pub use base_parser::BasicReasoningParser;
 pub use deepseek_r1_parser::DeepseekR1ReasoningParser;
+
+pub struct ParserResult {
+    /// The normal text outside of reasoning blocks.
+    pub normal_text: String,
+
+    /// The extracted reasoning text from within reasoning blocks.
+    pub reasoning_text: String,
+}
+
+pub trait ReasoningParser {
+    /// Detects and parses reasoning from the input text.
+    fn detect_and_parse_reasoning(&mut self, text: &str) -> ParserResult;
+
+    /// Parses reasoning incrementally from streaming input.
+    fn parse_reasoning_streaming_incremental(&mut self, text: &str) -> ParserResult;
+}
+
+pub enum ReasoningParserType {
+    DeepseekR1,
+    Basic,
+}
+
+impl ReasoningParserType {
+    pub fn get_reasoning_parser() -> Box<dyn ReasoningParser> {
+        match ReasoningParserType::Basic {
+            ReasoningParserType::DeepseekR1 => Box::new(DeepseekR1ReasoningParser::new()),
+            ReasoningParserType::Basic => Box::new(BasicReasoningParser::new(
+                "<think>".to_string(),
+                "</think>".to_string(),
+                false,
+                true,
+            )),
+        }
+    }
+}

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -19,6 +19,24 @@ pub struct ParserResult {
     pub reasoning_text: String,
 }
 
+impl ParserResult {
+    pub fn get_some_reasoning(&self) -> Option<String> {
+        if self.reasoning_text.is_empty() {
+            None
+        } else {
+            Some(self.reasoning_text.clone())
+        }
+    }
+
+    pub fn get_some_normal_text(&self) -> Option<String> {
+        if self.normal_text.is_empty() {
+            None
+        } else {
+            Some(self.normal_text.clone())
+        }
+    }
+}
+
 pub trait ReasoningParser: Send + std::fmt::Debug {
     /// Parses a standalone, non-streaming input chunk. Implementations may reset or ignore
     /// internal streaming state and should return the split of normal vs reasoning text for

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -4,6 +4,8 @@
 mod base_parser;
 mod deepseek_r1_parser;
 
+use std::sync::{Arc, Mutex};
+
 // Re-export main types and functions for convenience
 pub use base_parser::BasicReasoningParser;
 pub use deepseek_r1_parser::DeepseekR1ReasoningParser;
@@ -17,7 +19,7 @@ pub struct ParserResult {
     pub reasoning_text: String,
 }
 
-pub trait ReasoningParser {
+pub trait ReasoningParser: Send + std::fmt::Debug {
     /// Parses a standalone, non-streaming input chunk. Implementations may reset or ignore
     /// internal streaming state and should return the split of normal vs reasoning text for
     /// this complete input. Marker tokens must not be included in either output.
@@ -36,16 +38,38 @@ pub enum ReasoningParserType {
     Basic,
 }
 
+#[derive(std::fmt::Debug, Clone)]
+pub struct ReasoningParserWrapper {
+    parser: Arc<Mutex<dyn ReasoningParser>>,
+}
+
+impl ReasoningParser for ReasoningParserWrapper {
+    fn detect_and_parse_reasoning(&mut self, text: &str) -> ParserResult {
+        self.parser.lock().unwrap().detect_and_parse_reasoning(text)
+    }
+
+    fn parse_reasoning_streaming_incremental(&mut self, text: &str) -> ParserResult {
+        self.parser
+            .lock()
+            .unwrap()
+            .parse_reasoning_streaming_incremental(text)
+    }
+}
+
 impl ReasoningParserType {
-    pub fn get_reasoning_parser(self) -> Box<dyn ReasoningParser + Send> {
+    pub fn get_reasoning_parser(self) -> ReasoningParserWrapper {
         match self {
-            ReasoningParserType::DeepseekR1 => Box::new(DeepseekR1ReasoningParser::new()),
-            ReasoningParserType::Basic => Box::new(BasicReasoningParser::new(
-                "<think>".into(),
-                "</think>".into(),
-                false,
-                true,
-            )),
+            ReasoningParserType::DeepseekR1 => ReasoningParserWrapper {
+                parser: Arc::new(Mutex::new(DeepseekR1ReasoningParser::new())),
+            },
+            ReasoningParserType::Basic => ReasoningParserWrapper {
+                parser: Arc::new(Mutex::new(BasicReasoningParser::new(
+                    "<think>".into(),
+                    "</think>".into(),
+                    false,
+                    true,
+                ))),
+            },
         }
     }
 }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -8,6 +8,7 @@ mod deepseek_r1_parser;
 pub use base_parser::BasicReasoningParser;
 pub use deepseek_r1_parser::DeepseekR1ReasoningParser;
 
+#[derive(Debug, Clone, Default)]
 pub struct ParserResult {
     /// The normal text outside of reasoning blocks.
     pub normal_text: String,
@@ -17,26 +18,31 @@ pub struct ParserResult {
 }
 
 pub trait ReasoningParser {
-    /// Detects and parses reasoning from the input text.
+    /// Parses a standalone, non-streaming input chunk. Implementations may reset or ignore
+    /// internal streaming state and should return the split of normal vs reasoning text for
+    /// this complete input. Marker tokens must not be included in either output.
     fn detect_and_parse_reasoning(&mut self, text: &str) -> ParserResult;
 
-    /// Parses reasoning incrementally from streaming input.
+    /// Parses a streaming chunk and updates internal state. The return value should be the
+    /// delta: only the newly discovered normal and reasoning text attributable to this chunk
+    /// (not the cumulative totals). Marker tokens must not be included in either output.
     fn parse_reasoning_streaming_incremental(&mut self, text: &str) -> ParserResult;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ReasoningParserType {
     DeepseekR1,
     Basic,
 }
 
 impl ReasoningParserType {
-    pub fn get_reasoning_parser(self) -> Box<dyn ReasoningParser> {
+    pub fn get_reasoning_parser(self) -> Box<dyn ReasoningParser + Send> {
         match self {
             ReasoningParserType::DeepseekR1 => Box::new(DeepseekR1ReasoningParser::new()),
             ReasoningParserType::Basic => Box::new(BasicReasoningParser::new(
-                "<think>".to_string(),
-                "</think>".to_string(),
+                "<think>".into(),
+                "</think>".into(),
                 false,
                 true,
             )),


### PR DESCRIPTION
#### Overview:

Enable basic reasoning parsing of <think> </think> types of LLM outputs

#### Details:

- Moved traits around for better code 
- Rename Base to basic reasoning parser
- hardcode reasoning parser type to basic for now while we figure out how to get that from the frontend to there

#### Where should the reviewer start?

changes in aggregator and delta.rs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Streaming chat completions now separate "reasoning" from visible text; streams and final responses may include a reasoning field.
  - Think-tagged blocks (<think>…</think>) are stripped from visible message content and delivered via reasoning output.

- **Refactor**
  - Pluggable, selectable reasoning parser with a thread-safe wrapper for different parsing strategies.

- **Tests**
  - Expanded tests for incremental and streaming reasoning parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->