### PR TITLE
ci: use large runners for pre merge rust

### DIFF
--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -31,7 +31,8 @@ on:
 
 jobs:
   pre-merge-rust:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Fastchecker
     strategy:
       matrix: { dir: ['.', 'lib/bindings/python', 'lib/runtime/examples'] }
     permissions:

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -44,16 +44,16 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y protobuf-compiler
 
-    - name: Free runner disk space
-      run: |
-        echo "Disk space before:"
-        df -h
-        sudo rm -rf \
-          /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-          /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
-          /usr/lib/jvm /opt/hostedtoolcache
-        echo "Disk space after:"
-        df -h
+    # - name: Free runner disk space
+    #   run: |
+    #     echo "Disk space before:"
+    #     df -h
+    #     sudo rm -rf \
+    #       /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+    #       /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+    #       /usr/lib/jvm /opt/hostedtoolcache
+    #     echo "Disk space after:"
+    #     df -h
 
     # TODO: Caching target/ dir handles most of the build caching improvements
     #       currently, so sccache artifacts are mostly duplicates wasting disk space.

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -44,16 +44,16 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y protobuf-compiler
 
-    # - name: Free runner disk space
-    #   run: |
-    #     echo "Disk space before:"
-    #     df -h
-    #     sudo rm -rf \
-    #       /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-    #       /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
-    #       /usr/lib/jvm /opt/hostedtoolcache
-    #     echo "Disk space after:"
-    #     df -h
+    - name: Free runner disk space
+      run: |
+        echo "Disk space before:"
+        df -h
+        sudo rm -rf \
+          /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+          /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+          /usr/lib/jvm /opt/hostedtoolcache
+        echo "Disk space after:"
+        df -h
 
     # TODO: Caching target/ dir handles most of the build caching improvements
     #       currently, so sccache artifacts are mostly duplicates wasting disk space.

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -29,6 +29,11 @@ on:
     - 'Cargo.toml'
     - 'Cargo.lock'
 
+# Cancel any previous check runs for the same pull request to avoid redundant workflows.
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pre-merge-rust:
     runs-on:

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -49,17 +49,6 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y protobuf-compiler
 
-    - name: Free runner disk space
-      run: |
-        echo "Disk space before:"
-        df -h
-        sudo rm -rf \
-          /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-          /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
-          /usr/lib/jvm /opt/hostedtoolcache
-        echo "Disk space after:"
-        df -h
-
     # TODO: Caching target/ dir handles most of the build caching improvements
     #       currently, so sccache artifacts are mostly duplicates wasting disk space.
     #       Revisit this to see if sccache can improve current caching behavior.


### PR DESCRIPTION
#### Overview:

* Move pre merge rust to large github runners (fastchecker)
* Add concurrency to cancel old runs in PR
* Remove space cleanup, was only added cause space was low on default runners. Should not be required on fastchecker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Optimized pre-merge checks with PR-level cancellation to avoid redundant runs, reducing queue times and noise.
  - Switched to a faster grouped runner for Rust pre-merge checks to improve CI throughput.
  - Removed obsolete disk-space diagnostics to streamline workflows.
  - Overall, expect quicker, more reliable CI feedback on pull requests with no changes to product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->