### PR TITLE
fix: operator planner metric port injection

### DIFF
--- a/deploy/cloud/operator/internal/dynamo/component_planner.go
+++ b/deploy/cloud/operator/internal/dynamo/component_planner.go
@@ -32,7 +32,7 @@ func (p *PlannerDefaults) GetBaseContainer(context ComponentContext) (corev1.Con
 	}
 	container.Env = append(container.Env, []corev1.EnvVar{
 		{
-			Name:  "PROMETHEUS_PORT",
+			Name:  "PLANNER_PROMETHEUS_PORT",
 			Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort),
 		},
 	}...)

--- a/deploy/cloud/operator/internal/dynamo/component_planner_test.go
+++ b/deploy/cloud/operator/internal/dynamo/component_planner_test.go
@@ -55,7 +55,7 @@ func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
 					{Name: "DYN_NAMESPACE", Value: "dynamo-namespace"},
 					{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "name"},
 					{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: "namespace"},
-					{Name: "PROMETHEUS_PORT", Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort)},
+					{Name: "PLANNER_PROMETHEUS_PORT", Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort)},
 				},
 			},
 		},

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -167,7 +167,7 @@ func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphD
 		}
 		// merge the envs from the parent deployment with the envs from the service
 		if len(parentDynamoGraphDeployment.Spec.Envs) > 0 {
-			deployment.Spec.Envs = MergeEnvs(parentDynamoGraphDeployment.Spec.Envs, deployment.Spec.Envs)
+			deployment.Spec.Envs = MergeEnvs(deployment.Spec.Envs, parentDynamoGraphDeployment.Spec.Envs)
 		}
 		err := updateDynDeploymentConfig(deployment, commonconsts.DynamoServicePort)
 		if err != nil {
@@ -729,7 +729,7 @@ func GenerateBasePodSpec(
 			}
 		}
 	}
-	container.Env = MergeEnvs(component.Envs, container.Env)
+	container.Env = MergeEnvs(container.Env, component.Envs)
 
 	// Merge probes entirely if they are passed (no partial merge)
 	if component.LivenessProbe != nil {

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -167,7 +167,7 @@ func GenerateDynamoComponentsDeployments(ctx context.Context, parentDynamoGraphD
 		}
 		// merge the envs from the parent deployment with the envs from the service
 		if len(parentDynamoGraphDeployment.Spec.Envs) > 0 {
-			deployment.Spec.Envs = MergeEnvs(deployment.Spec.Envs, parentDynamoGraphDeployment.Spec.Envs)
+			deployment.Spec.Envs = MergeEnvs(parentDynamoGraphDeployment.Spec.Envs, deployment.Spec.Envs)
 		}
 		err := updateDynDeploymentConfig(deployment, commonconsts.DynamoServicePort)
 		if err != nil {

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -625,6 +625,12 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 								},
 							},
 						},
+						Envs: []corev1.EnvVar{
+							{
+								Name:  "TEST_ENV",
+								Value: "test-value",
+							},
+						},
 					},
 				},
 			},
@@ -666,6 +672,12 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 									Args:    []string{"echo hello world", "sleep 99999"},
 								},
 							},
+							Envs: []corev1.EnvVar{
+								{
+									Name:  "TEST_ENV",
+									Value: "test-value",
+								},
+							},
 						},
 					},
 				},
@@ -699,6 +711,12 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 								},
 							},
 							Autoscaling: nil,
+							Envs: []corev1.EnvVar{
+								{
+									Name:  "TEST_ENV",
+									Value: "test-value",
+								},
+							},
 						},
 					},
 				},
@@ -1501,7 +1519,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: "http://localhost:9090",
 													},
 													{
-														Name:  "PROMETHEUS_PORT",
+														Name:  "PLANNER_PROMETHEUS_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort),
 													},
 												},
@@ -2276,7 +2294,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: "test-namespace",
 													},
 													{
-														Name:  "PROMETHEUS_PORT",
+														Name:  "PLANNER_PROMETHEUS_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort),
 													},
 												},
@@ -3067,7 +3085,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: "test-namespace",
 													},
 													{
-														Name:  "PROMETHEUS_PORT",
+														Name:  "PLANNER_PROMETHEUS_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort),
 													},
 												},
@@ -4345,6 +4363,24 @@ func TestGenerateBasePodSpec_Frontend(t *testing.T) {
 			backendFramework: BackendFrameworkVLLM,
 			wantEnvVars: map[string]string{
 				"DYN_HTTP_PORT": fmt.Sprintf("%d", commonconsts.DynamoServicePort),
+			},
+		},
+		{
+			name: "frontend with overriding env var",
+			component: &v1alpha1.DynamoComponentDeploymentOverridesSpec{
+				DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: commonconsts.ComponentTypeFrontend,
+					Envs: []corev1.EnvVar{
+						{
+							Name:  "DYN_HTTP_PORT",
+							Value: "3000",
+						},
+					},
+				},
+			},
+			backendFramework: BackendFrameworkVLLM,
+			wantEnvVars: map[string]string{
+				"DYN_HTTP_PORT": "3000",
 			},
 		},
 	}


### PR DESCRIPTION
#### Overview:

Fixes the prometheus port env var injection by the dynamo operator.

#### Details:

- The operator creates a `containerPort` for the planner component to expose metrics. Previously it was passing the port as the env var `PROMETHEUS_PORT`. However, planner uses this env var to connect to the prometheus service (if `PROMETHEUS_ENDPOINT` is not set) https://github.com/ai-dynamo/dynamo/blob/97a98546ce3a34c6ce66aa8b1eb3d1b82811f3ee/components/planner/src/dynamo/planner/defaults.py#L85. This would result in the connection to the prometheus metrics endpoint to fail. Updates the injected env var to `PLANNER_PROMETHEUS_PORT` as planner uses this to construct the port for the metrics endpoint https://github.com/ai-dynamo/dynamo/blob/97a98546ce3a34c6ce66aa8b1eb3d1b82811f3ee/components/planner/src/dynamo/planner/defaults.py#L39.
- Also some small fixes where `MergeEnvs` is used in the operator to ensure proper user overrides

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- helps address NVBug: https://nvbugspro.nvidia.com/bug/5547608


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-component environment variable overrides via a new Envs field in the component spec.

- Refactor
  - Updated environment variable merge precedence: parent-level envs now override service-level values; base/container vs component precedence adjusted. This may change effective values when duplicates exist.

- Chores
  - Renamed Planner Prometheus port environment variable to PLANNER_PROMETHEUS_PORT (previously PROMETHEUS_PORT). Update configurations/manifests accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->