### PR TITLE
fix: resources in wrong location in vllm disag_router example (#2558)

### DIFF
--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -22,11 +22,11 @@ spec:
       dynamoNamespace: vllm-agg-router
       componentType: worker
       replicas: 2
+      resources:
+        limits:
+          gpu: "1"
       extraPodSpec:
         mainContainer:
-          resources:
-            limits:
-              gpu: "1"
           image: nvcr.io/nvidian/nim-llm-dev/vllm-runtime:dep-233.17
           workingDir: /workspace/components/backends/vllm
           command:


### PR DESCRIPTION
cherry-picking #2558 in 0.4.1
