### PR TITLE
fix: no reasoning parser by default

### DIFF
--- a/components/backends/sglang/src/dynamo/sglang/args.py
+++ b/components/backends/sglang/src/dynamo/sglang/args.py
@@ -45,7 +45,7 @@ DYNAMO_ARGS: Dict[str, Dict[str, Any]] = {
         "type": str,
         "default": None,
         "choices": get_reasoning_parser_names(),
-        "help": "Reasoning parser name for the model.",
+        "help": "Reasoning parser name for the model. If not specified, no reasoning parsing is performed.",
     },
 }
 

--- a/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -283,7 +283,7 @@ def cmd_line_args():
         type=str,
         default=None,
         choices=get_reasoning_parser_names(),
-        help="Reasoning parser name for the model.",
+        help="Reasoning parser name for the model. If not specified, no reasoning parsing is performed.",
     )
 
     args = parser.parse_args()

--- a/components/backends/vllm/src/dynamo/vllm/args.py
+++ b/components/backends/vllm/src/dynamo/vllm/args.py
@@ -114,7 +114,7 @@ def parse_args() -> Config:
         type=str,
         default=None,
         choices=get_reasoning_parser_names(),
-        help="Reasoning parser name for the model.",
+        help="Reasoning parser name for the model. If not specified, no reasoning parsing is performed.",
     )
     parser.add_argument(
         "--custom-jinja-template",

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -64,7 +64,8 @@ pub struct DeltaGenerator {
 
     /// Reasoning Parser object
     /// This is used to parse reasoning content in the response.
-    reasoning_parser: ReasoningParserWrapper,
+    /// None means no reasoning parsing will be performed.
+    reasoning_parser: Option<ReasoningParserWrapper>,
 }
 
 impl DeltaGenerator {
@@ -96,17 +97,12 @@ impl DeltaGenerator {
         };
 
         // Reasoning parser type
-        // This is hardcoded for now, but can be made configurable later.
-        // TODO: Make parser type configurable once front-end integration is determined
-        // Change to GptOss to test GptOSS parser
-        // Reasoning parser wrapper
-        let reasoning_parser = ReasoningParserType::get_reasoning_parser_from_name(
-            options
-                .runtime_config
-                .reasoning_parser
-                .as_deref()
-                .unwrap_or("basic"),
-        );
+        // If no parser is specified (None), no reasoning parsing will be performed
+        let reasoning_parser = options
+            .runtime_config
+            .reasoning_parser
+            .as_deref()
+            .map(|parser_name| ReasoningParserType::get_reasoning_parser_from_name(parser_name));
 
         let chatcmpl_id = format!("chatcmpl-{request_id}");
 
@@ -202,12 +198,14 @@ impl DeltaGenerator {
         text: &Option<String>,
         token_ids: &[u32],
     ) -> Option<ParserResult> {
+        // If no reasoning parser is configured, return None
+        let reasoning_parser = self.reasoning_parser.as_mut()?;
+
         let text_ref = text.as_deref().unwrap_or("");
         if text_ref.is_empty() && token_ids.is_empty() {
             return None;
         }
-        let parser_result = self
-            .reasoning_parser
+        let parser_result = reasoning_parser
             .parse_reasoning_streaming_incremental(text_ref, token_ids);
 
         Some(parser_result)
@@ -334,14 +332,19 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
             None => None,
         };
 
-        let reasoning_parser_result = self
-            .create_reasoning_content(&delta.text, &delta.token_ids)
-            .unwrap_or_default();
-
-        let (normal_text, reasoning_content) = (
-            reasoning_parser_result.get_some_normal_text(),
-            reasoning_parser_result.get_some_reasoning(),
-        );
+        // Handle reasoning parsing if enabled, otherwise treat all text as normal
+        let (normal_text, reasoning_content) = if self.reasoning_parser.is_some() {
+            let reasoning_parser_result = self
+                .create_reasoning_content(&delta.text, &delta.token_ids)
+                .unwrap_or_default();
+            (
+                reasoning_parser_result.get_some_normal_text(),
+                reasoning_parser_result.get_some_reasoning(),
+            )
+        } else {
+            // No reasoning parser configured, treat all text as normal
+            (delta.text, None)
+        };
 
         // Create the streaming response.
         let index = 0;


### PR DESCRIPTION
#### Overview:

Previously, we defaulted to using the `BasicReasoningParser` if no reasoning parser was specified, which extracts anything between `<think> </think>` tags as being reasoning content. With this PR, when no reasoning parser is specified, all content is treated as "Normal" non-reasoning content. This aligns with the behavior of vllm and sglang.

> [!NOTE]
> This PR retains the behavior that specifying a non-existent reasoning parser causes dynamo to fallback to the basic parser, rather than no parser. I think this is probably still the desired behavior. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Reasoning parsing is now optional in chat completion streaming. If no parser is configured, all output is treated as normal text with no reasoning content.
- Documentation
  - Updated CLI help for --dyn-reasoning-parser across backends to clarify it’s optional and that no reasoning parsing occurs when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->