### PR TITLE
feat: make connect_with_reset jetstream configurable

### DIFF
--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -520,13 +520,11 @@ impl NatsQueue {
                 .and_then(|s| s.parse::<u64>().ok())
                 .map(time::Duration::from_secs)
                 .unwrap_or_else(|| time::Duration::from_secs(60 * 60));
-
             // Always try to create the stream (removes the race condition)
             let stream_config = jetstream::stream::Config {
                 name: self.stream_name.clone(),
                 subjects: vec![self.subject.clone()],
-
-                max_age: max_age,
+                max_age,
                 ..Default::default()
             };
 

--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -514,12 +514,19 @@ impl NatsQueue {
 
             let client = client_options.connect().await?;
 
+            // messages older than a hour in the stream will be automatically purged
+            let max_age = std::env::var("DYN_NATS_STREAM_MAX_AGE")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .map(time::Duration::from_secs)
+                .unwrap_or_else(|| time::Duration::from_secs(60 * 60));
+
             // Always try to create the stream (removes the race condition)
             let stream_config = jetstream::stream::Config {
                 name: self.stream_name.clone(),
                 subjects: vec![self.subject.clone()],
-                // messages older than a hour in the stream will be automatically purged
-                max_age: time::Duration::from_secs(60 * 60),
+
+                max_age: max_age,
                 ..Default::default()
             };
 


### PR DESCRIPTION
Signed-off-by: michaelfeil <me@michaelfeil.eu>

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->
- very boring pr: makes the connect_with_reset configurable as time. I assume we might want to run it lower than 1 hour, to not crash multi-tenant nats backed by in memory jetstream. I don't know what a good value is for e.g. ~20GB jetstream disk and 50M tokens requests/min thoughput. Potentially we will limit it to 5 or 10min.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message retention duration for streams is now configurable via an environment variable, enabling dynamic control without redeploys.
  * Values are specified in seconds; when absent or invalid, the system continues to use a 1-hour default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->