### PR TITLE
chore: update the tags of deployment containers to thre 0.5.0 release

### DIFF
--- a/components/backends/sglang/deploy/README.md
+++ b/components/backends/sglang/deploy/README.md
@@ -61,7 +61,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/sglang-runtime:0.5.0
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
     workingDir: /workspace/components/backends/sglang
     args:
       - "python3"
@@ -92,7 +92,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: your-registry/sglang-runtime:your-tag
+image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
 
 # Configure your model
 args:

--- a/components/backends/sglang/deploy/README.md
+++ b/components/backends/sglang/deploy/README.md
@@ -61,7 +61,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/sglang-runtime:my-tag
+    image: my-registry/sglang-runtime:ABCDEFGH
     workingDir: /workspace/components/backends/sglang
     args:
       - "python3"

--- a/components/backends/sglang/deploy/README.md
+++ b/components/backends/sglang/deploy/README.md
@@ -61,7 +61,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/sglang-runtime:ABCDEFGH
+    image: my-registry/sglang-runtime:0.5.0
     workingDir: /workspace/components/backends/sglang
     args:
       - "python3"

--- a/components/backends/sglang/deploy/agg.yaml
+++ b/components/backends/sglang/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/agg.yaml
+++ b/components/backends/sglang/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/agg.yaml
+++ b/components/backends/sglang/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/agg_logging.yaml
+++ b/components/backends/sglang/deploy/agg_logging.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/sglang
           command:
           - /bin/sh

--- a/components/backends/sglang/deploy/agg_logging.yaml
+++ b/components/backends/sglang/deploy/agg_logging.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command:
           - /bin/sh

--- a/components/backends/sglang/deploy/agg_logging.yaml
+++ b/components/backends/sglang/deploy/agg_logging.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command:
           - /bin/sh

--- a/components/backends/sglang/deploy/agg_router.yaml
+++ b/components/backends/sglang/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/agg_router.yaml
+++ b/components/backends/sglang/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/agg_router.yaml
+++ b/components/backends/sglang/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/disagg-multinode.yaml
+++ b/components/backends/sglang/deploy/disagg-multinode.yaml
@@ -22,7 +22,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
     decode:
       multinode:
         nodeCount: 2
@@ -35,7 +35,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:
@@ -62,7 +62,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:

--- a/components/backends/sglang/deploy/disagg-multinode.yaml
+++ b/components/backends/sglang/deploy/disagg-multinode.yaml
@@ -22,7 +22,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
     decode:
       multinode:
         nodeCount: 2
@@ -35,7 +35,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:
@@ -62,7 +62,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:

--- a/components/backends/sglang/deploy/disagg-multinode.yaml
+++ b/components/backends/sglang/deploy/disagg-multinode.yaml
@@ -22,7 +22,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
     decode:
       multinode:
         nodeCount: 2
@@ -35,7 +35,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:
@@ -62,7 +62,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:

--- a/components/backends/sglang/deploy/disagg.yaml
+++ b/components/backends/sglang/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -51,7 +51,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: my-registry/sglang-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/disagg.yaml
+++ b/components/backends/sglang/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -51,7 +51,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:ABCDEFGH
+          image: my-registry/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/disagg.yaml
+++ b/components/backends/sglang/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -51,7 +51,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:0.5.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/trtllm/deploy/README.md
+++ b/components/backends/trtllm/deploy/README.md
@@ -120,7 +120,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: your-registry/trtllm-runtime:your-tag
+image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.0
 
 # Configure your model and deployment settings
 args:

--- a/components/backends/vllm/deploy/README.md
+++ b/components/backends/vllm/deploy/README.md
@@ -69,7 +69,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/vllm-runtime:my-tag
+    image: my-registry/vllm-runtime:ABCDEFGH
     workingDir: /workspace/components/backends/vllm
     args:
       - "python3"

--- a/components/backends/vllm/deploy/README.md
+++ b/components/backends/vllm/deploy/README.md
@@ -69,7 +69,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/vllm-runtime:ABCDEFGH
+    image: my-registry/vllm-runtime:0.5.0
     workingDir: /workspace/components/backends/vllm
     args:
       - "python3"

--- a/components/backends/vllm/deploy/README.md
+++ b/components/backends/vllm/deploy/README.md
@@ -69,7 +69,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/vllm-runtime:0.5.0
+    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
     workingDir: /workspace/components/backends/vllm
     args:
       - "python3"
@@ -116,7 +116,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: your-registry/vllm-runtime:your-tag
+image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
 
 # Configure your model
 args:

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/disagg.yaml
+++ b/components/backends/vllm/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -41,7 +41,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/disagg.yaml
+++ b/components/backends/vllm/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -41,7 +41,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -20,7 +20,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
     Planner:
       dynamoNamespace: vllm-disagg-planner
       envFromSecret: hf-token-secret
@@ -51,7 +51,7 @@ spec:
         mountPoint: /data/profiling_results
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
           workingDir: /workspace/components/planner/src/dynamo/planner
           ports:
             - name: metrics
@@ -95,7 +95,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -118,7 +118,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/vllm
           command:
             - python3
@@ -143,7 +143,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/vllm
           command:
             - python3

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -20,7 +20,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
     Planner:
       dynamoNamespace: vllm-disagg-planner
       envFromSecret: hf-token-secret
@@ -51,7 +51,7 @@ spec:
         mountPoint: /data/profiling_results
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/components/planner/src/dynamo/planner
           ports:
             - name: metrics
@@ -95,7 +95,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -118,7 +118,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/components/backends/vllm
           command:
             - python3
@@ -143,7 +143,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/components/backends/vllm
           command:
             - python3

--- a/components/backends/vllm/deploy/disagg_router.yaml
+++ b/components/backends/vllm/deploy/disagg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -44,7 +44,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/disagg_router.yaml
+++ b/components/backends/vllm/deploy/disagg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -44,7 +44,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:ABCDEFGH
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/examples/multimodal/deploy/agg_llava.yaml
+++ b/examples/multimodal/deploy/agg_llava.yaml
@@ -14,7 +14,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
     EncodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: agg-llava
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -42,7 +42,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -59,7 +59,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh

--- a/examples/multimodal/deploy/agg_qwen.yaml
+++ b/examples/multimodal/deploy/agg_qwen.yaml
@@ -14,7 +14,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
     EncodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: agg-qwen
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -42,7 +42,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -59,7 +59,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh

--- a/examples/runtime/hello_world/deploy/hello_world.yaml
+++ b/examples/runtime/hello_world/deploy/hello_world.yaml
@@ -41,7 +41,7 @@ spec:
           memory: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/dynamo:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:0.5.0
           workingDir: /workspace/examples/runtime/hello_world/
           command:
             - /bin/sh
@@ -80,7 +80,7 @@ spec:
           memory: "4Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/dynamo:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:0.5.0
           workingDir: /workspace/examples/runtime/hello_world/
           command:
             - /bin/sh


### PR DESCRIPTION
#### Overview:

Updates the tags on `.yaml` files to the current release for ease of deployment.

#### Details:

Run the following script with both `my-tag` and `0.4.1` (this one will be updated on `main` for the future to `my-tag`). Also handled were `my-registry` and`your-registry`
 
```bash
#!/bin/bash
# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
# SPDX-License-Identifier: Apache-2.0

TARGET_DIR="components/backends"
ORIGINAL_TAG="my-tag"
DESIRED_TAG_VERSION="0.5.0"

find "$TARGET_DIR" -type f -print0 | while IFS= read -r -d '' file; do
    if grep -q ":$ORIGINAL_TAG" "$file" 2>/dev/null; then
        echo "Updating: $file"
        sed -i '' "s/:$ORIGINAL_TAG/:$DESIRED_TAG_VERSION/g" "$file"
    fi
done
```
