### PR TITLE
docs: add benchmark section to KVBM vLLM runbook

### DIFF
--- a/docs/guides/run_kvbm_in_vllm.md
+++ b/docs/guides/run_kvbm_in_vllm.md
@@ -84,7 +84,8 @@ Once vllm serve is ready, follow below steps to use LMBenchmark to benchmark KVB
 ```bash
 git clone https://github.com/LMCache/LMBenchmark.git
 
-# show case of running the synthetic multi-turn chat dataset
+# show case of running the synthetic multi-turn chat dataset.
+# we are passing model, endpoint, output file prefix and qps to the sh script.
 cd LMBenchmark/synthetic-multi-round-qa
 ./long_input_short_output_run.sh \
     "deepseek-ai/DeepSeek-R1-Distill-Llama-8B" \

--- a/docs/guides/run_kvbm_in_vllm.md
+++ b/docs/guides/run_kvbm_in_vllm.md
@@ -77,3 +77,25 @@ sudo ufw allow 6881/tcp
 ```
 
 View grafana metrics via http://localhost:3001 (default login: dynamo/dynamo) and look for KVBM Dashboard
+
+## Benchmark KVBM
+
+Once vllm serve is ready, follow below steps to use LMBenchmark to benchmark KVBM performance:
+```bash
+git clone https://github.com/LMCache/LMBenchmark.git
+
+# show case of running the synthetic multi-turn chat dataset
+cd LMBenchmark/synthetic-multi-round-qa
+./long_input_short_output_run.sh \
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B" \
+    "http://localhost:8000" \
+    "benchmark_kvbm" \
+    1
+
+# Average TTFT and other perf numbers would be in the output from above cmd
+```
+More details about how to use LMBenchmark could be found [here](https://github.com/LMCache/LMBenchmark).
+
+`NOTE`: if metrics are enabled as mentioned in the above section, you can observe KV offloading, and KV onboarding in the grafana dashboard.
+
+To compare, you can run `vllm serve deepseek-ai/DeepSeek-R1-Distill-Llama-8B` to turn KVBM off as the baseline.


### PR DESCRIPTION
#### Overview:

title says all


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added “Benchmark KVBM” section to the vLLM guide.
  - Provides step-by-step workflow using LMBenchmark (clone, navigate to synthetic-multi-round-qa, run long_input_short_output_run.sh).
  - Includes example args: model, endpoint, benchmark name, and run count.
  - Notes where performance metrics (e.g., TTFT) appear in output.
  - Links to LMBenchmark repository.
  - Adds note on Grafana visibility for KV offloading/onboarding when metrics are enabled.
  - Suggests baseline comparison by disabling KVBM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->