### PR TITLE
feat: add DirectAccess for synchronous pool operations

### DIFF
--- a/lib/bindings/python/rust/llm/block_manager/vllm/slot.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/slot.rs
@@ -190,7 +190,6 @@ impl<S: Storage, L: LocalityProvider> Slot<S, L> {
         // apply the token blocks to the mutable blocks
         for (mut mutable_block, token_block) in zipped_blocks {
             mutable_block
-                .state_mut()
                 .apply_token_block(token_block.clone())
                 .map_err(|e| {
                     SlotError::from_str(&format!("failed to apply token block: {:?}", e))

--- a/lib/llm/src/block_manager/block.rs
+++ b/lib/llm/src/block_manager/block.rs
@@ -1014,17 +1014,17 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> MaybeReturnableBlock<S, 
 
             // Now try to unwrap the primary from self.block
             // This should work now that the duplicate's reference has been detached
-            if let Ok(mut primary_mutable) = Arc::try_unwrap(self.block) {
-                if let Some(primary_block) = primary_mutable.block.take() {
-                    blocks.push(primary_block);
-                }
+            if let Ok(mut primary_mutable) = Arc::try_unwrap(self.block)
+                && let Some(primary_block) = primary_mutable.block.take()
+            {
+                blocks.push(primary_block);
             }
         } else {
             // No duplicate, just try to unwrap the primary normally
-            if let Ok(mut primary_mutable) = Arc::try_unwrap(self.block) {
-                if let Some(primary_block) = primary_mutable.block.take() {
-                    blocks.push(primary_block);
-                }
+            if let Ok(mut primary_mutable) = Arc::try_unwrap(self.block)
+                && let Some(primary_block) = primary_mutable.block.take()
+            {
+                blocks.push(primary_block);
             }
         }
 

--- a/lib/llm/src/block_manager/block.rs
+++ b/lib/llm/src/block_manager/block.rs
@@ -292,7 +292,10 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> Block<S, L, M> {
 
     /// Returns true if the block is in the complete or registered state
     pub fn is_complete(&self) -> bool {
-        matches!(self.state, BlockState::Complete(_) | BlockState::Registered(_, _))
+        matches!(
+            self.state,
+            BlockState::Complete(_) | BlockState::Registered(_, _)
+        )
     }
 
     /// Returns true if the block is in the registered state
@@ -973,7 +976,6 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> ImmutableBlock<S, L, M> 
             .as_ref()
             .map_or(self.block.block_id(), |duplicate| duplicate.block_id())
     }
-
 }
 
 impl<S: Storage, L: LocalityProvider, M: BlockMetadata> StorageTypeProvider

--- a/lib/llm/src/block_manager/offload.rs
+++ b/lib/llm/src/block_manager/offload.rs
@@ -45,8 +45,8 @@
 //! of the [`OffloadManager::offload_worker`] and [`OffloadManager::onboard_worker`] methods.
 
 use super::block::{
-    BlockError, BlockMetadata, ImmutableBlock, MutableBlock,
-    locality::LocalityProvider, transfer::TransferContext,
+    BlockError, BlockMetadata, ImmutableBlock, MutableBlock, locality::LocalityProvider,
+    transfer::TransferContext,
 };
 use super::metrics::{BlockManagerMetrics, PoolMetrics};
 use super::pool::{BlockPool, BlockPoolError};

--- a/lib/llm/src/block_manager/offload/pending.rs
+++ b/lib/llm/src/block_manager/offload/pending.rs
@@ -48,7 +48,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use crate::block_manager::block::{
-    BlockDataProvider, BlockDataProviderMut, BlockError, BlockMetadata, BlockState, ImmutableBlock,
+    BlockDataProvider, BlockDataProviderMut, BlockError, BlockMetadata, ImmutableBlock,
     MutableBlock, ReadableBlock, WritableBlock,
     locality::LocalityProvider,
     transfer::{TransferContext, WriteTo, WriteToStrategy},
@@ -139,7 +139,7 @@ fn transfer_metadata<
     target: &mut MutableBlock<Target, Locality, Metadata>,
 ) -> Result<()> {
     // Only registered blocks can be transferred. There are upstream checks for this, so this shouldn't ever fail.
-    if let BlockState::Registered(reg_handle, _) = source.state() {
+    if let Some(reg_handle) = source.registration_handle() {
         // Bring the block back to the 'Reset' state.
         target.reset();
         // Transfer metadata.

--- a/lib/llm/src/block_manager/pool/managed.rs
+++ b/lib/llm/src/block_manager/pool/managed.rs
@@ -751,7 +751,7 @@ mod tests {
         // Commit the block - this will generate a sequence hash
         // This will put the block in a Complete state
         block.commit().unwrap();
-        assert!(block.state().is_complete()); // perhaps renamed to Commited
+        assert!(block.is_complete()); // perhaps renamed to Commited
 
         let sequence_hash = block.sequence_hash().unwrap();
         assert_eq!(sequence_hash, EXPECTED_SEQUENCE_HASH);
@@ -761,7 +761,7 @@ mod tests {
         // This will take ownership of the block and return an immutable block
         let mut immutable_blocks = pool.register_blocks_blocking(vec![block]).unwrap();
         let block = immutable_blocks.pop().unwrap();
-        assert!(block.state().is_registered());
+        assert!(block.is_registered());
         assert_eq!(block.sequence_hash(), sequence_hash);
 
         // Dropping the immutable block should return the block to the pool
@@ -1050,7 +1050,7 @@ mod tests {
         // Commit the block - this will generate a sequence hash
         // This will put the block in a Complete state
         block.commit().unwrap();
-        assert!(block.state().is_complete()); // perhaps renamed to Commited
+        assert!(block.is_complete()); // perhaps renamed to Commited
 
         let sequence_hash = block.sequence_hash().unwrap();
         assert_eq!(sequence_hash, EXPECTED_SEQUENCE_HASH);
@@ -1060,7 +1060,7 @@ mod tests {
         // This will take ownership of the block and return an immutable block
         let mut immutable_blocks = pool.register_blocks_blocking(vec![block]).unwrap();
         let block = immutable_blocks.pop().unwrap();
-        assert!(block.state().is_registered());
+        assert!(block.is_registered());
         assert_eq!(block.sequence_hash(), sequence_hash);
 
         block

--- a/lib/llm/src/block_manager/pool/managed.rs
+++ b/lib/llm/src/block_manager/pool/managed.rs
@@ -47,6 +47,7 @@ use super::*;
 
 pub mod active;
 pub mod controller;
+pub mod direct;
 pub mod inactive;
 pub mod priority_key;
 pub mod state;

--- a/lib/llm/src/block_manager/pool/managed/active.rs
+++ b/lib/llm/src/block_manager/pool/managed/active.rs
@@ -39,7 +39,7 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> ActiveBlockPool<S, L, M>
         &mut self,
         mut block: MutableBlock<S, L, M>,
     ) -> Result<ImmutableBlock<S, L, M>, BlockPoolError> {
-        if !block.state().is_registered() {
+        if !block.is_registered() {
             return Err(BlockPoolError::InvalidMutableBlock(
                 "block is not registered".to_string(),
             ));

--- a/lib/llm/src/block_manager/pool/managed/direct.rs
+++ b/lib/llm/src/block_manager/pool/managed/direct.rs
@@ -1,0 +1,79 @@
+use super::*;
+use crate::block_manager::pool::{BlockPoolError, BlockPoolResult, ResetBlocksResponse};
+use std::sync::{Arc, Mutex};
+
+/// Direct access to the block pool state, bypassing the progress engine.
+/// This provides synchronous access for performance-critical paths.
+///
+/// Note: This is a simplified initial implementation that provides basic
+/// direct access without complex retry logic.
+pub struct DirectAccess<S: Storage, L: LocalityProvider, M: BlockMetadata> {
+    state: Arc<Mutex<State<S, L, M>>>,
+}
+
+impl<S: Storage, L: LocalityProvider, M: BlockMetadata> Clone for DirectAccess<S, L, M> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl<S: Storage, L: LocalityProvider, M: BlockMetadata> DirectAccess<S, L, M> {
+    pub fn new(state: Arc<Mutex<State<S, L, M>>>) -> Self {
+        Self { state }
+    }
+
+    /// Get a reference to the state - used for testing
+    #[allow(dead_code)]
+    pub(crate) fn state(&self) -> Arc<Mutex<State<S, L, M>>> {
+        self.state.clone()
+    }
+
+    /// Allocate a set of blocks from the pool.
+    pub fn allocate_blocks(&self, count: usize) -> BlockPoolResult<Vec<MutableBlock<S, L, M>>> {
+        let mut state = self.state.lock().unwrap();
+        state.allocate_blocks(count)
+    }
+
+    /// Add blocks to the inactive pool.
+    pub fn add_blocks(&self, blocks: Vec<Block<S, L, M>>) {
+        let mut state = self.state.lock().unwrap();
+        state.inactive.add_blocks(blocks);
+    }
+
+    /// Try to return a block to the pool.
+    pub fn try_return_block(&self, block: Vec<Block<S, L, M>>) -> BlockPoolResult<()> {
+        if block.is_empty() {
+            return Ok(());
+        }
+
+        let mut state = self.state.lock().unwrap();
+        for b in block {
+            state.return_block(b);
+        }
+
+        Ok(())
+    }
+
+    /// Get the current status of the block pool.
+    pub fn status(&self) -> Result<BlockPoolStatus, BlockPoolError> {
+        let state = self.state.lock().unwrap();
+        Ok(state.status())
+    }
+
+    /// Reset the pool, returning all blocks to the inactive state.
+    pub fn reset(&self) -> Result<(), BlockPoolError> {
+        let mut state = self.state.lock().unwrap();
+        state.inactive.reset()
+    }
+
+    /// Reset specific blocks by sequence hash.
+    pub fn reset_blocks(
+        &self,
+        sequence_hashes: &[SequenceHash],
+    ) -> Result<ResetBlocksResponse, BlockPoolError> {
+        let mut state = self.state.lock().unwrap();
+        Ok(state.try_reset_blocks(sequence_hashes))
+    }
+}

--- a/lib/llm/src/block_manager/pool/managed/state.rs
+++ b/lib/llm/src/block_manager/pool/managed/state.rs
@@ -371,11 +371,11 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> State<S, L, M>
         self.inactive.return_block(block);
     }
 
-    fn publisher(&self) -> Publisher {
+    pub fn publisher(&self) -> Publisher {
         Publisher::new(self.event_manager.clone())
     }
 
-    fn status(&self) -> BlockPoolStatus {
+    pub fn status(&self) -> BlockPoolStatus {
         let active = self.active.status();
         let (inactive, empty) = self.inactive.status();
         BlockPoolStatus {
@@ -385,7 +385,7 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> State<S, L, M>
         }
     }
 
-    fn try_reset_blocks(&mut self, sequence_hashes: &[SequenceHash]) -> ResetBlocksResponse {
+    pub fn try_reset_blocks(&mut self, sequence_hashes: &[SequenceHash]) -> ResetBlocksResponse {
         let mut reset_blocks = Vec::new();
         let mut not_found = Vec::new();
         let mut not_reset = Vec::new();

--- a/lib/llm/src/block_manager/pool/managed/state.rs
+++ b/lib/llm/src/block_manager/pool/managed/state.rs
@@ -201,7 +201,7 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> State<S, L, M>
                 let immutable = if duplication_setting
                     == BlockRegistrationDuplicationSetting::Allowed
                 {
-                    immutable.with_duplicate(block.into()).expect("incompatible immutable block; only primary should be returned from match_sequence_hash")
+                    ImmutableBlock::from_duplicate(block, immutable).expect("incompatible immutable block; only primary should be returned from match_sequence_hash")
                 } else {
                     // immediate return the block to the pool if duplicates are disabled
                     if let Some(blocks) = block.try_take_block(private::PrivateToken) {
@@ -260,8 +260,7 @@ impl<S: Storage, L: LocalityProvider + 'static, M: BlockMetadata> State<S, L, M>
             match duplication_setting {
                 BlockRegistrationDuplicationSetting::Allowed => {
                     if let Some(duplicate) = duplicate {
-                        immutable = immutable
-                            .with_duplicate(duplicate.into())
+                        immutable = ImmutableBlock::from_duplicate(duplicate, immutable)
                             .expect("incompatible immutable block; only primary should be returned from ActiveBlockPool::register");
                     }
                 }


### PR DESCRIPTION
Introduces a DirectAccess struct that provides synchronous access to the block pool state, bypassing the progress engine for performance-critical paths.

This is a simplified initial implementation that provides basic direct access without complex retry logic. The implementation includes:
- Direct block allocation from the pool
- Direct block addition to inactive pool
- Block return functionality
- Pool status and reset operations

The DirectAccess pattern allows for more efficient pool operations when async coordination is not required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a direct, thread-safe interface for synchronous interaction with the block pool (allocate, add, return blocks; status, reset, targeted resets; cloneable).
  * Introduced duplicate-block tracking so duplicates are detected, associated with primaries, and safely returned/consumed.

* **Refactor**
  * Expanded public surface for status/publisher/reset operations to support advanced workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->