### PR TITLE
fix: Increase timeout for deepep test

### DIFF
--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -282,7 +282,7 @@ vllm_configs = {
             "--gpus-per-node",
             "2",
         ],
-        timeout=300,
+        timeout=500,
     ),
     "multimodal_agg": VLLMConfig(
         name="multimodal_agg",


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the readiness timeout for vLLM in test configuration from 300s to 500s to allow a longer startup window during test runs.
  * All other related configuration values (endpoints, model settings, scripts, arguments, and test markers) remain unchanged.
  * No changes to product functionality or user experience; this update affects the test suite only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->