### PR TITLE
docs: Fix inconsistent namespace naming in deployment documentation

### DIFF
--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -51,7 +51,7 @@ Each backend has deployment examples and configuration options:
 
 ```bash
 # Set same namespace from platform install
-export NAMESPACE=dynamo-cloud
+export NAMESPACE=dynamo-kubernetes
 
 # Deploy any example (this uses vLLM with Qwen model using aggregated serving)
 kubectl apply -f components/backends/vllm/deploy/agg.yaml -n ${NAMESPACE}

--- a/docs/kubernetes/installation_guide.md
+++ b/docs/kubernetes/installation_guide.md
@@ -108,8 +108,8 @@ Build and deploy from source for customization.
 
 ```bash
 # 1. Set environment
-export NAMESPACE=dynamo-cloud
-export DOCKER_SERVER=nvcr.io/nvidia/ai-dynamo/  # or your registry
+export NAMESPACE=dynamo-kubernetes
+export DOCKER_SERVER=nvcr.io/nvidia/ai-dynamo  # or your registry
 export DOCKER_USERNAME='$oauthtoken'
 export DOCKER_PASSWORD=<YOUR_NGC_CLI_API_KEY>
 export IMAGE_TAG=${RELEASE_VERSION}


### PR DESCRIPTION
#### Overview:

This PR addresses an issue where two different namespace names were used in the deployment documentation, causing confusion and potential execution errors during Kubernetes deployments.

#### Details:

The documentation contained inconsistent namespace references: `dynamo-cloud` and `dynamo-kubernetes`
Using the incorrect namespace (dynamo-cloud) would lead to execution failures when following the deployment guides




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment and installation guides to use the Kubernetes namespace dynamo-kubernetes instead of dynamo-cloud.
  * Adjusted example commands (including kubectl apply paths) and environment setup to reflect the new NAMESPACE.
  * Aligned Path C (Custom Development) with Path A for consistent guidance.
  * Clarified steps for deploying an aggregated vLLM backend using the updated namespace, reducing setup confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->