### PR TITLE
feat: Trtllm health check payload use bos_token_id

### DIFF
--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -318,7 +318,7 @@ async def init(runtime: DistributedRuntime, config: Config):
             )
 
         # Get health check payload (checks env var and falls back to TensorRT-LLM default)
-        health_check_payload = TrtllmHealthCheckPayload().to_dict()
+        health_check_payload = TrtllmHealthCheckPayload(tokenizer=tokenizer).to_dict()
 
         if config.publish_events_and_metrics and is_first_worker(config):
             # Initialize and pass in the publisher to the request handler to


### PR DESCRIPTION
#### Overview:

Trtllm health check payload use bos_token_id

#### Details:

Get bos_token_id from tokenizer. 
Default token id 1 isn’t model‑agnostic. Use the engine/tokenizer BOS id at call‑site to prevent OOV or unintended tokens.

#### Where should the reviewer start?

components/backends/trtllm/src/dynamo/trtllm/health_check.py: get bos_token_id

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-649


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Health checks now derive the BOS token from the active tokenizer, improving multi-model compatibility.
- Bug Fixes
  - Replaces hardcoded BOS token ID with model-specific value to prevent false health-check failures on certain models.
- Chores
  - Added detailed logging around BOS token retrieval to aid diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->