### PR TITLE
fix: pytest robustness and parsing error

### DIFF
--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -246,6 +246,24 @@ class Client:
 
     ...
 
+    def instance_ids(self) -> List[int]:
+        """
+        Get list of current instance IDs.
+
+        Returns:
+            A list of currently available instance IDs
+        """
+        ...
+
+    async def wait_for_instances(self) -> List[int]:
+        """
+        Wait for instances to be available for work and return their IDs.
+
+        Returns:
+            A list of instance IDs that are available for work
+        """
+        ...
+
     async def random(self, request: JsonLike) -> AsyncIterator[JsonLike]:
         """
         Pick a random instance of the endpoint and issue the request

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Common base classes and utilities for engine tests (vLLM, TRT-LLM, etc.)"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, List
+
+from tests.utils.deployment_graph import Payload
+
+# Common text prompt used across tests
+TEXT_PROMPT = "Tell me a short joke about AI."
+
+
+@dataclass
+class EngineConfig:
+    """Base configuration for engine test scenarios"""
+
+    name: str
+    directory: str
+    script_name: str
+    marks: List[Any]
+    endpoints: List[str]
+    response_handlers: List[Callable[[Any], str]]
+    model: str
+    timeout: int = 120
+    delayed_start: int = 0
+
+
+def create_payload_for_config(config: EngineConfig) -> Payload:
+    """Create a standard payload using the model from the engine config.
+
+    This provides the default implementation for text-only models.
+    """
+    return Payload(
+        payload_chat={
+            "model": config.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": TEXT_PROMPT,
+                }
+            ],
+            "max_tokens": 150,
+            "temperature": 0.1,
+            "stream": False,
+        },
+        payload_completions={
+            "model": config.model,
+            "prompt": TEXT_PROMPT,
+            "max_tokens": 150,
+            "temperature": 0.1,
+            "stream": False,
+        },
+        repeat_count=3,
+        expected_log=[],
+        expected_response=["AI"],
+    )

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -72,8 +72,8 @@ trtllm_configs = {
             completions_response_handler,
         ],
         model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
-        delayed_start=60,
-        timeout=300,
+        delayed_start=0,
+        timeout=360,
     ),
     "disaggregated": TRTLLMConfig(
         name="disaggregated",
@@ -86,8 +86,8 @@ trtllm_configs = {
             completions_response_handler,
         ],
         model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
-        delayed_start=60,
-        timeout=300,
+        delayed_start=0,
+        timeout=360,
     ),
     # TODO: These are sanity tests that the kv router examples launch
     # and inference without error, but do not do detailed checks on the
@@ -103,8 +103,8 @@ trtllm_configs = {
             completions_response_handler,
         ],
         model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
-        delayed_start=60,
-        timeout=300,
+        delayed_start=0,
+        timeout=360,
     ),
     "disaggregated_router": TRTLLMConfig(
         name="disaggregated_router",
@@ -117,8 +117,8 @@ trtllm_configs = {
             completions_response_handler,
         ],
         model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
-        delayed_start=60,
-        timeout=300,
+        delayed_start=0,
+        timeout=360,
     ),
 }
 

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -153,7 +153,7 @@ class VLLMProcess(ManagedProcess):
 vllm_configs = {
     "aggregated": VLLMConfig(
         name="aggregated",
-        directory="/home/ubuntu/dynamo/components/backends/vllm",
+        directory="/workspace/components/backends/vllm",
         script_name="agg.sh",
         marks=[pytest.mark.gpu_1, pytest.mark.vllm],
         endpoints=["v1/chat/completions", "v1/completions"],

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -98,7 +98,7 @@ class VLLMProcess(EngineProcess):
 vllm_configs = {
     "aggregated": VLLMConfig(
         name="aggregated",
-        directory="/home/ubuntu/dynamo/components/backends/vllm",
+        directory="/workspace/components/backends/vllm",
         script_name="agg.sh",
         marks=[pytest.mark.gpu_1, pytest.mark.vllm],
         endpoints=["v1/chat/completions", "v1/completions"],
@@ -108,7 +108,7 @@ vllm_configs = {
         ],
         model="Qwen/Qwen3-0.6B",
         delayed_start=0,
-        timeout=300,
+        timeout=360,
     ),
     "agg-router": VLLMConfig(
         name="agg-router",
@@ -121,8 +121,8 @@ vllm_configs = {
             completions_response_handler,
         ],
         model="Qwen/Qwen3-0.6B",
-        delayed_start=45,
-        timeout=300,
+        delayed_start=0,
+        timeout=360,
     ),
     "disaggregated": VLLMConfig(
         name="disaggregated",
@@ -135,8 +135,8 @@ vllm_configs = {
             completions_response_handler,
         ],
         model="Qwen/Qwen3-0.6B",
-        delayed_start=45,
-        timeout=300,
+        delayed_start=0,
+        timeout=360,
     ),
     "deepep": VLLMConfig(
         name="deepep",
@@ -153,7 +153,7 @@ vllm_configs = {
             completions_response_handler,
         ],
         model="deepseek-ai/DeepSeek-V2-Lite",
-        delayed_start=45,
+        delayed_start=0,
         args=[
             "--model",
             "deepseek-ai/DeepSeek-V2-Lite",
@@ -164,7 +164,7 @@ vllm_configs = {
             "--gpus-per-node",
             "2",
         ],
-        timeout=500,
+        timeout=560,
     ),
     "multimodal_agg": VLLMConfig(
         name="multimodal_agg",
@@ -176,9 +176,9 @@ vllm_configs = {
             chat_completions_response_handler,
         ],
         model="llava-hf/llava-1.5-7b-hf",
-        delayed_start=45,
+        delayed_start=0,
         args=["--model", "llava-hf/llava-1.5-7b-hf"],
-        timeout=300,
+        timeout=360,
     ),
     # TODO: Enable this test case when we have 4 GPUs runners.
     # "multimodal_disagg": VLLMConfig(

--- a/tests/utils/engine_process.py
+++ b/tests/utils/engine_process.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import logging
+import time
+from typing import Any, Callable, Dict
+
+import requests
+
+from tests.utils.managed_process import ManagedProcess
+
+logger = logging.getLogger(__name__)
+
+
+class EngineResponseError(Exception):
+    """Custom exception for engine response errors"""
+
+    pass
+
+
+class EngineProcess(ManagedProcess):
+    """Base class for LLM engine processes (vLLM, TRT-LLM, etc.)"""
+
+    def _check_models_api(self, response):
+        """Check if models API is working and returns models"""
+        try:
+            if response.status_code != 200:
+                return False
+            data = response.json()
+            return data.get("data") and len(data["data"]) > 0
+        except Exception:
+            return False
+
+    def send_request(
+        self, url: str, payload: Dict[str, Any], timeout: float = 30.0
+    ) -> requests.Response:
+        """
+        Send a POST request to the engine with detailed logging.
+
+        Args:
+            url: The endpoint URL
+            payload: The request payload
+            timeout: Request timeout in seconds
+
+        Returns:
+            The response object
+
+        Raises:
+            requests.RequestException: If the request fails
+        """
+
+        # Log the request as a curl command for easy reproduction
+        payload_json = json.dumps(payload, indent=2)
+        curl_command = f'curl -X POST "{url}" \\\n  -H "Content-Type: application/json" \\\n  -d \'{payload_json}\''
+        logger.info("Sending request (curl equivalent):\n%s", curl_command)
+
+        start_time = time.time()
+        try:
+            response = requests.post(url, json=payload, timeout=timeout)
+            elapsed = time.time() - start_time
+
+            # Log response details
+            logger.info(
+                "Received response: status=%d, elapsed=%.2fs",
+                response.status_code,
+                elapsed,
+            )
+
+            logger.debug("Response headers: %s", dict(response.headers))
+
+            # Try to log response body (truncated if too long)
+            try:
+                if response.headers.get("content-type", "").startswith(
+                    "application/json"
+                ):
+                    response_data = response.json()
+                    response_str = json.dumps(response_data, indent=2)
+                    if len(response_str) > 1000:
+                        response_str = response_str[:1000] + "... (truncated)"
+                    logger.debug("Response body: %s", response_str)
+                else:
+                    response_text = response.text
+                    if len(response_text) > 1000:
+                        response_text = response_text[:1000] + "... (truncated)"
+                    logger.debug("Response body: %s", response_text)
+            except Exception as e:
+                logger.debug("Could not parse response body: %s", e)
+
+            return response
+
+        except requests.exceptions.Timeout:
+            logger.error("Request timed out after %.2f seconds", timeout)
+            raise
+        except requests.exceptions.ConnectionError as e:
+            logger.error("Connection error: %s", e)
+            raise
+        except requests.exceptions.RequestException as e:
+            logger.error("Request failed: %s", e)
+            raise
+
+    def check_response(
+        self,
+        payload: Any,
+        response: requests.Response,
+        response_handler: Callable[[Any], str],
+    ) -> None:
+        """
+        Check if the response is valid and contains expected content.
+
+        Args:
+            payload: The original payload (should have expected_response attribute)
+            response: The response object
+            response_handler: Function to extract content from response
+
+        Raises:
+            EngineResponseError: If the response is invalid or missing expected content
+        """
+
+        if response.status_code != 200:
+            logger.error(
+                "Response returned non-200 status code: %d", response.status_code
+            )
+
+            error_msg = f"Response returned non-200 status code: {response.status_code}"
+            try:
+                error_data = response.json()
+                if "error" in error_data:
+                    error_msg += f"\nError details: {error_data['error']}"
+                logger.error(
+                    "Response error details: %s", json.dumps(error_data, indent=2)
+                )
+            except Exception:
+                logger.error("Response text: %s", response.text[:500])
+
+            raise EngineResponseError(error_msg)
+
+        # Extract content using the handler
+        try:
+            content = response_handler(response)
+            logger.info(
+                "Extracted content: \n%s",
+                content[:200] + "..." if len(content) > 200 else content,
+            )
+        except Exception as e:
+            raise EngineResponseError(f"Failed to extract content from response: {e}")
+
+        if not content:
+            raise EngineResponseError("Response contained empty content")
+
+        if hasattr(payload, "expected_response") and payload.expected_response:
+            missing_expected = []
+            for expected in payload.expected_response:
+                if expected not in content:
+                    missing_expected.append(expected)
+
+            if missing_expected:
+                raise EngineResponseError(
+                    f"Expected content not found in response. Missing: {missing_expected}"
+                )
+            else:
+                logger.info(
+                    f"SUCCESS: All expected content ({payload.expected_response}) found in response"
+                )

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -204,6 +204,39 @@ class ManagedProcess:
         except (OSError, IOError) as e:
             self._logger.warning("Warning: Failed to remove directory %s: %s", path, e)
 
+    def _log_tail_on_error(self, lines=20):
+        """Print the last few lines of the log file when process dies."""
+        if self._log_path and os.path.exists(self._log_path):
+            try:
+                with open(self._log_path, "r") as f:
+                    log_lines = f.readlines()
+                    if log_lines:
+                        self._logger.error(
+                            "=== Last %d lines from %s ===",
+                            min(lines, len(log_lines)),
+                            self._log_path,
+                        )
+                        for line in log_lines[-lines:]:
+                            self._logger.error(line.rstrip())
+                        self._logger.error("=== End of log tail ===")
+            except Exception as e:
+                self._logger.warning("Could not read log file: %s", e)
+
+    def _check_process_alive(self, context=""):
+        """Check if the main process is still alive. Raises RuntimeError if dead."""
+        if self.proc and self.proc.poll() is not None:
+            returncode = self.proc.returncode
+            self._logger.error(
+                "Main server process died with exit code %d%s",
+                returncode,
+                f" {context}" if context else "",
+            )
+            # Try to get last few lines from log for debugging
+            self._log_tail_on_error()
+            raise RuntimeError(
+                f"Main server process exited with code {returncode}{f' {context}' if context else ''}"
+            )
+
     def _check_ports(self, timeout):
         elapsed = 0.0
         for port in self.health_check_ports:
@@ -216,6 +249,9 @@ class ManagedProcess:
         self._logger.info("Checking Port: %s", port)
         elapsed = 0.0
         while elapsed < timeout:
+            # Check if the main process is still alive
+            self._check_process_alive(f"while waiting for port {port}")
+
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 if s.connect_ex(("localhost", port)) == 0:
                     self._logger.info("SUCCESS: Check Port: %s", port)
@@ -231,7 +267,7 @@ class ManagedProcess:
             elapsed += self._check_url(url, timeout - elapsed)
         return elapsed
 
-    def _check_url(self, url, timeout=30, sleep=0.1):
+    def _check_url(self, url, timeout=30, sleep=1, log_interval=10):
         if isinstance(url, tuple):
             response_check = url[1]
             url = url[0]
@@ -240,19 +276,54 @@ class ManagedProcess:
         start_time = time.time()
         self._logger.info("Checking URL %s", url)
         elapsed = 0.0
+        attempt = 0
+        last_log_time = 0
+
         while elapsed < timeout:
+            self._check_process_alive("while waiting for health check")
+
+            attempt += 1
+            check_failed = False
+            failure_reason = None
+
             try:
                 response = requests.get(url, timeout=timeout - elapsed)
                 if response.status_code == 200:
                     if response_check is None or response_check(response):
-                        self._logger.info("SUCCESS: Check URL: %s", url)
+                        self._logger.info(
+                            "SUCCESS: Check URL: %s (attempt=%d, elapsed=%.1fs)",
+                            url,
+                            attempt,
+                            elapsed,
+                        )
                         return time.time() - start_time
+                    else:
+                        check_failed = True
+                        failure_reason = "custom check failed"
+                else:
+                    check_failed = True
+                    failure_reason = f"status code {response.status_code}"
             except requests.RequestException as e:
-                self._logger.warning("URL check failed: %s", e)
+                check_failed = True
+                failure_reason = f"request exception: {e}"
+
+            # Log progress every log_interval seconds for any failure
+            if check_failed and elapsed - last_log_time >= log_interval:
+                self._logger.info(
+                    "Still waiting for URL %s (%s) (attempt=%d, elapsed=%.1fs)",
+                    url,
+                    failure_reason,
+                    attempt,
+                    elapsed,
+                )
+                last_log_time = elapsed
+
             time.sleep(sleep)
             elapsed = time.time() - start_time
 
-        self._logger.error("FAILED: Check URL: %s", url)
+        self._logger.error(
+            "FAILED: Check URL: %s (attempts=%d, elapsed=%.1fs)", url, attempt, elapsed
+        )
         raise RuntimeError("FAILED: Check URL: %s" % url)
 
     def _terminate_existing(self):

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -278,7 +278,7 @@ class ManagedProcess:
         self._logger.info("Checking URL %s", url)
         elapsed = 0.0
         attempt = 0
-        last_log_time = 0
+        last_log_time = 0.0
 
         while elapsed < timeout:
             self._check_process_alive("while waiting for health check")


### PR DESCRIPTION
#### Overview:

New parsing logic put text into a reasoning_content field, so when we checked the content field it looked like we were getting an empty message.

We also had some log spam because of a 0.1 sleep, so I've fixed it to print the log once every 10 seconds. I've also removed some redundant code and improved error logic. This should make things more resilient and less flakey. 

Also refactored multi-modal a bit to wait until each preceding pipeline step is ready to register with the frontend. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - More robust chat response parsing, supporting reasoning, refusals, and tool-call outputs with clearer errors on empty results.
  - Improved health checks with better liveness detection and throttled logging to reduce noise and flakiness.
  - Explicit non‑streaming requests in applicable scenarios to ensure consistent behavior.
  - Extended timeouts to avoid premature failures during startup.

- Tests
  - Simplified readiness flow by removing brittle polling and relying on health checks.
  - Updated configurations and paths to align with new environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->