### PR TITLE
DYN-952: Implement BLAKE3 content hashing and 32MiB size validation

### DIFF
--- a/components/oscar/src/error.rs
+++ b/components/oscar/src/error.rs
@@ -9,14 +9,14 @@ pub type OscarResult<T> = Result<T, OscarError>;
 /// Errors that can occur during Oscar operations.
 #[derive(Error, Debug)]
 pub enum OscarError {
-    #[error("Object too large: {size} bytes (max {max} bytes)")]
-    ObjectTooLarge { size: usize, max: usize },
+    #[error("Object too large: {size} bytes (max {max_size} bytes)")]
+    ObjectTooLarge { size: usize, max_size: usize },
 
     #[error("Storage error: {0}")]
     Storage(#[from] dynamo_runtime::storage::key_value_store::StorageError),
 
-    #[error("Hash mismatch: expected {expected}, got {actual}")]
-    HashMismatch { expected: String, actual: String },
+    #[error("Hash mismatch: expected {expected}, got {computed}")]
+    HashMismatch { expected: String, computed: String },
 
     #[error("Object not found: {hash}")]
     ObjectNotFound { hash: String },
@@ -26,6 +26,9 @@ pub enum OscarError {
 
     #[error("Concurrency error: {reason}")]
     Concurrency { reason: String },
+
+    #[error("I/O error accessing {path}: {error}")]
+    IoError { path: std::path::PathBuf, error: std::io::Error },
 
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),

--- a/components/oscar/src/hash.rs
+++ b/components/oscar/src/hash.rs
@@ -4,6 +4,7 @@
 use blake3::Hash;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use crate::{OscarError, OscarResult, MAX_OBJECT_SIZE};
 
 /// Content-addressable hash for objects using BLAKE3.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -81,5 +82,208 @@ impl ObjectHasher {
             hasher.update(&chunk);
         }
         ContentHash::new(hasher.finalize())
+    }
+
+    /// Validate that data size is within the maximum object size limit.
+    pub fn validate_size(data: &[u8]) -> OscarResult<()> {
+        if data.len() > MAX_OBJECT_SIZE {
+            return Err(OscarError::ObjectTooLarge {
+                size: data.len(),
+                max_size: MAX_OBJECT_SIZE,
+            });
+        }
+        Ok(())
+    }
+
+    /// Hash data with size validation.
+    pub fn hash_with_validation(data: &[u8]) -> OscarResult<ContentHash> {
+        Self::validate_size(data)?;
+        Ok(Self::hash(data))
+    }
+
+    /// Verify that computed hash matches the provided hash.
+    pub fn verify_hash(data: &[u8], expected_hash: &ContentHash) -> OscarResult<()> {
+        let computed_hash = Self::hash(data);
+        if computed_hash == *expected_hash {
+            Ok(())
+        } else {
+            Err(OscarError::HashMismatch {
+                expected: expected_hash.to_hex(),
+                computed: computed_hash.to_hex(),
+            })
+        }
+    }
+
+    /// Hash file contents with size validation.
+    pub fn hash_file<P: AsRef<std::path::Path>>(path: P) -> OscarResult<ContentHash> {
+        let data = std::fs::read(path.as_ref())
+            .map_err(|e| OscarError::IoError {
+                path: path.as_ref().to_path_buf(),
+                error: e,
+            })?;
+        Self::hash_with_validation(&data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_content_hash_creation() {
+        let data = b"hello world";
+        let hash = ObjectHasher::hash(data);
+        assert_eq!(hash.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn test_content_hash_hex_conversion() {
+        let data = b"hello world";
+        let hash = ObjectHasher::hash(data);
+        let hex_str = hash.to_hex();
+        assert_eq!(hex_str.len(), 64); // 32 bytes * 2 hex chars per byte
+        
+        let parsed_hash = ContentHash::from_hex(&hex_str).unwrap();
+        assert_eq!(hash, parsed_hash);
+    }
+
+    #[test]
+    fn test_content_hash_display() {
+        let data = b"hello world";
+        let hash = ObjectHasher::hash(data);
+        let display_str = format!("{}", hash);
+        assert_eq!(display_str, hash.to_hex());
+    }
+
+    #[test]
+    fn test_content_hash_serialization() {
+        let data = b"hello world";
+        let hash = ObjectHasher::hash(data);
+        
+        let serialized = serde_json::to_string(&hash).unwrap();
+        let deserialized: ContentHash = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(hash, deserialized);
+    }
+
+    #[test]
+    fn test_size_validation_within_limit() {
+        let small_data = vec![0u8; 1024]; // 1KB
+        assert!(ObjectHasher::validate_size(&small_data).is_ok());
+    }
+
+    #[test]
+    fn test_size_validation_at_limit() {
+        let max_data = vec![0u8; MAX_OBJECT_SIZE]; // Exactly 32MiB
+        assert!(ObjectHasher::validate_size(&max_data).is_ok());
+    }
+
+    #[test]
+    fn test_size_validation_exceeds_limit() {
+        let oversized_data = vec![0u8; MAX_OBJECT_SIZE + 1]; // 32MiB + 1 byte
+        let result = ObjectHasher::validate_size(&oversized_data);
+        assert!(result.is_err());
+        
+        if let Err(OscarError::ObjectTooLarge { size, max_size }) = result {
+            assert_eq!(size, MAX_OBJECT_SIZE + 1);
+            assert_eq!(max_size, MAX_OBJECT_SIZE);
+        } else {
+            panic!("Expected ObjectTooLarge error");
+        }
+    }
+
+    #[test]
+    fn test_hash_with_validation_success() {
+        let data = b"test data";
+        let result = ObjectHasher::hash_with_validation(data);
+        assert!(result.is_ok());
+        
+        let hash = result.unwrap();
+        assert_eq!(hash, ObjectHasher::hash(data));
+    }
+
+    #[test]
+    fn test_hash_with_validation_too_large() {
+        let oversized_data = vec![0u8; MAX_OBJECT_SIZE + 1];
+        let result = ObjectHasher::hash_with_validation(&oversized_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hash_verification_success() {
+        let data = b"test verification";
+        let hash = ObjectHasher::hash(data);
+        assert!(ObjectHasher::verify_hash(data, &hash).is_ok());
+    }
+
+    #[test]
+    fn test_hash_verification_failure() {
+        let data = b"test verification";
+        let hash = ObjectHasher::hash(data);
+        let different_data = b"different data";
+        
+        let result = ObjectHasher::verify_hash(different_data, &hash);
+        assert!(result.is_err());
+        
+        if let Err(OscarError::HashMismatch { expected, computed }) = result {
+            assert_eq!(expected, hash.to_hex());
+            assert_eq!(computed, ObjectHasher::hash(different_data).to_hex());
+        } else {
+            panic!("Expected HashMismatch error");
+        }
+    }
+
+    #[test]
+    fn test_hash_chunks_consistency() {
+        let data1 = bytes::Bytes::from("hello ");
+        let data2 = bytes::Bytes::from("world");
+        let chunks = vec![data1, data2];
+        
+        let chunked_hash = ObjectHasher::hash_chunks(chunks);
+        let direct_hash = ObjectHasher::hash(b"hello world");
+        
+        assert_eq!(chunked_hash, direct_hash);
+    }
+
+    #[test]
+    fn test_file_hashing() {
+        let mut temp_file = tempfile::NamedTempFile::new().unwrap();
+        let test_data = b"file content for hashing";
+        temp_file.write_all(test_data).unwrap();
+        
+        let file_hash = ObjectHasher::hash_file(temp_file.path()).unwrap();
+        let direct_hash = ObjectHasher::hash(test_data);
+        
+        assert_eq!(file_hash, direct_hash);
+    }
+
+    #[test]
+    fn test_file_hashing_too_large() {
+        let mut temp_file = tempfile::NamedTempFile::new().unwrap();
+        let oversized_data = vec![0u8; MAX_OBJECT_SIZE + 1];
+        temp_file.write_all(&oversized_data).unwrap();
+        
+        let result = ObjectHasher::hash_file(temp_file.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_file_hashing_nonexistent() {
+        let result = ObjectHasher::hash_file("/nonexistent/path");
+        assert!(result.is_err());
+    }
+
+    #[test] 
+    fn test_hex_parsing_invalid_length() {
+        let short_hex = "abc123";
+        let result = ContentHash::from_hex(short_hex);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hex_parsing_invalid_chars() {
+        let invalid_hex = "zz".repeat(32); // 64 chars but invalid hex
+        let result = ContentHash::from_hex(&invalid_hex);
+        assert!(result.is_err());
     }
 }

--- a/components/oscar/src/object.rs
+++ b/components/oscar/src/object.rs
@@ -143,7 +143,7 @@ impl SharedObject {
         if size > crate::MAX_OBJECT_SIZE {
             return Err(OscarError::ObjectTooLarge {
                 size,
-                max: crate::MAX_OBJECT_SIZE,
+                max_size: crate::MAX_OBJECT_SIZE,
             });
         }
 


### PR DESCRIPTION
- Add size validation with 32MiB limit (validate_size, hash_with_validation)
- Implement hash verification utility (verify_hash)
- Add file-based hashing with size validation (hash_file)
- Extend error types with IoError and corrected field names
- Add comprehensive unit tests (17 tests) covering:
  * Size validation edge cases (within/at/exceeds limit)
  * Hash verification success/failure scenarios
  * File operations (valid/oversized/non-existent)
  * Hex parsing, serialization, chunks consistency
- All tests passing, following TDD approach
- Reuses dynamo-runtime patterns for error handling and testing
