### PR TITLE
fix: devcontainer.json typo from b6b3a767c

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "name": "NVIDIA Dynamo Dev Container Development",
     "remoteUser": "ubuntu", // Matches our container user
     "updateRemoteUserUID": true, // Updates the UID of the remote user to match the host user, avoids permission errors
-    "image": "dynamo:latest-vllm-dev", // Use the latest VLLM dev image
+    "image": "dynamo:latest-vllm-local-dev", // Use the latest VLLM dev image
     "runArgs": [
         "--gpus=all",
         "--network=host",


### PR DESCRIPTION
#### Overview:

Fix typo in devcontainer.json image name from "dynamo:latest-vllm-dev" to "dynamo:latest-vllm-local-dev".

#### Details:

- Corrected image name in .devcontainer/devcontainer.json to match the actual Docker image name
- This fixes the devcontainer configuration to properly reference the local development image

#### Where should the reviewer start?

.devcontainer/devcontainer.json - single line change to fix the image name typo

#### Related Issues:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated development container image to dynamo:latest-vllm-local-dev.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->