### PR TITLE
fix: removed hardcoded metadata name "vllm-agg" for profiling job

### DIFF
--- a/benchmarks/profiler/utils/config.py
+++ b/benchmarks/profiler/utils/config.py
@@ -90,8 +90,9 @@ class VllmV1ConfigModifier:
     def convert_config(cls, config: dict, target: Literal["prefill", "decode"]) -> dict:
         config = deepcopy(config)
 
-        # set metadata name
-        config["metadata"]["name"] = "vllm-agg"
+        # hardcoding metadata name causes planner job to wait indefinitely if job
+        # is run with different config not matching "vllm-agg" name 
+        # config["metadata"]["name"] = "vllm-agg"
 
         # disable planner
         if "Planner" in config["spec"]["services"]:


### PR DESCRIPTION


#### Overview:
Hardcoding name to "vllm-agg" causes profiler job to look for deployments with this name and leads to  indefinite waiting if job is run with different config not having this name metadata. 
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
Removed overriding of metadata name to hardcoded `vllm-agg` from loaded config file during profiling run.
(e.g This line overrides the name `vllm-disagg-planner` when job is run with this config and causes profiler to look for different deployments. https://github.com/ai-dynamo/dynamo/blob/72ec5f5c7b9e3d482faa3485fa81994e99d33b22/components/backends/vllm/deploy/disagg_planner.yaml)
<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?
https://github.com/ai-dynamo/dynamo/blob/main/benchmarks/profiler/utils/config.py#L94
<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - When converting profiler configurations, the tool no longer forcibly renames the metadata name field. Existing names are preserved, preventing confusing or inconsistent labels across reports, exports, and dashboards. This change ensures outputs reflect the original configuration and avoids accidental collisions with similarly named runs, improving trace readability and aligning results with user-specified identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->