### PR TITLE
chore: use token ids for reasoning parsing instead of strings directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +351,29 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av1-grain"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3efb2ca85bc610acfa917b5aaa36f3fcbebed5b3182d7f877b02531c4b80c8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 7.1.3",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -694,6 +728,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bitstream-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
 name = "blake3"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,8 +793,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
+ "regex-automata 0.4.9",
  "serde",
 ]
+
+[[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
@@ -1991,6 +2038,7 @@ version = "0.4.1"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
+ "openai-harmony",
  "regex",
  "serde",
  "serde_json",
@@ -2351,6 +2399,17 @@ checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set 0.5.3",
  "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3131,6 +3190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hf-hub"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,6 +3613,9 @@ dependencies = [
  "num-traits",
  "png",
  "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
  "tiff",
  "zune-core",
  "zune-jpeg",
@@ -3564,6 +3632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imgref"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,6 +3645,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3628,6 +3703,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if 1.0.1",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3699,6 +3785,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -3864,6 +3959,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3975,6 +4080,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
 
 [[package]]
 name = "lrtable"
@@ -4091,6 +4205,16 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if 1.0.1",
+ "rayon",
 ]
 
 [[package]]
@@ -4383,7 +4507,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustfft",
  "safetensors 0.6.1",
- "schemars",
+ "schemars 0.8.22",
  "scraper",
  "serde",
  "serde-big-array",
@@ -4703,6 +4827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4775,6 +4905,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "num-integer"
@@ -4947,6 +5088,29 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openai-harmony"
+version = "0.0.4"
+source = "git+https://github.com/openai/harmony#508cbaa7f6b0277bd37c9bdf6d4dc8a4d51aada5"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bstr",
+ "clap 4.5.42",
+ "fancy-regex 0.13.0",
+ "futures",
+ "image",
+ "regex",
+ "reqwest 0.12.22",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha1",
+ "sha2",
+ "thiserror 2.0.12",
+]
 
 [[package]]
 name = "openssl"
@@ -5438,6 +5602,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5778,6 +5961,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if 1.0.1",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "simd_helpers",
+ "system-deps",
+ "thiserror 1.0.69",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.11.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5825c26fddd16ab9f515930d49028a630efec172e903483c94796cfe31893e6b"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error 2.0.1",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5871,6 +6104,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6024,6 +6277,12 @@ dependencies = [
  "reqwest 0.12.22",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "ring"
@@ -6419,6 +6678,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6664,6 +6947,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6823,6 +7138,15 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "similar"
@@ -8310,6 +8634,17 @@ dependencies = [
  "getrandom 0.3.3",
  "js-sys",
  "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 

--- a/lib/llm/src/engines.rs
+++ b/lib/llm/src/engines.rs
@@ -183,7 +183,7 @@ impl
         incoming_request: SingleIn<NvCreateChatCompletionRequest>,
     ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
         let (request, context) = incoming_request.transfer(());
-        let mut deltas = request.response_generator();
+        let mut deltas = request.response_generator(None, None);
         let ctx = context.context();
         let req = request.inner.messages.into_iter().next_back().unwrap();
 
@@ -204,12 +204,12 @@ impl
             for c in prompt.chars() {
                 // we are returning characters not tokens, so there will be some postprocessing overhead
                 tokio::time::sleep(*TOKEN_ECHO_DELAY).await;
-                let response = deltas.create_choice(0, Some(c.to_string()), None, None);
+                let response = deltas.create_choice(0, Some(c.to_string()), None, None, None);
                 yield Annotated{ id: Some(id.to_string()), data: Some(response), event: None, comment: None };
                 id += 1;
             }
 
-            let response = deltas.create_choice(0, None, Some(dynamo_async_openai::types::FinishReason::Stop), None);
+            let response = deltas.create_choice(0, None, None, Some(dynamo_async_openai::types::FinishReason::Stop), None);
             yield Annotated { id: Some(id.to_string()), data: Some(response), event: None, comment: None };
         };
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -129,7 +129,7 @@ impl OpenAIPreprocessor {
             tokenizer,
             model_info,
             mdcsum,
-            vocab
+            vocab,
         }))
     }
 
@@ -502,7 +502,8 @@ impl
         let (request, context) = request.into_parts();
 
         // create a response generator
-        let response_generator = request.response_generator(None, None);
+        let response_generator =
+            request.response_generator(Some(&self.tokenizer), Some(&self.vocab));
         let mut response_generator = Box::new(response_generator);
 
         // convert the chat completion request to a common completion request

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -94,6 +94,7 @@ pub struct OpenAIPreprocessor {
     formatter: Arc<dyn OAIPromptFormatter>,
     tokenizer: Arc<dyn Tokenizer>,
     model_info: Arc<dyn ModelInfo>,
+    vocab: HashMap<String, u32>,
 }
 
 impl OpenAIPreprocessor {
@@ -113,6 +114,7 @@ impl OpenAIPreprocessor {
                 );
             }
         };
+        let vocab = tokenizer.get_vocab(true);
         let tokenizer = Arc::new(tokenizer);
 
         let Some(model_info) = mdc.model_info else {
@@ -127,6 +129,7 @@ impl OpenAIPreprocessor {
             tokenizer,
             model_info,
             mdcsum,
+            vocab
         }))
     }
 
@@ -499,7 +502,7 @@ impl
         let (request, context) = request.into_parts();
 
         // create a response generator
-        let response_generator = request.response_generator();
+        let response_generator = request.response_generator(None, None);
         let mut response_generator = Box::new(response_generator);
 
         // convert the chat completion request to a common completion request

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -28,7 +28,7 @@ use super::{
 };
 
 pub mod aggregator;
-mod delta;
+pub mod delta;
 
 pub use aggregator::DeltaAggregator;
 pub use delta::DeltaGenerator;

--- a/lib/llm/src/tokenizers/hf.rs
+++ b/lib/llm/src/tokenizers/hf.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use tokenizers::tokenizer::Tokenizer as HfTokenizer;
 
 use super::{
@@ -34,6 +36,10 @@ impl HuggingFaceTokenizer {
 
     pub fn from_tokenizer(tokenizer: HfTokenizer) -> Self {
         HuggingFaceTokenizer { tokenizer }
+    }
+
+    pub fn get_vocab(&self, with_added_tokens: bool) -> HashMap<String, u32> {
+        self.tokenizer.get_vocab(with_added_tokens)
     }
 }
 

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -95,12 +95,12 @@ impl
         let max_tokens = request.inner.max_tokens.unwrap_or(0) as u64;
 
         // let generator = NvCreateChatCompletionStreamResponse::generator(request.model.clone());
-        let mut generator = request.response_generator();
+        let mut generator = request.response_generator(None, None);
 
         let stream = stream! {
             tokio::time::sleep(std::time::Duration::from_millis(max_tokens)).await;
             for i in 0..10 {
-                let output = generator.create_choice(i,Some(format!("choice {i}")), None, None);
+                let output = generator.create_choice(i,Some(format!("choice {i}")), None, None, None);
 
                 yield Annotated::from_data(output);
             }

--- a/lib/parsers/Cargo.toml
+++ b/lib/parsers/Cargo.toml
@@ -33,3 +33,4 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 regex = "1"
+openai-harmony = { git = "https://github.com/openai/harmony", version = "0.0.4" }

--- a/lib/parsers/src/reasoning/deepseek_r1_parser.rs
+++ b/lib/parsers/src/reasoning/deepseek_r1_parser.rs
@@ -20,18 +20,18 @@ impl DeepseekR1ReasoningParser {
                 "</think>".to_string(),
                 true,
                 true,
-                vocab
+                vocab,
             ),
         }
     }
 }
 
 impl ReasoningParser for DeepseekR1ReasoningParser {
-    fn parse_reasoning_streaming_incremental(&mut self, token_ids: &Vec<u32>) -> ParserResult {
+    fn parse_reasoning_streaming_incremental(&mut self, token_ids: &[u32]) -> ParserResult {
         self.base.parse_reasoning_streaming_incremental(token_ids)
     }
 
-    fn detect_and_parse_reasoning(&self, token_ids: &Vec<u32>) -> ParserResult {
+    fn detect_and_parse_reasoning(&self, token_ids: &[u32]) -> ParserResult {
         self.base.detect_and_parse_reasoning(token_ids)
     }
 }

--- a/lib/parsers/src/reasoning/deepseek_r1_parser.rs
+++ b/lib/parsers/src/reasoning/deepseek_r1_parser.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use super::base_parser::BasicReasoningParser;
 use crate::ParserResult;
 use crate::ReasoningParser;
@@ -11,24 +13,25 @@ pub struct DeepseekR1ReasoningParser {
 }
 
 impl DeepseekR1ReasoningParser {
-    pub fn new() -> Self {
+    pub fn new(vocab: &HashMap<String, u32>) -> Self {
         Self {
             base: BasicReasoningParser::new(
                 "<think>".to_string(),
                 "</think>".to_string(),
                 true,
                 true,
+                vocab
             ),
         }
     }
 }
 
 impl ReasoningParser for DeepseekR1ReasoningParser {
-    fn parse_reasoning_streaming_incremental(&mut self, text: &str) -> ParserResult {
-        self.base.parse_reasoning_streaming_incremental(text)
+    fn parse_reasoning_streaming_incremental(&mut self, token_ids: &Vec<u32>) -> ParserResult {
+        self.base.parse_reasoning_streaming_incremental(token_ids)
     }
 
-    fn detect_and_parse_reasoning(&self, text: &str) -> ParserResult {
-        self.base.detect_and_parse_reasoning(text)
+    fn detect_and_parse_reasoning(&self, token_ids: &Vec<u32>) -> ParserResult {
+        self.base.detect_and_parse_reasoning(token_ids)
     }
 }

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::Deref;
+
+use crate::ParserResult;
+use crate::ReasoningParser;
+
+use openai_harmony::chat::TextContent;
+use openai_harmony::StreamableParser;
+use openai_harmony::{load_harmony_encoding, HarmonyEncodingName, HarmonyEncoding, chat::Role};
+
+#[derive(Debug)]
+pub struct GptOssReasoningParser {
+    enc: HarmonyEncoding,
+}
+
+impl GptOssReasoningParser {
+    pub fn new() -> Self {
+        let enc = load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss).unwrap();
+        Self { enc }
+    }
+}
+
+impl GptOssReasoningParser {
+    fn reason_parsing_wrapper(&self, token_ids: &[u32]) -> ParserResult {
+        let mut parser = StreamableParser::new(self.enc.clone(), Some(Role::Assistant)).unwrap();
+        for token_id in token_ids {
+            parser.process(*token_id).unwrap();
+        }
+        let output_msgs = parser.messages();
+        // let mut reasoning_token_ids = vec![];
+        // let mut normal_token_ids = vec![];
+        match output_msgs.len() {
+            0 => {
+                return ParserResult {
+                    normal_token_ids: vec![], // No normal text in this example
+                    reasoning_token_ids: self.enc.tokenizer().encode_with_special_tokens(parser.current_content().unwrap().deref()),
+                }
+            },
+            1 => {
+                let mut reasoning_token_ids = vec![];
+                if let Some(openai_harmony::chat::Content::Text(TextContent { text })) = output_msgs[0].content.first() {
+                    reasoning_token_ids.extend(self.enc.tokenizer().encode_with_special_tokens(text));
+                }
+                return ParserResult {
+                    normal_token_ids: self.enc.tokenizer().encode_with_special_tokens(parser.current_content().unwrap().deref()),
+                    reasoning_token_ids: reasoning_token_ids,
+                };
+            },
+            _ => {
+                let mut reasoning_token_ids = vec![];
+                let mut normal_token_ids = vec![];
+
+                // Loop until second last message
+                for i in 0..(output_msgs.len() - 1) {
+                    let parse_msg = &output_msgs[i]; 
+                    if let Some(openai_harmony::chat::Content::Text(TextContent { text })) = parse_msg.content.first() {
+                        reasoning_token_ids.extend(self.enc.tokenizer().encode_with_special_tokens(text));
+                    }
+                }
+
+                let last_msg = &output_msgs[output_msgs.len() - 1];
+
+                // Handle the last message
+                if let Some(openai_harmony::chat::Content::Text(TextContent { text })) = last_msg.content.first() {
+                    normal_token_ids.extend(self.enc.tokenizer().encode_with_special_tokens(text));
+                }
+
+                return ParserResult {
+                    normal_token_ids,
+                    reasoning_token_ids,
+                };
+            }
+        }
+    }
+}
+
+impl ReasoningParser for  GptOssReasoningParser {
+
+    fn detect_and_parse_reasoning(&self, token_ids: &[u32]) -> ParserResult {
+        self.reason_parsing_wrapper(token_ids)
+    }
+
+    fn parse_reasoning_streaming_incremental(&mut self, token_ids: &[u32]) -> ParserResult {
+        self.reason_parsing_wrapper(token_ids)
+    }
+    
+}

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -40,12 +40,12 @@ pub trait ReasoningParser: Send + std::fmt::Debug {
     /// Parses a standalone, non-streaming input chunk. Implementations may reset or ignore
     /// internal streaming state and should return the split of normal vs reasoning text for
     /// this complete input. Marker tokens must not be included in either output.
-    fn detect_and_parse_reasoning(&self, token_ids: &Vec<u32>) -> ParserResult;
+    fn detect_and_parse_reasoning(&self, token_ids: &[u32]) -> ParserResult;
 
     /// Parses a streaming chunk and updates internal state. The return value should be the
     /// delta: only the newly discovered normal and reasoning text attributable to this chunk
     /// (not the cumulative totals). Marker tokens must not be included in either output.
-    fn parse_reasoning_streaming_incremental(&mut self, token_ids: &Vec<u32>) -> ParserResult;
+    fn parse_reasoning_streaming_incremental(&mut self, token_ids: &[u32]) -> ParserResult;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -61,11 +61,11 @@ pub struct ReasoningParserWrapper {
 }
 
 impl ReasoningParser for ReasoningParserWrapper {
-    fn detect_and_parse_reasoning(&self, token_ids: &Vec<u32>) -> ParserResult {
+    fn detect_and_parse_reasoning(&self, token_ids: &[u32]) -> ParserResult {
         self.parser.detect_and_parse_reasoning(token_ids)
     }
 
-    fn parse_reasoning_streaming_incremental(&mut self, token_ids: &Vec<u32>) -> ParserResult {
+    fn parse_reasoning_streaming_incremental(&mut self, token_ids: &[u32]) -> ParserResult {
         self.parser.parse_reasoning_streaming_incremental(token_ids)
     }
 }
@@ -82,7 +82,7 @@ impl ReasoningParserType {
                     "</think>".into(),
                     false,
                     true,
-                    vocab
+                    vocab,
                 )),
             },
         }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -3,6 +3,7 @@
 
 mod base_parser;
 mod deepseek_r1_parser;
+mod gpt_oss_parser;
 
 use std::collections::HashMap;
 
@@ -17,24 +18,6 @@ pub struct ParserResult {
     /// The extracted reasoning text from within reasoning blocks.
     pub reasoning_token_ids: Vec<u32>,
 }
-
-// impl ParserResult {
-//     pub fn get_some_reasoning(&self) -> Option<Vec<u32>> {
-//         if self.reasoning_token_ids.is_empty() {
-//             None
-//         } else {
-//             Some(self.reasoning_token_ids.clone())
-//         }
-//     }
-
-//     pub fn get_some_normal_text(&self) -> Option<Vec<u32>> {
-//         if self.normal_token_ids.is_empty() {
-//             None
-//         } else {
-//             Some(self.normal_token_ids.clone())
-//         }
-//     }
-// }
 
 pub trait ReasoningParser: Send + std::fmt::Debug {
     /// Parses a standalone, non-streaming input chunk. Implementations may reset or ignore
@@ -53,6 +36,7 @@ pub trait ReasoningParser: Send + std::fmt::Debug {
 pub enum ReasoningParserType {
     DeepseekR1,
     Basic,
+    GptOss,
 }
 
 #[derive(std::fmt::Debug)]
@@ -84,6 +68,9 @@ impl ReasoningParserType {
                     true,
                     vocab,
                 )),
+            },
+            ReasoningParserType::GptOss => ReasoningParserWrapper {
+                parser: Box::new(gpt_oss_parser::GptOssReasoningParser::new()),
             },
         }
     }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -4,6 +4,8 @@
 mod base_parser;
 mod deepseek_r1_parser;
 
+use std::collections::HashMap;
+
 // Re-export main types and functions for convenience
 pub use base_parser::BasicReasoningParser;
 pub use deepseek_r1_parser::DeepseekR1ReasoningParser;
@@ -11,40 +13,39 @@ pub use deepseek_r1_parser::DeepseekR1ReasoningParser;
 #[derive(Debug, Clone, Default)]
 pub struct ParserResult {
     /// The normal text outside of reasoning blocks.
-    pub normal_text: String,
-
+    pub normal_token_ids: Vec<u32>,
     /// The extracted reasoning text from within reasoning blocks.
-    pub reasoning_text: String,
+    pub reasoning_token_ids: Vec<u32>,
 }
 
-impl ParserResult {
-    pub fn get_some_reasoning(&self) -> Option<String> {
-        if self.reasoning_text.is_empty() {
-            None
-        } else {
-            Some(self.reasoning_text.clone())
-        }
-    }
+// impl ParserResult {
+//     pub fn get_some_reasoning(&self) -> Option<Vec<u32>> {
+//         if self.reasoning_token_ids.is_empty() {
+//             None
+//         } else {
+//             Some(self.reasoning_token_ids.clone())
+//         }
+//     }
 
-    pub fn get_some_normal_text(&self) -> Option<String> {
-        if self.normal_text.is_empty() {
-            None
-        } else {
-            Some(self.normal_text.clone())
-        }
-    }
-}
+//     pub fn get_some_normal_text(&self) -> Option<Vec<u32>> {
+//         if self.normal_token_ids.is_empty() {
+//             None
+//         } else {
+//             Some(self.normal_token_ids.clone())
+//         }
+//     }
+// }
 
 pub trait ReasoningParser: Send + std::fmt::Debug {
     /// Parses a standalone, non-streaming input chunk. Implementations may reset or ignore
     /// internal streaming state and should return the split of normal vs reasoning text for
     /// this complete input. Marker tokens must not be included in either output.
-    fn detect_and_parse_reasoning(&self, text: &str) -> ParserResult;
+    fn detect_and_parse_reasoning(&self, token_ids: &Vec<u32>) -> ParserResult;
 
     /// Parses a streaming chunk and updates internal state. The return value should be the
     /// delta: only the newly discovered normal and reasoning text attributable to this chunk
     /// (not the cumulative totals). Marker tokens must not be included in either output.
-    fn parse_reasoning_streaming_incremental(&mut self, text: &str) -> ParserResult;
+    fn parse_reasoning_streaming_incremental(&mut self, token_ids: &Vec<u32>) -> ParserResult;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,20 +61,20 @@ pub struct ReasoningParserWrapper {
 }
 
 impl ReasoningParser for ReasoningParserWrapper {
-    fn detect_and_parse_reasoning(&self, text: &str) -> ParserResult {
-        self.parser.detect_and_parse_reasoning(text)
+    fn detect_and_parse_reasoning(&self, token_ids: &Vec<u32>) -> ParserResult {
+        self.parser.detect_and_parse_reasoning(token_ids)
     }
 
-    fn parse_reasoning_streaming_incremental(&mut self, text: &str) -> ParserResult {
-        self.parser.parse_reasoning_streaming_incremental(text)
+    fn parse_reasoning_streaming_incremental(&mut self, token_ids: &Vec<u32>) -> ParserResult {
+        self.parser.parse_reasoning_streaming_incremental(token_ids)
     }
 }
 
 impl ReasoningParserType {
-    pub fn get_reasoning_parser(self) -> ReasoningParserWrapper {
+    pub fn get_reasoning_parser(self, vocab: &HashMap<String, u32>) -> ReasoningParserWrapper {
         match self {
             ReasoningParserType::DeepseekR1 => ReasoningParserWrapper {
-                parser: Box::new(DeepseekR1ReasoningParser::new()),
+                parser: Box::new(DeepseekR1ReasoningParser::new(vocab)),
             },
             ReasoningParserType::Basic => ReasoningParserWrapper {
                 parser: Box::new(BasicReasoningParser::new(
@@ -81,6 +82,7 @@ impl ReasoningParserType {
                     "</think>".into(),
                     false,
                     true,
+                    vocab
                 )),
             },
         }


### PR DESCRIPTION
#### Overview:

Use token ids directly instead of pure strings for reasoning parsers, also add a way through which tokenizer and vocab can be provided to the postprocessing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Streaming chat responses can now include separate “reasoning” content when available, alongside normal output.
  - Improved tokenization-aware streaming for smoother, more accurate partial outputs and logprobs.
  - Exposed advanced streaming delta utilities for deeper integrations.

- Refactor
  - Upgraded underlying streaming and parsing pipeline to operate on token IDs for better performance and reliability.
  - Consolidated generator initialization to a single, request-based entry point for consistency across the app.

- Tests
  - Updated tests to reflect token ID–based parsing and new streaming behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->