### PR TITLE
fix: always enable graceful shutdown as migration is not set in sglang

### DIFF
--- a/components/backends/sglang/src/dynamo/sglang/main.py
+++ b/components/backends/sglang/src/dynamo/sglang/main.py
@@ -118,7 +118,7 @@ async def init(runtime: DistributedRuntime, config: Config):
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
-                graceful_shutdown == config.migration_limit <= 0,
+                graceful_shutdown=True,
                 metrics_labels=metrics_labels,
             ),
             register_model(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Enabled graceful shutdown for model endpoints, reducing interrupted requests during deployments and restarts.
  - Improves stability during model reloads, lowering the chance of errors or timeouts for in-flight requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->