### PR TITLE
feat: support HF_HOME/_ENDPOINT env for Hugging Face models

### DIFF
--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -42,7 +42,7 @@ fn is_weight_file(filename: &str) -> bool {
 pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Result<PathBuf> {
     let name = name.as_ref();
     let token = env::var(HF_TOKEN_ENV_VAR).ok();
-    let api = ApiBuilder::new()
+    let api = ApiBuilder::from_env()
         .with_progress(true)
         .with_token(token)
         .high()


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This PR adds support for the `HF_HOME` and `HF_ENDPOINT` environment variables, allowing the use of already downloaded models or a Hugging Face cache server.

#### Details:

<!-- Describe the changes made in this PR. -->
Replaced `hf_hub::api::tokio::ApiBuilder::new()` with `hf_hub::api::tokio::ApiBuilder::from_env()`.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

`lib/llm/src/hub.rs`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: https://github.com/ai-dynamo/dynamo/issues/2631

#### Test

Before this PR, DecodeWorkers did not work. After this change, the following tests pass.

<details>

<summary>hf_home_test.yaml</summary>

```yaml
apiVersion: nvidia.com/v1alpha1
kind: DynamoGraphDeployment
metadata:
  name: pd
  namespace: dynamo-cloud
spec:
  envs:
    - name: HF_HOME
      value: /models
    - name: HF_HUB_OFFLINE
      value: "1"
  services:
    # ...
    VllmDecodeWorker:
      # ...
      pvc:
        name: models
        mountPoint: /models
      extraPodSpec:
        mainContainer:
          image: 192.168.212.30:1780/moreh/hyeonki/dynamo:v0.4.0.3
          command:
            - python3
            - -m
            - dynamo.vllm
          args:
            - --model
            - meta-llama/Meta-Llama-3-8B
    VllmPrefillWorker:
      # ...
      pvc:
        name: models
        mountPoint: /models
      extraPodSpec:
        mainContainer:
          image: 192.168.212.30:1780/moreh/hyeonki/dynamo:v0.4.0.3
          command:
            - python3
            - -m
            - dynamo.vllm
          args:
            - --model
            - meta-llama/Meta-Llama-3-8B
            - --is-prefill-worker
```

</details>


<details>

<summary>hf_endpoint_test.yaml</summary>

```yaml
apiVersion: nvidia.com/v1alpha1
kind: DynamoGraphDeployment
metadata:
  name: pd
  namespace: dynamo-cloud
spec:
  envs:
    - name: HF_ENDPOINT
      value: http://192.168.212.30:8090
  services:
    # ...
    VllmDecodeWorker:
      # ...
      extraPodSpec:
        mainContainer:
          image: 192.168.212.30:1780/moreh/hyeonki/dynamo:v0.4.0.3
          command:
            - python3
            - -m
            - dynamo.vllm
          args:
            - --model
            - meta-llama/Meta-Llama-3-8B
    VllmPrefillWorker:
      # ...
      extraPodSpec:
        mainContainer:
          image: 192.168.212.30:1780/moreh/hyeonki/dynamo:v0.4.0.3
          command:
            - python3
            - -m
            - dynamo.vllm
          args:
            - --model
            - meta-llama/Meta-Llama-3-8B
            - --is-prefill-worker
```

</details>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Switched external API client initialization to automatically read configuration from environment variables.
  * Preserves existing behavior (e.g., progress display and authentication) while aligning with env-based setup.
  * No changes to public interfaces or user-facing commands.
* **Chores**
  * Internal construction streamlined for consistency with environment-driven configuration.
  * Expected to reduce manual setup friction without impacting current workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->