### PR TITLE
docs: note that DCO check is required to merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,8 @@ By making a contribution to this project, I certify that:
 ```
 
 We require that every contribution to Dynamo is signed with
-a Developer Certificate of Origin. Additionally, please use your real name.
+a Developer Certificate of Origin, this is verified by a required CI check.
+Additionally, please use your real name.
 We do not accept anonymous contributors nor those utilizing pseudonyms.
 
 Each commit must include a DCO which looks like this


### PR DESCRIPTION
#### Overview:

This updates CONDTRIBUTING.md to highlight that all contributions must has a sign-off and that this is a required CI check.


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes: OPS-572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines to clarify the DCO sign-off requirement is verified by a required CI check.
  * Moved the “use your real name” directive to its own line for emphasis; policy against anonymous contributions remains unchanged.
  * Docs-only update with no impact on product functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->