### PR TITLE
fix: incorrect crate SPDX identifier, Apache-2.0

### DIFF
--- a/lib/async-openai/Cargo.toml
+++ b/lib/async-openai/Cargo.toml
@@ -11,7 +11,7 @@
 [package]
 name = "dynamo-async-openai"
 description = "Fork of async-openai customized for Dynamo."
-license = "Apache 2.0 AND MIT"
+license = "Apache-2.0 AND MIT"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
#### Overview:

On publication to crates.io the SPDX identifier of `Apache 2.0` needs to be `Apache-2.0`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Aligned package license metadata with SPDX-compliant formatting. No changes to configuration, dependencies, or APIs.
* **Documentation**
  * Updated displayed license string to standard SPDX identifiers to improve compliance tooling compatibility. No impact on runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->