### PR TITLE
test: Temporary exclude kvbm tests from vllm, nightly, gpu1...

### DIFF
--- a/tests/kvbm/test_determinism.py
+++ b/tests/kvbm/test_determinism.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
@@ -32,10 +31,10 @@ import requests
 # Todo: enable the rest when kvbm is built in the ci
 pytestmark = [
     pytest.mark.kvbm,
-#    pytest.mark.e2e,
-#    pytest.mark.slow,
-#    pytest.mark.nightly,
-#    pytest.mark.gpu_1,
+    #    pytest.mark.e2e,
+    #    pytest.mark.slow,
+    #    pytest.mark.nightly,
+    #    pytest.mark.gpu_1,
 ]
 
 

--- a/tests/kvbm/test_determinism.py
+++ b/tests/kvbm/test_determinism.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
@@ -28,12 +29,13 @@ import pytest
 import requests
 
 # Test markers to align with repository conventions
+# Todo: enable the rest when kvbm is built in the ci
 pytestmark = [
     pytest.mark.kvbm,
-    pytest.mark.e2e,
-    pytest.mark.slow,
-    pytest.mark.nightly,
-    pytest.mark.gpu_1,
+#    pytest.mark.e2e,
+#    pytest.mark.slow,
+#    pytest.mark.nightly,
+#    pytest.mark.gpu_1,
 ]
 
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Streamlined test marker configuration for KVBM determinism tests to align with current CI capabilities. This affects only how tests are selected in CI and has no impact on product functionality or performance.

- Chores
  - Added a note to re-enable broader test coverage (e.g., end-to-end, slow, nightly, GPU) once CI support is available, improving future test planning without affecting the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->