### PR TITLE
feat: add NIM FE (num_request_max) + runtime config metrics with periodic polling

### DIFF
--- a/deploy/metrics/README.md
+++ b/deploy/metrics/README.md
@@ -98,9 +98,11 @@ These metrics come from the Model Deployment Card information provided by worker
 - `dynamo_frontend_model_migration_limit`: Request migration limit for a worker serving the model (gauge)
 
 **Worker Management Metrics:**
-- `dynamo_frontend_model_workers_total`: Number of worker instances currently serving the model (gauge)
+- `dynamo_frontend_model_workers`: Number of worker instances currently serving the model (gauge)
 
-**Note**: The `dynamo_frontend_inflight_requests_total` metric tracks requests from HTTP handler start until the complete response is finished, while `dynamo_frontend_queued_requests_total` tracks requests from HTTP handler start until first token generation begins (including prefill time). HTTP queue time is a subset of inflight time.
+**Important Notes:**
+- The `dynamo_frontend_inflight_requests_total` metric tracks requests from HTTP handler start until the complete response is finished, while `dynamo_frontend_queued_requests_total` tracks requests from HTTP handler start until first token generation begins (including prefill time). HTTP queue time is a subset of inflight time.
+- **Model Name Deduplication**: When multiple worker instances register with the same model name, only the first instance's configuration metrics (runtime config and MDC metrics) will be populated. Subsequent instances with duplicate model names will be skipped for configuration metric updates, though the worker count metric will reflect all instances.
 
 #### Request Processing Flow
 

--- a/deploy/metrics/README.md
+++ b/deploy/metrics/README.md
@@ -79,6 +79,27 @@ When using Dynamo HTTP Frontend (`--framework VLLM` or `--framework TRTLLM`), th
 - `dynamo_frontend_requests_total`: Total LLM requests (counter)
 - `dynamo_frontend_time_to_first_token_seconds`: Time to first token (histogram)
 
+##### Model Configuration Metrics
+
+The frontend also exposes model configuration metrics with the `dynamo_frontend_model_*` prefix. These metrics are populated from the worker backend registration service when workers register with the system:
+
+**Runtime Config Metrics (from ModelRuntimeConfig):**
+These metrics come from the runtime configuration provided by worker backends during registration.
+
+- `dynamo_frontend_model_total_kv_blocks`: Total KV blocks available for a worker serving the model (gauge)
+- `dynamo_frontend_model_max_num_seqs`: Maximum number of sequences for a worker serving the model (gauge)
+- `dynamo_frontend_model_max_num_batched_tokens`: Maximum number of batched tokens for a worker serving the model (gauge)
+
+**MDC Metrics (from ModelDeploymentCard):**
+These metrics come from the Model Deployment Card information provided by worker backends during registration.
+
+- `dynamo_frontend_model_context_length`: Maximum context length for a worker serving the model (gauge)
+- `dynamo_frontend_model_kv_cache_block_size`: KV cache block size for a worker serving the model (gauge)
+- `dynamo_frontend_model_migration_limit`: Request migration limit for a worker serving the model (gauge)
+
+**Worker Management Metrics:**
+- `dynamo_frontend_model_workers_total`: Number of worker instances currently serving the model (gauge)
+
 **Note**: The `dynamo_frontend_inflight_requests_total` metric tracks requests from HTTP handler start until the complete response is finished, while `dynamo_frontend_queued_requests_total` tracks requests from HTTP handler start until first token generation begins (including prefill time). HTTP queue time is a subset of inflight time.
 
 #### Request Processing Flow

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -18,6 +18,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::discovery::ModelEntry;
+use crate::local_model::runtime_config::ModelRuntimeConfig;
+
 pub use prometheus::Registry;
 
 use super::RouteDoc;
@@ -32,6 +35,15 @@ pub struct Metrics {
     output_sequence_length: HistogramVec,
     time_to_first_token: HistogramVec,
     inter_token_latency: HistogramVec,
+
+    // Runtime configuration metrics
+    model_total_kv_blocks: IntGaugeVec,
+    model_max_num_seqs: IntGaugeVec,
+    model_max_num_batched_tokens: IntGaugeVec,
+    model_context_length: IntGaugeVec,
+    model_kv_cache_block_size: IntGaugeVec,
+    model_migration_limit: IntGaugeVec,
+    model_health_status: IntGaugeVec,
 }
 
 // Inflight tracks requests from HTTP handler start until complete response is finished.
@@ -126,6 +138,21 @@ impl Metrics {
     /// - `{prefix}_output_sequence_tokens` - HistogramVec for output sequence length in tokens
     /// - `{prefix}_time_to_first_token_seconds` - HistogramVec for time to first token in seconds
     /// - `{prefix}_inter_token_latency_seconds` - HistogramVec for inter-token latency in seconds
+    /// - `{prefix}_model_total_kv_blocks` - IntGaugeVec for total KV cache blocks available per model
+    /// - `{prefix}_model_max_num_seqs` - IntGaugeVec for maximum sequences per model
+    /// - `{prefix}_model_max_num_batched_tokens` - IntGaugeVec for maximum batched tokens per model
+    /// - `{prefix}_model_context_length` - IntGaugeVec for maximum context length per model
+    /// - `{prefix}_model_kv_cache_block_size` - IntGaugeVec for KV cache block size per model
+    /// - `{prefix}_model_migration_limit` - IntGaugeVec for request migration limit per model
+    /// - `{prefix}_model_health_status` - IntGaugeVec for model health status (1=healthy, 0=unhealthy, -1=unknown)
+    ///
+    /// ## Runtime Config Polling Configuration
+    ///
+    /// The polling behavior can be configured via environment variables:
+    /// - `DYN_RUNTIME_CONFIG_METRICS_POLL_INTERVAL_SECS`: Poll interval in seconds (default: 30)
+    ///
+    /// Metrics are never removed to preserve historical data. Models are marked as
+    /// healthy (1) or unhealthy (0) based on their current availability.
     pub fn new() -> Self {
         let raw_prefix = std::env::var(frontend_service::METRICS_PREFIX_ENV)
             .unwrap_or_else(|_| name_prefix::FRONTEND.to_string());
@@ -235,6 +262,70 @@ impl Metrics {
         )
         .unwrap();
 
+        // Runtime configuration metrics
+        let model_total_kv_blocks = IntGaugeVec::new(
+            Opts::new(
+                frontend_metric_name("model_total_kv_blocks"),
+                "Total KV cache blocks available for the model",
+            ),
+            &["model"],
+        )
+        .unwrap();
+
+        let model_max_num_seqs = IntGaugeVec::new(
+            Opts::new(
+                frontend_metric_name("model_max_num_seqs"),
+                "Maximum number of sequences the model can handle",
+            ),
+            &["model"],
+        )
+        .unwrap();
+
+        let model_max_num_batched_tokens = IntGaugeVec::new(
+            Opts::new(
+                frontend_metric_name("model_max_num_batched_tokens"),
+                "Maximum number of batched tokens for the model",
+            ),
+            &["model"],
+        )
+        .unwrap();
+
+        let model_context_length = IntGaugeVec::new(
+            Opts::new(
+                frontend_metric_name("model_context_length"),
+                "Maximum context length in tokens for the model",
+            ),
+            &["model"],
+        )
+        .unwrap();
+
+        let model_kv_cache_block_size = IntGaugeVec::new(
+            Opts::new(
+                frontend_metric_name("model_kv_cache_block_size"),
+                "KV cache block size in tokens for the model",
+            ),
+            &["model"],
+        )
+        .unwrap();
+
+        let model_migration_limit = IntGaugeVec::new(
+            Opts::new(
+                frontend_metric_name("model_migration_limit"),
+                "Maximum number of request migrations allowed for the model",
+            ),
+            &["model"],
+        )
+        .unwrap();
+
+        let model_health_status = IntGaugeVec::new(
+            Opts::new(
+                frontend_metric_name("model_health_status"),
+                "Health status of the model (1=healthy, 0=unhealthy, -1=unknown)",
+            ),
+            &["model"],
+        )
+        .unwrap();
+
         Metrics {
             request_counter,
             inflight_gauge,
@@ -245,6 +336,13 @@ impl Metrics {
             output_sequence_length,
             time_to_first_token,
             inter_token_latency,
+            model_total_kv_blocks,
+            model_max_num_seqs,
+            model_max_num_batched_tokens,
+            model_context_length,
+            model_kv_cache_block_size,
+            model_migration_limit,
+            model_health_status,
         }
     }
 
@@ -333,7 +431,198 @@ impl Metrics {
         registry.register(Box::new(self.output_sequence_length.clone()))?;
         registry.register(Box::new(self.time_to_first_token.clone()))?;
         registry.register(Box::new(self.inter_token_latency.clone()))?;
+
+        // Register runtime configuration metrics
+        registry.register(Box::new(self.model_total_kv_blocks.clone()))?;
+        registry.register(Box::new(self.model_max_num_seqs.clone()))?;
+        registry.register(Box::new(self.model_max_num_batched_tokens.clone()))?;
+        registry.register(Box::new(self.model_context_length.clone()))?;
+        registry.register(Box::new(self.model_kv_cache_block_size.clone()))?;
+        registry.register(Box::new(self.model_migration_limit.clone()))?;
+        registry.register(Box::new(self.model_health_status.clone()))?;
+
         Ok(())
+    }
+
+    /// Update runtime configuration metrics for a model
+    /// This should be called when model runtime configuration is available or updated
+    pub fn update_runtime_config_metrics(
+        &self,
+        model_name: &str,
+        runtime_config: &ModelRuntimeConfig,
+    ) {
+        if let Some(total_kv_blocks) = runtime_config.total_kv_blocks {
+            self.model_total_kv_blocks
+                .with_label_values(&[model_name])
+                .set(total_kv_blocks as i64);
+        }
+
+        if let Some(max_num_seqs) = runtime_config.max_num_seqs {
+            self.model_max_num_seqs
+                .with_label_values(&[model_name])
+                .set(max_num_seqs as i64);
+        }
+
+        if let Some(max_batched_tokens) = runtime_config.max_num_batched_tokens {
+            self.model_max_num_batched_tokens
+                .with_label_values(&[model_name])
+                .set(max_batched_tokens as i64);
+        }
+    }
+
+    /// Update model deployment card metrics for a model
+    /// This should be called when model deployment card information is available
+    pub fn update_mdc_metrics(
+        &self,
+        model_name: &str,
+        context_length: u32,
+        kv_cache_block_size: u32,
+        migration_limit: u32,
+    ) {
+        self.model_context_length
+            .with_label_values(&[model_name])
+            .set(context_length as i64);
+
+        self.model_kv_cache_block_size
+            .with_label_values(&[model_name])
+            .set(kv_cache_block_size as i64);
+
+        self.model_migration_limit
+            .with_label_values(&[model_name])
+            .set(migration_limit as i64);
+    }
+
+    /// Set model health status
+    /// 1 = healthy (model is active and responding)
+    /// 0 = unhealthy (model is known but not responding)
+    /// -1 = unknown (model status is unclear)
+    pub fn set_model_health_status(&self, model_name: &str, healthy: bool) {
+        let status = if healthy { 1 } else { 0 };
+        self.model_health_status
+            .with_label_values(&[model_name])
+            .set(status);
+    }
+
+    /// Mark model as having unknown health status
+    pub fn set_model_health_unknown(&self, model_name: &str) {
+        self.model_health_status
+            .with_label_values(&[model_name])
+            .set(-1);
+    }
+
+    /// Update metrics from a ModelEntry
+    /// This is a convenience method that extracts runtime config from a ModelEntry
+    /// and updates the appropriate metrics
+    pub fn update_metrics_from_model_entry(&self, model_entry: &ModelEntry) {
+        if let Some(runtime_config) = &model_entry.runtime_config {
+            self.update_runtime_config_metrics(&model_entry.name, runtime_config);
+        }
+    }
+
+    /// Update metrics from a ModelEntry and its ModelDeploymentCard
+    /// This updates both runtime config metrics and MDC-specific metrics
+    pub async fn update_metrics_from_model_entry_with_mdc(
+        &self,
+        model_entry: &ModelEntry,
+        etcd_client: &dynamo_runtime::transports::etcd::Client,
+    ) -> anyhow::Result<()> {
+        // Update runtime config metrics
+        if let Some(runtime_config) = &model_entry.runtime_config {
+            self.update_runtime_config_metrics(&model_entry.name, runtime_config);
+        }
+
+        // Load and update MDC metrics
+        match model_entry.load_mdc(etcd_client).await {
+            Ok(mdc) => {
+                self.update_mdc_metrics(
+                    &model_entry.name,
+                    mdc.context_length,
+                    mdc.kv_cache_block_size,
+                    mdc.migration_limit,
+                );
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!(
+                    model = %model_entry.name,
+                    error = %e,
+                    "Failed to load ModelDeploymentCard for metrics update"
+                );
+                Err(e)
+            }
+        }
+    }
+
+    /// Start a background task that periodically updates runtime config metrics
+    /// This polls the ModelManager for current models and updates metrics accordingly
+    /// Models are never removed - only marked as healthy/unhealthy to preserve historical data
+    pub fn start_runtime_config_polling_task(
+        metrics: Arc<Self>,
+        manager: Arc<crate::discovery::ModelManager>,
+        etcd_client: Option<dynamo_runtime::transports::etcd::Client>,
+        poll_interval: Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(poll_interval);
+            let mut known_models = std::collections::HashSet::new();
+
+            tracing::info!(
+                interval_secs = poll_interval.as_secs(),
+                "Starting runtime config metrics polling task (metrics never removed)"
+            );
+
+            loop {
+                interval.tick().await;
+
+                // Get current model entries from the manager
+                let current_entries = manager.get_model_entries();
+                let mut current_models = std::collections::HashSet::new();
+
+                // Update metrics for current models
+                for entry in current_entries {
+                    current_models.insert(entry.name.clone());
+
+                    // Mark model as healthy since it's currently active
+                    metrics.set_model_health_status(&entry.name, true);
+
+                    // Update runtime config metrics if available
+                    if let Some(runtime_config) = &entry.runtime_config {
+                        metrics.update_runtime_config_metrics(&entry.name, runtime_config);
+                    }
+
+                    // Optionally load MDC for additional metrics if etcd is available
+                    if let Some(ref etcd) = etcd_client
+                        && let Err(e) = metrics
+                            .update_metrics_from_model_entry_with_mdc(&entry, etcd)
+                            .await
+                    {
+                        tracing::debug!(
+                            model = %entry.name,
+                            error = %e,
+                            "Failed to update MDC metrics (this is normal if MDC is not available)"
+                        );
+                    }
+                }
+
+                // Mark models that are no longer active as unhealthy (but keep their metrics)
+                for model_name in known_models.difference(&current_models) {
+                    metrics.set_model_health_status(model_name, false);
+                    tracing::debug!(
+                        model = %model_name,
+                        "Model no longer active, marked as unhealthy (metrics preserved)"
+                    );
+                }
+
+                // Update our known models set
+                known_models.extend(current_models.iter().cloned());
+
+                tracing::trace!(
+                    active_models = current_models.len(),
+                    total_known_models = known_models.len(),
+                    "Updated runtime config metrics for active models"
+                );
+            }
+        })
     }
 
     /// Create a new [`InflightGuard`] for the given model and annotate if its a streaming request,

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -159,7 +159,7 @@ impl Metrics {
     /// ## Runtime Config Polling Configuration
     ///
     /// The polling behavior can be configured via environment variables:
-    /// - `DYN_HTTP_SVC_CONFIG_METRICS_POLL_INTERVAL_SECS`: Poll interval in seconds
+    /// - `DYN_HTTP_SVC_CONFIG_METRICS_POLL_INTERVAL_SECS`: Poll interval in seconds (must be > 0, defaults to 8)
     ///
     /// Metrics are never removed to preserve historical data. Runtime config and MDC
     /// metrics are updated when models are discovered and their configurations are available.

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -294,6 +294,7 @@ impl HttpServiceConfigBuilder {
         let config: HttpServiceConfig = self.build_internal()?;
 
         let model_manager = Arc::new(ModelManager::new());
+        let etcd_client = config.etcd_client.clone();
         let state = Arc::new(State::new_with_etcd(model_manager, config.etcd_client));
 
         state
@@ -312,6 +313,24 @@ impl HttpServiceConfigBuilder {
         // enable prometheus metrics
         let registry = metrics::Registry::new();
         state.metrics_clone().register(&registry)?;
+
+        // Start background task to poll runtime config metrics
+        // Poll every 30 seconds to keep metrics current as backends come and go
+        // Metrics are never removed - only marked as healthy/unhealthy
+        let poll_interval = Duration::from_secs(
+            std::env::var("DYN_RUNTIME_CONFIG_METRICS_POLL_INTERVAL_SECS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(30),
+        );
+
+        let _polling_task = super::metrics::Metrics::start_runtime_config_polling_task(
+            state.metrics_clone(),
+            state.manager_clone(),
+            etcd_client,
+            poll_interval,
+        );
+        // Note: We don't need to store the JoinHandle as the task will run for the lifetime of the service
 
         let mut router = axum::Router::new();
 

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -207,10 +207,10 @@ impl HttpService {
         // Start background task to poll runtime config metrics with proper cancellation
         let poll_interval_secs = std::env::var("DYN_HTTP_SVC_CONFIG_METRICS_POLL_INTERVAL_SECS")
             .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .filter(|&secs| secs > 0) // Guard against zero or negative values
-            .unwrap_or(8);
-        let poll_interval = Duration::from_secs(poll_interval_secs);
+            .and_then(|s| s.parse::<f64>().ok())
+            .filter(|&secs| secs > 0.0) // Guard against zero or negative values
+            .unwrap_or(8.0);
+        let poll_interval = Duration::from_secs_f64(poll_interval_secs);
 
         let _polling_task = super::metrics::Metrics::start_runtime_config_polling_task(
             self.state.metrics_clone(),

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -205,12 +205,12 @@ impl HttpService {
         tracing::info!(protocol, address, "Starting HTTP(S) service");
 
         // Start background task to poll runtime config metrics with proper cancellation
-        let poll_interval = Duration::from_secs(
-            std::env::var("DYN_HTTP_SVC_CONFIG_METRICS_POLL_INTERVAL_SECS")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(8),
-        );
+        let poll_interval_secs = std::env::var("DYN_HTTP_SVC_CONFIG_METRICS_POLL_INTERVAL_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .filter(|&secs| secs > 0) // Guard against zero or negative values
+            .unwrap_or(8);
+        let poll_interval = Duration::from_secs(poll_interval_secs);
 
         let _polling_task = super::metrics::Metrics::start_runtime_config_polling_task(
             self.state.metrics_clone(),

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -1,15 +1,65 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_llm::http::service::metrics::Endpoint;
-use dynamo_llm::http::service::service_v2::HttpService;
-use dynamo_runtime::CancellationToken;
+use anyhow::Error;
+use async_stream::stream;
+use dynamo_llm::{
+    http::service::metrics::Endpoint,
+    http::service::service_v2::HttpService,
+    protocols::{
+        Annotated,
+        openai::chat_completions::{
+            NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
+        },
+    },
+};
 use dynamo_runtime::metrics::prometheus_names::frontend_service::METRICS_PREFIX_ENV;
-use std::time::Duration;
+use dynamo_runtime::{
+    CancellationToken,
+    pipeline::{
+        AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn, async_trait,
+    },
+};
+use std::{sync::Arc, time::Duration};
 
 #[path = "common/ports.rs"]
 mod ports;
 use ports::get_random_port;
+
+// Mock engine for testing metrics
+struct MockModelEngine {}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateChatCompletionRequest>,
+        ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
+        Error,
+    > for MockModelEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateChatCompletionRequest>,
+    ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
+        let (request, context) = request.transfer(());
+        let ctx = context.context();
+
+        let mut generator = request.response_generator(ctx.id().to_string());
+
+        let stream = stream! {
+            // Simulate some processing time
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+            // Generate 5 response chunks
+            for i in 0..5 {
+                let output = generator.create_choice(i, Some(format!("Mock response {i}")), None, None, None);
+                yield Annotated::from_data(output);
+            }
+        };
+
+        Ok(ResponseStream::new(Box::pin(stream), ctx))
+    }
+}
 
 #[tokio::test]
 async fn test_metrics_prefix_default() {
@@ -37,7 +87,12 @@ async fn test_metrics_prefix_default() {
             .text()
             .await
             .unwrap();
+
+        // Assert metrics that are actually present in the default configuration
         assert!(body.contains("dynamo_frontend_requests_total"));
+        assert!(body.contains("dynamo_frontend_inflight_requests_total"));
+        assert!(body.contains("dynamo_frontend_request_duration_seconds"));
+        assert!(body.contains("dynamo_frontend_client_disconnects"));
 
         token.cancel();
         let _ = handle.await;
@@ -127,5 +182,389 @@ async fn wait_for_metrics_ready(port: u16) {
             Ok(resp) if resp.status().is_success() => break,
             _ => tokio::time::sleep(Duration::from_millis(50)).await,
         }
+    }
+}
+
+#[tokio::test]
+async fn test_metrics_with_mock_model() {
+    // Test metrics collection with a mock model serving requests
+    // Ensure we use the default prefix
+    temp_env::async_with_vars([(METRICS_PREFIX_ENV, None::<&str>)], async {
+        let port = get_random_port().await;
+        let service = HttpService::builder()
+            .port(port)
+            .enable_chat_endpoints(true)
+            .build()
+            .unwrap();
+
+        let state = service.state_clone();
+        let manager = state.manager();
+
+        // Start the HTTP service
+        let token = CancellationToken::new();
+        let cancel_token = token.clone();
+        let task = tokio::spawn(async move { service.run(token.clone()).await });
+
+        // Add mock model engine
+        let mock_engine = Arc::new(MockModelEngine {});
+        manager
+            .add_chat_completions_model("mockmodel", mock_engine)
+            .unwrap();
+
+        // Wait for service to be ready
+        wait_for_metrics_ready(port).await;
+
+        let client = reqwest::Client::new();
+
+        // Create a chat completion request
+        let message = dynamo_async_openai::types::ChatCompletionRequestMessage::User(
+            dynamo_async_openai::types::ChatCompletionRequestUserMessage {
+                content: dynamo_async_openai::types::ChatCompletionRequestUserMessageContent::Text(
+                    "Hello, mock model!".to_string(),
+                ),
+                name: None,
+            },
+        );
+
+        let request = dynamo_async_openai::types::CreateChatCompletionRequestArgs::default()
+            .model("mockmodel")
+            .messages(vec![message])
+            .max_tokens(50u32)
+            .stream(true)
+            .build()
+            .expect("Failed to build request");
+
+        // Make the request to the HTTP service
+        let response = client
+            .post(format!("http://localhost:{}/v1/chat/completions", port))
+            .json(&request)
+            .send()
+            .await
+            .unwrap();
+
+        assert!(
+            response.status().is_success(),
+            "Request failed: {:?}",
+            response
+        );
+
+        // Consume the response stream to complete the request
+        let _response_body = response.bytes().await.unwrap();
+
+        // Give some time for metrics to be updated
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Fetch and verify metrics
+        let metrics_response = client
+            .get(format!("http://localhost:{}/metrics", port))
+            .send()
+            .await
+            .unwrap();
+
+        assert!(metrics_response.status().is_success());
+        let metrics_body = metrics_response.text().await.unwrap();
+
+        println!("=== METRICS WITH MOCK MODEL ===");
+        println!("{}", metrics_body);
+        println!("=== END METRICS ===");
+
+        // Assert that key metrics are present with the mockmodel
+        assert!(metrics_body.contains("dynamo_frontend_requests_total"));
+        assert!(metrics_body.contains("model=\"mockmodel\""));
+        assert!(metrics_body.contains("dynamo_frontend_inflight_requests_total"));
+        assert!(metrics_body.contains("dynamo_frontend_request_duration_seconds"));
+        assert!(metrics_body.contains("dynamo_frontend_output_sequence_tokens"));
+        assert!(metrics_body.contains("dynamo_frontend_queued_requests_total"));
+
+        // Verify specific request counter incremented
+        assert!(metrics_body.contains("endpoint=\"chat_completions\""));
+        assert!(metrics_body.contains("request_type=\"stream\""));
+        assert!(metrics_body.contains("status=\"success\""));
+
+        // Clean up
+        cancel_token.cancel();
+        task.await.unwrap().unwrap();
+    })
+    .await;
+}
+
+// Integration tests that require distributed runtime with etcd
+#[cfg(feature = "integration")]
+mod integration_tests {
+    use super::*;
+    use dynamo_llm::{
+        discovery::ModelEntry, engines::make_echo_engine, entrypoint::EngineConfig,
+        local_model::LocalModelBuilder,
+    };
+    use dynamo_runtime::DistributedRuntime;
+
+    #[tokio::test]
+    #[ignore = "Requires etcd and distributed runtime"]
+    async fn test_metrics_with_mdc_registration() {
+        // Integration test for metrics collection with full MDC registration (like real model servers)
+        temp_env::async_with_vars([
+            (METRICS_PREFIX_ENV, None::<&str>),
+            ("DYN_HTTP_SVC_CONFIG_METRICS_POLL_INTERVAL_SECS", Some("0.6")), // Fast polling for tests (600ms)
+        ], async {
+            let port = get_random_port().await;
+
+            // Create distributed runtime (required for MDC registration)
+            let runtime = dynamo_runtime::Runtime::from_settings().unwrap();
+            let distributed_runtime = DistributedRuntime::from_settings(runtime.clone())
+                .await
+                .unwrap();
+
+            // Create LocalModel with realistic configuration for testing
+            let mut local_model = LocalModelBuilder::default()
+                .model_name(Some("test-mdc-model".to_string()))
+                .build()
+                .await
+                .unwrap();
+
+            // Create EngineConfig with EchoEngine
+            let engine_config = EngineConfig::StaticFull {
+                engine: make_echo_engine(),
+                model: Box::new(local_model.clone()),
+                is_static: false, // This enables MDC registration!
+            };
+
+            let service = HttpService::builder()
+                .port(port)
+                .enable_chat_endpoints(true)
+                .with_etcd_client(distributed_runtime.etcd_client())
+                .build()
+                .unwrap();
+
+            // Set up model watcher to discover models from etcd (like production)
+            // This is crucial for the polling task to find model entries
+            use dynamo_llm::discovery::{ModelWatcher, MODEL_ROOT_PATH};
+            use dynamo_runtime::pipeline::RouterMode;
+
+            let model_watcher = ModelWatcher::new(
+                distributed_runtime.clone(),
+                service.state().manager_clone(),
+                RouterMode::RoundRobin,
+                None,
+                None,
+            );
+
+            // Start watching etcd for model registrations
+            if let Some(etcd_client) = distributed_runtime.etcd_client() {
+                let models_watcher = etcd_client.kv_get_and_watch_prefix(MODEL_ROOT_PATH).await.unwrap();
+                let (_prefix, _watcher, receiver) = models_watcher.dissolve();
+
+                // Spawn watcher task to discover models from etcd
+                let _watcher_task = tokio::spawn(async move {
+                    model_watcher.watch(receiver, None).await;
+                });
+
+            }
+
+            // Set up the engine following the StaticFull pattern from http.rs
+            let EngineConfig::StaticFull { engine, model, .. } = engine_config else {
+                panic!("Expected StaticFull config");
+            };
+
+            let engine = Arc::new(dynamo_llm::engines::StreamingEngineAdapter::new(engine));
+            let manager = service.model_manager();
+            manager
+                .add_chat_completions_model(model.service_name(), engine.clone())
+                .unwrap();
+
+            // Now do the proper MDC registration via LocalModel::attach()
+            // Create a component and endpoint for proper registration
+            let namespace = distributed_runtime.namespace("test-namespace").unwrap();
+            let test_component = namespace.component("test-mdc-component").unwrap();
+            let test_endpoint = test_component.endpoint("test-mdc-endpoint");
+
+            // This will store the MDC in etcd and create the ModelEntry for discovery
+            local_model
+                .attach(
+                    &test_endpoint,
+                    dynamo_llm::model_type::ModelType::Chat,
+                    dynamo_llm::model_type::ModelInput::Text,
+                )
+                .await
+                .unwrap();
+
+
+            // Start the HTTP service
+            let token = CancellationToken::new();
+            let cancel_token = token.clone();
+            let service_for_task = service.clone();
+            let task = tokio::spawn(async move { service_for_task.run(token.clone()).await });
+
+            // Wait for service to be ready
+            wait_for_metrics_ready(port).await;
+
+            // Wait for MDC registration to complete by checking if the model appears
+            // This simulates the real polling that happens in production
+            let start = tokio::time::Instant::now();
+            let timeout = Duration::from_secs(10);
+            loop {
+                if start.elapsed() > timeout {
+                    break; // Continue with test even if MDC metrics aren't ready
+                }
+
+                // Check if our model is registered in the manager (indicates MDC registration completed)
+                let model_service_name = model.service_name();
+                if manager.has_model_any(model_service_name) {
+                    tracing::info!("MDC registration completed for {}", model_service_name);
+                    break;
+                }
+
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+
+            // Give a bit more time for background metrics collection
+            tokio::time::sleep(Duration::from_millis(200)).await;
+
+            let client = reqwest::Client::new();
+
+            // Create a chat completion request
+            let message = dynamo_async_openai::types::ChatCompletionRequestMessage::User(
+                dynamo_async_openai::types::ChatCompletionRequestUserMessage {
+                    content:
+                        dynamo_async_openai::types::ChatCompletionRequestUserMessageContent::Text(
+                            "Hello, MDC model!".to_string(),
+                        ),
+                    name: None,
+                },
+            );
+
+            let request = dynamo_async_openai::types::CreateChatCompletionRequestArgs::default()
+                .model(model.service_name())
+                .messages(vec![message])
+                .max_tokens(50u32)
+                .stream(true)
+                .build()
+                .expect("Failed to build request");
+
+            // Make the request to the HTTP service
+            let response = client
+                .post(format!("http://localhost:{}/v1/chat/completions", port))
+                .json(&request)
+                .send()
+                .await
+                .unwrap();
+
+            assert!(
+                response.status().is_success(),
+                "Request failed: {:?}",
+                response
+            );
+
+            // Consume the response stream to complete the request
+            let _response_body = response.bytes().await.unwrap();
+
+        // Wait for the fast polling interval (600ms) for MDC metrics
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+            // Fetch and verify metrics
+            let metrics_response = client
+                .get(format!("http://localhost:{}/metrics", port))
+                .send()
+                .await
+                .unwrap();
+
+            assert!(metrics_response.status().is_success());
+            let metrics_body = metrics_response.text().await.unwrap();
+
+            println!("=== METRICS WITH FULL MDC REGISTRATION ===");
+            println!("{}", metrics_body);
+            println!("=== END METRICS ===");
+
+            // Assert basic metrics are present (using service_name from the model)
+            let model_name = model.service_name();
+            assert!(metrics_body.contains("dynamo_frontend_requests_total"));
+            assert!(metrics_body.contains(&format!("model=\"{}\"", model_name)));
+            assert!(metrics_body.contains("dynamo_frontend_inflight_requests_total"));
+            assert!(metrics_body.contains("dynamo_frontend_request_duration_seconds"));
+            assert!(metrics_body.contains("dynamo_frontend_output_sequence_tokens"));
+            assert!(metrics_body.contains("dynamo_frontend_queued_requests_total"));
+
+            // Assert MDC-based model configuration metrics are present
+            // These MUST be present for the test to pass
+            assert!(metrics_body.contains("dynamo_frontend_model_context_length"),
+                    "MDC metrics not found! Metrics body: {}", metrics_body);
+
+            assert!(metrics_body.contains("dynamo_frontend_model_kv_cache_block_size"));
+            assert!(metrics_body.contains("dynamo_frontend_model_migration_limit"));
+
+            // Note: The following metrics are not present in this test because they require
+            // actual inference engines (vllm/sglang/trtllm *.py) with real runtime configurations:
+            // - dynamo_frontend_model_total_kv_blocks (requires actual KV cache from real engines)
+            // - dynamo_frontend_model_max_num_seqs (requires actual batching config from real engines)
+            // - dynamo_frontend_model_max_num_batched_tokens (requires actual batching config from real engines)
+
+
+            // Verify specific request counter incremented
+            assert!(metrics_body.contains("endpoint=\"chat_completions\""));
+            assert!(metrics_body.contains("request_type=\"stream\""));
+            assert!(metrics_body.contains("status=\"success\""));
+
+            // Now test the complete lifecycle: remove the model from etcd
+
+            // Get all model entries to find the one we need to delete
+            if let Some(etcd_client) = distributed_runtime.etcd_client() {
+                let kvs = etcd_client.kv_get_prefix("models").await.unwrap();
+
+                // Find our model's etcd key
+                let mut model_key_to_delete = None;
+                for kv in kvs {
+                    if let Ok(model_entry) = serde_json::from_slice::<ModelEntry>(kv.value())
+                        && model_entry.name == "test-mdc-model"
+                    {
+                        model_key_to_delete = Some(kv.key_str().unwrap().to_string());
+                        break;
+                    }
+                }
+
+                if let Some(key) = model_key_to_delete {
+                    etcd_client.kv_delete(key.as_str(), None).await.unwrap();
+
+                    // Poll every 80ms for up to 2 seconds to check when worker count drops to 0
+
+                    let start_time = tokio::time::Instant::now();
+                    let timeout = Duration::from_millis(2000);
+                    let mut worker_count_dropped = false;
+
+                    while start_time.elapsed() < timeout {
+                        // Check if the model was removed from the manager
+                        let has_model = manager.has_model_any(model.service_name());
+
+                        // Fetch current metrics
+                        let metrics_response = client
+                            .get(format!("http://localhost:{}/metrics", port))
+                            .send()
+                            .await
+                            .unwrap();
+
+                        if metrics_response.status().is_success() {
+
+                            // Since model_workers metric was removed, just check if model is gone from manager
+                            if !has_model {
+                                worker_count_dropped = true;
+                                break;
+                            }
+                        }
+
+                        tokio::time::sleep(Duration::from_millis(80)).await;
+                    }
+
+                    // Assert that model was removed from manager
+                    assert!(worker_count_dropped,
+                            "Model should be removed from manager after etcd removal and polling cycles");
+
+                } else {
+                }
+            }
+
+
+            // Clean up
+            cancel_token.cancel();
+            task.await.unwrap().unwrap();
+        })
+        .await;
     }
 }

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -116,9 +116,6 @@ pub mod frontend_service {
     /// Request migration limit for a worker serving the model (MDC)
     pub const MODEL_MIGRATION_LIMIT: &str = "model_migration_limit";
 
-    /// Number of worker instances currently serving a model
-    pub const MODEL_WORKERS_TOTAL: &str = "model_workers_total";
-
     /// Status label values
     pub mod status {
         /// Value for successful requests

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -94,6 +94,31 @@ pub mod frontend_service {
     /// Inter-token latency in seconds
     pub const INTER_TOKEN_LATENCY_SECONDS: &str = "inter_token_latency_seconds";
 
+    /// Model configuration metrics
+    ///
+    /// Runtime config metrics (from ModelRuntimeConfig):
+    /// Total KV blocks available for a worker serving the model
+    pub const MODEL_TOTAL_KV_BLOCKS: &str = "model_total_kv_blocks";
+
+    /// Maximum number of sequences for a worker serving the model (runtime config)
+    pub const MODEL_MAX_NUM_SEQS: &str = "model_max_num_seqs";
+
+    /// Maximum number of batched tokens for a worker serving the model (runtime config)
+    pub const MODEL_MAX_NUM_BATCHED_TOKENS: &str = "model_max_num_batched_tokens";
+
+    /// MDC metrics (from ModelDeploymentCard):
+    /// Maximum context length for a worker serving the model (MDC)
+    pub const MODEL_CONTEXT_LENGTH: &str = "model_context_length";
+
+    /// KV cache block size for a worker serving the model (MDC)
+    pub const MODEL_KV_CACHE_BLOCK_SIZE: &str = "model_kv_cache_block_size";
+
+    /// Request migration limit for a worker serving the model (MDC)
+    pub const MODEL_MIGRATION_LIMIT: &str = "model_migration_limit";
+
+    /// Number of worker instances currently serving a model
+    pub const MODEL_WORKERS_TOTAL: &str = "model_workers_total";
+
     /// Status label values
     pub mod status {
         /// Value for successful requests
@@ -421,6 +446,33 @@ pub fn build_component_metric_name(metric_name: &str) -> String {
     format!("{}_{}", name_prefix::COMPONENT, sanitized_name)
 }
 
+/// Safely converts a u64 value to i64 for Prometheus metrics
+///
+/// Since Prometheus IntGaugeVec uses i64 but our data types use u64,
+/// this function clamps large u64 values to i64::MAX to prevent overflow
+/// and ensure metrics remain positive.
+///
+/// # Arguments
+/// * `value` - The u64 value to convert
+///
+/// # Returns
+/// An i64 value, clamped to i64::MAX if the input exceeds i64::MAX
+///
+/// # Examples
+/// ```
+/// use dynamo_runtime::metrics::prometheus_names::clamp_u64_to_i64;
+///
+/// assert_eq!(clamp_u64_to_i64(100), 100);
+/// assert_eq!(clamp_u64_to_i64(u64::MAX), i64::MAX);
+/// ```
+pub fn clamp_u64_to_i64(value: u64) -> i64 {
+    if value > i64::MAX as u64 {
+        i64::MAX
+    } else {
+        value as i64
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -644,5 +696,21 @@ mod tests {
     fn test_build_component_metric_name_panics_on_empty_input() {
         // Test that empty input panics with clear message
         build_component_metric_name("");
+    }
+
+    #[test]
+    fn test_clamp_u64_to_i64() {
+        // Test normal values within i64 range
+        assert_eq!(clamp_u64_to_i64(0), 0);
+        assert_eq!(clamp_u64_to_i64(100), 100);
+        assert_eq!(clamp_u64_to_i64(1000000), 1000000);
+
+        // Test maximum i64 value
+        assert_eq!(clamp_u64_to_i64(i64::MAX as u64), i64::MAX);
+
+        // Test values that exceed i64::MAX
+        assert_eq!(clamp_u64_to_i64(u64::MAX), i64::MAX);
+        assert_eq!(clamp_u64_to_i64((i64::MAX as u64) + 1), i64::MAX);
+        assert_eq!(clamp_u64_to_i64((i64::MAX as u64) + 1000), i64::MAX);
     }
 }


### PR DESCRIPTION
#### Overview:

Add runtime configuration metrics for model deployment monitoring across all backend frameworks. Fix missing max_num_seqs metrics in SGLang and TensorRT-LLM backends while maintaining existing vLLM functionality.

#### Details:

- Add periodic polling system for model runtime config metrics (max_num_seqs, total_kv_blocks, max_num_batched_tokens)
- **vLLM Backend**: Maintain existing functionality where max_num_seqs is retrieved from engine.vllm_config.scheduler_config
- **TensorRT-LLM Backend**: Add missing runtime config metric population by setting max_num_seqs from config.max_batch_size and max_num_batched_tokens from config.max_num_tokens
- **SGLang Backend**: Fix max_num_seqs retrieval by accessing server_args instead of scheduler_info due to SGLang's architectural separation of configuration parameters from runtime statistics
- Rename MODEL_WORKER_COUNT to MODEL_WORKERS_TOTAL following Prometheus conventions
- Add configuration safety guard against invalid polling intervals
- Update metrics documentation with new runtime configuration metrics

#### Where should the reviewer start?

- lib/llm/src/http/service/metrics.rs - Core metrics implementation with periodic polling
- components/backends/trtllm/src/dynamo/trtllm/main.py - TensorRT-LLM metric consistency improvements
- components/backends/sglang/src/dynamo/sglang/register.py - SGLang architectural fix for config vs runtime separation

#### Related Issues:

DIS-607 DIS-641

/coderabbit profile chill