### PR TITLE
fix: router slot manager needs force expire requests

### DIFF
--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -122,6 +122,9 @@ impl ActiveSequences {
         isl: usize,
         overlap: u32,
     ) -> usize {
+        // Lazily check and clean up expired requests
+        self.force_expiry();
+
         let prefill_tokens = self.new_tokens(isl, overlap);
         self.prefill_tokens
             .insert(request_id.clone(), prefill_tokens);


### PR DESCRIPTION
#### Motivation

If a request is added to the slot manager of the Router, but for whatever reason is not freed afterwards, for example, due to: 1) user mistake of misusing the slot manager directly (not exposed currently); 2) a Router replica adding a request, propagating the signal to the other replicas, but crashing before freeing.  Therefore, we need a way to force-remove a request if it's in the slot for too long

#### Details

Since this force removal is considered an "exception" (not a "norm" unlike the `ApproxKvIndexer`), we are ok with O(n) clean up cost, considering that the cleanup set is small and cleanups should happen infrequently. We keep an `expiry_timer` that increments by 300 seconds every time we clean up, and we keep a cleanup set that is updated with snapshotted active requests every cleanup cycle. (The cleanup set will be freed naturally via the request cycles, and is expected to be empty during cleanup on normal operation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic time-based cleanup of inactive requests (~5 minutes) to free resources and keep the system responsive.
  - Added a manual trigger to run expiry checks on demand for operational control.

- Bug Fixes
  - Prevents previously freed requests from being expired again, reducing unnecessary warnings and avoiding edge-case errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->