### PR TITLE
fix: existing ubuntu user fix, and allow Docker run to execute as root for backward compatibility

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -271,7 +271,7 @@ COPY . /workspace/
 
 # Copy attribution files
 COPY ATTRIBUTION* LICENSE /workspace/
-# Copy launch banner
+# Copy launch banner as a root user
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \
     sed '/^#\s/d' /workspace/launch_message.txt > ~/.launch_screen && \
     echo "cat ~/.launch_screen" >> ~/.bashrc && \
@@ -296,30 +296,29 @@ CMD []
 
 FROM runtime AS dev
 
-# Don't want ubuntu to be editable, just change uid and gid.
+# Run as user ubuntu later on (see USER directive), that use USER_UID and USER_GID build args.
+# You should always pass in USER_UID and USER_GID build args as the host, so that they are
+# mapped correctly on volume mounts.
 ENV USERNAME=ubuntu
-ARG USER_UID
-ARG USER_GID
+ARG USER_UID=1000
+ARG USER_GID=1000
 ARG WORKSPACE_DIR=/workspace
 
 # Install utilities as root
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends  \
     # Install utilities
-    git \
-    gnupg1 \
-    gnupg2 \
-    htop \
-    iproute2 \
     nvtop \
-    openssh-client \
-    rsync \
-    sudo \
-    tmux \
-    unzip \
-    vim \
     wget \
+    tmux \
+    vim \
+    git \
+    openssh-client \
+    iproute2 \
+    rsync \
     zip \
+    unzip \
+    htop \
     # Build Dependencies
     autoconf \
     automake \
@@ -336,20 +335,20 @@ RUN apt-get update -y && \
 
 COPY --from=runtime /usr/local/bin /usr/local/bin
 
-# Create non-root user with host UID/GID for proper file permissions. This ensures
-# files created in mounted volumes have correct ownership. If an ubuntu user already
-# exists, it's removed first and recreated with the correct UID/GID. When the specified
-# GID conflicts with an existing group, that group is reused instead of creating a new one.
-# Reference: https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
-RUN (userdel -r $USERNAME 2>/dev/null || true) \
-    && (groupdel $USERNAME 2>/dev/null || true) \
-    && (getent group ${USER_GID} >/dev/null || groupadd -g ${USER_GID} $USERNAME) \
-    && useradd -m -u ${USER_UID} -g ${USER_GID} -s /bin/bash $USERNAME \
+# https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
+# Will use the default ubuntu user, but give sudo access
+# Needed so files permissions aren't set to root ownership when writing from inside container
+RUN apt-get update && apt-get install -y sudo gnupg2 gnupg1 \
     && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
-    && rm -rf /var/lib/apt/lists/*
+    && mkdir -p /home/$USERNAME \
+    && groupmod -g $USER_GID $USERNAME \
+    && usermod -u $USER_UID -g $USER_GID $USERNAME \
+    && chown -R $USERNAME:$USERNAME /home/$USERNAME \
+    && rm -rf /var/lib/apt/lists/* \
+    && chsh -s /bin/bash $USERNAME
 
-    # At this point, we are executing as the ubuntu user
+# At this point, we are executing as the ubuntu user
 USER $USERNAME
 ENV HOME=/home/$USERNAME
 WORKDIR $HOME

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -306,17 +306,20 @@ ARG WORKSPACE_DIR=/workspace
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends  \
     # Install utilities
-    nvtop \
-    wget \
-    tmux \
-    vim \
     git \
-    openssh-client \
-    iproute2 \
-    rsync \
-    zip \
-    unzip \
+    gnupg1 \
+    gnupg2 \
     htop \
+    iproute2 \
+    nvtop \
+    openssh-client \
+    rsync \
+    sudo \
+    tmux \
+    unzip \
+    vim \
+    wget \
+    zip \
     # Build Dependencies
     autoconf \
     automake \
@@ -333,20 +336,20 @@ RUN apt-get update -y && \
 
 COPY --from=runtime /usr/local/bin /usr/local/bin
 
-# https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
-# Will use the default ubuntu user, but give sudo access
-# Needed so files permissions aren't set to root ownership when writing from inside container
-RUN apt-get update && apt-get install -y sudo gnupg2 gnupg1 \
+# Create non-root user with host UID/GID for proper file permissions. This ensures
+# files created in mounted volumes have correct ownership. If an ubuntu user already
+# exists, it's removed first and recreated with the correct UID/GID. When the specified
+# GID conflicts with an existing group, that group is reused instead of creating a new one.
+# Reference: https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
+RUN (userdel -r $USERNAME 2>/dev/null || true) \
+    && (groupdel $USERNAME 2>/dev/null || true) \
+    && (getent group ${USER_GID} >/dev/null || groupadd -g ${USER_GID} $USERNAME) \
+    && useradd -m -u ${USER_UID} -g ${USER_GID} -s /bin/bash $USERNAME \
     && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
-    && mkdir -p /home/$USERNAME \
-    && groupmod -g $USER_GID $USERNAME \
-    && usermod -u $USER_UID -g $USER_GID $USERNAME \
-    && chown -R $USERNAME:$USERNAME /home/$USERNAME \
-    && rm -rf /var/lib/apt/lists/* \
-    && chsh -s /bin/bash $USERNAME
+    && rm -rf /var/lib/apt/lists/*
 
-# At this point, we are executing as the ubuntu user
+    # At this point, we are executing as the ubuntu user
 USER $USERNAME
 ENV HOME=/home/$USERNAME
 WORKDIR $HOME

--- a/container/build.sh
+++ b/container/build.sh
@@ -500,6 +500,7 @@ if [[ $TARGET == "dev" ]]; then
     if [ -z "$USER_GID" ]; then
         USER_GID=$(id -g)
     fi
+    echo "Building dev target with USER_UID=$USER_UID USER_GID=$USER_GID"
     BUILD_ARGS+=" --build-arg USER_UID=$USER_UID --build-arg USER_GID=$USER_GID "
 fi
 

--- a/container/run.sh
+++ b/container/run.sh
@@ -45,6 +45,7 @@ INTERACTIVE=
 USE_NIXL_GDS=
 RUNTIME=nvidia
 WORKDIR=/workspace
+DOCKER_USER=
 
 get_options() {
     while :; do
@@ -113,6 +114,14 @@ get_options() {
         --entrypoint)
             if [ "$2" ]; then
                 ENTRYPOINT=$2
+                shift
+            else
+                missing_requirement "$1"
+            fi
+            ;;
+        --user)
+            if [ "$2" ]; then
+                DOCKER_USER=$2
                 shift
             else
                 missing_requirement "$1"
@@ -230,11 +239,46 @@ get_options() {
         ENTRYPOINT_STRING="--entrypoint ${ENTRYPOINT}"
     fi
 
+    if [ -n "$MOUNT_WORKSPACE" ]; then
+        VOLUME_MOUNTS+=" -v $(dirname "${SOURCE_DIR}"):/workspace "
+        VOLUME_MOUNTS+=" -v /tmp:/tmp "
+        VOLUME_MOUNTS+=" -v /mnt/:/mnt "
+
+        if [ -z "$HF_CACHE" ]; then
+            HF_CACHE=$DEFAULT_HF_CACHE
+        fi
+
+        if [ -z "${PRIVILEGED}" ]; then
+            PRIVILEGED="TRUE"
+        fi
+
+        if [ -n "${HF_TOKEN}" ]; then
+            ENVIRONMENT_VARIABLES+=" -e HF_TOKEN"
+        fi
+
+        INTERACTIVE=" -it "
+
+        HOME_PATH="/home/ubuntu"
+    else
+        HOME_PATH="/root"
+    fi
+
+    ENVIRONMENT_VARIABLES+=" -e HOME=$HOME_PATH"
+
+    if [[ ${DOCKER_USER} == "" ]]; then
+        USER_STRING=""
+    else
+        USER_STRING="--user ${DOCKER_USER}"
+    fi
+
     if [[ ${HF_CACHE^^} == "NONE" ]]; then
         HF_CACHE=
     fi
 
-    # HF_CACHE mounting will be handled in workspace section
+    if [ -n "$HF_CACHE" ]; then
+        mkdir -p "$HF_CACHE"
+        VOLUME_MOUNTS+=" -v $HF_CACHE:$HOME_PATH/.cache/huggingface"
+    fi
 
     if [ -z "${PRIVILEGED}" ]; then
         PRIVILEGED="FALSE"
@@ -244,9 +288,9 @@ get_options() {
         RM="TRUE"
     fi
 
-    # Initialize PRIVILEGED_STRING
-    PRIVILEGED_STRING=""
-    if [[ ${PRIVILEGED^^} != "FALSE" ]]; then
+    if [[ ${PRIVILEGED^^} == "FALSE" ]]; then
+        PRIVILEGED_STRING=""
+    else
         PRIVILEGED_STRING="--privileged"
     fi
 
@@ -291,7 +335,7 @@ show_help() {
     echo "  [--framework framework one of ${!FRAMEWORKS[*]}]"
     echo "  [--target target stage to use, default is 'dev']"
     echo "  [--name name for launched container, default NONE]"
-    echo "  [--privileged whether to launch in privileged mode, default FALSE unless mounting workspace]"
+    echo "  [--privileged whether to launch in privileged mode, default FALSE]"
     echo "  [--dry-run print docker commands without running]"
     echo "  [--hf-cache directory to volume mount as the hf cache, default is NONE unless mounting workspace]"
     echo "  [--gpus gpus to enable, default is 'all', 'none' disables gpu support]"
@@ -303,6 +347,7 @@ show_help() {
     echo "  [--workdir set the working directory inside the container]"
     echo "  [--runtime add runtime variables]"
     echo "  [--entrypoint override container entrypoint]"
+    echo "  [--user username or UID:GID to run container as]"
     echo "  [-h, --help show this help]"
     exit 0
 }
@@ -317,48 +362,6 @@ error() {
 }
 
 get_options "$@"
-
-# Process workspace mounting after auto-detection
-if [ -n "$MOUNT_WORKSPACE" ]; then
-    HOME_PATH="/home/ubuntu"
-
-    # Common workspace setup
-    VOLUME_MOUNTS+=" -v $(dirname "${SOURCE_DIR}"):/workspace "
-    VOLUME_MOUNTS+=" -v /tmp:/tmp "
-    VOLUME_MOUNTS+=" -v /mnt/:/mnt "
-    WORKDIR=/workspace
-    INTERACTIVE=" -it "
-
-    # Set default HF_CACHE if not specified
-    if [ -z "$HF_CACHE" ]; then
-        HF_CACHE=$DEFAULT_HF_CACHE
-    fi
-
-    # Environment variables for all workspace modes
-    ENVIRONMENT_VARIABLES+=" -e HF_TOKEN"
-    ENVIRONMENT_VARIABLES+=" -e GITHUB_TOKEN"
-    ENVIRONMENT_VARIABLES+=" -e HOME=$HOME_PATH"
-
-    # Mount HF_CACHE to user's home cache directory
-    if [ -n "$HF_CACHE" ]; then
-        mkdir -p "$HF_CACHE"
-        VOLUME_MOUNTS+=" -v $HF_CACHE:$HOME_PATH/.cache/huggingface"
-    fi
-
-    if [ -n "$DEV_MODE" ]; then
-        # Dev Container-specific setup - the Dockerfile handles UID/GID mapping via build args
-        # This currently only works with Dockerfile.vllm which has proper ubuntu user setup.
-        echo "Dev Container mode enabled - using ubuntu user with host UID/GID"
-        # Use ubuntu user (with correct UID/GID baked into image)
-        PRIVILEGED_STRING+=" --user ubuntu"
-    else
-        # Standard workspace mode - enable privileged mode
-        # TODO(keivenc): Security risk, remove soon. Dockerfiles (trtllm, sglang) still need to run as root.
-        if [ -z "${PRIVILEGED}" ]; then
-            PRIVILEGED_STRING="--privileged"
-        fi
-    fi
-fi
 
 # RUN the image
 if [ -z "$RUN_PREFIX" ]; then
@@ -382,6 +385,7 @@ ${RUN_PREFIX} docker run \
     ${NIXL_GDS_CAPS} \
     --ipc host \
     ${PRIVILEGED_STRING} \
+    ${USER_STRING} \
     ${NAME_STRING} \
     ${ENTRYPOINT_STRING} \
     ${IMAGE} \


### PR DESCRIPTION
#### Overview:

Fix dev target user creation to work correctly in variable environments (e.g. non-local) where existing users/groups may conflict with specified UID/GID values.

#### Details:

Below is a matrix of `docker build` and `docker run` building/executing as different users.
```
+----------------------+----------------------+----------------------+----------------------+
|                      | A: host-user BUILD   | B: root-user BUILD   | C: non-existing-user |
|                      |                      |                      | BUILD                |
+----------------------+----------------------+----------------------+----------------------+
| 1: host-user RUN     | A1 (A+1): PERFECT    | B1 (B+1): ISSUES     | C1 (C+1): PARTIAL    |
|                      | Full R/W access      | Can't write container| Write mounts only    |
|                      | user-ids match       | dirs owned by root   | Can't write container|
+----------------------+----------------------+----------------------+----------------------+
| 2: root-user RUN     | A2 (A+2): SECURITY   | B2 (B+2): WORKS      | C2 (C+2): SECURITY   |
|                      | RISK                 | Expected behavior    | RISK                 |
|                      | Unnecessary root     | (still risky)        | Unnecessary root     |
+----------------------+----------------------+----------------------+----------------------+
| 3: non-existing-user | A3 (A+3): NO ACCESS  | B3 (B+3): ISSUES     | C3 (C+3): NO MOUNT   |
| RUN                  | Can't write anywhere | Can't write container| ACCESS               |
|                      | user-id mismatch     | dirs owned by root   | Mounts owned by host |
+----------------------+----------------------+----------------------+----------------------+
```
- The combination of C+2 (non-existing user 1000 BUILD + root-user RUN) was what we had before.
- I'm turning this into A+1 (host-user BUILD + host-user RUN) for vLLM
- However, I also understand that we should have backward compatibility, so I've added the capability such that you can do `build.sh --uid 1000 --gid 1000` and `run.sh --user root ...`, to achieve exactly what we had before (C+2).
- Handle existing GID conflicts by reusing the group if it already exists instead of failing
- Fix empty USER_UID/USER_GID build arguments that caused useradd failures in environments with existing ubuntu users
- Add debug output to show UID/GID values being used during build for easier troubleshooting
- Ensure consistent Docker image tagging whether --target dev is specified explicitly or used as default
- Add Dockerfile.test for isolated testing of user creation logic

#### Where should the reviewer start?

- container/Dockerfile.vllm - See the improved user creation logic (lines 344-351)
- container/build.sh - Check the UID/GID handling and debug output (lines 496-505)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standardized non-root user setup in development images with configurable UID/GID, home, and workspace.
  - Enhanced developer environment: user-scoped PATH/LD_LIBRARY_PATH, cargo/rust toolchain dirs, and PYTHONPATH.
  - Added maturin installation for per-user builds and quality-of-life shell/history defaults.
- Tests
  - Introduced a minimal test image that provisions a configurable non-root user and verifies identity at runtime.
- Chores
  - Added build-time logging to display resolved USER_UID and USER_GID when building development images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->