### PR TITLE
chore: set default tool calling behaviour to be disabled

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -78,7 +78,7 @@ pub struct JailState {
     finished: bool,                            // Add this flag to track if stream is finished
 }
 
-pub fn _maybe_enable_tool_call(
+pub fn maybe_enable_tool_call(
     parser_str: Option<&str>,
     request: &NvCreateChatCompletionRequest,
 ) -> bool {
@@ -949,7 +949,7 @@ impl
         let mut response_generator = Box::new(response_generator);
 
         let enable_tool_calling =
-            _maybe_enable_tool_call(self.tool_call_parser.as_deref(), &request);
+            maybe_enable_tool_call(self.tool_call_parser.as_deref(), &request);
         // convert the chat completion request to a common completion request
         let (common_request, annotations) = self.preprocess_request(&request)?;
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -974,11 +974,10 @@ impl
 
         // Apply tool calling jail to the stream if tool call parser is present
         let stream = if enable_tool_calling {
-            self.apply_tool_calling_jail_with_parser(stream)
+            self.apply_tool_calling_jail_with_parser(stream).await
         } else {
             stream
         };
-        //let stream = self.apply_tool_calling_jail_with_parser(stream);
 
         let context = stream.context();
         // prepend the annotations to the response stream

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -15,6 +15,7 @@ pub mod prompt;
 pub mod tools;
 
 use anyhow::Result;
+use dynamo_async_openai::types::ChatCompletionToolChoiceOption;
 use dynamo_async_openai::types::EncodingFormat;
 use futures::stream::{self, StreamExt};
 use prompt::OAIPromptFormatter;
@@ -75,6 +76,15 @@ pub struct JailState {
     accumulated_content: HashMap<u32, String>, // choice index -> accumulated content
     last_response_metadata: Option<NvCreateChatCompletionStreamResponse>, // for response structure
     finished: bool,                            // Add this flag to track if stream is finished
+}
+
+pub fn enable_tool_call(parser_str: Option<&str>, request: &NvCreateChatCompletionRequest) -> bool {
+    // Enable tool call if the below two conditions are satisfied
+    // 1. parser_str is not None
+    // 2. tool_choice is not None
+    parser_str.is_some()
+        && request.inner.tool_choice.is_some()
+        && (request.inner.tool_choice.clone() != Some(ChatCompletionToolChoiceOption::None))
 }
 
 impl LLMMetricAnnotation {
@@ -933,6 +943,7 @@ impl
         let response_generator = request.response_generator(context.id().to_string());
         let mut response_generator = Box::new(response_generator);
 
+        let enable_tool_calling = enable_tool_call(self.tool_call_parser.as_deref(), &request);
         // convert the chat completion request to a common completion request
         let (common_request, annotations) = self.preprocess_request(&request)?;
 
@@ -955,7 +966,16 @@ impl
         // transform the postprocessor stream
         let stream = Self::transform_postprocessor_stream(response_stream, response_generator);
 
-        let stream = self.apply_tool_calling_jail_with_parser(stream).await;
+        // Apply tool calling jail to the stream if tool call parser is present
+        let stream = if enable_tool_calling {
+            tracing::info!("Tool calling is enabled");
+            self.apply_tool_calling_jail_with_parser(stream)
+        } else {
+            tracing::info!("Tool calling is disabled");
+            stream
+        };
+        //let stream = self.apply_tool_calling_jail_with_parser(stream);
+
         let context = stream.context();
         // prepend the annotations to the response stream
         let stream = annotations_stream.chain(stream);

--- a/lib/llm/tests/test_preprocessor.rs
+++ b/lib/llm/tests/test_preprocessor.rs
@@ -2,13 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use dynamo_async_openai::types::ChatCompletionToolChoiceOption;
+use dynamo_async_openai::types::CreateChatCompletionRequest;
 use dynamo_async_openai::types::{
     ChatChoiceStream, ChatCompletionStreamResponseDelta, FinishReason as OAIFinishReason, Role,
 };
 use dynamo_llm::preprocessor::{
     ANNOTATION_POSSIBLE_TOOL_CALL, PossibleToolCallAnnotation, apply_tool_calling_jail_internal,
+    enable_tool_call,
 };
-use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+use dynamo_llm::protocols::openai::chat_completions::{
+    NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
+};
 use dynamo_parsers::tool_calling::parsers::detect_tool_call_start;
 use dynamo_runtime::pipeline::ResponseStream;
 use dynamo_runtime::protocols::annotated::Annotated;
@@ -708,4 +713,51 @@ async fn test_tool_calling_jail_internal_with_harmony_parser() {
     .unwrap();
     assert_eq!(name, "get_current_weather");
     assert_eq!(arguments["location"], "San Francisco");
+}
+
+#[test]
+fn test_enable_tool_call() {
+    let request = NvCreateChatCompletionRequest {
+        inner: CreateChatCompletionRequest {
+            tool_choice: Some(ChatCompletionToolChoiceOption::Auto),
+            ..Default::default()
+        },
+        common: Default::default(),
+        nvext: None,
+        chat_template_args: None,
+    };
+    assert!(enable_tool_call(Some("nemotron_deci"), &request));
+
+    let request = NvCreateChatCompletionRequest {
+        inner: CreateChatCompletionRequest {
+            tool_choice: Some(ChatCompletionToolChoiceOption::None),
+            ..Default::default()
+        },
+        common: Default::default(),
+        nvext: None,
+        chat_template_args: None,
+    };
+    assert!(!enable_tool_call(Some("nemotron_deci"), &request));
+
+    let request = NvCreateChatCompletionRequest {
+        inner: CreateChatCompletionRequest {
+            tool_choice: Some(ChatCompletionToolChoiceOption::Required),
+            ..Default::default()
+        },
+        common: Default::default(),
+        nvext: None,
+        chat_template_args: None,
+    };
+    assert!(enable_tool_call(Some("nemotron_deci"), &request));
+
+    let request = NvCreateChatCompletionRequest {
+        inner: CreateChatCompletionRequest {
+            tool_choice: None,
+            ..Default::default()
+        },
+        common: Default::default(),
+        nvext: None,
+        chat_template_args: None,
+    };
+    assert!(!enable_tool_call(Some("nemotron_deci"), &request));
 }

--- a/lib/llm/tests/test_preprocessor.rs
+++ b/lib/llm/tests/test_preprocessor.rs
@@ -8,8 +8,8 @@ use dynamo_async_openai::types::{
     ChatChoiceStream, ChatCompletionStreamResponseDelta, FinishReason as OAIFinishReason, Role,
 };
 use dynamo_llm::preprocessor::{
-    ANNOTATION_POSSIBLE_TOOL_CALL, PossibleToolCallAnnotation, apply_tool_calling_jail_internal,
-    enable_tool_call,
+    _maybe_enable_tool_call, ANNOTATION_POSSIBLE_TOOL_CALL, PossibleToolCallAnnotation,
+    apply_tool_calling_jail_internal,
 };
 use dynamo_llm::protocols::openai::chat_completions::{
     NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
@@ -726,7 +726,7 @@ fn test_enable_tool_call() {
         nvext: None,
         chat_template_args: None,
     };
-    assert!(enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(_maybe_enable_tool_call(Some("nemotron_deci"), &request));
 
     let request = NvCreateChatCompletionRequest {
         inner: CreateChatCompletionRequest {
@@ -737,7 +737,7 @@ fn test_enable_tool_call() {
         nvext: None,
         chat_template_args: None,
     };
-    assert!(!enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(!_maybe_enable_tool_call(Some("nemotron_deci"), &request));
 
     let request = NvCreateChatCompletionRequest {
         inner: CreateChatCompletionRequest {
@@ -748,7 +748,7 @@ fn test_enable_tool_call() {
         nvext: None,
         chat_template_args: None,
     };
-    assert!(enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(_maybe_enable_tool_call(Some("nemotron_deci"), &request));
 
     let request = NvCreateChatCompletionRequest {
         inner: CreateChatCompletionRequest {
@@ -759,5 +759,5 @@ fn test_enable_tool_call() {
         nvext: None,
         chat_template_args: None,
     };
-    assert!(!enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(!_maybe_enable_tool_call(Some("nemotron_deci"), &request));
 }

--- a/lib/llm/tests/test_preprocessor.rs
+++ b/lib/llm/tests/test_preprocessor.rs
@@ -726,7 +726,7 @@ fn test_enable_tool_call() {
         nvext: None,
         chat_template_args: None,
     };
-    assert!(!maybe_enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(maybe_enable_tool_call(Some("nemotron_deci"), &request));
 
     let request = NvCreateChatCompletionRequest {
         inner: CreateChatCompletionRequest {
@@ -748,16 +748,16 @@ fn test_enable_tool_call() {
         nvext: None,
         chat_template_args: None,
     };
-    assert!(!maybe_enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(maybe_enable_tool_call(Some("nemotron_deci"), &request));
 
     let request = NvCreateChatCompletionRequest {
         inner: CreateChatCompletionRequest {
-            tool_choice: None,
+            tool_choice: Some(ChatCompletionToolChoiceOption::Auto),
             ..Default::default()
         },
         common: Default::default(),
         nvext: None,
         chat_template_args: None,
     };
-    assert!(!maybe_enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(!maybe_enable_tool_call(None, &request));
 }

--- a/lib/llm/tests/test_preprocessor.rs
+++ b/lib/llm/tests/test_preprocessor.rs
@@ -8,8 +8,8 @@ use dynamo_async_openai::types::{
     ChatChoiceStream, ChatCompletionStreamResponseDelta, FinishReason as OAIFinishReason, Role,
 };
 use dynamo_llm::preprocessor::{
-    _maybe_enable_tool_call, ANNOTATION_POSSIBLE_TOOL_CALL, PossibleToolCallAnnotation,
-    apply_tool_calling_jail_internal,
+    ANNOTATION_POSSIBLE_TOOL_CALL, PossibleToolCallAnnotation, apply_tool_calling_jail_internal,
+    maybe_enable_tool_call,
 };
 use dynamo_llm::protocols::openai::chat_completions::{
     NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
@@ -726,7 +726,7 @@ fn test_enable_tool_call() {
         nvext: None,
         chat_template_args: None,
     };
-    assert!(_maybe_enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(!maybe_enable_tool_call(Some("nemotron_deci"), &request));
 
     let request = NvCreateChatCompletionRequest {
         inner: CreateChatCompletionRequest {
@@ -737,7 +737,7 @@ fn test_enable_tool_call() {
         nvext: None,
         chat_template_args: None,
     };
-    assert!(!_maybe_enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(!maybe_enable_tool_call(Some("nemotron_deci"), &request));
 
     let request = NvCreateChatCompletionRequest {
         inner: CreateChatCompletionRequest {
@@ -748,7 +748,7 @@ fn test_enable_tool_call() {
         nvext: None,
         chat_template_args: None,
     };
-    assert!(_maybe_enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(!maybe_enable_tool_call(Some("nemotron_deci"), &request));
 
     let request = NvCreateChatCompletionRequest {
         inner: CreateChatCompletionRequest {
@@ -759,5 +759,5 @@ fn test_enable_tool_call() {
         nvext: None,
         chat_template_args: None,
     };
-    assert!(!_maybe_enable_tool_call(Some("nemotron_deci"), &request));
+    assert!(!maybe_enable_tool_call(Some("nemotron_deci"), &request));
 }


### PR DESCRIPTION
#### Overview:

Change the default tool calling behaviour. Earlier if no tool call parser is provided , nemotron deci and llama parsing was tried by default

Current State: 
Try tool call parsing when below conditions are satisfied
- tool-call-parser is provided
- tool_choice in the request is not None

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tool calling is now applied conditionally. When a tool-call parser is configured and tool calling is requested, the system enforces tool-calling constraints; otherwise, normal responses are generated without tool-calling restrictions.
  - Improves response relevance by preventing unintended tool invocations when tool calling is not explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->