### PR TITLE
feat: add multimodal deployment example for llava based on vllm v1 #2628

### DIFF
--- a/examples/multimodal/deploy/agg_llava.yaml
+++ b/examples/multimodal/deploy/agg_llava.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: agg-llava
+spec:
+  backendFramework: vllm
+  services:
+    Frontend:
+      dynamoNamespace: agg-llava
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: my-registry/vllm-runtime:my-tag
+    EncodeWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: agg-llava
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: my-registry/vllm-runtime:my-tag
+          workingDir: /workspace/examples/multimodal
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 components/encode_worker.py --model llava-hf/llava-1.5-7b-hf
+    VLMWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: agg-llava
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: my-registry/vllm-runtime:my-tag
+          workingDir: /workspace/examples/multimodal
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - python3 components/worker.py --model llava-hf/llava-1.5-7b-hf --worker-type prefill
+    Processor:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: agg-llava
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: my-registry/vllm-runtime:my-tag
+          workingDir: /workspace/examples/multimodal
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - 'python3 components/processor.py --model llava-hf/llava-1.5-7b-hf --prompt-template "USER: <image>\n<prompt> ASSISTANT:"'


### PR DESCRIPTION
#### Overview:

Add multimodal example for llava based on vllm v1
closes: [dyn-932](https://linear.app/nvidia-dynamo/issue/DYN-932)
nvbug: https://nvbugspro.nvidia.com/bug/5472070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Kubernetes deployment templates and guides for SGLang, vLLM, and TensorRT-LLM (aggregated, router, and disaggregated), plus multi-node examples.
  - vLLM: configurable port range via new CLI flags with improved port allocation.
  - Operator: Grove is auto-detected with a configurable termination delay.

- Documentation
  - Major restructure: new backend guides, Support Matrix, quickstarts, and a Hello World runtime example.
  - Standardized run commands, refreshed links, and expanded SLURM/K8s instructions.

- DevOps
  - New multi-stage Dockerfile and image updates; optional KVBM build; dependency/version pins updated.

- Chores
  - Version updated to 0.4.0+post0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->