### PR TITLE
feat: allow specifying consumer name for NATS queue + manually purge old messages

### DIFF
--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -544,6 +544,45 @@ impl NatsQueue {
         Ok(())
     }
 
+    /// Shutdown the consumer by deleting it from the stream and closing the connection
+    /// This permanently removes the consumer from the server
+    pub async fn shutdown(&mut self) -> Result<()> {
+        if let (Some(client), Some(consumer_name)) = (&self.client, &self.consumer_name) {
+            // Get the stream and delete the consumer
+            let stream = client.jetstream().get_stream(&self.stream_name).await?;
+            stream.delete_consumer(consumer_name).await.map_err(|e| {
+                anyhow::anyhow!("Failed to delete consumer {}: {}", consumer_name, e)
+            })?;
+            log::debug!(
+                "Deleted consumer {} from stream {}",
+                consumer_name,
+                self.stream_name
+            );
+        } else {
+            log::warn!(
+                "Cannot shutdown consumer: client or consumer_name is None (client: {:?}, consumer_name: {:?})",
+                self.client.is_some(),
+                self.consumer_name.is_some()
+            );
+        }
+
+        // Then close the connection
+        self.close().await
+    }
+
+    /// Count the number of consumers for the stream
+    pub async fn count_consumers(&mut self) -> Result<usize> {
+        self.ensure_connection().await?;
+
+        if let Some(client) = &self.client {
+            let mut stream = client.jetstream().get_stream(&self.stream_name).await?;
+            let info = stream.info().await?;
+            Ok(info.state.consumer_count as usize)
+        } else {
+            Err(anyhow::anyhow!("Client not connected"))
+        }
+    }
+
     /// Enqueue a task using the provided data
     pub async fn enqueue_task(&mut self, task_data: Bytes) -> Result<()> {
         self.ensure_connection().await?;
@@ -630,6 +669,79 @@ impl NatsQueue {
         } else {
             Err(anyhow::anyhow!("Client not connected"))
         }
+    }
+
+    /// Purge messages from the stream up to the minimum acknowledged sequence across all consumers
+    /// This finds the lowest acknowledged sequence number across all consumers and purges up to that point
+    pub async fn purge_acknowledged(&mut self) -> Result<()> {
+        self.ensure_connection().await?;
+
+        let Some(client) = &self.client else {
+            return Err(anyhow::anyhow!("Client not connected"));
+        };
+
+        let stream = client.jetstream().get_stream(&self.stream_name).await?;
+
+        // Get all consumer names for the stream
+        let consumer_names: Vec<String> = stream
+            .consumer_names()
+            .try_collect()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to list consumers: {}", e))?;
+
+        if consumer_names.is_empty() {
+            log::debug!("No consumers found for stream {}", self.stream_name);
+            return Ok(());
+        }
+
+        // Find the minimum acknowledged sequence across all consumers
+        let mut min_ack_sequence = u64::MAX;
+
+        for consumer_name in &consumer_names {
+            let mut consumer: jetstream::consumer::PullConsumer = stream
+                .get_consumer(consumer_name)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to get consumer {}: {}", consumer_name, e))?;
+
+            let info = consumer.info().await.map_err(|e| {
+                anyhow::anyhow!("Failed to get consumer info for {}: {}", consumer_name, e)
+            })?;
+
+            // The ack_floor contains the stream sequence of the highest contiguously acknowledged message
+            // If stream_sequence is 0, it means no messages have been acknowledged yet
+            if info.ack_floor.stream_sequence > 0 {
+                min_ack_sequence = min_ack_sequence.min(info.ack_floor.stream_sequence);
+                log::debug!(
+                    "Consumer {} has ack_floor at sequence {}",
+                    consumer_name,
+                    info.ack_floor.stream_sequence
+                );
+            }
+        }
+
+        // Only purge if we found a valid minimum acknowledged sequence
+        if min_ack_sequence < u64::MAX && min_ack_sequence > 0 {
+            // Purge up to (but not including) the minimum acknowledged sequence + 1
+            // We add 1 because we want to include the minimum acknowledged message in the purge
+            let purge_sequence = min_ack_sequence + 1;
+
+            self.purge_up_to_sequence(purge_sequence).await?;
+
+            log::info!(
+                "Purged stream {} up to acknowledged sequence {} (purged up to sequence {})",
+                self.stream_name,
+                min_ack_sequence,
+                purge_sequence
+            );
+        } else {
+            log::debug!(
+                "No messages to purge for stream {} (min_ack_sequence: {})",
+                self.stream_name,
+                min_ack_sequence
+            );
+        }
+
+        Ok(())
     }
 }
 
@@ -916,45 +1028,115 @@ mod tests {
         // Give JetStream a moment to process the purge
         tokio::time::sleep(time::Duration::from_millis(100)).await;
 
-        // Now both consumers should only receive messages 3 and 4
-        let mut consumer1_messages = Vec::new();
-        let mut consumer2_messages = Vec::new();
+        // Consumer 1 dequeues one message (message3)
+        let msg3_consumer1 = queue1
+            .dequeue_task(Some(time::Duration::from_millis(500)))
+            .await
+            .expect("Failed to dequeue from queue1");
+        assert_eq!(
+            msg3_consumer1,
+            Some(messages[2].clone()),
+            "Consumer 1 should get message3"
+        );
 
-        // Collect messages from consumer 1
+        // Give JetStream a moment to process acknowledgments
+        tokio::time::sleep(time::Duration::from_millis(100)).await;
+
+        // Now run purge_acknowledged
+        // At this point:
+        // - Consumer 1 has ack'd message 3 (ack_floor = 3)
+        // - Consumer 2 hasn't consumed anything yet (ack_floor = 0)
+        // - Min ack_floor = 0, so nothing will be purged
+        queue1
+            .purge_acknowledged()
+            .await
+            .expect("Failed to purge acknowledged messages");
+
+        // Give JetStream a moment to process the purge
+        tokio::time::sleep(time::Duration::from_millis(100)).await;
+
+        // Now collect remaining messages from both consumers
+        let mut consumer1_remaining = Vec::new();
+        let mut consumer2_remaining = Vec::new();
+
+        // Collect remaining messages from consumer 1
         while let Some(msg) = queue1
             .dequeue_task(None)
             .await
             .expect("Failed to dequeue from queue1")
         {
-            consumer1_messages.push(msg);
+            consumer1_remaining.push(msg);
         }
 
-        // Collect messages from consumer 2
+        // Collect remaining messages from consumer 2
         while let Some(msg) = queue2
             .dequeue_task(None)
             .await
             .expect("Failed to dequeue from queue2")
         {
-            consumer2_messages.push(msg);
+            consumer2_remaining.push(msg);
         }
 
-        // Verify both consumers received exactly 2 messages (message3 and message4)
+        // Verify consumer 1 gets 1 remaining message (message4)
         assert_eq!(
-            consumer1_messages.len(),
-            2,
-            "Wrong message count for consumer 1"
+            consumer1_remaining.len(),
+            1,
+            "Consumer 1 should have 1 remaining message"
         );
         assert_eq!(
-            consumer2_messages.len(),
-            2,
-            "Wrong message count for consumer 2"
+            consumer1_remaining[0], messages[3],
+            "Consumer 1 should get message4"
         );
 
-        // Verify the messages are the last two (message3 and message4)
-        assert_eq!(consumer1_messages[0], messages[2]);
-        assert_eq!(consumer1_messages[1], messages[3]);
-        assert_eq!(consumer2_messages[0], messages[2]);
-        assert_eq!(consumer2_messages[1], messages[3]);
+        // Verify consumer 2 gets 2 messages (message3 and message4)
+        assert_eq!(
+            consumer2_remaining.len(),
+            2,
+            "Consumer 2 should have 2 messages"
+        );
+        assert_eq!(
+            consumer2_remaining[0], messages[2],
+            "Consumer 2 should get message3"
+        );
+        assert_eq!(
+            consumer2_remaining[1], messages[3],
+            "Consumer 2 should get message4"
+        );
+
+        // Test consumer count and shutdown behavior
+        // First verify via consumer 1 that there are two consumers
+        let consumer_count = queue1
+            .count_consumers()
+            .await
+            .expect("Failed to count consumers");
+        assert_eq!(consumer_count, 2, "Should have 2 consumers initially");
+
+        // Close consumer 1 and verify via consumer 2 that there are still two consumers
+        queue1.close().await.expect("Failed to close queue1");
+
+        let consumer_count = queue2
+            .count_consumers()
+            .await
+            .expect("Failed to count consumers");
+        assert_eq!(
+            consumer_count, 2,
+            "Should still have 2 consumers after closing queue1"
+        );
+
+        // Reconnect queue1 to be able to shutdown
+        queue1.connect().await.expect("Failed to reconnect queue1");
+
+        // Shutdown consumer 1 and verify via consumer 2 that there is only one consumer left
+        queue1.shutdown().await.expect("Failed to shutdown queue1");
+
+        let consumer_count = queue2
+            .count_consumers()
+            .await
+            .expect("Failed to count consumers");
+        assert_eq!(
+            consumer_count, 1,
+            "Should have only 1 consumer after shutting down queue1"
+        );
 
         // Clean up by deleting the stream
         client

--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -577,7 +577,7 @@ impl NatsQueue {
         if let Some(client) = &self.client {
             let mut stream = client.jetstream().get_stream(&self.stream_name).await?;
             let info = stream.info().await?;
-            Ok(info.state.consumer_count as usize)
+            Ok(info.state.consumer_count)
         } else {
             Err(anyhow::anyhow!("Client not connected"))
         }


### PR DESCRIPTION
## Add broadcast pattern and purge support to NatsQueue

### Summary
Extends `NatsQueue` to support multiple consumers independently receiving all messages (broadcast pattern) and adds stream purging to prevent unbounded storage growth.

### Motivation
- Multiple router replicas need to receive all KV events independently for redundancy
- Old KV events must be purged after radix tree snapshots to prevent unbounded storage

### Changes

#### 1. Configurable Consumer Names
- Added optional `consumer_name` field to `NatsQueue`
- Added `new_with_consumer()` constructor for creating queues with unique consumer names
- Each consumer with a unique name receives all messages (broadcast instead of work-queue)

#### 2. Stream Purging
- Added `purge_up_to_sequence()` to permanently remove messages up to a specified sequence
- Enables cleanup of old KV events after radix tree snapshots

### Testing
Added `test_nats_queue_broadcast_with_purge` integration test verifying:
- Multiple consumers with unique names receive all messages
- Purging removes messages for all consumers
- Only messages after purge sequence are delivered

### Backward Compatibility
Existing code using `NatsQueue::new()` continues unchanged with default "worker-group" consumer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-consumer broadcast support: run multiple named consumers that each receive the full message stream independently.
  * Ability to purge messages up to a specified sequence for easier stream maintenance.
* **Bug Fixes**
  * Queue size now correctly reflects the selected consumer rather than a fixed default.
* **Tests**
  * Added integration tests covering per-consumer broadcasts and purge behavior to ensure correct delivery and cleanup across multiple consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->