### PR TITLE
build: Copy pyproject.toml to avoid pytest warnings

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -234,6 +234,7 @@ RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/la
 COPY components/ /workspace/components/
 # Copy benchmarks, examples, and tests for CI
 # TODO: Remove this once we have a functional CI image built on top of the runtime image
+COPY pyproject.toml /workspace/
 COPY tests /workspace/tests
 COPY benchmarks /workspace/benchmarks
 COPY examples /workspace/examples

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -238,6 +238,7 @@ ENV LD_LIBRARY_PATH="/opt/hpcx/ucc/lib:${LD_LIBRARY_PATH}"
 COPY --from=framework /usr/local/cuda/lib64/libcusparseLt* /usr/local/cuda/lib64/
 
 # Copy tests, benchmarks, deploy and components for CI
+COPY pyproject.toml /workspace/
 COPY tests /workspace/tests
 COPY examples /workspace/examples
 COPY benchmarks /workspace/benchmarks


### PR DESCRIPTION
#### Overview:

Copy pyproject.toml to avoid pytest warnings to add to the runtime container. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated container images to include project metadata in the workspace, improving CI/build workflows and runtime tooling that rely on this information.
  - Applied the change across both framework and runtime/dev images to ensure consistent availability of metadata.

- Style
  - Minor formatting cleanup in container definitions (e.g., ensuring proper trailing newline in commands) with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->