### PR TITLE
docs: add trtllm known issue for al2023

### DIFF
--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -42,6 +42,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Ubuntu**           | 24.04       | ARM64            | Experimental |
 | **CentOS Stream**    | 9           | x86_64           | Experimental |
 
+
 > [!Note]
 > For **Linux**, the **ARM64** support is experimental and may have limitations.
 > Wheels are built using a manylinux_2_28-compatible environment and they have been validated on CentOS 9 and Ubuntu (22.04, 24.04).
@@ -79,8 +80,11 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 
 | **Host Operating System** | **Version** | **Architecture** | **Status**   |
 | :------------------------ | :---------- | :--------------- | :----------- |
-| **Amazon Linux**          | 2023        | x86_64           | Supported    |
+| **Amazon Linux**          | 2023        | x86_64           | Supported*   |
 
+
+> [!Caution]
+> * There is a known issue with the TensorRT-LLM framework when installed within the AL2023 container via the Python Wheels which makes effective environment setup challenging.
 
 
 ## Build Support

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -71,7 +71,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **NIXL**             | 0.4.1                                                                            |
 
 > [!Important]
-> ² Specific versions of TensorRT-LLM supported by Dynamo are subject to change.
+> Specific versions of TensorRT-LLM supported by Dynamo are subject to change.
 
 ## Cloud Service Provider Compatibility
 
@@ -79,11 +79,11 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 
 | **Host Operating System** | **Version** | **Architecture** | **Status**   |
 | :------------------------ | :---------- | :--------------- | :----------- |
-| **Amazon Linux**          | 2023        | x86_64           | Supported*   |
+| **Amazon Linux**          | 2023        | x86_64           | Supported¹   |
 
 
 > [!Caution]
-> * There is a known issue with the TensorRT-LLM framework when installed within the AL2023 container via the Python Wheels which makes effective environment setup challenging.
+> ¹ There is a known issue with the TensorRT-LLM framework when installed within the AL2023 container via the Python Wheels which makes effective environment setup challenging.
 
 
 ## Build Support

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -42,7 +42,6 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Ubuntu**           | 24.04       | ARM64            | Experimental |
 | **CentOS Stream**    | 9           | x86_64           | Experimental |
 
-
 > [!Note]
 > For **Linux**, the **ARM64** support is experimental and may have limitations.
 > Wheels are built using a manylinux_2_28-compatible environment and they have been validated on CentOS 9 and Ubuntu (22.04, 24.04).


### PR DESCRIPTION
#### Overview:

add trtllm known issue for al2023


ref: OPS-754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated AWS support matrix: Amazon Linux 2023 x86_64 now marked “Supported*” with a clarifying footnote.
  - Added caution notes highlighting a known TensorRT-LLM issue when installed inside the AL2023 container via Python Wheels.
  - No changes to code, APIs, or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->