### PR TITLE
fix: disable natsBox by default

### DIFF
--- a/deploy/cloud/helm/platform/values.yaml
+++ b/deploy/cloud/helm/platform/values.yaml
@@ -528,7 +528,7 @@ nats:
   ############################################################
   natsBox:
     # Whether to deploy NATS Box for CLI access and debugging
-    enabled: true
+    enabled: false
 
     ############################################################
     # NATS client contexts for authentication and connection


### PR DESCRIPTION
#### Overview:

disable natsBox by default


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Disabled NATS Box deployment by default. Environments will no longer spin up NATS Box unless explicitly enabled. Existing configuration values remain available and can be re-enabled via configuration overrides. This reduces default resource usage and avoids deploying optional tooling unless required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->