### PR TITLE
docs: Emphasize Release Assets in docs: updating the landing page repo link to point to latest

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ The NVIDIA Dynamo Platform is a high-performance, low-latency inference framewor
 .. admonition:: 💎 Discover the latest developments!
    :class: seealso
 
-   This guide is a snapshot at a specific point in time. For the latest information and examples, see the `Dynamo GitHub repository <https://github.com/ai-dynamo/dynamo>`_.
+   This guide is a snapshot of a specific point in time. For the latest information, examples, and Release Assets, see the `Dynamo GitHub repository <https://github.com/ai-dynamo/dynamo/releases/latest>`_.
 
 Quickstart
 ==========


### PR DESCRIPTION
#### Overview:

Per the Dynamo v0.5.1-0.6.0 Road map: https://linear.app/nvidia/initiative/dynamo-v051-060-roadmap-2f26ba2b5b46/overview

#### Details:

Updating the link to the Dynamo repo to point to the latest tag
Specifically calling out Release Assets in addition to examples
Resubmitting this change to side step unfortunate rebase mojo

#### Where should the reviewer start?

See line 29.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved wording in two introductory sections for clarity and correctness.
  * Updated guidance to reference the latest releases page, including examples and Release Assets.
  * Refreshed callouts under “Discover the latest developments!” and “Welcome to NVIDIA Dynamo” to direct users to up-to-date resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->