### PR TITLE
fix: do not fail if backendFramework cannot be detected

### DIFF
--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -1012,7 +1012,7 @@ func detectBackendFrameworkFromArgs(command []string, args []string) (BackendFra
 	}
 
 	if len(detected) == 0 {
-		return "", fmt.Errorf("no backend framework detected from command: %q", fullCommand)
+		return BackendFrameworkNoop, nil
 	}
 
 	if len(detected) > 1 {
@@ -1059,13 +1059,13 @@ func determineBackendFramework(
 	}
 
 	// Validate consistency if both detected and explicit exist
-	if detectedFramework != "" && explicitFramework != "" && detectedFramework != explicitFramework {
+	if detectedFramework != "" && detectedFramework != BackendFrameworkNoop && explicitFramework != "" && detectedFramework != explicitFramework {
 		return "", fmt.Errorf("backend framework mismatch: detected %q from command but explicitly configured as %q",
 			detectedFramework, explicitFramework)
 	}
 
 	// Return in order of preference: detected > explicit > error
-	if detectedFramework != "" {
+	if detectedFramework != "" && detectedFramework != BackendFrameworkNoop {
 		return detectedFramework, nil
 	}
 
@@ -1079,7 +1079,7 @@ func determineBackendFramework(
 	}
 
 	// No command/args to detect from and no explicit config
-	return "", fmt.Errorf("backend framework must be specified explicitly or detectable from command/args")
+	return BackendFrameworkNoop, nil
 }
 
 // getBackendFrameworkFromComponent attempts to determine backend framework using hybrid approach:

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -3626,10 +3626,10 @@ func TestDetectBackendFrameworkFromArgs(t *testing.T) {
 			expected: BackendFrameworkSGLang,
 		},
 		{
-			name:        "no backend detected",
-			command:     []string{"/bin/sh", "-c"},
-			args:        []string{"echo hello world"},
-			expectError: true,
+			name:     "no backend detected",
+			command:  []string{"/bin/sh", "-c"},
+			args:     []string{"echo hello world"},
+			expected: BackendFrameworkNoop,
 		},
 		{
 			name:        "multiple backends detected",
@@ -3709,17 +3709,17 @@ func TestDetermineBackendFramework(t *testing.T) {
 			errorContains:            "backend framework mismatch",
 		},
 		{
-			name:          "worker with no detection, no explicit - returns error",
+			name:          "worker with no detection, no explicit - returns noop",
 			componentType: "worker",
-			expectError:   true,
-			errorContains: "backend framework must be specified explicitly or detectable from command/args",
+			expected:      BackendFrameworkNoop,
+			expectError:   false,
 		},
 		{
-			name:          "worker with detection failure, no explicit - returns error",
+			name:          "worker with detection failure, no explicit - returns noop",
 			componentType: "worker",
 			args:          []string{"echo hello world"},
-			expectError:   true,
-			errorContains: "could not determine backend framework",
+			expected:      BackendFrameworkNoop,
+			expectError:   false,
 		},
 	}
 
@@ -3843,18 +3843,18 @@ func TestGetBackendFrameworkFromComponent(t *testing.T) {
 			expected:   BackendFrameworkNoop,
 		},
 		{
-			name: "worker with no detection, no explicit - returns error",
+			name: "worker with no detection, no explicit - returns noop",
 			component: &v1alpha1.DynamoComponentDeploymentOverridesSpec{
 				DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
 					ComponentType: "worker", // Worker component
 				},
 			},
-			deployment:    &v1alpha1.DynamoGraphDeployment{},
-			expectError:   true,
-			errorContains: "backend framework must be specified explicitly or detectable from command/args",
+			deployment:  &v1alpha1.DynamoGraphDeployment{},
+			expected:    BackendFrameworkNoop,
+			expectError: false,
 		},
 		{
-			name: "worker with detection failure, no explicit - returns error",
+			name: "worker with detection failure, no explicit - returns noop",
 			component: &v1alpha1.DynamoComponentDeploymentOverridesSpec{
 				DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
 					ComponentType: "worker", // Worker component
@@ -3865,9 +3865,9 @@ func TestGetBackendFrameworkFromComponent(t *testing.T) {
 					},
 				},
 			},
-			deployment:    &v1alpha1.DynamoGraphDeployment{},
-			expectError:   true,
-			errorContains: "could not determine backend framework",
+			deployment:  &v1alpha1.DynamoGraphDeployment{},
+			expected:    BackendFrameworkNoop,
+			expectError: false,
 		},
 	}
 


### PR DESCRIPTION
#### Overview:

do not fail if backendFramework cannot be detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “No-op” backend option; deployments with no detectable backend now proceed without error.
  - Enabled explicit selection of the no-op backend.
  - Enhanced multinode deployment support by applying backend-specific adjustments during pod/container generation.

- Refactor
  - Simplified backend detection and configuration handling to treat “no backend” as a valid outcome.

- Tests
  - Updated test cases to expect the no-op backend for no-detection scenarios and removed error expectations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->