### PR TITLE
chore: add dsr1 k8s yaml

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -6,7 +6,7 @@
 | llama-3-70b   | vllm    | disagg-multi-node   |     ✓      |     ✓     |
 | llama-3-70b   | vllm    | disagg-single-node  |     ✓      |     ✓     |
 | oss-gpt       | trtllm  | aggregated          |     ✓      |     ✓     |
-| DeepSeek-R1   | sglang  | disaggregated       |     🚧     |    🚧     |
+| DeepSeek-R1   | sglang  | disaggregated       |     ✓      |    🚧     |
 
 
 ## Prerequisites

--- a/recipes/deepseek-r1/model_cache/model-cache.yaml
+++ b/recipes/deepseek-r1/model_cache/model-cache.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1000Gi
+  storageClassName: "your-storage-class-name"

--- a/recipes/deepseek-r1/sglang-wideep/README.md
+++ b/recipes/deepseek-r1/sglang-wideep/README.md
@@ -1,0 +1,16 @@
+# Container
+
+Use the Dockerfile in `container/Dockerfile.sglang-wideep` to build the container, or
+
+```bash
+./container/build.sh --framework sglang-wideep
+```
+
+Dynamo commits after `1b3eed4b6a0e735d4ecec6681f4c0b89f2112167` (Sep 18, 2025) are required.
+
+# Hardware
+
+The two deployment recipes are for 8xH200 and 16xH200. It should also work for other GPU SKUs. Change the TDP and DEP size accordingly to match the GPU capacity.
+
+If you see NCCL errors when sending requests to the engines, it is usually caused by OOM error. Try to reduce `--mem-fraction-static` in both prefill and decode engines.
+

--- a/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
@@ -59,7 +59,7 @@ spec:
               --dp 16
               --enable-dp-attention
               --ep-size 16
-              --trust-remote-code 
+              --trust-remote-code
               --skip-tokenizer-init
               --disaggregation-mode decode
               --disaggregation-transfer-backend nixl

--- a/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-disagg
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: sglang-disagg
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 1800
+            failureThreshold: 60
+          image: nvcr.io/nvidian/dynamo-dev/dynamo-sglang-wideep-runtime:hzhou-0917-01
+    decode:
+      dynamoNamespace: sglang-disagg
+      componentType: worker
+      replicas: 1
+      multinode:
+        nodeCount: 2
+      resources:
+        limits:
+          gpu: "8"
+      pvc:
+        create: false
+        name: model-cache
+        mountPoint: /root/.cache/huggingface
+      sharedMemory:
+        size: 80Gi
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 1800
+            failureThreshold: 60
+          image: nvcr.io/nvidian/dynamo-dev/dynamo-sglang-wideep-runtime:hzhou-0917-01
+          workingDir: /workspace/components/backends/sglang
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - >-
+              python3 -m dynamo.sglang
+              --model-path deepseek-ai/DeepSeek-R1
+              --served-model-name deepseek-ai/DeepSeek-R1
+              --tp 16
+              --dp 16
+              --enable-dp-attention
+              --ep-size 16
+              --trust-remote-code 
+              --skip-tokenizer-init
+              --disaggregation-mode decode
+              --disaggregation-transfer-backend nixl
+              --disaggregation-bootstrap-port 30001
+              --mem-fraction-static 0.8
+    prefill:
+      dynamoNamespace: sglang-disagg
+      componentType: worker
+      replicas: 1
+      multinode:
+        nodeCount: 2
+      resources:
+        limits:
+          gpu: "8"
+      pvc:
+        create: false
+        name: model-cache
+        mountPoint: /root/.cache/huggingface
+      sharedMemory:
+        size: 80Gi
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 1800
+            failureThreshold: 60
+          image: nvcr.io/nvidian/dynamo-dev/dynamo-sglang-wideep-runtime:hzhou-0917-01
+          workingDir: /workspace/components/backends/sglang
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - >-
+              python3 -m dynamo.sglang
+              --model-path deepseek-ai/DeepSeek-R1
+              --served-model-name deepseek-ai/DeepSeek-R1
+              --tp 16
+              --ep-size 16
+              --trust-remote-code
+              --skip-tokenizer-init
+              --disaggregation-mode prefill
+              --disaggregation-transfer-backend nixl
+              --disaggregation-bootstrap-port 30001
+              --mem-fraction-static 0.8

--- a/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
@@ -52,7 +52,7 @@ spec:
             - -c
           args:
             - >-
-              python3 -m dynamo.sglang
+              exec python3 -m dynamo.sglang
               --model-path deepseek-ai/DeepSeek-R1
               --served-model-name deepseek-ai/DeepSeek-R1
               --tp 16
@@ -96,7 +96,7 @@ spec:
             - -c
           args:
             - >-
-              python3 -m dynamo.sglang
+              exec python3 -m dynamo.sglang
               --model-path deepseek-ai/DeepSeek-R1
               --served-model-name deepseek-ai/DeepSeek-R1
               --tp 16

--- a/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
@@ -4,11 +4,11 @@
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
-  name: sglang-disagg
+  name: sgl-dsr1-16gpu
 spec:
   services:
     Frontend:
-      dynamoNamespace: sglang-disagg
+      dynamoNamespace: sgl-dsr1-16gpu
       componentType: frontend
       replicas: 1
       extraPodSpec:
@@ -22,7 +22,7 @@ spec:
             failureThreshold: 60
           image: nvcr.io/nvidian/dynamo-dev/dynamo-sglang-wideep-runtime:hzhou-0917-01
     decode:
-      dynamoNamespace: sglang-disagg
+      dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
       replicas: 1
       multinode:
@@ -66,7 +66,7 @@ spec:
               --disaggregation-bootstrap-port 30001
               --mem-fraction-static 0.8
     prefill:
-      dynamoNamespace: sglang-disagg
+      dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
       replicas: 1
       multinode:

--- a/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
@@ -57,7 +57,7 @@ spec:
               --dp 8
               --enable-dp-attention
               --ep-size 8
-              --trust-remote-code 
+              --trust-remote-code
               --skip-tokenizer-init
               --disaggregation-mode decode
               --disaggregation-transfer-backend nixl

--- a/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-disagg
+spec:
+  services:
+    Frontend:
+      dynamoNamespace: sglang-disagg
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 1800
+            failureThreshold: 60
+          image: nvcr.io/nvidian/dynamo-dev/dynamo-sglang-wideep-runtime:hzhou-0917-01
+    decode:
+      dynamoNamespace: sglang-disagg
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "8"
+      pvc:
+        create: false
+        name: model-cache
+        mountPoint: /root/.cache/huggingface
+      sharedMemory:
+        size: 80Gi
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 1800
+            failureThreshold: 60
+          image: nvcr.io/nvidian/dynamo-dev/dynamo-sglang-wideep-runtime:hzhou-0917-01
+          workingDir: /workspace/components/backends/sglang
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - >-
+              python3 -m dynamo.sglang
+              --model-path deepseek-ai/DeepSeek-R1
+              --served-model-name deepseek-ai/DeepSeek-R1
+              --tp 8
+              --dp 8
+              --enable-dp-attention
+              --ep-size 8
+              --trust-remote-code 
+              --skip-tokenizer-init
+              --disaggregation-mode decode
+              --disaggregation-transfer-backend nixl
+              --disaggregation-bootstrap-port 30001
+    prefill:
+      dynamoNamespace: sglang-disagg
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "8"
+      pvc:
+        create: false
+        name: model-cache
+        mountPoint: /root/.cache/huggingface
+      sharedMemory:
+        size: 80Gi
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 1800
+            failureThreshold: 60
+          image: nvcr.io/nvidian/dynamo-dev/dynamo-sglang-wideep-runtime:hzhou-0917-01
+          workingDir: /workspace/components/backends/sglang
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - >-
+              python3 -m dynamo.sglang
+              --model-path deepseek-ai/DeepSeek-R1
+              --served-model-name deepseek-ai/DeepSeek-R1
+              --tp 8
+              --ep-size 8
+              --trust-remote-code
+              --skip-tokenizer-init
+              --disaggregation-mode prefill
+              --disaggregation-transfer-backend nixl
+              --disaggregation-bootstrap-port 30001

--- a/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
@@ -4,11 +4,11 @@
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
-  name: sglang-disagg
+  name: sgl-dsr1-8gpu
 spec:
   services:
     Frontend:
-      dynamoNamespace: sglang-disagg
+      dynamoNamespace: sgl-dsr1-8gpu
       componentType: frontend
       replicas: 1
       extraPodSpec:
@@ -22,7 +22,7 @@ spec:
             failureThreshold: 60
           image: nvcr.io/nvidian/dynamo-dev/dynamo-sglang-wideep-runtime:hzhou-0917-01
     decode:
-      dynamoNamespace: sglang-disagg
+      dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
       replicas: 1
       resources:
@@ -63,7 +63,7 @@ spec:
               --disaggregation-transfer-backend nixl
               --disaggregation-bootstrap-port 30001
     prefill:
-      dynamoNamespace: sglang-disagg
+      dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
       replicas: 1
       resources:

--- a/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
@@ -50,7 +50,7 @@ spec:
             - -c
           args:
             - >-
-              python3 -m dynamo.sglang
+              exec python3 -m dynamo.sglang
               --model-path deepseek-ai/DeepSeek-R1
               --served-model-name deepseek-ai/DeepSeek-R1
               --tp 8
@@ -91,7 +91,7 @@ spec:
             - -c
           args:
             - >-
-              python3 -m dynamo.sglang
+              exec python3 -m dynamo.sglang
               --model-path deepseek-ai/DeepSeek-R1
               --served-model-name deepseek-ai/DeepSeek-R1
               --tp 8


### PR DESCRIPTION
add a single-node engine (TEP8P+DEP8D) and multi-node engine (TEP16P+DEP16D).

closes: DEP-364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added deployment recipes for DeepSeek‑R1 with disaggregated prefill/decode services for 8‑GPU and 16‑GPU setups.
  - Introduced a shared model cache volume to speed up model availability across services.
  - Included health checks for frontend and worker services to improve reliability.

- Documentation
  - Updated DeepSeek‑R1 deployment status to available (deployment ✓; benchmark pending).


<!-- end of auto-generated comment: release notes by coderabbit.ai -->