### PR TITLE
docs: Add health check section to GPT OSS guide

### DIFF
--- a/components/backends/trtllm/gpt-oss.md
+++ b/components/backends/trtllm/gpt-oss.md
@@ -211,7 +211,28 @@ CUDA_VISIBLE_DEVICES=4,5,6,7 python3 -m dynamo.trtllm \
   --expert-parallel-size 4
 ```
 
-### 6. Test the Deployment
+### 6. Verify the Deployment is Ready
+
+Poll the `/health` endpoint to verify that both the prefill and decode worker endpoints have started:
+```
+curl http://localhost:8000/health
+```
+
+Make sure that both of the endpoints are available before sending an inference request:
+```
+{
+  "endpoints": [
+    "dyn://dynamo.tensorrt_llm.generate",
+    "dyn://dynamo.tensorrt_llm_next.generate"
+  ],
+  "status": "healthy"
+}
+```
+
+If only one is listed, the other one may still be starting up. You can watch the
+worker logs to see the progress of worker startup.
+
+### 7. Test the Deployment
 
 Send a test request to verify the deployment:
 

--- a/components/backends/trtllm/gpt-oss.md
+++ b/components/backends/trtllm/gpt-oss.md
@@ -229,8 +229,7 @@ Make sure that both of the endpoints are available before sending an inference r
 }
 ```
 
-If only one is listed, the other one may still be starting up. You can watch the
-worker logs to see the progress of worker startup.
+If only one worker endpoint is listed, the other may still be starting up. Monitor the worker logs to track startup progress.
 
 ### 7. Test the Deployment
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Clarify that both prefill/decode should be successfully started before sending any inference requests, by using the health endpoint.

#### Future Work

There will be a dedicated doc on health endpoint and how to use it in the near future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment verification steps to include a preflight readiness check that polls health until both prefill and decode workers are up, with guidance to monitor logs if one is still starting.
  * Revised testing instructions to use a real OpenAI-compatible API call to the responses endpoint with configurable parameters.
  * Applied these updates in both relevant sections of the guide for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->