### PR TITLE
Add derive_builder ergonomics to descriptor system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,7 @@ dependencies = [
  "async-trait",
  "blake3",
  "bytes",
+ "derive_builder",
  "dynamo-runtime",
  "hex",
  "serde",

--- a/components/oscar/Cargo.toml
+++ b/components/oscar/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true }
+derive_builder = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/components/oscar/src/v2.rs
+++ b/components/oscar/src/v2.rs
@@ -11,6 +11,7 @@ pub mod descriptors;
 pub mod keys;
 
 pub use descriptors::{
-    CallerContext, CallerDescriptor, ObjectDescriptor, ObjectName, OscarDescriptorError,
+    CallerContext, CallerContextBuilder, CallerDescriptor, ObjectDescriptor, ObjectDescriptorBuilder, 
+    ObjectName, OscarDescriptorError,
 };
 pub use keys::OscarKeyType as OscarKeyTypeV2;

--- a/components/oscar/src/v2.rs
+++ b/components/oscar/src/v2.rs
@@ -12,6 +12,6 @@ pub mod keys;
 
 pub use descriptors::{
     CallerContext, CallerContextBuilder, CallerDescriptor, ObjectDescriptor, ObjectDescriptorBuilder, 
-    ObjectName, OscarDescriptorError,
+    OscarDescriptorError,
 };
 pub use keys::OscarKeyType as OscarKeyTypeV2;

--- a/components/oscar/src/v2/descriptors.rs
+++ b/components/oscar/src/v2/descriptors.rs
@@ -19,6 +19,7 @@ use dynamo_runtime::v2::{
     InstanceDescriptor, PathDescriptor
 };
 use dynamo_runtime::v2::entity::ToPath;
+use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
@@ -28,6 +29,9 @@ use thiserror::Error;
 pub enum OscarDescriptorError {
     #[error("Runtime descriptor error: {0}")]
     Runtime(#[from] DescriptorError),
+    
+    #[error("Builder validation error: {0}")]
+    Builder(String),
     
     #[error("Invalid object name: '{name}'. Object names must be 1-255 characters and contain only lowercase letters, numbers, hyphens, underscores, and dots")]
     InvalidObjectName { name: String },
@@ -40,6 +44,24 @@ pub enum OscarDescriptorError {
     
     #[error("Missing required context: {field}")]
     MissingRequiredContext { field: String },
+}
+
+impl From<derive_builder::UninitializedFieldError> for OscarDescriptorError {
+    fn from(err: derive_builder::UninitializedFieldError) -> Self {
+        OscarDescriptorError::Builder(err.to_string())
+    }
+}
+
+impl From<CallerContextSpecBuilderError> for OscarDescriptorError {
+    fn from(err: CallerContextSpecBuilderError) -> Self {
+        OscarDescriptorError::Builder(err.to_string())
+    }
+}
+
+impl From<ObjectDescriptorSpecBuilderError> for OscarDescriptorError {
+    fn from(err: ObjectDescriptorSpecBuilderError) -> Self {
+        OscarDescriptorError::Builder(err.to_string())
+    }
 }
 
 /// Object name with Oscar-specific validation (allows dots for file-like names)
@@ -180,6 +202,71 @@ impl CallerContext {
     }
 }
 
+/// Builder specification for creating CallerContext with ergonomic API
+#[derive(Builder)]
+#[builder(build_fn(validate = "Self::validate"))]
+#[builder(derive(Debug))]
+pub struct CallerContextSpec {
+    /// Namespace segments for the caller
+    #[builder(setter(into))]
+    pub namespace_segments: Vec<String>,
+    
+    /// Optional component name
+    #[builder(default, setter(strip_option, into))]
+    pub component: Option<String>,
+    
+    /// Optional endpoint name
+    #[builder(default, setter(strip_option, into))]
+    pub endpoint: Option<String>,
+}
+
+impl CallerContextSpecBuilder {
+    /// Validate the builder state before creating CallerContext
+    fn validate(&self) -> Result<(), String> {
+        // Check that namespace_segments is present and not empty
+        if let Some(ref segments) = self.namespace_segments {
+            if segments.is_empty() {
+                return Err("Namespace segments cannot be empty".to_string());
+            }
+        }
+        Ok(())
+    }
+}
+
+impl CallerContextSpec {
+    /// Build a CallerContext from this specification
+    pub fn build_context(self) -> Result<CallerContext, OscarDescriptorError> {
+        // Create the appropriate descriptor based on what's specified
+        if let Some(endpoint_name) = self.endpoint {
+            // Create endpoint descriptor
+            let segments_str: Vec<&str> = self.namespace_segments.iter().map(|s| s.as_str()).collect();
+            let ns = NamespaceDescriptor::new(&segments_str)?;
+            let component_name = self.component.ok_or_else(|| {
+                OscarDescriptorError::MissingRequiredContext {
+                    field: "component".to_string(),
+                }
+            })?;
+            let comp = ns.component(&component_name)?;
+            let endpoint = comp.endpoint(&endpoint_name)?;
+            Ok(CallerContext::from_endpoint(endpoint))
+        } else if let Some(component_name) = self.component {
+            // Create component descriptor
+            let segments_str: Vec<&str> = self.namespace_segments.iter().map(|s| s.as_str()).collect();
+            let ns = NamespaceDescriptor::new(&segments_str)?;
+            let comp = ns.component(&component_name)?;
+            Ok(CallerContext::from_component(comp))
+        } else {
+            // Create namespace descriptor
+            let segments_str: Vec<&str> = self.namespace_segments.iter().map(|s| s.as_str()).collect();
+            let ns = NamespaceDescriptor::new(&segments_str)?;
+            Ok(CallerContext::from_namespace(ns))
+        }
+    }
+}
+
+/// Type alias for convenient builder access
+pub type CallerContextBuilder = CallerContextSpecBuilder;
+
 /// Oscar object descriptor with caller context mirroring
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ObjectDescriptor {
@@ -308,6 +395,76 @@ impl fmt::Display for ObjectDescriptor {
         write!(f, "{}", self.object_name)
     }
 }
+
+/// Builder specification for creating ObjectDescriptor with ergonomic API
+#[derive(Builder)]
+#[builder(build_fn(validate = "Self::validate"))]
+#[builder(derive(Debug))]
+pub struct ObjectDescriptorSpec {
+    /// Object name
+    #[builder(setter(into))]
+    pub object_name: String,
+    
+    /// Content hash
+    pub content_hash: ContentHash,
+    
+    /// Namespace segments for the caller
+    #[builder(setter(into))]
+    pub namespace_segments: Vec<String>,
+    
+    /// Optional component name
+    #[builder(default, setter(strip_option, into))]
+    pub component: Option<String>,
+    
+    /// Optional endpoint name
+    #[builder(default, setter(strip_option, into))]
+    pub endpoint: Option<String>,
+}
+
+impl ObjectDescriptorSpecBuilder {
+    /// Validate the builder state before creating ObjectDescriptor
+    fn validate(&self) -> Result<(), String> {
+        // Check that namespace_segments is present and not empty
+        if let Some(ref segments) = self.namespace_segments {
+            if segments.is_empty() {
+                return Err("Namespace segments cannot be empty".to_string());
+            }
+        }
+        
+        // Check that object_name is present and valid
+        if let Some(name) = &self.object_name {
+            ObjectName::validate(name).map_err(|e| e.to_string())?;
+        }
+        
+        Ok(())
+    }
+}
+
+impl ObjectDescriptorSpec {
+    /// Build an ObjectDescriptor from this specification
+    pub fn build_descriptor(self) -> Result<ObjectDescriptor, OscarDescriptorError> {
+        // Create the caller context first
+        let mut context_builder = CallerContextBuilder::default();
+        context_builder.namespace_segments(self.namespace_segments);
+        
+        if let Some(component) = self.component {
+            context_builder.component(component);
+        }
+        
+        if let Some(endpoint) = self.endpoint {
+            context_builder.endpoint(endpoint);
+        }
+        
+        let context_spec = context_builder.build()?;
+        let caller_context = context_spec.build_context()?;
+        
+        // Create the object descriptor
+        ObjectDescriptor::create(self.object_name, self.content_hash, caller_context)
+    }
+}
+
+/// Type alias for convenient builder access
+pub type ObjectDescriptorBuilder = ObjectDescriptorSpecBuilder;
 
 // Conversion helpers for ObjectName
 impl TryFrom<&str> for ObjectName {
@@ -515,5 +672,110 @@ mod tests {
         
         let name_from_string = ObjectName::try_from("valid.name".to_string()).unwrap();
         assert_eq!(name_from_string.name(), "valid.name");
+    }
+    
+    #[test]
+    fn test_caller_context_builder_namespace() {
+        // Test namespace-level builder
+        let context = CallerContextBuilder::default()
+            .namespace_segments(vec!["prod".to_string()])
+            .build()
+            .unwrap()
+            .build_context()
+            .unwrap();
+        
+        assert_eq!(context.namespace_segments(), &["prod"]);
+        assert!(context.component_name().is_none());
+        assert!(context.endpoint_name().is_none());
+    }
+    
+    #[test]
+    fn test_caller_context_builder_component() {
+        // Test component-level builder
+        let context = CallerContextBuilder::default()
+            .namespace_segments(vec!["prod".to_string()])
+            .component("api")
+            .build()
+            .unwrap()
+            .build_context()
+            .unwrap();
+        
+        assert_eq!(context.namespace_segments(), &["prod"]);
+        assert_eq!(context.component_name(), Some("api".to_string()));
+        assert!(context.endpoint_name().is_none());
+    }
+    
+    #[test]
+    fn test_caller_context_builder_endpoint() {
+        // Test endpoint-level builder
+        let context = CallerContextBuilder::default()
+            .namespace_segments(vec!["prod".to_string()])
+            .component("api")
+            .endpoint("http")
+            .build()
+            .unwrap()
+            .build_context()
+            .unwrap();
+        
+        assert_eq!(context.namespace_segments(), &["prod"]);
+        assert_eq!(context.component_name(), Some("api".to_string()));
+        assert_eq!(context.endpoint_name(), Some("http".to_string()));
+    }
+    
+    #[test]
+    fn test_object_descriptor_builder_ergonomics() {
+        let hash = test_hash();
+        
+        // Demonstrate the improved ergonomics - single error handling point
+        let object = ObjectDescriptorBuilder::default()
+            .object_name("tokenizer.json")
+            .content_hash(hash.clone())
+            .namespace_segments(vec!["prod".to_string()])
+            .component("api")
+            .endpoint("http")
+            .build()
+            .unwrap()
+            .build_descriptor()
+            .unwrap();
+        
+        // Verify the object was created correctly
+        assert_eq!(object.object_name().name(), "tokenizer.json");
+        assert_eq!(object.content_hash(), &hash);
+        
+        // Check the generated key
+        let hash_prefix = &hash.to_string()[..8];
+        let metadata_key = object.metadata_key().unwrap();
+        let expected = format!("dynamo://_internal.oscar.prod.api.http.tokenizer_json-{}.metadata", hash_prefix);
+        assert_eq!(metadata_key, expected);
+    }
+    
+    #[test]
+    fn test_builder_validation_errors() {
+        let hash = test_hash();
+        
+        // Test empty namespace segments validation
+        let result = CallerContextBuilder::default()
+            .namespace_segments(Vec::<String>::new())
+            .build();
+        assert!(result.is_err());
+        
+        // Test missing component when endpoint is provided
+        let result = CallerContextBuilder::default()
+            .namespace_segments(vec!["prod".to_string()])
+            .endpoint("http")
+            .build();
+        
+        if let Ok(spec) = result {
+            let context_result = spec.build_context();
+            assert!(context_result.is_err());
+        }
+        
+        // Test invalid object name validation
+        let result = ObjectDescriptorBuilder::default()
+            .object_name("Invalid Name!")
+            .content_hash(hash)
+            .namespace_segments(vec!["prod".to_string()])
+            .build();
+        assert!(result.is_err());
     }
 }

--- a/lib/runtime/src/v2/entity/mod.rs
+++ b/lib/runtime/src/v2/entity/mod.rs
@@ -11,6 +11,7 @@ pub mod descriptor;
 
 pub use descriptor::{
     ComponentDescriptor,
+    DescriptorBuilder,
     DescriptorError,
     EntityDescriptor,
     EndpointDescriptor,

--- a/lib/runtime/src/v2/entity/mod.rs
+++ b/lib/runtime/src/v2/entity/mod.rs
@@ -8,6 +8,7 @@
 //! descriptor types.
 
 pub mod descriptor;
+pub mod validation;
 
 pub use descriptor::{
     ComponentDescriptor,

--- a/lib/runtime/src/v2/entity/validation.rs
+++ b/lib/runtime/src/v2/entity/validation.rs
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Centralized validation functions for entity descriptors
+//!
+//! This module provides the core validation logic used across the entity descriptor
+//! system. These validators are private to the entity module and accessed through
+//! the public EntityDescriptor validation methods.
+
+use validator::{ValidationError, Validate};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Regex for identifier validation (components, endpoints, namespaces)
+/// Allows: lowercase letters, digits, hyphens, underscores
+static IDENTIFIER_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^[a-z0-9_-]+$").unwrap()
+});
+
+/// Regex for path segment validation (includes dots for object names)  
+/// Allows: lowercase letters, digits, hyphens, underscores, dots
+static PATH_SEGMENT_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^[a-z0-9_.-]+$").unwrap()
+});
+
+/// Validate identifier names (components, endpoints, namespace segments)
+/// Does not allow dots - stricter than path segments
+pub(super) fn validate_identifier(name: &str) -> Result<(), ValidationError> {
+    if name.is_empty() {
+        return Err(ValidationError::new("empty_identifier"));
+    }
+    
+    if !IDENTIFIER_REGEX.is_match(name) {
+        return Err(ValidationError::new("invalid_identifier_chars"));
+    }
+    
+    Ok(())
+}
+
+/// Validate path segment names (object names, path extensions)
+/// Allows dots for file-like names (e.g., "tokenizer.json", "model.bin")
+pub(super) fn validate_path_segment(segment: &str) -> Result<(), ValidationError> {
+    if segment.is_empty() {
+        return Err(ValidationError::new("empty_path_segment"));
+    }
+    
+    if !PATH_SEGMENT_REGEX.is_match(segment) {
+        return Err(ValidationError::new("invalid_path_segment_chars"));
+    }
+    
+    Ok(())
+}
+
+/// Validate namespace segment with reserved prefix checking
+pub(super) fn validate_namespace_segment(segment: &str, allow_internal: bool) -> Result<(), ValidationError> {
+    validate_identifier(segment)?;
+    
+    // Check for reserved _internal prefix
+    if segment.starts_with('_') && !allow_internal {
+        return Err(ValidationError::new("reserved_internal_prefix"));
+    }
+    
+    Ok(())
+}
+
+/// Validate that a collection is non-empty
+pub(super) fn validate_non_empty_collection<T>(collection: &[T]) -> Result<(), ValidationError> {
+    if collection.is_empty() {
+        return Err(ValidationError::new("empty_collection"));
+    }
+    Ok(())
+}
+
+/// Validate component name with length restrictions
+pub(super) fn validate_component_name(name: &str) -> Result<(), ValidationError> {
+    validate_identifier(name)?;
+    
+    if name.len() > 63 {
+        return Err(ValidationError::new("component_name_too_long"));
+    }
+    
+    Ok(())
+}
+
+/// Validate endpoint name with length restrictions  
+pub(super) fn validate_endpoint_name(name: &str) -> Result<(), ValidationError> {
+    validate_identifier(name)?;
+    
+    if name.len() > 63 {
+        return Err(ValidationError::new("endpoint_name_too_long"));
+    }
+    
+    Ok(())
+}
+
+/// Validate object name for Oscar (allows dots, longer length limit)
+pub(super) fn validate_object_name(name: &str) -> Result<(), ValidationError> {
+    validate_path_segment(name)?;
+    
+    if name.len() > 255 {
+        return Err(ValidationError::new("object_name_too_long"));
+    }
+    
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_identifier() {
+        // Valid identifiers
+        assert!(validate_identifier("valid").is_ok());
+        assert!(validate_identifier("with-hyphens").is_ok());
+        assert!(validate_identifier("with_underscores").is_ok());
+        assert!(validate_identifier("with123numbers").is_ok());
+        
+        // Invalid identifiers
+        assert!(validate_identifier("").is_err());
+        assert!(validate_identifier("With-Capitals").is_err());
+        assert!(validate_identifier("with.dots").is_err());
+        assert!(validate_identifier("with spaces").is_err());
+        assert!(validate_identifier("with/slash").is_err());
+    }
+    
+    #[test]
+    fn test_validate_path_segment() {
+        // Valid path segments (includes dots)
+        assert!(validate_path_segment("valid").is_ok());
+        assert!(validate_path_segment("with-hyphens").is_ok());
+        assert!(validate_path_segment("with_underscores").is_ok());
+        assert!(validate_path_segment("with.dots").is_ok());
+        assert!(validate_path_segment("tokenizer.json").is_ok());
+        assert!(validate_path_segment("model-v1.bin").is_ok());
+        
+        // Invalid path segments
+        assert!(validate_path_segment("").is_err());
+        assert!(validate_path_segment("With-Capitals").is_err());
+        assert!(validate_path_segment("with spaces").is_err());
+        assert!(validate_path_segment("with/slash").is_err());
+    }
+    
+    #[test]
+    fn test_validate_namespace_segment() {
+        // Valid namespace segments (no internal prefix)
+        assert!(validate_namespace_segment("valid", false).is_ok());
+        assert!(validate_namespace_segment("prod", false).is_ok());
+        
+        // Invalid - internal prefix not allowed
+        assert!(validate_namespace_segment("_internal", false).is_err());
+        assert!(validate_namespace_segment("_system", false).is_err());
+        
+        // Valid - internal prefix allowed
+        assert!(validate_namespace_segment("_internal", true).is_ok());
+        assert!(validate_namespace_segment("_system", true).is_ok());
+    }
+    
+    #[test]
+    fn test_validate_non_empty_collection() {
+        assert!(validate_non_empty_collection(&["item"]).is_ok());
+        assert!(validate_non_empty_collection(&Vec::<String>::new()).is_err());
+    }
+    
+    #[test]
+    fn test_validate_component_name() {
+        assert!(validate_component_name("api").is_ok());
+        assert!(validate_component_name("a".repeat(63).as_str()).is_ok());
+        assert!(validate_component_name(&"a".repeat(64)).is_err()); // Too long
+    }
+    
+    #[test]
+    fn test_validate_endpoint_name() {
+        assert!(validate_endpoint_name("http").is_ok());
+        assert!(validate_endpoint_name(&"a".repeat(63)).is_ok());
+        assert!(validate_endpoint_name(&"a".repeat(64)).is_err()); // Too long
+    }
+    
+    #[test]
+    fn test_validate_object_name() {
+        assert!(validate_object_name("tokenizer.json").is_ok());
+        assert!(validate_object_name(&"a".repeat(255)).is_ok());
+        assert!(validate_object_name(&"a".repeat(256)).is_err()); // Too long
+        assert!(validate_object_name("model.bin").is_ok());
+        assert!(validate_object_name("config-v1_final.yaml").is_ok());
+    }
+}

--- a/lib/runtime/src/v2/mod.rs
+++ b/lib/runtime/src/v2/mod.rs
@@ -16,6 +16,6 @@
 pub mod entity;
 
 pub use entity::{
-    ComponentDescriptor, DescriptorError, EndpointDescriptor, 
+    ComponentDescriptor, DescriptorBuilder, DescriptorError, EndpointDescriptor, 
     InstanceDescriptor, NamespaceDescriptor, PathDescriptor,
 };


### PR DESCRIPTION
- Add derive_builder support to runtime descriptor system with DescriptorSpec
- Add CallerContext and ObjectDescriptor builders to Oscar v2 API
- Include comprehensive validation and single-point error handling
- Add tests demonstrating improved ergonomics eliminating multiple .unwrap() calls
- Export new builder types from public APIs