### PR TITLE
fix: add back welcome banner for ubuntu user in dev target

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -271,7 +271,7 @@ COPY . /workspace/
 
 # Copy attribution files
 COPY ATTRIBUTION* LICENSE /workspace/
-# Copy launch banner
+# Copy launch banner as a root user
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \
     sed '/^#\s/d' /workspace/launch_message.txt > ~/.launch_screen && \
     echo "cat ~/.launch_screen" >> ~/.bashrc && \
@@ -390,6 +390,12 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=$HOME/.comman
     && mkdir -p $HOME/.commandhistory \
     && touch $HOME/.commandhistory/.bash_history \
     && echo "$SNIPPET" >> "$HOME/.bashrc"
+
+# Copy launch banner from root user to ubuntu user
+RUN sudo cp /root/.launch_screen $HOME/.launch_screen && \
+    sudo chown $USERNAME:$USERNAME $HOME/.launch_screen && \
+    echo "cat $HOME/.launch_screen" >> $HOME/.bashrc && \
+    echo "source $VIRTUAL_ENV/bin/activate" >> $HOME/.bashrc
 
 RUN mkdir -p /home/$USERNAME/.cache/
 

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -334,17 +334,16 @@ RUN apt-get update -y && \
 COPY --from=runtime /usr/local/bin /usr/local/bin
 
 # https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
-# Will use the default ubuntu user, but give sudo access
-# Needed so files permissions aren't set to root ownership when writing from inside container
+# Create ubuntu user with specific UID/GID for proper volume mount permissions
+# Clean up any existing user/group first, then create with sudo access
 RUN apt-get update && apt-get install -y sudo gnupg2 gnupg1 \
+    && (userdel -r $USERNAME 2>/dev/null || true) \
+    && (groupdel $USERNAME 2>/dev/null || true) \
+    && (getent group ${USER_GID} >/dev/null || groupadd -g ${USER_GID} $USERNAME) \
+    && useradd -m -u ${USER_UID} -g ${USER_GID} -s /bin/bash $USERNAME \
     && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
-    && mkdir -p /home/$USERNAME \
-    && groupmod -g $USER_GID $USERNAME \
-    && usermod -u $USER_UID -g $USER_GID $USERNAME \
-    && chown -R $USERNAME:$USERNAME /home/$USERNAME \
-    && rm -rf /var/lib/apt/lists/* \
-    && chsh -s /bin/bash $USERNAME
+    && rm -rf /var/lib/apt/lists/*
 
 # At this point, we are executing as the ubuntu user
 USER $USERNAME


### PR DESCRIPTION
#### Overview:

Restore welcome banner display for ubuntu user in dev target.

#### Details:

- Now that VLLM dev containers run as a safe `ubuntu` instead of `root` user, we no longer get the welcome message.
- Copy launch banner to ubuntu user's home directory
- Add to ubuntu's .bashrc for display on container entry

#### Where should the reviewer start?

container/Dockerfile.vllm - lines 394-398


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The login banner now displays for both root and non-root (ubuntu) users when opening a shell in the container.
  * The ubuntu user’s environment automatically activates the virtual environment on login in both runtime and local development images.
  * Consistent banner behavior is ensured across stages, with correct ownership applied so the banner and environment settings work seamlessly for the ubuntu user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->