### PR TITLE
docs: Fix Docker Compose path in example README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -54,7 +54,7 @@ Low-level runtime examples for developers using Python<>Rust bindings:
 
 2. **Set up prerequisites**: Most examples require etcd and NATS services. You can start them using:
    ```bash
-   docker compose -f deploy/metrics/docker-compose.yml up -d
+   docker compose -f deploy/docker-compose.yml up -d
    ```
 
 3. **Follow the example**: Each directory contains detailed setup instructions and configuration files specific to that deployment pattern.


### PR DESCRIPTION
Updated the Docker Compose file path for starting services.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

docker-compose.yml location was moved - fix typo in code snippet to new location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the prerequisites section to use the correct Docker Compose command, ensuring the proper compose file is referenced during setup.
  * Clarifies setup steps to reduce confusion and improve onboarding reliability.
  * No behavioral changes to the application; instructions only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->