### PR TITLE
fix: Remove duplicate import and update the test comment.

### DIFF
--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -175,7 +175,7 @@ def test_metrics_labels(request, runtime_services):
     Test that the trtllm backend correctly exports model labels in its metrics.
 
     This test uses the --extra-engine-args flag with agg.yaml configuration
-    to start the backend without needing a pre-built TensorRT-LLM engine.
+    to start the backend.
 
     The test runs from the trtllm directory to access engine_configs/agg.yaml
     """
@@ -195,9 +195,18 @@ def test_metrics_labels(request, runtime_services):
     metrics_port = 8081
     timeout = 60
 
-    # Change to the trtllm directory where engine_configs/agg.yaml exists
+    # Calculate the path to the trtllm directory from the test file location
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    # Go up two levels from tests/serve/
+    project_root = os.path.dirname(os.path.dirname(test_dir))
+    working_directory = os.path.join(project_root, "components", "backends", "trtllm")
 
-    working_directory = os.path.abspath("components/backends/trtllm")
+    # Verify the engine config file exists
+    engine_config_path = os.path.join(working_directory, agg_engine_args)
+    if not os.path.exists(engine_config_path):
+        pytest.fail(f"Engine config file not found at: {engine_config_path}")
+
+    logger.info(f"Using engine config from: {engine_config_path}")
 
     # Build command using the user's working command
     command = [

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -177,11 +177,8 @@ def test_metrics_labels(request, runtime_services):
     This test uses the --extra-engine-args flag with agg.yaml configuration
     to start the backend without needing a pre-built TensorRT-LLM engine.
 
-    Prerequisites:
-    - etcd and NATS must be running (docker compose -f deploy/docker-compose.yml up -d)
-    - The test runs from the trtllm directory to access engine_configs/agg.yaml
+    The test runs from the trtllm directory to access engine_configs/agg.yaml
     """
-    import os
     import re
     import subprocess
     import threading


### PR DESCRIPTION
#### Overview:

Fix test_metrics_labels trtllm test.

#### Details:

Remove duplicate import and update the test comment.
Use relative path to get tftllm directory.

#### Where should the reviewer start?

tests/serve/test_trtllm.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

[DIS-512 Add metric labels to trtllm](https://linear.app/nvidia/issue/DIS-512/add-metric-labels-to-trtllm)
DIS-570 test_metrics_labels fails in Gitlab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Clarified test docs by removing outdated etcd/NATS prerequisites and consolidating execution context into the main description.
  * General docstring cleanup for readability.

* Tests
  * Simplified test code by removing a redundant inner import; behavior remains unchanged.
  * No impact on runtime behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->