### PR TITLE
feat: user_metadata top-level field in OpenAI-compatible frontend

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -235,6 +235,10 @@ impl CommonExtProvider for NvCreateChatCompletionRequest {
     fn get_include_stop_str_in_output(&self) -> Option<bool> {
         self.common.include_stop_str_in_output
     }
+
+    fn get_user_metadata(&self) -> Option<&serde_json::Value> {
+        self.common.user_metadata.as_ref()
+    }
 }
 
 /// Implements `OpenAIStopConditionsProvider` for `NvCreateChatCompletionRequest`,

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -71,6 +71,11 @@ pub struct CommonExt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub guided_decoding_backend: Option<String>,
+
+    /// Arbitrary user_metadata object
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub user_metadata: Option<serde_json::Value>,
 }
 
 impl CommonExt {
@@ -96,6 +101,9 @@ pub trait CommonExtProvider {
     fn get_min_p(&self) -> Option<f32>;
     fn get_repetition_penalty(&self) -> Option<f32>;
     fn get_include_stop_str_in_output(&self) -> Option<bool>;
+
+    /// user_metadata passthrough object
+    fn get_user_metadata(&self) -> Option<&serde_json::Value>;
 }
 
 /// Helper function to emit deprecation warnings for nvext parameters
@@ -146,6 +154,7 @@ mod tests {
         assert_eq!(common_ext.guided_choice, None);
         assert_eq!(common_ext.guided_decoding_backend, None);
         assert_eq!(common_ext.include_stop_str_in_output, None);
+        assert_eq!(common_ext.user_metadata, None);
     }
 
     #[test]
@@ -161,6 +170,7 @@ mod tests {
             .guided_grammar("grammar".to_string())
             .guided_choice(vec!["choice1".to_string(), "choice2".to_string()])
             .guided_decoding_backend("backend".to_string())
+            .user_metadata(serde_json::json!({"key1": "value1", "key2": "value2"}))
             .build()
             .unwrap();
 
@@ -182,6 +192,10 @@ mod tests {
         assert_eq!(
             common_ext.guided_decoding_backend,
             Some("backend".to_string())
+        );
+        assert_eq!(
+            common_ext.user_metadata.as_ref(),
+            Some(&serde_json::json!({"key1": "value1", "key2": "value2"}))
         );
     }
 
@@ -215,6 +229,7 @@ mod tests {
             guided_grammar: None,
             guided_choice: None,
             guided_decoding_backend: None,
+            user_metadata: None,
         };
         assert!(common_ext.validate().is_ok());
     }

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -222,6 +222,10 @@ impl CommonExtProvider for NvCreateCompletionRequest {
     fn get_include_stop_str_in_output(&self) -> Option<bool> {
         self.common.include_stop_str_in_output
     }
+
+    fn get_user_metadata(&self) -> Option<&serde_json::Value> {
+        self.common.user_metadata.as_ref()
+    }
 }
 
 impl OpenAIStopConditionsProvider for NvCreateCompletionRequest {

--- a/lib/llm/tests/test_common_ext.rs
+++ b/lib/llm/tests/test_common_ext.rs
@@ -386,3 +386,42 @@ fn test_sampling_parameters_extraction() {
     assert_eq!(sampling_options.top_k, Some(42));
     assert_eq!(sampling_options.repetition_penalty, Some(1.3));
 }
+
+#[test]
+fn test_chat_completions_user_metadata_from_common() {
+    let json_str = r#"{
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "user_metadata": {"key1": "value1", "key2": "value2"}
+    }"#;
+
+    let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+
+    assert_eq!(
+        request.common.user_metadata,
+        Some(serde_json::json!({"key1": "value1", "key2": "value2"}))
+    );
+    assert_eq!(
+        request.get_user_metadata(),
+        Some(&serde_json::json!({"key1": "value1", "key2": "value2"}))
+    );
+}
+
+#[test]
+fn test_completions_user_metadata_from_common() {
+    let json_str = r#"{
+        "model": "test-model",
+        "prompt": "Hello world",
+        "user_metadata": {"key1": "value1", "key2": "value2"}
+    }"#;
+
+    let request: NvCreateCompletionRequest = serde_json::from_str(json_str).unwrap();
+    assert_eq!(
+        request.common.user_metadata,
+        Some(serde_json::json!({"key1": "value1", "key2": "value2"}))
+    );
+    assert_eq!(
+        request.get_user_metadata(),
+        Some(&serde_json::json!({"key1": "value1", "key2": "value2"}))
+    );
+}


### PR DESCRIPTION
#### Overview:
Adds support for a user_metadata top-level field in OAI-compatible frontend. This field functions as a passthrough and is ignored by the backends

#### Details:
Adds user_metadata field as part of CommonExt
Supported in completions and chat completions API
Currently unsupported in responses API

#### Where should the reviewer start?
lib/llm/src/protocols/openai/common_ext.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional user metadata on completion and chat completion requests, allowing clients to attach JSON-formatted metadata per request.
  * Metadata is now accessible through the public interface when present, with no changes required if not used.

* **Tests**
  * Added coverage to ensure user metadata is correctly parsed and exposed for both completion and chat completion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->