### PR TITLE
fix: update git version on pre1

### DIFF
--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -334,6 +334,13 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
     sed '/^#\s/d' /workspace/launch_message.txt > ~/.launch_screen && \
     echo "cat ~/.launch_screen" >> ~/.bashrc
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        software-properties-common \
+    && add-apt-repository -y ppa:git-core/ppa \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git
+
 # FIXME: May want a modification with dynamo banner on entry
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []

--- a/container/Dockerfile.trtllm_prebuilt
+++ b/container/Dockerfile.trtllm_prebuilt
@@ -69,6 +69,13 @@ RUN mkdir -p /opt/dynamo/bindings/wheels && \
 
 RUN pip install /workspace/dist/ai_dynamo_runtime*cp312*.whl && pip install /workspace/dist/ai_dynamo*any.whl
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        software-properties-common \
+    && add-apt-repository -y ppa:git-core/ppa \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git
+
 # Copy files for legal compliance
 COPY ATTRIBUTION* LICENSE /workspace/
 


### PR DESCRIPTION
#### Overview:

The git version in the container as built needs to be updated to address [CVE-2025-48384](https://ubuntu.com/security/CVE-2025-48384)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Multi-frontend (NGINX) mode for SGLang jobs with templated config and orchestration.
  - End-to-end benchmarking tooling: CLI/async benchmark runner, VLLM/SGLang bench scripts, health checks, warmup, and profiling hooks.
  - Disaggregated baseline workflows and helpers for TRT-LLM performance sweeps.

- Improvements
  - Enhanced SLURM submission: retries, extra args, consolidated welcome output.
  - Streamlined readiness checks, overlapped launches, and init-location controls.

- Documentation
  - Added guidance for switching ISL/OSL defaults (1k/1k example).

- Chores
  - Version bump to 0.5.1+rc0-pre1.
  - Container updates (new SGLang-wideep images, Git installed).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->