### PR TITLE
chore: bump version number of deploy artifacts

### DIFF
--- a/deploy/cloud/helm/crds/Chart.yaml
+++ b/deploy/cloud/helm/crds/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v2
 name: dynamo-crds
 description: A Helm chart for dynamo CRDs
 type: application
-version: 0.4.1
+version: 0.5.0
 dependencies: []

--- a/deploy/helm/chart/Chart.yaml
+++ b/deploy/helm/chart/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: dynamo-graph
 description: A Helm chart to deploy a Dynamo graph on Kubernetes
 type: application
-version: 0.4.1
-appVersion: 0.4.1
+version: 0.5.0
+appVersion: 0.5.0


### PR DESCRIPTION
#### Overview:

To keep `main` clean we have delayed bumping the version of the helm charts until `release/0.5.0` branch has been cut.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes OPS-785
