### PR TITLE
docs: fix doc for kvbm

### DIFF
--- a/docs/guides/run_kvbm_in_vllm.md
+++ b/docs/guides/run_kvbm_in_vllm.md
@@ -27,7 +27,7 @@ To use KVBM in vLLM, you can follow the steps below:
 
 ```bash
 # start up etcd for KVBM leader/worker registration and discovery
-docker compose -f deploy/metrics/docker-compose.yml up -d
+docker compose -f deploy/docker-compose.yml up -d
 
 # build a container containing vllm and kvbm
 ./container/build.sh --framework vllm --enable-kvbm


### PR DESCRIPTION
Fix deploy docker compose path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the Quick Start guide for running KVBM in vLLM to reference the correct etcd startup command.
  - The docker-compose path now points to deploy/docker-compose.yml (previously deploy/metrics/docker-compose.yml).
  - Improves accuracy of setup instructions while leaving all other steps unchanged.
  - No functional changes to the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->