### PR TITLE
fix: profiling script missing tests when kv cache is tight

### DIFF
--- a/benchmarks/profiler/utils/profile_decode.py
+++ b/benchmarks/profiler/utils/profile_decode.py
@@ -42,18 +42,25 @@ def profile_decode(
         (max_context_length - osl) // interpolation_granularity,
     ):
         max_concurrency = max_kv_tokens // (isl + osl)
-        if max_concurrency // interpolation_granularity == 0:
+        if max_concurrency == 0:
+            logger.warning(
+                f"max_kv_tokens {max_kv_tokens} is too small for"
+                f" isl {isl} + osl {osl}, skipping."
+            )
+            break
+        elif max_concurrency < interpolation_granularity:
             logger.warning(
                 f"max_concurrency {max_concurrency} is too small for"
                 f" interpolation granularity {interpolation_granularity}."
                 f" max_kv_tokens {max_kv_tokens}, isl {isl}, osl {osl}"
             )
-            break
-        sweep_num_request = range(
-            1,
-            max_concurrency,
-            max_concurrency // interpolation_granularity,
-        )
+            sweep_num_request = range(1, max_concurrency + 1)
+        else:
+            sweep_num_request = range(
+                1,
+                max_concurrency,
+                max_concurrency // interpolation_granularity,
+            )
         for num_request in sweep_num_request:
             genai_perf_artifact_dir = f"{work_dir}/gap_isl{isl}_osl{osl}_n{num_request}"
             gap_result = benchmark_decode(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved stability of decode profiling by preventing premature termination when max concurrency is small but non-zero; the sweep now continues with an adjusted range.
  - Added clear warnings when max concurrency is zero (too few KV tokens), exiting gracefully.
  - Preserved behavior for larger concurrency values to avoid regressions.
  - Results in more reliable profiling runs and clearer logs.
  - No changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->