### PR TITLE
chore: added more api error code validations

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -711,12 +711,6 @@ pub fn validate_chat_completion_unsupported_fields(
 ) -> Result<(), ErrorResponse> {
     let inner = &request.inner;
 
-    if inner.parallel_tool_calls == Some(true) {
-        return Err(ErrorMessage::not_implemented_error(
-            "`parallel_tool_calls: true` is not supported.",
-        ));
-    }
-
     if inner.function_call.is_some() {
         return Err(ErrorMessage::not_implemented_error(
             "`function_call` is deprecated. Please migrate to use `tool_choice` instead.",

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -133,6 +133,7 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
         let guided_regex = self.get_guided_regex();
         let guided_grammar = self.get_guided_grammar();
         let guided_choice = self.get_guided_choice();
+        let guided_whitespace_pattern = self.get_guided_whitespace_pattern();
 
         let guided_decoding = match common::GuidedDecodingOptions::from_optional(
             guided_json.cloned(),
@@ -140,6 +141,7 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
             guided_choice,
             guided_grammar,
             guided_decoding_backend,
+            guided_whitespace_pattern,
         ) {
             Ok(options) => options,
             Err(e) => {

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -206,6 +206,16 @@ impl CommonExtProvider for NvCreateChatCompletionRequest {
         )
     }
 
+    fn get_guided_whitespace_pattern(&self) -> Option<String> {
+        choose_with_deprecation(
+            "guided_whitespace_pattern",
+            self.common.guided_whitespace_pattern.as_ref(),
+            self.nvext
+                .as_ref()
+                .and_then(|nv| nv.guided_whitespace_pattern.as_ref()),
+        )
+    }
+
     fn get_top_k(&self) -> Option<i32> {
         choose_with_deprecation(
             "top_k",
@@ -349,6 +359,8 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
         // none for functions
         // Common Ext
         validate::validate_repetition_penalty(self.get_repetition_penalty())?;
+        validate::validate_min_p(self.get_min_p())?;
+        validate::validate_top_k(self.get_top_k())?;
 
         Ok(())
     }

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -1,7 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-use super::nvext::validate_top_k;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
@@ -25,20 +23,19 @@ pub struct CommonExt {
     /// Integer that controls the number of top tokens to consider. Set to -1 to consider all tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
-    #[validate(custom(function = "validate_top_k"))]
+    //#[validate(custom(function = "validate_top_k"))]
     pub top_k: Option<i32>,
 
     /// Relative probability floor
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
-    #[validate(range(min = 0.0, max = 1.0))]
+    //#[validate(range(min = 0.0, max = 1.0))]
     pub min_p: Option<f32>,
 
     /// How much to penalize tokens based on how frequently they occur in the text.
     /// A value of 1 means no penalty, while values larger than 1 discourage and values smaller encourage.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
-    #[validate(range(exclusive_min = 0.0, max = 2.0))]
     pub repetition_penalty: Option<f32>,
 
     /// include_stop_str_in_output
@@ -71,6 +68,12 @@ pub struct CommonExt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub guided_decoding_backend: Option<String>,
+
+    /// If specified, the output will follow the whitespace pattern. Can be a string or null.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    #[allow(unused)] // Not used
+    pub guided_whitespace_pattern: Option<String>,
 }
 
 impl CommonExt {
@@ -90,6 +93,8 @@ pub trait CommonExtProvider {
     fn get_guided_grammar(&self) -> Option<String>;
     fn get_guided_choice(&self) -> Option<Vec<String>>;
     fn get_guided_decoding_backend(&self) -> Option<String>;
+    #[allow(unused)] // Not used
+    fn get_guided_whitespace_pattern(&self) -> Option<String>;
 
     /// Other sampling Options
     fn get_top_k(&self) -> Option<i32>;
@@ -215,6 +220,7 @@ mod tests {
             guided_grammar: None,
             guided_choice: None,
             guided_decoding_backend: None,
+            guided_whitespace_pattern: None,
         };
         assert!(common_ext.validate().is_ok());
     }

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -23,13 +23,11 @@ pub struct CommonExt {
     /// Integer that controls the number of top tokens to consider. Set to -1 to consider all tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
-    //#[validate(custom(function = "validate_top_k"))]
     pub top_k: Option<i32>,
 
     /// Relative probability floor
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
-    //#[validate(range(min = 0.0, max = 1.0))]
     pub min_p: Option<f32>,
 
     /// How much to penalize tokens based on how frequently they occur in the text.

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -193,6 +193,16 @@ impl CommonExtProvider for NvCreateCompletionRequest {
         )
     }
 
+    fn get_guided_whitespace_pattern(&self) -> Option<String> {
+        choose_with_deprecation(
+            "guided_whitespace_pattern",
+            self.common.guided_whitespace_pattern.as_ref(),
+            self.nvext
+                .as_ref()
+                .and_then(|nv| nv.guided_whitespace_pattern.as_ref()),
+        )
+    }
+
     fn get_top_k(&self) -> Option<i32> {
         choose_with_deprecation(
             "top_k",
@@ -435,6 +445,8 @@ impl ValidateRequest for NvCreateCompletionRequest {
 
         // Common Ext
         validate::validate_repetition_penalty(self.get_repetition_penalty())?;
+        validate::validate_min_p(self.get_min_p())?;
+        validate::validate_top_k(self.get_top_k())?;
 
         Ok(())
     }

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -131,6 +131,15 @@ pub fn validate_top_p(top_p: Option<f32>) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+// Validate top_k
+pub fn validate_top_k(top_k: Option<i32>) -> Result<(), anyhow::Error> {
+    match top_k {
+        None => Ok(()),
+        Some(k) if k == -1 || k >= 1 => Ok(()),
+        _ => anyhow::bail!("Top_k must be null, -1, or greater than or equal to 1"),
+    }
+}
+
 /// Validates mutual exclusion of temperature and top_p
 pub fn validate_temperature_top_p_exclusion(
     temperature: Option<f32>,
@@ -175,14 +184,30 @@ pub fn validate_presence_penalty(presence_penalty: Option<f32>) -> Result<(), an
 }
 
 pub fn validate_repetition_penalty(repetition_penalty: Option<f32>) -> Result<(), anyhow::Error> {
+    // It should be greater than 0.0 and less than equal to 2.0
     if let Some(penalty) = repetition_penalty
-        && !(MIN_REPETITION_PENALTY..=MAX_REPETITION_PENALTY).contains(&penalty)
+        && (penalty <= MIN_REPETITION_PENALTY || penalty > MAX_REPETITION_PENALTY)
     {
         anyhow::bail!(
             "Repetition penalty must be between {} and {}, got {}",
             MIN_REPETITION_PENALTY,
             MAX_REPETITION_PENALTY,
             penalty
+        );
+    }
+    Ok(())
+}
+
+/// Validates min_p parameter
+pub fn validate_min_p(min_p: Option<f32>) -> Result<(), anyhow::Error> {
+    if let Some(p) = min_p
+        && !(MIN_MIN_P..=MAX_MIN_P).contains(&p)
+    {
+        anyhow::bail!(
+            "Min_p must be between {} and {}, got {}",
+            MIN_MIN_P,
+            MAX_MIN_P,
+            p
         );
     }
     Ok(())


### PR DESCRIPTION
#### Overview:

Fixes API Validations issues mentioned in #3223 

Things addressed

Category 1 : Return 400 (not 500) for invalid values:
- min_p < 0 [ Added min_p validations in validate.rs , removed inline ones ] 
- nvext.repetition_penalty = 0 (default=1, 0<val<2) [ removed inline one and updated criteria to be > 0 ]
- guided_whitespace_pattern invalid type [ this field was missing, added as no-op of Option<String> type, will get valid api errors]
- nvext.top_k: null, or negative except -1 (default=-1) [ No need to solve for now , null is ok , will be set to default downstream ] 

Category 2: Return 200 for valid-but-optional flags:
- parallel_tool_calls = true (no-op) [ Removed the flag validation that was raising error, with elyas PR, this will be supported ] 
- guided_whitespace_pattern: string or null [ Done ] 
- max_completion_tokens: alias of max_tokens [ This is already there for chat completions, right now not supported for completions in aysnc-openai, add later if p0 ] 
- 


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #3223


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for a guided whitespace pattern in completion and chat requests.
- Bug Fixes
  - Added validation for min_p and top_k parameters, providing clear errors for out-of-range values (top_k must be -1 or ≥1; min_p must be within supported bounds).
- Tests
  - Extended test coverage for the new guided whitespace pattern option and the updated validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->