### PR TITLE
feat: add init file to profiler folder

### DIFF
--- a/benchmarks/profiler/__init__.py
+++ b/benchmarks/profiler/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Profiler package for Kubernetes cluster profiling."""

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -497,6 +497,7 @@ COPY --from=build /usr/local/lib/python3.12/dist-packages/pytorch_triton-${PYTOR
 # TODO: Remove this once we have a functional CI image built on top of the runtime image
 COPY tests /workspace/tests
 COPY benchmarks /workspace/benchmarks
+COPY deploy /workspace/deploy
 COPY components/backends/trtllm /workspace/components/backends/trtllm
 RUN python3 -m pip install --no-cache-dir --break-system-packages /workspace/benchmarks
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added module-level documentation introducing the Profiler package for Kubernetes cluster profiling, improving clarity and discoverability.
- Chores
  - Established package initialization and applied SPDX license headers to align with licensing and packaging standards.
  - No executable code or public API introduced; no changes to runtime behavior.

Note: This update is non-functional and has no impact on user workflows or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->