### PR TITLE
fix: update golang container to remove CVE (#3088)

### DIFF
--- a/deploy/cloud/operator/Earthfile
+++ b/deploy/cloud/operator/Earthfile
@@ -40,7 +40,7 @@ docker:
     ARG DOCKER_SERVER=my-registry
     ARG IMAGE_TAG=latest
     ARG IMAGE_SUFFIX=dynamo-operator
-    FROM nvcr.io/nvidia/distroless/go:v3.1.10
+    FROM nvcr.io/nvidia/distroless/go:v3.1.12
     WORKDIR /
     COPY +build/manager .
     USER 65532:65532


### PR DESCRIPTION
#### Overview:

Cherry-pick of [PR# 3088](https://github.com/ai-dynamo/dynamo/pull/3088) bumping the base container version of the operator container to fix a CVE detected by scanning software.

closed OPS-1169
