### PR TITLE
[DO NOT MERGE] feat: cli for tool and reasoning parsers

### DIFF
--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -177,10 +177,10 @@ def parse_args():
         help="Prefix for Dynamo frontend metrics. If unset, uses DYN_METRICS_PREFIX env var or 'dynamo_frontend'.",
     )
     parser.add_argument(
-        "--tool-parser-name",
+        "--tool-call-parser",
         type=str,
         default=None,
-        help="Tool parser name for the model. Available options: 'hermes', 'nemotron_deci', 'llama3_json', 'mistral', 'phi4', 'default'.",
+        help="Tool parser name for the model. Available options: 'hermes', 'nemotron_deci', 'llama3_json', 'mistral', 'phi4'.",
     )
 
     flags = parser.parse_args()
@@ -239,8 +239,8 @@ async def async_main():
         kwargs["tls_cert_path"] = flags.tls_cert_path
     if flags.tls_key_path:
         kwargs["tls_key_path"] = flags.tls_key_path
-    if flags.tool_parser_name:
-        kwargs["tool_parser_name"] = flags.tool_parser_name
+    if flags.tool_call_parser:
+        kwargs["tool_call_parser"] = flags.tool_call_parser
 
     if is_static:
         # out=dyn://<static_endpoint>

--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -176,6 +176,12 @@ def parse_args():
         default=None,
         help="Prefix for Dynamo frontend metrics. If unset, uses DYN_METRICS_PREFIX env var or 'dynamo_frontend'.",
     )
+    parser.add_argument(
+        "--tool-parser-name",
+        type=str,
+        default=None,
+        help="Tool parser name for the model. Available options: 'hermes', 'nemotron_deci', 'llama3_json', 'mistral', 'phi4', 'default'.",
+    )
 
     flags = parser.parse_args()
 
@@ -233,6 +239,8 @@ async def async_main():
         kwargs["tls_cert_path"] = flags.tls_cert_path
     if flags.tls_key_path:
         kwargs["tls_key_path"] = flags.tls_key_path
+    if flags.tool_parser_name:
+        kwargs["tool_parser_name"] = flags.tool_parser_name
 
     if is_static:
         # out=dyn://<static_endpoint>

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -107,13 +107,14 @@ pub(crate) struct EntrypointArgs {
     tls_cert_path: Option<PathBuf>,
     tls_key_path: Option<PathBuf>,
     extra_engine_args: Option<PathBuf>,
+    tool_parser_name: Option<String>,
 }
 
 #[pymethods]
 impl EntrypointArgs {
     #[allow(clippy::too_many_arguments)]
     #[new]
-    #[pyo3(signature = (engine_type, model_path=None, model_name=None, model_config=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None))]
+    #[pyo3(signature = (engine_type, model_path=None, model_name=None, model_config=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, tool_parser_name=None))]
     pub fn new(
         engine_type: EngineType,
         model_path: Option<PathBuf>,
@@ -129,6 +130,7 @@ impl EntrypointArgs {
         tls_cert_path: Option<PathBuf>,
         tls_key_path: Option<PathBuf>,
         extra_engine_args: Option<PathBuf>,
+        tool_parser_name: Option<String>,
     ) -> PyResult<Self> {
         let endpoint_id_obj: Option<EndpointId> = match endpoint_id {
             Some(eid) => Some(eid.parse().map_err(|_| {
@@ -160,6 +162,7 @@ impl EntrypointArgs {
             tls_cert_path,
             tls_key_path,
             extra_engine_args,
+            tool_parser_name,
         })
     }
 }
@@ -192,7 +195,8 @@ pub fn make_engine<'p>(
         .tls_cert_path(args.tls_cert_path.clone())
         .tls_key_path(args.tls_key_path.clone())
         .is_mocker(matches!(args.engine_type, EngineType::Mocker))
-        .extra_engine_args(args.extra_engine_args.clone());
+        .extra_engine_args(args.extra_engine_args.clone())
+        .tool_parser_name(args.tool_parser_name.clone());
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let local_model = builder.build().await.map_err(to_pyerr)?;
         let inner = select_engine(distributed_runtime, args, local_model)

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -107,14 +107,14 @@ pub(crate) struct EntrypointArgs {
     tls_cert_path: Option<PathBuf>,
     tls_key_path: Option<PathBuf>,
     extra_engine_args: Option<PathBuf>,
-    tool_parser_name: Option<String>,
+    tool_call_parser: Option<String>,
 }
 
 #[pymethods]
 impl EntrypointArgs {
     #[allow(clippy::too_many_arguments)]
     #[new]
-    #[pyo3(signature = (engine_type, model_path=None, model_name=None, model_config=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, tool_parser_name=None))]
+    #[pyo3(signature = (engine_type, model_path=None, model_name=None, model_config=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, tool_call_parser=None))]
     pub fn new(
         engine_type: EngineType,
         model_path: Option<PathBuf>,
@@ -130,7 +130,7 @@ impl EntrypointArgs {
         tls_cert_path: Option<PathBuf>,
         tls_key_path: Option<PathBuf>,
         extra_engine_args: Option<PathBuf>,
-        tool_parser_name: Option<String>,
+        tool_call_parser: Option<String>,
     ) -> PyResult<Self> {
         let endpoint_id_obj: Option<EndpointId> = match endpoint_id {
             Some(eid) => Some(eid.parse().map_err(|_| {
@@ -162,7 +162,7 @@ impl EntrypointArgs {
             tls_cert_path,
             tls_key_path,
             extra_engine_args,
-            tool_parser_name,
+            tool_call_parser,
         })
     }
 }
@@ -196,7 +196,7 @@ pub fn make_engine<'p>(
         .tls_key_path(args.tls_key_path.clone())
         .is_mocker(matches!(args.engine_type, EngineType::Mocker))
         .extra_engine_args(args.extra_engine_args.clone())
-        .tool_parser_name(args.tool_parser_name.clone());
+        .tool_call_parser(args.tool_call_parser.clone());
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         let local_model = builder.build().await.map_err(to_pyerr)?;
         let inner = select_engine(distributed_runtime, args, local_model)

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -48,6 +48,10 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
     if let Some(http_host) = local_model.http_host() {
         http_service_builder = http_service_builder.host(http_host);
     }
+
+    if let Some(tool_parser_name) = local_model.tool_parser_name() {
+        http_service_builder = http_service_builder.with_tool_parser_name(Some(tool_parser_name));
+    }
     http_service_builder =
         http_service_builder.with_request_template(engine_config.local_model().request_template());
 

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -49,8 +49,8 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
         http_service_builder = http_service_builder.host(http_host);
     }
 
-    if let Some(tool_parser_name) = local_model.tool_parser_name() {
-        http_service_builder = http_service_builder.with_tool_parser_name(Some(tool_parser_name));
+    if let Some(tool_call_parser) = local_model.tool_call_parser() {
+        http_service_builder = http_service_builder.with_tool_call_parser(Some(tool_call_parser));
     }
     http_service_builder =
         http_service_builder.with_request_template(engine_config.local_model().request_template());

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -546,19 +546,20 @@ async fn chat_completions(
             process_metrics_only(response, &mut response_collector);
         });
 
-        let response = NvCreateChatCompletionResponse::from_annotated_stream(stream, tool_parser_name)
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    request_id,
-                    "Failed to fold chat completions stream for: {:?}",
-                    e
-                );
-                ErrorMessage::internal_server_error(&format!(
-                    "Failed to fold chat completions stream: {}",
-                    e
-                ))
-            })?;
+        let response =
+            NvCreateChatCompletionResponse::from_annotated_stream(stream, tool_parser_name)
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        request_id,
+                        "Failed to fold chat completions stream for: {:?}",
+                        e
+                    );
+                    ErrorMessage::internal_server_error(&format!(
+                        "Failed to fold chat completions stream: {}",
+                        e
+                    ))
+                })?;
 
         inflight_guard.mark_ok();
         Ok(Json(response).into_response())

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -295,7 +295,7 @@ async fn completions(
     // apply any annotations to the front of the stream
     let stream = stream::iter(annotations).chain(stream);
 
-    let tool_parser_name = state.tool_parser_name();
+    let tool_call_parser = state.tool_call_parser();
 
     if streaming {
         let stream = stream.map(move |response| {
@@ -316,7 +316,7 @@ async fn completions(
             process_metrics_only(response, &mut response_collector);
         });
 
-        let response = NvCreateCompletionResponse::from_annotated_stream(stream, tool_parser_name)
+        let response = NvCreateCompletionResponse::from_annotated_stream(stream, tool_call_parser)
             .await
             .map_err(|e| {
                 tracing::error!(
@@ -480,7 +480,7 @@ async fn chat_completions(
     // todo - determine the proper error code for when a request model is not present
     tracing::trace!("Getting chat completions engine for model: {}", model);
 
-    let tool_parser_name = state.tool_parser_name();
+    let tool_call_parser = state.tool_call_parser();
 
     let engine = state
         .manager()
@@ -547,7 +547,7 @@ async fn chat_completions(
         });
 
         let response =
-            NvCreateChatCompletionResponse::from_annotated_stream(stream, tool_parser_name)
+            NvCreateChatCompletionResponse::from_annotated_stream(stream, tool_call_parser)
                 .await
                 .map_err(|e| {
                     tracing::error!(
@@ -736,8 +736,8 @@ async fn responses(
         .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate completions"))?;
 
     // TODO: handle streaming, currently just unary
-    let tool_parser_name = state.tool_parser_name();
-    let response = NvCreateChatCompletionResponse::from_annotated_stream(stream, tool_parser_name)
+    let tool_call_parser = state.tool_call_parser();
+    let response = NvCreateChatCompletionResponse::from_annotated_stream(stream, tool_call_parser)
         .await
         .map_err(|e| {
             tracing::error!(

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -32,7 +32,7 @@ pub struct State {
     manager: Arc<ModelManager>,
     etcd_client: Option<etcd::Client>,
     flags: StateFlags,
-    tool_parser_name: Option<String>,
+    tool_call_parser: Option<String>,
 }
 
 #[derive(Default, Debug)]
@@ -72,7 +72,7 @@ impl StateFlags {
 }
 
 impl State {
-    pub fn new(manager: Arc<ModelManager>, tool_parser_name: Option<String>) -> Self {
+    pub fn new(manager: Arc<ModelManager>, tool_call_parser: Option<String>) -> Self {
         Self {
             manager,
             metrics: Arc::new(Metrics::default()),
@@ -83,14 +83,14 @@ impl State {
                 embeddings_endpoints_enabled: AtomicBool::new(false),
                 responses_endpoints_enabled: AtomicBool::new(false),
             },
-            tool_parser_name: Some(tool_parser_name.unwrap_or_else(|| String::from(""))),
+            tool_call_parser: Some(tool_call_parser.unwrap_or_else(|| String::from(""))),
         }
     }
 
     pub fn new_with_etcd(
         manager: Arc<ModelManager>,
         etcd_client: Option<etcd::Client>,
-        tool_parser_name: Option<String>,
+        tool_call_parser: Option<String>,
     ) -> Self {
         Self {
             manager,
@@ -102,7 +102,7 @@ impl State {
                 embeddings_endpoints_enabled: AtomicBool::new(false),
                 responses_endpoints_enabled: AtomicBool::new(false),
             },
-            tool_parser_name: Some(tool_parser_name.unwrap_or_else(|| String::from(""))),
+            tool_call_parser: Some(tool_call_parser.unwrap_or_else(|| String::from(""))),
         }
     }
     /// Get the Prometheus [`Metrics`] object which tracks request counts and inflight requests
@@ -127,8 +127,8 @@ impl State {
         None
     }
 
-    pub fn tool_parser_name(&self) -> Option<String> {
-        self.tool_parser_name.clone()
+    pub fn tool_call_parser(&self) -> Option<String> {
+        self.tool_call_parser.clone()
     }
 }
 
@@ -185,7 +185,7 @@ pub struct HttpServiceConfig {
     etcd_client: Option<etcd::Client>,
 
     #[builder(default = "None")]
-    tool_parser_name: Option<String>,
+    tool_call_parser: Option<String>,
 }
 
 impl HttpService {
@@ -311,7 +311,7 @@ impl HttpServiceConfigBuilder {
         let state = Arc::new(State::new_with_etcd(
             model_manager,
             config.etcd_client,
-            config.tool_parser_name,
+            config.tool_call_parser,
         ));
 
         state
@@ -375,8 +375,8 @@ impl HttpServiceConfigBuilder {
         self
     }
 
-    pub fn with_tool_parser_name(mut self, tool_parser_name: Option<String>) -> Self {
-        self.tool_parser_name = Some(tool_parser_name);
+    pub fn with_tool_call_parser(mut self, tool_call_parser: Option<String>) -> Self {
+        self.tool_call_parser = Some(tool_call_parser);
         self
     }
 

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -59,6 +59,7 @@ pub struct LocalModelBuilder {
     extra_engine_args: Option<PathBuf>,
     runtime_config: ModelRuntimeConfig,
     user_data: Option<serde_json::Value>,
+    tool_parser_name: Option<String>,
 }
 
 impl Default for LocalModelBuilder {
@@ -81,6 +82,7 @@ impl Default for LocalModelBuilder {
             extra_engine_args: Default::default(),
             runtime_config: Default::default(),
             user_data: Default::default(),
+            tool_parser_name: Default::default(),
         }
     }
 }
@@ -172,6 +174,11 @@ impl LocalModelBuilder {
         self
     }
 
+    pub fn tool_parser_name(&mut self, tool_parser_name: Option<String>) -> &mut Self {
+        self.tool_parser_name = tool_parser_name;
+        self
+    }
+
     /// Make an LLM ready for use:
     /// - Download it from Hugging Face (and NGC in future) if necessary
     /// - Resolve the path
@@ -213,6 +220,7 @@ impl LocalModelBuilder {
                 tls_key_path: self.tls_key_path.take(),
                 router_config: self.router_config.take().unwrap_or_default(),
                 runtime_config: self.runtime_config.clone(),
+                tool_parser_name: self.tool_parser_name.take(),
             });
         }
 
@@ -289,6 +297,7 @@ impl LocalModelBuilder {
             tls_key_path: self.tls_key_path.take(),
             router_config: self.router_config.take().unwrap_or_default(),
             runtime_config: self.runtime_config.clone(),
+            tool_parser_name: self.tool_parser_name.take(),
         })
     }
 }
@@ -305,6 +314,7 @@ pub struct LocalModel {
     tls_key_path: Option<PathBuf>,
     router_config: RouterConfig,
     runtime_config: ModelRuntimeConfig,
+    tool_parser_name: Option<String>,
 }
 
 impl LocalModel {
@@ -370,6 +380,10 @@ impl LocalModel {
     /// For the case where we only need the card and don't want to clone it.
     pub fn into_card(self) -> ModelDeploymentCard {
         self.card
+    }
+
+    pub fn tool_parser_name(&self) -> Option<String> {
+        self.tool_parser_name.clone()
     }
 
     /// Attach this model the endpoint. This registers it on the network

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -59,7 +59,7 @@ pub struct LocalModelBuilder {
     extra_engine_args: Option<PathBuf>,
     runtime_config: ModelRuntimeConfig,
     user_data: Option<serde_json::Value>,
-    tool_parser_name: Option<String>,
+    tool_call_parser: Option<String>,
 }
 
 impl Default for LocalModelBuilder {
@@ -82,7 +82,7 @@ impl Default for LocalModelBuilder {
             extra_engine_args: Default::default(),
             runtime_config: Default::default(),
             user_data: Default::default(),
-            tool_parser_name: Default::default(),
+            tool_call_parser: Default::default(),
         }
     }
 }
@@ -174,8 +174,8 @@ impl LocalModelBuilder {
         self
     }
 
-    pub fn tool_parser_name(&mut self, tool_parser_name: Option<String>) -> &mut Self {
-        self.tool_parser_name = tool_parser_name;
+    pub fn tool_call_parser(&mut self, tool_call_parser: Option<String>) -> &mut Self {
+        self.tool_call_parser = tool_call_parser;
         self
     }
 
@@ -220,7 +220,7 @@ impl LocalModelBuilder {
                 tls_key_path: self.tls_key_path.take(),
                 router_config: self.router_config.take().unwrap_or_default(),
                 runtime_config: self.runtime_config.clone(),
-                tool_parser_name: self.tool_parser_name.take(),
+                tool_call_parser: self.tool_call_parser.take(),
             });
         }
 
@@ -297,7 +297,7 @@ impl LocalModelBuilder {
             tls_key_path: self.tls_key_path.take(),
             router_config: self.router_config.take().unwrap_or_default(),
             runtime_config: self.runtime_config.clone(),
-            tool_parser_name: self.tool_parser_name.take(),
+            tool_call_parser: self.tool_call_parser.take(),
         })
     }
 }
@@ -314,7 +314,7 @@ pub struct LocalModel {
     tls_key_path: Option<PathBuf>,
     router_config: RouterConfig,
     runtime_config: ModelRuntimeConfig,
-    tool_parser_name: Option<String>,
+    tool_call_parser: Option<String>,
 }
 
 impl LocalModel {
@@ -382,8 +382,8 @@ impl LocalModel {
         self.card
     }
 
-    pub fn tool_parser_name(&self) -> Option<String> {
-        self.tool_parser_name.clone()
+    pub fn tool_call_parser(&self) -> Option<String> {
+        self.tool_call_parser.clone()
     }
 
     /// Attach this model the endpoint. This registers it on the network

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -165,7 +165,9 @@ impl DeltaAggregator {
         // After aggregation, inspect each choice's text for tool call syntax
         for choice in aggregator.choices.values_mut() {
             if choice.tool_calls.is_none() {
-                if let Ok(tool_calls) = try_tool_call_parse_aggregate(&choice.text, tool_parser_name.as_deref()) {
+                if let Ok(tool_calls) =
+                    try_tool_call_parse_aggregate(&choice.text, tool_parser_name.as_deref())
+                {
                     if tool_calls.is_empty() {
                         continue;
                     }

--- a/lib/llm/src/protocols/openai/completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/completions/aggregator.rs
@@ -65,9 +65,9 @@ impl DeltaAggregator {
     /// Aggregates a stream of [`Annotated<CompletionResponse>`]s into a single [`CompletionResponse`].
     pub async fn apply(
         stream: impl Stream<Item = Annotated<NvCreateCompletionResponse>>,
-        tool_parser_name: Option<String>,
+        tool_call_parser: Option<String>,
     ) -> Result<NvCreateCompletionResponse> {
-        tracing::trace!("Tool parser name: {:?}", tool_parser_name); // Remove this after enabling tool calling for completions
+        tracing::trace!("Tool parser name: {:?}", tool_call_parser); // Remove this after enabling tool calling for completions
         let aggregator = stream
             .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
                 let delta = match delta.ok() {
@@ -179,17 +179,17 @@ impl From<DeltaChoice> for dynamo_async_openai::types::Choice {
 impl NvCreateCompletionResponse {
     pub async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
-        tool_parser_name: Option<String>,
+        tool_call_parser: Option<String>,
     ) -> Result<NvCreateCompletionResponse> {
         let stream = convert_sse_stream::<NvCreateCompletionResponse>(stream);
-        NvCreateCompletionResponse::from_annotated_stream(stream, tool_parser_name).await
+        NvCreateCompletionResponse::from_annotated_stream(stream, tool_call_parser).await
     }
 
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateCompletionResponse>>,
-        tool_parser_name: Option<String>,
+        tool_call_parser: Option<String>,
     ) -> Result<NvCreateCompletionResponse> {
-        DeltaAggregator::apply(stream, tool_parser_name).await
+        DeltaAggregator::apply(stream, tool_call_parser).await
     }
 }
 

--- a/lib/llm/tests/aggregators.rs
+++ b/lib/llm/tests/aggregators.rs
@@ -37,7 +37,7 @@ async fn test_openai_chat_stream() {
 
     // note: we are only taking the first 16 messages to keep the size of the response small
     let stream = create_message_stream(&data).take(16);
-    let result = NvCreateChatCompletionResponse::from_sse_stream(Box::pin(stream))
+    let result = NvCreateChatCompletionResponse::from_sse_stream(Box::pin(stream), None)
         .await
         .unwrap();
 
@@ -59,7 +59,7 @@ async fn test_openai_chat_stream() {
 #[tokio::test]
 async fn test_openai_chat_edge_case_multi_line_data() {
     let stream = create_stream(CHAT_ROOT_PATH, "edge_cases/valid-multi-line-data");
-    let result = NvCreateChatCompletionResponse::from_sse_stream(Box::pin(stream))
+    let result = NvCreateChatCompletionResponse::from_sse_stream(Box::pin(stream), None)
         .await
         .unwrap();
 
@@ -79,7 +79,7 @@ async fn test_openai_chat_edge_case_multi_line_data() {
 #[tokio::test]
 async fn test_openai_chat_edge_case_comments_per_response() {
     let stream = create_stream(CHAT_ROOT_PATH, "edge_cases/valid-comments_per_response");
-    let result = NvCreateChatCompletionResponse::from_sse_stream(Box::pin(stream))
+    let result = NvCreateChatCompletionResponse::from_sse_stream(Box::pin(stream), None)
         .await
         .unwrap();
 
@@ -99,7 +99,7 @@ async fn test_openai_chat_edge_case_comments_per_response() {
 #[tokio::test]
 async fn test_openai_chat_edge_case_invalid_deserialize_error() {
     let stream = create_stream(CHAT_ROOT_PATH, "edge_cases/invalid-deserialize_error");
-    let result = NvCreateChatCompletionResponse::from_sse_stream(Box::pin(stream)).await;
+    let result = NvCreateChatCompletionResponse::from_sse_stream(Box::pin(stream), None).await;
 
     assert!(result.is_err());
     // insta::assert_debug_snapshot!(result);
@@ -112,7 +112,7 @@ async fn test_openai_chat_edge_case_invalid_deserialize_error() {
 #[tokio::test]
 async fn test_openai_cmpl_stream() {
     let stream = create_stream(CMPL_ROOT_PATH, "completion.streaming.1").take(16);
-    let result = NvCreateCompletionResponse::from_sse_stream(Box::pin(stream))
+    let result = NvCreateCompletionResponse::from_sse_stream(Box::pin(stream), None)
         .await
         .unwrap();
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional CLI flag --tool-parser-name to select the model’s tool parser (e.g., hermes, nemotron_deci, llama3_json, mistral, phi4, default).
  - Introduced service configuration support to set a default tool parser for the HTTP service.
  - Propagated the selected parser through chat and completion endpoints, including streaming, enabling parser-aware tool-call extraction.
  - Responses now carry parser metadata for improved tool-call handling.
  - Backwards compatible: no change in behavior unless a parser is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->