### PR TITLE
fix: ray not available error

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -266,6 +266,14 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
     --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.test.txt \
     uv pip install --requirement /tmp/requirements.txt --requirement /tmp/requirements.test.txt
 
+# Create Ray CLI script manually since uv pip doesn't always install console scripts properly
+RUN echo '#!/opt/dynamo/venv/bin/python' > /opt/dynamo/venv/bin/ray && \
+    echo 'import sys' >> /opt/dynamo/venv/bin/ray && \
+    echo 'from ray.scripts.scripts import main' >> /opt/dynamo/venv/bin/ray && \
+    echo 'if __name__ == "__main__":' >> /opt/dynamo/venv/bin/ray && \
+    echo '    sys.exit(main())' >> /opt/dynamo/venv/bin/ray && \
+    chmod +x /opt/dynamo/venv/bin/ray
+
 # Copy benchmarks, examples, and tests for CI
 COPY . /workspace/
 

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -40,6 +40,7 @@ pydantic==2.7.1
 pynvml
 pyright
 PyYAML
+ray[default]==2.49.1
 scikit-learn
 scipy<1.14.0  # Pin scipy version for pmdarima compatibility
 sentencepiece


### PR DESCRIPTION
#### Overview:

The ray binary is not available for runtime containers built by

./build.sh --framework VLLM --tag [image_tag] --target runtime

This pull request fixes the issue. The root cause is that uv pip sometimes has issues with this automatic console script creation.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
