### PR TITLE
docs: update how deploy util helper files are mentioned

### DIFF
--- a/docs/benchmarks/pre_deployment_profiling.md
+++ b/docs/benchmarks/pre_deployment_profiling.md
@@ -193,7 +193,7 @@ To download the results:
 
 ```bash
 # Download to directory
-python3 -m deploy.utils.inject_manifest.download_pvc_results --namespace $NAMESPACE --output-dir ./results --folder /data/profiling_results
+python3 -m deploy.utils.download_pvc_results --namespace $NAMESPACE --output-dir ./results --folder /data/profiling_results
 
 # Download without any of the auto-created config.yaml files used in profiling
 python3 -m deploy.utils.inject_manifest.download_pvc_results --namespace $NAMESPACE --output-dir ./results --folder /data/profiling_results --no-config

--- a/docs/benchmarks/pre_deployment_profiling.md
+++ b/docs/benchmarks/pre_deployment_profiling.md
@@ -196,7 +196,7 @@ To download the results:
 python3 -m deploy.utils.download_pvc_results --namespace $NAMESPACE --output-dir ./results --folder /data/profiling_results
 
 # Download without any of the auto-created config.yaml files used in profiling
-python3 -m deploy.utils.inject_manifest.download_pvc_results --namespace $NAMESPACE --output-dir ./results --folder /data/profiling_results --no-config
+python3 -m deploy.utils.download_pvc_results --namespace $NAMESPACE --output-dir ./results --folder /data/profiling_results --no-config
 ```
 
 The script will:

--- a/docs/benchmarks/pre_deployment_profiling.md
+++ b/docs/benchmarks/pre_deployment_profiling.md
@@ -102,7 +102,7 @@ Use the injector utility to place your DGD manifest into the PVC. The profiling 
 
 ```bash
 # Inject your disagg manifest
-python3 deploy/utils/inject_manifest.py \
+python3 -m deploy.utils.inject_manifest \
   --namespace $NAMESPACE \
   --src components/backends/vllm/deploy/disagg.yaml \
   --dest /data/configs/disagg.yaml
@@ -127,13 +127,13 @@ Use the default pre-built image and inject custom configurations via PVC:
 2. **Inject your custom disagg configuration:**
    ```bash
    # Use default disagg.yaml config
-   python3 deploy/utils/inject_manifest.py --namespace $NAMESPACE --src components/backends/vllm/deploy/disagg.yaml --dest /data/configs/disagg.yaml
+   python3 -m deploy.utils.inject_manifest --namespace $NAMESPACE --src components/backends/vllm/deploy/disagg.yaml --dest /data/configs/disagg.yaml
 
    # Or use a custom disagg config file
-   python3 deploy/utils/inject_manifest.py --namespace $NAMESPACE --src my-custom-disagg.yaml --dest /data/configs/disagg.yaml
+   python3 -m deploy.utils.inject_manifest --namespace $NAMESPACE --src my-custom-disagg.yaml --dest /data/configs/disagg.yaml
 
    # Or specify a custom target path in the PVC
-   python3 deploy/utils/inject_manifest.py --namespace $NAMESPACE --src my-custom-disagg.yaml --dest /data/profiling_results/my-disagg.yaml
+   python3 -m deploy.utils.inject_manifest --namespace $NAMESPACE --src my-custom-disagg.yaml --dest /data/profiling_results/my-disagg.yaml
    ```
 
    > **Note**: All paths must start with `/data/` for security reasons. If you forget this prefix, the script will show a helpful error message with the correct path.
@@ -193,10 +193,10 @@ To download the results:
 
 ```bash
 # Download to directory
-python3 deploy/utils/download_pvc_results.py --namespace $NAMESPACE --output-dir ./results --folder /data/profiling_results
+python3 -m deploy.utils.inject_manifest.download_pvc_results --namespace $NAMESPACE --output-dir ./results --folder /data/profiling_results
 
 # Download without any of the auto-created config.yaml files used in profiling
-python3 deploy/utils/download_pvc_results.py --namespace $NAMESPACE --output-dir ./results --folder /data/profiling_results --no-config
+python3 -m deploy.utils.inject_manifest.download_pvc_results --namespace $NAMESPACE --output-dir ./results --folder /data/profiling_results --no-config
 ```
 
 The script will:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated pre-deployment profiling guide to use Python’s -m module mode for CLI utilities instead of calling script files directly.
  - Standardized examples for the manifest injector and PVC results download commands to improve consistency.
  - Clarified that command arguments and paths remain unchanged; only the invocation method differs.
  - Improved readability and reduced ambiguity around how to run the provided utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->