### PR TITLE
fix: Keivenchang/v0.5.0  bug 5501463  fix dockerfile run permission problem harrison release

### DIFF
--- a/container/run.sh
+++ b/container/run.sh
@@ -43,6 +43,7 @@ INTERACTIVE=
 USE_NIXL_GDS=
 RUNTIME=nvidia
 WORKDIR=/workspace
+USER=
 
 get_options() {
     while :; do
@@ -119,6 +120,14 @@ get_options() {
         --workdir)
             if [ "$2" ]; then
                 WORKDIR="$2"
+                shift
+            else
+                missing_requirement "$1"
+            fi
+            ;;
+        --user)
+            if [ "$2" ]; then
+                USER="$2"
                 shift
             else
                 missing_requirement "$1"
@@ -274,6 +283,12 @@ get_options() {
         RM_STRING=" --rm "
     fi
 
+    if [[ ${USER} == "" ]]; then
+        USER_STRING=""
+    else
+        USER_STRING="--user ${USER}"
+    fi
+
     if [ -n "$USE_NIXL_GDS" ]; then
         VOLUME_MOUNTS+=" -v /run/udev:/run/udev:ro "
         NIXL_GDS_CAPS="--cap-add=IPC_LOCK"
@@ -310,6 +325,7 @@ show_help() {
     echo "  [-- stop processing and pass remaining args as command to docker run]"
     echo "  [--workdir set the working directory inside the container]"
     echo "  [--runtime add runtime variables]"
+    echo "  [--user override the user for running the container]"
     exit 0
 }
 
@@ -347,6 +363,7 @@ ${RUN_PREFIX} docker run \
     ${NIXL_GDS_CAPS} \
     --ipc host \
     ${PRIVILEGED_STRING} \
+    ${USER_STRING} \
     ${NAME_STRING} \
     ${ENTRYPOINT_STRING} \
     ${IMAGE} \


### PR DESCRIPTION
#### Overview:

Allows user to specify `--user` in `container/run.sh` to allow building when mounting the workspace

Closes:
NVBug 5501463


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Graceful shutdown for runtime endpoints/workers.
  - Streaming “hello world” example with cancellation support.
  - Added --user option to container/run.sh.
  - New multimodal Qwen deployment example.

- Bug Fixes
  - More robust vLLM prefill handling when workers are unavailable.
  - Corrected image pull secret name.
  - Timestamps normalized to integers in synthetic load.

- Documentation
  - Overhauled Kubernetes/Helm installation guides, links, and API reference notices.
  - Added uninstall steps and profiling guidance.

- Chores
  - Helm charts bumped to 0.5.0; etcd chart/version updates.
  - Dev container and build target renamed to “dev”.

- Tests
  - New perf test configs and image cache DaemonSet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->