### PR TITLE
fix: add retry for curl downloads

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -164,7 +164,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
         arm64) PLATFORM=linux-arm64 ;; \
         *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
     esac && \
-    curl -fsSL "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.${PLATFORM}.tar.gz" \
+    curl -fsSL --retry 5 --retry-delay 5 "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.${PLATFORM}.tar.gz" \
     | tar -xz -C /tmp && \
     mv "/tmp/prometheus-${PROM_VERSION}.${PLATFORM}/prometheus" /usr/local/bin/ && \
     chmod +x /usr/local/bin/prometheus && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -227,7 +227,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
         arm64) PLATFORM=linux-arm64 ;; \
         *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
     esac && \
-    curl -fsSL "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.${PLATFORM}.tar.gz" \
+    curl -fsSL --retry 5 --retry-delay 5 "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.${PLATFORM}.tar.gz" \
     | tar -xz -C /tmp && \
     mv "/tmp/prometheus-${PROM_VERSION}.${PLATFORM}/prometheus" /usr/local/bin/ && \
     chmod +x /usr/local/bin/prometheus && \


### PR DESCRIPTION
#### Overview:

avoid  connection reset and other network failures in curl download - https://github.com/ai-dynamo/dynamo/actions/runs/17615998578/job/50049141692?pr=2967#step:7:17474
```
#31 [runtime 13/25] RUN ARCH=$(dpkg --print-architecture) &&     case "$ARCH" in         amd64) PLATFORM=linux-amd64 ;;         arm64) PLATFORM=linux-arm64 ;;         *) echo "Unsupported architecture: $ARCH" && exit 1 ;;     esac &&     curl -fsSL "[https://github.com/prometheus/prometheus/releases/download/v3.4.1/prometheus-3.4.1.${PLATFORM}.tar.gz](https://github.com/prometheus/prometheus/releases/download/v3.4.1/prometheus-3.4.1.$%7BPLATFORM%7D.tar.gz)"     | tar -xz -C /tmp &&     mv "/tmp/prometheus-3.4.1.${PLATFORM}/prometheus" /usr/local/bin/ &&     chmod +x /usr/local/bin/prometheus &&     rm -rf "/tmp/prometheus-3.4.1.${PLATFORM}"
#31 1.996 curl: (55) Send failure: Connection reset by peer
#31 2.006 
#31 2.006 gzip: stdin: unexpected end of file
#31 2.006 tar: Unexpected EOF in archive
#31 2.006 tar: Unexpected EOF in archive
#31 2.006 tar: Error is not recoverable: exiting now
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of container image builds by adding automatic retry logic to the Prometheus download step, reducing failures from transient network issues.
  * Applies to multiple runtime variants, ensuring more consistent and successful builds without impacting runtime behavior or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->