### PR TITLE
fix: purge before snapshotting

### DIFF
--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -244,7 +244,7 @@ pub async fn start_kv_router_background(
                     };
 
                     // Perform snapshot upload and purge
-                    match perform_snapshot_and_purge(
+                    match purge_then_snapshot(
                         &mut nats_queue,
                         snapshot_tx,
                         resources
@@ -322,7 +322,7 @@ pub async fn start_kv_router_background(
 }
 
 /// Perform snapshot upload and purge operations
-async fn perform_snapshot_and_purge(
+async fn purge_then_snapshot(
     nats_queue: &mut NatsQueue,
     snapshot_tx: &mpsc::Sender<DumpRequest>,
     resources: &SnapshotResources,

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -327,10 +327,14 @@ async fn perform_snapshot_and_purge(
     snapshot_tx: &mpsc::Sender<DumpRequest>,
     resources: &SnapshotResources,
 ) -> anyhow::Result<()> {
-    // Snapshot before purge ensures we capture the current state before removing any messages.
-    // This guarantees the snapshot matches what has been acknowledged up to this point.
+    // Purge before snapshot ensures new/warm-restarted routers won't replay already-acknowledged messages.
+    // Since KV events are idempotent, this ordering reduces unnecessary reprocessing while maintaining
+    // at-least-once delivery guarantees. The snapshot will capture the clean state after purge.
 
-    // First, request a snapshot from the indexer
+    // First, purge acknowledged messages from the stream
+    nats_queue.purge_acknowledged().await?;
+
+    // Now request a snapshot from the indexer (which reflects the post-purge state)
     let (resp_tx, resp_rx) = oneshot::channel();
     let dump_req = DumpRequest { resp: resp_tx };
 
@@ -362,9 +366,6 @@ async fn perform_snapshot_and_purge(
         events.len(),
         resources.bucket_name
     );
-
-    // Now purge acknowledged messages from the stream
-    nats_queue.purge_acknowledged().await?;
 
     Ok(())
 }


### PR DESCRIPTION
Purge before snapshot ensures new/warm-restarted routers won't replay already-acknowledged messages. Since KV events are idempotent, this ordering reduces unnecessary reprocessing while maintaining at-least-once delivery guarantees. The snapshot will capture the clean state after purge.

In addition, the arm priorities in the biased tokio select should be:
1) cancel token, 2) remove worker, 3) kv events, 4) snapshot request, 5) find matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot handling to purge acknowledged messages before taking a snapshot, reducing duplicate message replays after restarts and improving reliability. No API changes.

* **Documentation**
  * Clarified snapshot and purge behavior to better reflect current flow and delivery guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->