### PR TITLE
feat: add HTTP queue metrics for NIM frontend request tracking

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -254,6 +254,15 @@ impl ModelManager {
             .and_then(|config| config.tool_call_parser.clone())
             .map(|parser| parser.to_string())
     }
+
+    /// Creates parsing options with tool call parser and reasoning parser for the specified model.
+    /// Currently reasoning parser is not implemented (returns None).
+    pub fn get_parsing_options(&self, model: &str) -> crate::protocols::openai::ParsingOptions {
+        let tool_call_parser = self.get_model_tool_call_parser(model);
+        let reasoning_parser = None; // TODO: Implement reasoning parser
+
+        crate::protocols::openai::ParsingOptions::new(tool_call_parser, reasoning_parser)
+    }
 }
 
 pub struct ModelEngines<E> {

--- a/lib/llm/src/grpc/service/kserve.rs
+++ b/lib/llm/src/grpc/service/kserve.rs
@@ -21,7 +21,8 @@ use tokio::task::JoinHandle;
 use tokio_stream::{Stream, StreamExt};
 use tokio_util::sync::CancellationToken;
 
-use crate::grpc::service::openai::{completion_response_stream, get_parsing_options};
+use crate::grpc::service::openai::completion_response_stream;
+use crate::http::service::metrics::get_parsing_options;
 use tonic::{Request, Response, Status, transport::Server};
 
 use crate::protocols::openai::completions::{

--- a/lib/llm/src/grpc/service/kserve.rs
+++ b/lib/llm/src/grpc/service/kserve.rs
@@ -22,7 +22,6 @@ use tokio_stream::{Stream, StreamExt};
 use tokio_util::sync::CancellationToken;
 
 use crate::grpc::service::openai::completion_response_stream;
-use crate::http::service::metrics::get_parsing_options;
 use tonic::{Request, Response, Status, transport::Server};
 
 use crate::protocols::openai::completions::{
@@ -208,7 +207,7 @@ impl GrpcInferenceService for KserveService {
         }
 
         let model = completion_request.inner.model.clone();
-        let parsing_options = get_parsing_options(self.state.manager(), &model);
+        let parsing_options = self.state.manager.get_parsing_options(&model);
 
         let stream = completion_response_stream(self.state_clone(), completion_request).await?;
 
@@ -278,7 +277,7 @@ impl GrpcInferenceService for KserveService {
                 }
 
                 let model = completion_request.inner.model.clone();
-                let parsing_options = get_parsing_options(state.manager(), &model);
+                let parsing_options = state.manager.get_parsing_options(&model);
 
                 let streaming = completion_request.inner.stream.unwrap_or(false);
 

--- a/lib/llm/src/grpc/service/openai.rs
+++ b/lib/llm/src/grpc/service/openai.rs
@@ -10,6 +10,7 @@ use futures::{Stream, StreamExt, stream};
 use std::sync::Arc;
 
 use crate::discovery::ModelManager;
+use crate::preprocessor::LLMMetricAnnotation;
 use crate::protocols::openai::{
     ParsingOptions,
     completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
@@ -23,7 +24,7 @@ use crate::http::service::{
     disconnect::{ConnectionHandle, create_connection_monitor},
     metrics::{Endpoint, ResponseMetricCollector},
 };
-use crate::{http::service::metrics::InflightGuard, preprocessor::LLMMetricAnnotation};
+use crate::http::service::metrics::InflightGuard;
 
 use tonic::Status;
 
@@ -72,6 +73,8 @@ pub async fn completion_response_stream(
         .get_completions_engine(model)
         .map_err(|_| Status::not_found("model not found"))?;
 
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(model);
+
     let inflight_guard =
         state
             .metrics_clone()
@@ -112,8 +115,15 @@ pub async fn completion_response_stream(
     // apply any annotations to the front of the stream
     let stream = stream::iter(annotations).chain(stream);
 
-    // Tap on the stream to collect response metrics
+    // Tap on the stream to collect response metrics and handle http_queue_guard
+    let mut http_queue_guard = Some(http_queue_guard);
     let stream = stream.inspect(move |response| {
+        // Check if this is the first token and drop http_queue_guard
+        if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(response)
+            && response_collector.is_first_token() && metrics.chunk_tokens > 0
+            && let Some(guard) = http_queue_guard.take() {
+            drop(guard);
+        }
         process_metrics_only(response, &mut response_collector);
     });
 

--- a/lib/llm/src/grpc/service/openai.rs
+++ b/lib/llm/src/grpc/service/openai.rs
@@ -9,11 +9,8 @@ use dynamo_runtime::{
 use futures::{Stream, StreamExt, stream};
 use std::sync::Arc;
 
-use crate::discovery::ModelManager;
-use crate::preprocessor::LLMMetricAnnotation;
-use crate::protocols::openai::{
-    ParsingOptions,
-    completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
+use crate::protocols::openai::completions::{
+    NvCreateCompletionRequest, NvCreateCompletionResponse,
 };
 use crate::types::Annotated;
 
@@ -22,9 +19,8 @@ use super::kserve;
 // [gluo NOTE] These are common utilities that should be shared between frontends
 use crate::http::service::{
     disconnect::{ConnectionHandle, create_connection_monitor},
-    metrics::{Endpoint, ResponseMetricCollector},
+    metrics::{Endpoint, InflightGuard, process_response_and_observe_metrics},
 };
-use crate::http::service::metrics::InflightGuard;
 
 use tonic::Status;
 
@@ -118,13 +114,12 @@ pub async fn completion_response_stream(
     // Tap on the stream to collect response metrics and handle http_queue_guard
     let mut http_queue_guard = Some(http_queue_guard);
     let stream = stream.inspect(move |response| {
-        // Check if this is the first token and drop http_queue_guard
-        if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(response)
-            && response_collector.is_first_token() && metrics.chunk_tokens > 0
-            && let Some(guard) = http_queue_guard.take() {
-            drop(guard);
-        }
-        process_metrics_only(response, &mut response_collector);
+        // Calls observe_response() on each token - drops http_queue_guard on first token
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
     });
 
     let stream = grpc_monitor_for_disconnects(stream, ctx, inflight_guard, stream_handle);
@@ -176,18 +171,8 @@ pub fn grpc_monitor_for_disconnects<T>(
     }
 }
 
-fn process_metrics_only<T>(
-    annotated: &Annotated<T>,
-    response_collector: &mut ResponseMetricCollector,
-) {
-    // update metrics
-    if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(annotated) {
-        response_collector.observe_current_osl(metrics.output_tokens);
-        response_collector.observe_response(metrics.input_tokens, metrics.chunk_tokens);
-    }
-}
-
 /// Get the request ID from a primary source, or lastly create a new one if not present
+// TODO: Similar function exists in lib/llm/src/http/service/openai.rs but with different signature and more complex logic (distributed tracing, headers)
 fn get_or_create_request_id(primary: Option<&str>) -> String {
     // Try to get the request ID from the primary source
     if let Some(primary) = primary
@@ -199,11 +184,4 @@ fn get_or_create_request_id(primary: Option<&str>) -> String {
     // Try to parse the request ID as a UUID, or generate a new one if missing/invalid
     let uuid = uuid::Uuid::new_v4();
     uuid.to_string()
-}
-
-pub fn get_parsing_options(manager: &ModelManager, model: &str) -> ParsingOptions {
-    let tool_call_parser = manager.get_model_tool_call_parser(model);
-    let reasoning_parser = None; // TODO: Implement reasoning parser
-
-    ParsingOptions::new(tool_call_parser, reasoning_parser)
 }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -484,6 +484,11 @@ impl ResponseMetricCollector {
         self.osl = osl;
     }
 
+    /// Check if this will be the first token (before calling observe_response)
+    pub fn is_first_token(&self) -> bool {
+        self.is_first_token
+    }
+
     /// Observe a response with input sequence length and number of new tokens
     pub fn observe_response(&mut self, isl: usize, num_tokens: usize) {
         if num_tokens == 0 {

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -661,20 +661,6 @@ pub fn process_response_using_event_converter_and_observe_metrics<T: Serialize>(
     Ok(event)
 }
 
-/// Get parsing options for a model
-///
-/// Creates parsing options with tool call parser and reasoning parser for the specified model.
-/// Currently reasoning parser is not implemented (returns None).
-pub fn get_parsing_options(
-    manager: &crate::discovery::ModelManager,
-    model: &str,
-) -> crate::protocols::openai::ParsingOptions {
-    let tool_call_parser = manager.get_model_tool_call_parser(model);
-    let reasoning_parser = None; // TODO: Implement reasoning parser
-
-    crate::protocols::openai::ParsingOptions::new(tool_call_parser, reasoning_parser)
-}
-
 /// Create a new router with the given path
 pub fn router(registry: Registry, path: Option<String>) -> (Vec<RouteDoc>, Router) {
     let registry = Arc::new(registry);

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -1,11 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use axum::{Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
+use axum::{
+    Router,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, sse::Event},
+    routing::get,
+};
 use dynamo_runtime::metrics::prometheus_names::{
     frontend_service, name_prefix, sanitize_frontend_prometheus_prefix,
 };
 use prometheus::{Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts};
+use serde::Serialize;
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -26,6 +33,62 @@ pub struct Metrics {
     time_to_first_token: HistogramVec,
     inter_token_latency: HistogramVec,
 }
+
+/*
+This section explains the distinction between two key metrics used to track request processing:
+
+1. HTTP Queue: Tracks requests from HTTP handler start until first token generation begins
+2. Inflight: Tracks requests from HTTP handler start until the complete response is finished
+
+Example Request Flow:
+curl -s localhost:8000/v1/completions -H "Content-Type: application/json" -d '{
+  "model": "Qwen/Qwen3-0.6B",
+  "prompt": "Hello let's talk about LLMs",
+  "stream": false,
+  "max_tokens": 1000
+}'
+
+Timeline:    0, 1, ...
+Client ────> Frontend:8000 ────────────────────> Dynamo component/backend (vLLM, SGLang, TRT)
+             │request start                     │received                              │
+             |                                  |                                      |
+             │                                  ├──> start prefill ──> first token ──> |last token
+             │                                  │     (not impl)       |               |
+             ├─────actual HTTP queue¹ ──────────┘                      │               |
+             │                                                         │               │
+             ├─────implemented HTTP queue ─────────────────────────────┘               |
+             │                                                                         │
+             └─────────────────────────────────── Inflight ────────────────────────────┘
+
+Concurrency Example:
+Suppose the backend allows 3 concurrent requests and there are 10 clients continuously hitting the frontend:
+- 3 requests will be actively processed (between first token and last token)
+- 7 requests will be in HTTP queue most of the time
+- All 10 requests will be counted as inflight (from start until complete response)
+
+Testing Setup:
+Try launching a frontend and a Mocker backend that allows 3 concurrent requests:
+$ python -m dynamo.frontend --http-port 8000
+$ python -m dynamo.mocker --model-path Qwen/Qwen3-0.6B --max-num-seqs 3
+# Launch your 10 concurrent clients here
+# Then check the http_queued_requests and inflight_requests metrics from the frontend:
+$ curl -s localhost:8000/metrics|grep -v '^#'|grep -E 'queue|inflight'
+dynamo_frontend_http_queued_requests{model="qwen/qwen3-0.6b"} 7
+dynamo_frontend_inflight_requests{model="qwen/qwen3-0.6b"} 10
+
+# Real setup using vLLM (instead of Mocker):
+$ python -m dynamo.vllm --model Qwen/Qwen3-0.6B  \
+   --enforce-eager --no-enable-prefix-caching --max-num-seqs 3
+
+Key Differences:
+- HTTP Queue: Measures queuing time before processing begins
+- Inflight: Measures total request lifetime including processing time
+- HTTP Queue <= Inflight (HTTP queue is a subset of inflight time)
+
+TODO¹: Implement the "actual" HTTP queue metric that tracks from request start
+until first token generation begins, rather than the current implementation
+that tracks until first token is received by the frontend
+*/
 
 /// RAII object for HTTP queue gauge
 /// Tracks requests from HTTP handler start until metrics processing begins
@@ -151,7 +214,7 @@ impl Metrics {
 
         let http_queue_gauge = IntGaugeVec::new(
             Opts::new(
-                frontend_metric_name(frontend_service::HTTP_QUEUE),
+                frontend_metric_name(frontend_service::HTTP_QUEUED_REQUESTS),
                 "Number of requests in HTTP processing queue",
             ),
             &["model"],
@@ -326,6 +389,13 @@ impl Metrics {
     ///
     /// The [`InflightGuard`] is an RAII object will handle incrementing the inflight gauge and
     /// request counters.
+    ///
+    /// # Metrics Distinction
+    ///
+    /// This method creates an inflight guard that tracks requests actively being processed by the LLM engine.
+    /// This is distinct from [`HttpQueueGuard`] which tracks requests from HTTP handler start until
+    /// first token generation. The separation allows monitoring both HTTP processing queue time
+    /// and actual LLM processing time.
     pub fn create_inflight_guard(
         self: Arc<Self>,
         model: &str,
@@ -352,6 +422,9 @@ impl Metrics {
     }
 
     /// Create a new [`HttpQueueGuard`] for tracking HTTP processing queue
+    ///
+    /// This guard tracks requests from HTTP handler start until first token generation,
+    /// providing visibility into HTTP processing queue time before actual LLM processing begins.
     pub fn create_http_queue_guard(self: Arc<Self>, model: &str) -> HttpQueueGuard {
         HttpQueueGuard::new(self, model.to_string().to_lowercase())
     }
@@ -540,6 +613,117 @@ impl Drop for ResponseMetricCollector {
             .with_label_values(&[&self.model])
             .observe(self.osl as f64);
     }
+}
+
+/// Process streaming metrics for annotated responses
+///
+/// This function handles metrics collection and http_queue_guard management for streaming responses.
+/// It observes the current output sequence length, drops the http_queue_guard on the first token,
+/// and records response metrics.
+pub fn process_response_and_observe_metrics<T>(
+    annotated: &crate::types::Annotated<T>,
+    response_collector: &mut ResponseMetricCollector,
+    http_queue_guard: &mut Option<HttpQueueGuard>,
+) {
+    use crate::preprocessor::LLMMetricAnnotation;
+
+    // update metrics
+    if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(annotated) {
+        response_collector.observe_current_osl(metrics.output_tokens);
+
+        // Drop http_queue_guard on first token for non-streaming (same as streaming)
+        if response_collector.is_first_token()
+            && metrics.chunk_tokens > 0
+            && let Some(guard) = http_queue_guard.take()
+        {
+            drop(guard);
+        }
+
+        response_collector.observe_response(metrics.input_tokens, metrics.chunk_tokens);
+    }
+}
+
+/// Event converter wrapper for streaming responses
+pub struct EventConverter<T>(pub crate::types::Annotated<T>);
+
+impl<T> From<crate::types::Annotated<T>> for EventConverter<T> {
+    fn from(annotated: crate::types::Annotated<T>) -> Self {
+        EventConverter(annotated)
+    }
+}
+
+/// Process streaming response with event conversion for SSE
+///
+/// This function handles metrics collection, http_queue_guard management, and converts
+/// annotated responses to SSE events for streaming responses.
+pub fn process_response_using_event_converter_and_observe_metrics<T: Serialize>(
+    annotated: EventConverter<T>,
+    response_collector: &mut ResponseMetricCollector,
+    http_queue_guard: &mut Option<HttpQueueGuard>,
+) -> Result<Event, axum::Error> {
+    use crate::preprocessor::LLMMetricAnnotation;
+
+    let mut annotated = annotated.0;
+
+    // update metrics
+    if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(&annotated) {
+        response_collector.observe_current_osl(metrics.output_tokens);
+
+        // Drop http_queue_guard on first token for streaming
+        if response_collector.is_first_token()
+            && metrics.chunk_tokens > 0
+            && let Some(guard) = http_queue_guard.take()
+        {
+            drop(guard);
+        }
+
+        response_collector.observe_response(metrics.input_tokens, metrics.chunk_tokens);
+
+        // Chomp the LLMMetricAnnotation so it's not returned in the response stream
+        // TODO: add a flag to control what is returned in the SSE stream
+        if annotated.event.as_deref() == Some(crate::preprocessor::ANNOTATION_LLM_METRICS) {
+            annotated.event = None;
+            annotated.comment = None;
+        }
+    }
+
+    let mut event = Event::default();
+
+    if let Some(data) = annotated.data {
+        event = event.json_data(data)?;
+    }
+
+    if let Some(msg) = annotated.event {
+        if msg == "error" {
+            let msgs = annotated
+                .comment
+                .unwrap_or_else(|| vec!["unspecified error".to_string()]);
+            return Err(axum::Error::new(msgs.join(" -- ")));
+        }
+        event = event.event(msg);
+    }
+
+    if let Some(comments) = annotated.comment {
+        for comment in comments {
+            event = event.comment(comment);
+        }
+    }
+
+    Ok(event)
+}
+
+/// Get parsing options for a model
+///
+/// Creates parsing options with tool call parser and reasoning parser for the specified model.
+/// Currently reasoning parser is not implemented (returns None).
+pub fn get_parsing_options(
+    manager: &crate::discovery::ModelManager,
+    model: &str,
+) -> crate::protocols::openai::ParsingOptions {
+    let tool_call_parser = manager.get_model_tool_call_parser(model);
+    let reasoning_parser = None; // TODO: Implement reasoning parser
+
+    crate::protocols::openai::ParsingOptions::new(tool_call_parser, reasoning_parser)
 }
 
 /// Create a new router with the given path

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -13,7 +13,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{
         IntoResponse, Response,
-        sse::{Event, KeepAlive, Sse},
+        sse::{KeepAlive, Sse},
     },
     routing::{get, post},
 };
@@ -28,12 +28,14 @@ use super::{
     RouteDoc,
     disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
     error::HttpError,
-    metrics::{Endpoint, HttpQueueGuard, ResponseMetricCollector},
+    metrics::{
+        Endpoint, EventConverter, get_parsing_options, process_response_and_observe_metrics,
+        process_response_using_event_converter_and_observe_metrics,
+    },
     service_v2,
 };
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
 use crate::protocols::openai::{
-    ParsingOptions,
     chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionResponse},
     completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
     embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
@@ -41,7 +43,6 @@ use crate::protocols::openai::{
 };
 use crate::request_template::RequestTemplate;
 use crate::types::Annotated;
-use crate::{discovery::ModelManager, preprocessor::LLMMetricAnnotation};
 use dynamo_runtime::logging::get_distributed_tracing_context;
 use tracing::Instrument;
 
@@ -164,6 +165,7 @@ impl From<HttpError> for ErrorMessage {
 }
 
 /// Get the request ID from a primary source, or next from the headers, or lastly create a new one if not present
+// TODO: Similar function exists in lib/llm/src/grpc/service/openai.rs but with different signature and simpler logic
 fn get_or_create_request_id(primary: Option<&str>, headers: &HeaderMap) -> String {
     // Try to get request id from trace context
     if let Some(trace_context) = get_distributed_tracing_context()
@@ -193,13 +195,6 @@ fn get_or_create_request_id(primary: Option<&str>, headers: &HeaderMap) -> Strin
     };
 
     uuid.to_string()
-}
-
-fn get_parsing_options(manager: &ModelManager, model: &str) -> ParsingOptions {
-    let tool_call_parser = manager.get_model_tool_call_parser(model);
-    let reasoning_parser = None; // TODO: Implement reasoning parser
-
-    ParsingOptions::new(tool_call_parser, reasoning_parser)
 }
 
 /// OpenAI Completions Request Handler
@@ -284,17 +279,17 @@ async fn completions(
     // prepare to process any annotations
     let annotations = request.annotations();
 
+    // Create inflight_guard before calling engine to ensure errors are counted
+    let mut inflight_guard =
+        state
+            .metrics_clone()
+            .create_inflight_guard(&model, Endpoint::Completions, streaming);
+
     // issue the generate call on the engine
     let stream = engine
         .generate(request)
         .await
         .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate completions"))?;
-
-    // Create inflight_guard now that actual processing has begun
-    let mut inflight_guard =
-        state
-            .metrics_clone()
-            .create_inflight_guard(&model, Endpoint::Completions, streaming);
 
     // capture the context to cancel the stream if the client disconnects
     let ctx = stream.context();
@@ -324,7 +319,11 @@ async fn completions(
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.map(move |response| {
             // Calls observe_response() on each token
-            process_streaming_with_event_converter(EventConverter::from(response), &mut response_collector, &mut http_queue_guard)
+            process_response_using_event_converter_and_observe_metrics(
+                EventConverter::from(response),
+                &mut response_collector,
+                &mut http_queue_guard,
+            )
         });
         let stream = monitor_for_disconnects(stream, ctx, inflight_guard, stream_handle);
 
@@ -340,7 +339,11 @@ async fn completions(
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.inspect(move |response| {
             // Calls observe_response() on each token - drops http_queue_guard on first token
-            process_streaming_with_metrics(response, &mut response_collector, &mut http_queue_guard);
+            process_response_and_observe_metrics(
+                response,
+                &mut response_collector,
+                &mut http_queue_guard,
+            );
         });
 
         let response = NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
@@ -379,6 +382,9 @@ async fn embeddings(
     // todo - when optional, if none, apply a default
     let model = &request.inner.model;
 
+    // Create http_queue_guard early - tracks time waiting to be processed
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(model);
+
     // todo - error handling should be more robust
     let engine = state
         .manager()
@@ -391,11 +397,24 @@ async fn embeddings(
             .metrics_clone()
             .create_inflight_guard(model, Endpoint::Embeddings, streaming);
 
+    let mut response_collector = state.metrics_clone().create_response_collector(model);
+
     // issue the generate call on the engine
     let stream = engine
         .generate(request)
         .await
         .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate embeddings"))?;
+
+    // Process stream to collect metrics and drop http_queue_guard on first token
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream.inspect(move |response| {
+        // Calls observe_response() on each token - drops http_queue_guard on first token
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
+    });
 
     // Embeddings are typically returned as a single response (non-streaming)
     // so we fold the stream into a single response
@@ -519,17 +538,17 @@ async fn chat_completions(
 
     let annotations = request.annotations();
 
+    // Create inflight_guard before calling engine to ensure errors are counted
+    let mut inflight_guard =
+        state
+            .metrics_clone()
+            .create_inflight_guard(&model, Endpoint::ChatCompletions, streaming);
+
     // issue the generate call on the engine
     let stream = engine
         .generate(request)
         .await
         .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate completions"))?;
-
-    // Create inflight_guard now that actual processing has begun
-    let mut inflight_guard =
-        state
-            .metrics_clone()
-            .create_inflight_guard(&model, Endpoint::ChatCompletions, streaming);
 
     // capture the context to cancel the stream if the client disconnects
     let ctx = stream.context();
@@ -560,7 +579,11 @@ async fn chat_completions(
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.map(move |response| {
             // Calls observe_response() on each token
-            process_streaming_with_event_converter(EventConverter::from(response), &mut response_collector, &mut http_queue_guard)
+            process_response_using_event_converter_and_observe_metrics(
+                EventConverter::from(response),
+                &mut response_collector,
+                &mut http_queue_guard,
+            )
         });
         let stream = monitor_for_disconnects(stream, ctx, inflight_guard, stream_handle);
 
@@ -575,7 +598,11 @@ async fn chat_completions(
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.inspect(move |response| {
             // Calls observe_response() on each token - drops http_queue_guard on first token
-            process_streaming_with_metrics(response, &mut response_collector, &mut http_queue_guard);
+            process_response_and_observe_metrics(
+                response,
+                &mut response_collector,
+                &mut http_queue_guard,
+            );
         });
 
         let response =
@@ -771,7 +798,11 @@ async fn responses(
     let mut http_queue_guard = Some(http_queue_guard);
     let stream = stream.inspect(move |response| {
         // Calls observe_response() on each token - drops http_queue_guard on first token
-        process_streaming_with_metrics(response, &mut response_collector, &mut http_queue_guard);
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
     });
 
     // TODO: handle streaming, currently just unary
@@ -975,86 +1006,6 @@ struct ModelListing {
     created: u64,         //  Seconds since epoch
     owned_by: String,
 }
-
-struct EventConverter<T>(Annotated<T>);
-
-impl<T> From<Annotated<T>> for EventConverter<T> {
-    fn from(annotated: Annotated<T>) -> Self {
-        EventConverter(annotated)
-    }
-}
-
-fn process_streaming_with_metrics<T>(
-    annotated: &Annotated<T>,
-    response_collector: &mut ResponseMetricCollector,
-    http_queue_guard: &mut Option<HttpQueueGuard>,
-) {
-    // update metrics
-    if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(annotated) {
-        response_collector.observe_current_osl(metrics.output_tokens);
-
-        // Drop http_queue_guard on first token for non-streaming (same as streaming)
-        if response_collector.is_first_token() && metrics.chunk_tokens > 0
-            && let Some(guard) = http_queue_guard.take() {
-            drop(guard);
-        }
-
-        response_collector.observe_response(metrics.input_tokens, metrics.chunk_tokens);
-    }
-}
-
-fn process_streaming_with_event_converter<T: Serialize>(
-    annotated: EventConverter<T>,
-    response_collector: &mut ResponseMetricCollector,
-    http_queue_guard: &mut Option<HttpQueueGuard>,
-) -> Result<Event, axum::Error> {
-    let mut annotated = annotated.0;
-
-    // update metrics
-    if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(&annotated) {
-        response_collector.observe_current_osl(metrics.output_tokens);
-
-        // Drop http_queue_guard on first token for streaming
-        if response_collector.is_first_token() && metrics.chunk_tokens > 0
-            && let Some(guard) = http_queue_guard.take() {
-            drop(guard);
-        }
-
-        response_collector.observe_response(metrics.input_tokens, metrics.chunk_tokens);
-
-        // Chomp the LLMMetricAnnotation so it's not returned in the response stream
-        // TODO: add a flag to control what is returned in the SSE stream
-        if annotated.event.as_deref() == Some(crate::preprocessor::ANNOTATION_LLM_METRICS) {
-            annotated.event = None;
-            annotated.comment = None;
-        }
-    }
-
-    let mut event = Event::default();
-
-    if let Some(data) = annotated.data {
-        event = event.json_data(data)?;
-    }
-
-    if let Some(msg) = annotated.event {
-        if msg == "error" {
-            let msgs = annotated
-                .comment
-                .unwrap_or_else(|| vec!["unspecified error".to_string()]);
-            return Err(axum::Error::new(msgs.join(" -- ")));
-        }
-        event = event.event(msg);
-    }
-
-    if let Some(comments) = annotated.comment {
-        for comment in comments {
-            event = event.comment(comment);
-        }
-    }
-
-    Ok(event)
-}
-
 
 /// Create an Axum [`Router`] for the OpenAI API Completions endpoint
 /// If not path is provided, the default path is `/v1/completions`

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -29,7 +29,7 @@ use super::{
     disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
     error::HttpError,
     metrics::{
-        Endpoint, EventConverter, get_parsing_options, process_response_and_observe_metrics,
+        Endpoint, EventConverter, process_response_and_observe_metrics,
         process_response_using_event_converter_and_observe_metrics,
     },
     service_v2,
@@ -272,7 +272,7 @@ async fn completions(
         .get_completions_engine(&model)
         .map_err(|_| ErrorMessage::model_not_found())?;
 
-    let parsing_options = get_parsing_options(state.manager(), &model);
+    let parsing_options = state.manager().get_parsing_options(&model);
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
@@ -533,7 +533,7 @@ async fn chat_completions(
         .get_chat_completions_engine(&model)
         .map_err(|_| ErrorMessage::model_not_found())?;
 
-    let parsing_options = get_parsing_options(state.manager(), &model);
+    let parsing_options = state.manager().get_parsing_options(&model);
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
@@ -777,7 +777,7 @@ async fn responses(
         .get_chat_completions_engine(&model)
         .map_err(|_| ErrorMessage::model_not_found())?;
 
-    let parsing_options = get_parsing_options(state.manager(), &model);
+    let parsing_options = state.manager().get_parsing_options(&model);
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -486,9 +486,6 @@ async fn chat_completions(
 
     let request_id = request.id().to_string();
 
-    // Create http_queue_guard early - tracks time waiting to be processed
-    let model = request.inner.model.clone();
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
 
     // Handle unsupported fields - if Some(resp) is returned by
     // validate_chat_completion_unsupported_fields,
@@ -525,6 +522,11 @@ async fn chat_completions(
     // todo - make the protocols be optional for model name
     // todo - when optional, if none, apply a default
     // todo - determine the proper error code for when a request model is not present
+    let model = request.inner.model.clone();
+
+    // Create HTTP queue guard after template resolution so labels are correct
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+
     tracing::trace!("Getting chat completions engine for model: {}", model);
 
     let engine = state

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -486,7 +486,6 @@ async fn chat_completions(
 
     let request_id = request.id().to_string();
 
-
     // Handle unsupported fields - if Some(resp) is returned by
     // validate_chat_completion_unsupported_fields,
     // then a field was used that is unsupported. We will log an error message

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -28,7 +28,7 @@ use super::{
     RouteDoc,
     disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
     error::HttpError,
-    metrics::{Endpoint, ResponseMetricCollector},
+    metrics::{Endpoint, HttpQueueGuard, ResponseMetricCollector},
     service_v2,
 };
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
@@ -259,30 +259,27 @@ async fn completions(
     // todo - decide on default
     let streaming = request.inner.stream.unwrap_or(false);
 
+    // todo - make the protocols be optional for model name
+    // todo - when optional, if none, apply a default
+    let model = request.inner.model.clone();
+    // Create http_queue_guard early - tracks time waiting to be processed
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+
     // update the request to always stream
     let request = request.map(|mut req| {
         req.inner.stream = Some(true);
         req
     });
 
-    // todo - make the protocols be optional for model name
-    // todo - when optional, if none, apply a default
-    let model = &request.inner.model;
-
     // todo - error handling should be more robust
     let engine = state
         .manager()
-        .get_completions_engine(model)
+        .get_completions_engine(&model)
         .map_err(|_| ErrorMessage::model_not_found())?;
 
-    let parsing_options = get_parsing_options(state.manager(), model);
+    let parsing_options = get_parsing_options(state.manager(), &model);
 
-    let mut inflight_guard =
-        state
-            .metrics_clone()
-            .create_inflight_guard(model, Endpoint::Completions, streaming);
-
-    let mut response_collector = state.metrics_clone().create_response_collector(model);
+    let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
     // prepare to process any annotations
     let annotations = request.annotations();
@@ -292,6 +289,12 @@ async fn completions(
         .generate(request)
         .await
         .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate completions"))?;
+
+    // Create inflight_guard now that actual processing has begun
+    let mut inflight_guard =
+        state
+            .metrics_clone()
+            .create_inflight_guard(&model, Endpoint::Completions, streaming);
 
     // capture the context to cancel the stream if the client disconnects
     let ctx = stream.context();
@@ -317,8 +320,11 @@ async fn completions(
     let stream = stream::iter(annotations).chain(stream);
 
     if streaming {
+        // For streaming, we'll drop the http_queue_guard on the first token
+        let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.map(move |response| {
-            process_event_converter(EventConverter::from(response), &mut response_collector)
+            // Calls observe_response() on each token
+            process_streaming_with_event_converter(EventConverter::from(response), &mut response_collector, &mut http_queue_guard)
         });
         let stream = monitor_for_disconnects(stream, ctx, inflight_guard, stream_handle);
 
@@ -331,8 +337,10 @@ async fn completions(
         Ok(sse_stream.into_response())
     } else {
         // Tap the stream to collect metrics for non-streaming requests without altering items
+        let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.inspect(move |response| {
-            process_metrics_only(response, &mut response_collector);
+            // Calls observe_response() on each token - drops http_queue_guard on first token
+            process_streaming_with_metrics(response, &mut response_collector, &mut http_queue_guard);
         });
 
         let response = NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
@@ -459,10 +467,9 @@ async fn chat_completions(
 
     let request_id = request.id().to_string();
 
-    // Create HTTP queue guard to track time from HTTP start to metrics processing
-    let http_queue_guard = state
-        .metrics_clone()
-        .create_http_queue_guard(&request.inner.model);
+    // Create http_queue_guard early - tracks time waiting to be processed
+    let model = request.inner.model.clone();
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
 
     // Handle unsupported fields - if Some(resp) is returned by
     // validate_chat_completion_unsupported_fields,
@@ -498,24 +505,17 @@ async fn chat_completions(
 
     // todo - make the protocols be optional for model name
     // todo - when optional, if none, apply a default
-    let model = &request.inner.model;
-
     // todo - determine the proper error code for when a request model is not present
     tracing::trace!("Getting chat completions engine for model: {}", model);
 
     let engine = state
         .manager()
-        .get_chat_completions_engine(model)
+        .get_chat_completions_engine(&model)
         .map_err(|_| ErrorMessage::model_not_found())?;
 
-    let parsing_options = get_parsing_options(state.manager(), model);
+    let parsing_options = get_parsing_options(state.manager(), &model);
 
-    let mut inflight_guard =
-        state
-            .metrics_clone()
-            .create_inflight_guard(model, Endpoint::ChatCompletions, streaming);
-
-    let mut response_collector = state.metrics_clone().create_response_collector(model);
+    let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
     let annotations = request.annotations();
 
@@ -524,6 +524,12 @@ async fn chat_completions(
         .generate(request)
         .await
         .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate completions"))?;
+
+    // Create inflight_guard now that actual processing has begun
+    let mut inflight_guard =
+        state
+            .metrics_clone()
+            .create_inflight_guard(&model, Endpoint::ChatCompletions, streaming);
 
     // capture the context to cancel the stream if the client disconnects
     let ctx = stream.context();
@@ -549,11 +555,12 @@ async fn chat_completions(
     // note - we might do this as part of the post processing set to make it more generic
 
     if streaming {
-        drop(http_queue_guard); // Request is no longer waiting, now being processed
-        stream_handle.arm();
+        stream_handle.arm(); // allows the system to detect client disconnects and cancel the LLM generation
 
+        let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.map(move |response| {
-            process_event_converter(EventConverter::from(response), &mut response_collector)
+            // Calls observe_response() on each token
+            process_streaming_with_event_converter(EventConverter::from(response), &mut response_collector, &mut http_queue_guard)
         });
         let stream = monitor_for_disconnects(stream, ctx, inflight_guard, stream_handle);
 
@@ -565,9 +572,10 @@ async fn chat_completions(
 
         Ok(sse_stream.into_response())
     } else {
-        drop(http_queue_guard); // Request is no longer waiting, now being processed
+        let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.inspect(move |response| {
-            process_metrics_only(response, &mut response_collector);
+            // Calls observe_response() on each token - drops http_queue_guard on first token
+            process_streaming_with_metrics(response, &mut response_collector, &mut http_queue_guard);
         });
 
         let response =
@@ -681,6 +689,10 @@ async fn responses(
     // return a 503 if the service is not ready
     check_ready(&state)?;
 
+    // Create http_queue_guard early - tracks time waiting to be processed
+    let model = request.inner.model.clone();
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+
     // Handle unsupported fields - if Some(resp) is returned by validate_unsupported_fields,
     // then a field was used that is unsupported. We will log an error message
     // and early return a 501 NOT_IMPLEMENTED status code. Otherwise, proceeed.
@@ -730,23 +742,16 @@ async fn responses(
         request
     });
 
-    let model = &request.inner.model;
-
     tracing::trace!("Getting chat completions engine for model: {}", model);
 
     let engine = state
         .manager()
-        .get_chat_completions_engine(model)
+        .get_chat_completions_engine(&model)
         .map_err(|_| ErrorMessage::model_not_found())?;
 
-    let parsing_options = get_parsing_options(state.manager(), model);
+    let parsing_options = get_parsing_options(state.manager(), &model);
 
-    let mut inflight_guard =
-        state
-            .metrics_clone()
-            .create_inflight_guard(model, Endpoint::Responses, false);
-
-    let _response_collector = state.metrics_clone().create_response_collector(model);
+    let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
     tracing::trace!("Issuing generate call for chat completions");
 
@@ -755,6 +760,19 @@ async fn responses(
         .generate(request)
         .await
         .map_err(|e| ErrorMessage::from_anyhow(e, "Failed to generate completions"))?;
+
+    // Create inflight_guard now that actual processing has begun
+    let mut inflight_guard =
+        state
+            .metrics_clone()
+            .create_inflight_guard(&model, Endpoint::Responses, false);
+
+    // Process stream to collect metrics and drop http_queue_guard on first token
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream.inspect(move |response| {
+        // Calls observe_response() on each token - drops http_queue_guard on first token
+        process_streaming_with_metrics(response, &mut response_collector, &mut http_queue_guard);
+    });
 
     // TODO: handle streaming, currently just unary
     let response =
@@ -966,26 +984,42 @@ impl<T> From<Annotated<T>> for EventConverter<T> {
     }
 }
 
-fn process_metrics_only<T>(
+fn process_streaming_with_metrics<T>(
     annotated: &Annotated<T>,
     response_collector: &mut ResponseMetricCollector,
+    http_queue_guard: &mut Option<HttpQueueGuard>,
 ) {
     // update metrics
     if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(annotated) {
         response_collector.observe_current_osl(metrics.output_tokens);
+
+        // Drop http_queue_guard on first token for non-streaming (same as streaming)
+        if response_collector.is_first_token() && metrics.chunk_tokens > 0
+            && let Some(guard) = http_queue_guard.take() {
+            drop(guard);
+        }
+
         response_collector.observe_response(metrics.input_tokens, metrics.chunk_tokens);
     }
 }
 
-fn process_event_converter<T: Serialize>(
+fn process_streaming_with_event_converter<T: Serialize>(
     annotated: EventConverter<T>,
     response_collector: &mut ResponseMetricCollector,
+    http_queue_guard: &mut Option<HttpQueueGuard>,
 ) -> Result<Event, axum::Error> {
     let mut annotated = annotated.0;
 
     // update metrics
     if let Ok(Some(metrics)) = LLMMetricAnnotation::from_annotation(&annotated) {
         response_collector.observe_current_osl(metrics.output_tokens);
+
+        // Drop http_queue_guard on first token for streaming
+        if response_collector.is_first_token() && metrics.chunk_tokens > 0
+            && let Some(guard) = http_queue_guard.take() {
+            drop(guard);
+        }
+
         response_collector.observe_response(metrics.input_tokens, metrics.chunk_tokens);
 
         // Chomp the LLMMetricAnnotation so it's not returned in the response stream
@@ -1020,6 +1054,7 @@ fn process_event_converter<T: Serialize>(
 
     Ok(event)
 }
+
 
 /// Create an Axum [`Router`] for the OpenAI API Completions endpoint
 /// If not path is provided, the default path is `/v1/completions`

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -459,6 +459,11 @@ async fn chat_completions(
 
     let request_id = request.id().to_string();
 
+    // Create HTTP queue guard to track time from HTTP start to metrics processing
+    let http_queue_guard = state
+        .metrics_clone()
+        .create_http_queue_guard(&request.inner.model);
+
     // Handle unsupported fields - if Some(resp) is returned by
     // validate_chat_completion_unsupported_fields,
     // then a field was used that is unsupported. We will log an error message
@@ -512,7 +517,6 @@ async fn chat_completions(
 
     let mut response_collector = state.metrics_clone().create_response_collector(model);
 
-    tracing::trace!("Issuing generate call for chat completions");
     let annotations = request.annotations();
 
     // issue the generate call on the engine
@@ -545,6 +549,7 @@ async fn chat_completions(
     // note - we might do this as part of the post processing set to make it more generic
 
     if streaming {
+        drop(http_queue_guard); // Request is no longer waiting, now being processed
         stream_handle.arm();
 
         let stream = stream.map(move |response| {
@@ -560,6 +565,7 @@ async fn chat_completions(
 
         Ok(sse_stream.into_response())
     } else {
+        drop(http_queue_guard); // Request is no longer waiting, now being processed
         let stream = stream.inspect(move |response| {
             process_metrics_only(response, &mut response_collector);
         });

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -45,9 +45,8 @@ pub mod frontend_service {
     /// Total number of LLM requests processed
     pub const REQUESTS_TOTAL: &str = "requests_total";
 
-    /// Number of requests waiting in HTTP queue before receiving a response.
-    /// This can measure the engine pool exhaustion if the engine is not able to process requests fast enough.
-    pub const HTTP_QUEUE: &str = "http_queue";
+    /// Number of requests waiting in HTTP queue before receiving the first response.
+    pub const HTTP_QUEUED_REQUESTS: &str = "http_queued_requests";
 
     /// Number of inflight requests going to the engine (vLLM, SGLang, ...)
     pub const INFLIGHT_REQUESTS: &str = "inflight_requests";

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -45,7 +45,11 @@ pub mod frontend_service {
     /// Total number of LLM requests processed
     pub const REQUESTS_TOTAL: &str = "requests_total";
 
-    /// Number of inflight requests
+    /// Number of requests waiting in HTTP queue before receiving a response.
+    /// This can measure the engine pool exhaustion if the engine is not able to process requests fast enough.
+    pub const HTTP_QUEUE: &str = "http_queue";
+
+    /// Number of inflight requests going to the engine (vLLM, SGLang, ...)
     pub const INFLIGHT_REQUESTS: &str = "inflight_requests";
 
     /// Duration of LLM requests

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -46,10 +46,10 @@ pub mod frontend_service {
     pub const REQUESTS_TOTAL: &str = "requests_total";
 
     /// Number of requests waiting in HTTP queue before receiving the first response.
-    pub const HTTP_QUEUED_REQUESTS: &str = "http_queued_requests";
+    pub const QUEUED_REQUESTS_TOTAL: &str = "queued_requests_total";
 
     /// Number of inflight requests going to the engine (vLLM, SGLang, ...)
-    pub const INFLIGHT_REQUESTS: &str = "inflight_requests";
+    pub const INFLIGHT_REQUESTS_TOTAL: &str = "inflight_requests_total";
 
     /// Duration of LLM requests
     pub const REQUEST_DURATION_SECONDS: &str = "request_duration_seconds";

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -6,6 +6,34 @@
 //! This module provides centralized Prometheus metric name constants and sanitization functions
 //! for various components to ensure consistency and avoid duplication across the codebase.
 //!
+//! ## Naming Conventions
+//!
+//! All metric names should follow: `{prefix}_{name}_{suffix}`
+//!
+//! **Prefix**: Component identifier (`dynamo_component_`, `dynamo_frontend_`, etc.)
+//! **Name**: Descriptive snake_case name indicating what is measured
+//! **Suffix**:
+//!   - Units: `_seconds`, `_bytes`, `_ms`, `_percent`
+//!   - Counters: `_total` (not `total_` prefix)
+//!   - Note: Do not use `_counter`, `_gauge`, `_time`, or `_size` in Prometheus names (too vague)
+//!
+//! **Common Transformations**:
+//! - ❌ `_counter` → ✅ `_total`
+//! - ❌ `_time` → ✅ `_seconds`, `_ms`, `_hours`, `_duration_seconds`
+//! - ❌ `_size` → ✅ `_bytes`, `_total`, `_length`
+//! - ❌ `_gauge` → ✅ (no suffix needed for current values)
+//! - ❌ `_rate` → ✅ `_per_second`, `_per_minute`
+//!
+//! **Examples**:
+//! - ✅ `dynamo_frontend_requests_total` - Total request counter (not `incoming_requests`)
+//! - ✅ `dynamo_frontend_request_duration_seconds` - Request duration histogram (not `response_time`)
+//! - ✅ `dynamo_component_errors_total` - Total error counter (not `total_errors`)
+//! - ✅ `dynamo_component_memory_usage_bytes` - Memory usage gauge
+//! - ✅ `dynamo_frontend_inflight_requests_total` - Current inflight requests gauge
+//! - ✅ `nats_client_connection_duration_ms` - Connection time in milliseconds
+//! - ✅ `dynamo_component_cpu_usage_percent` - CPU usage percentage
+//! - ✅ `dynamo_frontend_tokens_per_second` - Token generation rate
+//!
 //! ## Key Differences: Prometheus Metric Names vs Prometheus Label Names
 //!
 //! **Metric names**: Allow colons and `__` anywhere. **Label names**: No colons, no `__` prefix.


### PR DESCRIPTION
#### Overview:

This PR implements HTTP queue metrics for frontend request tracking to monitor request processing pipeline performance and detect engine pool exhaustion.

#### Details:

- Add new HTTP queue gauge metric to track requests waiting in HTTP processing queue
- Implement HttpQueueGuard RAII object for automatic queue time tracking from HTTP handler start to metrics processing
- Integrate HTTP queue tracking in OpenAI chat completions handler
- Add HTTP_QUEUE prometheus metric name constant
- Track time from request arrival until engine processing begins to identify bottlenecks

#### Where should the reviewer start?

- `lib/llm/src/http/service/metrics.rs` - New HTTP queue gauge and HttpQueueGuard implementation
- `lib/llm/src/http/service/openai.rs` - Integration of HTTP queue tracking in chat completions
- `lib/runtime/src/metrics/prometheus_names.rs` - New metric name constant

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to DIS-564, DIS-563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an HTTP queue metric to monitor the number of requests waiting before processing, exposed via Prometheus with per-model labeling.
  - Improved timing accuracy for request lifecycle metrics.
  - Instrumentation updates in chat completions ensure queue time is measured until processing begins, including streaming and non-streaming paths.

- Documentation
  - Clarified the definition of the inflight requests metric to indicate it covers requests sent to the engine (e.g., vLLM, SGLang).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->