### PR TITLE
fix: NIXL wheel missing from system packages in dev env

### DIFF
--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -228,7 +228,8 @@ RUN if [ "$ARCH" = "arm64" ]; then \
     fi && \
     # Install the wheel
     # TODO: Move NIXL wheel install to the wheel_builder stage
-    uv pip install /workspace/wheels/nixl/*.whl
+    uv pip install /workspace/wheels/nixl/*.whl && \
+    pip install /workspace/wheels/nixl/*.whl
 
 ###################################
 ####### WHEEL BUILD STAGE #########


### PR DESCRIPTION
#### Overview:

Installs NIXL wheel to `build` stage system-wide python environment so it is available in the `dev` stage as well.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes OPS-877


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build to install the NIXL wheel using both uv pip and standard pip within the same step, ensuring it’s present in both environments.

* **Bug Fixes**
  * Improves container reliability by making the NIXL package consistently available at runtime across environments, reducing potential import issues.

* **Build**
  * No changes to build stages or logic beyond the dual installation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->