### PR TITLE
chore: Remove ENABLE_LMCACHE env var, detect from connector list

### DIFF
--- a/components/backends/vllm/LMCache_Integration.md
+++ b/components/backends/vllm/LMCache_Integration.md
@@ -20,10 +20,14 @@ This document describes how LMCache is integrated into Dynamo's vLLM backend to 
 
 ### Configuration
 
-LMCache is enabled by setting the `ENABLE_LMCACHE` environment variable:
+LMCache is enabled when the `lmcache` connector is specified:
 
 ```bash
-export ENABLE_LMCACHE=1
+# Enable LMCache via connector flag
+python -m dynamo.vllm --connector lmcache
+
+# Or with multiple connectors
+python -m dynamo.vllm --connector lmcache nixl
 ```
 
 Additional LMCache configuration can be customized via environment variables:
@@ -62,7 +66,7 @@ Disaggregated serving separates prefill and decode operations into dedicated wor
 
 ### Configuration
 
-The same `ENABLE_LMCACHE=1` environment variable enables LMCache, but the system automatically configures different connector setups for prefill and decode workers.
+LMCache is enabled when the `lmcache` connector is specified. The system automatically configures different connector setups for prefill and decode workers.
 
 ### Deployment
 
@@ -142,12 +146,12 @@ lmcache_config = {
 ### Integration Points
 
 1. **Argument Parsing** (`args.py`):
-   - Detects `ENABLE_LMCACHE` environment variable
+   - Detects LMCache usage from connector list or KVTransferConfig
    - Configures appropriate KV transfer settings
    - Sets up connector configurations based on worker type
 
 2. **Engine Setup** (`main.py`):
-   - Initializes LMCache environment variables
+   - Initializes LMCache environment variables when lmcache connector is used
    - Creates vLLM engine with proper KV transfer config
    - Handles both aggregated and disaggregated modes
 

--- a/components/backends/vllm/launch/agg_lmcache.sh
+++ b/components/backends/vllm/launch/agg_lmcache.sh
@@ -8,8 +8,4 @@ trap 'echo Cleaning up...; kill 0' EXIT
 python -m dynamo.frontend &
 
 # run worker with LMCache enabled
-ENABLE_LMCACHE=1 \
-LMCACHE_CHUNK_SIZE=256 \
-LMCACHE_LOCAL_CPU=True \
-LMCACHE_MAX_LOCAL_CPU_SIZE=20 \
-  python -m dynamo.vllm --model Qwen/Qwen3-0.6B
+python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector lmcache

--- a/components/backends/vllm/launch/disagg_lmcache.sh
+++ b/components/backends/vllm/launch/disagg_lmcache.sh
@@ -14,10 +14,6 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B &
 sleep 20
 
 # run prefill worker on GPU 1 with LMCache
-ENABLE_LMCACHE=1 \
-LMCACHE_CHUNK_SIZE=256 \
-LMCACHE_LOCAL_CPU=True \
-LMCACHE_MAX_LOCAL_CPU_SIZE=20 \
 CUDA_VISIBLE_DEVICES=1 \
   python3 -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \

--- a/components/backends/vllm/src/dynamo/vllm/args.py
+++ b/components/backends/vllm/src/dynamo/vllm/args.py
@@ -32,9 +32,6 @@ DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
 
 VALID_CONNECTORS = {"nixl", "lmcache", "kvbm", "null", "none"}
 
-# Global LMCache configuration - initialize once on module import
-ENABLE_LMCACHE = os.getenv("ENABLE_LMCACHE", "0").lower() in ("1", "true", "yes")
-
 
 class Config:
     """Command line parameters or defaults"""

--- a/tests/lmcache/README.md
+++ b/tests/lmcache/README.md
@@ -5,8 +5,8 @@ Test the correctness of Dynamo integration with LMCache by comparing MMLU benchm
 
 ## Testing Principle
 Compare MMLU test results under two configurations:
-- **Baseline Test**: Dynamo without LMCache (`ENABLE_LMCACHE=0`)
-- **LMCache Test**: Dynamo with LMCache enabled (`ENABLE_LMCACHE=1`)
+- **Baseline Test**: Dynamo without LMCache (no lmcache connector)
+- **LMCache Test**: Dynamo with LMCache enabled (`--connector lmcache`)
 
 If both configurations produce the same inference results, it verifies that LMCache functionality is correct.
 
@@ -63,14 +63,14 @@ python3 summarize_scores_dynamo.py
 ### Baseline Architecture (deploy-baseline-dynamo.sh)
 ```
 HTTP Request → Dynamo Ingress(8080) → Dynamo Worker → Direct Inference
-Environment: ENABLE_LMCACHE=0
+Connectors: Default (none)
 ```
 
 ### LMCache Architecture (deploy-lmcache_enabled-dynamo.sh)
 ```
 HTTP Request → Dynamo Ingress(8080) → Dynamo Worker → LMCache-enabled Inference
-Environment: ENABLE_LMCACHE=1
-            LMCACHE_CHUNK_SIZE=256
+Connectors: --connector lmcache
+Environment: LMCACHE_CHUNK_SIZE=256
             LMCACHE_LOCAL_CPU=True
             LMCACHE_MAX_LOCAL_CPU_SIZE=1.0
 ```

--- a/tests/lmcache/deploy-baseline-dynamo-disag.sh
+++ b/tests/lmcache/deploy-baseline-dynamo-disag.sh
@@ -30,8 +30,6 @@ echo "🧹 Cleaning up any existing dynamo processes..."
 pkill -f "dynamo-run" || true
 sleep 2
 
-# Disable LMCache
-export ENABLE_LMCACHE=0
 echo "🔧 Starting dynamo disaggregated serving without LMCache..."
 
 python -m dynamo.frontend &

--- a/tests/lmcache/deploy-baseline-dynamo.sh
+++ b/tests/lmcache/deploy-baseline-dynamo.sh
@@ -28,10 +28,7 @@ echo "🧹 Cleaning up any existing dynamo processes..."
 pkill -f "dynamo-run" || true
 sleep 2
 
-# Disable LMCache
-export ENABLE_LMCACHE=0
 echo "🔧 Starting dynamo worker without LMCache..."
-
 
 python -m dynamo.frontend &
 python3 -m dynamo.vllm --model $MODEL_URL

--- a/tests/lmcache/deploy-lmcache_enabled-dynamo-disag.sh
+++ b/tests/lmcache/deploy-lmcache_enabled-dynamo-disag.sh
@@ -40,11 +40,8 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm --model $MODEL_URL&
 sleep 20
 
 # run prefill worker on GPU 1 with LMCache
-ENABLE_LMCACHE=1 \
-LMCACHE_CHUNK_SIZE=256 \
-LMCACHE_LOCAL_CPU=True \
-LMCACHE_MAX_LOCAL_CPU_SIZE=20 \
 CUDA_VISIBLE_DEVICES=1 \
   python3 -m dynamo.vllm \
     --model $MODEL_URL \
-    --is-prefill-worker
+    --is-prefill-worker \
+    --connector lmcache nixl

--- a/tests/lmcache/deploy-lmcache_enabled-dynamo.sh
+++ b/tests/lmcache/deploy-lmcache_enabled-dynamo.sh
@@ -32,5 +32,4 @@ sleep 2
 echo "🔧 Starting dynamo worker with LMCache enabled..."
 
 python -m dynamo.frontend &
-ENABLE_LMCACHE=1 \
-  python3 -m dynamo.vllm --model $MODEL_URL
+python3 -m dynamo.vllm --model $MODEL_URL --connector lmcache


### PR DESCRIPTION
#### Overview:

Removes the ENABLE_LMCACHE Environment variable. Now, we detect if lmcache is in the `connector` list or if `LMCacheConnectorV1` is included in the kv_connector section of the KVConfig.

Also updated examples and tests to reflect this. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * LMCache is now enabled via a CLI connector flag (--connector lmcache), automatically activating when specified.
* Documentation
  * Updated guides and test README to explain connector-based LMCache enablement and configuration.
* Tests
  * Updated deployment scripts to use --connector lmcache; removed environment-variable toggles and simplified baseline startup.
* Refactor
  * Centralized LMCache activation logic to derive from runtime configuration instead of environment variables, ensuring conditional initialization only when the connector is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->