### PR TITLE
chore: moved asyncio import to top of the file for planner test

### DIFF
--- a/tests/planner/test_replica_calculation.py
+++ b/tests/planner/test_replica_calculation.py
@@ -9,6 +9,7 @@ testing load prediction, interpolation, or correction factors.
 """
 
 import argparse
+import asyncio
 import math
 import os
 
@@ -151,8 +152,6 @@ class TestReplicaCalculation:
         planner.decode_interpolator.interpolate_itl.return_value = 10.0
 
         # Run the calculation
-        import asyncio
-
         asyncio.run(planner.make_adjustments())
 
         # Extract the calculated values from the log calls or by checking the mock calls
@@ -216,8 +215,6 @@ class TestReplicaCalculation:
         planner.decode_interpolator.interpolate_itl.return_value = 10.0
 
         # Run the calculation
-        import asyncio
-
         asyncio.run(planner.make_adjustments())
 
         # Check the results
@@ -289,8 +286,6 @@ class TestReplicaCalculation:
         planner.connector.reset_mock()
 
         # Run calculation
-        import asyncio
-
         asyncio.run(planner.make_adjustments())
 
         # Verify results
@@ -343,8 +338,6 @@ class TestReplicaCalculation:
         planner.decode_interpolator.interpolate_itl.return_value = 10.0
 
         # Run calculation
-        import asyncio
-
         asyncio.run(planner.make_adjustments())
 
         # Verify that total GPU usage doesn't exceed budget
@@ -400,8 +393,6 @@ class TestReplicaCalculation:
         planner.decode_interpolator.interpolate_itl.return_value = 10.0
 
         # Run calculation
-        import asyncio
-
         asyncio.run(planner.make_adjustments())
 
         # Verify minimum constraints are respected
@@ -464,8 +455,6 @@ class TestReplicaCalculation:
         )
 
         # Run calculation
-        import asyncio
-
         asyncio.run(planner.make_adjustments())
 
         # Verify that correction factor was effectively clamped
@@ -525,8 +514,6 @@ class TestReplicaCalculation:
                 planner.decode_interpolator.interpolate_itl.return_value = 10.0
 
                 # Run calculation
-                import asyncio
-
                 asyncio.run(planner.make_adjustments())
 
                 # Should handle gracefully without crashing
@@ -589,8 +576,6 @@ class TestReplicaCalculation:
         )  # 4 GPUs per engine
 
         # Run calculation
-        import asyncio
-
         asyncio.run(planner.make_adjustments())
 
         if planner.connector.set_component_replicas.called:
@@ -648,8 +633,6 @@ class TestReplicaCalculation:
         planner.decode_interpolator.interpolate_itl.return_value = 10.0
 
         # Run calculation
-        import asyncio
-
         asyncio.run(planner.make_adjustments())
 
         if planner.connector.set_component_replicas.called:


### PR DESCRIPTION
#### Overview:

Moved asyncio import so it is at the top of the file

#### Where should the reviewer start?

Just test_replica_calculation.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Tests
  * Consolidated asynchronous import usage across the replica calculation test suite by moving the import to module scope, reducing duplication and improving readability and consistency.
  * Maintains identical test behavior and coverage; asynchronous adjustment calls execute unchanged.
  * Non-functional change with zero impact on end users; no modifications to application features or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->