### PR TITLE
fix: bug 5501463 Dockerfile run permission problems

### DIFF
--- a/container/run.sh
+++ b/container/run.sh
@@ -45,6 +45,7 @@ INTERACTIVE=
 USE_NIXL_GDS=
 RUNTIME=nvidia
 WORKDIR=/workspace
+USER=
 
 get_options() {
     while :; do
@@ -121,6 +122,14 @@ get_options() {
         --workdir)
             if [ "$2" ]; then
                 WORKDIR="$2"
+                shift
+            else
+                missing_requirement "$1"
+            fi
+            ;;
+        --user)
+            if [ "$2" ]; then
+                USER="$2"
                 shift
             else
                 missing_requirement "$1"
@@ -256,6 +265,12 @@ get_options() {
         RM_STRING=" --rm "
     fi
 
+    if [[ ${USER} == "" ]]; then
+        USER_STRING=""
+    else
+        USER_STRING="--user ${USER}"
+    fi
+
     if [ -n "$USE_NIXL_GDS" ]; then
         VOLUME_MOUNTS+=" -v /run/udev:/run/udev:ro "
         NIXL_GDS_CAPS="--cap-add=IPC_LOCK"
@@ -303,6 +318,7 @@ show_help() {
     echo "  [--workdir set the working directory inside the container]"
     echo "  [--runtime add runtime variables]"
     echo "  [--entrypoint override container entrypoint]"
+    echo "  [--user override the user for running the container]"
     echo "  [-h, --help show this help]"
     exit 0
 }
@@ -382,6 +398,7 @@ ${RUN_PREFIX} docker run \
     ${NIXL_GDS_CAPS} \
     --ipc host \
     ${PRIVILEGED_STRING} \
+    ${USER_STRING} \
     ${NAME_STRING} \
     ${ENTRYPOINT_STRING} \
     ${IMAGE} \

--- a/deploy/cloud/helm/crds/Chart.yaml
+++ b/deploy/cloud/helm/crds/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v2
 name: dynamo-crds
 description: A Helm chart for dynamo CRDs
 type: application
-version: 0.4.1
+version: 0.5.0
 dependencies: []

--- a/deploy/helm/chart/Chart.yaml
+++ b/deploy/helm/chart/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: dynamo-graph
 description: A Helm chart to deploy a Dynamo graph on Kubernetes
 type: application
-version: 0.4.1
-appVersion: 0.4.1
+version: 0.5.0
+appVersion: 0.5.0


### PR DESCRIPTION
#### Overview:

Add --user parameter to container run.sh script to allow overriding the default user context when running Docker containers.

#### Details:

- Added new optional --user parameter to run.sh script
- Parameter accepts UID:GID format (e.g., 1000:1000) or username (e.g., ubuntu)
- Integrated user parameter into Docker run command
- Updated help documentation to include new parameter

#### Where should the reviewer start?

container/run.sh - specifically the parameter handling section (lines 128-134) and Docker run command integration (line 366)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to BUG-5501463  https://nvbugspro.nvidia.com/bug/5501463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --user option to container run script to override container user.
  - Hello World runtime example now streams per-word responses with cancellation support.
  - Helm values add etcd image repository and option to allow insecure images for easier deployment.

- Bug Fixes
  - Improved backend prefill handling and error resilience, reducing failures and ensuring safe defaults.

- Documentation
  - Major overhaul: consolidated installation guides, updated links, added profiling prerequisites/notes, and improved operator/Helm documentation and navigation.

- Chores
  - Bumped Helm chart versions to 0.5.0.
  - Standardized container/devcontainer targets from “local-dev” to “dev”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->