### PR TITLE
fix: guided_decoding parameter handling in vLLM handler

### DIFF
--- a/components/backends/vllm/src/dynamo/vllm/handlers.py
+++ b/components/backends/vllm/src/dynamo/vllm/handlers.py
@@ -11,7 +11,7 @@ from typing import AsyncGenerator
 
 import msgspec
 from vllm.inputs import TokensPrompt
-from vllm.sampling_params import SamplingParams, GuidedDecodingParams
+from vllm.sampling_params import GuidedDecodingParams, SamplingParams
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo.runtime.logging import configure_dynamo_logging

--- a/components/backends/vllm/src/dynamo/vllm/handlers.py
+++ b/components/backends/vllm/src/dynamo/vllm/handlers.py
@@ -223,6 +223,13 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         prompt = TokensPrompt(prompt_token_ids=request["token_ids"])
         sampling_params = msgspec.convert(request["sampling_params"], SamplingParams)
 
+        if hasattr(sampling_params, "guided_decoding") and isinstance(
+            sampling_params.guided_decoding, dict
+        ):
+            sampling_params.guided_decoding = GuidedDecodingParams(
+                **sampling_params.guided_decoding
+            )
+
         try:
             gen = self.engine_client.generate(prompt, sampling_params, request_id)
         except EngineDeadError as e:

--- a/components/backends/vllm/src/dynamo/vllm/handlers.py
+++ b/components/backends/vllm/src/dynamo/vllm/handlers.py
@@ -11,7 +11,7 @@ from typing import AsyncGenerator
 
 import msgspec
 from vllm.inputs import TokensPrompt
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import SamplingParams, GuidedDecodingParams
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -143,6 +143,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         sampling_params.detokenize = False
         for key, value in request["sampling_options"].items():
             if value is not None and hasattr(sampling_params, key):
+                if key == "guided_decoding" and isinstance(value, dict):
+                    value = GuidedDecodingParams(**value)
                 setattr(sampling_params, key, value)
 
         for key, value in request["stop_conditions"].items():

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -297,10 +297,7 @@ def test_serve_deployment(vllm_config_test, request, runtime_services):
 @pytest.mark.gpu_1
 @pytest.mark.vllm
 def test_guided_decoding(request, runtime_services):
-    """
-    Test guided decoding functionality with vLLM using Pydantic model schema.
-    """
-    # runtime_services is used to start nats and etcd
+    """Test guided decoding functionality with vLLM using Pydantic model schema."""
     logger = logging.getLogger(request.node.name)
     logger.info("Starting test_guided_decoding")
 
@@ -328,15 +325,12 @@ def test_guided_decoding(request, runtime_services):
             "messages": [
                 {
                     "role": "user",
-                    "content": "Generate a JSON with the name and age of one random person.",
+                    "content": "Generate a JSON with name and age of one random person. No thinking is required.",
                 }
             ],
-            "max_tokens": 50,
+            "max_tokens": 250,
             "temperature": 0.0,
-            "response_format": {
-                "type": "json_schema",
-                "json_schema": {"name": "people", "schema": People.model_json_schema()},
-            },
+            "guided_json": People.model_json_schema(),
         }
 
         response = server_process.send_request(
@@ -351,6 +345,9 @@ def test_guided_decoding(request, runtime_services):
         assert len(response_json["choices"]) > 0
 
         message_content = response_json["choices"][0]["message"]["content"]
+        if "</think>" in message_content:
+            message_content = message_content.split("</think>")[-1].strip()
+
         logger.info(f"Generated text with guided decoding: {message_content}")
 
         import json


### PR DESCRIPTION
Convert guided_decoding dict to GuidedDecodingParams object as expected by vLLM. This fixes 500 errors when guided decoding parameters are specified.

#### Overview:

Fixed a critical bug where guided_decoding parameters were causing 500 errors when passed to vLLM. The handler was passing guided_decoding as a dict, but vLLM's SamplingParams expects a GuidedDecodingParams instance.

#### Details:

- Added import for `GuidedDecodingParams` from `vllm.sampling_params`
- Added conversion logic to check if `guided_decoding` parameter is a dict and convert it to a GuidedDecodingParams object before setting it on SamplingParams
- This ensures compatibility with vLLM's expected input format as documented in [vLLM API reference](https://docs.vllm.ai/en/latest/api/vllm/sampling_params.html#vllm.sampling_params.GuidedDecodingParams.json)

#### Where should the reviewer start?

`components/backends/vllm/src/dynamo/vllm/handlers.py:146-148` - The core fix that converts dict to GuidedDecodingParams object

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes issue where requests with guided decoding parameters fail with 500 errors on new vLLM versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for guided decoding in generation options.
  * You can now pass structured guided decoding settings in requests to control output more precisely.
  * Improves compatibility with guided decoding-capable backends for more reliable constrained generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->