### PR TITLE
Publish KV perf metrics from TRTLLM

### DIFF
--- a/components/backends/trtllm/src/dynamo/trtllm/publisher.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/publisher.py
@@ -239,7 +239,6 @@ class Publisher:
 
         stats = self.engine.llm.get_stats_async(timeout=5)
         async for stat in stats:
-            logging.debug(f"Full Stat obj: {stat}")
             request_active_slots = stat["numActiveRequests"]
             request_total_slots = stat["maxNumActiveRequests"]
             kv_active_block = stat["kvCacheStats"]["usedNumBlocks"]

--- a/components/backends/trtllm/src/dynamo/trtllm/publisher.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/publisher.py
@@ -239,6 +239,7 @@ class Publisher:
 
         stats = self.engine.llm.get_stats_async(timeout=5)
         async for stat in stats:
+            logging.debug(f"Full Stat obj: {stat}")
             request_active_slots = stat["numActiveRequests"]
             request_total_slots = stat["maxNumActiveRequests"]
             kv_active_block = stat["kvCacheStats"]["usedNumBlocks"]

--- a/components/backends/trtllm/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -260,7 +260,7 @@ class HandlerBase:
                     latency, bytes_per_second = self.calculate_kv_perf_metrics(timing_metrics.kv_cache_size,
                                                                        timing_metrics.kv_cache_transfer_start.total_seconds(),
                                                                        timing_metrics.kv_cache_transfer_end.total_seconds())
-                    logging.info(f"latency={latency},bytes_per_second_for_request={bytes_per_second}")
+                    logging.info(f"latency={latency},bytes_per_second_for_request={bytes_per_second},trtllm_first_token_time={timing_metrics.first_token_time.total_seconds()}")
                 if output.disaggregated_params:
                     final_out["ctx_request_id"] = output.disaggregated_params.ctx_request_id
 

--- a/components/backends/trtllm/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -100,6 +100,8 @@ class HandlerBase:
                 result["finish_reason"] == "stop" or result["finish_reason"] == "error"
             )
 
+    def calculate_bytes_per_second(self, bytes, start, end):
+        pass
     def request_perf_metrics_to_json(self, perf_metrics):
         timing_metrics = perf_metrics.timing_metrics
         kv_cache_metrics = perf_metrics.kv_cache_metrics
@@ -246,7 +248,12 @@ class HandlerBase:
                 final_out = {}
                 output = res.outputs[0]
                 if output.request_perf_metrics:
-                    json_perf_metrics = self.request_perf_metrics_to_json(output.request_perf_metrics)
+                    request_perf_metrics = output.request_perf_metrics
+                    json_perf_metrics = self.request_perf_metrics_to_json(request_perf_metrics)
+                    bytes_per_second = self.calculate_bytes_per_second(request_perf_metrics.timing_metrics.kv_cache_size,
+                                                                       request_perf_metrics.timing_metrics.kv_cache_transfer_start.total_seconds(),
+                                                                       request_perf_metrics.timing_metrics.kv_cache_transfer_end.total_seconds())
+                    logging.info(f"bytes_per_second_for_request={bytes_per_second}")
                     final_out["request_perf_metrics"] = json_perf_metrics
                     logging.debug(f"Request perf metrics: {json_perf_metrics}")
                 if output.disaggregated_params:

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -63,6 +63,9 @@ pub mod frontend_service {
     /// Inter-token latency in seconds
     pub const INTER_TOKEN_LATENCY_SECONDS: &str = "inter_token_latency_seconds";
 
+    /// Inter-token latency in seconds
+    pub const KV_CACHE_TRANSFER_DURATION: &str = "kv_cache_transfer_duration";
+
     /// Status label values
     pub mod status {
         /// Value for successful requests


### PR DESCRIPTION
#### Overview:

This PR takes the performance metrics from TRTLLM and publishes them out of the dynamo worker. Namely, the KV cache performance metrics are the motivation for this change.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
