### PR TITLE
feat: Endpoint health check

### DIFF
--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -49,6 +49,13 @@ pub struct EndpointConfig {
     /// Whether to wait for inflight requests to complete during shutdown
     #[builder(default = "true")]
     graceful_shutdown: bool,
+
+    /// Health check payload for this endpoint
+    /// This payload will be sent to the endpoint during health checks
+    /// to verify it's responding properly
+    #[educe(Debug(ignore))]
+    #[builder(default, setter(into))]
+    health_check_payload: Option<serde_json::Value>,
 }
 
 impl EndpointConfigBuilder {
@@ -64,8 +71,15 @@ impl EndpointConfigBuilder {
     }
 
     pub async fn start(self) -> Result<()> {
-        let (endpoint, lease, handler, stats_handler, metrics_labels, graceful_shutdown) =
-            self.build_internal()?.dissolve();
+        let (
+            endpoint,
+            lease,
+            handler,
+            stats_handler,
+            metrics_labels,
+            graceful_shutdown,
+            health_check_payload,
+        ) = self.build_internal()?.dissolve();
         let lease = lease.or(endpoint.drt().primary_lease());
         let lease_id = lease.as_ref().map(|l| l.id()).unwrap_or(0);
 
@@ -85,6 +99,12 @@ impl EndpointConfigBuilder {
         // Add metrics to the handler. The endpoint provides additional information to the handler.
         handler.add_metrics(&endpoint, metrics_labels.as_deref())?;
 
+        // Set health tracking information on the handler
+        handler.set_health_tracking(
+            endpoint.subject_to(lease_id),
+            endpoint.drt().system_health.clone(),
+        )?;
+
         // get the group
         let group = registry
             .services
@@ -100,6 +120,19 @@ impl EndpointConfigBuilder {
             .expect("no stats handler registry; this is unexpected");
 
         drop(registry);
+
+        // Register health check payload in SystemHealth if provided
+        if let Some(health_check_payload) = &health_check_payload {
+            endpoint
+                .drt()
+                .system_health
+                .lock()
+                .unwrap()
+                .register_health_check_payload(
+                    &endpoint.subject_to(lease_id),
+                    health_check_payload.clone(),
+                );
+        }
 
         // insert the stats handler
         if let Some(stats_handler) = stats_handler {

--- a/lib/runtime/src/config.rs
+++ b/lib/runtime/src/config.rs
@@ -21,6 +21,11 @@ const DEFAULT_SYSTEM_PORT: u16 = 9090;
 const DEFAULT_SYSTEM_HEALTH_PATH: &str = "/health";
 const DEFAULT_SYSTEM_LIVE_PATH: &str = "/live";
 
+/// Default health check configuration
+pub const DEFAULT_HEALTH_CHECK_INTERVAL_SECS: u64 = 10;
+pub const DEFAULT_HEALTH_CHECK_RESPOND_STALE_THRESHOLD_SECS: u64 = 5;
+pub const DEFAULT_HEALTH_CHECK_REQUEST_TIMEOUT_SECS: u64 = 3;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerConfig {
     /// Grace shutdown period for the system server.
@@ -124,6 +129,30 @@ pub struct RuntimeConfig {
     #[builder(default = "DEFAULT_SYSTEM_LIVE_PATH.to_string()")]
     #[builder_field_attr(serde(skip_serializing_if = "Option::is_none"))]
     pub system_live_path: String,
+
+    /// Enable active health checking with payloads
+    /// Set this at runtime with environment variable DYN_HEALTH_CHECK_ENABLED
+    #[builder(default = "false")]
+    #[builder_field_attr(serde(skip_serializing_if = "Option::is_none"))]
+    pub health_check_enabled: bool,
+
+    /// Health check interval in seconds
+    /// Set this at runtime with environment variable DYN_HEALTH_CHECK_INTERVAL
+    #[builder(default = "DEFAULT_HEALTH_CHECK_INTERVAL_SECS")]
+    #[builder_field_attr(serde(skip_serializing_if = "Option::is_none"))]
+    pub health_check_interval_secs: u64,
+
+    /// Health check respond stale threshold in seconds
+    /// Set this at runtime with environment variable DYN_HEALTH_CHECK_RESPOND_STALE_THRESHOLD
+    #[builder(default = "DEFAULT_HEALTH_CHECK_RESPOND_STALE_THRESHOLD_SECS")]
+    #[builder_field_attr(serde(skip_serializing_if = "Option::is_none"))]
+    pub health_check_respond_stale_threshold_secs: u64,
+
+    /// Health check request timeout in seconds
+    /// Set this at runtime with environment variable DYN_HEALTH_CHECK_REQUEST_TIMEOUT
+    #[builder(default = "DEFAULT_HEALTH_CHECK_REQUEST_TIMEOUT_SECS")]
+    #[builder_field_attr(serde(skip_serializing_if = "Option::is_none"))]
+    pub health_check_request_timeout_secs: u64,
 }
 
 impl fmt::Display for RuntimeConfig {
@@ -150,6 +179,22 @@ impl fmt::Display for RuntimeConfig {
         )?;
         write!(f, ", system_health_path={}", self.system_health_path)?;
         write!(f, ", system_live_path={}", self.system_live_path)?;
+        write!(f, ", health_check_enabled={}", self.health_check_enabled)?;
+        write!(
+            f,
+            ", health_check_interval_secs={}",
+            self.health_check_interval_secs
+        )?;
+        write!(
+            f,
+            ", health_check_respond_stale_threshold_secs={}",
+            self.health_check_respond_stale_threshold_secs
+        )?;
+        write!(
+            f,
+            ", health_check_request_timeout_secs={}",
+            self.health_check_request_timeout_secs
+        )?;
 
         Ok(())
     }
@@ -194,6 +239,26 @@ impl RuntimeConfig {
                     _ => None,
                 }
             }))
+            .merge(Env::prefixed("DYN_HEALTH_CHECK_").filter_map(|k| {
+                let full_key = format!("DYN_HEALTH_CHECK_{}", k.as_str());
+                // filters out empty environment variables
+                match std::env::var(&full_key) {
+                    Ok(v) if !v.is_empty() => {
+                        // Map DYN_HEALTH_CHECK_* to the correct field names
+                        let mapped_key = match k.as_str() {
+                            "ENABLED" => "health_check_enabled",
+                            "INTERVAL" => "health_check_interval_secs",
+                            "RESPOND_STALE_THRESHOLD" => {
+                                "health_check_respond_stale_threshold_secs"
+                            }
+                            "REQUEST_TIMEOUT" => "health_check_request_timeout_secs",
+                            _ => k.as_str(),
+                        };
+                        Some(mapped_key.into())
+                    }
+                    _ => None,
+                }
+            }))
     }
 
     /// Load the runtime configuration from the environment and configuration files
@@ -227,6 +292,11 @@ impl RuntimeConfig {
             use_endpoint_health_status: vec![],
             system_health_path: DEFAULT_SYSTEM_HEALTH_PATH.to_string(),
             system_live_path: DEFAULT_SYSTEM_LIVE_PATH.to_string(),
+            health_check_enabled: false,
+            health_check_interval_secs: DEFAULT_HEALTH_CHECK_INTERVAL_SECS,
+            health_check_respond_stale_threshold_secs:
+                DEFAULT_HEALTH_CHECK_RESPOND_STALE_THRESHOLD_SECS,
+            health_check_request_timeout_secs: DEFAULT_HEALTH_CHECK_REQUEST_TIMEOUT_SECS,
         }
     }
 
@@ -256,6 +326,11 @@ impl Default for RuntimeConfig {
             use_endpoint_health_status: vec![],
             system_health_path: DEFAULT_SYSTEM_HEALTH_PATH.to_string(),
             system_live_path: DEFAULT_SYSTEM_LIVE_PATH.to_string(),
+            health_check_enabled: false,
+            health_check_interval_secs: DEFAULT_HEALTH_CHECK_INTERVAL_SECS,
+            health_check_respond_stale_threshold_secs:
+                DEFAULT_HEALTH_CHECK_RESPOND_STALE_THRESHOLD_SECS,
+            health_check_request_timeout_secs: DEFAULT_HEALTH_CHECK_REQUEST_TIMEOUT_SECS,
         }
     }
 }

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -167,6 +167,31 @@ impl DistributedRuntime {
             );
         }
 
+        // Start health check manager if enabled
+        if config.health_check_enabled {
+            let health_check_config = crate::health_check::HealthCheckConfig {
+                check_interval: std::time::Duration::from_secs(config.health_check_interval_secs),
+                respond_stale_threshold: std::time::Duration::from_secs(
+                    config.health_check_respond_stale_threshold_secs,
+                ),
+                request_timeout: std::time::Duration::from_secs(
+                    config.health_check_request_timeout_secs,
+                ),
+            };
+
+            let _health_check_handle = crate::health_check::start_health_check_manager(
+                Arc::new(distributed_runtime.clone()),
+                Some(health_check_config),
+            );
+
+            tracing::info!(
+                "Health check manager started (interval: {}s, respond_stale_threshold: {}s, timeout: {}s)",
+                config.health_check_interval_secs,
+                config.health_check_respond_stale_threshold_secs,
+                config.health_check_request_timeout_secs
+            );
+        }
+
         Ok(distributed_runtime)
     }
 

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -1,0 +1,775 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{DistributedRuntime, HealthStatus, SystemHealth};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::time::{MissedTickBehavior, interval};
+use tracing::{debug, error, info, warn};
+
+/// Configuration for health check behavior
+pub struct HealthCheckConfig {
+    /// How often to check endpoint health
+    pub check_interval: Duration,
+    /// How long since last response before considering unhealthy
+    pub respond_stale_threshold: Duration,
+    /// Timeout for health check requests
+    pub request_timeout: Duration,
+}
+
+impl Default for HealthCheckConfig {
+    fn default() -> Self {
+        Self {
+            check_interval: Duration::from_secs(crate::config::DEFAULT_HEALTH_CHECK_INTERVAL_SECS),
+            respond_stale_threshold: Duration::from_secs(
+                crate::config::DEFAULT_HEALTH_CHECK_RESPOND_STALE_THRESHOLD_SECS,
+            ),
+            request_timeout: Duration::from_secs(
+                crate::config::DEFAULT_HEALTH_CHECK_REQUEST_TIMEOUT_SECS,
+            ),
+        }
+    }
+}
+
+/// Health check manager that monitors endpoint health
+pub struct HealthCheckManager {
+    drt: Arc<DistributedRuntime>,
+    config: HealthCheckConfig,
+    /// Track when we last sent health checks to each endpoint
+    last_health_check_sent: Arc<Mutex<HashMap<String, Instant>>>,
+}
+
+impl HealthCheckManager {
+    pub fn new(drt: Arc<DistributedRuntime>, config: HealthCheckConfig) -> Self {
+        Self {
+            drt,
+            config,
+            last_health_check_sent: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Start the health check polling loop
+    pub async fn start(self: Arc<Self>) {
+        let mut check_interval = interval(self.config.check_interval);
+        check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        info!(
+            "Health check manager started with interval: {:?}, respond_stale_threshold: {:?}",
+            self.config.check_interval, self.config.respond_stale_threshold
+        );
+
+        loop {
+            check_interval.tick().await;
+
+            if let Err(e) = self.check_all_endpoints().await {
+                error!("Health check error: {}", e);
+            }
+        }
+    }
+
+    /// Check health of all registered endpoints
+    pub async fn check_all_endpoints(&self) -> anyhow::Result<()> {
+        // Get list of endpoints with health check payloads from SystemHealth
+        let endpoints_to_check: Vec<(String, serde_json::Value)> = {
+            let system_health = self.drt.system_health.lock().unwrap();
+            system_health.get_health_check_payloads()
+        };
+
+        debug!("Checking health of {} endpoints", endpoints_to_check.len());
+
+        for (endpoint_subject, health_check_payload) in endpoints_to_check {
+            self.check_endpoint_health(&endpoint_subject, &health_check_payload)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Check health of a single endpoint
+    ///
+    /// Simple health check logic:
+    /// 1. If endpoint responded recently -> mark as healthy
+    /// 2. Else:
+    ///    - If health check not sent -> send one
+    ///    - Else:
+    ///      - If within timeout -> keep status unchanged
+    ///      - Else -> mark as unhealthy
+    pub async fn check_endpoint_health(
+        &self,
+        endpoint_subject: &str,
+        health_check_payload: &serde_json::Value,
+    ) -> anyhow::Result<()> {
+        // Step 1: Check if endpoint has responded recently
+        let has_recent_response = {
+            let system_health = self.drt.system_health.lock().unwrap();
+            system_health
+                .has_responded_recently(endpoint_subject, self.config.respond_stale_threshold)
+        };
+
+        if has_recent_response {
+            debug!(
+                "Endpoint {} is healthy (responded within {:?})",
+                endpoint_subject, self.config.respond_stale_threshold
+            );
+            let system_health = self.drt.system_health.lock().unwrap();
+            system_health.set_endpoint_health_status(endpoint_subject, HealthStatus::Ready);
+
+            return Ok(());
+        }
+
+        // Step 2: No recent response - check if we've sent a health check
+        info!(
+            "Endpoint {} has not responded recently (threshold: {:?})",
+            endpoint_subject, self.config.respond_stale_threshold
+        );
+
+        let last_health_check_sent_at = {
+            let last_sent = self.last_health_check_sent.lock().unwrap();
+            last_sent.get(endpoint_subject).copied()
+        };
+
+        if let Some(sent_at) = last_health_check_sent_at {
+            // We've sent a health check - check if it has timed out
+            let elapsed = sent_at.elapsed();
+
+            if elapsed < self.config.request_timeout {
+                // Still within timeout - don't change status
+                debug!(
+                    "Waiting for health check response from {} (elapsed: {:?} of {:?})",
+                    endpoint_subject, elapsed, self.config.request_timeout
+                );
+                // Status remains unchanged
+            } else {
+                // Timeout exceeded - mark as unhealthy
+                warn!(
+                    "Health check timeout exceeded for {} (elapsed: {:?}, timeout: {:?})",
+                    endpoint_subject, elapsed, self.config.request_timeout
+                );
+                let system_health = self.drt.system_health.lock().unwrap();
+                system_health.set_endpoint_health_status(endpoint_subject, HealthStatus::NotReady);
+            }
+        } else {
+            // No health check sent yet - send one now
+            {
+                let mut last_sent = self.last_health_check_sent.lock().unwrap();
+                last_sent.insert(endpoint_subject.to_string(), Instant::now());
+            }
+
+            match self
+                .send_health_check_request(endpoint_subject, health_check_payload)
+                .await
+            {
+                Ok(()) => {
+                    info!("Health check request sent to {}", endpoint_subject);
+                    // Don't wait for response - let the normal payload handling update last_response_time
+                    // The next check cycle will determine if the endpoint responded
+                }
+                Err(e) => {
+                    error!("Failed to send health check to {}: {}", endpoint_subject, e);
+                    // Mark as unhealthy if we can't even send the health check
+                    let system_health = self.drt.system_health.lock().unwrap();
+                    system_health
+                        .set_endpoint_health_status(endpoint_subject, HealthStatus::NotReady);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Send a health check request to an endpoint (fire and forget)
+    async fn send_health_check_request(
+        &self,
+        endpoint_subject: &str,
+        payload: &serde_json::Value,
+    ) -> anyhow::Result<()> {
+        debug!(
+            "Sending health check request to {} with payload: {}",
+            endpoint_subject, payload
+        );
+
+        // Create a NATS client and send the request
+        let nats_client = self.drt.nats_client();
+        let payload_bytes = serde_json::to_vec(payload)?;
+
+        // Send request but don't wait for response - fire and forget
+        // The normal payload handling path will update last_response_time when response arrives
+        let client = nats_client.client().clone();
+        let subject = endpoint_subject.to_string();
+
+        tokio::spawn(async move {
+            // We don't care about the response - just send the request
+            let _ = client.request(subject, payload_bytes.into()).await;
+        });
+
+        debug!("Health check request dispatched to {}", endpoint_subject);
+        Ok(())
+    }
+}
+
+/// Start health check manager for the distributed runtime
+pub fn start_health_check_manager(
+    drt: Arc<DistributedRuntime>,
+    config: Option<HealthCheckConfig>,
+) -> tokio::task::JoinHandle<()> {
+    let config = config.unwrap_or_default();
+    let manager = Arc::new(HealthCheckManager::new(drt.clone(), config));
+
+    // Spawn the health check loop
+    tokio::spawn(async move {
+        manager.start().await;
+    })
+}
+
+/// Get health check status for all endpoints
+pub async fn get_health_check_status(
+    drt: &DistributedRuntime,
+    threshold: Duration,
+) -> anyhow::Result<serde_json::Value> {
+    // Get endpoints list from SystemHealth
+    let endpoint_subjects: Vec<String> = {
+        let system_health = drt.system_health.lock().unwrap();
+        system_health.get_health_check_endpoints()
+    };
+
+    let mut endpoint_statuses = std::collections::HashMap::new();
+
+    // Check each endpoint
+    {
+        let system_health = drt.system_health.lock().unwrap();
+        for endpoint_subject in &endpoint_subjects {
+            let has_recent_response =
+                system_health.has_responded_recently(endpoint_subject, threshold);
+
+            let last_response = system_health
+                .get_last_response_time(endpoint_subject)
+                .map(|t| t.elapsed().as_secs())
+                .unwrap_or(999999);
+
+            endpoint_statuses.insert(
+                endpoint_subject.clone(),
+                serde_json::json!({
+                    "healthy": has_recent_response,
+                    "seconds_since_last_response": last_response,
+                }),
+            );
+        }
+    }
+
+    let overall_healthy = endpoint_statuses
+        .values()
+        .all(|v| v["healthy"].as_bool().unwrap_or(false));
+
+    Ok(serde_json::json!({
+        "status": if overall_healthy { "ready" } else { "notready" },
+        "endpoints_checked": endpoint_subjects.len(),
+        "endpoint_statuses": endpoint_statuses,
+        "check_threshold_seconds": threshold.as_secs(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    // NOTE: These tests demonstrate the logic of HealthCheckManager but are limited
+    // because HealthCheckManager is tightly coupled with DistributedRuntime.
+    // For proper unit testing, HealthCheckManager would need to be refactored to:
+    // 1. Accept trait objects for SystemHealth instead of concrete types
+    // 2. Use dependency injection for NATS client
+    // 3. Or use a builder pattern that allows test configuration
+
+    #[test]
+    fn test_health_check_manager_creation() {
+        // Test HealthCheckManager::new() correctly stores configuration
+        let config = HealthCheckConfig {
+            check_interval: Duration::from_secs(5),
+            respond_stale_threshold: Duration::from_secs(10),
+            request_timeout: Duration::from_secs(2),
+        };
+
+        // Verify the config values themselves (can't create actual manager without DRT)
+        assert_eq!(config.check_interval, Duration::from_secs(5));
+        assert_eq!(config.respond_stale_threshold, Duration::from_secs(10));
+        assert_eq!(config.request_timeout, Duration::from_secs(2));
+
+        // The actual HealthCheckManager::new() would:
+        // 1. Store the drt reference
+        // 2. Store the config
+        // 3. Initialize empty last_health_check_sent HashMap
+    }
+
+    #[tokio::test]
+    async fn test_check_endpoint_health_healthy() {
+        // This test verifies the logic: "Recent response = healthy status"
+        // In check_endpoint_health(), if has_recent_response is true,
+        // it should mark the endpoint as Ready and return early
+
+        let threshold = Duration::from_secs(5);
+
+        // Simulate a recent response (3 seconds ago, within threshold)
+        let last_response_time = Instant::now() - Duration::from_secs(3);
+
+        // Check that elapsed time is within threshold
+        assert!(last_response_time.elapsed() < threshold);
+        // At this point, check_endpoint_health would:
+        // 1. Call system_health.has_responded_recently() -> returns true
+        // 2. Set endpoint status to HealthStatus::Ready
+        // 3. Return early without sending health check
+    }
+
+    #[tokio::test]
+    async fn test_check_endpoint_health_send_check() {
+        // This test verifies: "No recent response triggers health check"
+        // Logic path: has_recent_response = false, last_sent = None -> send health check
+
+        let threshold = Duration::from_secs(5);
+
+        // Simulate a stale response (create a time in the past)
+        let last_response_time = Instant::now() - Duration::from_secs(10);
+
+        // Verify response is stale
+        assert!(last_response_time.elapsed() > threshold);
+
+        // Simulate the last_health_check_sent tracking
+        let last_sent: Arc<Mutex<HashMap<String, Instant>>> = Arc::new(Mutex::new(HashMap::new()));
+        let endpoint = "test_endpoint";
+
+        // Initially, no health check has been sent
+        {
+            let sent = last_sent.lock().unwrap();
+            assert!(!sent.contains_key(endpoint));
+        }
+
+        // The manager would now:
+        // 1. Detect no recent response (has_recent_response = false)
+        // 2. Check last_health_check_sent -> None
+        // 3. Insert current time into last_health_check_sent
+        // 4. Call send_health_check_request()
+        {
+            let mut sent = last_sent.lock().unwrap();
+            sent.insert(endpoint.to_string(), Instant::now());
+        }
+
+        // Verify health check is now tracked
+        {
+            let sent = last_sent.lock().unwrap();
+            assert!(sent.contains_key(endpoint));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_check_endpoint_health_within_timeout() {
+        // This test verifies: "Pending check within timeout keeps status unchanged"
+        // Logic path: has_recent_response = false, last_sent = Some(time), elapsed < timeout
+
+        let timeout = Duration::from_secs(3);
+        let last_sent: Arc<Mutex<HashMap<String, Instant>>> = Arc::new(Mutex::new(HashMap::new()));
+        let endpoint = "test_endpoint";
+
+        // Record that we sent a health check 2 seconds ago (within timeout)
+        let sent_time = Instant::now() - Duration::from_secs(2);
+        {
+            let mut sent = last_sent.lock().unwrap();
+            sent.insert(endpoint.to_string(), sent_time);
+        }
+
+        // Check the elapsed time since health check was sent
+        {
+            let sent = last_sent.lock().unwrap();
+            let sent_time = sent.get(endpoint).unwrap();
+            let elapsed = sent_time.elapsed();
+
+            assert!(elapsed < timeout);
+            // At this point, check_endpoint_health would:
+            // 1. Find has_recent_response = false
+            // 2. Find last_health_check_sent_at = Some(sent_time)
+            // 3. Calculate elapsed < timeout
+            // 4. Log "Waiting for health check response"
+            // 5. NOT change the health status
+        }
+    }
+
+    #[tokio::test]
+    async fn test_check_endpoint_health_timeout_exceeded() {
+        // This test verifies: "Mark unhealthy after timeout"
+        // Logic path: has_recent_response = false, last_sent = Some(time), elapsed >= timeout
+
+        let timeout = Duration::from_secs(3);
+        let last_sent: Arc<Mutex<HashMap<String, Instant>>> = Arc::new(Mutex::new(HashMap::new()));
+        let endpoint = "test_endpoint";
+
+        // Record that we sent a health check in the past (5 seconds ago, exceeding timeout)
+        let sent_time = Instant::now() - Duration::from_secs(5);
+        {
+            let mut sent = last_sent.lock().unwrap();
+            sent.insert(endpoint.to_string(), sent_time);
+        }
+
+        // Verify timeout is exceeded
+        {
+            let sent = last_sent.lock().unwrap();
+            let sent_time = sent.get(endpoint).unwrap();
+            let elapsed = sent_time.elapsed();
+
+            assert!(elapsed >= timeout);
+            // At this point, check_endpoint_health would:
+            // 1. Find has_recent_response = false
+            // 2. Find last_health_check_sent_at = Some(sent_time)
+            // 3. Calculate elapsed >= timeout
+            // 4. Log "Health check timeout exceeded"
+            // 5. Set endpoint status to HealthStatus::NotReady
+        }
+    }
+
+    #[tokio::test]
+    async fn test_flood_prevention() {
+        // This test verifies: "No duplicate sends within timeout"
+        // The manager should not send multiple health checks while one is pending
+
+        let timeout = Duration::from_secs(3);
+        let last_sent: Arc<Mutex<HashMap<String, Instant>>> = Arc::new(Mutex::new(HashMap::new()));
+        let endpoint = "test_endpoint";
+
+        // First health check gets sent
+        let first_send_time = Instant::now();
+        {
+            let mut sent = last_sent.lock().unwrap();
+            assert!(!sent.contains_key(endpoint)); // No previous send
+            sent.insert(endpoint.to_string(), first_send_time);
+        }
+
+        // Check immediately after (simulating next polling interval)
+        // The health check is still pending (within timeout)
+        {
+            let sent = last_sent.lock().unwrap();
+            let sent_time = sent.get(endpoint).unwrap();
+
+            // Should be very recent (just sent)
+            assert!(sent_time.elapsed() < timeout);
+
+            // The manager would NOT send another health check because:
+            // 1. has_recent_response = false
+            // 2. last_health_check_sent_at = Some(time)
+            // 3. elapsed < timeout
+            // 4. It enters the "waiting for response" branch, not the "send" branch
+        }
+
+        // Simulate a check after timeout expires
+        // Create a new timestamp representing old send time
+        {
+            let mut sent = last_sent.lock().unwrap();
+            let old_send_time = Instant::now() - Duration::from_secs(5);
+            sent.insert(endpoint.to_string(), old_send_time);
+        }
+
+        // Now verify the timeout is exceeded
+        {
+            let sent = last_sent.lock().unwrap();
+            let sent_time = sent.get(endpoint).unwrap();
+            assert!(sent_time.elapsed() >= timeout);
+            // Now the manager would mark as unhealthy
+            // On the NEXT check cycle, it could send a new health check
+        }
+    }
+
+    #[test]
+    fn test_handle_health_check_response() {
+        // This test verifies: "Update response times correctly"
+        // When a health check response is received, SystemHealth should update last_response_time
+
+        // Simulate the response time tracking that happens in SystemHealth
+        let response_times: Arc<Mutex<HashMap<String, Instant>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let endpoint = "test_endpoint";
+
+        // Initial response
+        let first_response = Instant::now();
+        {
+            let mut times = response_times.lock().unwrap();
+            times.insert(endpoint.to_string(), first_response);
+        }
+
+        // Verify it was recorded
+        {
+            let times = response_times.lock().unwrap();
+            assert_eq!(times.get(endpoint), Some(&first_response));
+        }
+
+        // Simulate time passing and new response
+        std::thread::sleep(Duration::from_millis(10));
+        let second_response = Instant::now();
+
+        {
+            let mut times = response_times.lock().unwrap();
+            times.insert(endpoint.to_string(), second_response);
+        }
+
+        // Verify the update
+        {
+            let times = response_times.lock().unwrap();
+            let stored_time = times.get(endpoint).unwrap();
+            assert_eq!(*stored_time, second_response);
+            assert_ne!(*stored_time, first_response);
+            // This proves the response time was updated correctly
+        }
+    }
+
+    #[test]
+    fn test_health_check_config_default() {
+        // Test that default configuration uses the constants
+        let config = HealthCheckConfig::default();
+        assert_eq!(
+            config.check_interval,
+            Duration::from_secs(crate::config::DEFAULT_HEALTH_CHECK_INTERVAL_SECS)
+        );
+        assert_eq!(
+            config.respond_stale_threshold,
+            Duration::from_secs(crate::config::DEFAULT_HEALTH_CHECK_RESPOND_STALE_THRESHOLD_SECS)
+        );
+        assert_eq!(
+            config.request_timeout,
+            Duration::from_secs(crate::config::DEFAULT_HEALTH_CHECK_REQUEST_TIMEOUT_SECS)
+        );
+    }
+}
+
+// ===============================
+// Integration Tests (require DRT)
+// ===============================
+#[cfg(all(test, feature = "integration"))]
+mod integration_tests {
+    use super::*;
+    use crate::HealthStatus;
+    use crate::distributed::distributed_test_utils::create_test_drt_async;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_initialization() {
+        let drt = Arc::new(create_test_drt_async().await);
+
+        let check_interval = Duration::from_secs(5);
+        let respond_stale_threshold = Duration::from_secs(2);
+        let request_timeout = Duration::from_secs(3);
+
+        let config = HealthCheckConfig {
+            check_interval: check_interval,
+            respond_stale_threshold: respond_stale_threshold,
+            request_timeout: request_timeout,
+        };
+
+        let manager = HealthCheckManager::new(drt.clone(), config);
+
+        assert_eq!(manager.config.check_interval, check_interval);
+        assert_eq!(
+            manager.config.respond_stale_threshold,
+            respond_stale_threshold
+        );
+        assert_eq!(manager.config.request_timeout, request_timeout);
+
+        // Verify DRT is properly stored
+        assert!(Arc::ptr_eq(&manager.drt, &drt));
+    }
+
+    #[tokio::test]
+    async fn test_payload_registration() {
+        let drt = Arc::new(create_test_drt_async().await);
+
+        let endpoint = "test.endpoint";
+        let payload = serde_json::json!({
+            "prompt": "test",
+            "_health_check": true
+        });
+
+        drt.system_health
+            .lock()
+            .unwrap()
+            .register_health_check_payload(endpoint, payload.clone());
+
+        let retrieved = drt
+            .system_health
+            .lock()
+            .unwrap()
+            .get_health_check_payload(endpoint);
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap(), payload);
+
+        // Verify endpoint appears in the list
+        let endpoints = drt
+            .system_health
+            .lock()
+            .unwrap()
+            .get_health_check_endpoints();
+        assert!(endpoints.contains(&endpoint.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_poll_all_endpoints() {
+        let drt = Arc::new(create_test_drt_async().await);
+
+        for i in 0..3 {
+            let endpoint = format!("test.endpoint.{}", i);
+            let payload = serde_json::json!({
+                "prompt": format!("test{}", i),
+                "_health_check": true
+            });
+            drt.system_health
+                .lock()
+                .unwrap()
+                .register_health_check_payload(&endpoint, payload);
+        }
+
+        let config = HealthCheckConfig {
+            check_interval: Duration::from_secs(5),
+            respond_stale_threshold: Duration::from_secs(2),
+            request_timeout: Duration::from_secs(1),
+        };
+
+        let manager = HealthCheckManager::new(drt.clone(), config);
+        manager.check_all_endpoints().await.unwrap();
+
+        // Verify all endpoints were checked
+        let sent = manager.last_health_check_sent.lock().unwrap();
+        assert_eq!(sent.len(), 3);
+        assert!(sent.contains_key("test.endpoint.0"));
+        assert!(sent.contains_key("test.endpoint.1"));
+        assert!(sent.contains_key("test.endpoint.2"));
+    }
+
+    #[tokio::test]
+    async fn test_response_handling() {
+        let drt = Arc::new(create_test_drt_async().await);
+
+        let endpoint = "test.endpoint";
+
+        // Register endpoint
+        let payload = serde_json::json!({
+            "prompt": "test",
+            "_health_check": true
+        });
+        drt.system_health
+            .lock()
+            .unwrap()
+            .register_health_check_payload(endpoint, payload.clone());
+        // Simulate a response by updating the last response time
+        drt.system_health
+            .lock()
+            .unwrap()
+            .update_last_response_time(endpoint);
+
+        // Check that response was recorded
+        let response_times = drt.system_health.lock().unwrap().get_response_times();
+        let times = response_times.lock().unwrap();
+        assert!(times.contains_key(endpoint));
+
+        // Status should be Ready
+        let status = drt
+            .system_health
+            .lock()
+            .unwrap()
+            .get_endpoint_health_status(endpoint);
+        assert_eq!(status, Some(HealthStatus::Ready));
+    }
+
+    #[tokio::test]
+    async fn test_timeout_behavior() {
+        let drt = Arc::new(create_test_drt_async().await);
+
+        let endpoint = "test.endpoint.timeout";
+        let payload = serde_json::json!({
+            "prompt": "test",
+            "_health_check": true
+        });
+        drt.system_health
+            .lock()
+            .unwrap()
+            .register_health_check_payload(endpoint, payload.clone());
+
+        // Initially, the endpoint should be Ready (default after registration)
+        let initial_status = drt
+            .system_health
+            .lock()
+            .unwrap()
+            .get_endpoint_health_status(endpoint);
+        assert_eq!(initial_status, Some(HealthStatus::Ready));
+
+        // Simulate a recent response to ensure it starts healthy
+        drt.system_health
+            .lock()
+            .unwrap()
+            .update_last_response_time(endpoint);
+
+        let config = HealthCheckConfig {
+            check_interval: Duration::from_secs(5),
+            respond_stale_threshold: Duration::from_secs(2),
+            request_timeout: Duration::from_millis(100), // Very short timeout
+        };
+
+        let manager = HealthCheckManager::new(drt.clone(), config);
+
+        // First check while healthy - should NOT send health check (has recent response)
+        manager
+            .check_endpoint_health(endpoint, &payload)
+            .await
+            .unwrap();
+        {
+            let sent = manager.last_health_check_sent.lock().unwrap();
+            assert!(
+                !sent.contains_key(endpoint),
+                "Should NOT send health check when response is recent"
+            );
+        }
+        let status = drt
+            .system_health
+            .lock()
+            .unwrap()
+            .get_endpoint_health_status(endpoint);
+        assert_eq!(
+            status,
+            Some(HealthStatus::Ready),
+            "Should remain Ready with recent response"
+        );
+
+        // Wait for response to become stale (exceed respond_stale_threshold)
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // Now check - should send health check since response is stale
+        manager
+            .check_endpoint_health(endpoint, &payload)
+            .await
+            .unwrap();
+
+        // Verify health check was sent now that response is stale
+        {
+            let sent = manager.last_health_check_sent.lock().unwrap();
+            assert!(
+                sent.contains_key(endpoint),
+                "Should send health check when response is stale"
+            );
+        }
+
+        // Wait for timeout to expire (no response received)
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Check again - should mark as unhealthy due to timeout
+        manager
+            .check_endpoint_health(endpoint, &payload)
+            .await
+            .unwrap();
+
+        // Status should now be NotReady due to timeout
+        let final_status = drt
+            .system_health
+            .lock()
+            .unwrap()
+            .get_endpoint_health_status(endpoint);
+        assert_eq!(
+            final_status,
+            Some(HealthStatus::NotReady),
+            "Should be NotReady after timeout"
+        );
+    }
+}

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -21,7 +21,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, OnceLock, Weak},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 pub use anyhow::{
@@ -36,6 +36,7 @@ pub use config::RuntimeConfig;
 pub mod component;
 pub mod discovery;
 pub mod engine;
+pub mod health_check;
 pub mod system_status_server;
 pub use system_status_server::SystemStatusServerInfo;
 pub mod instances;
@@ -85,6 +86,37 @@ pub struct Runtime {
     graceful_shutdown_tracker: Arc<GracefulShutdownTracker>,
 }
 
+/// Information about an endpoint's health status and response tracking
+#[derive(Clone, Debug)]
+pub struct EndpointHealthInfo {
+    /// Current health status of the endpoint
+    pub status: HealthStatus,
+    /// Last time the endpoint responded (if any)
+    pub last_response_time: Option<Instant>,
+}
+
+impl EndpointHealthInfo {
+    /// Create a new EndpointHealthInfo with the given status and no response time
+    pub fn new(status: HealthStatus) -> Self {
+        Self {
+            status,
+            last_response_time: None,
+        }
+    }
+
+    /// Check if the endpoint has responded recently (within the given duration)
+    pub fn has_responded_recently(&self, within: Duration) -> bool {
+        self.last_response_time
+            .map(|t| t.elapsed() < within)
+            .unwrap_or(false)
+    }
+
+    /// Update the last response time to now
+    pub fn update_response_time(&mut self) {
+        self.last_response_time = Some(Instant::now());
+    }
+}
+
 /// Current Health Status
 /// If use_endpoint_health_status is set then
 /// initialize the endpoint_health hashmap to the
@@ -92,7 +124,9 @@ pub struct Runtime {
 #[derive(Clone)]
 pub struct SystemHealth {
     system_health: HealthStatus,
-    endpoint_health: HashMap<String, HealthStatus>,
+    endpoint_health: Arc<std::sync::RwLock<HashMap<String, EndpointHealthInfo>>>,
+    /// Maps endpoint subject to health check payload
+    health_check_payloads: Arc<std::sync::RwLock<HashMap<String, serde_json::Value>>>,
     use_endpoint_health_status: Vec<String>,
     health_path: String,
     live_path: String,
@@ -109,11 +143,15 @@ impl SystemHealth {
     ) -> Self {
         let mut endpoint_health = HashMap::new();
         for endpoint in &use_endpoint_health_status {
-            endpoint_health.insert(endpoint.clone(), starting_health_status.clone());
+            endpoint_health.insert(
+                endpoint.clone(),
+                EndpointHealthInfo::new(starting_health_status.clone()),
+            );
         }
         SystemHealth {
             system_health: starting_health_status,
-            endpoint_health,
+            endpoint_health: Arc::new(std::sync::RwLock::new(endpoint_health)),
+            health_check_payloads: Arc::new(std::sync::RwLock::new(HashMap::new())),
             use_endpoint_health_status,
             health_path,
             live_path,
@@ -125,17 +163,49 @@ impl SystemHealth {
         self.system_health = status;
     }
 
-    pub fn set_endpoint_health_status(&mut self, endpoint: &str, status: HealthStatus) {
-        self.endpoint_health.insert(endpoint.to_string(), status);
+    pub fn set_endpoint_health_status(&self, endpoint: &str, status: HealthStatus) {
+        let mut endpoint_health = self.endpoint_health.write().unwrap();
+        endpoint_health
+            .entry(endpoint.to_string())
+            .or_insert_with(|| EndpointHealthInfo::new(status.clone()))
+            .status = status.clone();
+    }
+
+    /// Update the last response time for an endpoint
+    pub fn update_last_response_time(&self, endpoint: &str) {
+        let mut endpoint_health = self.endpoint_health.write().unwrap();
+        endpoint_health
+            .entry(endpoint.to_string())
+            .or_insert_with(|| EndpointHealthInfo::new(HealthStatus::Ready))
+            .update_response_time();
+    }
+
+    /// Get the last response time for an endpoint
+    pub fn get_last_response_time(&self, endpoint: &str) -> Option<Instant> {
+        let endpoint_health = self.endpoint_health.read().unwrap();
+        endpoint_health
+            .get(endpoint)
+            .and_then(|info| info.last_response_time)
+    }
+
+    /// Check if an endpoint has responded recently (within the given duration)
+    pub fn has_responded_recently(&self, endpoint: &str, within: std::time::Duration) -> bool {
+        let endpoint_health = self.endpoint_health.read().unwrap();
+        endpoint_health
+            .get(endpoint)
+            .map(|info| info.has_responded_recently(within))
+            .unwrap_or(false)
     }
 
     /// Returns the overall health status and endpoint health statuses
     pub fn get_health_status(&self) -> (bool, HashMap<String, String>) {
+        let endpoint_health = self.endpoint_health.read().unwrap();
         let mut endpoints: HashMap<String, String> = HashMap::new();
-        for (endpoint, ready) in &self.endpoint_health {
+
+        for (endpoint, info) in endpoint_health.iter() {
             endpoints.insert(
                 endpoint.clone(),
-                if *ready == HealthStatus::Ready {
+                if info.status == HealthStatus::Ready {
                     "ready".to_string()
                 } else {
                     "notready".to_string()
@@ -145,15 +215,87 @@ impl SystemHealth {
 
         let healthy = if !self.use_endpoint_health_status.is_empty() {
             self.use_endpoint_health_status.iter().all(|endpoint| {
-                self.endpoint_health
+                endpoint_health
                     .get(endpoint)
-                    .is_some_and(|status| *status == HealthStatus::Ready)
+                    .is_some_and(|info| info.status == HealthStatus::Ready)
             })
         } else {
             self.system_health == HealthStatus::Ready
         };
 
         (healthy, endpoints)
+    }
+
+    /// Get detailed health info for an endpoint
+    pub fn get_endpoint_health_info(&self, endpoint: &str) -> Option<EndpointHealthInfo> {
+        let endpoint_health = self.endpoint_health.read().unwrap();
+        endpoint_health.get(endpoint).cloned()
+    }
+
+    /// Register a health check payload for an endpoint
+    pub fn register_health_check_payload(&self, endpoint: &str, payload: serde_json::Value) {
+        let mut payloads = self.health_check_payloads.write().unwrap();
+        payloads.insert(endpoint.to_string(), payload);
+
+        // Also initialize endpoint health info if needed
+        let mut endpoint_health = self.endpoint_health.write().unwrap();
+        endpoint_health
+            .entry(endpoint.to_string())
+            .or_insert_with(|| EndpointHealthInfo::new(HealthStatus::Ready));
+    }
+
+    /// Get all health check payloads
+    pub fn get_health_check_payloads(&self) -> Vec<(String, serde_json::Value)> {
+        let payloads = self.health_check_payloads.read().unwrap();
+        payloads
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+
+    /// Check if any health check payloads are registered
+    pub fn has_health_check_payloads(&self) -> bool {
+        let payloads = self.health_check_payloads.read().unwrap();
+        !payloads.is_empty()
+    }
+
+    /// Get list of endpoints with health check payloads
+    pub fn get_health_check_endpoints(&self) -> Vec<String> {
+        let payloads = self.health_check_payloads.read().unwrap();
+        payloads.keys().cloned().collect()
+    }
+
+    /// Get health check payload for a specific endpoint
+    pub fn get_health_check_payload(&self, endpoint: &str) -> Option<serde_json::Value> {
+        let payloads = self.health_check_payloads.read().unwrap();
+        payloads.get(endpoint).cloned()
+    }
+
+    /// Remove health check payload for an endpoint
+    pub fn remove_health_check_payload(&self, endpoint: &str) {
+        let mut payloads = self.health_check_payloads.write().unwrap();
+        payloads.remove(endpoint);
+    }
+
+    /// Get the endpoint health status (Ready/NotReady)
+    pub fn get_endpoint_health_status(&self, endpoint: &str) -> Option<HealthStatus> {
+        let endpoint_health = self.endpoint_health.read().unwrap();
+        endpoint_health
+            .get(endpoint)
+            .map(|info| info.status.clone())
+    }
+
+    /// Get the response times map (for testing)
+    pub fn get_response_times(&self) -> Arc<std::sync::Mutex<HashMap<String, Instant>>> {
+        // Create a new map with current response times
+        let endpoint_health = self.endpoint_health.read().unwrap();
+        let mut times = HashMap::new();
+        for (endpoint, info) in endpoint_health.iter() {
+            if let Some(time) = info.last_response_time {
+                times.insert(endpoint.clone(), time);
+            }
+        }
+        Arc::new(std::sync::Mutex::new(times))
     }
 
     /// Initialize the uptime gauge using the provided metrics registry

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -20,6 +20,7 @@ pub mod egress;
 pub mod ingress;
 pub mod tcp;
 
+use crate::SystemHealth;
 use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
@@ -284,6 +285,10 @@ struct RequestControlMessage {
 pub struct Ingress<Req: PipelineIO, Resp: PipelineIO> {
     segment: OnceLock<Arc<SegmentSource<Req, Resp>>>,
     metrics: OnceLock<Arc<WorkHandlerMetrics>>,
+    /// Endpoint subject for health tracking
+    endpoint_subject: OnceLock<String>,
+    /// System health for tracking response times
+    system_health: OnceLock<Arc<std::sync::Mutex<SystemHealth>>>,
 }
 
 impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
@@ -291,6 +296,8 @@ impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
         Arc::new(Self {
             segment: OnceLock::new(),
             metrics: OnceLock::new(),
+            endpoint_subject: OnceLock::new(),
+            system_health: OnceLock::new(),
         })
     }
 
@@ -354,6 +361,16 @@ pub trait PushWorkHandler: Send + Sync {
         endpoint: &crate::component::Endpoint,
         metrics_labels: Option<&[(&str, &str)]>,
     ) -> Result<()>;
+
+    /// Set endpoint subject and system health for tracking
+    fn set_health_tracking(
+        &self,
+        _endpoint_subject: String,
+        _system_health: Arc<std::sync::Mutex<SystemHealth>>,
+    ) -> Result<()> {
+        // Default implementation for backwards compatibility
+        Ok(())
+    }
 }
 
 /*

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -168,12 +168,52 @@ pub async fn spawn_system_status_server(
     Ok((actual_address, handle))
 }
 
-/// Health handler
+/// Health handler with optional active health checking
 #[tracing::instrument(skip_all, level = "trace")]
 async fn health_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
+    // Get basic health status
     let system_health = state.drt().system_health.lock().unwrap();
-    let (healthy, endpoints) = system_health.get_health_status();
+    let (healthy, endpoints_basic) = system_health.get_health_status();
     let uptime = Some(system_health.uptime());
+
+    // Enhanced: Add response time information for endpoints with health check payloads
+    let mut endpoint_details = serde_json::Map::new();
+
+    // Check if we have health check payloads registered
+    let has_health_checks = system_health.has_health_check_payloads();
+
+    if has_health_checks {
+        // Include detailed response time info for monitored endpoints
+        let threshold = std::time::Duration::from_secs(5);
+
+        for (endpoint, status_str) in &endpoints_basic {
+            // Get detailed health info for this endpoint
+            if let Some(health_info) = system_health.get_endpoint_health_info(endpoint) {
+                let mut details = serde_json::Map::new();
+                details.insert("status".to_string(), json!(status_str));
+
+                // Add response time if available
+                if let Some(last_time) = health_info.last_response_time {
+                    let seconds_ago = last_time.elapsed().as_secs();
+                    details.insert("last_response_seconds_ago".to_string(), json!(seconds_ago));
+                    details.insert(
+                        "responding_recently".to_string(),
+                        json!(last_time.elapsed() < threshold),
+                    );
+                }
+
+                endpoint_details.insert(endpoint.clone(), json!(details));
+            } else {
+                // Fallback if no detailed info available
+                endpoint_details.insert(endpoint.clone(), json!(status_str));
+            }
+        }
+    } else {
+        // Simple format for backwards compatibility when no health checks configured
+        for (endpoint, status) in endpoints_basic {
+            endpoint_details.insert(endpoint, json!(status));
+        }
+    }
 
     let healthy_string = if healthy { "ready" } else { "notready" };
     let status_code = if healthy {
@@ -185,7 +225,8 @@ async fn health_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
     let response = json!({
         "status": healthy_string,
         "uptime": uptime,
-        "endpoints": endpoints
+        "endpoints": endpoint_details,
+        "has_active_monitoring": has_health_checks
     });
 
     tracing::trace!("Response {}", response.to_string());
@@ -704,6 +745,128 @@ mod integration_tests {
                     );
                 }
                 // DRT handles server cleanup automatically
+            },
+        )
+        .await;
+    }
+
+    #[cfg(feature = "integration")]
+    #[tokio::test]
+    async fn test_health_check_with_payload_and_timeout() {
+        // Test the complete health check flow:
+        // 1. Endpoint registers with health check payload
+        // 2. Endpoint responds initially (healthy)
+        // 3. Endpoint stops responding (becomes stale)
+        // 4. Health check manager sends health check
+        // 5. No response received (timeout)
+        // 6. Endpoint marked as unhealthy
+        // 7. /health endpoint reflects the unhealthy status
+
+        temp_env::async_with_vars(
+            [
+                ("DYN_SYSTEM_ENABLED", Some("true")),
+                ("DYN_SYSTEM_PORT", Some("0")),
+                ("DYN_SYSTEM_STARTING_HEALTH_STATUS", Some("ready")),
+                (
+                    "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS",
+                    Some("[\"test.endpoint\"]"),
+                ),
+                // Enable health check with short intervals for testing
+                ("DYN_HEALTH_CHECK_ENABLED", Some("true")),
+                ("DYN_HEALTH_CHECK_INTERVAL", Some("1")),
+                ("DYN_HEALTH_CHECK_RESPOND_STALE_THRESHOLD", Some("2")),
+                ("DYN_HEALTH_CHECK_REQUEST_TIMEOUT", Some("1")),
+            ],
+            async {
+                let drt = Arc::new(create_test_drt_async().await);
+
+                // Get system status server info
+                let system_info = drt
+                    .system_status_server_info()
+                    .expect("System status server should be started");
+                let addr = system_info.socket_addr;
+
+                let client = reqwest::Client::new();
+                let health_url = format!("http://{}/health", addr);
+
+                // Register an endpoint with health check payload
+                let endpoint = "test.endpoint";
+                let health_check_payload = serde_json::json!({
+                    "prompt": "health check test",
+                    "_health_check": true
+                });
+
+                // Register the endpoint and its health check payload
+                {
+                    let system_health = drt.system_health.lock().unwrap();
+                    system_health
+                        .register_health_check_payload(endpoint, health_check_payload.clone());
+                    // Simulate initial response - endpoint is healthy
+                    system_health.update_last_response_time(endpoint);
+                }
+
+                // Check initial health - should be ready
+                let response = client.get(&health_url).send().await.unwrap();
+                let status = response.status();
+                let body = response.text().await.unwrap();
+                assert_eq!(status, 200, "Should be healthy initially");
+                assert!(
+                    body.contains("\"status\":\"ready\""),
+                    "Should show ready status"
+                );
+
+                // Wait for response to become stale (exceed respond_stale_threshold)
+                tokio::time::sleep(Duration::from_secs(3)).await;
+
+                // Now the health check manager should detect staleness and send health check
+                // Since we're not actually responding, it will timeout
+
+                // Wait for health check timeout
+                tokio::time::sleep(Duration::from_secs(2)).await;
+
+                // Check health again - should now be unhealthy
+                let response = client.get(&health_url).send().await.unwrap();
+                let status = response.status();
+                let body = response.text().await.unwrap();
+
+                assert_eq!(status, 503, "Should be unhealthy after timeout");
+                assert!(
+                    body.contains("\"status\":\"notready\""),
+                    "Should show notready status"
+                );
+
+                // Verify the endpoint status in SystemHealth directly
+                let endpoint_status = drt
+                    .system_health
+                    .lock()
+                    .unwrap()
+                    .get_endpoint_health_status(endpoint);
+                assert_eq!(
+                    endpoint_status,
+                    Some(HealthStatus::NotReady),
+                    "SystemHealth should show endpoint as NotReady"
+                );
+
+                // Now simulate endpoint recovery - it starts responding again
+                {
+                    let system_health = drt.system_health.lock().unwrap();
+                    system_health.update_last_response_time(endpoint);
+                    system_health.set_endpoint_health_status(endpoint, HealthStatus::Ready);
+                }
+
+                // Give a moment for status to propagate
+                tokio::time::sleep(Duration::from_millis(100)).await;
+
+                // Check health - should be ready again
+                let response = client.get(&health_url).send().await.unwrap();
+                let status = response.status();
+                let body = response.text().await.unwrap();
+
+                assert_eq!(status, 200, "Should be healthy after recovery");
+                assert!(
+                    body.contains("\"status\":\"ready\""),
+                    "Should show ready status after recovery"
+                );
             },
         )
         .await;


### PR DESCRIPTION
#### Overview:

Endpoint health check.

#### Details:

We're enhancing our /health endpoint to move beyond simple readiness checks. While the current implementation aggregates the health of configured endpoints to signal readiness, it lacks a mechanism to verify a running service's actual ability to process requests. The new approach introduces a "canary request" system. This system will periodically send a configured request to the endpoint on a background thread. If the endpoint hasn't processed a request within a configurable timeframe, this canary request will serve as a proactive health check, validating that the service is still capable of handling traffic. This method ensures our health signal is an active and reliable indicator of service availability.

#### Where should the reviewer start?
<img width="1811" height="1157" alt="Screenshot 2025-08-28 at 8 58 01 PM" src="https://github.com/user-attachments/assets/c7df5945-c66e-4c94-a874-8377affaf24c" />



#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-390


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces optional active health checks per endpoint, configurable via settings/env vars (enable, interval, staleness threshold, request timeout).
  - Supports per-endpoint payloads for health probes.
  - Enhances the health endpoint response with per-endpoint details (status, seconds since last response) and a has_active_monitoring flag, while preserving backward-compatible output when monitoring is disabled.

- Documentation
  - Updated health endpoint description to reflect detailed reporting and optional active monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->