### PR TITLE
fix: fix broken links

### DIFF
--- a/docs/benchmarks/benchmarking.md
+++ b/docs/benchmarks/benchmarking.md
@@ -300,7 +300,7 @@ The server-side benchmarking solution:
 
 ## Prerequisites
 
-1. **Kubernetes cluster** with NVIDIA GPUs and Dynamo namespace setup (see [Dynamo Cloud/Platform docs](../guides/dynamo_deploy/README.md))
+1. **Kubernetes cluster** with NVIDIA GPUs and Dynamo namespace setup (see [Dynamo Cloud/Platform docs](/docs/kubernetes/README.md))
 2. **Storage and service account** PersistentVolumeClaim and service account configured with appropriate permissions (see [deploy/utils README](../../deploy/utils/README.md))
 3. **Docker image** containing the Dynamo benchmarking tools
 

--- a/docs/kubernetes/sla_planner_deployment.md
+++ b/docs/kubernetes/sla_planner_deployment.md
@@ -3,7 +3,7 @@
 Quick deployment guide for the disaggregated planner with automatic scaling.
 
 > [!NOTE]
-> For high-level architecture and concepts, see [SLA-based Planner](../../architecture/sla_planner.md).
+> For high-level architecture and concepts, see [SLA-based Planner](/docs/architecture/sla_planner.md).
 
 ## Architecture Overview
 
@@ -23,11 +23,11 @@ flowchart LR
 
 ## Prerequisites
 - Kubernetes cluster with GPU nodes
-- [Pre-Deployment Profiling](../../benchmarks/pre_deployment_profiling.md) completed and its results saved to `dynamo-pvc` PVC.
+- [Pre-Deployment Profiling](/docs/benchmarks/pre_deployment_profiling.md) completed and its results saved to `dynamo-pvc` PVC.
 - Prefill and decode worker uses the best parallelization mapping suggested by the pre-deployment profiling script.
 
 > [!NOTE]
-> **Important**: The profiling that occurs before Planner deployment requires additional Kubernetes manifests (ServiceAccount, Role, RoleBinding, PVC) that are not included in standard Dynamo deployments. Apply these manifests in the same namespace as `$NAMESPACE`. For a complete setup, start with the [Quick Start guide](../../../deploy/utils/README.md#quick-start), which provides a fully encapsulated deployment including all required manifests.
+> **Important**: The profiling that occurs before Planner deployment requires additional Kubernetes manifests (ServiceAccount, Role, RoleBinding, PVC) that are not included in standard Dynamo deployments. Apply these manifests in the same namespace as `$NAMESPACE`. For a complete setup, start with the [Quick Start guide](/deploy/utils/README.md#quick-start), which provides a fully encapsulated deployment including all required manifests.
 ```bash
 export NAMESPACE=your-namespace
 ```


### PR DESCRIPTION
#### Overview:

fix broken links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized documentation links to absolute paths across benchmarking and SLA planner deployment pages for more reliable navigation.
  * Updated benchmarking prerequisites to point to the correct Kubernetes documentation.
  * Revised SLA planner deployment references (architecture, pre-deployment profiling, and quick start) to absolute docs paths.
  * Adjusted note wording to align with the new link structure.
  * No behavioral or functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->