### PR TITLE
feat: enable --dyn-reasoning-parser flag to set reasoning parser for …

### DIFF
--- a/components/backends/vllm/src/dynamo/vllm/args.py
+++ b/components/backends/vllm/src/dynamo/vllm/args.py
@@ -117,7 +117,7 @@ def parse_args() -> Config:
         "--dyn-reasoning-parser",
         type=str,
         default=None,
-        help="Reasoning parser name for the model.",
+        help="Reasoning parser name for the model. Available options: 'basic', 'deepseek_r1', 'gpt_oss'.",
     )
 
     parser = AsyncEngineArgs.add_cli_args(parser)

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1433,7 +1433,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "tokio",
  "tracing",
  "uuid",
 ]

--- a/lib/llm/src/engines.rs
+++ b/lib/llm/src/engines.rs
@@ -14,6 +14,7 @@ use dynamo_runtime::pipeline::{Error, ManyOut, SingleIn};
 use dynamo_runtime::protocols::annotated::Annotated;
 
 use crate::backend::ExecutionContext;
+use crate::local_model::runtime_config;
 use crate::preprocessor::PreprocessedRequest;
 use crate::protocols::common::llm_backend::LLMEngineOutput;
 use crate::protocols::openai::{
@@ -183,7 +184,7 @@ impl
         incoming_request: SingleIn<NvCreateChatCompletionRequest>,
     ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
         let (request, context) = incoming_request.transfer(());
-        let mut deltas = request.response_generator();
+        let mut deltas = request.response_generator(runtime_config::ModelRuntimeConfig::default());
         let ctx = context.context();
         let req = request.inner.messages.into_iter().next_back().unwrap();
 

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -202,6 +202,7 @@ impl LocalModelBuilder {
             );
             card.migration_limit = self.migration_limit;
             card.user_data = self.user_data.take();
+            card.runtime_config = self.runtime_config.clone();
 
             return Ok(LocalModel {
                 card,
@@ -276,6 +277,7 @@ impl LocalModelBuilder {
 
         card.migration_limit = self.migration_limit;
         card.user_data = self.user_data.take();
+        card.runtime_config = self.runtime_config.clone();
 
         Ok(LocalModel {
             card,

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::local_model::runtime_config::ModelRuntimeConfig;
 use anyhow::{Context, Result};
 use derive_builder::Builder;
 use dynamo_runtime::{slug::Slug, storage::key_value_store::Versioned, transports::nats};
@@ -137,6 +138,9 @@ pub struct ModelDeploymentCard {
     /// User-defined metadata for custom worker behavior
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_data: Option<serde_json::Value>,
+
+    #[serde(default)]
+    pub runtime_config: ModelRuntimeConfig,
 }
 
 impl ModelDeploymentCard {
@@ -441,6 +445,7 @@ impl ModelDeploymentCard {
             kv_cache_block_size: 0,
             migration_limit: 0,
             user_data: None,
+            runtime_config: ModelRuntimeConfig::default(),
         })
     }
 
@@ -482,6 +487,7 @@ impl ModelDeploymentCard {
             kv_cache_block_size: 0, // set later
             migration_limit: 0,
             user_data: None,
+            runtime_config: ModelRuntimeConfig::default(),
         })
     }
 }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -115,4 +115,20 @@ impl ReasoningParserType {
             },
         }
     }
+
+    pub fn get_reasoning_parser_from_name(name: &str) -> ReasoningParserWrapper {
+        tracing::debug!("Selected reasoning parser: {}", name);
+        match name.to_lowercase().as_str() {
+            "deepseek_r1" => Self::DeepseekR1.get_reasoning_parser(),
+            "basic" => Self::Basic.get_reasoning_parser(),
+            "gpt_oss" => Self::GptOss.get_reasoning_parser(),
+            _ => {
+                tracing::warn!(
+                    "Unknown reasoning parser type '{}', falling back to Basic Reasoning Parser",
+                    name
+                );
+                Self::Basic.get_reasoning_parser()
+            }
+        }
+    }
 }


### PR DESCRIPTION
…one deployment

#### Overview:

enable --dyn-reasoning-parser flag to set reasoning parser for any dynamo.vllm deployment

changes the signature of one function, updates ModelDeploymentCard to bring these changes over etcd

-- See the propagation of ModelRuntimeConfig



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added runtime configuration for chat completion responses, enabling selection of reasoning parsers at runtime (basic, deepseek_r1, gpt_oss).
  - Reasoning parser automatically falls back to a default if an unknown option is provided.
  - Consistent runtime settings are now carried through model cards and preprocessing, ensuring predictable behavior across deployments.

- Documentation
  - Improved CLI help for --dyn-reasoning-parser to clearly list available options (basic, deepseek_r1, gpt_oss).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->