### PR TITLE
fix: fixed Planner division by zero errors in sglang backend

### DIFF
--- a/components/planner/src/dynamo/planner/utils/planner_core.py
+++ b/components/planner/src/dynamo/planner/utils/planner_core.py
@@ -375,16 +375,22 @@ class Planner:
                 if expect_ttft > 0:
                     self.p_correction_factor = self.last_metrics.ttft / expect_ttft
                 else:
-                    logger.warning(f"Expected TTFT is {expect_ttft}, using default correction factor 1.0")
+                    logger.warning(
+                        f"Expected TTFT is {expect_ttft}, using default correction factor 1.0"
+                    )
                     self.p_correction_factor = 1.0
                 # for ITL, we expect the correction factor to be close to 1
                 if len(self.d_endpoints) > 0:
-                    concurrency = (self.last_metrics.num_req  # type: ignore
+                    concurrency = (
+                        self.last_metrics.num_req  # type: ignore
                         / len(self.d_endpoints)
                         * self.last_metrics.request_duration  # type: ignore
-                        / self.args.adjustment_interval)
+                        / self.args.adjustment_interval
+                    )
                 else:
-                    logger.warning("No decode workers available, using default concurrency of 1.0")
+                    logger.warning(
+                        "No decode workers available, using default concurrency of 1.0"
+                    )
                     concurrency = 1.0
 
                 expect_itl = self.decode_interpolator.interpolate_itl(
@@ -394,7 +400,9 @@ class Planner:
                 if expect_itl > 0:
                     self.d_correction_factor = self.last_metrics.itl / expect_itl
                 else:
-                    logger.warning(f"Expected ITL is {expect_itl}, using default correction factor 1.0")
+                    logger.warning(
+                        f"Expected ITL is {expect_itl}, using default correction factor 1.0"
+                    )
                     self.d_correction_factor = 1.0
                 logger.info(
                     f"Correction factors: TTFT: {self.p_correction_factor:.3f}, ITL: {self.d_correction_factor:.3f}"

--- a/components/planner/src/dynamo/planner/utils/planner_core.py
+++ b/components/planner/src/dynamo/planner/utils/planner_core.py
@@ -372,16 +372,30 @@ class Planner:
                 expect_ttft = self.prefill_interpolator.interpolate_ttft(
                     self.last_metrics.isl
                 )
-                self.p_correction_factor = self.last_metrics.ttft / expect_ttft
+                if expect_ttft > 0:
+                    self.p_correction_factor = self.last_metrics.ttft / expect_ttft
+                else:
+                    logger.warning(f"Expected TTFT is {expect_ttft}, using default correction factor 1.0")
+                    self.p_correction_factor = 1.0
                 # for ITL, we expect the correction factor to be close to 1
+                if len(self.d_endpoints) > 0:
+                    concurrency = (self.last_metrics.num_req  # type: ignore
+                        / len(self.d_endpoints)
+                        * self.last_metrics.request_duration  # type: ignore
+                        / self.args.adjustment_interval)
+                else:
+                    logger.warning("No decode workers available, using default concurrency of 1.0")
+                    concurrency = 1.0
+
                 expect_itl = self.decode_interpolator.interpolate_itl(
-                    concurrency=self.last_metrics.num_req  # type: ignore
-                    / len(self.d_endpoints)
-                    * self.last_metrics.request_duration  # type: ignore
-                    / self.args.adjustment_interval,
+                    concurrency=concurrency,
                     context_length=self.last_metrics.isl + self.last_metrics.osl / 2,  # type: ignore
                 )
-                self.d_correction_factor = self.last_metrics.itl / expect_itl
+                if expect_itl > 0:
+                    self.d_correction_factor = self.last_metrics.itl / expect_itl
+                else:
+                    logger.warning(f"Expected ITL is {expect_itl}, using default correction factor 1.0")
+                    self.d_correction_factor = 1.0
                 logger.info(
                     f"Correction factors: TTFT: {self.p_correction_factor:.3f}, ITL: {self.d_correction_factor:.3f}"
                 )


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Fixes division by zero errors in planner's autoscaling logic that prevented scaling decisions in disaggregated SGLang deployments.
#### Details:

<!-- Describe the changes made in this PR. -->

currently  Three division by zero scenarios in `planner_core.py:make_adjustments()`:

  1. **Line 375:** `self.p_correction_factor = self.last_metrics.ttft / expect_ttft`
     - When `expect_ttft = 0` from interpolation edge cases

  2. **Line 384:** `self.d_correction_factor = self.last_metrics.itl / expect_itl`
     - When `expect_itl = 0` from interpolation edge cases

  3. **Line 379:** `concurrency = self.last_metrics.num_req / len(self.d_endpoints)`
     - When `len(self.d_endpoints) = 0` (no decode workers initially)
     
### `components/planner/src/dynamo/planner/utils/planner_core.py`

  **1. TTFT Correction Factor (lines 375-379):**
  ```python
  # Before
  self.p_correction_factor = self.last_metrics.ttft / expect_ttft

  # After
  if expect_ttft > 0:
      self.p_correction_factor = self.last_metrics.ttft / expect_ttft
  else:
      logger.warning(f"Expected TTFT is {expect_ttft}, using default correction factor 1.0")
      self.p_correction_factor = 1.0
```
  2. Concurrency Calculation (lines 381-388):
  ```python
  # Before
  concurrency = self.last_metrics.num_req / len(self.d_endpoints) * ...
```
 ```python
  # After
  if len(self.d_endpoints) > 0:
      concurrency = (self.last_metrics.num_req / len(self.d_endpoints) * ...)
  else:
      logger.warning("No decode workers available, using default concurrency of 1.0")
      concurrency = 1.0
```
  4. ITL Correction Factor (lines 394-398):
   ```python
  # Before
  self.d_correction_factor = self.last_metrics.itl / expect_itl

  # After
  if expect_itl > 0:
      self.d_correction_factor = self.last_metrics.itl / expect_itl
  else:
      logger.warning(f"Expected ITL is {expect_itl}, using default correction factor 1.0")
      self.d_correction_factor = 1.0
```
  
#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
`components/planner/src/dynamo/planner/utils/planner_core.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #3112
