### PR TITLE
docs: some router-related doc fixes for 0.5.1 release

### DIFF
--- a/benchmarks/router/README.md
+++ b/benchmarks/router/README.md
@@ -51,7 +51,7 @@ This will start both etcd and NATS with the required configurations in the backg
 
 ### Step 1: Launch vLLM Workers
 
-First, start the vLLM worker engines in a terminal.
+Make sure you have 8 GPUs for these examples, unless you are using mockers (see below). First, start the vLLM worker engines in a terminal.
 
 ```bash
 # Default: 8 vLLM workers with DeepSeek model (explicitly sets --block-size 64)
@@ -60,6 +60,7 @@ First, start the vLLM worker engines in a terminal.
     --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 
 # Example: 4 vLLM workers with larger model using tensor parallelism (2 GPUs per worker)
+# NOTE: this would likely require each GPU having 80GB of VRAM
 ./run_engines.sh \
     --num-workers 4 \
     --model-path openai/gpt-oss-120b \

--- a/docs/architecture/kv_cache_routing.md
+++ b/docs/architecture/kv_cache_routing.md
@@ -318,7 +318,7 @@ Instead of launching the KV Router via command line, you can create a `KvPushRou
 
 First, launch your backend engines:
 ```bash
-python -m dynamo.vllm --model meta-llama/Llama-2-7b-hf --endpoint dyn://inference.vllm.generate
+python -m dynamo.vllm --model meta-llama/Llama-2-7b-hf
 ```
 
 ### Example Script


### PR DESCRIPTION
#### Overview:

1. dynamo vllm cli should not have `--endpoint` arg
2. mention in router benchmarking docs that 8 GPUs are needed, each with sufficient VRAM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified hardware prerequisites for routing benchmarks, recommending 8 GPUs unless using mockers.
  * Added VRAM guidance for multi-worker examples (e.g., 4 workers with large models may require ~80GB).
  * Inserted prerequisite notes before initial setup steps and added an inline note ahead of the 4-worker example.
  * Updated example commands in the KV cache routing guide to omit the explicit endpoint parameter, reflecting default or external configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->