### PR TITLE
feat: add support for vllm cache initialization in Dynamo Planner

### DIFF
--- a/components/backends/vllm/deploy/disagg_planner_cache_init.yaml
+++ b/components/backends/vllm/deploy/disagg_planner_cache_init.yaml
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Example deployment configuration with cache initialization mode enabled
+# This configuration demonstrates the cache initialization strategy where:
+# 1. Planner starts with 1 replica for each worker type
+# 2. Workers initialize the cache collaboratively with file-based locking
+# 3. Planner scales to target replicas once cache is ready
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg-planner-cache-init
+  annotations:
+    nvidia.com/enable-grove: "false" # temporarily disable grove because current k8s connector does not work with grove
+spec:
+  envs:
+    - name: DYNAMO_SERVICE_CONFIG
+      value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:8000"]}]},{"job_name":"frontend","static_configs":[{"targets":["vllm-disagg-planner-frontend-cache-init:8000"]}]}]}}'
+    - name: DYNAMO_NAMESPACE
+      value: "vllm-disagg-planner-cache-init"
+  services:
+    Frontend:
+      dynamoNamespace: vllm-disagg-planner-cache-init
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+    Planner:
+      dynamoNamespace: vllm-disagg-planner-cache-init
+      envFromSecret: hf-token-secret
+      componentType: planner
+      replicas: 1
+      livenessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      readinessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        initialDelaySeconds: 60
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      pvc:
+        create: false
+        name: dynamo-pvc # Must be pre-created before deployment and SLA profiler must have been run
+        mountPoint: /data/profiling_results
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1 # This should be updated to the latest RC version
+          workingDir: /workspace/components/planner/src/dynamo/planner
+          ports:
+            - name: metrics
+              containerPort: 9085
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - >-
+              python3 -m planner_sla
+              --environment=kubernetes
+              --backend=vllm
+              --adjustment-interval=60
+              --profile-results-dir=/data/profiling_results
+              --vllm-cache-initialization-mode
+              --post-vllm-cache-prefill-replicas=2
+              --post-vllm-cache-decode-replicas=2
+              --prometheus-port=8000
+    Prometheus: # NOTE: this is set on Prometheus to ensure a service is created for the Prometheus component. This is a workaround and should be managed differently.
+      dynamoNamespace: vllm-disagg-planner-cache-init
+      componentType: frontend
+      replicas: 1
+      envs:
+        - name: PYTHONPATH
+          value: "/workspace/components/planner/src"
+        - name: PROMETHEUS_PORT
+          value: "8000"
+      livenessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      readinessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - "exit 0"
+        initialDelaySeconds: 30
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - "python3 -m dynamo.planner.prometheus"
+    VllmDecodeWorker:
+      dynamoNamespace: vllm-disagg-planner-cache-init
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      pvc:
+        create: false
+        name: vllm-cache-pvc # Must be created before deployment
+        mountPoint: /root/.cache/vllm
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - python3
+          args:
+            - -m
+            - dynamo.vllm
+            - --model
+            - Qwen/Qwen3-0.6B
+    VllmPrefillWorker:
+      dynamoNamespace: vllm-disagg-planner-cache-init
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 0  # Start with 0 replica, will be scaled to TARGET_PREFILL_REPLICAS after cache init
+      resources:
+        limits:
+          gpu: "1"
+      pvc:
+        create: false
+        name: vllm-cache-pvc # Must be created before deployment
+        mountPoint: /root/.cache/vllm
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            failureThreshold: 60
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.4.1
+          workingDir: /workspace/components/backends/vllm
+          command:
+            - python3
+          args:
+            - -m
+            - dynamo.vllm
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --is-prefill-worker

--- a/components/planner/src/dynamo/planner/utils/planner_argparse.py
+++ b/components/planner/src/dynamo/planner/utils/planner_argparse.py
@@ -124,4 +124,22 @@ def create_sla_planner_parser() -> argparse.ArgumentParser:
         default=SLAPlannerDefaults.no_correction,
         help="Disable correction factor",
     )
+    parser.add_argument(
+        "--vllm-cache-initialization-mode",
+        action="store_true",
+        default=False,
+        help="Enable vLLM cache initialization mode - start with 1 replica to initialize vLLM cache, then scale up",
+    )
+    parser.add_argument(
+        "--post-vllm-cache-prefill-replicas",
+        type=int,
+        default=1,
+        help="Target number of prefill worker replicas after vLLM cache initialization",
+    )
+    parser.add_argument(
+        "--post-vllm-cache-decode-replicas",
+        type=int,
+        default=1,
+        help="Target number of decode worker replicas after vLLM cache initialization",
+    )
     return parser

--- a/components/planner/src/dynamo/planner/utils/planner_core.py
+++ b/components/planner/src/dynamo/planner/utils/planner_core.py
@@ -129,6 +129,17 @@ class Planner:
             self.no_correction = True
         else:
             self.no_correction = args.no_correction
+        
+        # Cache initialization mode settings
+        # This is only for vLLM backend
+        self.vllm_cache_initialization_mode = getattr(args, 'vllm_cache_initialization_mode', False)
+        self.post_vllm_cache_prefill_replicas = getattr(args, 'post_vllm_cache_prefill_replicas', 1)
+        self.post_vllm_cache_decode_replicas = getattr(args, 'post_vllm_cache_decode_replicas', 1)
+        self.vllm_cache_initialized = False
+        if self.vllm_cache_initialization_mode:
+            logger.info(
+                f"vLLM cache initialization mode enabled - targets: prefill={self.post_vllm_cache_prefill_replicas}, decode={self.post_vllm_cache_decode_replicas}"
+            )
 
     async def _async_init(self):
         """Async initialization for components that need it"""
@@ -352,6 +363,66 @@ class Planner:
 
         return next_num_p, next_num_d
 
+    async def check_vllm_cache_initialization_complete(self) -> bool:
+        """Check if vLLM cache has been initialized"""
+        if not self.vllm_cache_initialization_mode:
+            return True
+        try:
+            # Assume if a decode worker is ready, the cache has been initialized
+            if self.connector:
+                is_initial_deployment_ready = await self.connector.kube_api.is_deployment_ready(self.namespace)
+                if is_initial_deployment_ready:
+                    logger.info("Initial deployment is ready, vLLM cache initialization complete")
+                    return True
+        except Exception as e:
+            logger.warning(f"Failed to check vLLM cache initialization status: {e}")
+        return False
+
+    async def handle_vllm_cache_initialization(self):
+        if not self.vllm_cache_initialization_mode or self.vllm_cache_initialized:
+            return
+        
+        # Add a flag to track if initial replicas have been set to ensure they're only set once
+        if not hasattr(self, '_initial_replicas_set'):
+            self._initial_replicas_set = False
+        
+        # Set initial replicas only once
+        if not self._initial_replicas_set:
+            logger.info("vLLM cache initialization mode enabled, ensuring minimal initial replicas")
+            
+            # Force initial replicas to support vllm cache initialization
+            initial_replicas = {
+                WORKER_COMPONENT_NAMES[self.args.backend].prefill_worker_k8s_name: 0,
+                WORKER_COMPONENT_NAMES[self.args.backend].decode_worker_k8s_name: 1,
+            }
+                            
+            if not self.args.no_operation:
+                await self.connector.set_component_replicas(initial_replicas, blocking=False)
+            logger.info(f"Set initial replicas for vLLM cache initialization: {initial_replicas}")
+            self._initial_replicas_set = True
+            return
+            
+        # Check if vllm cache initialization is complete
+        if await self.check_vllm_cache_initialization_complete():
+            logger.info("vLLM cache initialization complete, scaling to target replicas")
+            self.vllm_cache_initialized = True
+            
+            # Scale to target replicas
+            target_replicas = {
+                WORKER_COMPONENT_NAMES[self.args.backend].prefill_worker_k8s_name: self.post_vllm_cache_prefill_replicas,
+                WORKER_COMPONENT_NAMES[self.args.backend].decode_worker_k8s_name: self.post_vllm_cache_decode_replicas,
+            }
+            
+            if not self.args.no_operation:
+                await self.connector.set_component_replicas(target_replicas, blocking=False)
+                
+            logger.info(f"Scaled to target replicas: prefill={self.post_vllm_cache_prefill_replicas}, decode={self.post_vllm_cache_decode_replicas}")
+            
+            # Update Prometheus metrics
+            if not self.dryrun:
+                self.num_p_workers_gauge.set(self.post_vllm_cache_prefill_replicas)
+                self.num_d_workers_gauge.set(self.post_vllm_cache_decode_replicas)
+
     async def make_adjustments(self):
         # Skip adjustment if no traffic
         if not self.last_metrics.is_valid():
@@ -418,6 +489,14 @@ class Planner:
 
         while True:
             current_time = time.time()
+
+            # Handle vLLM cache initialization completely separately from scaling adjustments
+            if self.args.backend == "vllm":
+                await self.handle_vllm_cache_initialization()
+                
+                # If cache initialization is in progress, skip all other operations
+                if self.vllm_cache_initialization_mode and not self.vllm_cache_initialized:
+                    continue
 
             if (
                 current_time - self.last_adjustment_time

--- a/deploy/utils/manifests/vllm-cache-pvc.yaml
+++ b/deploy/utils/manifests/vllm-cache-pvc.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dynamo-vllm-cache
+  namespace: ${NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ${STORAGE_CLASS_NAME}
+  resources:
+    requests:
+      storage: 400Gi


### PR DESCRIPTION
#### Overview:

This PR implements vLLM cache initialization mode for the SLA Planner, addressing performance bottlenecks during initial deployment startup. The feature enables controlled cache warming to reduce cold start latencies and improve initial request handling in disaggregated vLLM deployments.

I used `nvidia/Llama-3.1-8B-Instruct-FP8` to test the performance difference. Without caching, torch.compile takes ~45 seconds. With caching, loading the cached results takes ~8 seconds.

Note that we can extend this functionality to Dynamo in general and not just Planner, but that can be part of a future PR

#### Details:

Overall sequence diagram:
![Mermaid Chart - Create complex, visual diagrams with text  A smarter way of creating diagrams -2025-09-18-152924](https://github.com/user-attachments/assets/8b039116-f517-4635-bb11-090f49a22f4d)

1. **vLLM Cache Initialization Mode**: Added a new planner mode that orchestrates cache warming by:
   - Starting with minimal replicas (0 prefill, 1 decode worker) to initialize the vLLM cache
   - Monitoring deployment readiness to detect cache initialization completion
   - Automatically scaling to target replica counts once cache is ready

2. **Additional Planner CLI Arguments** (`planner_argparse.py`):
   - `--vllm-cache-initialization-mode`: Enable the cache initialization strategy
   - `--post-vllm-cache-prefill-replicas`: Target prefill worker count after initialization
   - `--post-vllm-cache-decode-replicas`: Target decode worker count after initialization

3. **Planner Core Logic** (`planner_core.py`):
   - `handle_vllm_cache_initialization()`: Manages the cache initialization workflow
   - `check_vllm_cache_initialization_complete()`: Monitors deployment readiness
   - Integration with existing scaling logic to prevent conflicts during initialization

4. **Deployment Configurations**:
   - `vllm-cache-pvc.yaml` - Dedicated PVC for vLLM cache storage (400Gi, ReadWriteMany). This is required to share the cache between different workers
   - `disagg_planner_cache_init.yaml` - Example deployment with cache initialization enabled


#### Where should the reviewer start?
1. **`components/planner/src/dynamo/planner/utils/planner_core.py`** - Core cache initialization logic (lines 133-425)
2. **`components/planner/src/dynamo/planner/utils/planner_argparse.py`** - New CLI arguments (lines 127-144)
3. **`deploy/utils/manifests/vllm-cache-pvc.yaml`** - PVC configuration for cache storage
4. **`components/backends/vllm/deploy/disagg_planner_cache_init.yaml`** - Example deployment configuration. I can move this to a different location since this is an example


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added cache initialization mode for the vLLM-based planner to warm up the model cache before normal operation.
  - Planner now auto-scales prefill and decode workers after cache warm-up completes.
  - New CLI options to enable cache init and configure post-init prefill/decode replica targets.

- Chores
  - Introduced a deployment manifest to run the cache initialization workflow with frontend, planner, workers, and monitoring.
  - Added a PVC manifest for shared vLLM cache storage to support initialization and subsequent runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->