### PR TITLE
chore: bump version number of deploy artifacts

### DIFF
--- a/deploy/cloud/helm/crds/Chart.yaml
+++ b/deploy/cloud/helm/crds/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v2
 name: dynamo-crds
 description: A Helm chart for dynamo CRDs
 type: application
-version: 0.4.1
+version: 0.5.0
 dependencies: []

--- a/deploy/helm/chart/Chart.yaml
+++ b/deploy/helm/chart/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: dynamo-graph
 description: A Helm chart to deploy a Dynamo graph on Kubernetes
 type: application
-version: 0.4.1
-appVersion: 0.4.1
+version: 0.5.0
+appVersion: 0.5.0


### PR DESCRIPTION
#### Overview:

Bring version bump back to main so ToT is in sync

closes OPS-798


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated Helm chart and CRD chart versions to 0.5.0, aligning appVersion for consistent release labeling across deployments.
  - No behavioral or template changes; this is a metadata-only version bump.
  - Operators can upgrade to 0.5.0 without configuration changes; existing deployments are unaffected.
  - Ensures clearer version tracking for future releases and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->