### PR TITLE
fix: incorrect crate SPDX identifier, Apache-2.0 (#3118)

### DIFF
--- a/lib/async-openai/Cargo.toml
+++ b/lib/async-openai/Cargo.toml
@@ -11,7 +11,7 @@
 [package]
 name = "dynamo-async-openai"
 description = "Fork of async-openai customized for Dynamo."
-license = "Apache 2.0 AND MIT"
+license = "Apache-2.0 AND MIT"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
#### Overview:

Cherry pick to fix `dynamo-openai-async` crate spdx identifier
