### PR TITLE
fix: CI is broken with a deprecated dependency on pynvml (#2926)

### DIFF
--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 accelerate==1.6.0
 aiofiles
@@ -28,6 +16,7 @@ matplotlib
 msgspec
 mypy
 numpy==1.26.4 # pmdarima is not compatible with numpy 2
+nvidia-ml-py==13.580.65
 opentelemetry-api
 opentelemetry-sdk
 pip
@@ -37,7 +26,6 @@ prometheus-api-client
 prophet
 protobuf==5.29.5
 pydantic==2.7.1
-pynvml
 pyright
 PyYAML
 scikit-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ filterwarnings = [
     "ignore:.*unclosed.*socket.*:ResourceWarning", # Ignore unclosed socket warnings
     "ignore:.*unclosed event loop.*:ResourceWarning", # Ignore unclosed event loop warnings
     "ignore:.*Exception ignored in.*:pytest.PytestUnraisableExceptionWarning", # Ignore unraisable exception warnings
+    "ignore:The pynvml package is deprecated.*:FutureWarning", # Ignore pynvml deprecation warning, temporary until upstream library updates to nvidia-ml-py
 ]
 
 


### PR DESCRIPTION
#### Overview:
Cherry-pick of [PR#2926](https://github.com/ai-dynamo/dynamo/pull/2926)
Fixes GitHub CI so checks pass
