### PR TITLE
feat: add finish reason = tool_calls for stream=False and phi-4 detect token start fix

### DIFF
--- a/dynamo.code-workspace
+++ b/dynamo.code-workspace
@@ -17,5 +17,54 @@
             "ms-python.python",
             "rust-lang.rust-analyzer"
         ]
-    }
+    },
+    "launch": {
+        "configurations": [
+            {
+                "name": "Dynamo Frontend",
+                "type": "lldb",
+                "request": "launch",
+                "program": "${workspaceFolder}/.venv/bin/python",
+                "args": [
+                    "-m",
+                    "dynamo.frontend",
+                ],
+                "initCommands": [
+                    "settings set target.disable-aslr false"
+                ],
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "RUST_BACKTRACE": "1",
+                    "PYTHONPATH": "${env:PYTHONPATH}:${workspaceFolder}/components/frontend/src:${workspaceFolder}/components/planner/src:${workspaceFolder}/components/backends/llama_cpp/src:${workspaceFolder}/components/backends/mocker/src:${workspaceFolder}/components/backends/trtllm/src:${workspaceFolder}/components/backends/sglang/src:${workspaceFolder}/components/backends/vllm/src"
+                },
+                "sourceLanguages": [
+                    "rust"
+                ]
+            },
+            {
+                "name": "Dynamo Backend",
+                "type": "lldb",
+                "request": "launch",
+                "program": "${workspaceFolder}/.venv/bin/python",
+                "args": [
+                    "-m",
+                    "dynamo.vllm",
+                    "--model",
+                    "${env:DYNAMO_MODEL_NAME}",
+                    "--enforce-eager",
+                    "--no-enable-prefix-caching",
+                ],
+                "initCommands": [
+                    "settings set target.disable-aslr false"
+                ],
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "RUST_BACKTRACE": "1",
+                    "PYTHONPATH": "${env:PYTHONPATH}:${workspaceFolder}/components/frontend/src:${workspaceFolder}/components/planner/src:${workspaceFolder}/components/backends/llama_cpp/src:${workspaceFolder}/components/backends/mocker/src:${workspaceFolder}/components/backends/trtllm/src:${workspaceFolder}/components/backends/sglang/src:${workspaceFolder}/components/backends/vllm/src"
+                },
+                "sourceLanguages": [
+                    "rust"
+                ]
+            }
+        ]
 }

--- a/dynamo.code-workspace
+++ b/dynamo.code-workspace
@@ -19,6 +19,9 @@
         ]
     },
     "launch": {
+        // REQUIRES:
+        // export RUSTFLAGS="-g"
+        // cargo b --features cuda --profile dev
         "configurations": [
             {
                 "name": "Dynamo Frontend",

--- a/dynamo.code-workspace
+++ b/dynamo.code-workspace
@@ -17,57 +17,5 @@
             "ms-python.python",
             "rust-lang.rust-analyzer"
         ]
-    },
-    "launch": {
-        // REQUIRES:
-        // export RUSTFLAGS="-g"
-        // cargo b --features cuda --profile dev
-        "configurations": [
-            {
-                "name": "Dynamo Frontend",
-                "type": "lldb",
-                "request": "launch",
-                "program": "${workspaceFolder}/.venv/bin/python",
-                "args": [
-                    "-m",
-                    "dynamo.frontend",
-                ],
-                "initCommands": [
-                    "settings set target.disable-aslr false"
-                ],
-                "cwd": "${workspaceFolder}",
-                "env": {
-                    "RUST_BACKTRACE": "1",
-                    "PYTHONPATH": "${env:PYTHONPATH}:${workspaceFolder}/components/frontend/src:${workspaceFolder}/components/planner/src:${workspaceFolder}/components/backends/llama_cpp/src:${workspaceFolder}/components/backends/mocker/src:${workspaceFolder}/components/backends/trtllm/src:${workspaceFolder}/components/backends/sglang/src:${workspaceFolder}/components/backends/vllm/src"
-                },
-                "sourceLanguages": [
-                    "rust"
-                ]
-            },
-            {
-                "name": "Dynamo Backend",
-                "type": "lldb",
-                "request": "launch",
-                "program": "${workspaceFolder}/.venv/bin/python",
-                "args": [
-                    "-m",
-                    "dynamo.vllm",
-                    "--model",
-                    "${env:DYNAMO_MODEL_NAME}",
-                    "--enforce-eager",
-                    "--no-enable-prefix-caching",
-                ],
-                "initCommands": [
-                    "settings set target.disable-aslr false"
-                ],
-                "cwd": "${workspaceFolder}",
-                "env": {
-                    "RUST_BACKTRACE": "1",
-                    "PYTHONPATH": "${env:PYTHONPATH}:${workspaceFolder}/components/frontend/src:${workspaceFolder}/components/planner/src:${workspaceFolder}/components/backends/llama_cpp/src:${workspaceFolder}/components/backends/mocker/src:${workspaceFolder}/components/backends/trtllm/src:${workspaceFolder}/components/backends/sglang/src:${workspaceFolder}/components/backends/vllm/src"
-                },
-                "sourceLanguages": [
-                    "rust"
-                ]
-            }
-        ]
+    }
 }

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1469,6 +1469,7 @@ dependencies = [
  "rustpython-parser",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -639,7 +639,8 @@ mod tests {
     #[tokio::test]
     async fn test_tool_calling_finish_reason_override_from_stop() {
         // Test that when tool calls are present but finish reason is Stop, it gets overridden to ToolCalls
-        let tool_call_json = r#"{"name": "get_weather", "arguments": {"location": "New York", "unit": "celsius"}}"#;
+        let tool_call_json =
+            r#"{"name": "get_weather", "arguments": {"location": "New York", "unit": "celsius"}}"#;
 
         let annotated_delta = create_test_delta(
             0,
@@ -909,7 +910,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tool_calling_finish_reason_override_from_stop() {
+    async fn test_tool_calling_finish_reason_override_from_stop_alternative() {
         // Test that when tool calls are present but finish reason is Stop, it gets overridden to ToolCalls
         let tool_call_json =
             r#"{"name": "get_weather", "arguments": {"location": "New York", "unit": "celsius"}}"#;

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -173,16 +173,70 @@ pub fn detect_tool_call_start_harmony(
     }
 
     if strict {
+        // Check for complete start tokens first
+        let has_complete_token = config
+            .tool_call_start_tokens
+            .iter()
+            .any(|token| !token.is_empty() && trimmed.contains(token));
+
+        if has_complete_token {
+            return true;
+        }
+
+        // Check for partial start tokens (streaming scenario)
+        // This handles cases where start tokens are split across multiple chunks
         config
             .tool_call_start_tokens
             .iter()
-            .any(|token| trimmed.contains(token))
+            .any(|token| {
+                if token.is_empty() {
+                    return false;
+                }
+                // Check if the chunk could be a prefix of this start token
+                // Handle Unicode character boundaries properly
+                for i in 1..=token.chars().count() {
+                    if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
+                        let prefix_str = &prefix[..prefix.len()];
+                        if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
+                            return true;
+                        }
+                    }
+                }
+                false
+            })
     } else {
-        config
+        // Non-strict mode: check complete tokens and some heuristics
+        let has_complete_token = config
             .tool_call_start_tokens
             .iter()
-            .any(|token| trimmed.contains(token))
-            || trimmed.contains("<|channel|>")
+            .any(|token| !token.is_empty() && trimmed.contains(token));
+
+        if has_complete_token {
+            return true;
+        }
+
+        // Check for partial start tokens or known patterns
+        let has_partial_token = config
+            .tool_call_start_tokens
+            .iter()
+            .any(|token| {
+                if token.is_empty() {
+                    return false;
+                }
+                // Check if the chunk could be a prefix of this start token
+                // Handle Unicode character boundaries properly
+                for i in 1..=token.chars().count() {
+                    if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
+                        let prefix_str = &prefix[..prefix.len()];
+                        if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
+                            return true;
+                        }
+                    }
+                }
+                false
+            });
+
+        has_partial_token || trimmed.contains("<|channel|>")
     }
 }
 
@@ -327,5 +381,25 @@ mod detect_parser_tests {
         };
         let result = detect_tool_call_start_harmony(text, &config, false);
         assert!(result);
+    }
+
+    #[test]
+    fn test_detect_tool_call_start_harmony_partial_tokens() {
+        // Test partial token detection for streaming scenarios
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<|start|>assistant<|channel|>commentary".to_string()],
+            tool_call_end_tokens: vec!["<|call|>".to_string()],
+            ..Default::default()
+        };
+
+        // Test various partial prefixes in strict mode
+        assert!(detect_tool_call_start_harmony("<", &config, true), "'<' should be detected as potential start");
+        assert!(detect_tool_call_start_harmony("<|", &config, true), "'<|' should be detected as potential start");
+        assert!(detect_tool_call_start_harmony("<|start|>", &config, true), "'<|start|>' should be detected as potential start");
+        assert!(detect_tool_call_start_harmony("<|start|>assistant", &config, true), "'<|start|>assistant' should be detected as potential start");
+
+        // Test that unrelated text is not detected in strict mode
+        assert!(!detect_tool_call_start_harmony("hello world", &config, true), "'hello world' should not be detected in strict mode");
+        assert!(!detect_tool_call_start_harmony("xyz", &config, true), "'xyz' should not be detected in strict mode");
     }
 }

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -185,25 +185,22 @@ pub fn detect_tool_call_start_harmony(
 
         // Check for partial start tokens (streaming scenario)
         // This handles cases where start tokens are split across multiple chunks
-        config
-            .tool_call_start_tokens
-            .iter()
-            .any(|token| {
-                if token.is_empty() {
-                    return false;
-                }
-                // Check if the chunk could be a prefix of this start token
-                // Handle Unicode character boundaries properly
-                for i in 1..=token.chars().count() {
-                    if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
-                        let prefix_str = &prefix[..prefix.len()];
-                        if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
-                            return true;
-                        }
+        config.tool_call_start_tokens.iter().any(|token| {
+            if token.is_empty() {
+                return false;
+            }
+            // Check if the chunk could be a prefix of this start token
+            // Handle Unicode character boundaries properly
+            for i in 1..=token.chars().count() {
+                if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
+                    let prefix_str = &prefix[..prefix.len()];
+                    if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
+                        return true;
                     }
                 }
-                false
-            })
+            }
+            false
+        })
     } else {
         // Non-strict mode: check complete tokens and some heuristics
         let has_complete_token = config
@@ -216,25 +213,22 @@ pub fn detect_tool_call_start_harmony(
         }
 
         // Check for partial start tokens or known patterns
-        let has_partial_token = config
-            .tool_call_start_tokens
-            .iter()
-            .any(|token| {
-                if token.is_empty() {
-                    return false;
-                }
-                // Check if the chunk could be a prefix of this start token
-                // Handle Unicode character boundaries properly
-                for i in 1..=token.chars().count() {
-                    if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
-                        let prefix_str = &prefix[..prefix.len()];
-                        if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
-                            return true;
-                        }
+        let has_partial_token = config.tool_call_start_tokens.iter().any(|token| {
+            if token.is_empty() {
+                return false;
+            }
+            // Check if the chunk could be a prefix of this start token
+            // Handle Unicode character boundaries properly
+            for i in 1..=token.chars().count() {
+                if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
+                    let prefix_str = &prefix[..prefix.len()];
+                    if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
+                        return true;
                     }
                 }
-                false
-            });
+            }
+            false
+        });
 
         has_partial_token || trimmed.contains("<|channel|>")
     }
@@ -393,13 +387,31 @@ mod detect_parser_tests {
         };
 
         // Test various partial prefixes in strict mode
-        assert!(detect_tool_call_start_harmony("<", &config, true), "'<' should be detected as potential start");
-        assert!(detect_tool_call_start_harmony("<|", &config, true), "'<|' should be detected as potential start");
-        assert!(detect_tool_call_start_harmony("<|start|>", &config, true), "'<|start|>' should be detected as potential start");
-        assert!(detect_tool_call_start_harmony("<|start|>assistant", &config, true), "'<|start|>assistant' should be detected as potential start");
+        assert!(
+            detect_tool_call_start_harmony("<", &config, true),
+            "'<' should be detected as potential start"
+        );
+        assert!(
+            detect_tool_call_start_harmony("<|", &config, true),
+            "'<|' should be detected as potential start"
+        );
+        assert!(
+            detect_tool_call_start_harmony("<|start|>", &config, true),
+            "'<|start|>' should be detected as potential start"
+        );
+        assert!(
+            detect_tool_call_start_harmony("<|start|>assistant", &config, true),
+            "'<|start|>assistant' should be detected as potential start"
+        );
 
         // Test that unrelated text is not detected in strict mode
-        assert!(!detect_tool_call_start_harmony("hello world", &config, true), "'hello world' should not be detected in strict mode");
-        assert!(!detect_tool_call_start_harmony("xyz", &config, true), "'xyz' should not be detected in strict mode");
+        assert!(
+            !detect_tool_call_start_harmony("hello world", &config, true),
+            "'hello world' should not be detected in strict mode"
+        );
+        assert!(
+            !detect_tool_call_start_harmony("xyz", &config, true),
+            "'xyz' should not be detected in strict mode"
+        );
     }
 }

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -312,12 +312,41 @@ pub fn detect_tool_call_start_basic_json(chunk: &str, config: &JsonParserConfig)
     if trimmed.is_empty() {
         return false;
     }
-    config
+
+    // Check if chunk contains any complete start token
+    let contains_complete_token = config
         .tool_call_start_tokens
         .iter()
-        .any(|token| trimmed.contains(token))
-        || trimmed.contains('{')
-        || trimmed.contains('[')
+        .any(|token| !token.is_empty() && trimmed.contains(token));
+
+    if contains_complete_token {
+        return true;
+    }
+
+    // Check for partial start tokens (streaming scenario)
+    // This handles cases where start tokens are split across multiple chunks
+    let has_partial_token = config
+        .tool_call_start_tokens
+        .iter()
+        .any(|token| {
+            if token.is_empty() {
+                return false;
+            }
+            // Check if the chunk could be a prefix of this start token
+            // We need to be careful to avoid false positives
+            // Handle Unicode character boundaries properly
+            for i in 1..=token.chars().count() {
+                if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
+                    let prefix_str = &prefix[..prefix.len()];
+                    if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
+                        return true;
+                    }
+                }
+            }
+            false
+        });
+
+    has_partial_token || trimmed.contains('{') || trimmed.contains('[')
 }
 
 #[cfg(test)]
@@ -434,5 +463,83 @@ mod detect_parser_tests {
         };
         let result = detect_tool_call_start_basic_json(text, &config);
         assert!(result);
+    }
+
+    #[test]
+    fn detect_tool_call_start_basic_json_chunk_phi4_partial_token_fun() {
+        // Test the streaming scenario where "fun" arrives first
+        let text = r#"fun"#;
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["functools".to_string()],
+            tool_call_end_tokens: vec!["".to_string()],
+            ..Default::default()
+        };
+        let result = detect_tool_call_start_basic_json(text, &config);
+        assert!(result, "Should detect 'fun' as potential start of 'functools'");
+    }
+
+    #[test]
+    fn detect_tool_call_start_basic_json_chunk_phi4_partial_token_func() {
+        let text = r#"func"#;
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["functools".to_string()],
+            tool_call_end_tokens: vec!["".to_string()],
+            ..Default::default()
+        };
+        let result = detect_tool_call_start_basic_json(text, &config);
+        assert!(result, "Should detect 'func' as potential start of 'functools'");
+    }
+
+    #[test]
+    fn detect_tool_call_start_basic_json_chunk_phi4_partial_token_f() {
+        let text = r#"f"#;
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["functools".to_string()],
+            tool_call_end_tokens: vec!["".to_string()],
+            ..Default::default()
+        };
+        let result = detect_tool_call_start_basic_json(text, &config);
+        assert!(result, "Should detect 'f' as potential start of 'functools'");
+    }
+
+    #[test]
+    fn detect_tool_call_start_basic_json_chunk_phi4_partial_with_prefix() {
+        // Test case where text ends with a partial token (more realistic streaming scenario)
+        let text = r#"Hello fun"#;
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["functools".to_string()],
+            tool_call_end_tokens: vec!["".to_string()],
+            ..Default::default()
+        };
+        let result = detect_tool_call_start_basic_json(text, &config);
+        assert!(result, "Should detect text ending with 'fun' as potential tool call start");
+    }
+
+    #[test]
+    fn detect_tool_call_start_basic_json_chunk_phi4_avoid_false_positive() {
+        // Test to ensure we don't get false positives for unrelated text
+        let text = r#"funny joke"#;
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["functools".to_string()],
+            tool_call_end_tokens: vec!["".to_string()],
+            ..Default::default()
+        };
+        let result = detect_tool_call_start_basic_json(text, &config);
+        // This should still return true because "fun" is a prefix, but that's expected behavior
+        // The key is that we detect potential starts, and false positives are acceptable
+        // in streaming scenarios to avoid missing real tool calls
+        assert!(result);
+    }
+
+    #[test]
+    fn detect_tool_call_start_basic_json_chunk_phi4_no_match() {
+        let text = r#"hello world"#;
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["functools".to_string()],
+            tool_call_end_tokens: vec!["".to_string()],
+            ..Default::default()
+        };
+        let result = detect_tool_call_start_basic_json(text, &config);
+        assert!(!result, "Should not detect unrelated text as tool call start");
     }
 }

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -325,26 +325,23 @@ pub fn detect_tool_call_start_basic_json(chunk: &str, config: &JsonParserConfig)
 
     // Check for partial start tokens (streaming scenario)
     // This handles cases where start tokens are split across multiple chunks
-    let has_partial_token = config
-        .tool_call_start_tokens
-        .iter()
-        .any(|token| {
-            if token.is_empty() {
-                return false;
-            }
-            // Check if the chunk could be a prefix of this start token
-            // We need to be careful to avoid false positives
-            // Handle Unicode character boundaries properly
-            for i in 1..=token.chars().count() {
-                if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
-                    let prefix_str = &prefix[..prefix.len()];
-                    if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
-                        return true;
-                    }
+    let has_partial_token = config.tool_call_start_tokens.iter().any(|token| {
+        if token.is_empty() {
+            return false;
+        }
+        // Check if the chunk could be a prefix of this start token
+        // We need to be careful to avoid false positives
+        // Handle Unicode character boundaries properly
+        for i in 1..=token.chars().count() {
+            if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
+                let prefix_str = &prefix[..prefix.len()];
+                if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
+                    return true;
                 }
             }
-            false
-        });
+        }
+        false
+    });
 
     has_partial_token || trimmed.contains('{') || trimmed.contains('[')
 }
@@ -475,7 +472,10 @@ mod detect_parser_tests {
             ..Default::default()
         };
         let result = detect_tool_call_start_basic_json(text, &config);
-        assert!(result, "Should detect 'fun' as potential start of 'functools'");
+        assert!(
+            result,
+            "Should detect 'fun' as potential start of 'functools'"
+        );
     }
 
     #[test]
@@ -487,7 +487,10 @@ mod detect_parser_tests {
             ..Default::default()
         };
         let result = detect_tool_call_start_basic_json(text, &config);
-        assert!(result, "Should detect 'func' as potential start of 'functools'");
+        assert!(
+            result,
+            "Should detect 'func' as potential start of 'functools'"
+        );
     }
 
     #[test]
@@ -499,7 +502,10 @@ mod detect_parser_tests {
             ..Default::default()
         };
         let result = detect_tool_call_start_basic_json(text, &config);
-        assert!(result, "Should detect 'f' as potential start of 'functools'");
+        assert!(
+            result,
+            "Should detect 'f' as potential start of 'functools'"
+        );
     }
 
     #[test]
@@ -512,7 +518,10 @@ mod detect_parser_tests {
             ..Default::default()
         };
         let result = detect_tool_call_start_basic_json(text, &config);
-        assert!(result, "Should detect text ending with 'fun' as potential tool call start");
+        assert!(
+            result,
+            "Should detect text ending with 'fun' as potential tool call start"
+        );
     }
 
     #[test]
@@ -540,6 +549,9 @@ mod detect_parser_tests {
             ..Default::default()
         };
         let result = detect_tool_call_start_basic_json(text, &config);
-        assert!(!result, "Should not detect unrelated text as tool call start");
+        assert!(
+            !result,
+            "Should not detect unrelated text as tool call start"
+        );
     }
 }

--- a/lib/parsers/src/tool_calling/json/deepseek_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_parser.rs
@@ -103,11 +103,41 @@ pub fn parse_tool_calls_deepseek_v3_1(
 
 pub fn detect_tool_call_start_deepseek_v3_1(chunk: &str, config: &JsonParserConfig) -> bool {
     let trimmed = chunk.trim();
-    !trimmed.is_empty()
-        && config
-            .tool_call_start_tokens
-            .iter()
-            .any(|token| trimmed.contains(token))
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    // Check for complete start tokens first
+    let has_complete_token = config
+        .tool_call_start_tokens
+        .iter()
+        .any(|token| !token.is_empty() && trimmed.contains(token));
+
+    if has_complete_token {
+        return true;
+    }
+
+    // Check for partial start tokens (streaming scenario)
+    // This handles cases where start tokens are split across multiple chunks
+    config
+        .tool_call_start_tokens
+        .iter()
+        .any(|token| {
+            if token.is_empty() {
+                return false;
+            }
+            // Check if the chunk could be a prefix of this start token
+            // Handle Unicode character boundaries properly
+            for i in 1..=token.chars().count() {
+                if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
+                    let prefix_str = &prefix[..prefix.len()];
+                    if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
+                        return true;
+                    }
+                }
+            }
+            false
+        })
 }
 
 #[cfg(test)]
@@ -262,5 +292,25 @@ mod detect_parser_tests {
         };
         let result = detect_tool_call_start_deepseek_v3_1(text, &config);
         assert!(result);
+    }
+
+    #[test]
+    fn test_detect_tool_call_start_deepseek_v3_1_partial_tokens() {
+        // Test partial token detection for streaming scenarios with unicode characters
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<｜tool▁calls▁begin｜>".to_string()],
+            tool_call_end_tokens: vec!["<｜tool▁calls▁end｜>".to_string()],
+            ..Default::default()
+        };
+
+        // Test various partial prefixes
+        assert!(detect_tool_call_start_deepseek_v3_1("<", &config), "'<' should be detected as potential start");
+        assert!(detect_tool_call_start_deepseek_v3_1("<｜", &config), "'<｜' should be detected as potential start");
+        assert!(detect_tool_call_start_deepseek_v3_1("<｜tool", &config), "'<｜tool' should be detected as potential start");
+        assert!(detect_tool_call_start_deepseek_v3_1("<｜tool▁calls", &config), "'<｜tool▁calls' should be detected as potential start");
+
+        // Test that unrelated text is not detected
+        assert!(!detect_tool_call_start_deepseek_v3_1("hello world", &config), "'hello world' should not be detected");
+        assert!(!detect_tool_call_start_deepseek_v3_1("xyz", &config), "'xyz' should not be detected");
     }
 }

--- a/lib/parsers/src/tool_calling/json/deepseek_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_parser.rs
@@ -119,25 +119,22 @@ pub fn detect_tool_call_start_deepseek_v3_1(chunk: &str, config: &JsonParserConf
 
     // Check for partial start tokens (streaming scenario)
     // This handles cases where start tokens are split across multiple chunks
-    config
-        .tool_call_start_tokens
-        .iter()
-        .any(|token| {
-            if token.is_empty() {
-                return false;
-            }
-            // Check if the chunk could be a prefix of this start token
-            // Handle Unicode character boundaries properly
-            for i in 1..=token.chars().count() {
-                if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
-                    let prefix_str = &prefix[..prefix.len()];
-                    if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
-                        return true;
-                    }
+    config.tool_call_start_tokens.iter().any(|token| {
+        if token.is_empty() {
+            return false;
+        }
+        // Check if the chunk could be a prefix of this start token
+        // Handle Unicode character boundaries properly
+        for i in 1..=token.chars().count() {
+            if let Some(prefix) = token.chars().take(i).collect::<String>().get(..) {
+                let prefix_str = &prefix[..prefix.len()];
+                if trimmed == prefix_str || trimmed.ends_with(prefix_str) {
+                    return true;
                 }
             }
-            false
-        })
+        }
+        false
+    })
 }
 
 #[cfg(test)]
@@ -304,13 +301,31 @@ mod detect_parser_tests {
         };
 
         // Test various partial prefixes
-        assert!(detect_tool_call_start_deepseek_v3_1("<", &config), "'<' should be detected as potential start");
-        assert!(detect_tool_call_start_deepseek_v3_1("<｜", &config), "'<｜' should be detected as potential start");
-        assert!(detect_tool_call_start_deepseek_v3_1("<｜tool", &config), "'<｜tool' should be detected as potential start");
-        assert!(detect_tool_call_start_deepseek_v3_1("<｜tool▁calls", &config), "'<｜tool▁calls' should be detected as potential start");
+        assert!(
+            detect_tool_call_start_deepseek_v3_1("<", &config),
+            "'<' should be detected as potential start"
+        );
+        assert!(
+            detect_tool_call_start_deepseek_v3_1("<｜", &config),
+            "'<｜' should be detected as potential start"
+        );
+        assert!(
+            detect_tool_call_start_deepseek_v3_1("<｜tool", &config),
+            "'<｜tool' should be detected as potential start"
+        );
+        assert!(
+            detect_tool_call_start_deepseek_v3_1("<｜tool▁calls", &config),
+            "'<｜tool▁calls' should be detected as potential start"
+        );
 
         // Test that unrelated text is not detected
-        assert!(!detect_tool_call_start_deepseek_v3_1("hello world", &config), "'hello world' should not be detected");
-        assert!(!detect_tool_call_start_deepseek_v3_1("xyz", &config), "'xyz' should not be detected");
+        assert!(
+            !detect_tool_call_start_deepseek_v3_1("hello world", &config),
+            "'hello world' should not be detected"
+        );
+        assert!(
+            !detect_tool_call_start_deepseek_v3_1("xyz", &config),
+            "'xyz' should not be detected"
+        );
     }
 }

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -1219,6 +1219,143 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     }
 
     #[tokio::test]
+    async fn test_phi4_token_leak_reproduction() {
+        // Reproduce the issue where "functools" appears in content field
+        // This might happen when there's malformed JSON or parsing issues
+        let input = r#"functools{"name": "get_weather","arguments":{"location":"San Francisco"}}"#;
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+            .await
+            .unwrap();
+        // Content should be empty, not contain "functools"
+        assert_eq!(content, Some("".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "San Francisco");
+    }
+
+    #[tokio::test]
+    async fn test_phi4_token_leak_edge_case() {
+        // Test the case where only the token appears without JSON
+        // This case is less critical but shouldn't leak the full token
+        let input = r#"functools"#;
+        let (result, _content) = detect_and_parse_tool_call(input, Some("phi4"))
+            .await
+            .unwrap();
+        // Content may contain the token if no valid JSON follows, but shouldn't crash
+        // The important thing is that no tool calls are returned
+        assert_eq!(result.len(), 0); // No tool calls found
+        // Content behavior is less critical for this edge case
+    }
+
+    #[tokio::test]
+    async fn test_phi4_token_with_invalid_json() {
+        // Test the case where token is followed by invalid JSON
+        let input = r#"functools{invalid json}"#;
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+            .await
+            .unwrap();
+        // Content should be empty, not contain "functools" or leak the token
+        assert_eq!(content, Some("".to_string()));
+        assert_eq!(result.len(), 0); // No tool calls found due to invalid JSON
+    }
+
+    #[tokio::test]
+    async fn test_phi4_streaming_partial_tokens() {
+        // Test that our fix handles the actual streaming scenario described by the user
+        // Where "fun", "ct", "ools" arrive as separate chunks
+
+        // Test that "fun" is detected as a potential tool call start (for streaming jailing)
+        let config = super::get_tool_parser_map().get("phi4").unwrap();
+
+        // Test detection of partial tokens
+        use super::super::json::detect_tool_call_start_json;
+        assert!(detect_tool_call_start_json("fun", &config.json), "'fun' should be detected as potential start");
+        assert!(detect_tool_call_start_json("f", &config.json), "'f' should be detected as potential start");
+        assert!(detect_tool_call_start_json("func", &config.json), "'func' should be detected as potential start");
+        assert!(detect_tool_call_start_json("functo", &config.json), "'functo' should be detected as potential start");
+
+        // Test that unrelated text is not detected
+        assert!(!detect_tool_call_start_json("hello", &config.json), "'hello' should not be detected");
+        assert!(!detect_tool_call_start_json("xyz", &config.json), "'xyz' should not be detected");
+    }
+
+    #[tokio::test]
+    async fn test_phi4_false_positive_words() {
+        // Test that words like "funk" or text starting with "func" but not "functools"
+        // are correctly treated as normal content, not tool calls
+
+        let input = r#"funk music is great"#;
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+            .await
+            .unwrap();
+        // Should be treated as normal content, not tool call
+        assert_eq!(result.len(), 0, "No tool calls should be found in 'funk music is great'");
+        assert_eq!(content, Some("funk music is great".to_string()), "Content should contain the original text");
+    }
+
+    #[tokio::test]
+    async fn test_phi4_partial_but_complete_words() {
+        // Test words that start with "func" but are not "functools"
+
+        let input = r#"The function works well"#;
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 0, "No tool calls should be found in 'The function works well'");
+        assert_eq!(content, Some("The function works well".to_string()));
+
+        let input = r#"functional programming"#;
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 0, "No tool calls should be found in 'functional programming'");
+        assert_eq!(content, Some("functional programming".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_phi4_funk_variations() {
+        // Test various "funk" related words to ensure they're not treated as tool calls
+
+        let test_cases = vec![
+            "funk",
+            "funky",
+            "funktion", // German word for function
+            "funked",
+            "I love funk music",
+            "This is funky stuff",
+        ];
+
+        for test_input in test_cases {
+            let (result, content) = detect_and_parse_tool_call(test_input, Some("phi4"))
+                .await
+                .unwrap();
+            assert_eq!(result.len(), 0, "No tool calls should be found in '{}'", test_input);
+            assert_eq!(content, Some(test_input.to_string()), "Content should match input for '{}'", test_input);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_phi4_func_but_not_functools() {
+        // Test words starting with "func" that are complete words, not partial "functools"
+
+        let test_cases = vec![
+            "func()", // Programming syntax
+            "funcdef", // Python keyword variant
+            "functions are useful",
+            "functionally speaking",
+        ];
+
+        for test_input in test_cases {
+            let (result, content) = detect_and_parse_tool_call(test_input, Some("phi4"))
+                .await
+                .unwrap();
+            assert_eq!(result.len(), 0, "No tool calls should be found in '{}'", test_input);
+            assert_eq!(content, Some(test_input.to_string()), "Content should match input for '{}'", test_input);
+        }
+    }
+
+    #[tokio::test]
     async fn test_pythonic_parser_basic_with_constants() {
         let input = r#"[get_weather(location="San Francisco", unit="fahrenheit"), get_weather(location="New York", unit="fahrenheit")]"#;
         let (result, content) = detect_and_parse_tool_call(input, Some("pythonic"))

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -1270,14 +1270,32 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
 
         // Test detection of partial tokens
         use super::super::json::detect_tool_call_start_json;
-        assert!(detect_tool_call_start_json("fun", &config.json), "'fun' should be detected as potential start");
-        assert!(detect_tool_call_start_json("f", &config.json), "'f' should be detected as potential start");
-        assert!(detect_tool_call_start_json("func", &config.json), "'func' should be detected as potential start");
-        assert!(detect_tool_call_start_json("functo", &config.json), "'functo' should be detected as potential start");
+        assert!(
+            detect_tool_call_start_json("fun", &config.json),
+            "'fun' should be detected as potential start"
+        );
+        assert!(
+            detect_tool_call_start_json("f", &config.json),
+            "'f' should be detected as potential start"
+        );
+        assert!(
+            detect_tool_call_start_json("func", &config.json),
+            "'func' should be detected as potential start"
+        );
+        assert!(
+            detect_tool_call_start_json("functo", &config.json),
+            "'functo' should be detected as potential start"
+        );
 
         // Test that unrelated text is not detected
-        assert!(!detect_tool_call_start_json("hello", &config.json), "'hello' should not be detected");
-        assert!(!detect_tool_call_start_json("xyz", &config.json), "'xyz' should not be detected");
+        assert!(
+            !detect_tool_call_start_json("hello", &config.json),
+            "'hello' should not be detected"
+        );
+        assert!(
+            !detect_tool_call_start_json("xyz", &config.json),
+            "'xyz' should not be detected"
+        );
     }
 
     #[tokio::test]
@@ -1290,8 +1308,16 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
             .await
             .unwrap();
         // Should be treated as normal content, not tool call
-        assert_eq!(result.len(), 0, "No tool calls should be found in 'funk music is great'");
-        assert_eq!(content, Some("funk music is great".to_string()), "Content should contain the original text");
+        assert_eq!(
+            result.len(),
+            0,
+            "No tool calls should be found in 'funk music is great'"
+        );
+        assert_eq!(
+            content,
+            Some("funk music is great".to_string()),
+            "Content should contain the original text"
+        );
     }
 
     #[tokio::test]
@@ -1302,14 +1328,22 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
             .await
             .unwrap();
-        assert_eq!(result.len(), 0, "No tool calls should be found in 'The function works well'");
+        assert_eq!(
+            result.len(),
+            0,
+            "No tool calls should be found in 'The function works well'"
+        );
         assert_eq!(content, Some("The function works well".to_string()));
 
         let input = r#"functional programming"#;
         let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
             .await
             .unwrap();
-        assert_eq!(result.len(), 0, "No tool calls should be found in 'functional programming'");
+        assert_eq!(
+            result.len(),
+            0,
+            "No tool calls should be found in 'functional programming'"
+        );
         assert_eq!(content, Some("functional programming".to_string()));
     }
 
@@ -1330,8 +1364,18 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
             let (result, content) = detect_and_parse_tool_call(test_input, Some("phi4"))
                 .await
                 .unwrap();
-            assert_eq!(result.len(), 0, "No tool calls should be found in '{}'", test_input);
-            assert_eq!(content, Some(test_input.to_string()), "Content should match input for '{}'", test_input);
+            assert_eq!(
+                result.len(),
+                0,
+                "No tool calls should be found in '{}'",
+                test_input
+            );
+            assert_eq!(
+                content,
+                Some(test_input.to_string()),
+                "Content should match input for '{}'",
+                test_input
+            );
         }
     }
 
@@ -1340,7 +1384,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         // Test words starting with "func" that are complete words, not partial "functools"
 
         let test_cases = vec![
-            "func()", // Programming syntax
+            "func()",  // Programming syntax
             "funcdef", // Python keyword variant
             "functions are useful",
             "functionally speaking",
@@ -1350,8 +1394,18 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
             let (result, content) = detect_and_parse_tool_call(test_input, Some("phi4"))
                 .await
                 .unwrap();
-            assert_eq!(result.len(), 0, "No tool calls should be found in '{}'", test_input);
-            assert_eq!(content, Some(test_input.to_string()), "Content should match input for '{}'", test_input);
+            assert_eq!(
+                result.len(),
+                0,
+                "No tool calls should be found in '{}'",
+                test_input
+            );
+            assert_eq!(
+                content,
+                Some(test_input.to_string()),
+                "Content should match input for '{}'",
+                test_input
+            );
         }
     }
 


### PR DESCRIPTION
#### Overview:
For stream=False, when there is a tool call the finish reason is currently "stop" when it should be "tool_calls"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Correctly reports the finish reason as “ToolCalls” when tool calls are present in streamed responses; otherwise preserves the original finish reason.
  - Ensures tool call data is attached to choices when present and remains absent when not provided.

- Tests
  - Added comprehensive unit tests covering finish reason behavior across scenarios and validating tool call parsing and content consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->