### PR TITLE
feat: publish kv perf metrics trtllm -- pseudo implementation

### DIFF
--- a/components/metrics/src/bin/mock_worker.rs
+++ b/components/metrics/src/bin/mock_worker.rs
@@ -137,6 +137,7 @@ fn mock_stats_handler(_stats: EndpointStats) -> serde_json::Value {
         worker_stats,
         kv_stats,
         spec_decode_stats,
+        performance_metrics: None,
     };
     tracing::info!("Stats: {stats:?}");
     serde_json::to_value(stats).unwrap()

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -111,6 +111,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ModelType>()?;
     m.add_class::<ModelInput>()?;
     m.add_class::<llm::kv::ForwardPassMetrics>()?;
+    m.add_class::<llm::kv::PerformanceMetrics>()?;
     m.add_class::<llm::kv::WorkerStats>()?;
     m.add_class::<llm::kv::KvStats>()?;
     m.add_class::<llm::kv::SpecDecodeStats>()?;

--- a/lib/llm/src/kv_router/protocols.rs
+++ b/lib/llm/src/kv_router/protocols.rs
@@ -29,10 +29,21 @@ pub struct WorkerSelectionResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct PerformanceMetrics {
+    /// Timestamp when the request arrived at the handler
+    pub arriving_time: Option<f64>,
+    /// Total number of KV cache blocks allocated
+    pub kv_cache_num_total_allocated_blocks: Option<u64>,
+    /// Speculative decoding acceptance rate (0.0 to 1.0)
+    pub spec_decoding_acceptance_rate: Option<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct ForwardPassMetrics {
     pub worker_stats: WorkerStats,
     pub kv_stats: KvStats,
     pub spec_decode_stats: Option<SpecDecodeStats>,
+    pub performance_metrics: Option<PerformanceMetrics>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -1125,6 +1125,7 @@ mod test_integration_publisher {
                     request_total_slots: 100,
                 },
                 spec_decode_stats: None,
+                performance_metrics: None,
             });
 
             publisher.publish(metrics).unwrap();
@@ -1166,6 +1167,7 @@ mod test_integration_publisher {
                     request_total_slots: 100 + (i * 10) as u64, // Change other metrics
                 },
                 spec_decode_stats: None,
+                performance_metrics: None,
             });
 
             publisher.publish(metrics).unwrap();
@@ -1227,6 +1229,7 @@ mod test_integration_publisher {
                 gpu_prefix_cache_hit_rate: 0.75,
             },
             spec_decode_stats: None,
+            performance_metrics: None,
         });
 
         // Test 1: Initial gauge values should be 0

--- a/lib/llm/src/mocker/scheduler.rs
+++ b/lib/llm/src/mocker/scheduler.rs
@@ -616,6 +616,7 @@ fn get_fwd_pass_metrics(
         worker_stats,
         kv_stats,
         spec_decode_stats,
+        performance_metrics: None,
     }
 }
 


### PR DESCRIPTION
#### Overview:

This PR extends the ForwardPassMetrics system to include performance metrics from TensorRT-LLM engines, enabling comprehensive monitoring of inference performance including arrival times, KV cache utilization, and speculative decoding acceptance rates.

#### Details:

- Add new PerformanceMetrics struct to ForwardPassMetrics containing arriving_time, kv_cache_num_total_allocated_blocks, and spec_decoding_acceptance_rate
- Implement Python bindings for PerformanceMetrics using PyO3 integration
- Add performance metrics collection in TensorRT-LLM request handlers with comprehensive type hints using Protocol definitions
- Integrate performance metrics publishing through the existing publisher infrastructure
- Update all ForwardPassMetrics instantiations across the codebase to maintain backward compatibility
- Add detailed documentation and type safety for TensorRT-LLM performance metrics interfaces

#### Where should the reviewer start?

- `lib/llm/src/kv_router/protocols.rs` - Core Rust data structures for PerformanceMetrics
- `components/backends/trtllm/src/dynamo/trtllm/request_handlers/handler_base.py` - Performance metrics collection logic and Protocol definitions
- `components/backends/trtllm/src/dynamo/trtllm/publisher.py` - Integration with existing metrics publishing system

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to performance monitoring enhancements for TensorRT-LLM backends