### PR TITLE
fix: Fix NaN metrics handling in Prometheus client

### DIFF
--- a/components/planner/src/dynamo/planner/utils/prometheus.py
+++ b/components/planner/src/dynamo/planner/utils/prometheus.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import logging
+import math
 
 from prometheus_api_client import PrometheusConnect
 
@@ -50,7 +51,11 @@ class PrometheusAPIClient:
             if not result:
                 # No data available yet (no requests made) - return 0 silently
                 return 0
-            return float(result[0]["value"][1])
+            value = float(result[0]["value"][1])
+            # Handle NaN case (0/0 division when no requests) - return 0
+            if math.isnan(value):
+                return 0
+            return value
         except Exception as e:
             logger.error(f"Error getting {operation_name}: {e}")
             return 0


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Fix NaN metrics handling in Prometheus client to enable proper scale-down decisions.

  When no requests are active, Prometheus queries like increase(metric_sum[interval])/increase(metric_count[interval]) return NaN (0/0), causing the planner to skip all scaling decisions with "Metrics contain None or NaN values"
  message.
#### Details:

<!-- Describe the changes made in this PR. -->
  Added NaN detection and conversion to 0.0 in the PrometheusAPIClient._get_average_metric() method:
```python
  value = float(result[0]["value"][1])
  # Handle NaN case (0/0 division when no requests) - return 0
  if math.isnan(value):
      return 0
  return value
```
  Changes Made
  - Added import math to prometheus.py
  - Added NaN checking in _get_average_metric() method
  - NaN values are now converted to 0.0, allowing proper zero-load handling
#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
start from the logic in prometheus.py
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #3131 
