### PR TITLE
HttpAsyncEngine awaits the first result from PythonAsyncEngine to check for errors

### DIFF
--- a/lib/bindings/python/rust/http.rs
+++ b/lib/bindings/python/rust/http.rs
@@ -177,7 +177,7 @@ where
     Resp: Data + for<'de> Deserialize<'de>,
 {
     async fn generate(&self, request: SingleIn<Req>) -> Result<ManyOut<Annotated<Resp>>, Error> {
-        match self.0 .0.generate_in_parts(request).await {
+        match self.0.0.generate_in_parts(request).await {
             Ok((mut stream, context)) => {
                 let first_item = match futures::StreamExt::next(&mut stream).await {
                     Some(item) => item,

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -377,6 +377,12 @@ impl DistributedRuntime {
         self.inner.runtime().shutdown();
     }
 
+    fn child_token(&self) -> CancellationToken {
+        CancellationToken {
+            inner: self.inner.runtime().child_token(),
+        }
+    }
+
     fn event_loop(&self) -> PyObject {
         self.event_loop.clone()
     }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -52,6 +52,30 @@ class DistributedRuntime:
         Shutdown the runtime by triggering the cancellation token
         """
         ...
+
+    def child_token(self) -> CancellationToken:
+        """
+        Get a child cancellation token from the runtime
+        """
+        ...
+
+class CancellationToken:
+    """
+    A cancellation token for coordinating shutdown across components
+    """
+
+    def cancel(self) -> None:
+        """
+        Cancel the token
+        """
+        ...
+
+    async def cancelled(self) -> None:
+        """
+        Wait for the token to be cancelled
+        """
+        ...
+
 class EtcdClient:
     """
     Etcd is used for discovery in the DistributedRuntime


### PR DESCRIPTION
#### Overview:
HttpAsyncEngine awaits the first result from PythonAsyncEngine to check for errors.
TODO - I need some help to better summarize the problem this is trying to solve before sending this PR upstream.

#### Details:

HttpAsyncEngine::generate awaits the first item and checks for errors, and then creates a new stream from this item and the remaining items.

To enable this, PythonServerStreamingEngine is modified to have a helper method which returns the stream and context (the parts) separately before they are combined into ResponseStream.

#### Where should the reviewer start?
lib/bindings/python/rust/http.rs is a good starting point.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Token-based cancellation in the Python SDK: DistributedRuntime.child_token now returns a CancellationToken with cancel() and async cancelled() for coordinated shutdown.
  - More responsive streaming generation with context propagation, enabling finer-grained, real-time outputs while preserving existing behavior.

- Improvements
  - HTTP streaming now validates the first chunk, attaches a request ID to logs, and surfaces clearer errors if a stream ends unexpectedly.
  - Enhanced logging and robustness for streamed responses without changing existing error handling for failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->