### PR TITLE
fix: fix hermes tool call config

### DIFF
--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -81,7 +81,7 @@ impl ToolCallConfig {
             format: ToolCallParserType::Json,
             json: JsonParserConfig {
                 tool_call_start_tokens: vec!["<tool_call>".to_string()],
-                tool_call_end_tokens: vec!["\n</tool_call>".to_string()],
+                tool_call_end_tokens: vec!["</tool_call>".to_string()],
                 ..Default::default()
             },
         }

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -1186,4 +1186,17 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         assert_eq!(name, "get_current_weather");
         assert_eq!(args["location"], "Paris");
     }
+
+    #[test]
+    fn test_hermes_parser_without_new_line() {
+        let input = r#"<tool_call>{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "celsius"}}</tool_call>"
+        "#;
+        let (result, content) = detect_and_parse_tool_call(input, Some("hermes")).unwrap();
+        assert_eq!(content, Some("".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "San Francisco, CA");
+        assert_eq!(args["unit"], "celsius");
+    }
 }


### PR DESCRIPTION
#### Overview:

There was a bug in hermes tool calling config end token which included \n. This PR fixes that. Some models were failing because of this.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tool-call parsing to correctly recognize the closing tag without a leading newline, ensuring reliable handling of single-line tool-call payloads and accurate extraction of tool names and arguments.

- **Tests**
  - Added coverage to validate Hermes parser behavior without a trailing newline, preventing regressions and confirming correct parsing of tool-call name and arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->