### PR TITLE
fix: update concurrency to not cancel main runs

### DIFF
--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -22,7 +22,7 @@ jobs:
     # Do not cancel main branch runs
     concurrency:
       group: ${{ matrix.framework }}-build-test-${{ github.ref_name || github.run_id }}
-      cancel-in-progress: ${{ github.ref_name != 'main' }}
+      cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
     name: Build and Test - ${{ matrix.framework }}
     env:

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -21,8 +21,8 @@ jobs:
             pytest_marks: "e2e and vllm and gpu_1 and not slow"
     # Do not cancel main branch runs
     concurrency:
-      group: ${{ matrix.framework }}-build-test-${{ github.ref_name || github.run_id }}
-      cancel-in-progress: ${{ !contains(github.ref, 'main')}}
+      group: ${{ github.workflow }}-${{ matrix.framework }}-build-test-${{ github.ref_name || github.run_id }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
     name: Build and Test - ${{ matrix.framework }}
     env:

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: NVIDIA Github Validation
+name: NVIDIA Dynamo Backends Github Validation
 
 on:
   push:

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: NVIDIA Github Validation
+name: NVIDIA Dynamo Github Validation
 
 on:
   push:

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -11,8 +11,8 @@ on:
 
 # Do not cancel main branch runs
 concurrency:
-  group: dynamo-build-test-${{ github.ref_name || github.run_id }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main')}}
+  group: ${{ github.workflow }}-dynamo-build-test-${{ github.ref_name || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build-test:

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -12,7 +12,7 @@ on:
 # Do not cancel main branch runs
 concurrency:
   group: dynamo-build-test-${{ github.ref_name || github.run_id }}
-  cancel-in-progress: ${{ github.ref_name != 'main' }}
+  cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
 jobs:
   build-test:


### PR DESCRIPTION
#### Overview:
Seeing some of the main branch runs cancelled - https://github.com/ai-dynamo/dynamo/actions/runs/17311463204

`Canceling since a higher priority waiting request for vllm-build-test-main exists`

Fix concurrency check as per github example - https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-only-cancel-in-progress-jobs-on-specific-branches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Refined CI concurrency settings to better manage in-progress runs, reducing redundant executions and queue times during active development.
  - Ensures main branch runs remain uninterrupted while improving cancellation behavior for non-main refs.
  - Applies to container validation workflows, enhancing pipeline efficiency and stability.
  - No impact on product functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->