### PR TITLE
feat: increase time of pvc access pod

### DIFF
--- a/deploy/utils/manifests/pvc-access-pod.yaml
+++ b/deploy/utils/manifests/pvc-access-pod.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: pvc-access
 spec:
-  activeDeadlineSeconds: 1800  # Auto-delete after 30 minutes
+  activeDeadlineSeconds: 3000  # Auto-delete after 50 minutes
   securityContext:
     runAsNonRoot: true
     runAsUser: 1000
@@ -17,7 +17,7 @@ spec:
   - name: ubuntu
     image: ubuntu:22.04
     command: ["/bin/bash"]
-    args: ["-c", "sleep 1800"]  # Sleep for slightly less than deadline - tools can be installed via kubectl exec if needed
+    args: ["-c", "sleep 3000"]
     securityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false

--- a/deploy/utils/manifests/pvc-access-pod.yaml
+++ b/deploy/utils/manifests/pvc-access-pod.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: pvc-access
 spec:
-  activeDeadlineSeconds: 3000  # Auto-delete after 50 minutes
+  activeDeadlineSeconds: 3000  # Auto-terminate after ~50 minutes; Pod will be Failed (not auto-deleted)
   securityContext:
     runAsNonRoot: true
     runAsUser: 1000

--- a/deploy/utils/manifests/pvc-access-pod.yaml
+++ b/deploy/utils/manifests/pvc-access-pod.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: pvc-access
 spec:
-  activeDeadlineSeconds: 300  # Auto-delete after 5 minutes
+  activeDeadlineSeconds: 1800  # Auto-delete after 30 minutes
   securityContext:
     runAsNonRoot: true
     runAsUser: 1000
@@ -17,7 +17,7 @@ spec:
   - name: ubuntu
     image: ubuntu:22.04
     command: ["/bin/bash"]
-    args: ["-c", "sleep 290"]  # Sleep for slightly less than deadline - tools can be installed via kubectl exec if needed
+    args: ["-c", "sleep 1800"]  # Sleep for slightly less than deadline - tools can be installed via kubectl exec if needed
     securityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the PVC access pod’s allowed runtime from 5 minutes to 50 minutes to better accommodate long-running storage operations.
  * Aligned the container’s wait duration with the new runtime limit for consistent behavior.
  * Improves reliability by reducing premature termination during maintenance and data access tasks.
  * No functional changes to application features or APIs; other components remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->