### PR TITLE
fix: Install nixl in GPT OSS container as WAR to initialization error

### DIFF
--- a/container/Dockerfile.trtllm_prebuilt
+++ b/container/Dockerfile.trtllm_prebuilt
@@ -67,7 +67,11 @@ RUN mkdir -p /opt/dynamo/bindings/wheels && \
     mkdir /opt/dynamo/bindings/lib && \
     cp dist/ai_dynamo*cp312*.whl /opt/dynamo/bindings/wheels/
 
-RUN pip install /workspace/dist/ai_dynamo_runtime*cp312*.whl && pip install /workspace/dist/ai_dynamo*any.whl
+# FIXME: Installing nixl as a WAR for multimodal nixl dependency in TRTLLM component
+#        However, the GPT OSS container hasn't been tested for running multimodal, and
+#        this separate Dockerfile may possibly be condensed back to single Dockerfile
+#        with recent trtllm pip package versions.
+RUN pip install /workspace/dist/ai_dynamo_runtime*cp312*.whl && pip install /workspace/dist/ai_dynamo*any.whl && pip install nixl==0.5.1
 
 # Copy files for legal compliance
 COPY ATTRIBUTION* LICENSE /workspace/


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Same idea as #2879, but for GPT-OSS TRTLLM container build to resolve an issue from nvbugs/5497851

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/dynamo/nixl_connect/__init__.py", line 38, in <module>
    import nixl._api as nixl_api
ModuleNotFoundError: No module named 'nixl'
```

Longer term fix is to move the nixl initialization parts to only where needed, such as for the multimodal/encoder worker constructors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image to include an additional multimodal dependency during build. No changes to runtime behavior or functionality.
* **Documentation**
  * Added clarifying comments in the build configuration about the new dependency and potential future consolidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->