### PR TITLE
chore: Switch lto to from "fat"/true to "thin"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,4 +108,4 @@ opt-level = 3
 [profile.release]
 # These make the build much slower but shrink the binary, and could help performance
 codegen-units = 1
-lto = true
+lto = "thin"


### PR DESCRIPTION
+ 30% faster builds
+ "takes substantially less time to run while still achieving performance gains similar to “fat”."

https://doc.rust-lang.org/cargo/reference/profiles.html#lto

Originally added here: https://github.com/ai-dynamo/dynamo/pull/279
And I raised concerns about build times here: https://github.com/ai-dynamo/dynamo/pull/279#issuecomment-2741062054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release build configuration to improve runtime performance and potentially reduce binary size using a more efficient link-time optimization strategy.
  * Users may experience faster startup and execution in production builds.
  * No functional changes or new features; app behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->