### PR TITLE
chore: set the default value of namespaceRestriction to false

### DIFF
--- a/deploy/cloud/helm/platform/values.yaml
+++ b/deploy/cloud/helm/platform/values.yaml
@@ -32,7 +32,7 @@ dynamo-operator:
   # -- Namespace access controls for the operator
   namespaceRestriction:
     # -- Whether to restrict operator to specific namespaces
-    enabled: true
+    enabled: false
     # -- Target namespace for operator deployment (leave empty for current namespace)
     targetNamespace:
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

By default, `namespaceRestriction` is set to true. As per the [NVIDIA Dynamo production deployment guide](https://docs.nvidia.com/dynamo/latest/guides/dynamo_deploy/dynamo_cloud.html#path-a-production-install), the Dynamo Operator will only reconcile DynamoGraphDeployment resources in the namespace where it is running (in this case, the `dynamo-kubernetes` namespace).

However, if a user then deploys a DynamoGraphDeployment using the provided examples (e.g., [agg.yaml](https://github.com/ai-dynamo/dynamo/blob/main/components/backends/vllm/deploy/agg.yaml)), which is deployed in the `default` namespace, the Dynamo Operator will not reconcile this DynamoGraphDeployment. Consequently, the Dynamo Operator does not create any vLLM instances, and no relevant logs are emitted. This behavior can be very confusing for new users.

To ensure new users can smoothly experience Dynamo, this PR sets the default value of namespaceRestriction to false, allowing users to successfully deploy DynamoGraphDeployment by following the existing installation guide and example.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated platform deployment configuration to align with current operational standards.
  - No changes to user-facing features or behavior.
  - No impact on existing settings or workflows for end-users.
  - Internal operational adjustment to improve manageability and consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->