### PR TITLE
fix: resources in wrong location in vllm disag_router example

### DIFF
--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -5,6 +5,8 @@ apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-agg-router
+  annotations:
+    nvidia.com/enable-grove: "false"
 spec:
   services:
     Frontend:
@@ -22,11 +24,11 @@ spec:
       dynamoNamespace: vllm-agg-router
       componentType: worker
       replicas: 2
+      resources:
+        limits:
+          gpu: "1"
       extraPodSpec:
         mainContainer:
-          resources:
-            limits:
-              gpu: "1"
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -5,8 +5,6 @@ apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-agg-router
-  annotations:
-    nvidia.com/enable-grove: "false"
 spec:
   services:
     Frontend:


### PR DESCRIPTION
#### Overview:

resources in wrong location in vllm disag_router example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment configuration to set GPU limits at the pod level for the VLLM decode worker, replacing per-container limits.

- **Impact**
  - Improves scheduling compatibility with cluster policies and ensures more consistent GPU allocation.
  - Reduces risk of misconfiguration during scaling and rolling updates.
  - No action required from end users; workloads continue to run as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->