### PR TITLE
docs: Fix profile_sla command in docs (cherry-pick from main)

### DIFF
--- a/docs/benchmarks/pre_deployment_profiling.md
+++ b/docs/benchmarks/pre_deployment_profiling.md
@@ -310,8 +310,8 @@ In addition to passing the `--use-ai-configurator` flag, you must also provide t
 
 Example command:
 ```bash
-python3 profile_sla.py \
-   --config ../../components/backends/trtllm/deploy/disagg.yaml \
+python3 -m benchmarks.profiler.profile_sla \
+   --config ./components/backends/trtllm/deploy/disagg.yaml \
    --use-ai-configurator \
    --aic-system h200_sxm \
    --aic-model-name QWEN3_32B \


### PR DESCRIPTION
This is a cherry-pick of https://github.com/ai-dynamo/dynamo/pull/3258

Overview:
Fixes command for running profile_sla.py with aiconfigurator options. The previous command was failing with

```
$ python3 benchmarks/profiler/profile_sla.py --config ../components/backends/trtllm/deploy/disagg.yaml    --use-ai-configurator    --aic-system h200_sxm    --aic-model-name QWEN3_32B    --backend trtllm    --backend-version 0.20.0 2>&1 | tee /workspace/logs/profiling/profiling-aic.txt
Traceback (most recent call last):
  File "/workspace/benchmarks/profiler/profile_sla.py", line 25, in <module>
    from benchmarks.profiler.utils.config import CONFIG_MODIFIERS, WORKER_COMPONENT_NAMES
ModuleNotFoundError: No module named 'benchmarks'
I verified that the new command works both with local dynamo install and inside the container.
```
