### PR TITLE
docs: remove hardcoded version in quick start

### DIFF
--- a/docs/_includes/quick_start_local.rst
+++ b/docs/_includes/quick_start_local.rst
@@ -10,14 +10,16 @@ Get started with Dynamo locally in just a few commands:
    # Create virtual environment and install Dynamo
    uv venv venv
    source venv/bin/activate
-   uv pip install "ai-dynamo[sglang]==0.4.1"  # or [vllm], [trtllm]
+   # Use prerelease flag to install RC versions of flashinfer and/or other dependencies
+   uv pip install --prerelease=allow "ai-dynamo[sglang]"  # or [vllm], [trtllm]
 
 **2. Start etcd/NATS**
 
 .. code-block:: bash
 
    # Fetch and start etcd and NATS using Docker Compose
-   curl -fsSL -o docker-compose.yml https://raw.githubusercontent.com/ai-dynamo/dynamo/release/0.4.1/deploy/docker-compose.yml
+   VERSION=$(uv pip show ai-dynamo | grep Version | cut -d' ' -f2)
+   curl -fsSL -o docker-compose.yml https://raw.githubusercontent.com/ai-dynamo/dynamo/release/${VERSION}/deploy/docker-compose.yml
    docker compose -f docker-compose.yml up -d
 
 **3. Run Dynamo**

--- a/docs/_includes/quick_start_local.rst
+++ b/docs/_includes/quick_start_local.rst
@@ -19,7 +19,7 @@ Get started with Dynamo locally in just a few commands:
 
    # Fetch and start etcd and NATS using Docker Compose
    VERSION=$(uv pip show ai-dynamo | grep Version | cut -d' ' -f2)
-   curl -fsSL -o docker-compose.yml https://raw.githubusercontent.com/ai-dynamo/dynamo/release/${VERSION}/deploy/docker-compose.yml
+   curl -fsSL -o docker-compose.yml https://raw.githubusercontent.com/ai-dynamo/dynamo/refs/tags/v${VERSION}/deploy/docker-compose.yml
    docker compose -f docker-compose.yml up -d
 
 **3. Run Dynamo**


### PR DESCRIPTION
#### Overview:

Remove hardcoded version in quick start

closes: OPS-1279 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start to support installing prerelease versions via uv pip with --prerelease=allow.
  * Instructions now fetch the docker-compose file matching the installed package version dynamically.
  * All other setup steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

