### PR TITLE
feat: Integrate Model Express Client into Dynamo Model Downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,9 +711,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -996,7 +996,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
 dependencies = [
- "clap 4.5.45",
+ "clap 4.5.46",
  "heck 0.4.1",
  "indexmap 2.11.0",
  "log",
@@ -1110,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1120,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2059,7 +2059,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "clap 4.5.45",
+ "clap 4.5.46",
  "dynamo-async-openai",
  "dynamo-engine-llamacpp",
  "dynamo-engine-mistralrs",
@@ -3011,7 +3011,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.3+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -3631,9 +3631,9 @@ dependencies = [
 
 [[package]]
 name = "image-webp"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6970fe7a5300b4b42e62c52efa0187540a5bef546c60edaf554ef595d2e6f0b"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
  "quick-error 2.0.1",
@@ -3890,7 +3890,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "bytecount",
- "clap 4.5.45",
+ "clap 4.5.46",
  "fancy-regex 0.11.0",
  "fraction",
  "getrandom 0.2.16",
@@ -4300,7 +4300,7 @@ name = "metrics"
 version = "0.4.1"
 dependencies = [
  "axum 0.8.4",
- "clap 4.5.45",
+ "clap 4.5.46",
  "dynamo-llm",
  "dynamo-runtime",
  "futures",
@@ -4430,7 +4430,7 @@ dependencies = [
  "anyhow",
  "candle-core 0.9.1 (git+https://github.com/EricLBuehler/candle.git?rev=95d713f9)",
  "candle-nn",
- "clap 4.5.45",
+ "clap 4.5.46",
  "either",
  "futures",
  "image",
@@ -4475,7 +4475,7 @@ dependencies = [
  "candle-nn",
  "cfgrammar",
  "chrono",
- "clap 4.5.45",
+ "clap 4.5.46",
  "csv",
  "derive-new",
  "derive_more 2.0.1",
@@ -5115,7 +5115,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bstr",
- "clap 4.5.45",
+ "clap 4.5.46",
  "fancy-regex 0.13.0",
  "futures",
  "image",
@@ -5803,9 +5803,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5814,7 +5814,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -5823,9 +5823,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -5844,16 +5844,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8802,11 +8802,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -9351,13 +9351,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.3",
-]
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,11 +140,7 @@ dependencies = [
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-<<<<<<< HEAD
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
-=======
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
->>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 
 [[package]]
 name = "apodize"
@@ -177,7 +173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-<<<<<<< HEAD
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,8 +184,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +725,6 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-<<<<<<< HEAD
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
@@ -740,9 +732,6 @@ name = "bitstream-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
-=======
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
->>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 
 [[package]]
 name = "blake3"
@@ -1848,11 +1837,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.106",
-=======
- "syn 2.0.104",
->>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 ]
 
 [[package]]
@@ -3866,11 +3851,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.106",
-=======
- "syn 2.0.104",
->>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 ]
 
 [[package]]
@@ -6358,23 +6339,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "router"
-version = "0.4.1"
-dependencies = [
- "clap 4.5.42",
- "dynamo-llm",
- "dynamo-runtime",
- "rand 0.9.2",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
->>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 name = "rstest"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,11 @@ dependencies = [
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+<<<<<<< HEAD
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+=======
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+>>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 
 [[package]]
 name = "apodize"
@@ -173,6 +177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+<<<<<<< HEAD
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +189,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +732,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+<<<<<<< HEAD
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
@@ -732,6 +740,9 @@ name = "bitstream-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+=======
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+>>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 
 [[package]]
 name = "blake3"
@@ -1837,7 +1848,11 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.106",
+=======
+ "syn 2.0.104",
+>>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 ]
 
 [[package]]
@@ -3851,7 +3866,11 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.106",
+=======
+ "syn 2.0.104",
+>>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 ]
 
 [[package]]
@@ -6339,6 +6358,23 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "router"
+version = "0.4.1"
+dependencies = [
+ "clap 4.5.42",
+ "dynamo-llm",
+ "dynamo-runtime",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+>>>>>>> 254c3123 (feat: make modelexpress crates optional dependencies)
 name = "rstest"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,7 @@ dependencies = [
  "tonic-build",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "unicode-segmentation",
  "url",
  "uuid 1.18.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,7 +2044,6 @@ dependencies = [
  "tonic-build",
  "tower-http",
  "tracing",
- "tracing-subscriber",
  "unicode-segmentation",
  "url",
  "uuid 1.18.0",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -125,6 +125,9 @@ name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arbitrary"
@@ -142,6 +145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+<<<<<<< HEAD
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +155,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+=======
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+>>>>>>> fe56f11d (feat: implement proper HF cache workflow)
 
 [[package]]
 name = "arrayref"
@@ -481,6 +491,12 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -589,6 +605,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+<<<<<<< HEAD
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
@@ -596,6 +613,12 @@ name = "bitstream-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+=======
+checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+dependencies = [
+ "serde",
+]
+>>>>>>> fe56f11d (feat: implement proper HF cache workflow)
 
 [[package]]
 name = "blake3"
@@ -781,8 +804,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -859,6 +884,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +917,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.15.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4092bf3922a966e2bd74640b80f36c73eaa7251a4fd0fbcda1f8a4de401352"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde-untagged",
+ "serde_json",
+ "toml 0.9.5",
+ "winnow",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,10 +956,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1295,6 +1378,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1481,8 @@ dependencies = [
  "memmap2",
  "minijinja",
  "minijinja-contrib",
+ "model_express_client",
+ "model_express_common",
  "ndarray",
  "nix 0.26.4",
  "nixl-sys",
@@ -1785,7 +1879,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml",
+ "toml 0.8.23",
  "uncased",
  "version_check",
 ]
@@ -1811,6 +1905,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -2328,6 +2428,18 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -2839,6 +2951,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,6 +3015,17 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -3189,6 +3353,48 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "model_express_client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "colored",
+ "futures",
+ "model_express_common",
+ "prost",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.15",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "model_express_common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "clap",
+ "config",
+ "hf-hub",
+ "jiff",
+ "prost",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.15",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tracing",
 ]
 
 [[package]]
@@ -3618,6 +3824,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "os_info"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,6 +3887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,6 +3929,50 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.15",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -4597,6 +4863,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.9.2",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rstest"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,6 +4902,17 @@ dependencies = [
  "rustc_version",
  "syn 2.0.106",
  "unicode-ident",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if 1.0.1",
+ "ordered-multimap",
+ "trim-in-place",
 ]
 
 [[package]]
@@ -4905,6 +5194,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34836a629bcbc6f1afdf0907a744870039b1e14c0561cb26094fa683b158eff3"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4968,6 +5268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4980,6 +5289,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "serde_with"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5020,6 +5330,18 @@ dependencies = [
  "cfg-if 1.0.3",
  "cpufeatures",
  "digest",
+=======
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+>>>>>>> fe56f11d (feat: implement proper HF cache workflow)
 ]
 
 [[package]]
@@ -5310,7 +5632,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml",
+ "toml 0.8.23",
  "version-compare",
 ]
 
@@ -5424,6 +5746,15 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -5621,9 +5952,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -5636,6 +5980,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5643,9 +5996,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.11.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
  "winnow",
 ]
 
@@ -5826,6 +6188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5852,6 +6220,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ug"
@@ -5933,6 +6307,12 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6536,6 +6916,17 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce2a4ff45552406d02501cea6c18d8a7e50228e7736a872951fe2fe75c91be7"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+]
 
 [[package]]
 name = "yansi"

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -125,9 +125,6 @@ name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "arbitrary"
@@ -145,7 +142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-<<<<<<< HEAD
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,12 +151,6 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
-=======
-name = "arraydeque"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
->>>>>>> fe56f11d (feat: implement proper HF cache workflow)
 
 [[package]]
 name = "arrayref"
@@ -491,12 +481,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -591,9 +575,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -605,7 +589,6 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-<<<<<<< HEAD
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
@@ -613,12 +596,6 @@ name = "bitstream-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
-=======
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
-dependencies = [
- "serde",
-]
->>>>>>> fe56f11d (feat: implement proper HF cache workflow)
 
 [[package]]
 name = "blake3"
@@ -804,10 +781,8 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -824,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -834,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -884,15 +859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "colored"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,26 +883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.15.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4092bf3922a966e2bd74640b80f36c73eaa7251a4fd0fbcda1f8a4de401352"
-dependencies = [
- "async-trait",
- "convert_case",
- "json5",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde",
- "serde-untagged",
- "serde_json",
- "toml 0.9.5",
- "winnow",
- "yaml-rust2",
-]
-
-[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,39 +902,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1378,15 +1295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,8 +1389,6 @@ dependencies = [
  "memmap2",
  "minijinja",
  "minijinja-contrib",
- "model_express_client",
- "model_express_common",
  "ndarray",
  "nix 0.26.4",
  "nixl-sys",
@@ -1879,7 +1785,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "toml 0.8.23",
+ "toml",
  "uncased",
  "version_check",
 ]
@@ -1905,12 +1811,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -2328,7 +2228,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.3+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -2428,18 +2328,6 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
-]
 
 [[package]]
 name = "heck"
@@ -2785,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "image-webp"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6970fe7a5300b4b42e62c52efa0187540a5bef546c60edaf554ef595d2e6f0b"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
  "quick-error",
@@ -2951,47 +2839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,17 +2862,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
 ]
 
 [[package]]
@@ -3353,48 +3189,6 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
-]
-
-[[package]]
-name = "model_express_client"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "colored",
- "futures",
- "model_express_common",
- "prost",
- "serde",
- "serde_json",
- "thiserror 2.0.15",
- "tokio",
- "tonic",
- "tracing",
- "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
-name = "model_express_common"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "clap",
- "config",
- "hf-hub",
- "jiff",
- "prost",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 2.0.15",
- "tokio",
- "tonic",
- "tonic-build",
- "tracing",
 ]
 
 [[package]]
@@ -3824,16 +3618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "os_info"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,12 +3671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3929,50 +3707,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
-dependencies = [
- "memchr",
- "thiserror 2.0.15",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
-dependencies = [
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "petgraph"
@@ -4419,9 +4153,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4430,7 +4164,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -4439,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -4460,16 +4194,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4863,18 +4597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
-dependencies = [
- "base64 0.21.7",
- "bitflags 2.9.2",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "rstest"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,17 +4624,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.106",
  "unicode-ident",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
-dependencies = [
- "cfg-if 1.0.1",
- "ordered-multimap",
- "trim-in-place",
 ]
 
 [[package]]
@@ -5194,17 +4905,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-untagged"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34836a629bcbc6f1afdf0907a744870039b1e14c0561cb26094fa683b158eff3"
-dependencies = [
- "erased-serde",
- "serde",
- "typeid",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5268,15 +4968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5289,7 +4980,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "serde_with"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5330,18 +5020,6 @@ dependencies = [
  "cfg-if 1.0.3",
  "cpufeatures",
  "digest",
-=======
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
->>>>>>> fe56f11d (feat: implement proper HF cache workflow)
 ]
 
 [[package]]
@@ -5632,7 +5310,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml 0.8.23",
+ "toml",
  "version-compare",
 ]
 
@@ -5746,15 +5424,6 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -5952,22 +5621,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "serde_spanned",
+ "toml_datetime",
  "toml_edit",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
-dependencies = [
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
- "toml_parser",
- "winnow",
 ]
 
 [[package]]
@@ -5980,15 +5636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5996,18 +5643,9 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.11.0",
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "serde_spanned",
+ "toml_datetime",
  "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
-dependencies = [
  "winnow",
 ]
 
@@ -6188,12 +5826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trim-in-place"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6220,12 +5852,6 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ug"
@@ -6307,12 +5933,6 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6461,11 +6081,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6887,13 +6507,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.3",
-]
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "writeable"
@@ -6916,17 +6533,6 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "yaml-rust2"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce2a4ff45552406d02501cea6c18d8a7e50228e7736a872951fe2fe75c91be7"
-dependencies = [
- "arraydeque",
- "encoding_rs",
- "hashlink",
-]
 
 [[package]]
 name = "yansi"

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -82,6 +82,8 @@ uuid = { workspace = true }
 xxhash-rust = { workspace = true }
 
 # ModelExpress client for model downloading
+model_express_client = { path = "../../../modelexpress/model_express_client" }
+model_express_common = { path = "../../../modelexpress/model_express_common" }
 
 akin = "0.4.0"
 blake3 = "1"

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -81,6 +81,10 @@ url = { workspace = true }
 uuid = { workspace = true }
 xxhash-rust = { workspace = true }
 
+# ModelExpress client for model downloading
+model_express_client = { path = "../../../model-express/model_express_client" }
+model_express_common = { path = "../../../model-express/model_express_common" }
+
 akin = "0.4.0"
 blake3 = "1"
 bytemuck = "1.22"

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -78,7 +78,6 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 validator = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -78,6 +78,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 validator = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -36,6 +36,8 @@ testing-etcd = []
 block-manager = ["dep:nixl-sys", "dep:cudarc", "dep:ndarray", "dep:nix"]
 cuda          = ["dep:cudarc"]
 integration = []
+# NOTE: This feature will be enabled once ModelExpress packages are published
+# model-express = ["dep:model_express_client", "dep:model_express_common"]
 
 [[bench]]
 name = "tokenizer"
@@ -82,8 +84,9 @@ uuid = { workspace = true }
 xxhash-rust = { workspace = true }
 
 # ModelExpress client for model downloading
-model_express_client = { path = "../../../modelexpress/model_express_client" }
-model_express_common = { path = "../../../modelexpress/model_express_common" }
+# NOTE: These will be uncommented once the packages are published to crates.io
+# model_express_client = { version = "0.1.0", optional = true }
+# model_express_common = { version = "0.1.0", optional = true }
 
 akin = "0.4.0"
 blake3 = "1"

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -82,8 +82,6 @@ uuid = { workspace = true }
 xxhash-rust = { workspace = true }
 
 # ModelExpress client for model downloading
-model_express_client = { path = "../../../model-express/model_express_client" }
-model_express_common = { path = "../../../model-express/model_express_common" }
 
 akin = "0.4.0"
 blake3 = "1"

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -182,13 +182,7 @@ async fn download_with_hf_hub(model_name: &str, ignore_weights: bool) -> anyhow:
     }
 
     match model_path.parent() {
-        Some(path) => {
-            tracing::info!(
-                "Successfully downloaded model '{model_name}' using hf-hub to: {}",
-                path.display()
-            );
-            Ok(path.to_path_buf())
-        }
+        Some(path) => Ok(path.to_path_buf()),
         None => Err(anyhow::anyhow!(
             "Invalid HF cache path: {}",
             model_path.display()

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -13,18 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use model_express_client::{Client, ClientConfig, ModelProvider};
+use model_express_common::download;
 use hf_hub::api::tokio::ApiBuilder;
 use std::env;
 use std::path::{Path, PathBuf};
 
-const IGNORED: [&str; 5] = [
-    ".gitattributes",
-    "LICENSE",
-    "LICENSE.txt",
-    "README.md",
-    "USE_POLICY.md",
-];
-
+const MODEL_EXPRESS_ENDPOINT_ENV_VAR: &str = "MODEL_EXPRESS_ENDPOINT";
+const DEFAULT_MODEL_EXPRESS_ENDPOINT: &str = "http://localhost:8001";
 const HF_TOKEN_ENV_VAR: &str = "HF_TOKEN";
 
 /// Checks if a file is a model weight file
@@ -36,68 +32,118 @@ fn is_weight_file(filename: &str) -> bool {
         || filename.ends_with(".ckpt.index")
 }
 
-/// Attempt to download a model from Hugging Face
+/// Attempt to download a model from Hugging Face using ModelExpress client with hf-hub fallback
 /// Returns the directory it is in
 /// If ignore_weights is true, model weight files will be skipped
 pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Result<PathBuf> {
     let name = name.as_ref();
+    let model_name = name.display().to_string();
+    
+    // Get ModelExpress server endpoint from environment or use default
+    let endpoint = env::var(MODEL_EXPRESS_ENDPOINT_ENV_VAR)
+        .unwrap_or_else(|_| DEFAULT_MODEL_EXPRESS_ENDPOINT.to_string());
+    
+    // Create client configuration
+    let config = ClientConfig::for_testing(&endpoint);
+    
+    // First try to use the server with fallback
+    let result = match Client::new(config.clone()).await {
+        Ok(mut client) => {
+            // Try server-based download first
+            match client.request_model_with_provider_and_fallback(&model_name, ModelProvider::HuggingFace).await {
+                Ok(()) => {
+                    // Server download succeeded, now get the path
+                    get_model_path_from_cache(&model_name)
+                }
+                Err(e) => {
+                    // Server failed, fallback to direct download
+                    tracing::warn!("Server download failed for model '{}': {}. Falling back to direct download.", model_name, e);
+                    download_model_directly(&model_name).await
+                }
+            }
+        }
+        Err(e) => {
+            // Can't connect to server, use direct download
+            tracing::warn!("Cannot connect to ModelExpress server: {}. Using direct download.", e);
+            download_model_directly(&model_name).await
+        }
+    };
+    
+    // If ModelExpress methods fail, try hf-hub as final fallback
+    match result {
+        Ok(path) => Ok(path),
+        Err(e) => {
+            tracing::warn!("ModelExpress download failed for model '{}': {}. Falling back to hf-hub.", model_name, e);
+            download_with_hf_hub(&model_name, ignore_weights).await
+        }
+    }
+}
+
+/// Download model directly using ModelExpress download function
+async fn download_model_directly(model_name: &str) -> anyhow::Result<PathBuf> {
+    // Get cache directory
+    let cache_dir = get_model_express_cache_dir();
+    
+    // Use ModelExpress download function directly
+    download::download_model(model_name, ModelProvider::HuggingFace, Some(cache_dir)).await
+}
+
+/// Download model using hf-hub as final fallback
+async fn download_with_hf_hub(model_name: &str, ignore_weights: bool) -> anyhow::Result<PathBuf> {
+    tracing::info!("Downloading model '{}' using hf-hub", model_name);
+    
+    // Get cache directory
+    let cache_dir = get_model_express_cache_dir();
+    
+    // Get Hugging Face token if available
     let token = env::var(HF_TOKEN_ENV_VAR).ok();
     let api = ApiBuilder::from_env()
         .with_progress(true)
         .with_token(token)
         .high()
+        .with_cache_dir(cache_dir)
         .build()?;
-    let model_name = name.display().to_string();
-
-    let repo = api.model(model_name.clone());
-
-    let info = match repo.info().await {
-        Ok(info) => info,
-        Err(e) => {
-            return Err(anyhow::anyhow!(
-                "Failed to fetch model '{}' from HuggingFace: {}. Is this a valid HuggingFace ID?",
-                model_name,
-                e
-            ));
-        }
-    };
-
+    
+    let repo = api.model(model_name.to_string());
+    
+    // Get model info
+    let info = repo.info().await
+        .map_err(|e| anyhow::anyhow!("Failed to fetch model '{}' from HuggingFace: {}. Is this a valid HuggingFace ID?", model_name, e))?;
+    
     if info.siblings.is_empty() {
-        return Err(anyhow::anyhow!(
-            "Model '{}' exists but contains no downloadable files.",
-            model_name
-        ));
+        return Err(anyhow::anyhow!("Model '{}' exists but contains no downloadable files.", model_name));
     }
-
-    let mut p = PathBuf::new();
+    
+    // Download files (excluding ignored files)
+    let mut model_path = PathBuf::new();
     let mut files_downloaded = false;
-
-    for sib in info.siblings {
-        if IGNORED.contains(&sib.rfilename.as_str()) || is_image(&sib.rfilename) {
+    
+    for sibling in info.siblings {
+        if is_ignored_file(&sibling.rfilename) || is_image_file(&sibling.rfilename) {
             continue;
         }
 
         // If ignore_weights is true, skip weight files
-        if ignore_weights && is_weight_file(&sib.rfilename) {
+        if ignore_weights && is_weight_file(&sibling.rfilename) {
             continue;
         }
-
-        match repo.get(&sib.rfilename).await {
+        
+        match repo.get(&sibling.rfilename).await {
             Ok(path) => {
-                p = path;
+                model_path = path;
                 files_downloaded = true;
             }
             Err(e) => {
                 return Err(anyhow::anyhow!(
                     "Failed to download file '{}' from model '{}': {}",
-                    sib.rfilename,
+                    sibling.rfilename,
                     model_name,
                     e
                 ));
             }
         }
     }
-
+    
     if !files_downloaded {
         let file_type = if ignore_weights {
             "non-weight"
@@ -110,18 +156,126 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
             model_name
         ));
     }
-
-    match p.parent() {
-        Some(p) => Ok(p.to_path_buf()),
-        None => Err(anyhow::anyhow!("Invalid HF cache path: {}", p.display())),
+    
+    // Return the parent directory (model directory)
+    match model_path.parent() {
+        Some(path) => {
+            tracing::info!("Successfully downloaded model '{}' using hf-hub to: {}", model_name, path.display());
+            Ok(path.to_path_buf())
+        }
+        None => Err(anyhow::anyhow!("Invalid HF cache path: {}", model_path.display())),
     }
 }
 
-fn is_image(s: &str) -> bool {
-    s.ends_with(".png")
-        || s.ends_with("PNG")
-        || s.ends_with(".jpg")
-        || s.ends_with("JPG")
-        || s.ends_with(".jpeg")
-        || s.ends_with("JPEG")
+/// Check if a file should be ignored during download
+fn is_ignored_file(filename: &str) -> bool {
+    const IGNORED_FILES: [&str; 5] = [
+        ".gitattributes",
+        "LICENSE",
+        "LICENSE.txt",
+        "README.md",
+        "USE_POLICY.md",
+    ];
+    IGNORED_FILES.contains(&filename)
+}
+
+/// Check if a file is an image file that should be ignored
+fn is_image_file(filename: &str) -> bool {
+    filename.ends_with(".png")
+        || filename.ends_with("PNG")
+        || filename.ends_with(".jpg")
+        || filename.ends_with("JPG")
+        || filename.ends_with(".jpeg")
+        || filename.ends_with("JPEG")
+}
+
+/// Get the model path from cache after server download
+fn get_model_path_from_cache(model_name: &str) -> anyhow::Result<PathBuf> {
+    let cache_dir = get_model_express_cache_dir();
+    let model_dir = cache_dir.join(model_name);
+    
+    if !model_dir.exists() {
+        return Err(anyhow::anyhow!(
+            "Model '{}' was downloaded but directory not found at expected location: {}",
+            model_name,
+            model_dir.display()
+        ));
+    }
+    
+    Ok(model_dir)
+}
+
+/// Get the ModelExpress cache directory
+fn get_model_express_cache_dir() -> PathBuf {
+    // Try to get from environment variable first
+    if let Ok(cache_path) = env::var("HF_HUB_CACHE") {
+        return PathBuf::from(cache_path);
+    }
+    
+    // Fall back to default Hugging Face cache location
+    let home = env::var("HOME")
+        .or_else(|_| env::var("USERPROFILE"))
+        .unwrap_or_else(|_| ".".to_string());
+    
+    PathBuf::from(home).join(".cache/huggingface/hub")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_from_hf_with_model_express() {
+        // This test verifies that the function compiles and can be called
+        // We don't actually download a model in tests to avoid network dependencies
+        
+        // Test with a simple path
+        let test_path = PathBuf::from("test-model");
+        
+        // The function should compile and be callable
+        // In a real scenario, this would attempt to download the model
+        // For testing purposes, we just verify the function signature is correct
+        let _result: anyhow::Result<PathBuf> = from_hf(test_path, false).await;
+        
+        // If we get here, the function compiled and ran without panicking
+        // The actual result will depend on whether ModelExpress server is available
+        // and whether the test model exists
+    }
+
+    #[test]
+    fn test_get_model_express_cache_dir() {
+        let cache_dir = get_model_express_cache_dir();
+        
+        // Should return a valid path
+        assert!(!cache_dir.to_string_lossy().is_empty());
+        
+        // Should be an absolute path
+        assert!(cache_dir.is_absolute() || cache_dir.starts_with("."));
+    }
+
+    #[test]
+    fn test_is_ignored_file() {
+        assert!(is_ignored_file(".gitattributes"));
+        assert!(is_ignored_file("LICENSE"));
+        assert!(is_ignored_file("LICENSE.txt"));
+        assert!(is_ignored_file("README.md"));
+        assert!(is_ignored_file("USE_POLICY.md"));
+        
+        assert!(!is_ignored_file("model.bin"));
+        assert!(!is_ignored_file("tokenizer.json"));
+        assert!(!is_ignored_file("config.json"));
+    }
+
+    #[test]
+    fn test_is_weight_file() {
+        assert!(is_weight_file("model.bin"));
+        assert!(is_weight_file("model.safetensors"));
+        assert!(is_weight_file("model.h5"));
+        assert!(is_weight_file("model.msgpack"));
+        assert!(is_weight_file("model.ckpt.index"));
+        
+        assert!(!is_weight_file("tokenizer.json"));
+        assert!(!is_weight_file("config.json"));
+        assert!(!is_weight_file("README.md"));
+    }
 }

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(unexpected_cfgs)]
+
 use hf_hub::api::tokio::ApiBuilder;
 use std::env;
 use std::path::{Path, PathBuf};

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -115,6 +115,7 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
     download_with_hf_hub(&model_name, ignore_weights).await
 }
 
+// Direct download using the ModelExpress client.
 #[cfg(feature = "model-express")]
 async fn mx_download_direct(model_name: &str) -> anyhow::Result<PathBuf> {
     let cache_dir = get_model_express_cache_dir();

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -13,14 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use model_express_client::{Client, ClientConfig, ModelProvider};
-use model_express_common::download;
 use hf_hub::api::tokio::ApiBuilder;
 use std::env;
 use std::path::{Path, PathBuf};
 
-const MODEL_EXPRESS_ENDPOINT_ENV_VAR: &str = "MODEL_EXPRESS_ENDPOINT";
-const DEFAULT_MODEL_EXPRESS_ENDPOINT: &str = "http://localhost:8001";
+const IGNORED: [&str; 5] = [
+    ".gitattributes",
+    "LICENSE",
+    "LICENSE.txt",
+    "README.md",
+    "USE_POLICY.md",
+];
+
 const HF_TOKEN_ENV_VAR: &str = "HF_TOKEN";
 
 /// Checks if a file is a model weight file
@@ -32,118 +36,68 @@ fn is_weight_file(filename: &str) -> bool {
         || filename.ends_with(".ckpt.index")
 }
 
-/// Attempt to download a model from Hugging Face using ModelExpress client with hf-hub fallback
+/// Attempt to download a model from Hugging Face
 /// Returns the directory it is in
 /// If ignore_weights is true, model weight files will be skipped
 pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Result<PathBuf> {
     let name = name.as_ref();
-    let model_name = name.display().to_string();
-    
-    // Get ModelExpress server endpoint from environment or use default
-    let endpoint = env::var(MODEL_EXPRESS_ENDPOINT_ENV_VAR)
-        .unwrap_or_else(|_| DEFAULT_MODEL_EXPRESS_ENDPOINT.to_string());
-    
-    // Create client configuration
-    let config = ClientConfig::for_testing(&endpoint);
-    
-    // First try to use the server with fallback
-    let result = match Client::new(config.clone()).await {
-        Ok(mut client) => {
-            // Try server-based download first
-            match client.request_model_with_provider_and_fallback(&model_name, ModelProvider::HuggingFace).await {
-                Ok(()) => {
-                    // Server download succeeded, now get the path
-                    get_model_path_from_cache(&model_name)
-                }
-                Err(e) => {
-                    // Server failed, fallback to direct download
-                    tracing::warn!("Server download failed for model '{}': {}. Falling back to direct download.", model_name, e);
-                    download_model_directly(&model_name).await
-                }
-            }
-        }
-        Err(e) => {
-            // Can't connect to server, use direct download
-            tracing::warn!("Cannot connect to ModelExpress server: {}. Using direct download.", e);
-            download_model_directly(&model_name).await
-        }
-    };
-    
-    // If ModelExpress methods fail, try hf-hub as final fallback
-    match result {
-        Ok(path) => Ok(path),
-        Err(e) => {
-            tracing::warn!("ModelExpress download failed for model '{}': {}. Falling back to hf-hub.", model_name, e);
-            download_with_hf_hub(&model_name, ignore_weights).await
-        }
-    }
-}
-
-/// Download model directly using ModelExpress download function
-async fn download_model_directly(model_name: &str) -> anyhow::Result<PathBuf> {
-    // Get cache directory
-    let cache_dir = get_model_express_cache_dir();
-    
-    // Use ModelExpress download function directly
-    download::download_model(model_name, ModelProvider::HuggingFace, Some(cache_dir)).await
-}
-
-/// Download model using hf-hub as final fallback
-async fn download_with_hf_hub(model_name: &str, ignore_weights: bool) -> anyhow::Result<PathBuf> {
-    tracing::info!("Downloading model '{}' using hf-hub", model_name);
-    
-    // Get cache directory
-    let cache_dir = get_model_express_cache_dir();
-    
-    // Get Hugging Face token if available
     let token = env::var(HF_TOKEN_ENV_VAR).ok();
     let api = ApiBuilder::from_env()
         .with_progress(true)
         .with_token(token)
         .high()
-        .with_cache_dir(cache_dir)
         .build()?;
-    
-    let repo = api.model(model_name.to_string());
-    
-    // Get model info
-    let info = repo.info().await
-        .map_err(|e| anyhow::anyhow!("Failed to fetch model '{}' from HuggingFace: {}. Is this a valid HuggingFace ID?", model_name, e))?;
-    
+    let model_name = name.display().to_string();
+
+    let repo = api.model(model_name.clone());
+
+    let info = match repo.info().await {
+        Ok(info) => info,
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "Failed to fetch model '{}' from HuggingFace: {}. Is this a valid HuggingFace ID?",
+                model_name,
+                e
+            ));
+        }
+    };
+
     if info.siblings.is_empty() {
-        return Err(anyhow::anyhow!("Model '{}' exists but contains no downloadable files.", model_name));
+        return Err(anyhow::anyhow!(
+            "Model '{}' exists but contains no downloadable files.",
+            model_name
+        ));
     }
-    
-    // Download files (excluding ignored files)
-    let mut model_path = PathBuf::new();
+
+    let mut p = PathBuf::new();
     let mut files_downloaded = false;
-    
-    for sibling in info.siblings {
-        if is_ignored_file(&sibling.rfilename) || is_image_file(&sibling.rfilename) {
+
+    for sib in info.siblings {
+        if IGNORED.contains(&sib.rfilename.as_str()) || is_image(&sib.rfilename) {
             continue;
         }
 
         // If ignore_weights is true, skip weight files
-        if ignore_weights && is_weight_file(&sibling.rfilename) {
+        if ignore_weights && is_weight_file(&sib.rfilename) {
             continue;
         }
-        
-        match repo.get(&sibling.rfilename).await {
+
+        match repo.get(&sib.rfilename).await {
             Ok(path) => {
-                model_path = path;
+                p = path;
                 files_downloaded = true;
             }
             Err(e) => {
                 return Err(anyhow::anyhow!(
                     "Failed to download file '{}' from model '{}': {}",
-                    sibling.rfilename,
+                    sib.rfilename,
                     model_name,
                     e
                 ));
             }
         }
     }
-    
+
     if !files_downloaded {
         let file_type = if ignore_weights {
             "non-weight"
@@ -156,126 +110,18 @@ async fn download_with_hf_hub(model_name: &str, ignore_weights: bool) -> anyhow:
             model_name
         ));
     }
-    
-    // Return the parent directory (model directory)
-    match model_path.parent() {
-        Some(path) => {
-            tracing::info!("Successfully downloaded model '{}' using hf-hub to: {}", model_name, path.display());
-            Ok(path.to_path_buf())
-        }
-        None => Err(anyhow::anyhow!("Invalid HF cache path: {}", model_path.display())),
+
+    match p.parent() {
+        Some(p) => Ok(p.to_path_buf()),
+        None => Err(anyhow::anyhow!("Invalid HF cache path: {}", p.display())),
     }
 }
 
-/// Check if a file should be ignored during download
-fn is_ignored_file(filename: &str) -> bool {
-    const IGNORED_FILES: [&str; 5] = [
-        ".gitattributes",
-        "LICENSE",
-        "LICENSE.txt",
-        "README.md",
-        "USE_POLICY.md",
-    ];
-    IGNORED_FILES.contains(&filename)
-}
-
-/// Check if a file is an image file that should be ignored
-fn is_image_file(filename: &str) -> bool {
-    filename.ends_with(".png")
-        || filename.ends_with("PNG")
-        || filename.ends_with(".jpg")
-        || filename.ends_with("JPG")
-        || filename.ends_with(".jpeg")
-        || filename.ends_with("JPEG")
-}
-
-/// Get the model path from cache after server download
-fn get_model_path_from_cache(model_name: &str) -> anyhow::Result<PathBuf> {
-    let cache_dir = get_model_express_cache_dir();
-    let model_dir = cache_dir.join(model_name);
-    
-    if !model_dir.exists() {
-        return Err(anyhow::anyhow!(
-            "Model '{}' was downloaded but directory not found at expected location: {}",
-            model_name,
-            model_dir.display()
-        ));
-    }
-    
-    Ok(model_dir)
-}
-
-/// Get the ModelExpress cache directory
-fn get_model_express_cache_dir() -> PathBuf {
-    // Try to get from environment variable first
-    if let Ok(cache_path) = env::var("HF_HUB_CACHE") {
-        return PathBuf::from(cache_path);
-    }
-    
-    // Fall back to default Hugging Face cache location
-    let home = env::var("HOME")
-        .or_else(|_| env::var("USERPROFILE"))
-        .unwrap_or_else(|_| ".".to_string());
-    
-    PathBuf::from(home).join(".cache/huggingface/hub")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_from_hf_with_model_express() {
-        // This test verifies that the function compiles and can be called
-        // We don't actually download a model in tests to avoid network dependencies
-        
-        // Test with a simple path
-        let test_path = PathBuf::from("test-model");
-        
-        // The function should compile and be callable
-        // In a real scenario, this would attempt to download the model
-        // For testing purposes, we just verify the function signature is correct
-        let _result: anyhow::Result<PathBuf> = from_hf(test_path, false).await;
-        
-        // If we get here, the function compiled and ran without panicking
-        // The actual result will depend on whether ModelExpress server is available
-        // and whether the test model exists
-    }
-
-    #[test]
-    fn test_get_model_express_cache_dir() {
-        let cache_dir = get_model_express_cache_dir();
-        
-        // Should return a valid path
-        assert!(!cache_dir.to_string_lossy().is_empty());
-        
-        // Should be an absolute path
-        assert!(cache_dir.is_absolute() || cache_dir.starts_with("."));
-    }
-
-    #[test]
-    fn test_is_ignored_file() {
-        assert!(is_ignored_file(".gitattributes"));
-        assert!(is_ignored_file("LICENSE"));
-        assert!(is_ignored_file("LICENSE.txt"));
-        assert!(is_ignored_file("README.md"));
-        assert!(is_ignored_file("USE_POLICY.md"));
-        
-        assert!(!is_ignored_file("model.bin"));
-        assert!(!is_ignored_file("tokenizer.json"));
-        assert!(!is_ignored_file("config.json"));
-    }
-
-    #[test]
-    fn test_is_weight_file() {
-        assert!(is_weight_file("model.bin"));
-        assert!(is_weight_file("model.safetensors"));
-        assert!(is_weight_file("model.h5"));
-        assert!(is_weight_file("model.msgpack"));
-        assert!(is_weight_file("model.ckpt.index"));
-        
-        assert!(!is_weight_file("tokenizer.json"));
-        assert!(!is_weight_file("config.json"));
-        assert!(!is_weight_file("README.md"));
-    }
+fn is_image(s: &str) -> bool {
+    s.ends_with(".png")
+        || s.ends_with("PNG")
+        || s.ends_with(".jpg")
+        || s.ends_with("JPG")
+        || s.ends_with(".jpeg")
+        || s.ends_with("JPEG")
 }

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -136,7 +136,7 @@ async fn mx_download_direct(model_name: &str) -> anyhow::Result<PathBuf> {
 async fn download_with_hf_hub(model_name: &str, ignore_weights: bool) -> anyhow::Result<PathBuf> {
     let token = env::var(HF_TOKEN_ENV_VAR).ok();
 
-    let api = ApiBuilder::new()
+    let api = ApiBuilder::from_env()
         .with_progress(true)
         .with_token(token)
         .high()

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -18,7 +18,9 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "model-express")]
-use model_express_client::{Client as MxClient, ClientConfig as MxClientConfig, ModelProvider as MxModelProvider};
+use model_express_client::{
+    Client as MxClient, ClientConfig as MxClientConfig, ModelProvider as MxModelProvider,
+};
 #[cfg(feature = "model-express")]
 use model_express_common::download as mx;
 
@@ -52,7 +54,13 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
             let result = match MxClient::new(config.clone()).await {
                 Ok(mut client) => {
                     tracing::info!("Successfully connected to ModelExpress server");
-                    match client.request_model_with_provider_and_fallback(&model_name, MxModelProvider::HuggingFace).await {
+                    match client
+                        .request_model_with_provider_and_fallback(
+                            &model_name,
+                            MxModelProvider::HuggingFace,
+                        )
+                        .await
+                    {
                         Ok(()) => {
                             tracing::info!("Server download succeeded for model: {model_name}");
                             get_mx_model_path_from_cache(&model_name)
@@ -64,14 +72,18 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
                     }
                 }
                 Err(e) => {
-                    tracing::warn!("Cannot connect to ModelExpress server: {e}. Using direct download.");
+                    tracing::warn!(
+                        "Cannot connect to ModelExpress server: {e}. Using direct download."
+                    );
                     mx_download_direct(&model_name).await
                 }
             };
 
             match result {
                 Ok(path) => {
-                    tracing::info!("ModelExpress download completed successfully for model: {model_name}");
+                    tracing::info!(
+                        "ModelExpress download completed successfully for model: {model_name}"
+                    );
                     return Ok(path);
                 }
                 Err(e) => {
@@ -116,7 +128,9 @@ async fn download_with_hf_hub(model_name: &str, ignore_weights: bool) -> anyhow:
         .map_err(|e| anyhow::anyhow!("Failed to fetch model '{model_name}' from HuggingFace: {e}. Is this a valid HuggingFace ID?"))?;
 
     if info.siblings.is_empty() {
-        return Err(anyhow::anyhow!("Model '{model_name}' exists but contains no downloadable files."));
+        return Err(anyhow::anyhow!(
+            "Model '{model_name}' exists but contains no downloadable files."
+        ));
     }
 
     let mut model_path = PathBuf::new();
@@ -158,10 +172,16 @@ async fn download_with_hf_hub(model_name: &str, ignore_weights: bool) -> anyhow:
 
     match model_path.parent() {
         Some(path) => {
-            tracing::info!("Successfully downloaded model '{model_name}' using hf-hub to: {}", path.display());
+            tracing::info!(
+                "Successfully downloaded model '{model_name}' using hf-hub to: {}",
+                path.display()
+            );
             Ok(path.to_path_buf())
         }
-        None => Err(anyhow::anyhow!("Invalid HF cache path: {}", model_path.display())),
+        None => Err(anyhow::anyhow!(
+            "Invalid HF cache path: {}",
+            model_path.display()
+        )),
     }
 }
 

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -49,7 +49,9 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
 
     // Only use ModelExpress if the environment variable is explicitly set
     if let Ok(endpoint) = env::var(MODEL_EXPRESS_ENDPOINT_ENV_VAR) {
-        tracing::info!("ModelExpress endpoint configured, attempting to use ModelExpress for model: {model_name}");
+        tracing::info!(
+            "ModelExpress endpoint configured, attempting to use ModelExpress for model: {model_name}"
+        );
 
         let config: MxClientConfig = MxClientConfig::default().with_endpoint(endpoint.clone());
 
@@ -68,7 +70,9 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
                         get_mx_model_path_from_cache(&model_name)
                     }
                     Err(e) => {
-                        tracing::warn!("Server download failed for model '{model_name}': {e}. Falling back to direct download.");
+                        tracing::warn!(
+                            "Server download failed for model '{model_name}': {e}. Falling back to direct download."
+                        );
                         mx_download_direct(&model_name).await
                     }
                 }
@@ -89,7 +93,9 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
                 return Ok(path);
             }
             Err(e) => {
-                tracing::warn!("ModelExpress download failed for model '{model_name}': {e}. Falling back to hf-hub.");
+                tracing::warn!(
+                    "ModelExpress download failed for model '{model_name}': {e}. Falling back to hf-hub."
+                );
             }
         }
     }
@@ -108,7 +114,9 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
     let model_name = name.display().to_string();
 
     if env::var(MODEL_EXPRESS_ENDPOINT_ENV_VAR).is_ok() {
-        tracing::warn!("ModelExpress endpoint configured but model-express feature not enabled. Using hf-hub.");
+        tracing::warn!(
+            "ModelExpress endpoint configured but model-express feature not enabled. Using hf-hub."
+        );
     }
 
     tracing::info!("Using hf-hub for model: {model_name}");


### PR DESCRIPTION
#### Overview:

Integrate Model Express Client into Dynamo Model Downloads

#### Details:

Migrated Dynamo model downloads to use the modelexpress (if the env variable is set).

If the env is not set, it should default to hf-hub as it has operated so far.

NOTE: The 0.1.0 crates have not released yet, which is why they are commented out for the time being

#### Where should the reviewer start?

Primarily: lib/llm/src/hub.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Will need https://github.com/ai-dynamo/modelexpress/pull/47 upstream to merge first (if locally building the crate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Faster, more reliable model downloads with automatic fallbacks (server → direct → hub).
  - Configurable server endpoint via environment variable.
  - Consistent cache handling, honoring cache-related environment variables.
  - Smarter file selection during downloads (ignores non-essential/image files; optional weight skipping).

- Chores
  - Added new dependencies to enable server-based downloads.

- Tests
  - Added unit tests for cache resolution, file filtering, and basic download flow compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->