### PR TITLE
feat: add SGLANG devcontainer documentation

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -255,7 +255,7 @@ Afterwards, edit your `.devcontainer/sglang/devcontainer.json` so that the name 
 ```json
     "name": "[sglang] This is my amazing custom Dev Container Development",
     ...
-    "image": "dynamo:latest-vllm-local-dev",
+    "image": "dynamo:latest-sglang-local-dev",
 ```
 
 Now, go to **Dev Containers: Open Folder in Container** and select `[sglang] This is my amazing custom Dev Container Development`. The post-create.sh script should be running.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -92,10 +92,10 @@ Follow these steps to get your NVIDIA Dynamo development environment up and runn
 ### Step 1: Build the Development Container Image
 
 Build `dynamo:latest-vllm-local-dev` from scratch from the source:
-- Note that currently, `local-dev` is only implemented.
+- Note that currently, `local-dev` is only implemented for `--framework VLLM`.
 
 ```bash
-./container/build.sh --target local-dev
+./container/build.sh --target local-dev --framework VLLM
 ```
 
 The container will be built and give certain file permissions to your local uid and gid.
@@ -195,13 +195,6 @@ File Structure:
 - Bash memory preserved between sessions at `/home/ubuntu/.commandhistory` using docker volume `dynamo-bashhistory`
 - Precommit preserved between sessions at `/home/ubuntu/.cache/precommit` using docker volume `dynamo-precommit-cache`
 
-## Customization
-Edit `.devcontainer/devcontainer.json` to modify:
-- VS Code settings and extensions
-- Environment variables
-- Container configuration
-- Custom Mounts
-
 ## Documentation
 
 To look at the docs run:
@@ -242,6 +235,31 @@ cp .devcontainer/devcontainer.json .devcontainer/jensen_dev/devcontainer.json
 ```
 
 Common customizations include additional mounts, environment variables, IDE extensions, and build arguments. When you open a new Dev Container, you can pick from any of the `.devcontainer/<path>/devcontainer.json` files available.
+
+### SGLANG Custom devcontainer.json Configuration (EXPERIMENTAL)
+
+This is experimental. Please update/fix if you encounter problems. For sglang Dev Container, you first need to build `dynamo:latest-sglang-local-dev` image like this (wait about half an hour):
+
+```bash
+./container/build.sh --framework SGLANG --target local-dev
+```
+
+Then, make a copy of the `devcontainer.json file` to a directory of your choice. For this example, we'll just call it `sglang`:
+
+```bash
+mkdir .devcontainer/sglang/
+cp -a .devcontainer/devcontainer.json .devcontainer/sglang/
+```
+
+Afterwards, edit your `.devcontainer/sglang/devcontainer.json` so that the name and image correspond to SGLANG. Example:
+```json
+    "name": "[sglang] This is my amazing custom Dev Container Development",
+    ...
+    "image": "dynamo:latest-vllm-local-dev",
+```
+
+Now, go to **Dev Containers: Open Folder in Container** and select `[sglang] This is my amazing custom Dev Container Development`. The post-create.sh script should be running.
+
 
 ### SSH Keys for Git Operations
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -57,13 +57,15 @@ cargo build --locked --profile dev --features mistralrs
 
 # install the python bindings
 
-# Install maturin if not already installed
-if ! command -v maturin &> /dev/null; then
-    echo "Installing maturin..."
-    retry uv pip install maturin[patchelf]
-else
-    echo "maturin is already installed"
-fi
+# Install maturin if not already installed.
+# TODO: Uncomment for SGLANG. Right now, the CI team is making a refactor
+#       to the Dockerfile, so this is a temporary fix.
+# if ! command -v maturin &> /dev/null; then
+#     echo "Installing maturin..."
+#     retry uv pip install maturin[patchelf]
+# else
+#     echo "maturin is already installed"
+# fi
 
 (cd $HOME/dynamo/lib/bindings/python && retry maturin develop)
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -56,6 +56,15 @@ uv pip uninstall --yes ai-dynamo ai-dynamo-runtime 2>/dev/null || true
 cargo build --locked --profile dev --features mistralrs
 
 # install the python bindings
+
+# Install maturin if not already installed
+if ! command -v maturin &> /dev/null; then
+    echo "Installing maturin..."
+    retry uv pip install maturin[patchelf]
+else
+    echo "maturin is already installed"
+fi
+
 (cd $HOME/dynamo/lib/bindings/python && retry maturin develop)
 
 # installs overall python packages, grabs binaries from .build/target/debug


### PR DESCRIPTION
#### Overview:

Add experimental SGLANG devcontainer support documentation and improve the post-create script.

#### Details:

- Added documentation for setting up SGLANG custom devcontainer configuration
- Added conditional maturin installation in post-create.sh to prevent build failures
- Removed redundant permission fix commands (mkdir/chown for cache and dynamo dirs)
- Corrected typo in local-dev implementation note

#### Where should the reviewer start?

- .devcontainer/README.md (lines 189-211) - new SGLANG configuration section
- .devcontainer/post-create.sh (lines 65-71) - maturin installation check

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that local-dev currently supports VLLM only; minor grammar fix.
  * Added an experimental guide for using SGLANG with a custom devcontainer, including sample config and steps.
  * Removed the generic customization section to streamline the flow.
* **Chores**
  * Dev container setup now conditionally installs maturin and retries build steps for improved reliability.
  * Python bindings are built via maturin develop within the bindings directory.
  * Removed the volume permission normalization step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->