### PR TITLE
feat: FT Python Context and Unit Tests

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -16,7 +16,8 @@ use tokio::sync::Mutex;
 use dynamo_runtime::{
     self as rs, logging,
     pipeline::{
-        network::egress::push_router::RouterMode as RsRouterMode, EngineStream, ManyOut, SingleIn,
+        context::Context as RsContext, network::egress::push_router::RouterMode as RsRouterMode,
+        EngineStream, ManyOut, SingleIn,
     },
     protocols::annotated::Annotated as RsAnnotated,
     traits::DistributedRuntimeProvider,
@@ -104,7 +105,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<http::HttpService>()?;
     m.add_class::<http::HttpError>()?;
     m.add_class::<http::HttpAsyncEngine>()?;
-    m.add_class::<context::PyContext>()?;
+    m.add_class::<context::Context>()?;
     m.add_class::<EtcdKvCache>()?;
     m.add_class::<ModelType>()?;
     m.add_class::<llm::kv::ForwardPassMetrics>()?;
@@ -697,27 +698,29 @@ impl Client {
     }
 
     /// Issue a request to the endpoint using the default routing strategy.
-    #[pyo3(signature = (request, annotated=DEFAULT_ANNOTATED_SETTING))]
+    #[pyo3(signature = (request, annotated=DEFAULT_ANNOTATED_SETTING, context=None))]
     fn generate<'p>(
         &self,
         py: Python<'p>,
         request: PyObject,
         annotated: Option<bool>,
+        context: Option<context::Context>,
     ) -> PyResult<Bound<'p, PyAny>> {
         if self.router.client.is_static() {
-            self.r#static(py, request, annotated)
+            self.r#static(py, request, annotated, context)
         } else {
-            self.random(py, request, annotated)
+            self.random(py, request, annotated, context)
         }
     }
 
     /// Send a request to the next endpoint in a round-robin fashion.
-    #[pyo3(signature = (request, annotated=DEFAULT_ANNOTATED_SETTING))]
+    #[pyo3(signature = (request, annotated=DEFAULT_ANNOTATED_SETTING, context=None))]
     fn round_robin<'p>(
         &self,
         py: Python<'p>,
         request: PyObject,
         annotated: Option<bool>,
+        context: Option<context::Context>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let request: serde_json::Value = pythonize::depythonize(&request.into_bound(py))?;
         let annotated = annotated.unwrap_or(false);
@@ -726,7 +729,15 @@ impl Client {
         let client = self.router.clone();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let stream = client.round_robin(request.into()).await.map_err(to_pyerr)?;
+            let stream = match context {
+                Some(context) => {
+                    let request = RsContext::with_id(request, context.inner().id().to_string());
+                    let stream = client.round_robin(request).await.map_err(to_pyerr)?;
+                    context.inner().link_child(stream.context());
+                    stream
+                }
+                _ => client.round_robin(request.into()).await.map_err(to_pyerr)?,
+            };
             tokio::spawn(process_stream(stream, tx));
             Ok(AsyncResponseStream {
                 rx: Arc::new(Mutex::new(rx)),
@@ -736,12 +747,13 @@ impl Client {
     }
 
     /// Send a request to a random endpoint.
-    #[pyo3(signature = (request, annotated=DEFAULT_ANNOTATED_SETTING))]
+    #[pyo3(signature = (request, annotated=DEFAULT_ANNOTATED_SETTING, context=None))]
     fn random<'p>(
         &self,
         py: Python<'p>,
         request: PyObject,
         annotated: Option<bool>,
+        context: Option<context::Context>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let request: serde_json::Value = pythonize::depythonize(&request.into_bound(py))?;
         let annotated = annotated.unwrap_or(false);
@@ -750,7 +762,15 @@ impl Client {
         let client = self.router.clone();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let stream = client.random(request.into()).await.map_err(to_pyerr)?;
+            let stream = match context {
+                Some(context) => {
+                    let request = RsContext::with_id(request, context.inner().id().to_string());
+                    let stream = client.random(request).await.map_err(to_pyerr)?;
+                    context.inner().link_child(stream.context());
+                    stream
+                }
+                _ => client.random(request.into()).await.map_err(to_pyerr)?,
+            };
             tokio::spawn(process_stream(stream, tx));
             Ok(AsyncResponseStream {
                 rx: Arc::new(Mutex::new(rx)),
@@ -760,13 +780,14 @@ impl Client {
     }
 
     /// Directly send a request to a specific endpoint.
-    #[pyo3(signature = (request, instance_id, annotated=DEFAULT_ANNOTATED_SETTING))]
+    #[pyo3(signature = (request, instance_id, annotated=DEFAULT_ANNOTATED_SETTING, context=None))]
     fn direct<'p>(
         &self,
         py: Python<'p>,
         request: PyObject,
         instance_id: i64,
         annotated: Option<bool>,
+        context: Option<context::Context>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let request: serde_json::Value = pythonize::depythonize(&request.into_bound(py))?;
         let annotated = annotated.unwrap_or(false);
@@ -775,10 +796,21 @@ impl Client {
         let client = self.router.clone();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let stream = client
-                .direct(request.into(), instance_id)
-                .await
-                .map_err(to_pyerr)?;
+            let stream = match context {
+                Some(context) => {
+                    let request = RsContext::with_id(request, context.inner().id().to_string());
+                    let stream = client
+                        .direct(request, instance_id)
+                        .await
+                        .map_err(to_pyerr)?;
+                    context.inner().link_child(stream.context());
+                    stream
+                }
+                _ => client
+                    .direct(request.into(), instance_id)
+                    .await
+                    .map_err(to_pyerr)?,
+            };
 
             tokio::spawn(process_stream(stream, tx));
 
@@ -790,12 +822,13 @@ impl Client {
     }
 
     /// Directly send a request to a pre-defined static worker
-    #[pyo3(signature = (request, annotated=DEFAULT_ANNOTATED_SETTING))]
+    #[pyo3(signature = (request, annotated=DEFAULT_ANNOTATED_SETTING, context=None))]
     fn r#static<'p>(
         &self,
         py: Python<'p>,
         request: PyObject,
         annotated: Option<bool>,
+        context: Option<context::Context>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let request: serde_json::Value = pythonize::depythonize(&request.into_bound(py))?;
         let annotated = annotated.unwrap_or(false);
@@ -804,7 +837,15 @@ impl Client {
         let client = self.router.clone();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let stream = client.r#static(request.into()).await.map_err(to_pyerr)?;
+            let stream = match context {
+                Some(context) => {
+                    let request = RsContext::with_id(request, context.inner().id().to_string());
+                    let stream = client.r#static(request).await.map_err(to_pyerr)?;
+                    context.inner().link_child(stream.context());
+                    stream
+                }
+                _ => client.r#static(request.into()).await.map_err(to_pyerr)?,
+            };
 
             tokio::spawn(process_stream(stream, tx));
 

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -25,12 +25,12 @@ from pydantic import BaseModel, ValidationError
 from dynamo._core import Backend as Backend
 from dynamo._core import Client as Client
 from dynamo._core import Component as Component
+from dynamo._core import Context as Context
 from dynamo._core import DistributedRuntime as DistributedRuntime
 from dynamo._core import Endpoint as Endpoint
 from dynamo._core import EtcdKvCache as EtcdKvCache
 from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
 from dynamo._core import OAIChatPreprocessor as OAIChatPreprocessor
-from dynamo._core import PyContext as PyContext
 
 
 def dynamo_worker(static=False):

--- a/lib/bindings/python/tests/test_cancellation/conftest.py
+++ b/lib/bindings/python/tests/test_cancellation/conftest.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import random
+import string
+import subprocess
+import time
+
+import pytest
+
+from dynamo._core import DistributedRuntime
+
+
+class MockServer:
+    """
+    Test request handler that simulates a generate method with cancellation support
+    """
+
+    def __init__(self):
+        self.context_is_stopped = False
+        self.context_is_killed = False
+
+    async def generate(self, request, context):
+        self.context_is_stopped = False
+        self.context_is_killed = False
+
+        method_name = request
+        assert hasattr(
+            self, method_name
+        ), f"Method '{method_name}' not found on {self.__class__.__name__}"
+        method = getattr(self, method_name)
+        async for response in method(request, context):
+            yield response
+
+    async def _generate_until_context_cancelled(self, request, context):
+        """
+        Generate method that yields numbers 0-999 every 0.1 seconds
+        Checks for context.is_stopped() / context.is_killed() before each yield and raises
+        CancelledError if stopped / killed
+        """
+        for i in range(1000):
+            print(f"Processing iteration {i}")
+
+            # Check if context is stopped
+            if context.is_stopped():
+                print(f"Context stopped at iteration {i}")
+                self.context_is_stopped = True
+                self.context_is_killed = context.is_killed()
+                raise asyncio.CancelledError
+
+            # Check if context is killed
+            if context.is_killed():
+                print(f"Context killed at iteration {i}")
+                self.context_is_stopped = context.is_stopped()
+                self.context_is_killed = True
+                raise asyncio.CancelledError
+
+            await asyncio.sleep(0.1)
+
+            print(f"Sending iteration {i}")
+            yield i
+
+        assert (
+            False
+        ), "Test failed: generate_until_cancelled did not raise CancelledError"
+
+    async def _generate_until_asyncio_cancelled(self, request, context):
+        """
+        Generate method that yields numbers 0-999 every 0.1 seconds
+        """
+        i = 0
+        try:
+            for i in range(1000):
+                print(f"Processing iteration {i}")
+                await asyncio.sleep(0.1)
+                print(f"Sending iteration {i}")
+                yield i
+        except asyncio.CancelledError:
+            print(f"Cancelled at iteration {i}")
+            self.context_is_stopped = context.is_stopped()
+            self.context_is_killed = context.is_killed()
+            raise
+
+        assert (
+            False
+        ), "Test failed: generate_until_cancelled did not raise CancelledError"
+
+    async def _generate_and_cancel_context(self, request, context):
+        """
+        Generate method that yields numbers 0-1, and then cancel the context
+        """
+        for i in range(2):
+            print(f"Processing iteration {i}")
+            await asyncio.sleep(0.1)
+            print(f"Sending iteration {i}")
+            yield i
+
+        context.stop_generating()
+
+        self.context_is_stopped = context.is_stopped()
+        self.context_is_killed = context.is_killed()
+
+    async def _generate_and_raise_cancelled(self, request, context):
+        """
+        Generate method that yields numbers 0-1, and then raise asyncio.CancelledError
+        """
+        for i in range(2):
+            print(f"Processing iteration {i}")
+            await asyncio.sleep(0.1)
+            print(f"Sending iteration {i}")
+            yield i
+
+        raise asyncio.CancelledError
+
+
+def random_string(length=10):
+    """Generate a random string for namespace isolation"""
+    # Start with a letter to satisfy Prometheus naming requirements
+    first_char = random.choice(string.ascii_lowercase)
+    remaining_chars = string.ascii_lowercase + string.digits
+    rest = "".join(random.choices(remaining_chars, k=length - 1))
+    return first_char + rest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def nats_and_etcd():
+    nats_server = subprocess.Popen(["nats-server", "-js"])
+    etcd = subprocess.Popen(["etcd"])
+    time.sleep(5)  # time to start services
+    yield
+    etcd.terminate()
+    nats_server.terminate()
+    etcd.wait()
+    nats_server.wait()
+
+
+@pytest.fixture
+async def runtime():
+    """Create a DistributedRuntime for testing"""
+    loop = asyncio.get_running_loop()
+    runtime = DistributedRuntime(loop, True)
+    yield runtime
+    runtime.shutdown()
+
+
+@pytest.fixture
+def namespace():
+    """Generate a random namespace for test isolation"""
+    return random_string()
+
+
+@pytest.fixture
+async def server(runtime, namespace):
+    """Start a test server in the background"""
+
+    handler = MockServer()
+
+    async def init_server():
+        """Initialize the test server component and serve the generate endpoint"""
+        component = runtime.namespace(namespace).component("backend")
+        await component.create_service()
+
+        endpoint = component.endpoint("generate")
+        print("Started test server instance")
+
+        # Serve the endpoint - this will block until shutdown
+        await endpoint.serve_endpoint(handler.generate)
+
+    # Start server in background task
+    server_task = asyncio.create_task(init_server())
+
+    # Give server time to start up
+    await asyncio.sleep(0.5)
+
+    yield server_task, handler
+
+    # Cleanup - cancel server task
+    if not server_task.done():
+        server_task.cancel()
+        try:
+            await server_task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.fixture
+async def client(runtime, namespace):
+    """Create a client connected to the test server"""
+    # Create client
+    endpoint = runtime.namespace(namespace).component("backend").endpoint("generate")
+    client = await endpoint.client()
+    await client.wait_for_instances()
+
+    return client

--- a/lib/bindings/python/tests/test_cancellation/test_cancellation.py
+++ b/lib/bindings/python/tests/test_cancellation/test_cancellation.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.pre_merge
+
+
+def _run_test_in_subprocess(test_name: str):
+    """Helper function to run a test file in a separate process"""
+    test_file = os.path.join(os.path.dirname(__file__), f"{test_name}.py")
+    result = subprocess.run(
+        ["pytest", test_file, "-v"],
+        capture_output=True,
+        text=True,
+        cwd=os.path.dirname(__file__),
+    )
+
+    print("STDOUT:", result.stdout)
+    print("STDERR:", result.stderr)
+    print("Return code:", result.returncode)
+
+    assert (
+        result.returncode == 0
+    ), f"Test {test_name} failed with return code {result.returncode}"
+
+
+def test_client_context_cancel():
+    _run_test_in_subprocess("test_client_context_cancel")
+
+
+def test_client_loop_break():
+    _run_test_in_subprocess("test_client_loop_break")
+
+
+def test_server_context_cancel():
+    _run_test_in_subprocess("test_server_context_cancel")
+
+
+def test_server_raise_cancelled():
+    _run_test_in_subprocess("test_server_raise_cancelled")

--- a/lib/bindings/python/tests/test_cancellation/test_client_context_cancel.py
+++ b/lib/bindings/python/tests/test_cancellation/test_client_context_cancel.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pytest
+
+from dynamo._core import Context
+
+
+@pytest.mark.asyncio
+async def test_client_context_cancel(server, client):
+    _, handler = server
+    context = Context()
+    stream = await client.generate("_generate_until_context_cancelled", context=context)
+
+    iteration_count = 0
+    async for annotated in stream:
+        number = annotated.data()
+        print(f"Received iteration: {number}")
+
+        # Verify received valid number
+        assert number == iteration_count
+
+        # Break after receiving 2 responses
+        if iteration_count >= 2:
+            print("Cancelling after 2 responses...")
+            context.stop_generating()
+            break
+
+        iteration_count += 1
+
+    # Give server a moment to process the cancellation
+    await asyncio.sleep(0.2)
+
+    # Verify server detected the cancellation
+    assert handler.context_is_stopped
+    assert handler.context_is_killed
+
+    # TODO: Test with _generate_until_asyncio_cancelled server handler

--- a/lib/bindings/python/tests/test_cancellation/test_client_loop_break.py
+++ b/lib/bindings/python/tests/test_cancellation/test_client_loop_break.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_client_loop_break(server, client):
+    _, handler = server
+    stream = await client.generate("_generate_until_context_cancelled")
+
+    iteration_count = 0
+    async for annotated in stream:
+        number = annotated.data()
+        print(f"Received iteration: {number}")
+
+        # Verify received valid number
+        assert number == iteration_count
+
+        # Break after receiving 2 responses
+        if iteration_count >= 2:
+            print("Cancelling after 2 responses...")
+            break
+
+        iteration_count += 1
+
+    # Give server a moment to process the cancellation
+    await asyncio.sleep(0.2)
+
+    # TODO: Implicit cancellation is not yet implemented, so the server context will not
+    #       show any cancellation.
+    assert not handler.context_is_stopped
+    assert not handler.context_is_killed
+
+    # TODO: Test with _generate_until_asyncio_cancelled server handler

--- a/lib/bindings/python/tests/test_cancellation/test_server_context_cancel.py
+++ b/lib/bindings/python/tests/test_cancellation/test_server_context_cancel.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_server_context_cancel(server, client):
+    _, handler = server
+    stream = await client.generate("_generate_and_cancel_context")
+
+    iteration_count = 0
+    try:
+        async for annotated in stream:
+            number = annotated.data()
+            print(f"Received iteration: {number}")
+            assert number == iteration_count
+            iteration_count += 1
+        assert False, "Stream completed without cancellation"
+    except ValueError as e:
+        # Verify the expected cancellation exception is received
+        # TODO: Should this be a asyncio.CancelledError?
+        assert str(e) == "Stream ended before generation completed"
+
+    # Verify server context cancellation status
+    assert handler.context_is_stopped
+    assert not handler.context_is_killed

--- a/lib/bindings/python/tests/test_cancellation/test_server_raise_cancelled.py
+++ b/lib/bindings/python/tests/test_cancellation/test_server_raise_cancelled.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_server_raise_cancelled(server, client):
+    _, handler = server
+    stream = await client.generate("_generate_and_raise_cancelled")
+
+    iteration_count = 0
+    try:
+        async for annotated in stream:
+            number = annotated.data()
+            print(f"Received iteration: {number}")
+            assert number == iteration_count
+            iteration_count += 1
+        assert False, "Stream completed without cancellation"
+    except ValueError as e:
+        # Verify the expected cancellation exception is received
+        # TODO: Should this be a asyncio.CancelledError?
+        assert (
+            str(e)
+            == "a python exception was caught while processing the async generator: CancelledError: "
+        )
+
+    # Verify server context cancellation status
+    # TODO: Server to gracefully stop the stream?
+    assert not handler.context_is_stopped
+    assert not handler.context_is_killed

--- a/lib/llm/src/http/client.rs
+++ b/lib/llm/src/http/client.rs
@@ -8,7 +8,7 @@
 //! for performance analysis.
 
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::Instant;
 
@@ -64,6 +64,8 @@ pub struct HttpRequestContext {
     created_at: Instant,
     /// Whether the request has been stopped
     stopped: Arc<std::sync::atomic::AtomicBool>,
+    /// Child contexts to be stopped if this is stopped
+    child_context: Arc<Mutex<Vec<Arc<dyn AsyncEngineContext>>>>,
 }
 
 impl HttpRequestContext {
@@ -74,6 +76,7 @@ impl HttpRequestContext {
             cancel_token: CancellationToken::new(),
             created_at: Instant::now(),
             stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            child_context: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -84,6 +87,7 @@ impl HttpRequestContext {
             cancel_token: CancellationToken::new(),
             created_at: Instant::now(),
             stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            child_context: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -95,6 +99,7 @@ impl HttpRequestContext {
             cancel_token: self.cancel_token.child_token(),
             created_at: Instant::now(),
             stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            child_context: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -105,6 +110,7 @@ impl HttpRequestContext {
             cancel_token: self.cancel_token.child_token(),
             created_at: Instant::now(),
             stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            child_context: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -144,17 +150,35 @@ impl AsyncEngineContext for HttpRequestContext {
     }
 
     fn stop(&self) {
+        self.child_context
+            .lock()
+            .expect("Failed to lock child context")
+            .iter()
+            .for_each(|child| child.stop());
+
         self.stopped
             .store(true, std::sync::atomic::Ordering::Release);
         self.cancel_token.cancel();
     }
 
     fn stop_generating(&self) {
+        self.child_context
+            .lock()
+            .expect("Failed to lock child context")
+            .iter()
+            .for_each(|child| child.stop_generating());
+
         // For HTTP clients, stop_generating is the same as stop
         self.stop();
     }
 
     fn kill(&self) {
+        self.child_context
+            .lock()
+            .expect("Failed to lock child context")
+            .iter()
+            .for_each(|child| child.kill());
+
         self.stopped
             .store(true, std::sync::atomic::Ordering::Release);
         self.cancel_token.cancel();
@@ -175,6 +199,13 @@ impl AsyncEngineContext for HttpRequestContext {
     async fn killed(&self) {
         // For HTTP clients, killed is the same as stopped
         self.cancel_token.cancelled().await;
+    }
+
+    fn link_child(&self, child: Arc<dyn AsyncEngineContext>) {
+        self.child_context
+            .lock()
+            .expect("Failed to lock child context")
+            .push(child);
     }
 }
 

--- a/lib/llm/src/perf.rs
+++ b/lib/llm/src/perf.rs
@@ -552,5 +552,9 @@ pub mod tests {
         async fn killed(&self) {
             // No-op for testing
         }
+
+        fn link_child(&self, _: Arc<dyn AsyncEngineContext>) {
+            // No-op for testing
+        }
     }
 }

--- a/lib/llm/src/perf/logprobs.rs
+++ b/lib/llm/src/perf/logprobs.rs
@@ -1613,5 +1613,9 @@ mod tests {
         async fn killed(&self) {
             // No-op for testing
         }
+
+        fn link_child(&self, _: Arc<dyn dynamo_runtime::engine::AsyncEngineContext>) {
+            // No-op for testing
+        }
     }
 }

--- a/lib/runtime/src/engine.rs
+++ b/lib/runtime/src/engine.rs
@@ -159,6 +159,12 @@ pub trait AsyncEngineContext: Send + Sync + Debug {
     /// terminate without draining the remaining items in the stream. This is implementation
     /// specific and may not be supported by all engines.
     fn kill(&self);
+
+    /// Links child AsyncEngineContext to this AsyncEngineContext. If the `stop_generating`, `stop`
+    /// or `kill` on this AsyncEngineContext is called, the same method is called on all linked
+    /// child AsyncEngineContext, in the order they are linked, and then the method on this
+    /// AsyncEngineContext continues.
+    fn link_child(&self, child: Arc<dyn AsyncEngineContext>);
 }
 
 /// Provides access to the [`AsyncEngineContext`] associated with an engine operation.

--- a/lib/runtime/src/pipeline/context.rs
+++ b/lib/runtime/src/pipeline/context.rs
@@ -22,7 +22,7 @@
 //!   registry and visitors. `StreamAdaptors` will amend themselves to the [`StreamContext`] to allow for the
 
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use super::{AsyncEngineContext, AsyncEngineContextProvider, Data};
 use crate::engine::AsyncEngineController;
@@ -300,6 +300,10 @@ impl AsyncEngineContext for StreamContext {
     async fn killed(&self) {
         self.controller.killed().await
     }
+
+    fn link_child(&self, child: Arc<dyn AsyncEngineContext>) {
+        self.controller.link_child(child);
+    }
 }
 
 impl AsyncEngineContextProvider for StreamContext {
@@ -331,12 +335,18 @@ pub struct Controller {
     id: String,
     tx: Sender<State>,
     rx: Receiver<State>,
+    child_context: Mutex<Vec<Arc<dyn AsyncEngineContext>>>,
 }
 
 impl Controller {
     pub fn new(id: String) -> Self {
         let (tx, rx) = channel(State::Live);
-        Self { id, tx, rx }
+        Self {
+            id,
+            tx,
+            rx,
+            child_context: Mutex::new(Vec::new()),
+        }
     }
 
     pub fn id(&self) -> &str {
@@ -387,11 +397,28 @@ impl AsyncEngineContext for Controller {
     }
 
     fn stop(&self) {
+        self.child_context
+            .lock()
+            .expect("Failed to lock child context")
+            .iter()
+            .for_each(|child| child.stop());
         let _ = self.tx.send(State::Stopped);
     }
 
     fn kill(&self) {
+        self.child_context
+            .lock()
+            .expect("Failed to lock child context")
+            .iter()
+            .for_each(|child| child.kill());
         let _ = self.tx.send(State::Killed);
+    }
+
+    fn link_child(&self, child: Arc<dyn AsyncEngineContext>) {
+        self.child_context
+            .lock()
+            .expect("Failed to lock child context")
+            .push(child);
     }
 }
 


### PR DESCRIPTION
#### Overview:

Add Python context access to outgoing requests, and unit tests for the context object in Python.

#### Details:

N/A

#### Where should the reviewer start?

Start with the outgoing requests implementation, and then the context object unit tests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A
