### PR TITLE
ci: Limit cpus in docker processes

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -40,7 +40,10 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+      with:
+        install: true # alias `docker build` to `docker buildx build`
+        driver-opts: ["--driver-opt=cpus=10"]
     - name: Login to NGC
       if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
       shell: bash
@@ -72,6 +75,7 @@ runs:
         ./container/build.sh --tag "$IMAGE_TAG" \
           --target ${{ inputs.target }} \
           --framework ${{ inputs.framework }} \
+          --cpus=10 \
           --use-sccache \
           --sccache-bucket "$SCCACHE_S3_BUCKET" \
           --sccache-region "$AWS_DEFAULT_REGION"

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -43,7 +43,7 @@ runs:
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
       with:
         install: true # alias `docker build` to `docker buildx build`
-        driver-opts: ["--driver-opt=cpus=10"]
+        driver-opts: ["cpus=10"]
     - name: Login to NGC
       if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
       shell: bash

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -43,7 +43,7 @@ runs:
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
       with:
         install: true # alias `docker build` to `docker buildx build`
-        driver-opts: ["cpus=10"]
+        driver-opts: ['cpus=10']
     - name: Login to NGC
       if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
       shell: bash

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -42,6 +42,7 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
       with:
+        # This is not # of CPUs, this is CPU priority, 1024 is the default
         driver-opts: 'cpu-shares=100'
     - name: Login to NGC
       if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -42,8 +42,7 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
       with:
-        install: true # alias `docker build` to `docker buildx build`
-        driver-opts: 'cpuset-cpus=10'
+        driver-opts: 'cpus=12'
     - name: Login to NGC
       if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
       shell: bash

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
       with:
-        driver-opts: 'cpus=12'
+        driver-opts: 'cpu-shares=16'
     - name: Login to NGC
       if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
       shell: bash

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -75,7 +75,6 @@ runs:
         ./container/build.sh --tag "$IMAGE_TAG" \
           --target ${{ inputs.target }} \
           --framework ${{ inputs.framework }} \
-          --cpus=10 \
           --use-sccache \
           --sccache-bucket "$SCCACHE_S3_BUCKET" \
           --sccache-region "$AWS_DEFAULT_REGION"

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -43,7 +43,7 @@ runs:
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
       with:
         install: true # alias `docker build` to `docker buildx build`
-        driver-opts: ['cpus=10']
+        driver-opts: 'cpuset-cpus=10'
     - name: Login to NGC
       if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
       shell: bash

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
       with:
-        driver-opts: 'cpu-shares=16'
+        driver-opts: 'cpu-shares=100'
     - name: Login to NGC
       if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
       shell: bash

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -8,6 +8,10 @@ inputs:
   image_tag:
     description: 'Image Tag to run tests on'
     required: true
+  cpu_limit:
+    description: 'Maximum number of cores available to docker'
+    required: false
+    default: '10'
 
 
 runs:
@@ -16,12 +20,13 @@ runs:
     - name: Run tests
       shell: bash
       env:
+        NUM_CPUS: ${{ inputs.cpu_limit }}
         CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}
         PYTEST_XML_FILE: pytest_test_report.xml
         HF_HOME: /runner/_work/_temp
       run: |
         docker run --runtime=nvidia --rm --gpus all -w /workspace \
-          --cpus=12 \
+          --cpus=${NUM_CPUS} \
           --network host \
           --name ${{ env.CONTAINER_ID }}_pytest \
           ${{ inputs.image_tag }} \

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -21,6 +21,7 @@ runs:
         HF_HOME: /runner/_work/_temp
       run: |
         docker run --runtime=nvidia --rm --gpus all -w /workspace \
+          --cpus=10 \
           --network host \
           --name ${{ env.CONTAINER_ID }}_pytest \
           ${{ inputs.image_tag }} \

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -21,7 +21,7 @@ runs:
         HF_HOME: /runner/_work/_temp
       run: |
         docker run --runtime=nvidia --rm --gpus all -w /workspace \
-          --cpus=10 \
+          --cpus=12 \
           --network host \
           --name ${{ env.CONTAINER_ID }}_pytest \
           ${{ inputs.image_tag }} \


### PR DESCRIPTION
#### Overview:

This PR sets a `cpu-shares` for `docker build` which heavily lowers the CPU priority of the `docker build` processes.

https://docs.docker.com/engine/containers/resource_constraints/#configure-the-default-cfs-scheduler

This will not slow down the build, but rather give CPU priority to other things on the host, hopefully lowering or removing the crashing rates.

In the same vein, I added `--cpus` flag to `docker run`, which is an effort to limit the CPU cores of the `pytest` container since the Kubernetes `resources.limits` was potentially not throttling the CPU fast enough.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - None

- Chores
  - Pinned Docker Buildx action to a specific revision for reproducible builds.
  - Configured Buildx installation and CPU driver options.
  - Aligned image build step with explicit CPU allocation (10 CPUs) to improve build performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->