### PR TITLE
fix: Define HF_HOME to be a mounted/cleaned dir

### DIFF
--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -66,7 +66,7 @@ jobs:
             --sccache-region "$AWS_DEFAULT_REGION"
       - name: Run pytest
         env:
-          HF_HOME: /runner/_work/_tmp
+          HF_HOME: /runner/_work/_temp
         run: |
           docker run --runtime=nvidia --rm --gpus all -w /workspace \
             --network host \

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -65,6 +65,8 @@ jobs:
             --sccache-bucket "$SCCACHE_S3_BUCKET" \
             --sccache-region "$AWS_DEFAULT_REGION"
       - name: Run pytest
+        env:
+          HF_HOME: /runner/_work/_tmp
         run: |
           docker run --runtime=nvidia --rm --gpus all -w /workspace \
             --network host \


### PR DESCRIPTION
#### Overview:

Small PR which explicitly defines `HF_HOME`, a variable used for the home of Hugging Face model downloads. By default, this is the user's home directory. In CI's case, the home directory is `/home/runner`, which is neither a mounted directory, nor is it a directory that is cleaned between CI jobs. `/runner/_work/_temp` is both a mounted directory and cleaned up by default.

- Lower the expansion of `overlay2` docker folder, since we are no longer downloading models into a docker layer
- Possibly increase the speed at which we download models, since `overlay2` will be slow to change compared to a mounted volume


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability for backend container validation by configuring the test environment to use an isolated cache/home path during pytest runs.
  * Enhances consistency across runners and reduces interference from residual data in shared environments.

* **Tests**
  * Stabilized pytest execution in CI, reducing flakiness and transient failures related to environment state.

* **Notes**
  * No user-facing changes; behavior of the application remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->