### PR TITLE
fix: `skip-tokenizer-init` by default in sglang

### DIFF
--- a/components/backends/sglang/src/dynamo/sglang/args.py
+++ b/components/backends/sglang/src/dynamo/sglang/args.py
@@ -128,9 +128,9 @@ def parse_args(args: list[str]) -> Config:
 
     server_args = ServerArgs.from_cli_args(parsed_args)
 
-    if server_args.skip_tokenizer_init == False:
+    if not server_args.skip_tokenizer_init:
         logging.warning(
-            "When using the dynamo frontend (python3 -m dynamo.frontend), we perform tokenization and detokenization"
+            "When using the dynamo frontend (python3 -m dynamo.frontend), we perform tokenization and detokenization "
             "in the frontend. Automatically setting --skip-tokenizer-init to True."
         )
         server_args.skip_tokenizer_init = True

--- a/components/backends/sglang/src/dynamo/sglang/args.py
+++ b/components/backends/sglang/src/dynamo/sglang/args.py
@@ -128,6 +128,13 @@ def parse_args(args: list[str]) -> Config:
 
     server_args = ServerArgs.from_cli_args(parsed_args)
 
+    if server_args.skip_tokenizer_init == False:
+        logging.warning(
+            "When using the dynamo frontend (python3 -m dynamo.frontend), we perform tokenization and detokenization"
+            "in the frontend. Automatically setting --skip-tokenizer-init to True."
+        )
+        server_args.skip_tokenizer_init = True
+
     return Config(server_args, dynamo_args)
 
 

--- a/components/backends/sglang/src/dynamo/sglang/request_handlers/decode_handler.py
+++ b/components/backends/sglang/src/dynamo/sglang/request_handlers/decode_handler.py
@@ -102,7 +102,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             if finish_reason:
                 out = {"token_ids": [], "finish_reason": finish_reason["type"]}
             else:
-                next_total_toks = len(res["output_ids"])
+                try:
+                    next_total_toks = len(res["output_ids"])
+                except KeyError:
+                    raise ValueError(
+                        f"Missing 'output_ids' in response. This often happens when using skip_tokenizer_init=True. "
+                        f"If you're using ModelType.CHAT or custom model configurations, you may need to modify "
+                        f"the tokenization/detokenization logic in your handler. Response keys: {list(res.keys())}"
+                    ) from None
                 out = {"token_ids": res["output_ids"][num_output_tokens_so_far:]}
                 num_output_tokens_so_far = next_total_toks
 

--- a/components/backends/sglang/src/dynamo/sglang/request_handlers/decode_handler.py
+++ b/components/backends/sglang/src/dynamo/sglang/request_handlers/decode_handler.py
@@ -109,7 +109,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         f"Missing 'output_ids' in response. This often happens when using skip_tokenizer_init=True. "
                         f"If you're using ModelType.CHAT or custom model configurations, you may need to modify "
                         f"the tokenization/detokenization logic in your handler. Response keys: {list(res.keys())}"
-                    ) from None
+                    )
                 out = {"token_ids": res["output_ids"][num_output_tokens_so_far:]}
                 num_output_tokens_so_far = next_total_toks
 


### PR DESCRIPTION
1. auto set `skip-tokenizer-init` when using dynamo components
2. add a key error if output ids is not found - could be the case when someone uses a type != `ModelType.Chat`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically skips backend tokenizer initialization when frontend tokenization is detected, with a clear warning to avoid duplicate work.

* **Bug Fixes**
  * Improved streaming stability by safely handling missing output IDs and providing a descriptive error when configuration conflicts occur (e.g., chat/custom models).
  * Ensures consistent token counting and output slicing during streaming responses, reducing unexpected failures in decode flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->