### PR TITLE
build: default to using dev instead of local-dev for vllm build

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -91,11 +91,10 @@ Follow these steps to get your NVIDIA Dynamo development environment up and runn
 
 ### Step 1: Build the Development Container Image
 
-Build `dynamo:latest-vllm-local-dev` from scratch from the source:
-- Note that currently, `local-dev` is only implemented for `--framework VLLM`.
+Build `dynamo:latest-vllm` from scratch from the source:
 
 ```bash
-./container/build.sh --target local-dev --framework VLLM
+./container/build.sh --target dev --framework VLLM
 ```
 
 The container will be built and give certain file permissions to your local uid and gid.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "name": "NVIDIA Dynamo Dev Container Development",
     "remoteUser": "ubuntu", // Matches our container user
     "updateRemoteUserUID": true, // Updates the UID of the remote user to match the host user, avoids permission errors
-    "image": "dynamo:latest-vllm-local-dev", // Use the latest VLLM local dev image
+    "image": "dynamo:latest-vllm", // Use the latest VLLM local dev image
     "runArgs": [
         "--gpus=all",
         "--network=host",

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -294,7 +294,7 @@ CMD []
 # Use this stage when you need a full development environment with additional
 # tooling beyond the base runtime image.
 
-FROM runtime AS local-dev
+FROM runtime AS dev
 
 # Install utilities
 RUN apt-get update -y && \

--- a/container/build.sh
+++ b/container/build.sh
@@ -465,7 +465,7 @@ fi
 # Add NIXL_REF as a build argument
 BUILD_ARGS+=" --build-arg NIXL_REF=${NIXL_REF} "
 
-if [[ $TARGET == "local-dev" ]]; then
+if [[ $TARGET == "dev" ]]; then
     BUILD_ARGS+=" --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) "
 fi
 


### PR DESCRIPTION
#### Overview:

Recent changes to Dockerfile.vllm resulted in the deletion of the dev stage in favor of local-dev stage. This was to align with the .devcontainer setup. However, to keep parity with other backends, the decision was made to keep the dev stage instead of local-dev. This PR updates the Dockerfile to use the dev stage as default instead of local-dev. 

https://github.com/ai-dynamo/dynamo/commit/e432ae4abbe76e8fc0a01230a0a07f25397871b7

#### Details:

- Use dev as default stage instead of local-dev.

#### Where should the reviewer start?

- .devcontainer/README.md
- .devcontainer/devcontainer.json
- container/Dockerfile.vllm
- container/build.sh

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Integrated prefill path for vLLM generation to enable faster first-token response and KV transfer for subsequent decoding.

- Documentation
  - Introduced a comprehensive installation guide and updated links across guides.
  - Added API reference generation notes and prerequisites for profiling/SLA planner.
  - Streamlined Helm docs, replacing legacy deployment instructions with chart-focused guidance.

- Chores
  - Bumped Helm chart versions to 0.5.0.
  - Updated devcontainer image tag and build target naming.
  - Adjusted platform defaults to support insecure etcd images and legacy repository.
  - Removed deprecated Helm deploy scripts and sample values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
