### PR TITLE
feat: allow users to only plot certain subdirs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -33,6 +33,9 @@ python3 -m benchmarks.utils.benchmark \
 
 # Generate plots
 python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results
+
+# Or plot only specific benchmark experiments
+python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark_name my-benchmark
 ```
 
 ## Features

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,7 +35,7 @@ python3 -m benchmarks.utils.benchmark \
 python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results
 
 # Or plot only specific benchmark experiments
-python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark_name my-benchmark
+python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark-name my-benchmark
 ```
 
 ## Features

--- a/docs/benchmarks/benchmarking.md
+++ b/docs/benchmarks/benchmarking.md
@@ -136,7 +136,7 @@ python3 -m benchmarks.utils.benchmark \
 python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results
 
 # Or plot only specific benchmark experiments
-python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark_name experiment-a --benchmark_name experiment-b
+python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark-name experiment-a --benchmark-name experiment-b
 ```
 
 ## Use Cases
@@ -203,7 +203,7 @@ The plotting script supports several options for customizing which experiments t
 python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results
 
 # Plot only specific benchmark experiments
-python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark_name experiment-a --benchmark_name experiment-b
+python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark-name experiment-a --benchmark-name experiment-b
 
 # Specify custom output directory for plots
 python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --output-dir ./custom-plots
@@ -211,10 +211,10 @@ python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --output-dir ./
 
 **Available Options:**
 - `--data-dir`: Directory containing benchmark results (required)
-- `--benchmark_name`: Specific benchmark experiment name to plot (can be specified multiple times)
+- `--benchmark-name`: Specific benchmark experiment name to plot (can be specified multiple times). Names must match subdirectory names under the data dir.
 - `--output-dir`: Custom output directory for plots (defaults to data-dir/plots)
 
-**Note**: If `--benchmark_name` is not specified, the script will plot all subdirectories found in the data directory.
+**Note**: If `--benchmark-name` is not specified, the script will plot all subdirectories found in the data directory.
 
 ### Using Your Own Models and Configuration
 

--- a/docs/benchmarks/benchmarking.md
+++ b/docs/benchmarks/benchmarking.md
@@ -134,6 +134,9 @@ python3 -m benchmarks.utils.benchmark \
 ```bash
 # Generate plots and summary using Python plotting script
 python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results
+
+# Or plot only specific benchmark experiments
+python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark_name experiment-a --benchmark_name experiment-b
 ```
 
 ## Use Cases
@@ -190,6 +193,28 @@ The Python benchmarking module:
 The Python plotting module:
 1. **Generates** comparison plots using your custom labels in `<OUTPUT_DIR>/plots/`
 2. **Creates** summary statistics and visualizations
+
+### Plotting Options
+
+The plotting script supports several options for customizing which experiments to visualize:
+
+```bash
+# Plot all benchmark experiments in the data directory
+python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results
+
+# Plot only specific benchmark experiments
+python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark_name experiment-a --benchmark_name experiment-b
+
+# Specify custom output directory for plots
+python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --output-dir ./custom-plots
+```
+
+**Available Options:**
+- `--data-dir`: Directory containing benchmark results (required)
+- `--benchmark_name`: Specific benchmark experiment name to plot (can be specified multiple times)
+- `--output-dir`: Custom output directory for plots (defaults to data-dir/plots)
+
+**Note**: If `--benchmark_name` is not specified, the script will plot all subdirectories found in the data directory.
 
 ### Using Your Own Models and Configuration
 


### PR DESCRIPTION
#### Overview:

Allow users to only plot certain benchmark experiments:
```
python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark_name my-benchmark
```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a repeatable --benchmark_name option to the plotting CLI to filter which benchmark experiments are visualized.
  - Improved no-results messaging, including listing requested benchmark names when none are found.
- Documentation
  - Expanded benchmarking docs with a Plotting Options section, including examples for plotting all or specific experiments and configuring output directories.
  - Added an example command demonstrating targeted plotting in the benchmarks README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->