### PR TITLE
fix: rm unused metrics-endpoint-port args in vllm

### DIFF
--- a/components/backends/vllm/README.md
+++ b/components/backends/vllm/README.md
@@ -161,7 +161,6 @@ vLLM workers are configured through command-line arguments. Key parameters inclu
 
 - `--model`: Model to serve (e.g., `Qwen/Qwen3-0.6B`)
 - `--is-prefill-worker`: Enable prefill-only mode for disaggregated serving
-- `--metrics-endpoint-port`: Port for publishing KV metrics to Dynamo
 - `--connector`: Specify which kv_transfer_config you want vllm to use `[nixl, lmcache, kvbm, none]`. This is a helper flag which overwrites the engines KVTransferConfig.
 
 See `args.py` for the full list of configuration options and their defaults.

--- a/components/backends/vllm/deploy/README.md
+++ b/components/backends/vllm/deploy/README.md
@@ -188,7 +188,6 @@ vLLM workers are configured through command-line arguments. Key parameters inclu
 
 - `--model`: Model to serve (e.g., `Qwen/Qwen3-0.6B`)
 - `--is-prefill-worker`: Enable prefill-only mode for disaggregated serving
-- `--metrics-endpoint-port`: Port for publishing KV metrics to Dynamo
 
 See the [vLLM CLI documentation](https://docs.vllm.ai/en/v0.9.2/configuration/serve_args.html?h=serve+arg) for the full list of configuration options.
 


### PR DESCRIPTION
#### Overview:

rm unused args call out by https://github.com/ai-dynamo/dynamo/issues/3161 to prevent confusion

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: https://github.com/ai-dynamo/dynamo/issues/3161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated vLLM configuration and deployment guides to remove the metrics-endpoint-port option from listed flags.
  - Aligns documentation with currently supported configuration options and reduces potential confusion.
  - No functional or behavioral changes; existing deployments are unaffected.
  - Improves clarity of setup instructions without altering defaults or required parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->