### PR TITLE
fix: fix some trtllm tests

### DIFF
--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -59,7 +59,6 @@ trtllm_configs = {
         request_payloads=[
             chat_payload_default(
                 expected_log=[
-                    r"ZMQ listener .* received batch with \d+ events \(seq=\d+\)",
                     r"Event processor for worker_id \d+ processing event: Stored\(",
                     r"Selected worker: \d+, logit: ",
                 ]
@@ -123,7 +122,7 @@ def test_chat_only_aggregated_with_test_logits_processor(
         script_name=base.script_name,  # agg.sh
         marks=[],  # not used by this direct test
         request_payloads=[
-            chat_payload_default(),
+            chat_payload_default(expected_response=["Hello world!"]),
         ],
         model="Qwen/Qwen3-0.6B",
         delayed_start=base.delayed_start,

--- a/tests/utils/engine_process.py
+++ b/tests/utils/engine_process.py
@@ -4,6 +4,7 @@
 import json
 import logging
 import os
+import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -110,6 +111,9 @@ class EngineProcess(ManagedProcess):
 
         # Optionally validate expected log patterns after response handling
         if payload.expected_log:
+            time.sleep(
+                0.5
+            )  # The kv event sometimes needs extra time to arrive and be reflected in the log.
             self.validate_expected_logs(payload.expected_log)
 
     def validate_expected_logs(self, patterns: Any) -> None:


### PR DESCRIPTION
#### Overview:

https://gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/-/jobs/210682524
Fix some failing trtllm tests

#### Details:

1. TRTLLM is not using ZmqKvEventListenser, so no ZMQ listener logs will be present.
2. Add some time sleep to wait for the kv event to arrive, since there could be delay
3. Add the expected response in the logits_processor test

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Refined log expectations to remove an unstable batch log pattern, reducing flakiness.
  - Made the aggregated chat test deterministic by asserting a specific response when the logits processor is enabled.
  - Added a brief delay before validating logs to ensure events are captured reliably, improving CI stability.
- **Chores**
  - No changes to public APIs or runtime behavior; end-user functionality remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->