### PR TITLE
chore(CODEOWNERS): Manage permissions by team not by individual

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,6 @@
 # For more information about CODEOWNERS files, see:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Rust - Keep these two the same. Or better make an alias like devops have.
 *.rs @ai-dynamo/dynamo-rust-codeowners
 Cargo.toml @ai-dynamo/dynamo-rust-codeowners
 
@@ -11,15 +10,15 @@ Cargo.toml @ai-dynamo/dynamo-rust-codeowners
 *.py @ai-dynamo/python-codeowners @ai-dynamo/Devops
 
 # Container/Environments
-/container/ @rmccorm4 @tanmayv25 @richardhuo-nv @ptarasiewiczNV @ishandhanani @alec-flowers @nnshah1 @ai-dynamo/Devops
+/container/ @ai-dynamo/Devops @ai-dynamo/dynamo-rust-codeowners @ai-dynamo/python-codeowners
 
 # Dynamo deploy
 /deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @nnshah1 @mohammedabdulwahhab @atchernych
 
 # Examples
-/examples/ @ai-dynamo/Devops @nnshah1 @whoisj @nealvaidya @ishandhanani @ai-dynamo/dynamo-rust-codeowners
+/examples/ @ai-dynamo/Devops @ai-dynamo/dynamo-rust-codeowners @ai-dynamo/python-codeowners
 /examples/*/deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @mohammedabdulwahhab @atchernych
-/examples/multimodal/ @indrajit96 @krishung5 @whoisj @hhzhang16 @biswapanda
+/examples/multimodal/ @ai-dynamo/python-codeowners @ai-dynamo/Devops
 
 # CI/CD
 /.github/ @ai-dynamo/Devops @nnshah1
@@ -27,9 +26,9 @@ Cargo.toml @ai-dynamo/dynamo-rust-codeowners
 CODEOWNERS @ai-dynamo/Devops @nnshah1
 
 # Planner
-/components/planner/ @tedzhouhk @hhzhang16 @jasonqinzhou @PeaBrane @Aphoh @alec-flowers @michaelshin
-/benchmarks/profiler/ @tedzhouhk @hhzhang16 @jasonqinzhou @PeaBrane @Aphoh @alec-flowers @michaelshin
-/tests/planner/ @tedzhouhk @hhzhang16 @jasonqinzhou @PeaBrane @Aphoh @alec-flowers @michaelshin
+/components/planner/ @ai-dynamo/python-codeowners @ai-dynamo/Devops
+/benchmarks/profiler/ @ai-dynamo/python-codeowners @ai-dynamo/Devops
+/tests/planner/ @ai-dynamo/python-codeowners @ai-dynamo/Devops
 
 # recipes
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,6 @@
 # CODEOWNERS file for Dynamo
 #
-# For more information about CODEOWNERS files, see:
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# DO NOT ADD ANY INDIVIDUALS. The groups here are all teams: https://github.com/orgs/ai-dynamo/teams
 
 *.rs @ai-dynamo/dynamo-rust-codeowners
 Cargo.toml @ai-dynamo/dynamo-rust-codeowners
@@ -10,20 +9,20 @@ Cargo.toml @ai-dynamo/dynamo-rust-codeowners
 *.py @ai-dynamo/python-codeowners @ai-dynamo/Devops
 
 # Container/Environments
-/container/ @ai-dynamo/Devops @ai-dynamo/dynamo-rust-codeowners @ai-dynamo/python-codeowners
-
-# Dynamo deploy
-/deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @nnshah1 @mohammedabdulwahhab @atchernych
+/container/ @ai-dynamo/Devops @ai-dynamo/dynamo-rust-codeowners @ai-dynamo/python-codeowners @ai-dynamo/dynamo-deploy-codeowners
 
 # Examples
 /examples/ @ai-dynamo/Devops @ai-dynamo/dynamo-rust-codeowners @ai-dynamo/python-codeowners
-/examples/*/deploy/ @hutm @biswapanda @ishandhanani @julienmancuso @hhzhang16 @mohammedabdulwahhab @atchernych
 /examples/multimodal/ @ai-dynamo/python-codeowners @ai-dynamo/Devops
 
+# Dynamo deploy
+/deploy/ @ai-dynamo/dynamo-deploy-codeowners
+/examples/*/deploy/ @ai-dynamo/dynamo-deploy-codeowners
+
 # CI/CD
-/.github/ @ai-dynamo/Devops @nnshah1
-/.github/workflows/*.ps1 @ai-dynamo/Devops @whoisj
-CODEOWNERS @ai-dynamo/Devops @nnshah1
+/.github/ @ai-dynamo/Devops
+/.github/workflows/*.ps1 @ai-dynamo/Devops
+CODEOWNERS @ai-dynamo/Devops
 
 # Planner
 /components/planner/ @ai-dynamo/python-codeowners @ai-dynamo/Devops
@@ -32,7 +31,7 @@ CODEOWNERS @ai-dynamo/Devops @nnshah1
 
 # recipes
 
-/recipes/ @ai-dynamo/python-codeowners @ai-dynamo/Devops
+/recipes/ @ai-dynamo/python-codeowners @ai-dynamo/Devops @ai-dynamo/dynamo-deploy-codeowners
 
 # Legal
 /ATTRIBUTIONS-Rust.md @ai-dynamo/Devops


### PR DESCRIPTION
Manually adding and removing people from these lists doesn't really scale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Consolidated repository ownership settings in CODEOWNERS from individual maintainers to team-based groups across multiple areas.
  - Standardized ownership coverage for examples, multimodal examples, planner components, benchmarks, tests, and container-related code.
  - No changes to CI/CD or deployment ownership mappings.
  - No impact on product functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->