### PR TITLE
fix: sglang -- queue requests until model registration completes

### DIFF
--- a/components/backends/sglang/src/dynamo/sglang/register.py
+++ b/components/backends/sglang/src/dynamo/sglang/register.py
@@ -16,8 +16,12 @@ async def register_llm_with_runtime_config(
     endpoint: Endpoint,
     server_args: ServerArgs,
     migration_limit: int,
-):
-    """Register LLM with runtime config"""
+) -> bool:
+    """Register LLM with runtime config
+
+    Returns:
+        bool: True if registration succeeded, False if it failed
+    """
     runtime_config = await _get_runtime_config(engine)
     try:
         await register_llm(
@@ -29,9 +33,11 @@ async def register_llm_with_runtime_config(
             migration_limit=migration_limit,
             runtime_config=runtime_config,
         )
+        logging.info("Successfully registered LLM with runtime config")
+        return True
     except Exception as e:
         logging.error(f"Failed to register with runtime config: {e}")
-        return None
+        return False
 
 
 async def _get_runtime_config(engine: sgl.Engine) -> Optional[ModelRuntimeConfig]:


### PR DESCRIPTION
#### Overview:

Bugfix: add readiness gating to prevent race condition during sglang startup

This MR implements readiness gating to solve a race condition where the KV Scheduler selects workers before model registration completes. Now, the endpoint starts immediately and becomes discoverable but queues incoming requests until model registration succeeds, eliminating "instance_id not found" errors during startup.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Decoupled service startup from model registration, launching the endpoint in the background with a brief stabilization delay.
  * Enables concurrent registration during startup, reducing overall initialization time.
  * Preserves existing error handling and cleanup flows.

* **Bug Fixes**
  * Improves startup reliability by avoiding race conditions during registration and endpoint initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->