### PR TITLE
feat: update planner to use DYN_PARENT_DGD_K8S_NAME

### DIFF
--- a/components/planner/src/dynamo/planner/kubernetes_connector.py
+++ b/components/planner/src/dynamo/planner/kubernetes_connector.py
@@ -74,7 +74,7 @@ class KubernetesConnector(PlannerConnector):
         """Set the replicas for multiple components at once"""
         if not target_replicas:
             raise ValueError("target_replicas cannot be empty")
-            
+
         deployment = await self.kube_api.get_graph_deployment()
         if deployment is None:
             raise ValueError("Parent DynamoGraphDeployment not found")

--- a/components/planner/src/dynamo/planner/kubernetes_connector.py
+++ b/components/planner/src/dynamo/planner/kubernetes_connector.py
@@ -32,12 +32,10 @@ class KubernetesConnector(PlannerConnector):
     async def add_component(self, component_name: str, blocking: bool = True):
         """Add a component by increasing its replica count by 1"""
 
-        deployment = await self.kube_api.get_graph_deployment(
-            component_name, self.dynamo_namespace
-        )
+        deployment = await self.kube_api.get_graph_deployment()
         if deployment is None:
             raise ValueError(
-                f"Graph not found for component {component_name} in dynamo namespace {self.dynamo_namespace}"
+                f"Parent DynamoGraphDeployment not found"
             )
 
         # get current replicas or 1 if not found
@@ -55,12 +53,10 @@ class KubernetesConnector(PlannerConnector):
     async def remove_component(self, component_name: str, blocking: bool = True):
         """Remove a component by decreasing its replica count by 1"""
 
-        deployment = await self.kube_api.get_graph_deployment(
-            component_name, self.dynamo_namespace
-        )
+        deployment = await self.kube_api.get_graph_deployment()
         if deployment is None:
             raise ValueError(
-                f"Graph {component_name} not found for namespace {self.dynamo_namespace}"
+                f"Parent DynamoGraphDeployment not found"
             )
 
         # get current replicas or 1 if not found
@@ -76,48 +72,19 @@ class KubernetesConnector(PlannerConnector):
                     self._get_graph_deployment_name(deployment)
                 )
 
-    async def _validate_components_same_deployment(
-        self, target_replicas: dict[str, int]
-    ) -> dict:
-        """
-        Validate that all target components belong to the same DynamoGraphDeployment.
-        """
-        if not target_replicas:
-            raise ValueError("target_replicas cannot be empty")
-
-        # Get deployment for first component
-        first_component = next(iter(target_replicas))
-        deployment = await self.kube_api.get_graph_deployment(
-            first_component, self.dynamo_namespace
-        )
-        if deployment is None:
-            raise ValueError(
-                f"Component {first_component} not found in namespace {self.dynamo_namespace}"
-            )
-
-        # Validate that all components belong to the same DGD
-        graph_name = deployment["metadata"]["name"]
-        for component in target_replicas:
-            comp_deployment = await self.kube_api.get_graph_deployment(
-                component, self.dynamo_namespace
-            )
-            if comp_deployment is None:
-                raise ValueError(
-                    f"Component {component} not found in namespace {self.dynamo_namespace}"
-                )
-            if comp_deployment["metadata"]["name"] != graph_name:
-                raise ValueError(
-                    f"Component {component} belongs to graph '{comp_deployment['metadata']['name']}' "
-                    f"but expected graph '{graph_name}'. All components must belong to the same GraphDeployment."
-                )
-
-        return deployment
-
     async def set_component_replicas(
         self, target_replicas: dict[str, int], blocking: bool = True
     ):
         """Set the replicas for multiple components at once"""
-        deployment = await self._validate_components_same_deployment(target_replicas)
+        if not target_replicas:
+            raise ValueError("target_replicas cannot be empty")
+            
+        deployment = await self.kube_api.get_graph_deployment()
+        if deployment is None:
+            raise ValueError(
+                f"Parent DynamoGraphDeployment not found"
+            )
+
         if not await self.kube_api.is_deployment_ready(
             self._get_graph_deployment_name(deployment)
         ):

--- a/components/planner/src/dynamo/planner/kubernetes_connector.py
+++ b/components/planner/src/dynamo/planner/kubernetes_connector.py
@@ -34,9 +34,7 @@ class KubernetesConnector(PlannerConnector):
 
         deployment = await self.kube_api.get_graph_deployment()
         if deployment is None:
-            raise ValueError(
-                f"Parent DynamoGraphDeployment not found"
-            )
+            raise ValueError("Parent DynamoGraphDeployment not found")
 
         # get current replicas or 1 if not found
         current_replicas = self._get_current_replicas(deployment, component_name)
@@ -55,9 +53,7 @@ class KubernetesConnector(PlannerConnector):
 
         deployment = await self.kube_api.get_graph_deployment()
         if deployment is None:
-            raise ValueError(
-                f"Parent DynamoGraphDeployment not found"
-            )
+            raise ValueError("Parent DynamoGraphDeployment not found")
 
         # get current replicas or 1 if not found
         current_replicas = self._get_current_replicas(deployment, component_name)
@@ -81,9 +77,7 @@ class KubernetesConnector(PlannerConnector):
             
         deployment = await self.kube_api.get_graph_deployment()
         if deployment is None:
-            raise ValueError(
-                f"Parent DynamoGraphDeployment not found"
-            )
+            raise ValueError("Parent DynamoGraphDeployment not found")
 
         if not await self.kube_api.is_deployment_ready(
             self._get_graph_deployment_name(deployment)

--- a/components/planner/test/kube.py
+++ b/components/planner/test/kube.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
-import os
 
 import pytest
 
@@ -252,13 +252,13 @@ async def test_wait_for_graph_deployment_ready_on_second_attempt(
 async def test_get_parent_graph_deployment_with_env_var(k8s_api, mock_custom_api):
     """Test get_parent_graph_deployment with environment variable set"""
     mock_deployment = {"metadata": {"name": "parent-dgd"}}
-    
+
     with patch.dict(os.environ, {"DYN_PARENT_DGD_K8S_NAME": "parent-dgd"}):
         with patch.object(
             k8s_api, "_get_graph_deployment_from_name", return_value=mock_deployment
         ) as mock_get:
             result = await k8s_api.get_parent_graph_deployment()
-            
+
             assert result == mock_deployment
             mock_get.assert_called_once_with("parent-dgd")
 
@@ -275,11 +275,11 @@ async def test_get_parent_graph_deployment_without_env_var(k8s_api, mock_custom_
 async def test_get_graph_deployment_delegates_to_parent(k8s_api, mock_custom_api):
     """Test get_graph_deployment delegates to get_parent_graph_deployment"""
     mock_deployment = {"metadata": {"name": "parent-dgd"}}
-    
+
     with patch.object(
         k8s_api, "get_parent_graph_deployment", return_value=mock_deployment
     ) as mock_parent:
         result = await k8s_api.get_graph_deployment()
-        
+
         assert result == mock_deployment
         mock_parent.assert_called_once()

--- a/components/planner/test/kube.py
+++ b/components/planner/test/kube.py
@@ -15,6 +15,7 @@
 
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
+import os
 
 import pytest
 
@@ -245,3 +246,40 @@ async def test_wait_for_graph_deployment_ready_on_second_attempt(
         await k8s_api.wait_for_graph_deployment_ready(
             "test-deployment", max_attempts=2, delay_seconds=0.1
         )
+
+
+@pytest.mark.asyncio
+async def test_get_parent_graph_deployment_with_env_var(k8s_api, mock_custom_api):
+    """Test get_parent_graph_deployment with environment variable set"""
+    mock_deployment = {"metadata": {"name": "parent-dgd"}}
+    
+    with patch.dict(os.environ, {"DYN_PARENT_DGD_K8S_NAME": "parent-dgd"}):
+        with patch.object(
+            k8s_api, "_get_graph_deployment_from_name", return_value=mock_deployment
+        ) as mock_get:
+            result = await k8s_api.get_parent_graph_deployment()
+            
+            assert result == mock_deployment
+            mock_get.assert_called_once_with("parent-dgd")
+
+
+@pytest.mark.asyncio
+async def test_get_parent_graph_deployment_without_env_var(k8s_api, mock_custom_api):
+    """Test get_parent_graph_deployment without environment variable"""
+    with patch.dict(os.environ, {}, clear=True):
+        result = await k8s_api.get_parent_graph_deployment()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_graph_deployment_delegates_to_parent(k8s_api, mock_custom_api):
+    """Test get_graph_deployment delegates to get_parent_graph_deployment"""
+    mock_deployment = {"metadata": {"name": "parent-dgd"}}
+    
+    with patch.object(
+        k8s_api, "get_parent_graph_deployment", return_value=mock_deployment
+    ) as mock_parent:
+        result = await k8s_api.get_graph_deployment()
+        
+        assert result == mock_deployment
+        mock_parent.assert_called_once()

--- a/components/planner/test/kubernetes_connector.py
+++ b/components/planner/test/kubernetes_connector.py
@@ -99,9 +99,7 @@ async def test_add_component_deployment_not_found(kubernetes_connector, mock_kub
     mock_kube_api.get_graph_deployment.return_value = None
 
     # Act & Assert
-    with pytest.raises(
-        ValueError, match="Parent DynamoGraphDeployment not found"
-    ):
+    with pytest.raises(ValueError, match="Parent DynamoGraphDeployment not found"):
         await kubernetes_connector.add_component(component_name)
 
 
@@ -149,7 +147,9 @@ async def test_set_component_replicas(kubernetes_connector, mock_kube_api):
     target_replicas = {"component1": 3, "component2": 2}
     mock_deployment = {
         "metadata": {"name": "test-graph"},
-        "spec": {"services": {"component1": {"replicas": 1}, "component2": {"replicas": 1}}},
+        "spec": {
+            "services": {"component1": {"replicas": 1}, "component2": {"replicas": 1}}
+        },
     }
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
     mock_kube_api.is_deployment_ready.return_value = True
@@ -168,7 +168,9 @@ async def test_set_component_replicas(kubernetes_connector, mock_kube_api):
 
 
 @pytest.mark.asyncio
-async def test_set_component_replicas_deployment_not_found(kubernetes_connector, mock_kube_api):
+async def test_set_component_replicas_deployment_not_found(
+    kubernetes_connector, mock_kube_api
+):
     # Arrange
     target_replicas = {"component1": 3}
     mock_kube_api.get_graph_deployment.return_value = None
@@ -186,7 +188,5 @@ async def test_set_component_replicas_empty_target_replicas(kubernetes_connector
     target_replicas: dict[str, int] = {}
 
     # Act & Assert
-    with pytest.raises(
-        ValueError, match="target_replicas cannot be empty"
-    ):
+    with pytest.raises(ValueError, match="target_replicas cannot be empty"):
         await kubernetes_connector.set_component_replicas(target_replicas)

--- a/components/planner/test/kubernetes_connector.py
+++ b/components/planner/test/kubernetes_connector.py
@@ -183,7 +183,7 @@ async def test_set_component_replicas_deployment_not_found(kubernetes_connector,
 @pytest.mark.asyncio
 async def test_set_component_replicas_empty_target_replicas(kubernetes_connector, mock_kube_api):
     # Arrange
-    target_replicas = {}
+    target_replicas: dict[str, int] = {}
 
     # Act & Assert
     with pytest.raises(

--- a/components/planner/test/kubernetes_connector.py
+++ b/components/planner/test/kubernetes_connector.py
@@ -26,6 +26,7 @@ def mock_kube_api():
     mock_api.get_graph_deployment = AsyncMock()
     mock_api.update_graph_replicas = AsyncMock()
     mock_api.wait_for_graph_deployment_ready = AsyncMock()
+    mock_api.is_deployment_ready = AsyncMock()
     return mock_api
 
 
@@ -42,7 +43,7 @@ def kubernetes_connector(mock_kube_api_class, monkeypatch):
     monkeypatch.setattr(
         "dynamo.planner.kubernetes_connector.KubernetesAPI", mock_kube_api_class
     )
-    connector = KubernetesConnector("default")
+    connector = KubernetesConnector("test-dynamo-namespace", "default")
     return connector
 
 
@@ -62,9 +63,7 @@ async def test_add_component_increases_replicas(kubernetes_connector, mock_kube_
     await kubernetes_connector.add_component(component_name)
 
     # Assert
-    mock_kube_api.get_graph_deployment.assert_called_once_with(
-        component_name, kubernetes_connector.dynamo_namespace
-    )
+    mock_kube_api.get_graph_deployment.assert_called_once()
     mock_kube_api.update_graph_replicas.assert_called_once_with(
         "test-graph", component_name, 2
     )
@@ -101,7 +100,7 @@ async def test_add_component_deployment_not_found(kubernetes_connector, mock_kub
 
     # Act & Assert
     with pytest.raises(
-        ValueError, match=f"Graph not found for component {component_name}"
+        ValueError, match="Parent DynamoGraphDeployment not found"
     ):
         await kubernetes_connector.add_component(component_name)
 
@@ -142,3 +141,52 @@ async def test_remove_component_with_zero_replicas(kubernetes_connector, mock_ku
     # Assert
     mock_kube_api.update_graph_replicas.assert_not_called()
     mock_kube_api.wait_for_graph_deployment_ready.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_component_replicas(kubernetes_connector, mock_kube_api):
+    # Arrange
+    target_replicas = {"component1": 3, "component2": 2}
+    mock_deployment = {
+        "metadata": {"name": "test-graph"},
+        "spec": {"services": {"component1": {"replicas": 1}, "component2": {"replicas": 1}}},
+    }
+    mock_kube_api.get_graph_deployment.return_value = mock_deployment
+    mock_kube_api.is_deployment_ready.return_value = True
+    mock_kube_api.update_graph_replicas.return_value = None
+    mock_kube_api.wait_for_graph_deployment_ready.return_value = None
+
+    # Act
+    await kubernetes_connector.set_component_replicas(target_replicas)
+
+    # Assert
+    mock_kube_api.get_graph_deployment.assert_called_once()
+    mock_kube_api.is_deployment_ready.assert_called_once_with("test-graph")
+    # Should be called twice, once for each component
+    assert mock_kube_api.update_graph_replicas.call_count == 2
+    mock_kube_api.wait_for_graph_deployment_ready.assert_called_once_with("test-graph")
+
+
+@pytest.mark.asyncio
+async def test_set_component_replicas_deployment_not_found(kubernetes_connector, mock_kube_api):
+    # Arrange
+    target_replicas = {"component1": 3}
+    mock_kube_api.get_graph_deployment.return_value = None
+
+    # Act & Assert
+    with pytest.raises(
+        ValueError, match="Parent DynamoGraphDeployment not found"
+    ):
+        await kubernetes_connector.set_component_replicas(target_replicas)
+
+
+@pytest.mark.asyncio
+async def test_set_component_replicas_empty_target_replicas(kubernetes_connector, mock_kube_api):
+    # Arrange
+    target_replicas = {}
+
+    # Act & Assert
+    with pytest.raises(
+        ValueError, match="target_replicas cannot be empty"
+    ):
+        await kubernetes_connector.set_component_replicas(target_replicas)

--- a/components/planner/test/kubernetes_connector.py
+++ b/components/planner/test/kubernetes_connector.py
@@ -176,14 +176,14 @@ async def test_set_component_replicas_deployment_not_found(
     mock_kube_api.get_graph_deployment.return_value = None
 
     # Act & Assert
-    with pytest.raises(
-        ValueError, match="Parent DynamoGraphDeployment not found"
-    ):
+    with pytest.raises(ValueError, match="Parent DynamoGraphDeployment not found"):
         await kubernetes_connector.set_component_replicas(target_replicas)
 
 
 @pytest.mark.asyncio
-async def test_set_component_replicas_empty_target_replicas(kubernetes_connector, mock_kube_api):
+async def test_set_component_replicas_empty_target_replicas(
+    kubernetes_connector, mock_kube_api
+):
     # Arrange
     target_replicas: dict[str, int] = {}
 


### PR DESCRIPTION
#### Overview:

update planner to use DYN_PARENT_DGD_K8S_NAME

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Select the parent graph deployment via the DYN_PARENT_DGD_K8S_NAME environment variable.
  - Bulk scale replicas across multiple components with optional blocking until ready.

- Improvements
  - Simplified deployment discovery with generalized “Parent DynamoGraphDeployment not found” errors.
  - Readiness checks added before scaling; early return if not ready.

- Tests
  - Added tests for environment-variable selection, readiness checks, and multi-component replica scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->