### PR TITLE
refactor: share common drt test functions

### DIFF
--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -359,9 +359,11 @@ impl DistributedConfig {
 #[cfg(test)]
 pub mod test_helpers {
     //! Common test helper functions for DistributedRuntime tests
+    // TODO: Use in-memory DistributedRuntime for tests instead of full runtime when available.
 
     /// Helper function to create a DRT instance for basic unit tests
     /// Uses from_current to leverage existing tokio runtime without environment configuration
+    #[cfg(feature = "integration")]
     pub async fn create_test_drt_async() -> crate::DistributedRuntime {
         let rt = crate::Runtime::from_current().unwrap();
         crate::DistributedRuntime::from_settings_without_discovery(rt)

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -361,39 +361,12 @@ pub mod test_helpers {
     //! Common test helper functions for DistributedRuntime tests
     // TODO: Use in-memory DistributedRuntime for tests instead of full runtime when available.
 
-    /// Helper function to create a DRT instance for basic unit tests
-    /// Uses from_current to leverage existing tokio runtime without environment configuration
+    /// Helper function to create a DRT instance for tests
+    /// Uses from_current to leverage existing tokio runtime
+    /// Note: Settings are read from environment variables inside DistributedRuntime::from_settings_without_discovery
     #[cfg(feature = "integration")]
     pub async fn create_test_drt_async() -> crate::DistributedRuntime {
         let rt = crate::Runtime::from_current().unwrap();
-        crate::DistributedRuntime::from_settings_without_discovery(rt)
-            .await
-            .unwrap()
-    }
-
-    /// Helper function to create a DRT instance for integration tests
-    /// Uses spawn_blocking to create runtime safely without ownership issues
-    /// Enables system status server for integration testing
-    /// Note: This function uses environment variables to configure and create the DistributedRuntime.
-    #[cfg(feature = "integration")]
-    pub async fn create_test_drt_with_settings_async() -> crate::DistributedRuntime {
-        // Create runtime in blocking context where it can be safely dropped
-        let handle = tokio::task::spawn_blocking(|| {
-            // Load configuration from environment/settings
-            let config = crate::config::RuntimeConfig::from_settings().unwrap();
-
-            // Create runtime with the configuration and extract handle
-            let runtime = config.create_runtime().unwrap();
-            let handle = runtime.handle().clone();
-
-            // Runtime will be automatically dropped when it goes out of scope
-            handle
-        })
-        .await
-        .unwrap();
-
-        // Create Runtime using external handle (no ownership)
-        let rt = crate::Runtime::from_handle(handle).unwrap();
         crate::DistributedRuntime::from_settings_without_discovery(rt)
             .await
             .unwrap()

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -578,8 +578,6 @@ mod test_helpers {
     use super::prometheus_names::{nats_client, nats_service};
     use super::*;
 
-    // Helper function moved to crate::test_helpers::create_test_drt_async
-
     /// Base function to filter Prometheus output lines based on a predicate.
     /// Returns lines that match the predicate, converted to String.
     fn filter_prometheus_lines<F>(input: &str, mut predicate: F) -> Vec<String>
@@ -815,7 +813,6 @@ mod test_metricsregistry_units {
         println!("✓ Prometheus metric parsing works correctly!");
     }
 
-    #[cfg(feature = "integration")]
     #[test]
     fn test_metrics_registry_entry_callbacks() {
         use crate::MetricsRegistryEntry;
@@ -916,11 +913,12 @@ mod test_metricsregistry_units {
 #[cfg(test)]
 mod test_metricsregistry_prefixes {
     use super::*;
+    use crate::distributed::test_helpers::create_test_drt_async;
     use prometheus::core::Collector;
 
     #[tokio::test]
     async fn test_hierarchical_prefixes_and_parent_hierarchies() {
-        let drt = crate::distributed::test_helpers::create_test_drt_async().await;
+        let drt = create_test_drt_async().await;
 
         const DRT_NAME: &str = "";
         const NAMESPACE_NAME: &str = "ns901";
@@ -995,7 +993,7 @@ mod test_metricsregistry_prefixes {
     #[tokio::test]
     async fn test_recursive_namespace() {
         // Create a distributed runtime for testing
-        let drt = crate::distributed::test_helpers::create_test_drt_async().await;
+        let drt = create_test_drt_async().await;
 
         // Create a deeply chained namespace: ns1.ns2.ns3
         let ns1 = drt.namespace("ns1").unwrap();
@@ -1047,13 +1045,14 @@ mod test_metricsregistry_prometheus_fmt_outputs {
     use super::prometheus_names::{nats_client, nats_service};
     use super::prometheus_names::{COMPONENT_NATS_METRICS, DRT_NATS_METRICS};
     use super::*;
+    use crate::distributed::test_helpers::create_test_drt_async;
     use prometheus::Counter;
     use std::sync::Arc;
 
     #[tokio::test]
     async fn test_prometheusfactory_using_metrics_registry_trait() {
         // Setup real DRT and registry using the test-friendly constructor
-        let drt = crate::distributed::test_helpers::create_test_drt_async().await;
+        let drt = create_test_drt_async().await;
 
         // Use a simple constant namespace name
         let namespace_name = "ns345";
@@ -1305,13 +1304,14 @@ mod test_metricsregistry_nats {
     use super::prometheus_names::{nats_client, nats_service};
     use super::prometheus_names::{COMPONENT_NATS_METRICS, DRT_NATS_METRICS};
     use super::*;
+    use crate::distributed::test_helpers::create_test_drt_async;
     use crate::pipeline::PushRouter;
     use crate::{DistributedRuntime, Runtime};
     use tokio::time::{sleep, Duration};
     #[tokio::test]
     async fn test_drt_nats_metrics() {
         // Setup real DRT and registry using the test-friendly constructor
-        let drt = crate::distributed::test_helpers::create_test_drt_async().await;
+        let drt = create_test_drt_async().await;
 
         // Get DRT output which should include NATS client metrics
         let drt_output = drt.prometheus_metrics_fmt().unwrap();
@@ -1375,7 +1375,7 @@ mod test_metricsregistry_nats {
         // the values of the metrics.
 
         // Setup real DRT and registry using the test-friendly constructor
-        let drt = crate::distributed::test_helpers::create_test_drt_async().await;
+        let drt = create_test_drt_async().await;
 
         // Create a namespace and components from the DRT
         let namespace = drt.namespace("ns789").unwrap();

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -578,14 +578,7 @@ mod test_helpers {
     use super::prometheus_names::{nats_client, nats_service};
     use super::*;
 
-    /// Helper function to create a DRT instance for testing in async contexts
-    #[cfg(feature = "integration")]
-    pub async fn create_test_drt_async() -> crate::DistributedRuntime {
-        let rt = crate::Runtime::from_current().unwrap();
-        crate::DistributedRuntime::from_settings_without_discovery(rt)
-            .await
-            .unwrap()
-    }
+    // Helper function moved to crate::test_helpers::create_test_drt_async
 
     /// Base function to filter Prometheus output lines based on a predicate.
     /// Returns lines that match the predicate, converted to String.
@@ -927,7 +920,7 @@ mod test_metricsregistry_prefixes {
 
     #[tokio::test]
     async fn test_hierarchical_prefixes_and_parent_hierarchies() {
-        let drt = super::test_helpers::create_test_drt_async().await;
+        let drt = crate::distributed::test_helpers::create_test_drt_async().await;
 
         const DRT_NAME: &str = "";
         const NAMESPACE_NAME: &str = "ns901";
@@ -1002,7 +995,7 @@ mod test_metricsregistry_prefixes {
     #[tokio::test]
     async fn test_recursive_namespace() {
         // Create a distributed runtime for testing
-        let drt = super::test_helpers::create_test_drt_async().await;
+        let drt = crate::distributed::test_helpers::create_test_drt_async().await;
 
         // Create a deeply chained namespace: ns1.ns2.ns3
         let ns1 = drt.namespace("ns1").unwrap();
@@ -1060,7 +1053,7 @@ mod test_metricsregistry_prometheus_fmt_outputs {
     #[tokio::test]
     async fn test_prometheusfactory_using_metrics_registry_trait() {
         // Setup real DRT and registry using the test-friendly constructor
-        let drt = super::test_helpers::create_test_drt_async().await;
+        let drt = crate::distributed::test_helpers::create_test_drt_async().await;
 
         // Use a simple constant namespace name
         let namespace_name = "ns345";
@@ -1318,7 +1311,7 @@ mod test_metricsregistry_nats {
     #[tokio::test]
     async fn test_drt_nats_metrics() {
         // Setup real DRT and registry using the test-friendly constructor
-        let drt = super::test_helpers::create_test_drt_async().await;
+        let drt = crate::distributed::test_helpers::create_test_drt_async().await;
 
         // Get DRT output which should include NATS client metrics
         let drt_output = drt.prometheus_metrics_fmt().unwrap();
@@ -1382,7 +1375,7 @@ mod test_metricsregistry_nats {
         // the values of the metrics.
 
         // Setup real DRT and registry using the test-friendly constructor
-        let drt = super::test_helpers::create_test_drt_async().await;
+        let drt = crate::distributed::test_helpers::create_test_drt_async().await;
 
         // Create a namespace and components from the DRT
         let namespace = drt.namespace("ns789").unwrap();

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -332,9 +332,7 @@ mod tests {
 #[cfg(all(test, feature = "integration"))]
 mod integration_tests {
     use super::*;
-    use crate::distributed::test_helpers::{
-        create_test_drt_async, create_test_drt_with_settings_async,
-    };
+    use crate::distributed::test_helpers::create_test_drt_async;
     use crate::logging::tests::load_log;
     use crate::metrics::MetricsRegistry;
     use anyhow::{anyhow, Result};
@@ -479,7 +477,7 @@ mod integration_tests {
                 ("DYN_SYSTEM_LIVE_PATH", custom_live_path),
             ],
             (async || {
-                let drt = Arc::new(create_test_drt_with_settings_async().await);
+                let drt = Arc::new(create_test_drt_async().await);
 
                 // Get system status server info from DRT (instead of manually spawning)
                 let system_info = drt
@@ -558,7 +556,7 @@ mod integration_tests {
 
                 crate::logging::init();
 
-                let drt = Arc::new(create_test_drt_with_settings_async().await);
+                let drt = Arc::new(create_test_drt_async().await);
 
                 // Get system status server info from DRT (instead of manually spawning)
                 let system_info = drt
@@ -607,7 +605,7 @@ mod integration_tests {
                 ("DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS", Some(ENDPOINT_HEALTH_CONFIG)),
             ],
             async {
-                let drt = Arc::new(create_test_drt_with_settings_async().await);
+                let drt = Arc::new(create_test_drt_async().await);
 
                 // Check if system status server was started
                 let system_info_opt = drt.system_status_server_info();
@@ -716,7 +714,7 @@ mod integration_tests {
                 ("DYN_SYSTEM_STARTING_HEALTH_STATUS", Some("ready")),
             ],
             async {
-                let drt = Arc::new(create_test_drt_with_settings_async().await);
+                let drt = Arc::new(create_test_drt_async().await);
 
                 // Get system status server info from DRT (instead of manually spawning)
                 let system_info = drt

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -333,18 +333,11 @@ mod tests {
 mod integration_tests {
     use super::*;
     use crate::distributed::test_helpers::create_test_drt_async;
-    use crate::logging::tests::load_log;
     use crate::metrics::MetricsRegistry;
-    use anyhow::{anyhow, Result};
-    use chrono::{DateTime, Utc};
-    use jsonschema::{Draft, JSONSchema};
+    use anyhow::Result;
     use rstest::rstest;
-    use serde_json::Value;
-    use std::fs::File;
-    use std::io::{BufRead, BufReader};
     use std::sync::Arc;
-    use stdio_override::*;
-    use tokio::time::{sleep, Duration};
+    use tokio::time::Duration;
 
     #[tokio::test]
     async fn test_uptime_without_initialization() {

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -299,42 +299,10 @@ async fn metrics_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
 // Integration tests: cargo test system_status_server --lib --features integration
 
 #[cfg(test)]
-/// Helper function to create a DRT instance for basic unit tests
-/// Uses from_current to leverage existing tokio runtime without environment configuration
-async fn create_test_drt_async() -> crate::DistributedRuntime {
-    let rt = crate::Runtime::from_current().unwrap();
-    crate::DistributedRuntime::from_settings_without_discovery(rt)
-        .await
-        .unwrap()
-}
+use crate::distributed::test_helpers::create_test_drt_async;
 
-#[cfg(test)]
-/// Helper function to create a DRT instance for integration tests
-/// Uses spawn_blocking to create runtime safely without ownership issues
-/// Enables system status server for integration testing
-/// Note: This function uses environment variables to configure and create the DistributedRuntime.
-async fn create_test_drt_with_settings_async() -> crate::DistributedRuntime {
-    // Create runtime in blocking context where it can be safely dropped
-    let handle = tokio::task::spawn_blocking(|| {
-        // Load configuration from environment/settings
-        let config = crate::config::RuntimeConfig::from_settings().unwrap();
-
-        // Create runtime with the configuration and extract handle
-        let runtime = config.create_runtime().unwrap();
-        let handle = runtime.handle().clone();
-
-        // Runtime will be automatically dropped when it goes out of scope
-        handle
-    })
-    .await
-    .unwrap();
-
-    // Create Runtime using external handle (no ownership)
-    let rt = crate::Runtime::from_handle(handle).unwrap();
-    crate::DistributedRuntime::from_settings_without_discovery(rt)
-        .await
-        .unwrap()
-}
+#[cfg(all(test, feature = "integration"))]
+use crate::distributed::test_helpers::create_test_drt_with_settings_async;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
#### Overview:

Refactors test helper functions to eliminate code duplication by consolidating shared test utilities into a centralized module and cleaning up unused imports.

#### Details:

- Improved code maintainability by reducing duplication across test modules. I consolidated `create_test_drt_async` and `create_test_drt_with_settings_async` functions from multiple modules into `distributed::test_helpers`
- Removed unused imports from system_status_server.rs (HashMap, body, DefaultMakeSpan, TraceParent)
- Reorganized test modules to clearly separate regular tests from integration tests
- Cleaned up redundant feature gate attributes within integration test modules

#### Where should the reviewer start?

- lib/runtime/src/distributed.rs - Review the new test_helpers module with consolidated test functions
- lib/runtime/src/system_status_server.rs - Check the reorganized test module structure and import cleanup
- lib/runtime/src/metrics.rs - Verify updated imports now use the centralized test helpers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Centralized test helpers for distributed runtime, reducing duplication.
  * Reorganized integration tests under a single gated module; unit tests remain separate.
  * Simplified configuration gates so some tests run unconditionally.
  * Updated tests to use shared helpers for runtime creation and server info.

* **Chores**
  * Cleaned up imports and minor formatting across test-related code.

No user-facing changes; functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->