### PR TITLE
fix: fixed failing health probes to enable state transition between s…

### DIFF
--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -28,6 +28,7 @@ matplotlib
 msgspec
 mypy
 numpy==1.26.4 # pmdarima is not compatible with numpy 2
+nvidia-ml-py
 opentelemetry-api
 opentelemetry-sdk
 pip
@@ -37,7 +38,6 @@ prometheus-api-client
 prophet
 protobuf==5.29.5
 pydantic==2.7.1
-nvidia-ml-py
 pyright
 PyYAML
 scikit-learn

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -37,7 +37,7 @@ prometheus-api-client
 prophet
 protobuf==5.29.5
 pydantic==2.7.1
-pynvml
+nvidia-ml-py
 pyright
 PyYAML
 scikit-learn

--- a/lib/runtime/src/config.rs
+++ b/lib/runtime/src/config.rs
@@ -70,7 +70,7 @@ pub enum HealthTransitionPolicy {
     /// Ready when service has registered at least one endpoint
     EndpointBasedReady,
     /// Custom readiness logic with configurable parameters
-    Custom { 
+    Custom {
         auto_ready_after_seconds: Option<u64>,
         require_endpoints_ready: bool,
     },

--- a/lib/runtime/src/config.rs
+++ b/lib/runtime/src/config.rs
@@ -237,7 +237,6 @@ impl RuntimeConfig {
     /// Environment variables are prefixed with `DYN_RUNTIME_` and `DYN_SYSTEM`
     pub fn from_settings() -> Result<RuntimeConfig> {
         let mut config: RuntimeConfig = Self::figment().extract()?;
-        
         // Handle DYN_SYSTEM_AUTO_READY_AFTER_SECONDS environment variable
         // This provides a convenient shortcut for time-based health transition
         if let Ok(seconds_str) = std::env::var("DYN_SYSTEM_AUTO_READY_AFTER_SECONDS") {
@@ -250,7 +249,6 @@ impl RuntimeConfig {
                 }
             }
         }
-        
         config.validate()?;
         Ok(config)
     }

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -75,11 +75,13 @@ impl DistributedRuntime {
         };
         let starting_health_status = config.starting_health_status.clone();
         let use_endpoint_health_status = config.use_endpoint_health_status.clone();
+        let health_transition_policy = config.health_transition_policy.clone();
         let health_endpoint_path = config.system_health_path.clone();
         let live_endpoint_path = config.system_live_path.clone();
         let system_health = Arc::new(std::sync::Mutex::new(SystemHealth::new(
             starting_health_status,
             use_endpoint_health_status,
+            health_transition_policy,
             health_endpoint_path,
             live_endpoint_path,
         )));

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -140,7 +140,6 @@ impl SystemHealth {
         }
 
         let uptime = self.start_time.elapsed();
-        
         match &self.health_transition_policy {
             HealthTransitionPolicy::Manual => {
                 // No automatic transition (current behavior)
@@ -156,9 +155,9 @@ impl SystemHealth {
                 if !self.endpoint_health.is_empty() {
                     let all_endpoints_ready = self.endpoint_health.values()
                         .all(|status| *status == HealthStatus::Ready);
-                    
+
                     if all_endpoints_ready {
-                        tracing::info!("Auto-transitioning to ready - all {} endpoints are ready (policy: endpoint_based_ready)", 
+                        tracing::info!("Auto-transitioning to ready - all {} endpoints are ready (policy: endpoint_based_ready)",
                                      self.endpoint_health.len());
                         self.system_health = HealthStatus::Ready;
                     }
@@ -166,14 +165,14 @@ impl SystemHealth {
             },
             HealthTransitionPolicy::Custom { auto_ready_after_seconds, require_endpoints_ready } => {
                 let mut ready_conditions_met = true;
-                
+
                 // Check time-based condition if specified
                 if let Some(after_seconds) = auto_ready_after_seconds {
                     if uptime.as_secs() < *after_seconds {
                         ready_conditions_met = false;
                     }
                 }
-                
+
                 // Check endpoint-based condition if required
                 if *require_endpoints_ready {
                     if self.endpoint_health.is_empty() {
@@ -186,7 +185,7 @@ impl SystemHealth {
                         }
                     }
                 }
-                
+
                 if ready_conditions_met {
                     tracing::info!("Auto-transitioning to ready after {}s uptime (policy: custom)", uptime.as_secs());
                     self.system_health = HealthStatus::Ready;
@@ -200,7 +199,7 @@ impl SystemHealth {
     pub fn get_health_status_with_transition_check(&mut self) -> (bool, HashMap<String, String>) {
         // Check for automatic health transitions BEFORE reporting status
         self.check_and_update_health_status();
-        
+
         // Now get the current status
         self.get_health_status()
     }

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -65,7 +65,7 @@ use crate::metrics::prometheus_names::distributed_runtime;
 use component::{Endpoint, InstanceSource};
 use utils::GracefulShutdownTracker;
 
-use config::HealthStatus;
+use config::{HealthStatus, HealthTransitionPolicy};
 
 /// Types of Tokio runtimes that can be used to construct a Dynamo [Runtime].
 #[derive(Clone)]
@@ -94,6 +94,7 @@ pub struct SystemHealth {
     system_health: HealthStatus,
     endpoint_health: HashMap<String, HealthStatus>,
     use_endpoint_health_status: Vec<String>,
+    health_transition_policy: HealthTransitionPolicy,
     health_path: String,
     live_path: String,
     start_time: Instant,
@@ -104,6 +105,7 @@ impl SystemHealth {
     pub fn new(
         starting_health_status: HealthStatus,
         use_endpoint_health_status: Vec<String>,
+        health_transition_policy: HealthTransitionPolicy,
         health_path: String,
         live_path: String,
     ) -> Self {
@@ -115,6 +117,7 @@ impl SystemHealth {
             system_health: starting_health_status,
             endpoint_health,
             use_endpoint_health_status,
+            health_transition_policy,
             health_path,
             live_path,
             start_time: Instant::now(),
@@ -129,7 +132,80 @@ impl SystemHealth {
         self.endpoint_health.insert(endpoint.to_string(), status);
     }
 
-    /// Returns the overall health status and endpoint health statuses
+    /// Check and automatically update health status based on transition policy
+    /// This is the core fix for the health transition issue
+    pub fn check_and_update_health_status(&mut self) {
+        if self.system_health == HealthStatus::Ready {
+            return; // Already ready, no need to transition
+        }
+
+        let uptime = self.start_time.elapsed();
+        
+        match &self.health_transition_policy {
+            HealthTransitionPolicy::Manual => {
+                // No automatic transition (current behavior)
+            },
+            HealthTransitionPolicy::TimeBasedReady { after_seconds } => {
+                if uptime.as_secs() >= *after_seconds {
+                    tracing::info!("Auto-transitioning to ready after {}s uptime (policy: time_based_ready)", uptime.as_secs());
+                    self.system_health = HealthStatus::Ready;
+                }
+            },
+            HealthTransitionPolicy::EndpointBasedReady => {
+                // Ready when service has registered at least one endpoint
+                if !self.endpoint_health.is_empty() {
+                    let all_endpoints_ready = self.endpoint_health.values()
+                        .all(|status| *status == HealthStatus::Ready);
+                    
+                    if all_endpoints_ready {
+                        tracing::info!("Auto-transitioning to ready - all {} endpoints are ready (policy: endpoint_based_ready)", 
+                                     self.endpoint_health.len());
+                        self.system_health = HealthStatus::Ready;
+                    }
+                }
+            },
+            HealthTransitionPolicy::Custom { auto_ready_after_seconds, require_endpoints_ready } => {
+                let mut ready_conditions_met = true;
+                
+                // Check time-based condition if specified
+                if let Some(after_seconds) = auto_ready_after_seconds {
+                    if uptime.as_secs() < *after_seconds {
+                        ready_conditions_met = false;
+                    }
+                }
+                
+                // Check endpoint-based condition if required
+                if *require_endpoints_ready {
+                    if self.endpoint_health.is_empty() {
+                        ready_conditions_met = false;
+                    } else {
+                        let all_endpoints_ready = self.endpoint_health.values()
+                            .all(|status| *status == HealthStatus::Ready);
+                        if !all_endpoints_ready {
+                            ready_conditions_met = false;
+                        }
+                    }
+                }
+                
+                if ready_conditions_met {
+                    tracing::info!("Auto-transitioning to ready after {}s uptime (policy: custom)", uptime.as_secs());
+                    self.system_health = HealthStatus::Ready;
+                }
+            }
+        }
+    }
+
+    /// Check for automatic transitions and return the overall health status and endpoint health statuses
+    /// This is the main method that should be called by the health handler
+    pub fn get_health_status_with_transition_check(&mut self) -> (bool, HashMap<String, String>) {
+        // Check for automatic health transitions BEFORE reporting status
+        self.check_and_update_health_status();
+        
+        // Now get the current status
+        self.get_health_status()
+    }
+
+    /// Returns the overall health status and endpoint health statuses (read-only)
     pub fn get_health_status(&self) -> (bool, HashMap<String, String>) {
         let mut endpoints: HashMap<String, String> = HashMap::new();
         for (endpoint, ready) in &self.endpoint_health {

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -171,8 +171,8 @@ pub async fn spawn_system_status_server(
 /// Health handler
 #[tracing::instrument(skip_all, level = "trace")]
 async fn health_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
-    let system_health = state.drt().system_health.lock().unwrap();
-    let (healthy, endpoints) = system_health.get_health_status();
+    let mut system_health = state.drt().system_health.lock().unwrap();
+    let (healthy, endpoints) = system_health.get_health_status_with_transition_check();
     let uptime = Some(system_health.uptime());
 
     let healthy_string = if healthy { "ready" } else { "notready" };


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

This fix solves deployment where health probes were failing because services never transitioned to ready state.

#### Details:

<!-- Describe the changes made in this PR. -->

 Files Modified:

  1. /code/dynamo/lib/runtime/src/config.rs

  - Added HealthTransitionPolicy enum with 4 options:
    - Manual - No auto-transition (original behavior)
    - TimeBasedReady { after_seconds } - Auto-ready after uptime
    - EndpointBasedReady - Ready when endpoints are registered
    - Custom { auto_ready_after_seconds, require_endpoints_ready } - Flexible logic
  - Added health_transition_policy field to RuntimeConfig struct
  - Added environment variable mapping for:
    - DYN_SYSTEM_HEALTH_TRANSITION_POLICY
    - DYN_SYSTEM_AUTO_READY_AFTER_SECONDS
  - Default policy: TimeBasedReady { after_seconds: 30 } (much better than Manual!)

  2. /code/dynamo/lib/runtime/src/lib.rs

  - Updated SystemHealth struct to include health_transition_policy field
  - Added check_and_update_health_status() method with transition logic for all policies
  - Added get_health_status_with_transition_check() method for the health handler to use
  - Updated constructor to accept health_transition_policy parameter

  3. /code/dynamo/lib/runtime/src/system_status_server.rs

  - Updated health_handler() to use mutable lock and call the transition check method
  - Fixed the core issue: Health status now automatically transitions from "notready" to "ready"

  4. /code/dynamo/lib/runtime/src/distributed.rs

  - Updated SystemHealth::new() call to include the health_transition_policy parameter


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
1. from health_handler in system_status_server.rs I have state transition check.
2. check that how to config should be in dynamo/lib/runtime/src/config.rs and dynamo/lib/runtime/src/lib.rs


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #2916 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configurable health transition policy with manual, time-based, endpoint-based, and custom options.
  - Automatic readiness transitions based on uptime and/or endpoint status.
  - Health checks now evaluate and apply transitions during requests for more accurate status.
  - Uptime reporting: expose current uptime and a gauge for metrics backends.
  - New configuration via environment variables: DYN_SYSTEM_HEALTH_TRANSITION_POLICY, HEALTH_TRANSITION_POLICY, AUTO_READY_AFTER_SECONDS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->