### PR TITLE
chore: deprecate duplicate params in nvext

### DIFF
--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -8,7 +8,7 @@ use super::{
     ContentProvider,
     common::{self, OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider},
 };
-use crate::protocols::openai::common_ext::CommonExtProvider;
+use crate::protocols::openai::common_ext::{CommonExtProvider, choose_with_deprecation};
 
 pub mod chat_completions;
 pub mod common_ext;
@@ -61,9 +61,11 @@ trait OpenAIStopConditionsProvider {
     /// Get the effective ignore_eos value, considering both CommonExt and NvExt.
     /// CommonExt (root-level) takes precedence over NvExt.
     fn get_ignore_eos(&self) -> Option<bool> {
-        // Check common first (takes precedence), then fall back to nvext
-        self.get_common_ignore_eos()
-            .or_else(|| self.nvext().and_then(|nv| nv.ignore_eos))
+        choose_with_deprecation(
+            "ignore_eos",
+            self.get_common_ignore_eos().as_ref(),
+            self.nvext().and_then(|nv| nv.ignore_eos.as_ref()),
+        )
     }
 }
 

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -21,7 +21,9 @@ use crate::engines::ValidateRequest;
 
 use super::{
     OpenAIOutputOptionsProvider, OpenAISamplingOptionsProvider, OpenAIStopConditionsProvider,
-    common_ext::{CommonExt, CommonExtProvider},
+    common_ext::{
+        CommonExt, CommonExtProvider, choose_with_deprecation, emit_nvext_deprecation_warning,
+    },
     nvext::NvExt,
     nvext::NvExtProvider,
     validate,
@@ -149,6 +151,12 @@ impl CommonExtProvider for NvCreateChatCompletionRequest {
 
     /// Guided Decoding Options
     fn get_guided_json(&self) -> Option<&serde_json::Value> {
+        // Note: This one needs special handling since it returns a reference
+        if let Some(nvext) = &self.nvext
+            && nvext.guided_json.is_some()
+        {
+            emit_nvext_deprecation_warning("guided_json", true, self.common.guided_json.is_some());
+        }
         self.common
             .guided_json
             .as_ref()
@@ -156,32 +164,39 @@ impl CommonExtProvider for NvCreateChatCompletionRequest {
     }
 
     fn get_guided_regex(&self) -> Option<String> {
-        self.common
-            .guided_regex
-            .clone()
-            .or_else(|| self.nvext.as_ref().and_then(|nv| nv.guided_regex.clone()))
+        choose_with_deprecation(
+            "guided_regex",
+            self.common.guided_regex.as_ref(),
+            self.nvext.as_ref().and_then(|nv| nv.guided_regex.as_ref()),
+        )
     }
 
     fn get_guided_grammar(&self) -> Option<String> {
-        self.common
-            .guided_grammar
-            .clone()
-            .or_else(|| self.nvext.as_ref().and_then(|nv| nv.guided_grammar.clone()))
+        choose_with_deprecation(
+            "guided_grammar",
+            self.common.guided_grammar.as_ref(),
+            self.nvext
+                .as_ref()
+                .and_then(|nv| nv.guided_grammar.as_ref()),
+        )
     }
 
     fn get_guided_choice(&self) -> Option<Vec<String>> {
-        self.common
-            .guided_choice
-            .clone()
-            .or_else(|| self.nvext.as_ref().and_then(|nv| nv.guided_choice.clone()))
+        choose_with_deprecation(
+            "guided_choice",
+            self.common.guided_choice.as_ref(),
+            self.nvext.as_ref().and_then(|nv| nv.guided_choice.as_ref()),
+        )
     }
 
     fn get_guided_decoding_backend(&self) -> Option<String> {
-        self.common.guided_decoding_backend.clone().or_else(|| {
+        choose_with_deprecation(
+            "guided_decoding_backend",
+            self.common.guided_decoding_backend.as_ref(),
             self.nvext
                 .as_ref()
-                .and_then(|nv| nv.guided_decoding_backend.clone())
-        })
+                .and_then(|nv| nv.guided_decoding_backend.as_ref()),
+        )
     }
 }
 
@@ -223,6 +238,16 @@ impl OpenAIStopConditionsProvider for NvCreateChatCompletionRequest {
     /// Get ignore_eos from CommonExt.
     fn get_common_ignore_eos(&self) -> Option<bool> {
         self.common.ignore_eos
+    }
+
+    /// Get the effective ignore_eos value, considering both CommonExt and NvExt.
+    /// CommonExt (root-level) takes precedence over NvExt.
+    fn get_ignore_eos(&self) -> Option<bool> {
+        choose_with_deprecation(
+            "ignore_eos",
+            self.get_common_ignore_eos().as_ref(),
+            NvExtProvider::nvext(self).and_then(|nv| nv.ignore_eos.as_ref()),
+        )
     }
 }
 

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -24,7 +24,9 @@ use super::{
     ContentProvider, OpenAIOutputOptionsProvider, OpenAISamplingOptionsProvider,
     OpenAIStopConditionsProvider,
     common::{self, OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider},
-    common_ext::{CommonExt, CommonExtProvider},
+    common_ext::{
+        CommonExt, CommonExtProvider, choose_with_deprecation, emit_nvext_deprecation_warning,
+    },
     nvext::{NvExt, NvExtProvider},
     validate,
 };
@@ -143,6 +145,12 @@ impl CommonExtProvider for NvCreateCompletionRequest {
 
     /// Guided Decoding Options
     fn get_guided_json(&self) -> Option<&serde_json::Value> {
+        // Note: This one needs special handling since it returns a reference
+        if let Some(nvext) = &self.nvext
+            && nvext.guided_json.is_some()
+        {
+            emit_nvext_deprecation_warning("guided_json", true, self.common.guided_json.is_some());
+        }
         self.common
             .guided_json
             .as_ref()
@@ -150,32 +158,39 @@ impl CommonExtProvider for NvCreateCompletionRequest {
     }
 
     fn get_guided_regex(&self) -> Option<String> {
-        self.common
-            .guided_regex
-            .clone()
-            .or_else(|| self.nvext.as_ref().and_then(|nv| nv.guided_regex.clone()))
+        choose_with_deprecation(
+            "guided_regex",
+            self.common.guided_regex.as_ref(),
+            self.nvext.as_ref().and_then(|nv| nv.guided_regex.as_ref()),
+        )
     }
 
     fn get_guided_grammar(&self) -> Option<String> {
-        self.common
-            .guided_grammar
-            .clone()
-            .or_else(|| self.nvext.as_ref().and_then(|nv| nv.guided_grammar.clone()))
+        choose_with_deprecation(
+            "guided_grammar",
+            self.common.guided_grammar.as_ref(),
+            self.nvext
+                .as_ref()
+                .and_then(|nv| nv.guided_grammar.as_ref()),
+        )
     }
 
     fn get_guided_choice(&self) -> Option<Vec<String>> {
-        self.common
-            .guided_choice
-            .clone()
-            .or_else(|| self.nvext.as_ref().and_then(|nv| nv.guided_choice.clone()))
+        choose_with_deprecation(
+            "guided_choice",
+            self.common.guided_choice.as_ref(),
+            self.nvext.as_ref().and_then(|nv| nv.guided_choice.as_ref()),
+        )
     }
 
     fn get_guided_decoding_backend(&self) -> Option<String> {
-        self.common.guided_decoding_backend.clone().or_else(|| {
+        choose_with_deprecation(
+            "guided_decoding_backend",
+            self.common.guided_decoding_backend.as_ref(),
             self.nvext
                 .as_ref()
-                .and_then(|nv| nv.guided_decoding_backend.clone())
-        })
+                .and_then(|nv| nv.guided_decoding_backend.as_ref()),
+        )
     }
 }
 
@@ -198,6 +213,16 @@ impl OpenAIStopConditionsProvider for NvCreateCompletionRequest {
 
     fn get_common_ignore_eos(&self) -> Option<bool> {
         self.common.ignore_eos
+    }
+
+    /// Get the effective ignore_eos value, considering both CommonExt and NvExt.
+    /// CommonExt (root-level) takes precedence over NvExt.
+    fn get_ignore_eos(&self) -> Option<bool> {
+        choose_with_deprecation(
+            "ignore_eos",
+            self.get_common_ignore_eos().as_ref(),
+            NvExtProvider::nvext(self).and_then(|nv| nv.ignore_eos.as_ref()),
+        )
     }
 }
 


### PR DESCRIPTION
#### Overview:

Deprecate parameters that are available both under `nvext` and at the top level of the request. Going forward engine-level args should be placed at the top-level.

This removes duplication within the API and aligns with the conventions most common today in API schemas associated with backends like vLLM and SGLang.

#### Details:

Parameters deprecated
`nvext.ignore_eos` -> Use `ignore_eos`
`nvext.guided_json` ->  Use `guided_json`
`nvext.guided_regex `->  Use `guided_regex`
`nvext.guided_grammar` ->  Use `guided_grammar`
`nvext.guided_choice` ->  Use `guided_choice`
`nvext.guided_decoding_backend` ->  Use `guided_decoding_backend`

Changes:
- Added `choose_with_deprecation()` helper for consistent deprecation handling  
- Server logs warnings when deprecated `nvext` parameters are used  
- Top-level parameters take precedence (existing behavior)  
- Backward compatible – both versions still work  

Next Steps:
- Follow-on MR: Add `top_k` and `repetition_penalty` to top-level  and deprecate in `nvext`
- 0.6.0: Remove deprecated `nvext` parameters entirely  

#### Where should the reviewer start?

Review the helper functions added to emit deprecation warnings and that all parameters to be deprecated have been covered.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Deprecation-aware handling for guidance options and ignore_eOS across Completions and Chat Completions.
  - Clear precedence: top-level settings now take priority over nested overrides.
  - User-facing warnings when deprecated nested fields are used.
  - Unified logic for selecting effective values, including stop-condition behavior.

- Documentation
  - Clarified precedence rules and deprecation behavior for guidance and stop-condition settings.

- Tests
  - Added unit tests to validate precedence and deprecation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->