### PR TITLE
feat: add sglang-wideep support to container/build.sh

### DIFF
--- a/container/Dockerfile.sglang-wideep
+++ b/container/Dockerfile.sglang-wideep
@@ -3,7 +3,7 @@
 
 ARG SGLANG_IMAGE_TAG="v0.5.0rc2-cu126"
 
-FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG}
+FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG} AS dev
 
 ARG MODE="hopper"
 ARG ARCH="amd64"

--- a/container/build.sh
+++ b/container/build.sh
@@ -49,7 +49,7 @@ PYTHON_PACKAGE_VERSION=${current_tag:-$latest_tag.dev+$commit_id}
 # dependencies are specified in the /container/deps folder and
 # installed within framework specific sections of the Dockerfile.
 
-declare -A FRAMEWORKS=(["VLLM"]=1 ["TRTLLM"]=2 ["NONE"]=3 ["SGLANG"]=4)
+declare -A FRAMEWORKS=(["VLLM"]=1 ["TRTLLM"]=2 ["NONE"]=3 ["SGLANG"]=4 ["SGLANG_WIDEEP"]=5)
 
 DEFAULT_FRAMEWORK=VLLM
 
@@ -114,6 +114,8 @@ NONE_BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 
 SGLANG_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 SGLANG_BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
+SGLANG_WIDEEP_BASE_IMAGE="$SGLANG_BASE_IMAGE"
+SGLANG_WIDEEP_BASE_IMAGE_TAG="$SGLANG_BASE_IMAGE_TAG"
 
 NIXL_REF=0.4.1
 NIXL_UCX_REF=v1.19.0
@@ -368,6 +370,7 @@ get_options() {
 
     if [ -n "$FRAMEWORK" ]; then
         FRAMEWORK=${FRAMEWORK^^}
+        FRAMEWORK=${FRAMEWORK//-/_}
 
         if [[ -z "${FRAMEWORKS[$FRAMEWORK]}" ]]; then
             error 'ERROR: Unknown framework: ' "$FRAMEWORK"
@@ -508,6 +511,8 @@ elif [[ $FRAMEWORK == "NONE" ]]; then
     DOCKERFILE=${SOURCE_DIR}/Dockerfile
 elif [[ $FRAMEWORK == "SGLANG" ]]; then
     DOCKERFILE=${SOURCE_DIR}/Dockerfile.sglang
+elif [[ $FRAMEWORK == "SGLANG_WIDEEP" ]]; then
+    DOCKERFILE=${SOURCE_DIR}/Dockerfile.sglang-wideep
 fi
 
 # Add NIXL_REF as a build argument


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

https://github.com/ai-dynamo/dynamo/tree/main/recipes/deepseek-r1/sglang-wideep recipe mentions this framework input but this isn't actually implemented in `build.sh`


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for building SGLANG-WIDEEP images with corresponding base image options.
- Bug Fixes
  - Improved framework option handling by normalizing input (case and dashes) to reduce configuration errors.
- Chores
  - Extended build logic to route SGLANG-WIDEEP builds to the correct Dockerfile and base image selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->