### PR TITLE
test: remove nighlty marker in kvbm tests

### DIFF
--- a/tests/kvbm/test_determinism.py
+++ b/tests/kvbm/test_determinism.py
@@ -35,7 +35,6 @@ pytestmark = [
     pytest.mark.kvbm,
     pytest.mark.e2e,
     pytest.mark.slow,
-    pytest.mark.nightly,
     pytest.mark.gpu_1,
 ]
 


### PR DESCRIPTION
#### Overview:

add #2958 to release

closes: OPS-974