### PR TITLE
docs: update trtllm know issue message

### DIFF
--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -83,7 +83,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 
 
 > [!Caution]
-> ¹ There is a known issue with the TensorRT-LLM framework when installed within the AL2023 container via the Python Wheels which makes effective environment setup challenging.
+> ¹ There is a known issue with the TRTLLM framework when running the AL2023 container locally with `docker run --network host ...` due to a [bug](https://github.com/mpi4py/mpi4py/discussions/491#discussioncomment-12660609) in mpi4py. To avoid this issue, replace the `--network host` flag with more precise networking configuration by mapping only the necessary ports (e.g., 4222 for nats, 2379/2380 for etcd, 8080 for frontend).
 
 
 ## Build Support

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -83,7 +83,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 
 
 > [!Caution]
-> ¹ There is a known issue with the TRTLLM framework when running the AL2023 container locally with `docker run --network host ...` due to a [bug](https://github.com/mpi4py/mpi4py/discussions/491#discussioncomment-12660609) in mpi4py. To avoid this issue, replace the `--network host` flag with more precise networking configuration by mapping only the necessary ports (e.g., 4222 for nats, 2379/2380 for etcd, 8080 for frontend).
+> ¹ There is a known issue with the TensorRT-LLM framework when running the AL2023 container locally with `docker run --network host ...` due to a [bug](https://github.com/mpi4py/mpi4py/discussions/491#discussioncomment-12660609) in mpi4py. To avoid this issue, replace the `--network host` flag with more precise networking configuration by mapping only the necessary ports (e.g., 4222 for nats, 2379/2380 for etcd, 8080 for frontend).
 
 
 ## Build Support


### PR DESCRIPTION
#### Overview:

Update the trtllm al2023 known issue to be more precise

ref: OPS-754


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the support matrix to clarify a networking issue when running the AL2023 container locally with host networking, referencing a known mpi4py-related problem.
  * Added guidance to avoid host networking and use explicit port mappings instead, with examples (e.g., 4222 for NATS, 2379/2380 for etcd, 8080 for the frontend).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->