### PR TITLE
fix: update regex for namespace query in Grafana dashboard

### DIFF
--- a/deploy/logging/grafana/dashboard.json
+++ b/deploy/logging/grafana/dashboard.json
@@ -108,7 +108,7 @@
           "options": [],
           "query": "label_values(namespace)",
           "refresh": 1,
-          "regex": "",
+          "regex": ".+",
           "skipUrlSync": false,
           "sort": 1,
           "type": "query"

--- a/deploy/logging/grafana/logging-dashboard.yaml
+++ b/deploy/logging/grafana/logging-dashboard.yaml
@@ -118,7 +118,7 @@ data:
             "options": [],
             "query": "label_values(namespace)",
             "refresh": 1,
-            "regex": "",
+            "regex": ".+",
             "skipUrlSync": false,
             "sort": 1,
             "type": "query"


### PR DESCRIPTION
#### Overview:

Update loki query so it can't default to all empty values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Improved the Grafana Logging dashboard’s Namespace filter to disallow empty selections, ensuring queries exclude empty namespace values. This removes a misleading empty option in the dropdown and provides more reliable, consistent panel results.

- Chores
  - Configuration updated for the Namespace filter behavior in the logging dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->