### PR TITLE
fix: Load the tokenizer JSON once for chat and completions.

### DIFF
--- a/lib/bindings/python/rust/llm/backend.rs
+++ b/lib/bindings/python/rust/llm/backend.rs
@@ -1,17 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use super::*;
 use crate::llm::model_card::ModelDeploymentCard;
@@ -33,10 +21,7 @@ pub(crate) struct Backend {
 impl Backend {
     #[new]
     fn new(mdc: ModelDeploymentCard, endpoint: Endpoint) -> PyResult<Self> {
-        let runtime = pyo3_async_runtimes::tokio::get_runtime();
-        let backend = runtime
-            .block_on(llm_rs::backend::Backend::from_mdc(mdc.inner))
-            .map_err(to_pyerr)?;
+        let backend = llm_rs::backend::Backend::from_mdc(&mdc.inner);
         Ok(Self {
             inner: backend,
             endpoint,

--- a/lib/bindings/python/rust/llm/model_card.rs
+++ b/lib/bindings/python/rust/llm/model_card.rs
@@ -16,14 +16,10 @@ impl ModelDeploymentCard {}
 impl ModelDeploymentCard {
     // Previously called "from_local_path"
     #[staticmethod]
-    fn load(path: String, model_name: String, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let mut card = RsModelDeploymentCard::load(&path, None)
-                .await
-                .map_err(to_pyerr)?;
-            card.set_name(&model_name);
-            Ok(ModelDeploymentCard { inner: card })
-        })
+    fn load(path: String, model_name: String) -> PyResult<ModelDeploymentCard> {
+        let mut card = RsModelDeploymentCard::load(&path, None).map_err(to_pyerr)?;
+        card.set_name(&model_name);
+        Ok(ModelDeploymentCard { inner: card })
     }
 
     #[staticmethod]

--- a/lib/bindings/python/rust/llm/preprocessor.rs
+++ b/lib/bindings/python/rust/llm/preprocessor.rs
@@ -1,17 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 use super::*;
 use crate::llm::model_card::ModelDeploymentCard;
@@ -42,10 +30,7 @@ pub(crate) struct OAIChatPreprocessor {
 impl OAIChatPreprocessor {
     #[new]
     fn new(mdc: ModelDeploymentCard, current: Endpoint, next: Endpoint) -> PyResult<Self> {
-        let runtime = pyo3_async_runtimes::tokio::get_runtime();
-        let preprocessor = runtime
-            .block_on(OpenAIPreprocessor::new(mdc.inner.clone()))
-            .map_err(to_pyerr)?;
+        let preprocessor = OpenAIPreprocessor::new(mdc.inner.clone()).map_err(to_pyerr)?;
         Ok(Self {
             inner: preprocessor,
             current,

--- a/lib/llm/src/entrypoint/input/batch.rs
+++ b/lib/llm/src/entrypoint/input/batch.rs
@@ -67,7 +67,9 @@ pub async fn run(
     let mut prepared_engine = common::prepare_engine(runtime, engine_config).await?;
 
     let pre_processor = if prepared_engine.has_tokenizer() {
-        Some(OpenAIPreprocessor::new(prepared_engine.card.take().unwrap()).await?)
+        Some(OpenAIPreprocessor::new(
+            prepared_engine.card.take().unwrap(),
+        )?)
     } else {
         None
     };

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -278,7 +278,7 @@ where
     let frontend = SegmentSource::<SingleIn<Req>, ManyOut<Annotated<Resp>>>::new();
     let preprocessor_op = preprocessor.into_operator();
     let backend = Backend::from_tokenizer(hf_tokenizer).into_operator();
-    let migration = Migration::from_mdc(card.clone()).into_operator();
+    let migration = Migration::from_mdc(card).into_operator();
     let router =
         PushRouter::<PreprocessedRequest, Annotated<LLMEngineOutput>>::from_client_with_threshold(
             client.clone(),

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -11,7 +11,7 @@ use crate::{
     kv_router::{KvPushRouter, KvRouter},
     migration::Migration,
     model_card::ModelDeploymentCard,
-    preprocessor::OpenAIPreprocessor,
+    preprocessor::{OpenAIPreprocessor, prompt::PromptFormatter},
     protocols::common::llm_backend::{BackendOutput, LLMEngineOutput, PreprocessedRequest},
     request_template::RequestTemplate,
     types::{
@@ -131,10 +131,18 @@ pub async fn prepare_engine(
                 None
             };
 
+            let hf_tokenizer = card.tokenizer_hf()?;
             let chat_engine = entrypoint::build_routed_pipeline::<
                 NvCreateChatCompletionRequest,
                 NvCreateChatCompletionStreamResponse,
-            >(card, &client, router_mode, None, kv_chooser.clone())
+            >(
+                card,
+                &client,
+                router_mode,
+                None,
+                kv_chooser.clone(),
+                hf_tokenizer,
+            )
             .await?;
 
             let service_name = local_model.service_name().to_string();
@@ -167,7 +175,7 @@ pub async fn prepare_engine(
             let pipeline = build_pipeline::<
                 NvCreateChatCompletionRequest,
                 NvCreateChatCompletionStreamResponse,
-            >(model.card(), inner_engine)
+            >(model.card(), inner_engine, model.card().tokenizer_hf()?)
             .await?;
 
             let service_name = model.service_name().to_string();
@@ -186,6 +194,7 @@ pub async fn prepare_engine(
 pub async fn build_pipeline<Req, Resp>(
     card: &ModelDeploymentCard,
     engine: ExecutionContext,
+    hf_tokenizer: tokenizers::Tokenizer,
 ) -> anyhow::Result<Arc<ServiceFrontend<SingleIn<Req>, ManyOut<Annotated<Resp>>>>>
 where
     Req: Data,
@@ -198,10 +207,11 @@ where
         >,
 {
     let frontend = ServiceFrontend::<SingleIn<Req>, ManyOut<Annotated<Resp>>>::new();
-    let preprocessor = OpenAIPreprocessor::new((*card).clone())
-        .await?
-        .into_operator();
-    let backend = Backend::from_mdc((*card).clone()).await?.into_operator();
+    let PromptFormatter::OAI(formatter) = PromptFormatter::from_mdc(card)?;
+    let preprocessor =
+        OpenAIPreprocessor::new_with_parts(card.clone(), formatter, hf_tokenizer.clone())?
+            .into_operator();
+    let backend = Backend::from_tokenizer(hf_tokenizer).into_operator();
     let engine = ServiceBackend::from_engine(engine);
 
     Ok(frontend
@@ -219,6 +229,7 @@ pub async fn build_routed_pipeline<Req, Resp>(
     router_mode: RouterMode,
     busy_threshold: Option<f64>,
     chooser: Option<Arc<KvRouter>>,
+    hf_tokenizer: tokenizers::Tokenizer,
 ) -> anyhow::Result<ServiceEngine<SingleIn<Req>, ManyOut<Annotated<Resp>>>>
 where
     Req: Data,
@@ -230,7 +241,9 @@ where
             Pin<Box<dyn AsyncEngineStream<Annotated<BackendOutput>>>>,
         >,
 {
-    let preprocessor = OpenAIPreprocessor::new(card.clone()).await?;
+    let PromptFormatter::OAI(formatter) = PromptFormatter::from_mdc(card)?;
+    let preprocessor =
+        OpenAIPreprocessor::new_with_parts(card.clone(), formatter, hf_tokenizer.clone())?;
     build_routed_pipeline_with_preprocessor(
         card,
         client,
@@ -238,6 +251,7 @@ where
         busy_threshold,
         chooser,
         preprocessor,
+        hf_tokenizer,
     )
     .await
 }
@@ -249,6 +263,7 @@ pub async fn build_routed_pipeline_with_preprocessor<Req, Resp>(
     busy_threshold: Option<f64>,
     chooser: Option<Arc<KvRouter>>,
     preprocessor: Arc<OpenAIPreprocessor>,
+    hf_tokenizer: tokenizers::Tokenizer,
 ) -> anyhow::Result<ServiceEngine<SingleIn<Req>, ManyOut<Annotated<Resp>>>>
 where
     Req: Data,
@@ -262,8 +277,8 @@ where
 {
     let frontend = SegmentSource::<SingleIn<Req>, ManyOut<Annotated<Resp>>>::new();
     let preprocessor_op = preprocessor.into_operator();
-    let backend = Backend::from_mdc(card.clone()).await?.into_operator();
-    let migration = Migration::from_mdc(card.clone()).await?.into_operator();
+    let backend = Backend::from_tokenizer(hf_tokenizer).into_operator();
+    let migration = Migration::from_mdc(card.clone()).into_operator();
     let router =
         PushRouter::<PreprocessedRequest, Annotated<LLMEngineOutput>>::from_client_with_threshold(
             client.clone(),
@@ -312,14 +327,14 @@ mod tests {
     #[tokio::test]
     async fn test_build_chat_completions_pipeline_core_engine_succeeds() -> anyhow::Result<()> {
         // Create test model card
-        let card = ModelDeploymentCard::load(HF_PATH, None).await?;
+        let card = ModelDeploymentCard::load(HF_PATH, None)?;
         let engine = crate::engines::make_engine_core();
 
         // Build pipeline for chat completions
         let pipeline = build_pipeline::<
             NvCreateChatCompletionRequest,
             NvCreateChatCompletionStreamResponse,
-        >(&card, engine)
+        >(&card, engine, card.tokenizer_hf()?)
         .await?;
 
         // Verify pipeline was created
@@ -331,13 +346,16 @@ mod tests {
     #[tokio::test]
     async fn test_build_completions_pipeline_core_engine_succeeds() -> anyhow::Result<()> {
         // Create test model card
-        let card = ModelDeploymentCard::load(HF_PATH, None).await?;
+        let card = ModelDeploymentCard::load(HF_PATH, None)?;
         let engine = crate::engines::make_engine_core();
 
         // Build pipeline for completions
-        let pipeline =
-            build_pipeline::<NvCreateCompletionRequest, NvCreateCompletionResponse>(&card, engine)
-                .await?;
+        let pipeline = build_pipeline::<NvCreateCompletionRequest, NvCreateCompletionResponse>(
+            &card,
+            engine,
+            card.tokenizer_hf()?,
+        )
+        .await?;
 
         // Verify pipeline was created
         assert!(Arc::strong_count(&pipeline) >= 1);

--- a/lib/llm/src/entrypoint/input/endpoint.rs
+++ b/lib/llm/src/entrypoint/input/endpoint.rs
@@ -73,9 +73,7 @@ pub async fn run(
                 SingleIn<PreprocessedRequest>,
                 ManyOut<Annotated<BackendOutput>>,
             >::new();
-            let backend = Backend::from_mdc(model.card().clone())
-                .await?
-                .into_operator();
+            let backend = Backend::from_mdc(model.card()).into_operator();
             let engine = ServiceBackend::from_engine(inner_engine);
             let pipeline = frontend
                 .link(backend.forward_edge())?

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -253,8 +253,7 @@ impl LocalModelBuilder {
         let model_config_path = self.model_config.as_ref().unwrap_or(&full_path);
 
         let mut card =
-            ModelDeploymentCard::load(&model_config_path, self.custom_template_path.as_deref())
-                .await?;
+            ModelDeploymentCard::load(model_config_path, self.custom_template_path.as_deref())?;
 
         // Usually we infer from the path, self.model_name is user override
         let model_name = self.model_name.take().unwrap_or_else(|| {

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -28,7 +28,7 @@ pub struct Migration {
 }
 
 impl Migration {
-    pub fn from_mdc(mdc: ModelDeploymentCard) -> Arc<Self> {
+    pub fn from_mdc(mdc: &ModelDeploymentCard) -> Arc<Self> {
         tracing::debug!(
             "model {} migration limit {}",
             mdc.display_name,

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -28,15 +28,15 @@ pub struct Migration {
 }
 
 impl Migration {
-    pub async fn from_mdc(mdc: ModelDeploymentCard) -> Result<Arc<Self>> {
+    pub fn from_mdc(mdc: ModelDeploymentCard) -> Arc<Self> {
         tracing::debug!(
             "model {} migration limit {}",
             mdc.display_name,
             mdc.migration_limit
         );
-        Ok(Arc::new(Self {
+        Arc::new(Self {
             migration_limit: mdc.migration_limit,
-        }))
+        })
     }
 }
 

--- a/lib/llm/tests/backend.rs
+++ b/lib/llm/tests/backend.rs
@@ -6,11 +6,9 @@ use dynamo_llm::model_card::ModelDeploymentCard;
 
 #[tokio::test]
 async fn test_sequence_factory() {
-    let mdc = ModelDeploymentCard::load("tests/data/sample-models/TinyLlama_v1.1", None)
-        .await
-        .unwrap();
+    let mdc = ModelDeploymentCard::load("tests/data/sample-models/TinyLlama_v1.1", None).unwrap();
 
-    let operator = Backend::from_mdc(mdc).await.unwrap();
+    let operator = Backend::from_mdc(mdc);
 
     let mut decode_stream = operator
         .tokenizer

--- a/lib/llm/tests/backend.rs
+++ b/lib/llm/tests/backend.rs
@@ -4,11 +4,11 @@
 use dynamo_llm::backend::Backend;
 use dynamo_llm::model_card::ModelDeploymentCard;
 
-#[tokio::test]
-async fn test_sequence_factory() {
+#[test]
+fn test_sequence_factory() {
     let mdc = ModelDeploymentCard::load("tests/data/sample-models/TinyLlama_v1.1", None).unwrap();
 
-    let operator = Backend::from_mdc(mdc);
+    let operator = Backend::from_mdc(&mdc);
 
     let mut decode_stream = operator
         .tokenizer

--- a/lib/llm/tests/model_card.rs
+++ b/lib/llm/tests/model_card.rs
@@ -8,8 +8,8 @@ const HF_PATH: &str = "tests/data/sample-models/TinyLlama_v1.1";
 
 #[tokio::test]
 async fn test_model_info_from_hf_like_local_repo() {
-    let mdc = ModelDeploymentCard::load(HF_PATH, None).await.unwrap();
-    let info = mdc.model_info.unwrap().get_model_info().await.unwrap();
+    let mdc = ModelDeploymentCard::load(HF_PATH, None).unwrap();
+    let info = mdc.model_info.unwrap().get_model_info().unwrap();
     assert_eq!(info.model_type(), "llama");
     assert_eq!(info.bos_token_id(), 1);
     assert_eq!(info.eos_token_ids(), vec![2]);
@@ -20,13 +20,13 @@ async fn test_model_info_from_hf_like_local_repo() {
 #[tokio::test]
 async fn test_model_info_from_non_existent_local_repo() {
     let path = "tests/data/sample-models/this-model-does-not-exist";
-    let result = ModelDeploymentCard::load(path, None).await;
+    let result = ModelDeploymentCard::load(path, None);
     assert!(result.is_err());
 }
 
 #[tokio::test]
 async fn test_tokenizer_from_hf_like_local_repo() {
-    let mdc = ModelDeploymentCard::load(HF_PATH, None).await.unwrap();
+    let mdc = ModelDeploymentCard::load(HF_PATH, None).unwrap();
     // Verify tokenizer file was found
     match mdc.tokenizer.unwrap() {
         TokenizerKind::HfTokenizerJson(_) => (),
@@ -36,7 +36,7 @@ async fn test_tokenizer_from_hf_like_local_repo() {
 
 #[tokio::test]
 async fn test_prompt_formatter_from_hf_like_local_repo() {
-    let mdc = ModelDeploymentCard::load(HF_PATH, None).await.unwrap();
+    let mdc = ModelDeploymentCard::load(HF_PATH, None).unwrap();
     // Verify prompt formatter was found
     match mdc.prompt_formatter {
         Some(PromptFormatterArtifact::HfTokenizerConfigJson(_)) => (),
@@ -48,7 +48,7 @@ async fn test_prompt_formatter_from_hf_like_local_repo() {
 async fn test_missing_required_files() {
     // Create empty temp directory
     let temp_dir = tempdir().unwrap();
-    let result = ModelDeploymentCard::load(temp_dir.path(), None).await;
+    let result = ModelDeploymentCard::load(temp_dir.path(), None);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     // Should fail because config.json is missing

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -57,9 +57,7 @@ async fn make_mdc_from_repo(
     //TODO: remove this once we have nim-hub support. See the NOTE above.
     let downloaded_path = maybe_download_model(local_path, hf_repo, hf_revision).await;
     let display_name = format!("{}--{}", hf_repo, hf_revision);
-    let mut mdc = ModelDeploymentCard::load(downloaded_path, None)
-        .await
-        .unwrap();
+    let mut mdc = ModelDeploymentCard::load(downloaded_path, None).unwrap();
     mdc.set_name(&display_name);
     mdc.prompt_context = mixins;
     mdc
@@ -285,7 +283,7 @@ async fn test_single_turn() {
     let mdcs = make_mdcs().await;
 
     for mdc in mdcs.iter() {
-        let formatter = PromptFormatter::from_mdc(mdc.clone()).await.unwrap();
+        let formatter = PromptFormatter::from_mdc(mdc).unwrap();
 
         // assert its an OAI formatter
         let formatter = match formatter {
@@ -317,7 +315,7 @@ async fn test_single_turn_with_tools() {
     let mdcs = make_mdcs().await;
 
     for mdc in mdcs.iter() {
-        let formatter = PromptFormatter::from_mdc(mdc.clone()).await.unwrap();
+        let formatter = PromptFormatter::from_mdc(mdc).unwrap();
 
         // assert its an OAI formatter
         let formatter = match formatter {
@@ -354,7 +352,7 @@ async fn test_mulit_turn_without_system() {
     let mdcs = make_mdcs().await;
 
     for mdc in mdcs.iter() {
-        let formatter = PromptFormatter::from_mdc(mdc.clone()).await.unwrap();
+        let formatter = PromptFormatter::from_mdc(mdc).unwrap();
 
         // assert its an OAI formatter
         let formatter = match formatter {
@@ -386,7 +384,7 @@ async fn test_mulit_turn_with_system() {
     let mdcs = make_mdcs().await;
 
     for mdc in mdcs.iter() {
-        let formatter = PromptFormatter::from_mdc(mdc.clone()).await.unwrap();
+        let formatter = PromptFormatter::from_mdc(mdc).unwrap();
 
         // assert its an OAI formatter
         let formatter = match formatter {
@@ -424,7 +422,7 @@ async fn test_multi_turn_with_system_with_tools() {
     let mdcs = make_mdcs().await;
 
     for mdc in mdcs.iter() {
-        let formatter = PromptFormatter::from_mdc(mdc.clone()).await.unwrap();
+        let formatter = PromptFormatter::from_mdc(mdc).unwrap();
 
         // assert its an OAI formatter
         let formatter = match formatter {
@@ -467,7 +465,7 @@ async fn test_multi_turn_with_continuation() {
     )
     .await;
 
-    let formatter = PromptFormatter::from_mdc(mdc.clone()).await.unwrap();
+    let formatter = PromptFormatter::from_mdc(&mdc).unwrap();
 
     // assert its an OAI formatter
     let formatter = match formatter {

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -2265,7 +2265,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
-version = "0.5.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [


### PR DESCRIPTION
Loading the tokenizer JSON from disk can be expensive (it can be a ~10MiB file).

Previously we loaded once building the chat handler and again building the completions handler. That also meant the completions handler was not ready until slightly after the chat handler.

Note some Python bindings may have gone from async to sync, tests should catch if so.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Reuse of a single tokenizer across chat, completions, and embeddings to reduce load times and memory.
  - Simplified Python model loading API returning a concrete object (no async context required).

- Refactor
  - Converted model loading, preprocessing, and backend initialization to synchronous flows, cutting startup latency and overhead.
  - Backend creation is more resilient if tokenization cannot be initialized.

- Chores
  - More structured, informative logging around model add/remove and readiness.

- Tests
  - Updated to reflect synchronous APIs and added assertions for model metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->