### PR TITLE
fix: move deep_update function to trtllm folder

### DIFF
--- a/benchmarks/profiler/utils/config.py
+++ b/benchmarks/profiler/utils/config.py
@@ -159,21 +159,6 @@ def parse_override_engine_args(args: list[str]) -> tuple[dict, list[str]]:
     return override_dict, args
 
 
-def deep_update(target: dict, source: dict) -> None:
-    """
-    Recursively update nested dictionaries.
-
-    Args:
-        target: Dictionary to update
-        source: Dictionary with new values
-    """
-    for key, value in source.items():
-        if isinstance(value, dict) and key in target and isinstance(target[key], dict):
-            deep_update(target[key], value)
-        else:
-            target[key] = value
-
-
 class ConfigModifierProtocol(Protocol):
     @classmethod
     def convert_config(cls, config: dict, target: Literal["prefill", "decode"]) -> dict:

--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -23,7 +23,6 @@ from torch.cuda import device_count
 from transformers import AutoConfig
 
 import dynamo.nixl_connect as nixl_connect
-from benchmarks.profiler.utils.config import deep_update
 from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_llm
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -37,6 +36,7 @@ from dynamo.trtllm.request_handlers.handlers import (
 from dynamo.trtllm.utils.trtllm_utils import (
     Config,
     cmd_line_args,
+    deep_update,
     is_first_worker,
     parse_endpoint,
 )

--- a/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -368,3 +368,18 @@ def cmd_line_args():
     config.tool_call_parser = args.dyn_tool_call_parser
 
     return config
+
+
+def deep_update(target: dict, source: dict) -> None:
+    """
+    Recursively update nested dictionaries.
+
+    Args:
+        target: Dictionary to update
+        source: Dictionary with new values
+    """
+    for key, value in source.items():
+        if isinstance(value, dict) and key in target and isinstance(target[key], dict):
+            deep_update(target[key], value)
+        else:
+            target[key] = value


### PR DESCRIPTION
`deep_update` is not used in profiler any more and is causing dependency issue in trtllm examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated a nested-dictionary merge utility within the TRT-LLM backend and updated internal references to use the new location.
  - Removed the duplicated implementation from the benchmarks area to reduce redundancy.
  - Ensured existing behavior for merging configuration overrides remains unchanged.

- Chores
  - General code cleanup related to utility placement.

- Notes
  - No user-facing changes. Existing workflows and outputs remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->