### PR TITLE
fix: In non-epp dynamo integration we do not provide the config file

### DIFF
--- a/deploy/inference-gateway/README.md
+++ b/deploy/inference-gateway/README.md
@@ -102,11 +102,6 @@ cd deploy/inference-gateway
 helm install dynamo-gaie ./helm/dynamo-gaie -n my-model -f ./vllm_agg_qwen.yaml
 ```
 
-You can delete the installation later if needed by running:
-```bash
-helm uninstall dynamo-gaie -n my-model
-```
-
 #### EPP-aware Integration with the custom Dynamo Plugin ####
 
 ##### 1. Build the custom EPP image #####
@@ -196,6 +191,7 @@ NAME        HOSTNAMES   AGE
 qwen-route               33m
 ```
 
+
 ### 6. Usage ###
 
 The Inference Gateway provides HTTP endpoints for model inference.
@@ -207,10 +203,11 @@ export GATEWAY_URL=<Gateway-URL>
 
 To test the gateway in minikube, use the following command:
 a. User minikube tunnel to expose the gateway to the host
-   This requires `sudo` access to the host machine. alternatively, you can use port-forward to expose the gateway to the host as shown in alternateive (b).
+   This requires `sudo` access to the host machine. alternatively, you can use port-forward to expose the gateway to the host as shown in alternative (b).
 ```bash
 # in first terminal
-minikube tunnel
+ps aux | grep "minikube tunnel" | grep -v grep # make sure minikube tunnel is not already running.
+minikube tunnel & # start the tunnel
 
 # in second terminal where you want to send inference requests
 GATEWAY_URL=$(kubectl get svc inference-gateway -n my-model -o yaml -o jsonpath='{.spec.clusterIP}')
@@ -303,4 +300,12 @@ Sample inference output:
     "total_tokens": 225
   }
 }
+```
+
+### 7. Deleting the installation ###
+You can delete the installation if needed by running:
+
+```bash
+kubectl delete dynamoGraphDeployment vllm-agg
+helm uninstall dynamo-gaie -n my-model
 ```

--- a/deploy/inference-gateway/README.md
+++ b/deploy/inference-gateway/README.md
@@ -303,7 +303,7 @@ Sample inference output:
 ```
 
 ### 7. Deleting the installation ###
-You can delete the installation if needed by running:
+If you need to uninstall run:
 
 ```bash
 kubectl delete dynamoGraphDeployment vllm-agg

--- a/deploy/inference-gateway/README.md
+++ b/deploy/inference-gateway/README.md
@@ -102,6 +102,11 @@ cd deploy/inference-gateway
 helm install dynamo-gaie ./helm/dynamo-gaie -n my-model -f ./vllm_agg_qwen.yaml
 ```
 
+You can delete the installation later if needed by running:
+```bash
+helm uninstall dynamo-gaie -n my-model
+```
+
 #### EPP-aware Integration with the custom Dynamo Plugin ####
 
 ##### 1. Build the custom EPP image #####

--- a/deploy/inference-gateway/helm/dynamo-gaie/templates/dynamo-epp.yaml
+++ b/deploy/inference-gateway/helm/dynamo-gaie/templates/dynamo-epp.yaml
@@ -59,8 +59,10 @@ spec:
           - "9002"
           - -grpcHealthPort
           - "9003"
-          - -configFile
+        {{- if .Values.eppAware.enabled }}
+          - -configFile{{"\n"}}
           - "/etc/epp/epp-config-dynamo.yaml"
+        {{- end }}
         {{- end }}
         {{- if .Values.eppAware.enabled }}
         volumeMounts:

--- a/deploy/inference-gateway/helm/dynamo-gaie/templates/dynamo-epp.yaml
+++ b/deploy/inference-gateway/helm/dynamo-gaie/templates/dynamo-epp.yaml
@@ -60,7 +60,7 @@ spec:
           - -grpcHealthPort
           - "9003"
         {{- if .Values.eppAware.enabled }}
-          - -configFile{{"\n"}}
+          - -configFile
           - "/etc/epp/epp-config-dynamo.yaml"
         {{- end }}
         {{- end }}


### PR DESCRIPTION
#### Overview:

(https://nvbugspro.nvidia.com/bug/5500454)(bug: In non-epp dynamo integration we do not provide the config file)

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None; no user-facing functionality added.
- Bug Fixes
  - Ensures EPP configuration is only applied when the feature is enabled, preventing unintended configuration arguments during deployment.
- Chores
  - Streamlined Helm template logic for EPP-aware deployments; no changes to volume mounts or probes.
  - Improves deployment configuration clarity without affecting runtime behavior.
- Documentation
  - No changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->