### PR TITLE
Feat/completion request template 2494

### DIFF
--- a/components/frontend/src/dynamo/frontend/main.py
+++ b/components/frontend/src/dynamo/frontend/main.py
@@ -200,6 +200,12 @@ def parse_args():
         default=False,
         help="Start KServe gRPC server.",
     )
+    parser.add_argument(
+        "--request-template",
+        type=pathlib.Path,
+        default=None,
+        help="Path to JSON file containing default request parameters (model, temperature, max_completion_tokens).",
+    )
 
     flags = parser.parse_args()
 
@@ -262,6 +268,8 @@ async def async_main():
         kwargs["tls_key_path"] = flags.tls_key_path
     if flags.namespace:
         kwargs["namespace"] = flags.namespace
+    if flags.request_template:
+        kwargs["template_file"] = flags.request_template
 
     if is_static:
         # out=dyn://<static_endpoint>

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -368,8 +368,11 @@ impl HttpServiceConfigBuilder {
             request_template.clone(),
             var(HTTP_SVC_CHAT_PATH_ENV).ok(),
         );
-        let (cmpl_docs, cmpl_route) =
-            super::openai::completions_router(state.clone(), var(HTTP_SVC_CMP_PATH_ENV).ok());
+        let (cmpl_docs, cmpl_route) = super::openai::completions_router(
+            state.clone(),
+            request_template.clone(),
+            var(HTTP_SVC_CMP_PATH_ENV).ok(),
+        );
         let (embed_docs, embed_route) =
             super::openai::embeddings_router(state.clone(), var(HTTP_SVC_EMB_PATH_ENV).ok());
         let (responses_docs, responses_route) = super::openai::responses_router(

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -57,8 +57,6 @@ pub struct DeltaGenerator {
     service_tier: Option<dynamo_async_openai::types::ServiceTierResponse>,
     /// Tracks token usage for the completion request.
     usage: dynamo_async_openai::types::CompletionUsage,
-    /// Tracks reasoning tokens separately for observability
-    reasoning_token_count: u32,
     /// Counter tracking the number of messages issued.
     msg_counter: u64,
     /// Configuration options for response generation.
@@ -120,7 +118,6 @@ impl DeltaGenerator {
             system_fingerprint: None,
             service_tier: None,
             usage,
-            reasoning_token_count: 0,
             msg_counter: 0,
             options,
             reasoning_parser,
@@ -133,27 +130,6 @@ impl DeltaGenerator {
     /// * `isl` - The number of prompt tokens used.
     pub fn update_isl(&mut self, isl: u32) {
         self.usage.prompt_tokens = isl;
-    }
-
-    /// Updates the reasoning token count based on the reasoning text and available token IDs.
-    ///
-    /// # Arguments
-    /// * `reasoning_text` - The reasoning text to count tokens for.
-    /// * `total_text` - The total text (reasoning + normal) from the delta.
-    /// * `token_ids` - The token IDs for the total text.
-    fn update_reasoning_tokens(&mut self, reasoning_text: &str, total_text: &str, token_ids: &[u32]) {
-        if !reasoning_text.is_empty() && !total_text.is_empty() {
-            // Estimate reasoning tokens based on the proportion of reasoning text to total text
-            // This is more accurate than word counting alone
-            let reasoning_chars = reasoning_text.chars().count() as f32;
-            let total_chars = total_text.chars().count() as f32;
-
-            if total_chars > 0.0 {
-                let reasoning_proportion = reasoning_chars / total_chars;
-                let estimated_reasoning_tokens = (token_ids.len() as f32 * reasoning_proportion).ceil() as u32;
-                self.reasoning_token_count += estimated_reasoning_tokens;
-            }
-        }
     }
 
     pub fn create_logprobs(
@@ -281,14 +257,6 @@ impl DeltaGenerator {
         let mut usage = self.usage.clone();
         if self.options.enable_usage {
             usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
-
-            // Update completion_tokens_details with reasoning tokens if we have any
-            if self.reasoning_token_count > 0 {
-                // Preserve existing completion_tokens_details if they exist, or create new ones
-                let mut details = usage.completion_tokens_details.unwrap_or_default();
-                details.reasoning_tokens = Some(self.reasoning_token_count);
-                usage.completion_tokens_details = Some(details);
-            }
         }
 
         dynamo_async_openai::types::CreateChatCompletionStreamResponse {
@@ -374,12 +342,6 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
             reasoning_parser_result.get_some_normal_text(),
             reasoning_parser_result.get_some_reasoning(),
         );
-
-        // Update reasoning token count if we have reasoning content
-        if let Some(ref reasoning_text) = reasoning_content {
-            let total_text = delta.text.as_deref().unwrap_or("");
-            self.update_reasoning_tokens(reasoning_text, total_text, &delta.token_ids);
-        }
 
         // Create the streaming response.
         let index = 0;


### PR DESCRIPTION
#### Overview:
Adds request template support to `/v1/completions` endpoint to match existing `/v1/chat/completions` functionality. Templates now provide default values for model, temperature, and max_tokens when not specified in completion requests.

#### Details:
- Modified `handler_completions` to parse JSON before deserialization and apply template values
- Updated `completions_router` to accept template parameter
- Added `--request-template` CLI argument to Python frontend
- Template values applied before JSON validation, enabling minimal requests like `{"prompt": "hello"}`

#### Where should the reviewer start?
- `lib/llm/src/http/service/openai.rs` - Main template application logic in `handler_completions`
- `components/frontend/src/dynamo/frontend/main.py` - CLI argument addition

#### Related Issues:
- Fixes #2494


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional --request-template flag to load default request parameters (model, temperature, max tokens) from a JSON file.
  - Server now applies sensible defaults for missing or zeroed completion parameters.
  - Streaming responses include usage details for reasoning tokens.

- Bug Fixes
  - Clearer 400 errors for invalid JSON and invalid request formats in completions requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->