### PR TITLE
ci: Set parallelism to 6 for builds

### DIFF
--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -55,6 +55,7 @@ jobs:
           docker system prune -af
       - name: Build image
         env:
+          MAX_JOBS: 6
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           SCCACHE_S3_BUCKET:  ${{ secrets.SCCACHE_S3_BUCKET }}
@@ -62,6 +63,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           ./container/build.sh --tag ${{ matrix.framework }}:latest \
+            --build-arg MAX_JOBS=${MAX_JOBS} \
             --target ${{ matrix.target }} \
             --framework ${{ matrix.framework }} \
             --use-sccache \


### PR DESCRIPTION
#### Overview:

This PR sets the parallelism on the CI machines to `6` instead of the default of `16`.

After lots of testing, `vllm` builds were peaking at `~10GB` of RAM per thread in a build, causing the runner Pods to crash, which is this error: https://github.com/ai-dynamo/dynamo/actions/runs/17923063593

```
The self-hosted runner lost communication with the server. Verify the machine is running and
has a healthy network connection. Anything in your workflow that terminates the runner process,
starves it for CPU/Memory, or blocks its network access can cause this error.
```

This update should significantly reduce or eliminate this occurrence happening due to build processes.

**Will this slow down workflows?**

With `sccache`, lowering parallelization shouldn't affect the speed of builds that mostly have cache hits. For source files that must be rebuilt, it will be slower, but should be more stable as well. Generally, the expectation is that PRs with large changes will be slower, but also shouldn't fail.

I have upgraded the machines to make it fit better. If the speed is considered a problem, we can discuss upgrading the node groups further to accommodate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI builds now support configurable parallelism to optimize container build performance.
  * Introduced a MAX_JOBS setting (default 6) to control concurrent build jobs during container validation.
  * Improves build speed and resource utilization in CI without affecting application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->