### PR TITLE
chore: bump version numbers ahead of 0.5.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-engine-llamacpp"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "dynamo-llm",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-engine-mistralrs"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1971,7 +1971,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "akin",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-run"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bytemuck",
  "derive-getters",
@@ -4009,7 +4009,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libdynamo_llm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "axum 0.8.4",
  "clap 4.5.46",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "Dynamo Inference Framework"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -27,11 +27,11 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed", "dynamo"]
 
 [workspace.dependencies]
 # Local crates
-dynamo-runtime = { path = "lib/runtime", version = "0.4.1" }
-dynamo-llm = { path = "lib/llm", version = "0.4.1" }
-dynamo-tokens = { path = "lib/tokens", version = "0.4.1" }
-dynamo-async-openai = { path = "lib/async-openai", version = "0.4.1", features = ["byot", "rustls"]}
-dynamo-parsers = { path = "lib/parsers", version = "0.4.1" }
+dynamo-runtime = { path = "lib/runtime", version = "0.5.0" }
+dynamo-llm = { path = "lib/llm", version = "0.5.0" }
+dynamo-tokens = { path = "lib/tokens", version = "0.5.0" }
+dynamo-async-openai = { path = "lib/async-openai", version = "0.5.0", features = ["byot", "rustls"]}
+dynamo-parsers = { path = "lib/parsers", version = "0.5.0" }
 
 # External dependencies
 anyhow = { version = "1" }

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -60,7 +60,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | :----------------- | :------------ | :----------------------------------- | :----------- |
 | ai-dynamo          | 0.5.0         | >=2.28                               |              |
 | ai-dynamo-runtime  | 0.5.0         | >=2.28 (Python 3.12 has known issues)|              |
-| NIXL               | 0.5.0         | >=2.27                               | >=11.8       |
+| NIXL               | 0.4.1         | >=2.27                               | >=11.8       |
 
 ### Build Dependency
 

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -58,9 +58,9 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 
 | **Python Package** | **Version**   | glibc version                        | CUDA Version |
 | :----------------- | :------------ | :----------------------------------- | :----------- |
-| ai-dynamo          | 0.4.1         | >=2.28                               |              |
-| ai-dynamo-runtime  | 0.4.1         | >=2.28 (Python 3.12 has known issues)|              |
-| NIXL               | 0.4.1         | >=2.27                               | >=11.8       |
+| ai-dynamo          | 0.5.0         | >=2.28                               |              |
+| ai-dynamo-runtime  | 0.5.0         | >=2.28 (Python 3.12 has known issues)|              |
+| NIXL               | 0.5.0         | >=2.27                               | >=11.8       |
 
 ### Build Dependency
 

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.5.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743ed1038b386b75451f9e0bba37cb2e3eea75873635268337d6531be99c9303"
 dependencies = [

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "akin",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-py3"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743ed1038b386b75451f9e0bba37cb2e3eea75873635268337d6531be99c9303"
 dependencies = [

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -19,7 +19,7 @@
 
 [package]
 name = "dynamo-py3"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "ai-dynamo-runtime"
-version = "0.4.1"
+version = "0.5.0"
 description = "Dynamo Inference Framework Runtime"
 readme = "README.md"
 authors = [

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1030,7 +1030,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello_world"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "dynamo-runtime",
 ]
@@ -2265,7 +2265,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "service_metrics"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "dynamo-runtime",
  "futures",
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "system_metrics"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dynamo-runtime",

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "ai-dynamo-runtime==0.4.1",
+    "ai-dynamo-runtime==0.5.0",
     "pytest>=8.3.4",
     "types-psutil>=7.0.0.20250218",
     "kubernetes>=32.0.1,<33.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "ai-dynamo"
-version = "0.4.1"
+version = "0.5.0"
 description = "Distributed Inference Framework"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
#### Overview:

Bump version numbers to `0.5.0` ahead of release


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes: OPS-785


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped project and Python bindings to version 0.5.0 across the workspace and example packages.
  - Aligned internal module versions to 0.5.0; no functional or API changes.

- Documentation
  - Updated Support Matrix to reflect 0.5.0 versions for relevant components; other compatibility details remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->