### PR TITLE
chore: added middleware layer to catch json validation errors

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1082,8 +1082,8 @@ pub fn completions_router(
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let router = Router::new()
         .route(&path, post(handler_completions))
-        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .layer(middleware::from_fn(smart_json_error_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state(state);
     (vec![doc], router)
 }
@@ -1099,8 +1099,8 @@ pub fn chat_completions_router(
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let router = Router::new()
         .route(&path, post(handler_chat_completions))
-        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .layer(middleware::from_fn(smart_json_error_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state((state, template));
     (vec![doc], router)
 }
@@ -1115,8 +1115,8 @@ pub fn embeddings_router(
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let router = Router::new()
         .route(&path, post(embeddings))
-        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .layer(middleware::from_fn(smart_json_error_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state(state);
     (vec![doc], router)
 }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -206,15 +206,13 @@ pub async fn smart_json_error_middleware(request: Request<Body>, next: Next) -> 
 
     // Try to parse as JSON first to catch pure JSON syntax errors
     match serde_json::from_slice::<serde_json::Value>(&body_bytes) {
-        Err(json_err) => {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorMessage {
-                    error: format!("Invalid JSON syntax: {}", json_err),
-                }),
-            )
-                .into_response()
-        }
+        Err(json_err) => (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorMessage {
+                error: format!("Invalid JSON syntax: {}", json_err),
+            }),
+        )
+            .into_response(),
         // Pass through for any other errors as it is
         Ok(_) => {
             let new_body = Body::from(body_bytes);

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -531,12 +531,7 @@ async fn test_http_service() {
         .await
         .unwrap();
 
-    assert_eq!(
-        response.status(),
-        StatusCode::UNPROCESSABLE_ENTITY,
-        "{:?}",
-        response
-    );
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{:?}", response);
 
     // =========== Query /metrics endpoint ===========
     let response = client


### PR DESCRIPTION
#### Overview:

Currently we are using JSON from axum as the request validator. Whenever there is an invalid JSON, it will return a 422.
But all the downstream apps that relies on openai based APIs, expects to get 400 for all these cases otherwise they fail badly
Solution: Added a middleware at axum router level to catch read the raw request and catch any json syntax errors and return a 400.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON error handling for POST requests to Completions, Chat Completions, Embeddings, and Responses endpoints. Invalid or unreadable JSON now returns a 400 Bad Request with a clear, actionable message, making it easier to diagnose malformed requests.
  * More consistent and descriptive error messages in responses and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->