### PR TITLE
docs: Fix dynamo cloud quickstart links

### DIFF
--- a/examples/deployments/AKS/AKS-deployment.md
+++ b/examples/deployments/AKS/AKS-deployment.md
@@ -90,7 +90,7 @@ git clone https://github.com/ai-dynamo/dynamo.git
 cd dynamo
 ```
 
-2. Install Dynamo from Published Artifacts on NGC (refer: https://github.com/ai-dynamo/dynamo/blob/main/docs/guides/dynamo_deploy/quickstart.md):
+2. Install Dynamo from Published Artifacts on NGC (refer: https://github.com/ai-dynamo/dynamo/blob/main/docs/guides/dynamo_deploy/dynamo_cloud.md):
 ```bash
 export NAMESPACE=dynamo-cloud
 export RELEASE_VERSION=0.3.2
@@ -124,7 +124,7 @@ dynamo-platform-nats-0                                            2/2     Runnin
 dynamo-platform-nats-box-5dbf45c748-kln82                         1/1     Running   0          2m51s
 ```
 
-There are other ways to install Dynamo, you can find them [here](https://github.com/ai-dynamo/dynamo/blob/main/docs/guides/dynamo_deploy/quickstart.md)
+There are other ways to install Dynamo, you can find them [here](https://github.com/ai-dynamo/dynamo/blob/main/docs/guides/dynamo_deploy/dynamo_cloud.md)
 
 ### Task 4. Deploy a model
 

--- a/examples/deployments/AKS/AKS-deployment.md
+++ b/examples/deployments/AKS/AKS-deployment.md
@@ -90,7 +90,7 @@ git clone https://github.com/ai-dynamo/dynamo.git
 cd dynamo
 ```
 
-2. Install Dynamo from Published Artifacts on NGC (refer: https://github.com/ai-dynamo/dynamo/blob/main/docs/guides/dynamo_deploy/dynamo_cloud.md):
+2. Install Dynamo from Published Artifacts on NGC (see the [Dynamo Cloud guide](../../../docs/guides/dynamo_deploy/dynamo_cloud.md)):
 ```bash
 export NAMESPACE=dynamo-cloud
 export RELEASE_VERSION=0.3.2
@@ -124,7 +124,7 @@ dynamo-platform-nats-0                                            2/2     Runnin
 dynamo-platform-nats-box-5dbf45c748-kln82                         1/1     Running   0          2m51s
 ```
 
-There are other ways to install Dynamo, you can find them [here](https://github.com/ai-dynamo/dynamo/blob/main/docs/guides/dynamo_deploy/dynamo_cloud.md)
+There are other ways to install Dynamo, you can find them [here](../../../docs/guides/dynamo_deploy/dynamo_cloud.md).
 
 ### Task 4. Deploy a model
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Fix broken links caught by lychee on main: https://github.com/ai-dynamo/dynamo/actions/runs/17258593879/job/48975115450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated two references in Task 3 of the AKS deployment guide to point to the Dynamo Cloud installation guide instead of the Quickstart.
  * Improves accuracy and reduces confusion by directing users to the most relevant installation instructions.
  * No changes to commands, steps, or overall workflow; existing procedures remain the same.
  * Expect a smoother installation experience with clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->