### PR TITLE
feat: frontend, disconnect metrics (#1)

### DIFF
--- a/lib/llm/src/grpc/service/openai.rs
+++ b/lib/llm/src/grpc/service/openai.rs
@@ -52,7 +52,8 @@ pub async fn completion_response_stream(
     let context = request.context();
 
     // create the connection handles
-    let (mut connection_handle, stream_handle) = create_connection_monitor(context.clone()).await;
+    let (mut connection_handle, stream_handle) =
+        create_connection_monitor(context.clone(), Some(state.metrics_clone())).await;
 
     let streaming = request.inner.stream.unwrap_or(false);
     // update the request to always stream

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -224,7 +224,8 @@ async fn handler_completions(
     let context = request.context();
 
     // create the connection handles
-    let (mut connection_handle, stream_handle) = create_connection_monitor(context.clone()).await;
+    let (mut connection_handle, stream_handle) =
+        create_connection_monitor(context.clone(), Some(state.metrics_clone())).await;
 
     // possibly long running task
     // if this returns a streaming response, the stream handle will be armed and captured by the response stream
@@ -419,7 +420,8 @@ async fn handler_chat_completions(
     let context = request.context();
 
     // create the connection handles
-    let (mut connection_handle, stream_handle) = create_connection_monitor(context.clone()).await;
+    let (mut connection_handle, stream_handle) =
+        create_connection_monitor(context.clone(), Some(state.metrics_clone())).await;
 
     let response =
         tokio::spawn(chat_completions(state, template, request, stream_handle).in_current_span())
@@ -651,7 +653,8 @@ async fn handler_responses(
     let context = request.context();
 
     // create the connection handles
-    let (mut connection_handle, _stream_handle) = create_connection_monitor(context.clone()).await;
+    let (mut connection_handle, _stream_handle) =
+        create_connection_monitor(context.clone(), Some(state.metrics_clone())).await;
 
     let response = tokio::spawn(responses(state, template, request).in_current_span())
         .await


### PR DESCRIPTION
* adds metrics for client side dropped requests in the frontend.
dropping user requests can lead to various exploits and should be monitored. Additionally, any issues here are hard to debug, and could e.g. help debug upstream components.
Continuation of https://github.com/ai-dynamo/dynamo/pull/2929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Prometheus metric for client disconnects to surface dropped connections.
  * Streaming requests across OpenAI-compatible endpoints now report per-connection metrics when enabled.

* **Refactor**
  * Connection monitoring is instrumented to accept optional metrics for per-connection observability without changing runtime behavior.

* **Chores**
  * Metrics wiring added to relevant request handlers; no user-facing behavior changes unless monitoring is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->