### PR TITLE
fix: replace hard coded dynamo namespace with env var

### DIFF
--- a/components/backends/llama_cpp/src/dynamo/llama_cpp/main.py
+++ b/components/backends/llama_cpp/src/dynamo/llama_cpp/main.py
@@ -5,6 +5,7 @@
 
 import argparse
 import logging
+import os
 import sys
 from typing import Optional
 
@@ -17,7 +18,8 @@ from dynamo.runtime.logging import configure_dynamo_logging
 
 from . import __version__
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
+DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
 
 configure_dynamo_logging()
 

--- a/components/backends/sglang/src/dynamo/sglang/args.py
+++ b/components/backends/sglang/src/dynamo/sglang/args.py
@@ -20,7 +20,9 @@ from dynamo.sglang import __version__
 
 configure_dynamo_logging()
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
+DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
+
 DYNAMO_ARGS: Dict[str, Dict[str, Any]] = {
     "endpoint": {
         "flags": ["--endpoint"],

--- a/examples/multimodal/components/encode_worker.py
+++ b/examples/multimodal/components/encode_worker.py
@@ -176,8 +176,9 @@ class VllmEncodeWorker:
 
     @classmethod
     def parse_args(cls) -> Tuple[argparse.Namespace, Config]:
-        DEFAULT_ENDPOINT = "dyn://dynamo.encoder.generate"
-        DEFAULT_DOWNSTREAM_ENDPOINT = "dyn://dynamo.llm.generate"
+        DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+        DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.encoder.generate"
+        DEFAULT_DOWNSTREAM_ENDPOINT = f"dyn://{DYN_NAMESPACE}.llm.generate"
 
         parser = FlexibleArgumentParser(
             description="vLLM based encoder for Dynamo LLM."

--- a/examples/multimodal/components/processor.py
+++ b/examples/multimodal/components/processor.py
@@ -63,8 +63,9 @@ class Processor(ProcessMixIn):
 
     @classmethod
     def parse_args(cls) -> Tuple[argparse.Namespace, Config]:
-        DEFAULT_ENDPOINT = "dyn://dynamo.processor.generate"
-        DEFAULT_DOWNSTREAM_ENDPOINT = "dyn://dynamo.encoder.generate"
+        DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+        DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.processor.generate"
+        DEFAULT_DOWNSTREAM_ENDPOINT = f"dyn://{DYN_NAMESPACE}.encoder.generate"
 
         parser = FlexibleArgumentParser(
             description="vLLM based processor for Dynamo LLM."

--- a/examples/multimodal/components/video_encode_worker.py
+++ b/examples/multimodal/components/video_encode_worker.py
@@ -217,8 +217,9 @@ class VllmEncodeWorker:
 
     @classmethod
     def parse_args(cls) -> Tuple[argparse.Namespace, Config]:
-        DEFAULT_ENDPOINT = "dyn://dynamo.encoder.generate"
-        DEFAULT_DOWNSTREAM_ENDPOINT = "dyn://dynamo.llm.generate"
+        DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+        DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.encoder.generate"
+        DEFAULT_DOWNSTREAM_ENDPOINT = f"dyn://{DYN_NAMESPACE}.llm.generate"
 
         parser = FlexibleArgumentParser(
             description="vLLM based encoder for Dynamo LLM."

--- a/examples/multimodal/components/worker.py
+++ b/examples/multimodal/components/worker.py
@@ -84,17 +84,23 @@ class VllmBaseWorker:
 
         # use endpoint_overwrite to set the default endpoint based on worker type
         def endpoint_overwrite(args):
+            DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
             # default endpoint for this worker
             if args.worker_type == "prefill":
-                args.endpoint = args.endpoint or "dyn://dynamo.llm.generate"
+                args.endpoint = args.endpoint or f"dyn://{DYN_NAMESPACE}.llm.generate"
             elif args.worker_type == "decode":
-                args.endpoint = args.endpoint or "dyn://dynamo.decoder.generate"
+                args.endpoint = (
+                    args.endpoint or f"dyn://{DYN_NAMESPACE}.decoder.generate"
+                )
             elif args.worker_type == "encode_prefill":
-                args.endpoint = args.endpoint or "dyn://dynamo.encoder.generate"
+                args.endpoint = (
+                    args.endpoint or f"dyn://{DYN_NAMESPACE}.encoder.generate"
+                )
             # set downstream endpoint for disaggregated workers
             if args.enable_disagg:
                 args.downstream_endpoint = (
-                    args.downstream_endpoint or "dyn://dynamo.decoder.generate"
+                    args.downstream_endpoint
+                    or f"dyn://{DYN_NAMESPACE}.decoder.generate"
                 )
 
             return args

--- a/examples/multimodal/utils/args.py
+++ b/examples/multimodal/utils/args.py
@@ -29,7 +29,8 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
+DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
 
 
 class Config:

--- a/lib/bindings/python/examples/hello_world/server_sglang.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang.py
@@ -21,6 +21,7 @@
 
 import argparse
 import asyncio
+import os
 import sys
 
 import sglang
@@ -30,7 +31,8 @@ from sglang.srt.server_args import ServerArgs
 from dynamo.llm import ModelInput, ModelType, register_llm
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
+DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
 DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
 DEFAULT_TEMPERATURE = 0.7
 

--- a/lib/bindings/python/examples/hello_world/server_sglang_static.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang_static.py
@@ -13,6 +13,7 @@
 
 import argparse
 import asyncio
+import os
 import sys
 
 import sglang
@@ -21,7 +22,8 @@ from sglang.srt.server_args import ServerArgs
 
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
+DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
 DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
 DEFAULT_TEMPERATURE = 0.7
 

--- a/lib/bindings/python/examples/hello_world/server_sglang_tok.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang_tok.py
@@ -22,6 +22,7 @@
 
 import argparse
 import asyncio
+import os
 import sys
 import time
 
@@ -34,7 +35,8 @@ from sglang.srt.server_args import ServerArgs
 from dynamo.llm import ModelInput, ModelType, register_llm
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
+DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
 DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
 
 

--- a/lib/bindings/python/examples/hello_world/server_vllm.py
+++ b/lib/bindings/python/examples/hello_world/server_vllm.py
@@ -29,6 +29,7 @@
 
 import argparse
 import asyncio
+import os
 import sys
 
 import uvloop
@@ -42,7 +43,8 @@ from vllm.inputs import TokensPrompt
 from dynamo.llm import ModelInput, ModelType, register_llm
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
-DEFAULT_ENDPOINT = "dyn://dynamo.backend.generate"
+DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
 DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
 DEFAULT_TEMPERATURE = 0.7
 


### PR DESCRIPTION
#### Overview:

We have hard coded dynamo namespaces in examples. 

Replace them with env var `DYN_NAMESPACE` 

closes: 
- nvbug: [5512383](https://nvbugspro.nvidia.com/bug/5512383)
- linear ticket: DEP-384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default Dynamo endpoints are now configurable via the DYN_NAMESPACE environment variable across backends (llama.cpp, sglang, vLLM) and examples (hello_world, multimodal processor/encoder/video).
  * Set DYN_NAMESPACE to route requests to a custom namespace; if unset, it defaults to “dynamo”.
  * CLI help and inferred defaults now reflect the selected namespace; no changes required for existing setups and no API behavior altered beyond default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->