### PR TITLE
fix: hook up worker removals for indexer

### DIFF
--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -419,6 +419,7 @@ impl KvIndexer {
                 component.inner.clone(),
                 consumer_uuid.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
                 inner.event_sender(),
+                inner.remove_worker_sender(),
                 None,
                 cancellation_token,
                 None,

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -266,6 +266,7 @@ impl KvRouter {
                 component.clone(),
                 consumer_uuid,
                 kv_indexer.event_sender(),
+                kv_indexer.remove_worker_sender(),
                 kv_router_config
                     .router_snapshot_threshold
                     .map(|_| kv_indexer.snapshot_event_sender()),

--- a/lib/llm/src/kv_router/indexer.rs
+++ b/lib/llm/src/kv_router/indexer.rs
@@ -1103,34 +1103,6 @@ impl KvIndexerSharded {
         self.kv_block_size
     }
 
-    /// Get a combined sender for worker removal requests that fans out to all shards.
-    ///
-    /// ### Returns
-    ///
-    /// A `mpsc::Sender` that will forward removal requests to all shards.
-    pub fn remove_worker_sender(&self) -> mpsc::Sender<WorkerId> {
-        // Create a channel that will fan out to all shards
-        let (tx, mut rx) = mpsc::channel::<WorkerId>(16);
-        let shard_senders = self.remove_worker_tx.clone();
-
-        tokio::spawn(async move {
-            while let Some(worker_id) = rx.recv().await {
-                // Send to all shards - each will handle if it owns the worker
-                for (shard_idx, sender) in shard_senders.iter().enumerate() {
-                    if let Err(e) = sender.send(worker_id).await {
-                        tracing::warn!(
-                            "Failed to send remove_worker to shard {}: {:?}",
-                            shard_idx,
-                            e
-                        );
-                    }
-                }
-            }
-        });
-
-        tx
-    }
-
     pub fn new(
         token: CancellationToken,
         num_shards: usize,


### PR DESCRIPTION
#### Overview:

We had the ability to remove stale/dead workers from the `KvIndexer` but for some reason, it was never hooked up. This PR hooks it up via watching the delete events of the `generate` instances (etcd latency is acceptable here, as slow worker removal does not affect the functionality/correctness of the indexer)
