### PR TITLE
feat: add file permission checking to dynamo_check.py

### DIFF
--- a/deploy/dynamo_check.py
+++ b/deploy/dynamo_check.py
@@ -35,15 +35,15 @@ System info (hostname=jensen-linux, IP=10.111.122.133)
 ├─ OS Ubuntu 24.04.1 LTS (Noble Numbat) (Linux 6.11.0-28-generic x86_64), Memory=26.7/125.5 GiB, Cores=32
 ├─ ✅ NVIDIA GPU NVIDIA RTX 6000 Ada Generation, driver 570.133.07, CUDA 12.8, Power=26.14/300.00 W, Memory=289/49140 MiB
 ├─ File Permissions
-│  ├─ ✅ Dynamo home ($HOME/dynamo) writable
-│  ├─ ✅ .git directory writable
-│  ├─ ✅ RUSTUP_HOME ($HOME/.rustup) writable
-│  ├─ ✅ CARGO_HOME ($HOME/.cargo) writable
+│  ├─ ✅ Dynamo workspace ($HOME/dynamo) writable
+│  ├─ ✅ Dynamo .git directory writable
+│  ├─ ✅ Rustup home ($HOME/.rustup) writable
+│  ├─ ✅ Cargo home ($HOME/.cargo) writable
 │  ├─ ✅ Cargo target ($HOME/dynamo/.build/target) writable
-│  └─ ✅ site-packages (/opt/dynamo/venv/lib/python3.12/site-packages) writable
-├─ ✅ Cargo /usr/local/cargo/bin/cargo, cargo 1.89.0 (c24e10642 2025-06-23)
-│  ├─ cargo home directory $HOME/dynamo/.build/.cargo (CARGO_HOME is set)
-│  └─ cargo target directory $HOME/dynamo/.build/target (CARGO_TARGET_DIR is set)
+│  └─ ✅ Python site-packages ($HOME/dynamo/venv/lib/python3.12/site-packages) writable
+├─ ✅ Cargo $HOME/.cargo/bin/cargo, cargo 1.89.0 (c24e10642 2025-06-23)
+│  ├─ Cargo home directory CARGO_HOME=$HOME/.cargo
+│  └─ Cargo target directory CARGO_TARGET_DIR=$HOME/dynamo/.build/target
 │     ├─ Debug $HOME/dynamo/.build/target/debug, modified=2025-08-30 16:26:49 PDT
 │     ├─ Release $HOME/dynamo/.build/target/release, modified=2025-08-30 18:21:12 PDT
 │     └─ Binary $HOME/dynamo/.build/target/debug/libdynamo_llm_capi.so, modified=2025-08-30 16:25:37 PDT

--- a/deploy/dynamo_check.py
+++ b/deploy/dynamo_check.py
@@ -76,10 +76,11 @@ System info (hostname=jensen-linux, IP=10.111.122.133)
       └─ ✅ dynamo.vllm      $HOME/dynamo/components/backends/vllm/src/dynamo/vllm/__init__.py
 
 Usage:
-    python dynamo_check.py [--thorough-check]
+    python dynamo_check.py [--thorough-check] [--terse]
 
 Options:
     --thorough-check  Enable thorough checking (file permissions, directory sizes, etc.)
+    --terse           Enable terse output mode
 """
 
 import datetime


### PR DESCRIPTION
#### Overview:

Add file permission checking functionality to the `dynamo_check.py` diagnostic tool. The new feature validates writability of critical development directories and files needed for Dynamo development workflows.

#### Details:

- Example output 1:
```
├─ File Permissions
│  ├─ ✅ Dynamo workspace ($HOME/dynamo) writable
│  ├─ ✅ Dynamo .git directory writable
│  ├─ ✅ Rustup home ($HOME/.rustup) writable
│  ├─ ✅ Cargo home ($HOME/.cargo) writable
│  ├─ ✅ Cargo target ($HOME/dynamo/.build/target) writable
│  └─ ✅ Python site-packages ($HOME/dynamo/venv/lib/python3.12/site-packages) writable
```
- Example output 2 (using the `--thorough` flag, which is slower)
```
├─ File Permissions
│  ├─ ✅ Dynamo workspace ($HOME/dynamo) writable
│  ├─ ⚠️  Dynamo .git directory not available
│  ├─ ⚠️  Rustup home ($HOME/.rustup) directory does not exist
│  ├─ ⚠️  Cargo home ($HOME/.cargo) directory does not exist
│  ├─ ❌ Cargo target ($HOME/dynamo/.build/target) Path does not exist
│  └─ ❌ Python site-packages ($HOME/dynamo/venv/lib/python3.12/site-packages) Permission check failed: [Errno 2] No such file or directory
```
- Add FilePermissionsInfo class with unified permission checking function
- Check writability of dynamo root, .git, RUSTUP_HOME, CARGO_HOME, cargo target, and site-packages directories
- Implement ownership-aware permission logic (files owned by user or root are considered writable)
- Support directory-only checking (default) and recursive file checking (--thorough-check flag)
- Replace --fast flag with --thorough-check for more explicit behavior
- Skip symbolic links during file permission analysis
- Update documentation and example output to reflect new functionality

#### Where should the reviewer start?

deploy/dynamo_check.py - Focus on the FilePermissionsInfo class (lines ~592-950).
