### PR TITLE
docs: Use GFM Admonition style

### DIFF
--- a/docs/guides/dynamo_deploy/minikube.md
+++ b/docs/guides/dynamo_deploy/minikube.md
@@ -25,9 +25,9 @@ First things first! Start by installing Minikube. Follow the official [Minikube 
 ## 2. Configure GPU Support (Optional)
 Planning to use GPU-accelerated workloads? You'll need to configure GPU support in Minikube. Follow the [Minikube GPU guide](https://minikube.sigs.k8s.io/docs/tutorials/nvidia/) to set up NVIDIA GPU support before proceeding.
 
-```{tip}
-Make sure to configure GPU support before starting Minikube if you plan to use GPU workloads!
-```
+> [!TIP]
+> Make sure to configure GPU support before starting Minikube if you plan to use GPU workloads!
+
 
 ## 3. Start Minikube
 Time to launch your local cluster!


### PR DESCRIPTION
Increases prominence of admonition in GitHub and still works correctly in sphinx thanks to `./docs/_extensions/github_alerts.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the Minikube deployment guide to use a clear tip callout for the GPU setup reminder, improving readability and visibility.
  - Ensures users are prompted earlier to configure GPU support before starting Minikube when planning GPU workloads.
  - Aligns the guide with consistent admonition styling across docs.
  - No functional changes to workflows or commands; content remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->