### PR TITLE
chore: a few small benchmarking and profiling improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ TensorRT-LLM
 /.cursor/instructions.md.bak
 /CLAUDE.md
 /CLAUDE.md.bak
+
+# Benchmarks
+benchmarks/results

--- a/benchmarks/benchmark.sh
+++ b/benchmarks/benchmark.sh
@@ -271,20 +271,8 @@ print_config() {
     echo
 }
 
-clear_output_directory() {
-    if [[ -d "$OUTPUT_DIR" ]]; then
-        echo "🧹 Clearing existing output directory: $OUTPUT_DIR"
-        rm -rf "$OUTPUT_DIR"
-    fi
-    mkdir -p "$OUTPUT_DIR"
-    echo "✅ Output directory prepared: $OUTPUT_DIR"
-}
-
 run_benchmark() {
     echo "🚀 Starting benchmark workflow..."
-
-    # Clear and recreate output directory
-    clear_output_directory
 
     # Change to dynamo root directory
     cd "$DYNAMO_ROOT"

--- a/docs/benchmarks/pre_deployment_profiling.md
+++ b/docs/benchmarks/pre_deployment_profiling.md
@@ -39,7 +39,7 @@ This sequential approach ensures:
 - **Reliable cleanup** between different TP configuration tests
 - **Accurate SLA compliance verification** for each configuration
 
-After the profiling finishes, two plots will be generated in the `output-dir`. For example, here are the profiling results for `examples/llm/configs/disagg.yaml`:
+After the profiling finishes, two plots will be generated in the `output-dir`. For example, here are the profiling results for `components/backends/vllm/deploy/disagg.yaml`:
 
 ![Prefill Performance](../../docs/images/h100_prefill_performance.png)
 ![Decode Performance](../../docs/images/h100_decode_performance.png)


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

* add benchmarks/results to gitignore
* correct path in profiling doc 
* remove logic to clear output dir (kind of a no-op because the script will be removed soon)

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Ignored benchmark results directory in version control to keep repos clean.
  - Benchmark runner no longer auto-clears the output directory, preserving previous results between runs. Manually delete outputs if a fresh run is needed.

- Documentation
  - Updated the pre-deployment profiling guide with corrected configuration path references and examples for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->