### PR TITLE
feat: add network isolation modes to container/run.sh script

### DIFF
--- a/container/README.md
+++ b/container/README.md
@@ -302,54 +302,31 @@ python -m dynamo.vllm --model Qwen/Qwen3-0.6B --gpu-memory-utilization 0.20 &
 ```
 
 ### CI/CD Workflow
-
-#### 1. Build image for CI
 ```bash
+# 1. Build image for CI
 ./build.sh --framework vllm --no-cache
-```
 
-#### 2. Run tests with network isolation for reproducible results
-```
+# 2. Run tests with network isolation for reproducible results
 ./run.sh --image dynamo:latest-vllm --mount-workspace --network bridge -v $HOME/.cache:/home/ubuntu/.cache -- python -m pytest tests/
-```
 
-**Note:** When using `--network bridge`, all the services launched inside the container are accessible by each other.
+# 3. Inside the container with bridge networking, start services
+# Note: Services are only accessible from the same container - no port conflicts with host
+nats-server -js &
+etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://0.0.0.0:2379 --data-dir /tmp/etcd &
+python -m dynamo.frontend &
 
-#### 3. Start services
-
-When inside the container with bridge networking, make sure you start nats-server & etcd. These will only be accessible from the same container -- it will not collide with the host ports:
-
-```bash
-$ nats-server -js &
-$ etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://0.0.0.0:2379 --data-dir /tmp/etcd &
-$ python -m dynamo.frontend &
-```
-
-#### 4. Start the worker backends:
-
-**vLLM:**
-- `--gpu-memory-utilization 0.20`: Use 20% of GPU memory
-- `--enforce-eager`: Disable CUDA graphs for lower memory usage
-- `--no-enable-prefix-caching`: Disable prefix caching to save memory
-- `--max-num-seqs 64`: Maximum concurrent sequences
-
-```bash
+# 4. Start worker backend (choose one framework):
+# vLLM
 DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=8081 python -m dynamo.vllm --model Qwen/Qwen3-0.6B --gpu-memory-utilization 0.20 --enforce-eager --no-enable-prefix-caching --max-num-seqs 64 &
-```
 
-**SGLang:**
-- `--mem-fraction-static 0.20`: Use 20% of GPU memory for static allocation
-- `--max-running-requests 64`: Maximum concurrent running requests
-
-```bash
+# SGLang
 DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=8081 python -m dynamo.sglang --model Qwen/Qwen3-0.6B --mem-fraction-static 0.20 --max-running-requests 64 &
-```
 
-**TensorRT-LLM:**
-- `--free-gpu-memory-fraction 0.20`: Reserve 20% of GPU memory
-- `--max-num-tokens 8192`: Maximum number of tokens in batch
-- `--max-batch-size 64`: Maximum batch size
-
-```bash
+# TensorRT-LLM
 DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=8081 python -m dynamo.trtllm --model Qwen/Qwen3-0.6B --free-gpu-memory-fraction 0.20 --max-num-tokens 8192 --max-batch-size 64 &
 ```
+
+**Framework-Specific GPU Memory Arguments:**
+- **vLLM**: `--gpu-memory-utilization 0.20` (use 20% GPU memory), `--enforce-eager` (disable CUDA graphs), `--no-enable-prefix-caching` (save memory), `--max-num-seqs 64` (max concurrent sequences)
+- **SGLang**: `--mem-fraction-static 0.20` (20% GPU memory for static allocation), `--max-running-requests 64` (max concurrent requests)
+- **TensorRT-LLM**: `--free-gpu-memory-fraction 0.20` (reserve 20% GPU memory), `--max-num-tokens 8192` (max tokens in batch), `--max-batch-size 64` (max batch size)

--- a/container/run.sh
+++ b/container/run.sh
@@ -43,6 +43,7 @@ INTERACTIVE=
 USE_NIXL_GDS=
 RUNTIME=nvidia
 WORKDIR=/workspace
+NETWORK=host
 
 get_options() {
     while :; do
@@ -164,6 +165,14 @@ get_options() {
             ;;
         --use-nixl-gds)
             USE_NIXL_GDS=TRUE
+            ;;
+        --network)
+            if [ "$2" ]; then
+                NETWORK=$2
+                shift
+            else
+                missing_requirement "$1"
+            fi
             ;;
         --dry-run)
             RUN_PREFIX="echo"
@@ -304,6 +313,10 @@ show_help() {
     echo "  [--hf-cache directory to volume mount as the hf cache, default is NONE unless mounting workspace]"
     echo "  [--gpus gpus to enable, default is 'all', 'none' disables gpu support]"
     echo "  [--use-nixl-gds add volume mounts and capabilities needed for NVIDIA GPUDirect Storage]"
+    echo "  [--network network mode for container, default is 'host']"
+    echo "           Options: 'host' (default), 'bridge', 'none', 'container:name'"
+    echo "           Examples: --network bridge (isolated), --network none (no network - WARNING: breaks most functionality)"
+    echo "                    --network container:redis (share network with 'redis' container)"
     echo "  [-v add volume mount]"
     echo "  [-e add environment variable]"
     echo "  [--mount-workspace set up for local development]"
@@ -335,7 +348,7 @@ ${RUN_PREFIX} docker run \
     ${GPU_STRING} \
     ${INTERACTIVE} \
     ${RM_STRING} \
-    --network host \
+    --network "$NETWORK" \
     ${RUNTIME:+--runtime "$RUNTIME"} \
     --shm-size=10G \
     --ulimit memlock=-1 \

--- a/container/run.sh
+++ b/container/run.sh
@@ -36,6 +36,7 @@ DEFAULT_HF_CACHE=${SOURCE_DIR}/.cache/huggingface
 GPUS="all"
 PRIVILEGED=
 VOLUME_MOUNTS=
+PORT_MAPPINGS=
 MOUNT_WORKSPACE=
 ENVIRONMENT_VARIABLES=
 REMAINING_ARGS=
@@ -144,6 +145,14 @@ get_options() {
         -v)
             if [ "$2" ]; then
                 VOLUME_MOUNTS+=" -v $2 "
+                shift
+            else
+                missing_requirement "$1"
+            fi
+            ;;
+        -p|--port)
+            if [ "$2" ]; then
+                PORT_MAPPINGS+=" -p $2 "
                 shift
             else
                 missing_requirement "$1"
@@ -318,6 +327,7 @@ show_help() {
     echo "           Examples: --network bridge (isolated), --network none (no network - WARNING: breaks most functionality)"
     echo "                    --network container:redis (share network with 'redis' container)"
     echo "  [-v add volume mount]"
+    echo "  [-p|--port add port mapping (host_port:container_port)]"
     echo "  [-e add environment variable]"
     echo "  [--mount-workspace set up for local development]"
     echo "  [-- stop processing and pass remaining args as command to docker run]"
@@ -356,6 +366,7 @@ ${RUN_PREFIX} docker run \
     --ulimit nofile=65536:65536 \
     ${ENVIRONMENT_VARIABLES} \
     ${VOLUME_MOUNTS} \
+    ${PORT_MAPPINGS} \
     -w "$WORKDIR" \
     --cap-add CAP_SYS_PTRACE \
     ${NIXL_GDS_CAPS} \


### PR DESCRIPTION
#### Overview:

Add network isolation modes to container run script with comprehensive configuration options. This enables secure CI/CD pipelines and flexible networking for different deployment scenarios.

#### Details:

- Add `--network` flag to `run.sh` supporting host, bridge, none, and container sharing modes
- Update container README with detailed network configuration documentation and use cases
- Add CI/CD workflow examples demonstrating bridge networking for test isolation
- Document performance/security tradeoffs and limitations for each network mode
- Include comparison table and warnings for restricted functionality modes

#### Where should the reviewer start?

- `container/run.sh` - New network flag implementation and argument parsing
- `container/README.md` - Comprehensive network configuration documentation and examples

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable networking option to the container runner with modes: host (default), bridge, none, and container sharing. Help text updated with usage and examples.

* **Documentation**
  * Expanded network configuration guidance with detailed use cases and examples for each mode, including custom networks.
  * Updated usage examples to be network-aware; removed outdated GPU-focused example.
  * Introduced a CI/CD Workflow section emphasizing network isolation and in-container integration tests.
  * Augmented examples for workspace mounting, volume/cache flags, and a multi-service startup sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->