### PR TITLE
feat: add and enable reasoning and tool parser flags for trtllm and sglang

### DIFF
--- a/components/backends/sglang/src/dynamo/sglang/args.py
+++ b/components/backends/sglang/src/dynamo/sglang/args.py
@@ -10,7 +10,7 @@ import sys
 from argparse import Namespace
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from sglang.srt.server_args import ServerArgs
 
@@ -38,6 +38,10 @@ class DynamoArgs:
     component: str
     endpoint: str
     migration_limit: int
+
+    # tool and reasoning parser options
+    tool_call_parser: Optional[str] = None
+    reasoning_parser: Optional[str] = None
 
 
 class DisaggregationMode(Enum):
@@ -69,6 +73,20 @@ def parse_args(args: list[str]) -> Config:
 
     parser.add_argument(
         "--version", action="version", version=f"Dynamo Backend SGLang {__version__}"
+    )
+
+    # To avoid name conflicts with different backends, adoped prefix "dyn-" for dynamo specific args
+    parser.add_argument(
+        "--dyn-tool-call-parser",
+        type=str,
+        default=None,
+        help="Tool call parser name for the model. Available options: 'hermes', 'nemotron_deci', 'llama3_json', 'mistral', 'phi4'.",
+    )
+    parser.add_argument(
+        "--dyn-reasoning-parser",
+        type=str,
+        default=None,
+        help="Reasoning parser name for the model. Available options: 'basic', 'deepseek_r1', 'gpt_oss'.",
     )
 
     # Dynamo args
@@ -123,6 +141,8 @@ def parse_args(args: list[str]) -> Config:
         component=parsed_component_name,
         endpoint=parsed_endpoint_name,
         migration_limit=parsed_args.migration_limit,
+        tool_call_parser=parsed_args.dyn_tool_call_parser,
+        reasoning_parser=parsed_args.dyn_reasoning_parser,
     )
     logging.debug(f"Dynamo args: {dynamo_args}")
 

--- a/components/backends/sglang/src/dynamo/sglang/main.py
+++ b/components/backends/sglang/src/dynamo/sglang/main.py
@@ -97,8 +97,11 @@ async def init(runtime: DistributedRuntime, config: Config):
     async def register_model():
         """Register the model and signal readiness"""
         registration_success = await register_llm_with_runtime_config(
-            engine, generate_endpoint, server_args, dynamo_args,
-        )
+                                        engine,
+                                        generate_endpoint,
+                                        server_args,
+                                        dynamo_args,
+                                    )
 
         if not registration_success:
             logging.error("Model registration failed; shutting down")

--- a/components/backends/sglang/src/dynamo/sglang/main.py
+++ b/components/backends/sglang/src/dynamo/sglang/main.py
@@ -97,8 +97,8 @@ async def init(runtime: DistributedRuntime, config: Config):
     async def register_model():
         """Register the model and signal readiness"""
         registration_success = await register_llm_with_runtime_config(
-        engine, generate_endpoint, server_args, dynamo_args, dynamo_args.migration_limit
-    )
+            engine, generate_endpoint, server_args, dynamo_args,
+        )
 
         if not registration_success:
             logging.error("Model registration failed; shutting down")

--- a/components/backends/sglang/src/dynamo/sglang/main.py
+++ b/components/backends/sglang/src/dynamo/sglang/main.py
@@ -97,8 +97,8 @@ async def init(runtime: DistributedRuntime, config: Config):
     async def register_model():
         """Register the model and signal readiness"""
         registration_success = await register_llm_with_runtime_config(
-            engine, generate_endpoint, server_args, dynamo_args.migration_limit
-        )
+        engine, generate_endpoint, server_args, dynamo_args, dynamo_args.migration_limit
+    )
 
         if not registration_success:
             logging.error("Model registration failed; shutting down")

--- a/components/backends/sglang/src/dynamo/sglang/main.py
+++ b/components/backends/sglang/src/dynamo/sglang/main.py
@@ -97,11 +97,11 @@ async def init(runtime: DistributedRuntime, config: Config):
     async def register_model():
         """Register the model and signal readiness"""
         registration_success = await register_llm_with_runtime_config(
-                                        engine,
-                                        generate_endpoint,
-                                        server_args,
-                                        dynamo_args,
-                                    )
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+        )
 
         if not registration_success:
             logging.error("Model registration failed; shutting down")

--- a/components/backends/sglang/src/dynamo/sglang/register.py
+++ b/components/backends/sglang/src/dynamo/sglang/register.py
@@ -17,7 +17,6 @@ async def register_llm_with_runtime_config(
     endpoint: Endpoint,
     server_args: ServerArgs,
     dynamo_args: DynamoArgs,
-    migration_limit: int,
 ) -> bool:
     """Register LLM with runtime config
 
@@ -32,7 +31,7 @@ async def register_llm_with_runtime_config(
             server_args.model_path,
             server_args.served_model_name,
             kv_cache_block_size=server_args.page_size,
-            migration_limit=migration_limit,
+            migration_limit=dynamo_args.migration_limit,
             runtime_config=runtime_config,
         )
         logging.info("Successfully registered LLM with runtime config")

--- a/components/backends/sglang/src/dynamo/sglang/register.py
+++ b/components/backends/sglang/src/dynamo/sglang/register.py
@@ -6,10 +6,10 @@ from typing import Optional
 
 import sglang as sgl
 from sglang.srt.server_args import ServerArgs
-from dynamo.sglang.args import DynamoArgs
 
 from dynamo._core import Endpoint
 from dynamo.llm import ModelRuntimeConfig, ModelType, register_llm
+from dynamo.sglang.args import DynamoArgs
 
 
 async def register_llm_with_runtime_config(
@@ -41,7 +41,9 @@ async def register_llm_with_runtime_config(
         return False
 
 
-async def _get_runtime_config(engine: sgl.Engine, dynamo_args: DynamoArgs) -> Optional[ModelRuntimeConfig]:
+async def _get_runtime_config(
+    engine: sgl.Engine, dynamo_args: DynamoArgs
+) -> Optional[ModelRuntimeConfig]:
     """Get runtime config from SGLang engine"""
     runtime_config = ModelRuntimeConfig()
     # set reasoning parser and tool call parser
@@ -50,7 +52,6 @@ async def _get_runtime_config(engine: sgl.Engine, dynamo_args: DynamoArgs) -> Op
     try:
         # Try to check if the engine has a scheduler attribute with the computed values
         if hasattr(engine, "scheduler_info") and engine.scheduler_info is not None:
-
             # Get max_total_num_tokens from scheduler_info
             if "max_total_num_tokens" in engine.scheduler_info:
                 max_total_tokens = engine.scheduler_info["max_total_num_tokens"]

--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -231,7 +231,10 @@ async def init(runtime: DistributedRuntime, config: Config):
     async with get_llm_engine(engine_args) as engine:
         endpoint = component.endpoint(config.endpoint)
 
-        runtime_config = await get_engine_runtime_config(engine, config)
+        runtime_config = ModelRuntimeConfig()
+
+        runtime_config.reasoning_parser = config.reasoning_parser
+        runtime_config.tool_call_parser = config.tool_call_parser
 
         if is_first_worker(config):
             # Register the model with runtime config

--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -231,7 +231,7 @@ async def init(runtime: DistributedRuntime, config: Config):
     async with get_llm_engine(engine_args) as engine:
         endpoint = component.endpoint(config.endpoint)
 
-        runtime_config = get_engine_runtime_config(engine, config)
+        runtime_config = await get_engine_runtime_config(engine, config)
 
         if is_first_worker(config):
             # Register the model with runtime config

--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -228,6 +228,12 @@ async def init(runtime: DistributedRuntime, config: Config):
     async with get_llm_engine(engine_args) as engine:
         endpoint = component.endpoint(config.endpoint)
 
+        # should ideally call get_engine_runtime_config
+        # this is because we don't have a good way to
+        # get total_kv_blocks from the engine yet without calling get_stats_async
+        # This causes an issue because get_stats_async doesn't work when no requests are sent to the engine
+        # So for now, we just set the parsers from the config
+        # TODO: fix this once we have a better way to get total_kv_blocks
         runtime_config = ModelRuntimeConfig()
 
         runtime_config.reasoning_parser = config.reasoning_parser

--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -55,9 +55,6 @@ async def get_engine_runtime_config(
     """Retrieve runtime configuration from TensorRT-LLM engine."""
     runtime_config = ModelRuntimeConfig()
 
-    runtime_config.reasoning_parser = config.reasoning_parser
-    runtime_config.tool_call_parser = config.tool_call_parser
-
     try:
         # Extract total_kv_blocks from engine stats
         stats = engine.llm.get_stats_async(timeout=5)

--- a/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -240,7 +240,6 @@ def cmd_line_args():
         help=f"Endpoint(in 'dyn://namespace.component.endpoint' format) to send requests to when running in disaggregation mode. Default: {DEFAULT_NEXT_ENDPOINT} if first worker, empty if next worker",
     )
 
-
     # To avoid name conflicts with different backends, adoped prefix "dyn-" for dynamo specific args
     parser.add_argument(
         "--dyn-tool-call-parser",

--- a/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -49,6 +49,9 @@ class Config:
         self.next_endpoint: str = ""
         self.modality: str = "text"
 
+        self.reasoning_parser: Optional[str] = None
+        self.tool_call_parser: Optional[str] = None
+
     def __str__(self) -> str:
         return (
             f"Config(namespace={self.namespace}, "
@@ -73,6 +76,8 @@ class Config:
             f"disaggregation_strategy={self.disaggregation_strategy}, "
             f"next_endpoint={self.next_endpoint}, "
             f"modality={self.modality})"
+            f"reasoning_parser={self.reasoning_parser})"
+            f"tool_call_parser={self.tool_call_parser})"
         )
 
 
@@ -234,6 +239,22 @@ def cmd_line_args():
         default="",
         help=f"Endpoint(in 'dyn://namespace.component.endpoint' format) to send requests to when running in disaggregation mode. Default: {DEFAULT_NEXT_ENDPOINT} if first worker, empty if next worker",
     )
+
+
+    # To avoid name conflicts with different backends, adoped prefix "dyn-" for dynamo specific args
+    parser.add_argument(
+        "--dyn-tool-call-parser",
+        type=str,
+        default=None,
+        help="Tool call parser name for the model. Available options: 'hermes', 'nemotron_deci', 'llama3_json', 'mistral', 'phi4'.",
+    )
+    parser.add_argument(
+        "--dyn-reasoning-parser",
+        type=str,
+        default=None,
+        help="Reasoning parser name for the model. Available options: 'basic', 'deepseek_r1', 'gpt_oss'.",
+    )
+
     args = parser.parse_args()
 
     config = Config()
@@ -293,5 +314,8 @@ def cmd_line_args():
     config.extra_engine_args = args.extra_engine_args
     config.publish_events_and_metrics = args.publish_events_and_metrics
     config.modality = args.modality
+
+    config.reasoning_parser = args.dyn_reasoning_parser
+    config.tool_call_parser = args.dyn_tool_call_parser
 
     return config


### PR DESCRIPTION


#### Overview:

Follow the same recipe used for vLLM (#2619 ) component to enable tool and reasoning parsing for sglang and trtllm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added CLI options to select tool-call and reasoning parsers: --dyn-tool-call-parser and --dyn-reasoning-parser.
  - Backend configs now accept optional parser selections to tailor parsing behavior.
  - Introduced new disaggregation modes: PREFILL and DECODE for more flexible serving strategies.

- Bug Fixes
  - More resilient runtime configuration initialization with graceful fallbacks and warnings if scheduler info is unavailable.
  - Consistent propagation of runtime configuration during model registration, improving reliability across backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->