### PR TITLE
feat: add multimodal deployment example for llava based on vllm v1 

### DIFF
--- a/examples/multimodal/deploy/agg_llava.yaml
+++ b/examples/multimodal/deploy/agg_llava.yaml
@@ -74,6 +74,8 @@ spec:
           env:
             - name: MODEL_NAME
               value: llava-hf/llava-1.5-7b-hf
+            - name: PROMPT_TEMPLATE
+              value: "USER: <image>\n<prompt> ASSISTANT:"
           command:
             - /bin/sh
             - -c

--- a/examples/multimodal/deploy/agg_llava.yaml
+++ b/examples/multimodal/deploy/agg_llava.yaml
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: agg-llava
+spec:
+  backendFramework: vllm
+  services:
+    Frontend:
+      dynamoNamespace: agg-llava
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: my-registry/vllm-runtime:my-tag
+    EncodeWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: agg-llava
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: my-registry/vllm-runtime:my-tag
+          workingDir: /workspace/examples/multimodal
+          env:
+            - name: MODEL_NAME
+              value: llava-hf/llava-1.5-7b-hf
+            - name: PROMPT_TEMPLATE
+              value: "USER: <image>\n<prompt> ASSISTANT:"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 components/encode_worker.py --model $MODEL_NAME
+    VLMWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: agg-llava
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: my-registry/vllm-runtime:my-tag
+          workingDir: /workspace/examples/multimodal
+          env:
+            - name: MODEL_NAME
+              value: llava-hf/llava-1.5-7b-hf
+            - name: PROMPT_TEMPLATE
+              value: "USER: <image>\n<prompt> ASSISTANT:"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 components/worker.py --model $MODEL_NAME --worker-type prefill
+    Processor:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: agg-llava
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: my-registry/vllm-runtime:my-tag
+          workingDir: /workspace/examples/multimodal
+          env:
+            - name: MODEL_NAME
+              value: llava-hf/llava-1.5-7b-hf
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 components/processor.py --model $MODEL_NAME --prompt-template "$PROMPT_TEMPLATE"

--- a/examples/multimodal/deploy/agg_llava.yaml
+++ b/examples/multimodal/deploy/agg_llava.yaml
@@ -27,16 +27,11 @@ spec:
         mainContainer:
           image: my-registry/vllm-runtime:my-tag
           workingDir: /workspace/examples/multimodal
-          env:
-            - name: MODEL_NAME
-              value: llava-hf/llava-1.5-7b-hf
-            - name: PROMPT_TEMPLATE
-              value: "USER: <image>\n<prompt> ASSISTANT:"
           command:
             - /bin/sh
             - -c
           args:
-            - python3 components/encode_worker.py --model $MODEL_NAME
+            - python3 components/encode_worker.py --model llava-hf/llava-1.5-7b-hf
     VLMWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: agg-llava
@@ -49,16 +44,11 @@ spec:
         mainContainer:
           image: my-registry/vllm-runtime:my-tag
           workingDir: /workspace/examples/multimodal
-          env:
-            - name: MODEL_NAME
-              value: llava-hf/llava-1.5-7b-hf
-            - name: PROMPT_TEMPLATE
-              value: "USER: <image>\n<prompt> ASSISTANT:"
           command:
             - /bin/sh
             - -c
           args:
-            - python3 components/worker.py --model $MODEL_NAME --worker-type prefill
+            - python3 components/worker.py --model llava-hf/llava-1.5-7b-hf --worker-type prefill
     Processor:
       envFromSecret: hf-token-secret
       dynamoNamespace: agg-llava
@@ -71,13 +61,8 @@ spec:
         mainContainer:
           image: my-registry/vllm-runtime:my-tag
           workingDir: /workspace/examples/multimodal
-          env:
-            - name: MODEL_NAME
-              value: llava-hf/llava-1.5-7b-hf
-            - name: PROMPT_TEMPLATE
-              value: "USER: <image>\n<prompt> ASSISTANT:"
           command:
             - /bin/sh
             - -c
           args:
-            - python3 components/processor.py --model $MODEL_NAME --prompt-template "$PROMPT_TEMPLATE"
+            - 'python3 components/processor.py --model llava-hf/llava-1.5-7b-hf --prompt-template "USER: <image>\n<prompt> ASSISTANT:"'


### PR DESCRIPTION
#### Overview:

Add multimodal example for llava based on vllm v1
closes: dyn-932
nvbug: https://nvbugspro.nvidia.com/bug/5472070



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduces an example multimodal deployment (agg-llava) for image+text understanding using a VLM backend.
  * Provides a ready-to-run manifest with a frontend and GPU-powered workers, secured via secret-based authentication.
  * Supports configurable model and prompt template with sensible defaults.
  * Enables quick spin-up of a single-replica pipeline in an isolated namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<img width="1043" height="168" alt="Screenshot 2025-08-21 at 8 18 25 PM" src="https://github.com/user-attachments/assets/41e83648-be23-4e69-8f2d-8dbd68abc75d" />

--------
<img width="1423" height="626" alt="Screenshot 2025-08-21 at 8 19 54 PM" src="https://github.com/user-attachments/assets/1917e915-c07c-40f2-8e91-9530915340df" />

