### PR TITLE
feat: Implement reasoning token counting in usage field

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -605,6 +605,7 @@ impl OpenAIPreprocessor {
                         && !inner.finished
                     {
                         inner.usage_chunk_sent = true;
+                        inner.finished = true; // Mark as finished BEFORE returning the usage chunk
 
                         // Create the final usage chunk
                         let usage_chunk = inner.response_generator.create_usage_chunk();
@@ -956,6 +957,8 @@ impl
 
         // set the runtime configuration
         response_generator.set_reasoning_parser(self.runtime_config.clone());
+        // set the tokenizer for reasoning token counting
+        response_generator.set_tokenizer(Some(self.tokenizer.clone()));
         let enable_tool_calling =
             maybe_enable_tool_call(self.tool_call_parser.as_deref(), &request);
         // convert the chat completion request to a common completion request


### PR DESCRIPTION
**Before:** `"reasoning_tokens": null`  
**After:** `"reasoning_tokens": 350` (actual count)

## Changes

- Add tokenizer integration to DeltaGenerator 
- Implement token counting with reasoning content separation
- Fix stream termination bug in usage chunk generation
- Add comprehensive unit tests

## Where should the reviewer start?

- `lib/llm/src/protocols/openai/chat_completions/delta.rs` - Main implementation
- `lib/llm/src/preprocessor.rs` - Tokenizer integration (

## Related Issues

- Resolves #2941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Optional tokenizer-aware token counting that distinguishes reasoning vs. completion tokens when available.

* Bug Fixes
  * Ensured final usage records are finalized before being emitted, fixing edge-case usage/reporting discrepancies.

* Refactor
  * Integrated tokenizer-aware counting into usage reporting with a reliable fallback to approximate counts to preserve metrics.

* Style
  * Debug output improved to mask sensitive tokenizer internals while retaining useful state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->