### PR TITLE
fix: CI is broken with a deprecated dependency on pynvml

### DIFF
--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 accelerate==1.6.0
 aiofiles

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -28,6 +28,7 @@ matplotlib
 msgspec
 mypy
 numpy==1.26.4 # pmdarima is not compatible with numpy 2
+nvidia-ml-py==13.580.65
 opentelemetry-api
 opentelemetry-sdk
 pip
@@ -37,7 +38,6 @@ prometheus-api-client
 prophet
 protobuf==5.29.5
 pydantic==2.7.1
-pynvml
 pyright
 PyYAML
 scikit-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ filterwarnings = [
     "ignore:.*unclosed.*socket.*:ResourceWarning", # Ignore unclosed socket warnings
     "ignore:.*unclosed event loop.*:ResourceWarning", # Ignore unclosed event loop warnings
     "ignore:.*Exception ignored in.*:pytest.PytestUnraisableExceptionWarning", # Ignore unraisable exception warnings
+    "ignore:The pynvml package is deprecated.*:FutureWarning", # Ignore pynvml deprecation warning, temporary until upstream library updates to nvidia-ml-py
 ]
 
 


### PR DESCRIPTION
#### Overview:

`pynvml` is deprecated and is breaking CI. It is recommended to be replaced with `nvidia-ml-py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes OPS-995


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Replaced deprecated GPU monitoring dependency with a maintained alternative to improve compatibility and reliability during installation and runtime.
  - Removed obsolete dependency to reduce deprecation risks.

- Tests
  - Suppressed a noisy deprecation warning in test runs to produce cleaner CI output.

- Notes
  - No user-facing features or application logic changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->