### PR TITLE
build: OPS-757 Install a newer version of nsight-systems in devel container

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -302,7 +302,6 @@ ARG USER_UID
 ARG USER_GID
 ARG WORKSPACE_DIR=/workspace
 
-ARG ARCH_ALT
 
 # Install utilities as root
 RUN apt-get update -y && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -302,7 +302,6 @@ ARG USER_UID
 ARG USER_GID
 ARG WORKSPACE_DIR=/workspace
 
-
 # Install utilities as root
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends  \
@@ -332,13 +331,12 @@ RUN apt-get update -y && \
     protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
-ARG ARCH_ALT
-RUN rm -f /etc/apt/sources.list.d/cuda*.list && \
-    curl -o /tmp/cuda-keyring.deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${ARCH_ALT}/cuda-keyring_1.1-1_all.deb && \
-    apt install /tmp/cuda-keyring.deb && \
-    rm /tmp/cuda-keyring.deb && \
+
+ARG ARCH
+RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu2404/${ARCH}/nvidia.pub | gpg --dearmor -o /etc/apt/keyrings/nvidia-devtools.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nvidia-devtools.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu2404/${ARCH} /" | tee /etc/apt/sources.list.d/nvidia-devtools.list && \
     apt-get update && \
-    apt-get install -y nsight-systems-2025.3.2 && \
+    apt-get install -y nsight-systems-2025.5.1 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=runtime /usr/local/bin /usr/local/bin

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -302,6 +302,8 @@ ARG USER_UID
 ARG USER_GID
 ARG WORKSPACE_DIR=/workspace
 
+ARG ARCH_ALT
+
 # Install utilities as root
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends  \
@@ -329,6 +331,15 @@ RUN apt-get update -y && \
     clang \
     libclang-dev \
     protobuf-compiler && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG ARCH_ALT
+RUN rm -f /etc/apt/sources.list.d/cuda*.list && \
+    curl -o /tmp/cuda-keyring.deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${ARCH_ALT}/cuda-keyring_1.1-1_all.deb && \
+    apt install /tmp/cuda-keyring.deb && \
+    rm /tmp/cuda-keyring.deb && \
+    apt-get update && \
+    apt-get install -y nsight-systems-2025.3.2 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=runtime /usr/local/bin /usr/local/bin


### PR DESCRIPTION
#### Overview:

The devel container contains an older version of nsight-systems since the CUDA base container is based on CUDA version 12.8.1. This PR installs the latest nsight-systems version available (2025.5.1) until we can safely upgrade to a new CUDA version where this step wouldn't be required. 

Latest nsys version:
````
nsys --version
NVIDIA Nsight Systems version 2025.5.1.121-255136380782v0
````

#### Details:

- Uograde nsight-systems version in vllm devel container

#### Where should the reviewer start?

- container/Dockerfile.vllm

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bundles NVIDIA Nsight Systems in framework and development images for GPU profiling.
  * Adds architecture-aware CUDA setup to improve compatibility across Ubuntu 24.04 variants.

* **Chores**
  * Aligns available binaries with the runtime image by syncing system executables across stages.
  * Improves image build reliability and consistency during CUDA configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->