### PR TITLE
fix: Use /health endpoint instead of /v1/models endpoint for health check

### DIFF
--- a/components/backends/trtllm/performance_sweeps/scripts/bench.sh
+++ b/components/backends/trtllm/performance_sweeps/scripts/bench.sh
@@ -103,25 +103,34 @@ if [ -f "${log_path}/deployment_config.json" ]; then
 fi
 echo "${deployment_config}" > "${log_path}/deployment_config.json"
 
-# Wait for server to load (up to 50 attempts)
+# Wait for server to become healthy (up to 50 attempts)
 failed=true
 for ((i=1; i<=50; i++)); do
     sleep $((i == 1 ? WAIT_TIME : 20))
-    response=$(curl -s -w "\n%{http_code}" "${hostname}:${port}/v1/models")
+    response=$(curl -s -w "\n%{http_code}" "${hostname}:${port}/health")
     http_code=$(echo "$response" | tail -n1)
     body=$(echo "$response" | sed '$d')
 
-    if [[ "$http_code" == "200" ]]; then
-        echo "$body"
-        if echo "$body" | grep -q "\"id\":\"${model}\""; then
-            echo "Model check succeeded on attempt $i"
+    # NOTE: This can be replaced with simply checking /v1/models endpoint after this PR:
+    # https://github.com/ai-dynamo/dynamo/pull/2683
+    if [[ "$http_code" == "200" ]] && echo "$body" | grep -q '"status":"healthy"' && echo "$body" | grep -q '"endpoints":\[[^]]*"dyn://dynamo.tensorrt_llm.generate"'; then
+        if [[ "$kind" == *disagg* ]]; then
+            if echo "$body" | grep -q '"tensorrt_llm_next"'; then
+                echo "Health check succeeded on attempt $i"
+                echo "$body"
+                failed=false
+                break
+            else
+                echo "Attempt $i: tensorrt_llm_next key not found in etcd."
+            fi
+        else
+            echo "Health check succeeded on attempt $i"
+            echo "$body"
             failed=false
             break
-        else
-            echo "Attempt $i: Model '${model}' not found in /v1/models response."
         fi
     else
-        echo "Attempt $i failed: /v1/models not ready (HTTP $http_code)."
+        echo "Attempt $i failed: /health not ready (HTTP $http_code)."
     fi
 done
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

After PR #2683, disagg TRTLLM workers won't register themselves as available to frontend until at least one of both prefill/decode workers are available, avoiding the race on possibly decode being ready but prefill not being ready, for example. With this included, this makes checking /v1/models endpoint a relatively safe option to determine model readiness (though may not account for whether ALL prefill/decode instances have started when there are multiple of either). 

However, that commit isn't included in this branch, and including that commit in this branch would require a container rebuild. So the v1/models endpoint isn't sufficient to determine inference readiness, so switch back to using the /health endpoint instead for now.

This is to increase the stability and consistency of disagg benchmarking jobs not starting until both P and D are ready.