### PR TITLE
docs: Update README.md to bypass nvidia runtime for dcgm-exporter service when deploying container for etcd and nats

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ To coordinate across a data center, Dynamo relies on etcd and NATS. To run Dynam
 To quickly setup etcd & NATS, you can also run:
 ```
 # At the root of the repository:
+# Edit deploy/docker-compose.yml to comment out "runtime: nvidia" of the dcgm-exporter service if the nvidia container runtime isn't deployed or to be used.  
 docker compose -f deploy/docker-compose.yml up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To coordinate across a data center, Dynamo relies on etcd and NATS. To run Dynam
 To quickly setup etcd & NATS, you can also run:
 ```
 # At the root of the repository:
-# Edit deploy/docker-compose.yml to comment out "runtime: nvidia" of the dcgm-exporter service if the nvidia container runtime isn't deployed or to be used.  
+# Edit deploy/docker-compose.yml to comment out "runtime: nvidia" of the dcgm-exporter service if the nvidia container runtime isn't deployed or to be used.
 docker compose -f deploy/docker-compose.yml up -d
 ```
 


### PR DESCRIPTION
#### Overview:

When setting up etcd & NATS by following the instruction in https://github.com/ai-dynamo/dynamo?tab=readme-ov-file#1-initial-setup and using command "docker compose -f deploy/docker-compose.yml up -d", the command failed with the below error, either etcd or NATS brought up. 

_**✘ Container deploy-dcgm-exporter-1  Error response from daemon: unk...                                    0.0s 
Error response from daemon: unknown or invalid runtime name: nvidia**_
 

#### Details:
The root cause is the dcgm-exporter service defined in docker-compose.yml explicitly uses the nvidia container runtime like below, which was not installed and running in the environment. To deploy the services successfully, the "runtime: nvidia" parameter needs to be commented out. This PR is to add additional information to the instruction to help others avoid the same issue.  

<img width="984" height="790" alt="image" src="https://github.com/user-attachments/assets/cfe1fbf2-4f18-4270-a60d-f7dd9b87db0a" />



#### Where should the reviewer start?

The "Install etcd and NATS (required)" section of the main README.md file

<img width="1294" height="601" alt="image" src="https://github.com/user-attachments/assets/07b537cb-f5d4-4474-9be5-b7d6f654b0bd" />


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes GitHub issue: #3133 
