### PR TITLE
docs: mention need for H100 for gpt-oss-120b in router benchmarking docs

### DIFF
--- a/benchmarks/router/README.md
+++ b/benchmarks/router/README.md
@@ -1,17 +1,5 @@
 <!-- # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License. -->
+# SPDX-License-Identifier: Apache-2.0 -->
 
 # Router Benchmarking Guide
 
@@ -20,6 +8,7 @@ This directory contains scripts for benchmarking the Dynamo router with prefix c
 ## Prerequisites
 
 - NVIDIA GPUs (8 GPUs for default configuration)
+- (optional) H100 GPUs or later for gpt-oss-120b examples
 - CUDA environment properly configured
 - etcd and NATS running (required for Dynamo coordination)
 - Required Python packages:
@@ -60,7 +49,7 @@ Make sure you have 8 GPUs for these examples, unless you are using mockers (see 
     --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 
 # Example: 4 vLLM workers with larger model using tensor parallelism (2 GPUs per worker)
-# NOTE: this would likely require each GPU having 80GB of VRAM
+# NOTE: this would likely require having H100 GPUs or later
 ./run_engines.sh \
     --num-workers 4 \
     --model-path openai/gpt-oss-120b \

--- a/benchmarks/router/README.md
+++ b/benchmarks/router/README.md
@@ -49,7 +49,7 @@ Make sure you have 8 GPUs for these examples, unless you are using mockers (see 
     --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 
 # Example: 4 vLLM workers with larger model using tensor parallelism (2 GPUs per worker)
-# NOTE: this would likely require having H100 GPUs or later
+# NOTE: this requires having Hopper or later GPU SKUs to support MXFP4 precision.
 ./run_engines.sh \
     --num-workers 4 \
     --model-path openai/gpt-oss-120b \


### PR DESCRIPTION
#### Overview:

as titled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Replaced full Apache 2.0 license header with a concise SPDX header in the router benchmark README.
  - Added an optional note about using H100 (or newer) GPUs in prerequisites.
  - Updated usage guidance to reference H100-class GPUs instead of specifying 80GB VRAM per GPU.
  - Performed minor text cleanups and clarifications.
  - No changes to functionality, scripts, or configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->