### PR TITLE
fix: Remove metric_labels from multimodal codes.

### DIFF
--- a/examples/multimodal/components/worker.py
+++ b/examples/multimodal/components/worker.py
@@ -142,7 +142,6 @@ class VllmBaseWorker:
         self.stats_logger = StatLoggerFactory(
             component,
             self.engine_args.data_parallel_rank or 0,
-            metrics_labels=[("model", self.engine_args.model)],
         )
         self.engine_client = AsyncLLM.from_vllm_config(
             vllm_config=vllm_config,


### PR DESCRIPTION
#### Overview:

Remove metric_labels from multimodal codes. 

#### Details:

Multimodal is using different classes from vllm. Remove metric labels to unblock. Will add metric_labels if needed in the future.

#### Where should the reviewer start?

examples/multimodal/components/worker.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-444 feat: Add model label for vllm backend metrics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated statistics logging to remove model-specific labels, aligning with the current metrics schema.
  - No changes to functionality or performance; engine initialization and behavior remain the same.
  - Monitoring/telemetry dashboards may now show aggregated metrics without per-model breakdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->