### PR TITLE
chore: version bumps for 0.5.1 release

### DIFF
--- a/benchmarks/incluster/benchmark_job.yaml
+++ b/benchmarks/incluster/benchmark_job.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: benchmark-runner
         # TODO: update to latest public image in next release
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/benchmarks/nixl/nixl-benchmark-deployment.yaml
+++ b/benchmarks/nixl/nixl-benchmark-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         - name: nvcr-imagepullsecret
       containers:
       - name: nixl-benchmark
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:nixlbench-e42c07a8
+        image: my-registry/vllm-runtime:nixlbench-e42c07a8
         command: ["sh", "-c"]
         args:
           - "nixlbench -etcd_endpoints http://dynamo-platform-etcd:2379 --target_seg_type VRAM --initiator_seg_type VRAM && sleep infinity"

--- a/benchmarks/nixl/nixl-benchmark-deployment.yaml
+++ b/benchmarks/nixl/nixl-benchmark-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         - name: nvcr-imagepullsecret
       containers:
       - name: nixl-benchmark
-        image: my-registry/vllm-runtime:nixlbench-e42c07a8
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:nixlbench-e42c07a8
         command: ["sh", "-c"]
         args:
           - "nixlbench -etcd_endpoints http://dynamo-platform-etcd:2379 --target_seg_type VRAM --initiator_seg_type VRAM && sleep infinity"

--- a/components/backends/sglang/README.md
+++ b/components/backends/sglang/README.md
@@ -130,7 +130,7 @@ uv pip install --prerelease=allow sglang[all]==0.4.9.post6
 <summary>Instructions</summary>
 
 ```bash
-docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime:my-tag
+docker pull nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
 ```
 
 </details>

--- a/components/backends/sglang/deploy/README.md
+++ b/components/backends/sglang/deploy/README.md
@@ -61,7 +61,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/sglang-runtime:my-tag
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
     workingDir: /workspace/components/backends/sglang
     args:
       - "python3"
@@ -92,7 +92,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: my-registry/sglang-runtime:my-tag
+image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
 
 # Configure your model
 args:

--- a/components/backends/sglang/deploy/agg.yaml
+++ b/components/backends/sglang/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/agg_logging.yaml
+++ b/components/backends/sglang/deploy/agg_logging.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
           - /bin/sh

--- a/components/backends/sglang/deploy/agg_router.yaml
+++ b/components/backends/sglang/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/disagg-multinode.yaml
+++ b/components/backends/sglang/deploy/disagg-multinode.yaml
@@ -22,7 +22,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
     decode:
       multinode:
         nodeCount: 2
@@ -35,7 +35,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:
@@ -62,7 +62,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command: ["sh", "-c"]
           args:

--- a/components/backends/sglang/deploy/disagg.yaml
+++ b/components/backends/sglang/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -51,7 +51,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/components/backends/sglang/deploy/disagg_planner.yaml
+++ b/components/backends/sglang/deploy/disagg_planner.yaml
@@ -18,7 +18,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
     Planner:
       dynamoNamespace: dynamo
       envFromSecret: hf-token-secret
@@ -49,7 +49,7 @@ spec:
         mountPoint: /data
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/planner/src/dynamo/planner
           command:
             - /bin/sh
@@ -89,7 +89,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -106,7 +106,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - python3
@@ -137,7 +137,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - python3

--- a/components/backends/trtllm/deploy/README.md
+++ b/components/backends/trtllm/deploy/README.md
@@ -89,7 +89,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/trtllm-runtime:my-tag
+    image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
     workingDir: /workspace/components/backends/trtllm
     args:
       - "python3"
@@ -109,7 +109,7 @@ Before using these templates, ensure you have:
 
 ### Container Images
 
-The deployment files currently require access to `my-registry/trtllm-runtime`. If you don't have access, build and push your own image:
+The deployment files currently require access to `nvcr.io/nvidia/ai-dynamo/trtllm-runtime`. If you don't have access, build and push your own image:
 
 ```bash
 ./container/build.sh --framework tensorrtllm
@@ -141,7 +141,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: my-registry/trtllm-runtime:my-tag
+image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
 
 # Configure your model and deployment settings
 args:

--- a/components/backends/trtllm/deploy/agg-with-config.yaml
+++ b/components/backends/trtllm/deploy/agg-with-config.yaml
@@ -34,7 +34,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.5.1
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: trtllm-agg
@@ -50,7 +50,7 @@ spec:
           configMap:
             name: nvidia-config
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           # mount the configmap as a volume
           volumeMounts:

--- a/components/backends/trtllm/deploy/agg.yaml
+++ b/components/backends/trtllm/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: trtllm-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh

--- a/components/backends/trtllm/deploy/agg_router.yaml
+++ b/components/backends/trtllm/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh

--- a/components/backends/trtllm/deploy/disagg-multinode.yaml
+++ b/components/backends/trtllm/deploy/disagg-multinode.yaml
@@ -93,7 +93,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh
@@ -123,7 +123,7 @@ spec:
             - name: nvidia-config
               mountPath: /workspace/components/backends/trtllm/engine_configs
               readOnly: true
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh
@@ -153,7 +153,7 @@ spec:
             - name: nvidia-config
               mountPath: /workspace/components/backends/trtllm/engine_configs
               readOnly: true
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh

--- a/components/backends/trtllm/deploy/disagg.yaml
+++ b/components/backends/trtllm/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
     TRTLLMPrefillWorker:
       dynamoNamespace: trtllm-disagg
       envFromSecret: hf-token-secret
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh
@@ -41,7 +41,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh

--- a/components/backends/trtllm/deploy/disagg_planner.yaml
+++ b/components/backends/trtllm/deploy/disagg_planner.yaml
@@ -18,7 +18,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - python3
@@ -69,7 +69,7 @@ spec:
         mountPoint: /data
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/planner/src/dynamo/planner
           ports:
             - name: metrics
@@ -114,7 +114,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - python3
@@ -152,7 +152,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - python3
@@ -186,7 +186,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - python3

--- a/components/backends/trtllm/deploy/disagg_router.yaml
+++ b/components/backends/trtllm/deploy/disagg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh
@@ -44,7 +44,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/README.md
+++ b/components/backends/vllm/deploy/README.md
@@ -69,7 +69,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/vllm-runtime:my-tag
+    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
     workingDir: /workspace/components/backends/vllm
     args:
       - "python3"
@@ -116,7 +116,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: my-registry/vllm-runtime:my-tag
+image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
 
 # Configure your model
 args:

--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/agg_router.yaml
+++ b/components/backends/vllm/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/disagg-multinode.yaml
+++ b/components/backends/vllm/deploy/disagg-multinode.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -32,7 +32,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -51,7 +51,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/disagg.yaml
+++ b/components/backends/vllm/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -41,7 +41,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -20,7 +20,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
     Planner:
       dynamoNamespace: vllm-disagg-planner
       envFromSecret: hf-token-secret
@@ -51,7 +51,7 @@ spec:
         mountPoint: /data
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/planner/src/dynamo/planner
           command:
             - /bin/sh
@@ -91,7 +91,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -114,7 +114,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - python3
@@ -139,7 +139,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - python3

--- a/components/backends/vllm/deploy/disagg_router.yaml
+++ b/components/backends/vllm/deploy/disagg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -44,7 +44,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/deploy/cloud/helm/crds/Chart.yaml
+++ b/deploy/cloud/helm/crds/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v2
 name: dynamo-crds
 description: A Helm chart for dynamo CRDs
 type: application
-version: 0.5.0
+version: 0.5.1
 dependencies: []

--- a/deploy/cloud/helm/platform/Chart.yaml
+++ b/deploy/cloud/helm/platform/Chart.yaml
@@ -19,11 +19,11 @@ maintainers:
     url: https://www.nvidia.com
 description: A Helm chart for NVIDIA Dynamo Platform.
 type: application
-version: 0.5.0
+version: 0.5.1
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator
-    version: 0.5.0
+    version: 0.5.1
     repository: file://components/operator
     condition: dynamo-operator.enabled
   - name: nats

--- a/deploy/cloud/helm/platform/components/operator/Chart.yaml
+++ b/deploy/cloud/helm/platform/components/operator/Chart.yaml
@@ -27,9 +27,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.0"
+appVersion: "0.5.1"

--- a/deploy/cloud/operator/Earthfile
+++ b/deploy/cloud/operator/Earthfile
@@ -45,7 +45,7 @@ test:
     SAVE ARTIFACT cover.out
 
 docker:
-    ARG DOCKER_SERVER=my-registry
+    ARG DOCKER_SERVER=nvcr.io/nvidia/ai-dynamo
     ARG IMAGE_TAG=latest
     ARG IMAGE_SUFFIX=dynamo-operator
     FROM nvcr.io/nvidia/distroless/go:v3.1.12

--- a/deploy/cloud/operator/internal/secrets/docker_test.go
+++ b/deploy/cloud/operator/internal/secrets/docker_test.go
@@ -21,7 +21,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 			},
 			Type: corev1.SecretTypeDockerConfigJson,
 			Data: map[string][]byte{
-				".dockerconfigjson": []byte(`{"auths":{"docker.io":{}, "my-registry.com:5005/registry1":{}}}`),
+				".dockerconfigjson": []byte(`{"auths":{"docker.io":{}, "nvcr.io/nvidia/ai-dynamo.com:5005/registry1":{}}}`),
 			},
 		},
 		{
@@ -31,7 +31,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 			},
 			Type: corev1.SecretTypeDockerConfigJson,
 			Data: map[string][]byte{
-				".dockerconfigjson": []byte(`{"auths":{"my-registry.com:5005/registry2":{}}}`),
+				".dockerconfigjson": []byte(`{"auths":{"nvcr.io/nvidia/ai-dynamo.com:5005/registry2":{}}}`),
 			},
 		},
 		{
@@ -41,7 +41,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 			},
 			Type: corev1.SecretTypeDockerConfigJson,
 			Data: map[string][]byte{
-				".dockerconfigjson": []byte(`{"auths":{"my-registry.com:5005/registry2":{}}}`),
+				".dockerconfigjson": []byte(`{"auths":{"nvcr.io/nvidia/ai-dynamo.com:5005/registry2":{}}}`),
 			},
 		},
 	}
@@ -68,7 +68,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 		t.Errorf("DockerSecretIndexer.GetSecrets() = %v, want %v", secrets[0], "secret1")
 	}
 
-	secrets, err = i.GetSecrets("default", "my-registry.com:5005")
+	secrets, err = i.GetSecrets("default", "nvcr.io/nvidia/ai-dynamo.com:5005")
 	if err != nil {
 		t.Errorf("DockerSecretIndexer.GetSecrets() error = %v, wantErr %v", err, nil)
 	}
@@ -82,7 +82,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 		t.Errorf("DockerSecretIndexer.GetSecrets() = %v, want %v", secrets[1], "secret2")
 	}
 
-	secrets, err = i.GetSecrets("another-namespace", "my-registry.com:5005")
+	secrets, err = i.GetSecrets("another-namespace", "nvcr.io/nvidia/ai-dynamo.com:5005")
 	if err != nil {
 		t.Errorf("DockerSecretIndexer.GetSecrets() error = %v, wantErr %v", err, nil)
 	}

--- a/deploy/helm/chart/Chart.yaml
+++ b/deploy/helm/chart/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: dynamo-graph
 description: A Helm chart to deploy a Dynamo graph on Kubernetes
 type: application
-version: 0.5.0
-appVersion: 0.5.0
+version: 0.5.1
+appVersion: 0.5.1

--- a/deploy/inference-gateway/helm/dynamo-gaie/values.yaml
+++ b/deploy/inference-gateway/helm/dynamo-gaie/values.yaml
@@ -73,7 +73,7 @@ eppAware:
     # Container name for the sidecar
     name: frontend-router
     # Sidecar image
-    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
     # Image pull policy for the sidecar
     imagePullPolicy: IfNotPresent
     # Command and args for running the frontend in router mode.

--- a/docs/_includes/install.rst
+++ b/docs/_includes/install.rst
@@ -10,7 +10,7 @@ Install a pre-built wheel from PyPI.
    source venv/bin/activate
 
    # Install Dynamo from PyPI (choose one backend extra)
-   uv pip install "ai-dynamo[sglang]==my-tag"  # or [vllm], [trtllm]
+   uv pip install "ai-dynamo[sglang]==0.5.1"  # or [vllm], [trtllm]
 
 
 Pip from source
@@ -41,4 +41,4 @@ Pull and run prebuilt images from NVIDIA NGC (`nvcr.io`).
    docker run --rm -it \
      --gpus all \
      --network host \
-     nvcr.io/nvidia/ai-dynamo/sglang-runtime:my-tag  # or vllm, tensorrtllm
+     nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1  # or vllm, tensorrtllm

--- a/docs/benchmarks/benchmarking.md
+++ b/docs/benchmarks/benchmarking.md
@@ -410,7 +410,7 @@ The benchmark job is configured directly in the YAML file.
 - **Model**: `Qwen/Qwen3-0.6B`
 - **Benchmark Name**: `qwen3-0p6b-vllm-agg`
 - **Service**: `vllm-agg-frontend:8000`
-- **Docker Image**: `nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag`
+- **Docker Image**: `nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1`
 
 ### Customizing the Job
 

--- a/docs/benchmarks/pre_deployment_profiling.md
+++ b/docs/benchmarks/pre_deployment_profiling.md
@@ -151,7 +151,7 @@ spec:
 
 1. **Set the container image:**
    ```bash
-   export DOCKER_IMAGE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+   export DOCKER_IMAGE=nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
    ```
 
 2. **Set the config path for the profiling job:**

--- a/docs/kubernetes/create_deployment.md
+++ b/docs/kubernetes/create_deployment.md
@@ -158,7 +158,7 @@ When disabled, you can manually specify secrets as you would for a normal pod sp
         nvidia.com/disable-image-pull-secret-discovery: "true"
       extraPodSpec:
         imagePullSecrets:
-          - name: my-registry-secret
+          - name: nvcr.io/nvidia/ai-dynamo-secret
           - name: another-secret
         mainContainer:
           image: your-image

--- a/examples/basics/kubernetes/Distributed_Inference/agg_router.yaml
+++ b/examples/basics/kubernetes/Distributed_Inference/agg_router.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -95,7 +95,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           volumeMounts:
           - name: local-model-cache
             mountPath: /root/.cache

--- a/examples/custom_backend/hello_world/deploy/hello_world.yaml
+++ b/examples/custom_backend/hello_world/deploy/hello_world.yaml
@@ -41,7 +41,7 @@ spec:
           memory: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/dynamo:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:0.5.1
           workingDir: /workspace/examples/custom_backend/hello_world/
           command:
             - /bin/sh
@@ -80,7 +80,7 @@ spec:
           memory: "4Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/dynamo:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:0.5.1
           workingDir: /workspace/examples/custom_backend/hello_world/
           command:
             - /bin/sh

--- a/examples/deployments/ECS/task_definition_frontend.json
+++ b/examples/deployments/ECS/task_definition_frontend.json
@@ -3,7 +3,7 @@
     "containerDefinitions": [
         {
             "name": "dynamo-vllm-frontend",
-            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag",
+            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:us-east-2:AWS_ID:secret:ngc_nvcr_access"
             },

--- a/examples/deployments/ECS/task_definition_prefillworker.json
+++ b/examples/deployments/ECS/task_definition_prefillworker.json
@@ -3,7 +3,7 @@
     "containerDefinitions": [
         {
             "name": "dynamo-prefill",
-            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag",
+            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:us-east-2:AWS_ID:secret:ngc_access"
             },

--- a/examples/multimodal/deploy/agg_llava.yaml
+++ b/examples/multimodal/deploy/agg_llava.yaml
@@ -14,7 +14,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
     EncodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: agg-llava
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -42,7 +42,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -59,7 +59,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh

--- a/examples/multimodal/deploy/agg_qwen.yaml
+++ b/examples/multimodal/deploy/agg_qwen.yaml
@@ -14,7 +14,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
     EncodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: agg-qwen
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -42,7 +42,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -59,7 +59,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh

--- a/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
@@ -20,7 +20,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:0.5.1
     decode:
       dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
@@ -45,7 +45,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -89,7 +89,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
@@ -20,7 +20,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
     decode:
       dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
@@ -45,7 +45,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -89,7 +89,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
@@ -20,7 +20,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:my-tag
     decode:
       dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
@@ -45,7 +45,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:my-tag
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -89,7 +89,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:my-tag
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
@@ -20,7 +20,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:my-tag
     decode:
       dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
@@ -43,7 +43,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:my-tag
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:my-tag
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
@@ -20,7 +20,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:0.5.1
     decode:
       dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
@@ -43,7 +43,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
+          image: my-registry/sglang-wideep-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
@@ -20,7 +20,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
     decode:
       dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
@@ -43,7 +43,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.5.1
           workingDir: /workspace/components/backends/sglang
           command:
             - /bin/sh

--- a/recipes/gpt-oss-120b/trtllm/agg/bench.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/bench.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: perf
-        image: my-registry/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
         workingDir: /workspace/components/backends/vllm
         env:
           - name: TARGET_MODEL

--- a/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
@@ -56,7 +56,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/trtllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/agg/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/agg/deploy.yaml
@@ -16,7 +16,7 @@ spec:
         mountPoint: /root/.cache/huggingface
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
       replicas: 1
     VllmPrefillWorker:
@@ -36,7 +36,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/agg/perf.yaml
+++ b/recipes/llama-3-70b/vllm/agg/perf.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: perf
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
         workingDir: /workspace/components/backends/vllm
         command:
         - /bin/sh

--- a/recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml
@@ -16,7 +16,7 @@ spec:
         mountPoint: /root/.cache/huggingface
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
       replicas: 1
     VllmPrefillWorker:
@@ -36,7 +36,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
       replicas: 1
       resources:
@@ -61,7 +61,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/disagg-multi-node/perf.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-multi-node/perf.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: perf
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
         workingDir: /workspace/components/backends/vllm
         command:
         - /bin/sh

--- a/recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml
@@ -16,7 +16,7 @@ spec:
         mountPoint: /root/.cache/huggingface
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
       replicas: 1
     VllmPrefillWorker:
@@ -46,7 +46,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
       replicas: 2
       resources:
@@ -81,7 +81,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/disagg-single-node/perf.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-single-node/perf.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: perf
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
         workingDir: /workspace/components/backends/vllm
         command:
         - /bin/sh

--- a/tests/planner/perf_test_configs/agg_8b.yaml
+++ b/tests/planner/perf_test_configs/agg_8b.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -88,7 +88,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_2p2d.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_2p2d.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -88,7 +88,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -138,7 +138,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_3p1d.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_3p1d.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -88,7 +88,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -138,7 +138,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_planner.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_planner.yaml
@@ -43,7 +43,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -79,7 +79,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/planner/src/dynamo/planner
           ports:
             - name: metrics
@@ -128,7 +128,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -179,7 +179,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - python3
@@ -235,7 +235,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - python3

--- a/tests/planner/perf_test_configs/disagg_8b_tp2.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_tp2.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -88,7 +88,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -138,7 +138,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/image_cache_daemonset.yaml
+++ b/tests/planner/perf_test_configs/image_cache_daemonset.yaml
@@ -20,7 +20,7 @@ spec:
       - name: nvcr-imagepullsecret
       containers:
       - name: image-cache
-        image: my-registry/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
         command:
         - /bin/sh
         - -c

--- a/tests/planner/profiling_results/H200_TP1P_TP1D/disagg.yaml
+++ b/tests/planner/profiling_results/H200_TP1P_TP1D/disagg.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -88,7 +88,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -138,7 +138,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/scaling/disagg_planner.yaml
+++ b/tests/planner/scaling/disagg_planner.yaml
@@ -20,7 +20,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
     Planner:
       dynamoNamespace: vllm-disagg-planner
       envFromSecret: hf-token-secret
@@ -43,7 +43,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/planner/src/dynamo/planner
           ports:
             - name: metrics
@@ -91,7 +91,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -114,7 +114,7 @@ spec:
               port: 9090
             periodSeconds: 30
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh
@@ -137,7 +137,7 @@ spec:
               port: 9090
             periodSeconds: 30
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.5.1
           workingDir: /workspace/components/backends/vllm
           command:
             - /bin/sh


### PR DESCRIPTION
#### Overview:

Update `my-registry` and `my-tag` for the release. Update the helm chart versions.

closes OPS-1215