### PR TITLE
fix: NIXL wheel missing from system packages in dev env (#2879)

### DIFF
--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -228,7 +228,8 @@ RUN if [ "$ARCH" = "arm64" ]; then \
     fi && \
     # Install the wheel
     # TODO: Move NIXL wheel install to the wheel_builder stage
-    uv pip install /workspace/wheels/nixl/*.whl
+    uv pip install /workspace/wheels/nixl/*.whl && \
+    pip install /workspace/wheels/nixl/*.whl
 
 ###################################
 ####### WHEEL BUILD STAGE #########


### PR DESCRIPTION
#### Overview:

Cherry-pick installation of NIXL wheel into `dev` target of trtllm image

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes OPS-877
