### PR TITLE
fix: ensure nats fails fast with jetstream failure

### DIFF
--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -279,6 +279,12 @@ impl ClientOptions {
 
         let js_ctx = jetstream::new(client.clone());
 
+        // Validate JetStream is available
+        js_ctx
+            .query_account()
+            .await
+            .map_err(|e| anyhow::anyhow!("JetStream not available: {e}"))?;
+
         Ok(Client { client, js_ctx })
     }
 }


### PR DESCRIPTION
#### Overview:

Some Dynamo components start fine when NATS runs without JetStream, but JetStream is required.
Frontend connects successfully because it only checks plain NATS, not JetStream, so the failure is deferred until workers actually use JetStream features.


#### Details:

Fix: validate JetStream at startup (e.g. js_ctx.query_account().await?) and update docs/tests to require nats-server --js.

testing:
start nats `nats-server &` start etcd
after the fix nats without js and running `python -m dynamo.frontend` yield
```
python -m dynamo.frontend                 
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/lanqing/repos/risingwave/.venv/lib/python3.12/site-packages/dynamo/frontend/__main__.py", line 7, in <module>
    main()
  File "/Users/lanqing/repos/risingwave/.venv/lib/python3.12/site-packages/dynamo/frontend/main.py", line 215, in main
    uvloop.run(async_main())
  File "/Users/lanqing/repos/risingwave/.venv/lib/python3.12/site-packages/uvloop/__init__.py", line 109, in run
    return __asyncio.run(
           ^^^^^^^^^^^^^^
  File "/Users/lanqing/.pyenv/versions/3.12.3/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/lanqing/.pyenv/versions/3.12.3/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/Users/lanqing/repos/risingwave/.venv/lib/python3.12/site-packages/uvloop/__init__.py", line 61, in wrapper
    return await main
           ^^^^^^^^^^
  File "/Users/lanqing/repos/risingwave/.venv/lib/python3.12/site-packages/dynamo/frontend/main.py", line 166, in async_main
    runtime = DistributedRuntime(asyncio.get_running_loop(), is_static)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Exception: JetStream not available: JetStream unavailable: requested JetStream resource does not exist
```

#### Where should the reviewer start?

lib/runtime/src/transports/nats.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: [#2577 ](https://github.com/ai-dynamo/dynamo/issues/2577)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Validates JetStream availability during client connection, ensuring the service is reachable before proceeding.
  - Fails fast with a clear, descriptive error (“JetStream not available: …”) when JetStream cannot be queried.
  - Prevents delayed runtime errors by checking account info immediately after creating the JetStream context.
  - Maintains existing behavior when JetStream is available; the client connects as before.
  - No changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->