### PR TITLE
chore: add additional param support for multimodal models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,6 +1942,8 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "tokio-util",
  "tracing",
+ "url",
+ "uuid 1.18.0",
 ]
 
 [[package]]

--- a/lib/async-openai/Cargo.toml
+++ b/lib/async-openai/Cargo.toml
@@ -52,6 +52,8 @@ tokio = { version = "1.43.0", features = ["fs", "macros"] }
 tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.13", features = ["codec", "io-util"] }
 tracing = "0.1.41"
+uuid = { version = "1.18.0", features = ["serde"] }
+url = "2.5.7"
 derive_builder = "0.20.2"
 secrecy = { version = "0.10.3", features = ["serde"] }
 bytes = "1.9.0"

--- a/lib/async-openai/Cargo.toml
+++ b/lib/async-openai/Cargo.toml
@@ -52,8 +52,8 @@ tokio = { version = "1.43.0", features = ["fs", "macros"] }
 tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.13", features = ["codec", "io-util"] }
 tracing = "0.1.41"
-uuid = { version = "1.18.0", features = ["serde"] }
-url = "2.5.7"
+url = { workspace = true }
+uuid = { workspace = true }
 derive_builder = "0.20.2"
 secrecy = { version = "0.10.3", features = ["serde"] }
 bytes = "1.9.0"

--- a/lib/async-openai/src/types/chat.rs
+++ b/lib/async-openai/src/types/chat.rs
@@ -14,6 +14,9 @@ use derive_builder::Builder;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
 
+use url::Url;
+use uuid::{Uuid, uuid};
+
 use crate::error::OpenAIError;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -199,76 +202,76 @@ pub enum ImageDetail {
     High,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone, Builder, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Builder, PartialEq)]
 #[builder(name = "ImageUrlArgs")]
 #[builder(pattern = "mutable")]
-#[builder(setter(into, strip_option), default)]
+#[builder(setter(into, strip_option))]
 #[builder(derive(Debug))]
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct ImageUrl {
     /// Either a URL of the image or the base64 encoded image data.
-    pub url: String,
+    pub url: url::Url,
     /// Specifies the detail level of the image. Learn more in the [Vision guide](https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding).
     pub detail: Option<ImageDetail>,
     /// Optional unique identifier for the image.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub uuid: Option<String>,
+    pub uuid: Option<uuid::Uuid>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone, Builder, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Builder, PartialEq)]
 #[builder(name = "VideoUrlArgs")]
 #[builder(pattern = "mutable")]
-#[builder(setter(into, strip_option), default)]
+#[builder(setter(into, strip_option))]
 #[builder(derive(Debug))]
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct VideoUrl {
     /// Either a URL of the video or the base64 encoded video data.
-    pub url: String,
+    pub url: url::Url,
     /// Specifies the detail level of the video processing.
     pub detail: Option<ImageDetail>,
     /// Optional unique identifier for the video.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub uuid: Option<String>,
+    pub uuid: Option<uuid::Uuid>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone, Builder, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Builder, PartialEq)]
 #[builder(name = "ChatCompletionRequestMessageContentPartImageArgs")]
 #[builder(pattern = "mutable")]
-#[builder(setter(into, strip_option), default)]
+#[builder(setter(into, strip_option))]
 #[builder(derive(Debug))]
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct ChatCompletionRequestMessageContentPartImage {
     pub image_url: ImageUrl,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone, Builder, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Builder, PartialEq)]
 #[builder(name = "ChatCompletionRequestMessageContentPartVideoArgs")]
 #[builder(pattern = "mutable")]
-#[builder(setter(into, strip_option), default)]
+#[builder(setter(into, strip_option))]
 #[builder(derive(Debug))]
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct ChatCompletionRequestMessageContentPartVideo {
     pub video_url: VideoUrl,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone, Builder, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Builder, PartialEq)]
 #[builder(name = "AudioUrlArgs")]
 #[builder(pattern = "mutable")]
-#[builder(setter(into, strip_option), default)]
+#[builder(setter(into, strip_option))]
 #[builder(derive(Debug))]
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct AudioUrl {
     /// URL of the audio file
-    pub url: String,
+    pub url: url::Url,
     /// Optional unique identifier for the audio.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub uuid: Option<String>,
+    pub uuid: Option<uuid::Uuid>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone, Builder, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Builder, PartialEq)]
 #[builder(name = "ChatCompletionRequestMessageContentPartAudioUrlArgs")]
 #[builder(pattern = "mutable")]
-#[builder(setter(into, strip_option), default)]
+#[builder(setter(into, strip_option))]
 #[builder(derive(Debug))]
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct ChatCompletionRequestMessageContentPartAudioUrl {
@@ -1142,14 +1145,20 @@ mod tests {
 
     #[test]
     fn test_audio_url_content_part_json() {
-        let json = r#"{"type": "audio_url", "audio_url": {"url": "https://example.com/audio.mp3", "uuid": "test-123"}}"#;
+        let json = r#"{"type": "audio_url", "audio_url": {"url": "https://example.com/audio.mp3", "uuid": "67e55044-10b1-426f-9247-bb680e5fe0c8"}}"#;
         let content_part: ChatCompletionRequestUserMessageContentPart =
             serde_json::from_str(json).unwrap();
 
         match content_part {
             ChatCompletionRequestUserMessageContentPart::AudioUrl(part) => {
-                assert_eq!(part.audio_url.url, "https://example.com/audio.mp3");
-                assert_eq!(part.audio_url.uuid, Some("test-123".to_string()));
+                assert_eq!(
+                    part.audio_url.url,
+                    "https://example.com/audio.mp3".parse().unwrap()
+                );
+                assert_eq!(
+                    part.audio_url.uuid,
+                    Some(uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"))
+                );
             }
             _ => panic!("Expected AudioUrl variant"),
         }

--- a/lib/async-openai/src/types/impls.rs
+++ b/lib/async-openai/src/types/impls.rs
@@ -797,7 +797,7 @@ impl From<String> for ChatCompletionRequestMessageContentPartText {
 impl From<&str> for ImageUrl {
     fn from(value: &str) -> Self {
         Self {
-            url: value.into(),
+            url: value.parse().expect("Invalid URL"),
             detail: Default::default(),
             uuid: None,
         }
@@ -807,7 +807,7 @@ impl From<&str> for ImageUrl {
 impl From<String> for ImageUrl {
     fn from(value: String) -> Self {
         Self {
-            url: value,
+            url: value.parse().expect("Invalid URL"),
             detail: Default::default(),
             uuid: None,
         }
@@ -817,7 +817,7 @@ impl From<String> for ImageUrl {
 impl From<&str> for VideoUrl {
     fn from(value: &str) -> Self {
         Self {
-            url: value.into(),
+            url: value.parse().expect("Invalid URL"),
             detail: Default::default(),
             uuid: None,
         }
@@ -827,7 +827,7 @@ impl From<&str> for VideoUrl {
 impl From<String> for VideoUrl {
     fn from(value: String) -> Self {
         Self {
-            url: value,
+            url: value.parse().expect("Invalid URL"),
             detail: Default::default(),
             uuid: None,
         }
@@ -837,7 +837,7 @@ impl From<String> for VideoUrl {
 impl From<&str> for AudioUrl {
     fn from(value: &str) -> Self {
         Self {
-            url: value.into(),
+            url: value.parse().expect("Invalid URL"),
             uuid: None,
         }
     }
@@ -846,7 +846,7 @@ impl From<&str> for AudioUrl {
 impl From<String> for AudioUrl {
     fn from(value: String) -> Self {
         Self {
-            url: value,
+            url: value.parse().expect("Invalid URL"),
             uuid: None,
         }
     }

--- a/lib/async-openai/src/types/impls.rs
+++ b/lib/async-openai/src/types/impls.rs
@@ -24,12 +24,13 @@ use crate::{
 use bytes::Bytes;
 
 use super::{
-    AddUploadPartRequest, AudioInput, AudioResponseFormat, ChatCompletionFunctionCall,
+    AddUploadPartRequest, AudioInput, AudioResponseFormat, AudioUrl, ChatCompletionFunctionCall,
     ChatCompletionFunctions, ChatCompletionNamedToolChoice, ChatCompletionRequestAssistantMessage,
     ChatCompletionRequestAssistantMessageContent, ChatCompletionRequestDeveloperMessage,
     ChatCompletionRequestDeveloperMessageContent, ChatCompletionRequestFunctionMessage,
     ChatCompletionRequestMessage, ChatCompletionRequestMessageContentPartAudio,
-    ChatCompletionRequestMessageContentPartImage, ChatCompletionRequestMessageContentPartText,
+    ChatCompletionRequestMessageContentPartAudioUrl, ChatCompletionRequestMessageContentPartImage,
+    ChatCompletionRequestMessageContentPartText, ChatCompletionRequestMessageContentPartVideo,
     ChatCompletionRequestSystemMessage, ChatCompletionRequestSystemMessageContent,
     ChatCompletionRequestToolMessage, ChatCompletionRequestToolMessageContent,
     ChatCompletionRequestUserMessage, ChatCompletionRequestUserMessageContent,
@@ -38,7 +39,7 @@ use super::{
     CreateSpeechResponse, CreateTranscriptionRequest, CreateTranslationRequest, DallE2ImageSize,
     EmbeddingInput, FileInput, FilePurpose, FunctionName, Image, ImageInput, ImageModel,
     ImageResponseFormat, ImageSize, ImageUrl, ImagesResponse, ModerationInput, Prompt, Role, Stop,
-    TimestampGranularity,
+    TimestampGranularity, VideoUrl,
     responses::{CodeInterpreterContainer, Input, InputContent, Role as ResponsesRole},
 };
 
@@ -765,6 +766,22 @@ impl From<ChatCompletionRequestMessageContentPartAudio>
     }
 }
 
+impl From<ChatCompletionRequestMessageContentPartVideo>
+    for ChatCompletionRequestUserMessageContentPart
+{
+    fn from(value: ChatCompletionRequestMessageContentPartVideo) -> Self {
+        ChatCompletionRequestUserMessageContentPart::VideoUrl(value)
+    }
+}
+
+impl From<ChatCompletionRequestMessageContentPartAudioUrl>
+    for ChatCompletionRequestUserMessageContentPart
+{
+    fn from(value: ChatCompletionRequestMessageContentPartAudioUrl) -> Self {
+        ChatCompletionRequestUserMessageContentPart::AudioUrl(value)
+    }
+}
+
 impl From<&str> for ChatCompletionRequestMessageContentPartText {
     fn from(value: &str) -> Self {
         ChatCompletionRequestMessageContentPartText { text: value.into() }
@@ -782,6 +799,7 @@ impl From<&str> for ImageUrl {
         Self {
             url: value.into(),
             detail: Default::default(),
+            uuid: None,
         }
     }
 }
@@ -791,6 +809,45 @@ impl From<String> for ImageUrl {
         Self {
             url: value,
             detail: Default::default(),
+            uuid: None,
+        }
+    }
+}
+
+impl From<&str> for VideoUrl {
+    fn from(value: &str) -> Self {
+        Self {
+            url: value.into(),
+            detail: Default::default(),
+            uuid: None,
+        }
+    }
+}
+
+impl From<String> for VideoUrl {
+    fn from(value: String) -> Self {
+        Self {
+            url: value,
+            detail: Default::default(),
+            uuid: None,
+        }
+    }
+}
+
+impl From<&str> for AudioUrl {
+    fn from(value: &str) -> Self {
+        Self {
+            url: value.into(),
+            uuid: None,
+        }
+    }
+}
+
+impl From<String> for AudioUrl {
+    fn from(value: String) -> Self {
+        Self {
+            url: value,
+            uuid: None,
         }
     }
 }

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1373,6 +1373,8 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -6302,9 +6304,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -6304,9 +6304,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",


### PR DESCRIPTION
#### Overview:

**New Multimodal Request Parameters:**
- `mm_processor_kwargs` - Top-level field for multi-modal processor kwargs (e.g., `max_pixels`)
- `audio_url` content parts with `url` and optional `uuid` fields
- `uuid` fields added to existing `image_url` and `video_url` content parts

**vLLM docs**
- https://docs.vllm.ai/en/latest/configuration/engine_args.html#-mm-processor-kwargs
- https://docs.vllm.ai/en/latest/features/multimodal_inputs.html

#### Details:

- Added `AudioUrl` struct and `ChatCompletionRequestMessageContentPartAudioUrl` wrapper
- Extended `ChatCompletionRequestUserMessageContentPart` enum with `AudioUrl` variant
- Added `mm_processor_kwargs: Option<serde_json::Value>` to `CreateChatCompletionRequest`

#### Where should the reviewer start?

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add support for audio and video URL content parts in chat messages.
  - Enable optional multimodal processor settings on chat completion requests.
- Enhancements
  - Introduce optional identifiers for media URLs (image, video, audio) to help track assets; included only when provided.
  - Improve serialization and JSON handling for media content parts.
- Tests
  - Add coverage for audio URL content parts and multimodal processor settings serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->