### PR TITLE
fix: crates.io allows at most 5 keywords (#3122)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/ai-dynamo/dynamo"
 repository = "https://github.com/ai-dynamo/dynamo.git"
-keywords = ["llm", "genai", "inference", "nvidia", "distributed", "dynamo"]
+keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 
 [workspace.dependencies]
 # Local crates


### PR DESCRIPTION
#### Overview:

Cherry-pick of 3122 to reduce number of keywords for crates.io usage