### PR TITLE
fix: prevent crash looping hello world

### DIFF
--- a/examples/runtime/hello_world/client.py
+++ b/examples/runtime/hello_world/client.py
@@ -31,10 +31,15 @@ async def worker(runtime: DistributedRuntime):
     client = await endpoint.client()
     await client.wait_for_instances()
 
-    # Issue request and process the stream
-    stream = await client.generate("world,sun,moon,star")
-    async for response in stream:
-        print(response.data())
+    idx = 0
+    while True:
+        # Issue request and process the stream
+        idx += 1
+        stream = await client.generate(f"Query[{idx}] world,sun,moon,star")
+        async for response in stream:
+            print(response.data())
+        # Sleep for 1 second
+        await asyncio.sleep(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Overview:

Prevent crashloops in helloworld k8s example

nvbug: https://nvbugspro.nvidia.com/bug/5471412
closes: DYN-926

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The hello_world example now continuously issues streaming requests at 1-second intervals, labeling each request sequentially and printing all streamed responses.
* **Documentation**
  * Updated the example to demonstrate repeated, tagged streaming requests instead of a single run, helping users see continuous streaming behavior in practice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->