### PR TITLE
fix: Skip checksum tests in release mode since they're not computed

### DIFF
--- a/lib/runtime/src/pipeline/network/codec/two_part.rs
+++ b/lib/runtime/src/pipeline/network/codec/two_part.rs
@@ -455,6 +455,8 @@ mod tests {
 
     /// Test decoding of a message with checksum mismatch.
     #[test]
+    // Checksum only computed in debug mode, so only test in debug mode.
+    #[cfg(debug_assertions)]
     fn test_checksum_mismatch() {
         // Create a message
         let header_data = Bytes::from("header data");
@@ -646,6 +648,8 @@ mod tests {
 
     /// Test handling of corrupted data in a stream
     #[tokio::test]
+    // Checksum only computed in debug mode, so only test in debug mode.
+    #[cfg(debug_assertions)]
     async fn test_streaming_corrupted_data() {
         // Create messages
         let header_data = Bytes::from("header data");


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

https://github.com/ai-dynamo/dynamo/pull/2446 updated the codec code to only compute the checksum in a debug build.

I just so happened to be running tests on a release build (not common) while investigating this [PR](https://github.com/ai-dynamo/dynamo/pull/2585), and noticed these tests failing as a result. This skips these two tests on a release build since the checksum isn't computed.

```
$ cargo test --locked --all-targets --release
...
failures:

---- pipeline::network::codec::two_part::tests::test_checksum_mismatch stdout ----

thread 'pipeline::network::codec::two_part::tests::test_checksum_mismatch' panicked at lib/runtime/src/pipeline/network/codec/two_part.rs:478:9:
assertion failed: result.is_err()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- pipeline::network::codec::two_part::tests::test_streaming_corrupted_data stdout ----

thread 'pipeline::network::codec::two_part::tests::test_streaming_corrupted_data' panicked at lib/runtime/src/pipeline/network/codec/two_part.rs:671:13:
assertion failed: result.is_err()
```