### PR TITLE
docs: add mention of deploy/utils quickstart to planner deployment docs

### DIFF
--- a/docs/architecture/sla_planner.md
+++ b/docs/architecture/sla_planner.md
@@ -28,7 +28,9 @@ The SLA planner consists of several key components:
 
 ## Pre-Deployment Profiling
 
-SLA-based planner requires pre-deployment profiling to operate. See [Pre-Deployment Profiling](../benchmarks/pre_deployment_profiling.md) for more details.
+**Prerequisite**: SLA-based planner requires pre-deployment profiling to be completed before deployment. The profiling process analyzes your model's performance characteristics to determine optimal tensor parallelism configurations and scaling parameters that the planner will use during operation.
+
+See [Pre-Deployment Profiling](../benchmarks/pre_deployment_profiling.md) for detailed instructions on running the profiling process.
 
 ## Load Prediction
 

--- a/docs/guides/dynamo_deploy/sla_planner_deployment.md
+++ b/docs/guides/dynamo_deploy/sla_planner_deployment.md
@@ -23,9 +23,11 @@ flowchart LR
 
 ## Prerequisites
 - Kubernetes cluster with GPU nodes
-- `hf-token-secret` created in target namespace
 - [Pre-Deployment Profiling](../../benchmarks/pre_deployment_profiling.md) results saved to `dynamo-pvc` PVC.
 - Prefill and decode worker uses the best parallelization mapping suggested by the pre-deployment profiling script.
+
+> [!NOTE]
+> **Important**: The profiling that occurs before Planner deployment requires additional Kubernetes manifests (ServiceAccount, Role, RoleBinding, PVC) that are not included in standard Dynamo deployments. For a complete setup, start with the [Quick Start guide](../../deploy/utils/README.md#quick-start) in `deploy/utils/README.md` which provides a fully encapsulated deployment setup including all required manifests.
 
 ```bash
 export NAMESPACE=your-namespace

--- a/docs/guides/dynamo_deploy/sla_planner_deployment.md
+++ b/docs/guides/dynamo_deploy/sla_planner_deployment.md
@@ -27,8 +27,7 @@ flowchart LR
 - Prefill and decode worker uses the best parallelization mapping suggested by the pre-deployment profiling script.
 
 > [!NOTE]
-> **Important**: The profiling that occurs before Planner deployment requires additional Kubernetes manifests (ServiceAccount, Role, RoleBinding, PVC) that are not included in standard Dynamo deployments. For a complete setup, start with the [Quick Start guide](../../deploy/utils/README.md#quick-start) in `deploy/utils/README.md` which provides a fully encapsulated deployment setup including all required manifests.
-
+> **Important**: The profiling that occurs before Planner deployment requires additional Kubernetes manifests (ServiceAccount, Role, RoleBinding, PVC) that are not included in standard Dynamo deployments. Apply these manifests in the same namespace as `$NAMESPACE`. For a complete setup, start with the [Quick Start guide](../../../deploy/utils/README.md#quick-start), which provides a fully encapsulated deployment including all required manifests.
 ```bash
 export NAMESPACE=your-namespace
 ```

--- a/docs/guides/dynamo_deploy/sla_planner_deployment.md
+++ b/docs/guides/dynamo_deploy/sla_planner_deployment.md
@@ -23,7 +23,7 @@ flowchart LR
 
 ## Prerequisites
 - Kubernetes cluster with GPU nodes
-- [Pre-Deployment Profiling](../../benchmarks/pre_deployment_profiling.md) results saved to `dynamo-pvc` PVC.
+- [Pre-Deployment Profiling](../../benchmarks/pre_deployment_profiling.md) completed and its results saved to `dynamo-pvc` PVC.
 - Prefill and decode worker uses the best parallelization mapping suggested by the pre-deployment profiling script.
 
 > [!NOTE]


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SLA Planner deployment guide prerequisites.
  * Removed requirement to create hf-token-secret in the target namespace.
  * Added note that pre-deployment profiling needs extra Kubernetes resources (ServiceAccount, Role, RoleBinding, PVC) not included in standard deployments.
  * Linked Quick Start for a fully encapsulated deployment path.
  * Clarified existing prerequisites: store profiling results to dynamo-pvc and use best-parallelization mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->