### PR TITLE
fix: limit Support for HTTP Body limit in axum server

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -48,6 +48,8 @@ pub const DYNAMO_REQUEST_ID_HEADER: &str = "x-dynamo-request-id";
 /// Dynamo Annotation for the request ID
 pub const ANNOTATION_REQUEST_ID: &str = "request_id";
 
+const BODY_LIMIT: usize = 45 * 1024 * 1024;
+
 pub type ErrorResponse = (StatusCode, Json<ErrorMessage>);
 
 #[derive(Serialize, Deserialize)]
@@ -1002,6 +1004,7 @@ pub fn completions_router(
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let router = Router::new()
         .route(&path, post(handler_completions))
+        .layer(axum::extract::DefaultBodyLimit::max(BODY_LIMIT))
         .with_state(state);
     (vec![doc], router)
 }
@@ -1017,6 +1020,7 @@ pub fn chat_completions_router(
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let router = Router::new()
         .route(&path, post(handler_chat_completions))
+        .layer(axum::extract::DefaultBodyLimit::max(BODY_LIMIT))
         .with_state((state, template));
     (vec![doc], router)
 }
@@ -1046,6 +1050,7 @@ pub fn list_models_router(
 
     let router = Router::new()
         .route(&openai_path, get(list_models_openai))
+        .layer(axum::extract::DefaultBodyLimit::max(BODY_LIMIT))
         .with_state(state);
 
     (vec![doc_for_openai], router)

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -48,6 +48,9 @@ pub const DYNAMO_REQUEST_ID_HEADER: &str = "x-dynamo-request-id";
 /// Dynamo Annotation for the request ID
 pub const ANNOTATION_REQUEST_ID: &str = "request_id";
 
+// Default axum max body limit without configuring is 2MB: https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html
+// Configure max body limit here to 45MB to support long contexts (500K+ tokens)
+// TODO: Add a `DYN_*` env var to configure this limit without code change
 const BODY_LIMIT: usize = 45 * 1024 * 1024;
 
 pub type ErrorResponse = (StatusCode, Json<ErrorMessage>);

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1035,6 +1035,7 @@ pub fn embeddings_router(
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let router = Router::new()
         .route(&path, post(embeddings))
+        .layer(axum::extract::DefaultBodyLimit::max(BODY_LIMIT))
         .with_state(state);
     (vec![doc], router)
 }
@@ -1050,7 +1051,6 @@ pub fn list_models_router(
 
     let router = Router::new()
         .route(&openai_path, get(list_models_openai))
-        .layer(axum::extract::DefaultBodyLimit::max(BODY_LIMIT))
         .with_state(state);
 
     (vec![doc_for_openai], router)


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enforced a 45 MB maximum request body size for the Completions, Chat Completions, and Embeddings endpoints.
  * Requests exceeding this limit will be rejected, ensuring more reliable performance and protection against oversized payloads.
  * Typical usage is unaffected; only unusually large inputs are impacted.
  * No changes to public APIs or request/response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->