### PR TITLE
fix: update golang container to remove CVE

### DIFF
--- a/deploy/cloud/operator/Earthfile
+++ b/deploy/cloud/operator/Earthfile
@@ -40,7 +40,7 @@ docker:
     ARG DOCKER_SERVER=my-registry
     ARG IMAGE_TAG=latest
     ARG IMAGE_SUFFIX=dynamo-operator
-    FROM nvcr.io/nvidia/distroless/go:v3.1.10
+    FROM nvcr.io/nvidia/distroless/go:v3.1.12
     WORKDIR /
     COPY +build/manager .
     USER 65532:65532


### PR DESCRIPTION
#### Overview:

Security scan of operator container resulted in detection of [CVE-2025-4802](https://security-tracker.debian.org/tracker/CVE-2025-4802). By bumping the base container to `nvcr.io/nvidia/distroless/go:v3.1.12` the vulnerability is no longer detected by NSpect

Relates to OPS-1169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the operator’s container base image to a newer patch release to incorporate the latest security and maintenance updates.
  * No functional changes expected; existing behavior should remain unchanged.
  * Minor improvements to reliability and runtime environment consistency.
  * End users may see slightly smoother deployments with no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->