### PR TITLE
feat: dyn namespace scoping for trtllm

### DIFF
--- a/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import os
 from typing import Optional
 
 from tensorrt_llm.llmapi import BuildConfig
@@ -13,11 +14,13 @@ from dynamo.trtllm.request_handlers.handler_base import (
     DisaggregationStrategy,
 )
 
+DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+
 # Default endpoint for the next worker.
-DEFAULT_ENDPOINT = "dyn://dynamo.tensorrt_llm.generate"
+DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.tensorrt_llm.generate"
 DEFAULT_MODEL_PATH = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
-DEFAULT_NEXT_ENDPOINT = "dyn://dynamo.tensorrt_llm_next.generate"
-DEFAULT_ENCODE_ENDPOINT = "dyn://dynamo.tensorrt_llm_encode.generate"
+DEFAULT_NEXT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.tensorrt_llm_next.generate"
+DEFAULT_ENCODE_ENDPOINT = f"dyn://{DYN_NAMESPACE}.tensorrt_llm_encode.generate"
 DEFAULT_DISAGGREGATION_STRATEGY = DisaggregationStrategy.DECODE_FIRST
 DEFAULT_DISAGGREGATION_MODE = DisaggregationMode.AGGREGATED
 


### PR DESCRIPTION
#### Overview:

Scope trtllm worker to DYN_NAMESPACE for namespace isolation
 
Related PR: https://github.com/ai-dynamo/dynamo/pull/2475

closes: [DYN-838](https://linear.app/nvidia-dynamo/issue/DYN-838)


fixes : https://nvbugspro.nvidia.com/bug/5507011


Supports scoping backend to a specific dynamo namespace based on env variable  DYN_NAMESPACE



#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Endpoints now adapt to a configurable namespace set via environment variables, enabling flexible deployment across different environments and multi-tenant setups without code changes.
  * Defaults remain unchanged if no environment configuration is provided, preserving existing behavior.
  * Improves portability for staging, testing, and production by allowing namespace overrides at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->