### PR TITLE
fix: SGLang component names to match worker registration patterns

### DIFF
--- a/components/planner/src/dynamo/planner/defaults.py
+++ b/components/planner/src/dynamo/planner/defaults.py
@@ -94,10 +94,10 @@ class VllmComponentName:
 
 class SGLangComponentName:
     prefill_worker_k8s_name = "SGLangPrefillWorker"
-    prefill_worker_component_name = "worker"
+    prefill_worker_component_name = "prefill"
     prefill_worker_endpoint = "generate"
     decode_worker_k8s_name = "SGLangDecodeWorker"
-    decode_worker_component_name = "decode"
+    decode_worker_component_name = "backend"
     decode_worker_endpoint = "generate"
 
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
SGLang planner cannot detect SGLang workers due to component name mismatch, preventing autoscaling functionality.
#### Details:
 The SGLang planner expects workers at:
  - Prefill: `instances/dynamo/worker/generate`
  - Decode: `instances/dynamo/decode/generate`

  But SGLang workers actually register at:
  - Default: `instances/dynamo/backend/generate`
  - Prefill mode: `instances/dynamo/prefill/generate`
<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
components/planner/src/dynamo/planner/defaults.py
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #3106 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized component names: the prefill worker is now labeled “prefill,” and the decode worker is now labeled “backend.”
  * Improves consistency across services for clearer identification in dashboards, logs, and configurations.
  * If you reference the old labels in custom configs, monitors, or scripts, update them to the new names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->