### PR TITLE
fix: crates.io allows at most 5 keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/ai-dynamo/dynamo"
 repository = "https://github.com/ai-dynamo/dynamo.git"
-keywords = ["llm", "genai", "inference", "nvidia", "distributed", "dynamo"]
+keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 
 [workspace.dependencies]
 # Local crates


### PR DESCRIPTION
#### Overview:

The crate `dynamo-parsers` uses the workspace keywords when packaged. However `crates.io` only allows 5 keywords and there are 6 listed. Removing Dynamo as that word is in the name of the crate and (hopefully) will turn up in search


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata by removing the “dynamo” keyword from the published keywords list to better reflect current project scope and improve discoverability on package indexes.

* **No User-Facing Changes**
  * No impact on features, APIs, configuration, performance, or build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->