### PR TITLE
fix: make HF cache mount point dynamic based on target

### DIFF
--- a/container/run.sh
+++ b/container/run.sh
@@ -269,7 +269,13 @@ get_options() {
 
     if [ -n "$HF_CACHE" ]; then
         mkdir -p "$HF_CACHE"
-        VOLUME_MOUNTS+=" -v $HF_CACHE:/root/.cache/huggingface"
+        # Use /home/ubuntu for local-dev target, /root for dev target.
+        if [ "$TARGET" = "local-dev" ] || [[ "$IMAGE" == *"local-dev"* ]]; then
+            HF_CACHE_TARGET="/home/ubuntu/.cache/huggingface"
+        else
+            HF_CACHE_TARGET="/root/.cache/huggingface"
+        fi
+        VOLUME_MOUNTS+=" -v $HF_CACHE:$HF_CACHE_TARGET"
     fi
 
     if [ -z "${PRIVILEGED}" ]; then


### PR DESCRIPTION
#### Overview:

This PR fixes the HF cache mount point in the container run script to dynamically determine the correct user directory based on the target type.
#### Details:

- **Dynamic cache mount point**: Modified `container/run.sh` to use `/home/ubuntu/.cache/huggingface` for `local-dev` targets and `/root/.cache/huggingface` for `dev`/production targets
- **Backward compatibility**: Maintains existing behavior for all non-local-dev targets while fixing the issue for local-dev environments

#### Where should the reviewer start?

Review the changes in `container/run.sh` around lines 270-279, specifically the logic that determines `HF_CACHE_TARGET` based on the target type.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Container now auto-detects environment and mounts the Hugging Face cache to the appropriate path, improving compatibility between local-dev and other images.
  * Preserves the existing host cache location and ensures directories are created before mounting, reducing first-run failures and permission errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->