### PR TITLE
fix: mark stream as finished after sending the usage chunk

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -565,6 +565,7 @@ impl OpenAIPreprocessor {
                             "Sending final usage chunk for OpenAI compliance"
                         );
 
+                        inner.finished = true;
                         Some((annotated_usage, inner))
                     } else {
                         // stream closed


### PR DESCRIPTION
#### Overview:

prevent unfold panic in streaming usage chunk

#### Details:

set finished=true before sending usage chunk to prevent unfold panic  
The futures::stream::unfold panics when polled after returning None.  

#### Where should the reviewer start?

transform_postprocessor_stream

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #[xxx](https://github.com/ai-dynamo/dynamo/issues/3247)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures streamed responses end cleanly after the final usage update, preventing any stray or duplicated chunks.
  * Improves reliability of end-of-stream handling, reducing the chance of lingering or spurious updates.
  * Enhances overall stability of streaming sessions for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->