### PR TITLE
revert: restore Dockerfile.vllm and build/run scripts to August 28 vers

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -280,21 +280,55 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []
 
-#######################################
-########## Local Development #######
-#######################################
+#######################################################################
+########## DEVELOPMENT TARGETS FEATURE MATRIX #########################
+#######################################################################
+# Feature              │ local-dev Target    │ dev Target
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Purpose              │ Dev Container       │ Command-line with
+#                      │ plugin use only     │ run.sh script
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Default User         │ ubuntu user         │ root user
+# ─────────────────────┼─────────────────────┼─────────────────────
+# User Setup           │ Full ubuntu user    │ No user setup
+#                      │ with UID/GID        │
+#                      │ mapping             │
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Permissions          │ ubuntu user with    │ Root-level
+#                      │ sudo privileges     │ permissions
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Home Directory       │ /home/ubuntu        │ /root
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Working Directory    │ /home/ubuntu/dynamo │ /workspace
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Rust Toolchain       │ User's home         │ System locations
+#                      │ (~/.rustup,         │ (/usr/local/rustup,
+#                      │  ~/.cargo)          │  /usr/local/cargo)
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Python Environment   │ User-owned venv     │ System location
+#                      │                     │ (/opt/dynamo/venv)
+# ─────────────────────┼─────────────────────┼─────────────────────
+# File Permissions     │ User-level with     │ Root-level
+#                      │ proper ownership    │ permissions
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Compatibility        │ MS Plug-in: Dev     │ Backward compatibility
+#                      │ Container workflow  │ with existing
+#                      │                     │ workflows
 #
-# PURPOSE: Local development
-#
-# This stage adds development tools, utilities, and dependencies specifically
-# needed for:
-# - Local development and debugging
-# - vscode/cursor development
-#
-# Use this stage when you need a full development environment with additional
-# tooling beyond the base runtime image.
+# USAGE GUIDELINES:
+# • Use local-dev: VS Code/Cursor Dev Container plugin only
+# • Use dev: run.sh script for command-line development
 
-FROM runtime AS dev
+
+#######################################################################
+########## Development (Dev Container only) ###########################
+#######################################################################
+#
+# This stage is for Dev Container plug-in use only.
+# It provides a local development environment with extra tools and dependencies
+# not present in the base runtime image.
+
+FROM runtime AS local-dev
 
 # Don't want ubuntu to be editable, just change uid and gid.
 ENV USERNAME=ubuntu
@@ -392,6 +426,82 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=$HOME/.comman
     && echo "$SNIPPET" >> "$HOME/.bashrc"
 
 RUN mkdir -p /home/$USERNAME/.cache/
+
+ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
+CMD []
+
+
+###########################################################
+########## Development (run.sh, runs as root user) ########
+###########################################################
+#
+# PURPOSE: Local development environment for use with run.sh (not Dev Container plug-in)
+#
+# This stage runs as root and provides:
+# - Development tools and utilities for local debugging
+# - Support for vscode/cursor development outside the Dev Container plug-in
+#
+# Use this stage if you need a full-featured development environment with extra tools,
+# but do not use it with the Dev Container plug-in.
+
+FROM runtime AS dev
+
+# Don't want ubuntu to be editable, just change uid and gid.
+ARG WORKSPACE_DIR=/workspace
+
+# Install utilities as root
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends  \
+    # Install utilities
+    nvtop \
+    wget \
+    tmux \
+    vim \
+    git \
+    openssh-client \
+    iproute2 \
+    rsync \
+    zip \
+    unzip \
+    htop \
+    # Build Dependencies
+    autoconf \
+    automake \
+    cmake \
+    libtool \
+    meson \
+    net-tools \
+    pybind11-dev \
+    # Rust build dependencies
+    clang \
+    libclang-dev \
+    protobuf-compiler && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=runtime /usr/local/bin /usr/local/bin
+
+# Set workspace directory variable
+ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
+    DYNAMO_HOME=${WORKSPACE_DIR} \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    CARGO_TARGET_DIR=/workspace/target \
+    VIRTUAL_ENV=/opt/dynamo/venv \
+    PATH=/usr/local/cargo/bin:$PATH
+
+COPY --from=dynamo_base /usr/local/rustup /usr/local/rustup
+COPY --from=dynamo_base /usr/local/cargo /usr/local/cargo
+
+# This is a slow operation (~40s on my cpu)
+# Much better than chown -R $USERNAME:$USERNAME /opt/dynamo/venv (~10min on my cpu)
+COPY --from=runtime ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+
+# so we can use maturin develop
+RUN uv pip install maturin[patchelf]
+
+# Make sure to sync this with the one specified on README.md.
+# This is a generic PYTHONPATH which works for all the frameworks, so some paths may not be relevant for this particular framework.
+ENV PYTHONPATH=${WORKSPACE_DIR}/components/metrics/src:${WORKSPACE_DIR}/components/frontend/src:${WORKSPACE_DIR}/components/planner/src:${WORKSPACE_DIR}/components/backends/mocker/src:${WORKSPACE_DIR}/components/backends/trtllm/src:${WORKSPACE_DIR}/components/backends/vllm/src:${WORKSPACE_DIR}/components/backends/sglang/src:${WORKSPACE_DIR}/components/backends/llama_cpp/src
 
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []

--- a/container/build.sh
+++ b/container/build.sh
@@ -245,22 +245,6 @@ get_options() {
                 missing_requirement "$1"
             fi
             ;;
-        --uid)
-            if [ "$2" ]; then
-                USER_UID="$2"
-                shift
-            else
-                missing_requirement "$1"
-            fi
-            ;;
-        --gid)
-            if [ "$2" ]; then
-                USER_GID="$2"
-                shift
-            else
-                missing_requirement "$1"
-            fi
-            ;;
         --dry-run)
             RUN_PREFIX="echo"
             echo ""
@@ -437,8 +421,6 @@ show_help() {
     echo "  [--cache-from cache location to start from]"
     echo "  [--cache-to location where to cache the build output]"
     echo "  [--tag tag for image]"
-    echo "  [--uid user ID for dev target (default: current user)]"
-    echo "  [--gid group ID for dev target (default: current group)]"
     echo "  [--no-cache disable docker build cache]"
     echo "  [--dry-run print docker commands without running]"
     echo "  [--build-context name=path to add build context]"
@@ -463,14 +445,6 @@ error() {
 
 get_options "$@"
 
-# Validate UID/GID flags are only used with dev target
-if [ -n "$USER_UID" ] || [ -n "$USER_GID" ]; then
-    if [[ "$TARGET" != "dev" ]]; then
-        echo "⚠️  Warning: --uid and --gid flags are only effective with --target dev"
-        echo "   Current target: ${TARGET:-}"
-    fi
-fi
-
 # Automatically set ARCH and ARCH_ALT if PLATFORM is linux/arm64
 ARCH="amd64"
 if [[ "$PLATFORM" == *"linux/arm64"* ]]; then
@@ -492,15 +466,8 @@ fi
 # Add NIXL_REF as a build argument
 BUILD_ARGS+=" --build-arg NIXL_REF=${NIXL_REF} "
 
-if [[ $TARGET == "dev" ]]; then
-    # Use provided UID/GID or default to current user
-    if [ -z "$USER_UID" ]; then
-        USER_UID=$(id -u)
-    fi
-    if [ -z "$USER_GID" ]; then
-        USER_GID=$(id -g)
-    fi
-    BUILD_ARGS+=" --build-arg USER_UID=$USER_UID --build-arg USER_GID=$USER_GID "
+if [[ $TARGET == "local-dev" ]]; then
+    BUILD_ARGS+=" --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) "
 fi
 
 # BUILD DEV IMAGE

--- a/container/build.sh
+++ b/container/build.sh
@@ -24,8 +24,6 @@ set -e
 TAG=
 RUN_PREFIX=
 PLATFORM=linux/amd64
-USER_UID=
-USER_GID=
 
 # Get short commit hash
 commit_id=$(git rev-parse --short HEAD)

--- a/container/run.sh
+++ b/container/run.sh
@@ -162,7 +162,6 @@ get_options() {
         --mount-workspace)
             MOUNT_WORKSPACE=TRUE
             ;;
-
         --use-nixl-gds)
             USE_NIXL_GDS=TRUE
             ;;

--- a/container/run.sh
+++ b/container/run.sh
@@ -31,14 +31,12 @@ DEFAULT_FRAMEWORK=VLLM
 SOURCE_DIR=$(dirname "$(readlink -f "$0")")
 
 IMAGE=
-TARGET="dev"
 HF_CACHE=
 DEFAULT_HF_CACHE=${SOURCE_DIR}/.cache/huggingface
 GPUS="all"
 PRIVILEGED=
 VOLUME_MOUNTS=
 MOUNT_WORKSPACE=
-DEV_MODE=
 ENVIRONMENT_VARIABLES=
 REMAINING_ARGS=
 INTERACTIVE=
@@ -230,11 +228,32 @@ get_options() {
         ENTRYPOINT_STRING="--entrypoint ${ENTRYPOINT}"
     fi
 
+    if [ -n "$MOUNT_WORKSPACE" ]; then
+        VOLUME_MOUNTS+=" -v ${SOURCE_DIR}/..:/workspace "
+        VOLUME_MOUNTS+=" -v /tmp:/tmp "
+        VOLUME_MOUNTS+=" -v /mnt/:/mnt "
+
+        if [ -z "$HF_CACHE" ]; then
+            HF_CACHE=$DEFAULT_HF_CACHE
+        fi
+
+        if [ -z "${PRIVILEGED}" ]; then
+            PRIVILEGED="TRUE"
+        fi
+
+        ENVIRONMENT_VARIABLES+=" -e HF_TOKEN"
+
+        INTERACTIVE=" -it "
+    fi
+
     if [[ ${HF_CACHE^^} == "NONE" ]]; then
         HF_CACHE=
     fi
 
-    # HF_CACHE mounting will be handled in workspace section
+    if [ -n "$HF_CACHE" ]; then
+        mkdir -p "$HF_CACHE"
+        VOLUME_MOUNTS+=" -v $HF_CACHE:/root/.cache/huggingface"
+    fi
 
     if [ -z "${PRIVILEGED}" ]; then
         PRIVILEGED="FALSE"
@@ -244,9 +263,9 @@ get_options() {
         RM="TRUE"
     fi
 
-    # Initialize PRIVILEGED_STRING
-    PRIVILEGED_STRING=""
-    if [[ ${PRIVILEGED^^} != "FALSE" ]]; then
+    if [[ ${PRIVILEGED^^} == "FALSE" ]]; then
+        PRIVILEGED_STRING=""
+    else
         PRIVILEGED_STRING="--privileged"
     fi
 
@@ -273,15 +292,6 @@ get_options() {
             RUNTIME=""
     fi
 
-    # Auto-enable DEV_MODE for vllm dev images
-    # TODO(keivenc): Currently only Dockerfile.vllm has proper permissions to run as ubuntu user.
-    # Other Dockerfiles (trtllm, sglang, etc.) still require root access.
-    if [[ "$IMAGE" == *"-vllm-dev" ]]; then
-        DEV_MODE=TRUE
-        MOUNT_WORKSPACE=TRUE
-        # Interactive mode is implied when MOUNT_WORKSPACE is TRUE
-    fi
-
     REMAINING_ARGS=("$@")
 }
 
@@ -289,7 +299,6 @@ show_help() {
     echo "usage: run.sh"
     echo "  [--image image]"
     echo "  [--framework framework one of ${!FRAMEWORKS[*]}]"
-    echo "  [--target target stage to use, default is 'dev']"
     echo "  [--name name for launched container, default NONE]"
     echo "  [--privileged whether to launch in privileged mode, default FALSE unless mounting workspace]"
     echo "  [--dry-run print docker commands without running]"
@@ -317,48 +326,6 @@ error() {
 }
 
 get_options "$@"
-
-# Process workspace mounting after auto-detection
-if [ -n "$MOUNT_WORKSPACE" ]; then
-    HOME_PATH="/home/ubuntu"
-
-    # Common workspace setup
-    VOLUME_MOUNTS+=" -v $(dirname "${SOURCE_DIR}"):/workspace "
-    VOLUME_MOUNTS+=" -v /tmp:/tmp "
-    VOLUME_MOUNTS+=" -v /mnt/:/mnt "
-    WORKDIR=/workspace
-    INTERACTIVE=" -it "
-
-    # Set default HF_CACHE if not specified
-    if [ -z "$HF_CACHE" ]; then
-        HF_CACHE=$DEFAULT_HF_CACHE
-    fi
-
-    # Environment variables for all workspace modes
-    ENVIRONMENT_VARIABLES+=" -e HF_TOKEN"
-    ENVIRONMENT_VARIABLES+=" -e GITHUB_TOKEN"
-    ENVIRONMENT_VARIABLES+=" -e HOME=$HOME_PATH"
-
-    # Mount HF_CACHE to user's home cache directory
-    if [ -n "$HF_CACHE" ]; then
-        mkdir -p "$HF_CACHE"
-        VOLUME_MOUNTS+=" -v $HF_CACHE:$HOME_PATH/.cache/huggingface"
-    fi
-
-    if [ -n "$DEV_MODE" ]; then
-        # Dev Container-specific setup - the Dockerfile handles UID/GID mapping via build args
-        # This currently only works with Dockerfile.vllm which has proper ubuntu user setup.
-        echo "Dev Container mode enabled - using ubuntu user with host UID/GID"
-        # Use ubuntu user (with correct UID/GID baked into image)
-        PRIVILEGED_STRING+=" --user ubuntu"
-    else
-        # Standard workspace mode - enable privileged mode
-        # TODO(keivenc): Security risk, remove soon. Dockerfiles (trtllm, sglang) still need to run as root.
-        if [ -z "${PRIVILEGED}" ]; then
-            PRIVILEGED_STRING="--privileged"
-        fi
-    fi
-fi
 
 # RUN the image
 if [ -z "$RUN_PREFIX" ]; then


### PR DESCRIPTION
#### Overview:

This PR reverts Dockerfile.vllm and build/run scripts to maintain the same build and run behaviors as before August 28 commit 82bae247b56258a08e26bb6dd305e69981be98b0. This is to maintain backward compatibility.

#### Details:

- Split Dockerfile.vllm dev target into two distinct targets:
  - `local-dev`: For VS Code/Cursor Dev Container plugin use only
  - `dev`: For command-line development with run.sh script
- Add comprehensive feature matrix comparing both development targets
- Remove --uid/--gid options from build.sh (now handled by local-dev target)
- Remove DEV_MODE logic from run.sh (simplified workspace mounting)
- Consolidate ENV variables in both targets for better maintainability
- Update build.sh to use local-dev target for UID/GID mapping
- Maintain backward compatibility with existing workflows

#### Where should the reviewer start?

- container/Dockerfile.vllm: Review the feature matrix and target separation
- container/build.sh: Check removal of --uid/--gid options and UID/GID handling
- container/run.sh: Verify simplified workspace mounting logic

#### Related Issues:

BUG-5501463