### PR TITLE
fix: add jq to sglang-wideep docker image

### DIFF
--- a/container/Dockerfile.sglang-wideep
+++ b/container/Dockerfile.sglang-wideep
@@ -18,7 +18,7 @@ RUN apt-get update -y && \
     apt-get install -y \
       cmake meson ninja-build pybind11-dev patchelf net-tools \
       build-essential protobuf-compiler libssl-dev pkg-config \
-      clang libclang-dev git rapidjson-dev zlib1g-dev && \
+      clang libclang-dev git rapidjson-dev zlib1g-dev jq && \
     pip install --break-system-packages meson-python wheel build
 
 # Build UCX + NIXL for x86/hopper until its fully tested on GB200


### PR DESCRIPTION
This is causing k8s probe to fail. All other container's dockerfile has it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image to include the jq utility for JSON parsing.
  * Enhances automation, scripting, and diagnostics in environments that rely on JSON outputs.
  * Improves compatibility with tooling that expects jq to be available.
  * No changes to application behavior, settings, or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->