### PR TITLE
fix: typo in .devcontainer/README.md from "./container/build.sh --tar…

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -94,7 +94,7 @@ Follow these steps to get your NVIDIA Dynamo development environment up and runn
 Build `dynamo:latest-vllm` from scratch from the source:
 
 ```bash
-./container/build.sh --target dev --framework VLLM
+./container/build.sh --target local-dev --framework VLLM
 ```
 
 The container will be built and give certain file permissions to your local uid and gid.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -91,7 +91,7 @@ Follow these steps to get your NVIDIA Dynamo development environment up and runn
 
 ### Step 1: Build the Development Container Image
 
-Build `dynamo:latest-vllm` from scratch from the source:
+Build `dynamo:latest-vllm-local-dev` from scratch from the source:
 
 ```bash
 ./container/build.sh --target local-dev --framework VLLM


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This pull request fixes a typo in the .devcontainer/README.md file. It corrects the Docker build target from `./container/build.sh --target dev` to `./container/build.sh --target local-dev`.

#### Details:

* Correction: The Docker build target has been changed to local-dev, which is the correct target for the development container image.
* Reasoning: The local-dev image uses the current user and group IDs from the host system as USER_UID and USER_GID.

#### Where should the reviewer start?

single file changed: .devcontainer/README.md 

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
Relates to PR #2892


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the development container setup guide to reflect the latest build command, targeting local development while maintaining compatibility with the VLLM framework.
  * Clarified step-by-step instructions to improve accuracy and reduce potential setup issues during environment preparation.
  * Enhances readability and consistency of setup guidance without affecting application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->