### PR TITLE
Fix TRTLLM config modifier to handle aggregated configurations

### DIFF
--- a/benchmarks/profiler/utils/config.py
+++ b/benchmarks/profiler/utils/config.py
@@ -795,8 +795,9 @@ class TrtllmConfigModifier:
                 ]
                 del cfg.spec.services["TRTLLMPrefillWorker"]
 
-            # Remove decode worker
-            del cfg.spec.services["TRTLLMDecodeWorker"]
+            # Remove decode worker if it exists
+            if "TRTLLMDecodeWorker" in cfg.spec.services:
+                del cfg.spec.services["TRTLLMDecodeWorker"]
 
             worker_service = cfg.spec.services["TRTLLMWorker"]
             if (
@@ -839,7 +840,7 @@ class TrtllmConfigModifier:
 
         elif target == "decode":
             # Convert to decode-only aggregated setup
-            # Use decode worker as the main worker
+            # Use decode worker as the main worker if it exists
             if "TRTLLMDecodeWorker" in cfg.spec.services:
                 # Rename decode worker to generic worker
                 cfg.spec.services["TRTLLMWorker"] = cfg.spec.services[


### PR DESCRIPTION
- Add conditional check for TRTLLMDecodeWorker existence before deletion
- Fixes KeyError when using agg.yaml with profile_sla.py
- Allows config modifier to work with both disaggregated and aggregated setups
- Resolves issue where TRTLLMDecodeWorker service doesn't exist in agg.yaml

## Problem

When running `profile_sla.py` with `agg.yaml` using aiconfigurator, the script fails with a `KeyError: 'TRTLLMDecodeWorker'` error. This happens because the TRTLLM config modifier assumes the input configuration has separate `TRTLLMPrefillWorker` and `TRTLLMDecodeWorker` services (disaggregated setup), but `agg.yaml` already has a single `TRTLLMWorker` service (aggregated setup).

## Solution

Added conditional checks to ensure the config modifier can handle both:
- **Disaggregated configurations** (with separate `TRTLLMPrefillWorker` and `TRTLLMDecodeWorker` services)
- **Aggregated configurations** (with a single `TRTLLMWorker` service like in `agg.yaml`)

## Changes

- Added `if "TRTLLMDecodeWorker" in cfg.spec.services:` check before attempting to delete the service
- Updated comment to clarify that decode worker is used "if it exists"

## Testing

Tested with the failing command:
```bash
python3 profile_sla.py --config components/backends/trtllm/deploy/agg.yaml --use-ai-configurator --isl 2048 --osl 2048  --aic-system h100_sxm --num-gpus-per-node 8 --aic-model-name QWEN3_32B --backend trtllm --backend-version 1.0.0rc3 --dry-run
```

The KeyError is now resolved and the script proceeds to the next step (module import errors, which is expected in dry-run mode).

## Related Issue

Fixes the error encountered when using aggregated TRTLLM configurations with the profiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Improved robustness of TRT-LLM configuration handling: the decode worker is now used or removed only when present, preventing errors in setups without a decode worker and ensuring smoother runs across varied configurations.

- Chores
  - Minor text/comment updates to reflect the guarded behavior (no impact on public APIs).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->