### PR TITLE
chore: Remove revision from ModelDeploymentCard

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -11,7 +11,6 @@
 //! - Model information (ModelInfoType)
 //! - Tokenizer configuration (TokenizerKind)
 //! - Prompt formatter settings (PromptFormatterArtifact)
-//! - Various metadata like revision, publish time, etc.
 
 use std::fmt;
 use std::fs::File;
@@ -121,10 +120,6 @@ pub struct ModelDeploymentCard {
 
     /// When this card was last advertised by a worker. None if not yet published.
     pub last_published: Option<chrono::DateTime<chrono::Utc>>,
-
-    /// Incrementing count of how many times we published this card
-    #[serde(default, skip_serializing)]
-    pub revision: u64,
 
     /// Max context (in number of tokens) this model can handle
     pub context_length: u32,
@@ -496,7 +491,6 @@ impl ModelDeploymentCard {
             prompt_formatter: Some(PromptFormatterArtifact::GGUF(gguf_file.to_path_buf())),
             chat_template_file: None,
             prompt_context: None, // TODO - auto-detect prompt context
-            revision: 0,
             last_published: None,
             context_length,
             kv_cache_block_size: 0,
@@ -560,7 +554,6 @@ impl ModelDeploymentCard {
             prompt_formatter: PromptFormatterArtifact::from_repo(repo_id)?,
             chat_template_file,
             prompt_context: None, // TODO - auto-detect prompt context
-            revision: 0,
             last_published: None,
             context_length,
             kv_cache_block_size: 0, // set later
@@ -572,14 +565,14 @@ impl ModelDeploymentCard {
     }
 }
 
+/// A ModelDeploymentCard is published a single time per instance and never updated.
 impl Versioned for ModelDeploymentCard {
     fn revision(&self) -> u64 {
-        self.revision
+        0
     }
 
-    fn set_revision(&mut self, revision: u64) {
+    fn set_revision(&mut self, _revision: u64) {
         self.last_published = Some(chrono::Utc::now());
-        self.revision = revision;
     }
 }
 


### PR DESCRIPTION
Currently it is published a single time and never updated, so revision never changes from 0.

Most things that can change in a ModelDeploymentCard would require the engine to restart, and the frontend to rebuild it's pipeline, but that may change in the future.

`revision` (removed here) and `last_published` (removed in #3292) were the two parts of the ModelDeploymentCard that could cause comparison to fail. Without them if two models are identical they should publish identical MDC's, which the frontend will notice and load balance between them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Refactor
  - Simplified model deployment cards to be single-publish and immutable; revisions are no longer tracked or updated, and any revision will display as 0.

- Documentation
  - Clarified that each model deployment card is published once and never updated thereafter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->