### PR TITLE
fix: copy wheel from trtllm wheel stage

### DIFF
--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -195,6 +195,8 @@ ARG HAS_TRTLLM_CONTEXT
 ARG TENSORRTLLM_PIP_WHEEL
 ARG TENSORRTLLM_INDEX_URL
 
+# Copy only wheel files from trtllm_wheel stage from build_context
+COPY --from=trtllm_wheel /*.whl /trtllm_wheel/
 # Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel
 # because there might be mismatched versions of TensorRT between the NGC PyTorch
 # and the TRTLLM wheel.


### PR DESCRIPTION
#### Overview:

This PR copies the wheel generated from the trtllm_wheel into the runtime stage.
Previously, observing the following error:

````
 > [runtime 38/51] RUN [ -f /etc/pip/constraint.txt ] && : > /etc/pip/constraint.txt || true &&     if [ "1" = "1" ]; then         WHEEL_FILE=$(find /trtllm_wheel -name "*.whl" | head -n 1);         if [ -n "$WHEEL_FILE" ]; then             uv pip install "$WHEEL_FILE";         else             echo "No wheel file found in /trtllm_wheel directory.";             exit 1;         fi;     else         uv pip install --extra-index-url "https://pypi.python.org/simple"; "tensorrt-llm";     fi:
0.189 find: '/trtllm_wheel': No such file or directory
0.189 No wheel file found in /trtllm_wheel directory.
````

#### Details:

- Copy wheel from trtllm_wheel before installing TRT-LLM to support custom-built wheels.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
