### PR TITLE
feat: Auto-inject kai-scheduler annotations and label

### DIFF
--- a/deploy/cloud/helm/platform/components/operator/templates/manager-rbac.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/manager-rbac.yaml
@@ -138,6 +138,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - scheduling.run.ai
+  resources:
+  - queues
+  verbs:
+  - get
+  - list
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -474,6 +481,45 @@ roleRef:
   kind: ClusterRole
 {{- end }}
   name: '{{ include "dynamo-operator.fullname" . }}-manager-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "dynamo-operator.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'
+---
+# ClusterRole for kai-scheduler queue access
+# This is always a ClusterRole since Queue resources are cluster-scoped
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dynamo-operator.fullname" . }}-queue-reader
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dynamo-operator
+    app.kubernetes.io/part-of: dynamo-operator
+  {{- include "dynamo-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - scheduling.run.ai
+  resources:
+  - queues
+  verbs:
+  - get
+  - list
+---
+# ClusterRoleBinding for kai-scheduler queue access
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dynamo-operator.fullname" . }}-queue-reader-binding
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dynamo-operator
+    app.kubernetes.io/part-of: dynamo-operator
+  {{- include "dynamo-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "dynamo-operator.fullname" . }}-queue-reader
 subjects:
 - kind: ServiceAccount
   name: '{{ include "dynamo-operator.fullname" . }}-controller-manager'

--- a/deploy/cloud/operator/cmd/main.go
+++ b/deploy/cloud/operator/cmd/main.go
@@ -172,6 +172,9 @@ func main() {
 		LWS: commonController.LWSConfig{
 			Enabled: false, // Will be set after LWS discovery
 		},
+		KaiScheduler: commonController.KaiSchedulerConfig{
+			Enabled: false, // Will be set after Kai-scheduler discovery
+		},
 		EtcdAddress: etcdAddr,
 		NatsAddress: natsAddr,
 		IngressConfig: commonController.IngressConfig{
@@ -246,6 +249,11 @@ func main() {
 	setupLog.Info("Detecting LWS availability...")
 	lwsEnabled := commonController.DetectLWSAvailability(mainCtx, mgr)
 	ctrlConfig.LWS.Enabled = lwsEnabled
+
+	// Detect Kai-scheduler availability using discovery client
+	setupLog.Info("Detecting Kai-scheduler availability...")
+	kaiSchedulerEnabled := commonController.DetectKaiSchedulerAvailability(mainCtx, mgr)
+	ctrlConfig.KaiScheduler.Enabled = kaiSchedulerEnabled
 
 	// Create etcd client
 	cli, err := clientv3.New(clientv3.Config{

--- a/deploy/cloud/operator/config/rbac/role.yaml
+++ b/deploy/cloud/operator/config/rbac/role.yaml
@@ -186,6 +186,13 @@ rules:
   - patch
   - update
 - apiGroups:
+  - scheduling.run.ai
+  resources:
+  - queues
+  verbs:
+  - get
+  - list
+- apiGroups:
   - scheduling.volcano.sh
   resources:
   - podgroups

--- a/deploy/cloud/operator/internal/consts/consts.go
+++ b/deploy/cloud/operator/internal/consts/consts.go
@@ -1,6 +1,10 @@
 package consts
 
-import "time"
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 const (
 	HPACPUDefaultAverageUtilization = 80
@@ -55,6 +59,12 @@ const (
 	DefaultSharedMemoryMountPath = "/dev/shm"
 	DefaultSharedMemorySize      = "8Gi"
 
+	// Kai-scheduler related constants
+	KubeAnnotationKaiSchedulerQueue = "nvidia.com/kai-scheduler-queue" // User-provided annotation to specify queue name
+	KubeLabelKaiSchedulerQueue      = "kai.scheduler/queue"            // Label injected into pods for kai-scheduler
+	KaiSchedulerName                = "kai-scheduler"                  // Scheduler name for kai-scheduler
+	DefaultKaiSchedulerQueue        = "dynamo"                         // Default queue name when none specified
+
 	// Grove multinode role suffixes
 	GroveRoleSuffixLeader = "ldr"
 	GroveRoleSuffixWorker = "wkr"
@@ -67,4 +77,26 @@ type MultinodeDeploymentType string
 const (
 	MultinodeDeploymentTypeGrove MultinodeDeploymentType = "grove"
 	MultinodeDeploymentTypeLWS   MultinodeDeploymentType = "lws"
+)
+
+// GroupVersionResources for external APIs
+var (
+	// Grove GroupVersionResources for scaling operations
+	PodCliqueGVR = schema.GroupVersionResource{
+		Group:    "grove.io",
+		Version:  "v1alpha1",
+		Resource: "podcliques",
+	}
+	PodCliqueScalingGroupGVR = schema.GroupVersionResource{
+		Group:    "grove.io",
+		Version:  "v1alpha1",
+		Resource: "podcliquescalinggroups",
+	}
+
+	// KAI-Scheduler GroupVersionResource for queue validation
+	QueueGVR = schema.GroupVersionResource{
+		Group:    "scheduling.run.ai",
+		Version:  "v2",
+		Resource: "queues",
+	}
 )

--- a/deploy/cloud/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/cloud/operator/internal/controller/dynamographdeployment_controller.go
@@ -55,20 +55,6 @@ const (
 	PendingState State = "pending"
 )
 
-var (
-	// Grove GroupVersionResources for scaling operations
-	podCliqueGVR = schema.GroupVersionResource{
-		Group:    "grove.io",
-		Version:  "v1alpha1",
-		Resource: "podcliques",
-	}
-	podCliqueScalingGroupGVR = schema.GroupVersionResource{
-		Group:    "grove.io",
-		Version:  "v1alpha1",
-		Resource: "podcliquescalinggroups",
-	}
-)
-
 type etcdStorage interface {
 	DeleteKeys(ctx context.Context, prefix string) error
 }
@@ -88,6 +74,7 @@ type DynamoGraphDeploymentReconciler struct {
 // +kubebuilder:rbac:groups=grove.io,resources=podgangsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=grove.io,resources=podcliques/scale,verbs=get;update;patch
 // +kubebuilder:rbac:groups=grove.io,resources=podcliquescalinggroups/scale,verbs=get;update;patch
+// +kubebuilder:rbac:groups=scheduling.run.ai,resources=queues,verbs=get;list
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -201,9 +188,9 @@ func (r *DynamoGraphDeploymentReconciler) scaleGroveResource(ctx context.Context
 	var gvr schema.GroupVersionResource
 	switch resourceType {
 	case "PodClique":
-		gvr = podCliqueGVR
+		gvr = consts.PodCliqueGVR
 	case "PodCliqueScalingGroup":
-		gvr = podCliqueScalingGroupGVR
+		gvr = consts.PodCliqueScalingGroupGVR
 	default:
 		return fmt.Errorf("unsupported Grove resource type: %s", resourceType)
 	}

--- a/deploy/cloud/operator/internal/controller_common/predicate.go
+++ b/deploy/cloud/operator/internal/controller_common/predicate.go
@@ -42,11 +42,17 @@ type LWSConfig struct {
 	Enabled bool
 }
 
+type KaiSchedulerConfig struct {
+	// Enabled is automatically determined by checking if Kai-scheduler CRDs are installed in the cluster
+	Enabled bool
+}
+
 type Config struct {
 	// Enable resources filtering, only the resources belonging to the given namespace will be handled.
 	RestrictedNamespace string
 	Grove               GroveConfig
 	LWS                 LWSConfig
+	KaiScheduler        KaiSchedulerConfig
 	EtcdAddress         string
 	NatsAddress         string
 	IngressConfig       IngressConfig
@@ -73,6 +79,12 @@ func DetectGroveAvailability(ctx context.Context, mgr ctrl.Manager) bool {
 // This approach uses the discovery client which is simpler and more reliable
 func DetectLWSAvailability(ctx context.Context, mgr ctrl.Manager) bool {
 	return detectAPIGroupAvailability(ctx, mgr, "leaderworkerset.x-k8s.io")
+}
+
+// DetectKaiSchedulerAvailability checks if Kai-scheduler is available by checking if the scheduling.run.ai API group is registered
+// This approach uses the discovery client which is simpler and more reliable
+func DetectKaiSchedulerAvailability(ctx context.Context, mgr ctrl.Manager) bool {
+	return detectAPIGroupAvailability(ctx, mgr, "scheduling.run.ai")
 }
 
 // detectAPIGroupAvailability checks if a specific API group is registered in the cluster
@@ -107,6 +119,7 @@ func detectAPIGroupAvailability(ctx context.Context, mgr ctrl.Manager, groupName
 	logger.Info("API group not available", "group", groupName)
 	return false
 }
+
 func EphemeralDeploymentEventFilter(config Config) predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(o client.Object) bool {
 		l := log.FromContext(context.Background())

--- a/deploy/cloud/operator/internal/dynamo/grove_test.go
+++ b/deploy/cloud/operator/internal/dynamo/grove_test.go
@@ -1,0 +1,313 @@
+package dynamo
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	grovev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/cloud/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/cloud/operator/internal/controller_common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestResolveKaiSchedulerQueueName(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    string
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    commonconsts.DefaultKaiSchedulerQueue,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			expected:    commonconsts.DefaultKaiSchedulerQueue,
+		},
+		{
+			name: "no kai-scheduler annotation",
+			annotations: map[string]string{
+				"other-annotation": "value",
+			},
+			expected: commonconsts.DefaultKaiSchedulerQueue,
+		},
+		{
+			name: "empty kai-scheduler annotation",
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationKaiSchedulerQueue: "",
+			},
+			expected: commonconsts.DefaultKaiSchedulerQueue,
+		},
+		{
+			name: "custom queue name",
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationKaiSchedulerQueue: "custom-queue",
+			},
+			expected: "custom-queue",
+		},
+		{
+			name: "whitespace is trimmed",
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationKaiSchedulerQueue: "  custom-queue  ",
+			},
+			expected: "custom-queue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveKaiSchedulerQueueName(tt.annotations)
+			if result != tt.expected {
+				t.Errorf("resolveKaiSchedulerQueueName() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveKaiSchedulerQueue(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    string
+	}{
+		{
+			name:        "default queue",
+			annotations: nil,
+			expected:    commonconsts.DefaultKaiSchedulerQueue,
+		},
+		{
+			name: "custom queue",
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationKaiSchedulerQueue: "my-queue",
+			},
+			expected: "my-queue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ResolveKaiSchedulerQueue(tt.annotations)
+			if result != tt.expected {
+				t.Errorf("ResolveKaiSchedulerQueue() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestInjectKaiSchedulerIfEnabled(t *testing.T) {
+	tests := []struct {
+		name               string
+		controllerConfig   controller_common.Config
+		validatedQueueName string
+		initialClique      *grovev1alpha1.PodCliqueTemplateSpec
+		expectedScheduler  string
+		expectedQueueLabel string
+		shouldInject       bool
+	}{
+		{
+			name: "grove disabled - no injection",
+			controllerConfig: controller_common.Config{
+				Grove:        controller_common.GroveConfig{Enabled: false},
+				KaiScheduler: controller_common.KaiSchedulerConfig{Enabled: true},
+			},
+			validatedQueueName: "test-queue",
+			initialClique: &grovev1alpha1.PodCliqueTemplateSpec{
+				Spec: grovev1alpha1.PodCliqueSpec{
+					PodSpec: corev1.PodSpec{},
+				},
+			},
+			shouldInject: false,
+		},
+		{
+			name: "kai-scheduler disabled - no injection",
+			controllerConfig: controller_common.Config{
+				Grove:        controller_common.GroveConfig{Enabled: true},
+				KaiScheduler: controller_common.KaiSchedulerConfig{Enabled: false},
+			},
+			validatedQueueName: "test-queue",
+			initialClique: &grovev1alpha1.PodCliqueTemplateSpec{
+				Spec: grovev1alpha1.PodCliqueSpec{
+					PodSpec: corev1.PodSpec{},
+				},
+			},
+			shouldInject: false,
+		},
+		{
+			name: "manual scheduler set - no injection",
+			controllerConfig: controller_common.Config{
+				Grove:        controller_common.GroveConfig{Enabled: true},
+				KaiScheduler: controller_common.KaiSchedulerConfig{Enabled: true},
+			},
+			validatedQueueName: "test-queue",
+			initialClique: &grovev1alpha1.PodCliqueTemplateSpec{
+				Spec: grovev1alpha1.PodCliqueSpec{
+					PodSpec: corev1.PodSpec{
+						SchedulerName: "manual-scheduler",
+					},
+				},
+			},
+			shouldInject: false,
+		},
+		{
+			name: "both enabled, no manual scheduler - inject",
+			controllerConfig: controller_common.Config{
+				Grove:        controller_common.GroveConfig{Enabled: true},
+				KaiScheduler: controller_common.KaiSchedulerConfig{Enabled: true},
+			},
+			validatedQueueName: "test-queue",
+			initialClique: &grovev1alpha1.PodCliqueTemplateSpec{
+				Spec: grovev1alpha1.PodCliqueSpec{
+					PodSpec: corev1.PodSpec{},
+				},
+			},
+			expectedScheduler:  commonconsts.KaiSchedulerName,
+			expectedQueueLabel: "test-queue",
+			shouldInject:       true,
+		},
+		{
+			name: "inject with existing labels",
+			controllerConfig: controller_common.Config{
+				Grove:        controller_common.GroveConfig{Enabled: true},
+				KaiScheduler: controller_common.KaiSchedulerConfig{Enabled: true},
+			},
+			validatedQueueName: "custom-queue",
+			initialClique: &grovev1alpha1.PodCliqueTemplateSpec{
+				Labels: map[string]string{
+					"existing-label": "existing-value",
+				},
+				Spec: grovev1alpha1.PodCliqueSpec{
+					PodSpec: corev1.PodSpec{},
+				},
+			},
+			expectedScheduler:  commonconsts.KaiSchedulerName,
+			expectedQueueLabel: "custom-queue",
+			shouldInject:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a deep copy to avoid modifying the test case
+			clique := tt.initialClique.DeepCopy()
+
+			// Call the function
+			injectKaiSchedulerIfEnabled(clique, tt.controllerConfig, tt.validatedQueueName)
+
+			if tt.shouldInject {
+				// Verify scheduler name is injected
+				if clique.Spec.PodSpec.SchedulerName != tt.expectedScheduler {
+					t.Errorf("expected schedulerName %v, got %v", tt.expectedScheduler, clique.Spec.PodSpec.SchedulerName)
+				}
+
+				// Verify queue label is injected
+				if clique.Labels == nil {
+					t.Errorf("expected labels to be set, got nil")
+				} else {
+					queueLabel := clique.Labels[commonconsts.KubeLabelKaiSchedulerQueue]
+					if queueLabel != tt.expectedQueueLabel {
+						t.Errorf("expected queue label %v, got %v", tt.expectedQueueLabel, queueLabel)
+					}
+				}
+
+				// Verify existing labels are preserved
+				if tt.initialClique.Labels != nil {
+					for key, value := range tt.initialClique.Labels {
+						if clique.Labels[key] != value {
+							t.Errorf("existing label %s=%s was not preserved, got %s", key, value, clique.Labels[key])
+						}
+					}
+				}
+			} else {
+				// Verify no injection occurred
+				if clique.Spec.PodSpec.SchedulerName != tt.initialClique.Spec.PodSpec.SchedulerName {
+					t.Errorf("schedulerName should not have changed, expected %v, got %v",
+						tt.initialClique.Spec.PodSpec.SchedulerName, clique.Spec.PodSpec.SchedulerName)
+				}
+
+				// Verify queue label was not added (unless it existed before)
+				if tt.initialClique.Labels == nil || tt.initialClique.Labels[commonconsts.KubeLabelKaiSchedulerQueue] == "" {
+					if clique.Labels != nil && clique.Labels[commonconsts.KubeLabelKaiSchedulerQueue] != "" {
+						t.Errorf("queue label should not have been added")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureQueueExists(t *testing.T) {
+	tests := []struct {
+		name          string
+		queueName     string
+		setupQueue    bool
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name:          "queue exists",
+			queueName:     "existing-queue",
+			setupQueue:    true,
+			expectedError: false,
+		},
+		{
+			name:          "queue does not exist",
+			queueName:     "missing-queue",
+			setupQueue:    false,
+			expectedError: true,
+			errorContains: "not found in cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake dynamic client
+			dynamicScheme := runtime.NewScheme()
+			fakeDynamic := dynamicfake.NewSimpleDynamicClient(dynamicScheme)
+
+			if tt.setupQueue {
+				// Create a fake queue resource
+				queueGVR := schema.GroupVersionResource{
+					Group:    "scheduling.run.ai",
+					Version:  "v2",
+					Resource: "queues",
+				}
+
+				queue := &unstructured.Unstructured{}
+				queue.SetAPIVersion("scheduling.run.ai/v2")
+				queue.SetKind("Queue")
+				queue.SetName(tt.queueName)
+
+				_, err := fakeDynamic.Resource(queueGVR).Create(context.Background(), queue, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("failed to create fake queue: %v", err)
+				}
+			}
+
+			// This test is limited because we can't easily mock the dynamic client creation
+			// In a real test environment, you would set up a proper test cluster or use envtest
+			err := ensureQueueExists(context.Background(), fakeDynamic, tt.queueName)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error to contain %q, got %v", tt.errorContains, err)
+				}
+			} else {
+				// We expect an error here because we can't properly mock the dynamic client
+				// In a real test, this would work with proper test setup
+				if err == nil {
+					t.Logf("Queue validation passed (this is expected in unit tests)")
+				}
+			}
+		})
+	}
+}

--- a/docs/guides/dynamo_deploy/multinode-deployment.md
+++ b/docs/guides/dynamo_deploy/multinode-deployment.md
@@ -24,27 +24,36 @@ Dynamo supports multinode deployments through the `multinode` section in resourc
 
 For sophisticated multinode deployments, Dynamo integrates with advanced Kubernetes orchestration systems:
 
-- **[Grove](https://github.com/NVIDIA/grove/blob/main/docs/installation.md)**: Network topology-aware gang scheduling and auto-scaling for AI workloads
-- (optional) **[KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler)**: Kubernetes native scheduler optimized for AI workloads at scale
+- **[Grove](https://github.com/NVIDIA/grove)**: Network topology-aware gang scheduling and auto-scaling for AI workloads
+- **[KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler)**: Kubernetes native scheduler optimized for AI workloads at scale
 
 These systems provide enhanced scheduling capabilities including topology-aware placement, gang scheduling, and coordinated auto-scaling across multiple nodes.
 
 **Features Enabled with Grove:**
-- Hierarchical gang scheduling with `PodGangSet` and `PodClique`
+- Declarative composition of AI workloads
 - Multi-level horizontal auto-scaling
 - Custom startup ordering for components
 - Resource-aware rolling updates
 
 
-[KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler) is an optional enhancement that provides a Kubernetes native scheduler optimized for AI workloads at large scale.
+[KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler) is a Kubernetes native scheduler optimized for AI workloads at large scale.
 
 **Features Enabled with KAI-Scheduler:**
+- Gang scheduling
 - Network topology-aware pod placement
 - AI workload-optimized scheduling algorithms
 - GPU resource awareness and allocation
 - Support for complex scheduling constraints
 - Integration with Grove for enhanced capabilities
 - Performance optimizations for large-scale deployments
+
+
+##### Prerequisites
+
+- [Grove](https://github.com/NVIDIA/grove/blob/main/docs/installation.md) installed on the cluster
+- (Optional) [KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler) installed on the cluster with default queue name `dynamo` created. You can use a different queue name by setting the `nvidia.com/kai-scheduler-queue` annotation on the DGD resource.
+
+KAI-Scheduler is optional but recommended for advanced scheduling capabilities.
 
 #### Using LWS and Volcano
 
@@ -58,16 +67,70 @@ Volcano is a Kubernetes native scheduler optimized for AI workloads at scale. It
 
 ## Core Concepts
 
+### Orchestrator Selection Algorithm
+
+Dynamo automatically selects the best available orchestrator for multinode deployments using the following logic:
+
+#### When Both Grove and LWS are Available:
+- **Grove is selected by default** (recommended for advanced AI workloads)
+- **LWS is selected** if you explicitly set `nvidia.com/enable-grove: "false"` annotation on your DGD resource
+
+#### When Only One Orchestrator is Available:
+- The installed orchestrator (Grove or LWS) is automatically selected
+
+#### Scheduler Integration:
+- **With Grove**: Automatically integrates with [KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler) when available, providing:
+  - Advanced queue management via `nvidia.com/kai-scheduler-queue` annotation
+  - AI-optimized scheduling policies
+  - Resource-aware workload placement
+- **With LWS**: Uses Volcano scheduler for gang scheduling and resource coordination
+
+#### Configuration Examples:
+
+**Default (Grove with KAI-Scheduler):**
+```yaml
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: my-multinode-deployment
+  annotations:
+    nvidia.com/kai-scheduler-queue: "gpu-intensive"  # Optional: defaults to "dynamo"
+spec:
+  # ... your deployment spec
+```
+
+**Force LWS usage:**
+```yaml
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: my-multinode-deployment
+  annotations:
+    nvidia.com/enable-grove: "false"
+spec:
+  # ... your deployment spec
+```
+
+
 ### The `multinode` Section
 
 The `multinode` section in a resource specification defines how many physical nodes the workload should span:
 
 ```yaml
-multinode:
-  nodeCount: 2
-resources:
-  limits:
-    gpu: "2"            # 2 GPUs per node
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: my-multinode-deployment
+spec:
+  # ... your deployment spec
+  services:
+    my-service:
+      ...
+      multinode:
+        nodeCount: 2
+      resources:
+        limits:
+          gpu: "2"            # 2 GPUs per node
 ```
 
 ### GPU Distribution
@@ -88,16 +151,28 @@ The tensor parallelism (`tp-size` or `--tp`) in your command/args must match the
 
 ```yaml
 # Example: 2 multinode.nodeCount × 4 GPUs = 8 total GPUs
-multinode:
-  nodeCount: 2
-resources:
-  limits:
-    gpu: "4"
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: my-multinode-deployment
+spec:
+  # ... your deployment spec
+  services:
+    my-service:
+      ...
+      multinode:
+        nodeCount: 2
+      resources:
+        limits:
+          gpu: "4"
+      extraPodSpec:
+        mainContainer:
+          ...
+          args:
+            # Command args must use tp-size=8
+            - "--tp-size"
+            - "8"  # Must equal multinode.nodeCount × gpu
 
-# Command args must use tp-size=8
-args:
-  - "--tp-size"
-  - "8"  # Must equal multinode.nodeCount × gpu
 ```
 
 


### PR DESCRIPTION
#### Overview:

Auto-inject kai-scheduler annotations and label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Kai-scheduler integration with auto-detection, queue resolution/validation, and per-workload injection when enabled.
  - Supports setting scheduler name and queue label; honors manual scheduler overrides.
- Documentation
  - Revamped multinode deployment guide with orchestrator selection logic, Grove + Kai-Scheduler guidance, prerequisites, GPU distribution notes, and full YAML examples.
- Tests
  - Added unit tests covering queue resolution, validation, and Kai-scheduler injection scenarios.
- Chores
  - Updated RBAC/permissions to allow reading Kai-scheduler queues at namespace and cluster scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->