### PR TITLE
fix: 0.5.0 by reverting Dockerfile.vllm, build.sh, and run.sh (cherry pick 82bae247b56258a08e26bb6dd305e69981be98b0 from main)

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -280,21 +280,55 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []
 
-#######################################
-########## Local Development #######
-#######################################
+#######################################################################
+########## DEVELOPMENT TARGETS FEATURE MATRIX #########################
+#######################################################################
+# Feature              │ local-dev Target    │ dev Target
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Purpose              │ Dev Container       │ Command-line with
+#                      │ plugin use only     │ run.sh script
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Default User         │ ubuntu user         │ root user
+# ─────────────────────┼─────────────────────┼─────────────────────
+# User Setup           │ Full ubuntu user    │ No user setup
+#                      │ with UID/GID        │
+#                      │ mapping             │
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Permissions          │ ubuntu user with    │ Root-level
+#                      │ sudo privileges     │ permissions
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Home Directory       │ /home/ubuntu        │ /root
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Working Directory    │ /home/ubuntu/dynamo │ /workspace
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Rust Toolchain       │ User's home         │ System locations
+#                      │ (~/.rustup,         │ (/usr/local/rustup,
+#                      │  ~/.cargo)          │  /usr/local/cargo)
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Python Environment   │ User-owned venv     │ System location
+#                      │                     │ (/opt/dynamo/venv)
+# ─────────────────────┼─────────────────────┼─────────────────────
+# File Permissions     │ User-level with     │ Root-level
+#                      │ proper ownership    │ permissions
+# ─────────────────────┼─────────────────────┼─────────────────────
+# Compatibility        │ MS Plug-in: Dev     │ Backward compatibility
+#                      │ Container workflow  │ with existing
+#                      │                     │ workflows
 #
-# PURPOSE: Local development
-#
-# This stage adds development tools, utilities, and dependencies specifically
-# needed for:
-# - Local development and debugging
-# - vscode/cursor development
-#
-# Use this stage when you need a full development environment with additional
-# tooling beyond the base runtime image.
+# USAGE GUIDELINES:
+# • Use local-dev: VS Code/Cursor Dev Container plugin only
+# • Use dev: run.sh script for command-line development
 
-FROM runtime AS dev
+
+#######################################################################
+########## Development (Dev Container only) ###########################
+#######################################################################
+#
+# This stage is for Dev Container plug-in use only.
+# It provides a local development environment with extra tools and dependencies
+# not present in the base runtime image.
+
+FROM runtime AS local-dev
 
 # Install utilities
 RUN apt-get update -y && \
@@ -373,6 +407,82 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=$HOME/.comman
     && echo "$SNIPPET" >> "$HOME/.bashrc"
 
 RUN mkdir -p /home/$USERNAME/.cache/
+
+ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
+CMD []
+
+
+###########################################################
+########## Development (run.sh, runs as root user) ########
+###########################################################
+#
+# PURPOSE: Local development environment for use with run.sh (not Dev Container plug-in)
+#
+# This stage runs as root and provides:
+# - Development tools and utilities for local debugging
+# - Support for vscode/cursor development outside the Dev Container plug-in
+#
+# Use this stage if you need a full-featured development environment with extra tools,
+# but do not use it with the Dev Container plug-in.
+
+FROM runtime AS dev
+
+# Don't want ubuntu to be editable, just change uid and gid.
+ARG WORKSPACE_DIR=/workspace
+
+# Install utilities as root
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends  \
+    # Install utilities
+    nvtop \
+    wget \
+    tmux \
+    vim \
+    git \
+    openssh-client \
+    iproute2 \
+    rsync \
+    zip \
+    unzip \
+    htop \
+    # Build Dependencies
+    autoconf \
+    automake \
+    cmake \
+    libtool \
+    meson \
+    net-tools \
+    pybind11-dev \
+    # Rust build dependencies
+    clang \
+    libclang-dev \
+    protobuf-compiler && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=runtime /usr/local/bin /usr/local/bin
+
+# Set workspace directory variable
+ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
+    DYNAMO_HOME=${WORKSPACE_DIR} \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    CARGO_TARGET_DIR=/workspace/target \
+    VIRTUAL_ENV=/opt/dynamo/venv \
+    PATH=/usr/local/cargo/bin:$PATH
+
+COPY --from=dynamo_base /usr/local/rustup /usr/local/rustup
+COPY --from=dynamo_base /usr/local/cargo /usr/local/cargo
+
+# This is a slow operation (~40s on my cpu)
+# Much better than chown -R $USERNAME:$USERNAME /opt/dynamo/venv (~10min on my cpu)
+COPY --from=runtime ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+
+# so we can use maturin develop
+RUN uv pip install maturin[patchelf]
+
+# Make sure to sync this with the one specified on README.md.
+# This is a generic PYTHONPATH which works for all the frameworks, so some paths may not be relevant for this particular framework.
+ENV PYTHONPATH=${WORKSPACE_DIR}/components/metrics/src:${WORKSPACE_DIR}/components/frontend/src:${WORKSPACE_DIR}/components/planner/src:${WORKSPACE_DIR}/components/backends/mocker/src:${WORKSPACE_DIR}/components/backends/trtllm/src:${WORKSPACE_DIR}/components/backends/vllm/src:${WORKSPACE_DIR}/components/backends/sglang/src:${WORKSPACE_DIR}/components/backends/llama_cpp/src
 
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []

--- a/container/build.sh
+++ b/container/build.sh
@@ -443,7 +443,6 @@ error() {
 
 get_options "$@"
 
-
 # Automatically set ARCH and ARCH_ALT if PLATFORM is linux/arm64
 ARCH="amd64"
 if [[ "$PLATFORM" == *"linux/arm64"* ]]; then
@@ -465,7 +464,7 @@ fi
 # Add NIXL_REF as a build argument
 BUILD_ARGS+=" --build-arg NIXL_REF=${NIXL_REF} "
 
-if [[ $TARGET == "dev" ]]; then
+if [[ $TARGET == "local-dev" ]]; then
     BUILD_ARGS+=" --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) "
 fi
 
@@ -599,8 +598,6 @@ if [ "$USE_SCCACHE" = true ]; then
     BUILD_ARGS+=" --build-arg USE_SCCACHE=true"
     BUILD_ARGS+=" --build-arg SCCACHE_BUCKET=${SCCACHE_BUCKET}"
     BUILD_ARGS+=" --build-arg SCCACHE_REGION=${SCCACHE_REGION}"
-
-
 fi
 
 LATEST_TAG="--tag dynamo:latest-${FRAMEWORK,,}"


### PR DESCRIPTION
#### Overview:

This PR reverts Dockerfile.vllm and build/run scripts to maintain the same build and run behaviors as before August 28 commit 82bae247b56258a08e26bb6dd305e69981be98b0. This is to maintain backward compatibility.

#### Details:

- Split Dockerfile.vllm dev target into two distinct targets:
  - `local-dev`: For VS Code/Cursor Dev Container plugin use only
  - `dev`: For command-line development with run.sh script
- Add comprehensive feature matrix comparing both development targets
- Remove --uid/--gid options from build.sh (now handled by local-dev target)
- Remove DEV_MODE logic from run.sh (simplified workspace mounting)
- Consolidate ENV variables in both targets for better maintainability
- Update build.sh to use local-dev target for UID/GID mapping
- Maintain backward compatibility with existing workflows

#### Where should the reviewer start?

- container/Dockerfile.vllm: Review the feature matrix and target separation
- container/build.sh: Check removal of --uid/--gid options and UID/GID handling
- container/run.sh: Verify simplified workspace mounting logic

#### Related Issues:

BUG-5501463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Namespace scoping via DYN_NAMESPACE across frontend/backends; per-namespace model discovery.
  - Runtime graceful shutdown with coordinated endpoint draining.
  - container/run.sh supports --entrypoint override.
  - New multimodal Qwen deployment example and multiple perf test configs.
- Improvements
  - Workers invoke Python modules directly; decode workers use conditional graceful shutdown.
  - Planner input handling (NaN→0, ignore initial idle); better logs.
  - Hello World example streams with cancellation.
- Bug Fixes
  - Profiler timestamps normalized to integer ms.
- Documentation
  - Helm-based installation overhaul, updated links, chart/version bumps, etcd image guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->