### PR TITLE
chore: Update trtllm version to 1.1.0rc3

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/
 
 > [!Note]
 > Ensure that you select a PyTorch container image version that matches the version of TensorRT-LLM you are using.
-> For example, if you are using `tensorrt-llm==1.0.0rc6`, use the PyTorch container image version `25.06`.
+> For example, if you are using `tensorrt-llm==1.1.0rc1`, use the PyTorch container image version `25.06`.
 > To find the correct PyTorch container version for your desired `tensorrt-llm` release, visit the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) on GitHub. Switch to the branch that matches your `tensorrt-llm` version, and look for the `BASE_TAG` line to identify the recommended PyTorch container tag.
 
 > [!Important]

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/
 
 > [!Note]
 > Ensure that you select a PyTorch container image version that matches the version of TensorRT-LLM you are using.
-> For example, if you are using `tensorrt-llm==1.1.0rc1`, use the PyTorch container image version `25.06`.
+> For example, if you are using `tensorrt-llm==1.1.0rc3`, use the PyTorch container image version `25.06`.
 > To find the correct PyTorch container version for your desired `tensorrt-llm` release, visit the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) on GitHub. Switch to the branch that matches your `tensorrt-llm` version, and look for the `BASE_TAG` line to identify the recommended PyTorch container tag.
 
 > [!Important]

--- a/components/backends/trtllm/engine_configs/decode.yaml
+++ b/components/backends/trtllm/engine_configs/decode.yaml
@@ -28,4 +28,4 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.85
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/deepseek_r1/mtp/mtp_decode.yaml
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/mtp/mtp_decode.yaml
@@ -54,4 +54,4 @@ cuda_graph_config:
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/deepseek_r1/mtp/mtp_prefill.yaml
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/mtp/mtp_prefill.yaml
@@ -38,4 +38,4 @@ speculative_config:
   num_nextn_predict_layers: 1
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/deepseek_r1/simple/decode.yaml
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/simple/decode.yaml
@@ -57,4 +57,4 @@ cuda_graph_config:
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/deepseek_r1/simple/prefill.yaml
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/simple/prefill.yaml
@@ -36,4 +36,4 @@ disable_overlap_scheduler: true
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/wide_ep_decode.yaml
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/wide_ep_decode.yaml
@@ -63,4 +63,4 @@ cuda_graph_config:
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/wide_ep_prefill.yaml
+++ b/components/backends/trtllm/engine_configs/deepseek_r1/wide_ep/wide_ep_prefill.yaml
@@ -41,4 +41,4 @@ disable_overlap_scheduler: true
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/encode.yaml
+++ b/components/backends/trtllm/engine_configs/encode.yaml
@@ -27,4 +27,4 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.85
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/gemma3/vswa_decode.yaml
+++ b/components/backends/trtllm/engine_configs/gemma3/vswa_decode.yaml
@@ -26,4 +26,4 @@ kv_cache_config:
     - 32768
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/gemma3/vswa_prefill.yaml
+++ b/components/backends/trtllm/engine_configs/gemma3/vswa_prefill.yaml
@@ -27,4 +27,4 @@ kv_cache_config:
     - 32768
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/gpt_oss/decode.yaml
+++ b/components/backends/trtllm/engine_configs/gpt_oss/decode.yaml
@@ -19,7 +19,7 @@ moe_config:
 cuda_graph_config:
     enable_padding: true
 cache_transceiver_config:
-  backend: ucx
+  backend: UCX
   max_tokens_in_buffer: 65536
 print_iter_log: false
 stream_interval: 10

--- a/components/backends/trtllm/engine_configs/gpt_oss/prefill.yaml
+++ b/components/backends/trtllm/engine_configs/gpt_oss/prefill.yaml
@@ -21,7 +21,7 @@ cuda_graph_config:
     max_batch_size: 32
     enable_padding: true
 cache_transceiver_config:
-  backend: ucx
+  backend: UCX
   max_tokens_in_buffer: 65536
 print_iter_log: false
 stream_interval: 10

--- a/components/backends/trtllm/engine_configs/llama4/eagle/eagle_decode.yaml
+++ b/components/backends/trtllm/engine_configs/llama4/eagle/eagle_decode.yaml
@@ -49,4 +49,4 @@ cuda_graph_config:
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/llama4/eagle/eagle_prefill.yaml
+++ b/components/backends/trtllm/engine_configs/llama4/eagle/eagle_prefill.yaml
@@ -34,4 +34,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/multimodal/agg.yaml
+++ b/components/backends/trtllm/engine_configs/multimodal/agg.yaml
@@ -26,7 +26,7 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT
 # NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
 # NOTE: overlap_scheduler enabled by default since this commit and changed
 # config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':

--- a/components/backends/trtllm/engine_configs/multimodal/decode.yaml
+++ b/components/backends/trtllm/engine_configs/multimodal/decode.yaml
@@ -26,4 +26,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/multimodal/llama4/decode.yaml
+++ b/components/backends/trtllm/engine_configs/multimodal/llama4/decode.yaml
@@ -26,4 +26,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/multimodal/llama4/prefill.yaml
+++ b/components/backends/trtllm/engine_configs/multimodal/llama4/prefill.yaml
@@ -28,4 +28,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/multimodal/prefill.yaml
+++ b/components/backends/trtllm/engine_configs/multimodal/prefill.yaml
@@ -28,4 +28,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/engine_configs/prefill.yaml
+++ b/components/backends/trtllm/engine_configs/prefill.yaml
@@ -27,4 +27,4 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.85
 
 cache_transceiver_config:
-  backend: default
+  backend: DEFAULT

--- a/components/backends/trtllm/multimodal_support.md
+++ b/components/backends/trtllm/multimodal_support.md
@@ -14,24 +14,6 @@ limitations under the License.
 
 # Multimodal Support
 
-> [!Important]
-> There are some known issues in tensorrt_llm==1.0.0rc6 version for multimodal support
-> It is important to rebuild the dynamo container with a specific version of tensorrt_llm
-> commit to use multimodal feature.
-## Build Container
-
-```bash
-./container/build.sh --framework trtllm --tensorrtllm-commit b4065d8ca64a64eee9fdc64b39cb66d73d4be47c
-```
-
-## Run Container
-
-```bash
-./container/run.sh --framework trtllm -it
-```
-
-## Usage Guide
-
 TRTLLM supports multimodal models with dynamo. You can provide multimodal inputs in the following ways:
 
 - By sending image URLs

--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -8,7 +8,6 @@ import signal
 import sys
 
 import uvloop
-from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.llmapi import (
     BuildConfig,
     CapacitySchedulerPolicy,
@@ -16,6 +15,7 @@ from tensorrt_llm.llmapi import (
     KvCacheConfig,
     SchedulerConfig,
 )
+from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.llmapi.tokenizer import tokenizer_factory
 from torch.cuda import device_count

--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -8,7 +8,7 @@ import signal
 import sys
 
 import uvloop
-from tensorrt_llm import SamplingParams
+from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.llmapi import (
     BuildConfig,
     CapacitySchedulerPolicy,

--- a/components/backends/trtllm/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -21,8 +21,8 @@ from enum import Enum
 from typing import Optional, Union
 
 import torch
-from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
+from tensorrt_llm.llmapi.llm import SamplingParams
 
 from dynamo.logits_processing.examples import HelloWorldLogitsProcessor
 from dynamo.nixl_connect import Connector

--- a/components/backends/trtllm/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -21,7 +21,7 @@ from enum import Enum
 from typing import Optional, Union
 
 import torch
-from tensorrt_llm import SamplingParams
+from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
 
 from dynamo.logits_processing.examples import HelloWorldLogitsProcessor

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -140,7 +140,6 @@ COPY --from=trtllm_wheel . /trtllm_wheel/
 # Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel
 # because there might be mismatched versions of TensorRT between the NGC PyTorch
 # and the TRTLLM wheel.
-# Locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.1.0rc1
 RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
     pip uninstall -y tensorrt && \
     if [ "$HAS_TRTLLM_CONTEXT" = "1" ]; then \
@@ -148,9 +147,6 @@ RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
         WHEEL_FILE=$(find /trtllm_wheel -name "*.whl" | head -n 1); \
         if [ -n "$WHEEL_FILE" ]; then \
             pip install "$WHEEL_FILE"; \
-            if [ "$ARCH" = "amd64" ]; then \
-                pip install "triton==3.3.1"; \
-            fi; \
         else \
             echo "No wheel file found in /trtllm_wheel directory."; \
             exit 1; \
@@ -158,9 +154,6 @@ RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
     else \
         # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
         pip install --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}"; \
-        if [ "$ARCH" = "amd64" ]; then \
-            pip install "triton==3.3.1"; \
-        fi; \
     fi
 
 # Install test dependencies
@@ -477,12 +470,7 @@ COPY --from=dev /workspace/target/release/metrics /usr/local/bin/metrics
 # NOTE: If a package (tensorrt_llm) exists on both --index-url and --extra-index-url,
 # uv will prioritize the --extra-index-url, unless --index-strategy unsafe-best-match
 # is also specified. So set the configurable index as a --extra-index-url for prioritization.
-# NOTE: locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.1.0rc1
-# NOTE: locking cuda-python version to <13 to avoid breaks with tensorrt-llm 1.1.0rc1. This
-#       can be removed after https://github.com/NVIDIA/TensorRT-LLM/pull/6703 is merged
-#       we upgrade to a published pip wheel containing this change.
-RUN python3 -m pip install --no-cache-dir --break-system-packages "cuda-python>=12,<13" && \
-    python3 -m pip install --no-cache-dir --break-system-packages --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" && \
+RUN python3 -m pip install --no-cache-dir --break-system-packages --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" && \
     python3 -m pip install --no-cache-dir --break-system-packages \
         /workspace/wheelhouse/ai_dynamo_runtime*cp312*.whl \
         /workspace/wheelhouse/ai_dynamo*any.whl \

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -140,7 +140,7 @@ COPY --from=trtllm_wheel . /trtllm_wheel/
 # Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel
 # because there might be mismatched versions of TensorRT between the NGC PyTorch
 # and the TRTLLM wheel.
-# Locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc6
+# Locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.1.0rc1
 RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true && \
     pip uninstall -y tensorrt && \
     if [ "$HAS_TRTLLM_CONTEXT" = "1" ]; then \
@@ -477,8 +477,8 @@ COPY --from=dev /workspace/target/release/metrics /usr/local/bin/metrics
 # NOTE: If a package (tensorrt_llm) exists on both --index-url and --extra-index-url,
 # uv will prioritize the --extra-index-url, unless --index-strategy unsafe-best-match
 # is also specified. So set the configurable index as a --extra-index-url for prioritization.
-# NOTE: locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.0.0rc6
-# NOTE: locking cuda-python version to <13 to avoid breaks with tensorrt-llm 1.0.0rc6. This
+# NOTE: locking triton version to 3.3.1 as 3.4.0 breaks tensorrt-llm 1.1.0rc1
+# NOTE: locking cuda-python version to <13 to avoid breaks with tensorrt-llm 1.1.0rc1. This
 #       can be removed after https://github.com/NVIDIA/TensorRT-LLM/pull/6703 is merged
 #       we upgrade to a published pip wheel containing this change.
 RUN python3 -m pip install --no-cache-dir --break-system-packages "cuda-python>=12,<13" && \

--- a/container/build.sh
+++ b/container/build.sh
@@ -89,7 +89,7 @@ TENSORRTLLM_PIP_WHEEL_DIR="/tmp/trtllm_wheel/"
 # TensorRT-LLM commit to use for building the trtllm wheel if not provided.
 # Important Note: This commit is not used in our CI pipeline. See the CI
 # variables to learn how to run a pipeline with a specific commit.
-DEFAULT_EXPERIMENTAL_TRTLLM_COMMIT="a16ba6445c61ed70e7aadfe787d6f316bb422652"
+DEFAULT_EXPERIMENTAL_TRTLLM_COMMIT="e81c50dbd2811ec858eccc2c71b5e7a330ff7e24"
 TRTLLM_COMMIT=""
 TRTLLM_USE_NIXL_KVCACHE_EXPERIMENTAL="0"
 TRTLLM_GIT_URL=""

--- a/container/build.sh
+++ b/container/build.sh
@@ -98,7 +98,7 @@ TRTLLM_GIT_URL=""
 TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"
 # TODO: Remove the version specification from here and use the ai-dynamo[trtllm] package.
 # Need to update the Dockerfile.trtllm to use the ai-dynamo[trtllm] package.
-DEFAULT_TENSORRTLLM_PIP_WHEEL="tensorrt-llm==1.1.0rc1"
+DEFAULT_TENSORRTLLM_PIP_WHEEL="tensorrt-llm==1.1.0rc3"
 TENSORRTLLM_PIP_WHEEL=""
 
 

--- a/container/build.sh
+++ b/container/build.sh
@@ -98,7 +98,7 @@ TRTLLM_GIT_URL=""
 TENSORRTLLM_INDEX_URL="https://pypi.python.org/simple"
 # TODO: Remove the version specification from here and use the ai-dynamo[trtllm] package.
 # Need to update the Dockerfile.trtllm to use the ai-dynamo[trtllm] package.
-DEFAULT_TENSORRTLLM_PIP_WHEEL="tensorrt-llm==1.0.0rc6"
+DEFAULT_TENSORRTLLM_PIP_WHEEL="tensorrt-llm==1.1.0rc1"
 TENSORRTLLM_PIP_WHEEL=""
 
 

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -67,7 +67,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Build Dependency** | **Version**                                                                      |
 | :------------------- | :------------------------------------------------------------------------------- |
 | **Base Container**   | [25.03](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-dl-base/tags) |
-| **TensorRT-LLM**     | 1.0.0rc6                                                                         |
+| **TensorRT-LLM**     | 1.1.0rc1                                                                         |
 | **NIXL**             | 0.4.1                                                                            |
 | **vLLM**             | 0.10.1.1                                                                         |
 | **SGLang**           | 0.5.0rc2                                                                         |

--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -67,7 +67,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Build Dependency** | **Version**                                                                      |
 | :------------------- | :------------------------------------------------------------------------------- |
 | **Base Container**   | [25.03](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-dl-base/tags) |
-| **TensorRT-LLM**     | 1.1.0rc1                                                                         |
+| **TensorRT-LLM**     | 1.1.0rc3                                                                         |
 | **NIXL**             | 0.4.1                                                                            |
 | **vLLM**             | 0.10.1.1                                                                         |
 | **SGLang**           | 0.5.0rc2                                                                         |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 [project.optional-dependencies]
 trtllm =[
     "uvloop",
-    "tensorrt-llm==1.0.0rc6",
-    "triton==3.3.1",  # locking triton as version 3.4.0 breaks tensorrt-llm 1.0.0rc6
+    "tensorrt-llm==1.1.0rc1",
+    "triton==3.3.1",  # locking triton as version 3.4.0 breaks tensorrt-llm 1.1.0rc1
 ]
 
 vllm = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 [project.optional-dependencies]
 trtllm =[
     "uvloop",
-    "tensorrt-llm==1.1.0rc1",
-    "triton==3.3.1",  # locking triton as version 3.4.0 breaks tensorrt-llm 1.1.0rc1
+    "tensorrt-llm==1.1.0rc3",
 ]
 
 vllm = [


### PR DESCRIPTION
#### Overview:

Update trtllm version in dynamo container from `1.0.0rc6` to `1.1.0rc3`

#### Details:

Slight change in usage of llmapi Sampling params

#### Where should the reviewer start?

`components/backends/trtllm/src/dynamo/trtllm/main.py` for API changes
`container/build.sh` for Docker changes


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Bumped default TensorRT-LLM to 1.1.0rc1 and aligned dependency pins; updated container/build defaults.

* Documentation
  * Updated README and support matrix to reflect TensorRT-LLM 1.1.0rc1.
  * Revised TRT-LLM multimodal guidance and important notes.

* Refactor
  * Standardized backend identifiers in TRT-LLM engine configs (consistent casing like DEFAULT/UCX).
  * Adjusted internal imports to match the latest TensorRT-LLM package layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->