### PR TITLE
fix: DIS-706 skip offloading the G1 matched blocks during offloading

### DIFF
--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader/slot.rs
@@ -632,12 +632,15 @@ impl Slot for VllmConnectorSlot {
             self.device_blocks.extend(block_ids);
         }
 
-        // This approach is fragile, but it’s the only way I can think of to skip evaluating
-        // the G1-matched blocks and to avoid offloading them again.
+        // This approach is fragile, but it’s the only way currently to skip evaluating
+        // the device matched blocks and to avoid offloading them again.
         // TODO: Consider adding an indicator in the scheduler output to distinguish between
         // matched and unmatched device blocks/tokens from the scheduler.
-        if is_new_request && computed_position > 0 && self.evaluated_blocks == 0 {
-            self.evaluated_blocks += (computed_position + 1) / self.block_size;
+        let maybe_have_device_matched_blocks =
+            is_new_request && computed_position > 0 && self.evaluated_blocks == 0;
+
+        if maybe_have_device_matched_blocks {
+            self.evaluated_blocks = (computed_position + 1) / self.block_size;
         }
 
         let num_candidate_blocks =

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_leader.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_leader.rs
@@ -334,6 +334,7 @@ impl Leader for KvConnectorLeader {
                 &new_req.prompt_token_ids,
                 &new_req.block_ids,
                 new_req.num_computed_tokens,
+                true,
             )?;
 
             if let Some(pending_ops) = slot.take_pending_operations() {
@@ -364,6 +365,7 @@ impl Leader for KvConnectorLeader {
                 &cached_req.new_token_ids,
                 &cached_req.new_block_ids,
                 cached_req.num_computed_tokens,
+                false
             )?;
 
             if let Some(pending_ops) = slot.take_pending_operations() {

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_leader.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/trtllm_leader.rs
@@ -365,7 +365,7 @@ impl Leader for KvConnectorLeader {
                 &cached_req.new_token_ids,
                 &cached_req.new_block_ids,
                 cached_req.num_computed_tokens,
-                false
+                false,
             )?;
 
             if let Some(pending_ops) = slot.take_pending_operations() {

--- a/lib/llm/src/block_manager/offload.rs
+++ b/lib/llm/src/block_manager/offload.rs
@@ -739,7 +739,7 @@ mod tests {
         let disk_pool = if let Some(disk_blocks) = disk_blocks {
             config.num_blocks = disk_blocks;
             Some(build_layout(
-                config,
+                config.clone(),
                 layout_type,
                 agent,
                 &DiskAllocator,


### PR DESCRIPTION
#### Overview:

There is a bug in TRTLLM KVBM offloading, that we might double offloading the G1 matched blocks again. This PR fixed this bug.

#### Details:

In the prefill stage, the scheduler output for a new request will always report 0 computed tokens; it only indicates the connector of the device blocks, and the prefill tokens.

Therefore, if the request is new and the computed position is greater than 0, but the slot’s evaluated blocks count is 0, it means there are matched tokens already present on the GPU.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable handling of new vs. cached requests during scheduling.
  * Prevented negative candidate calculations, improving stability.
  * Refined offloading decisions for more accurate memory management.

* **Performance Improvements**
  * Reduced unnecessary block evaluations for new requests, potentially lowering latency.
  * Improved disk-backed pool initialization to avoid side effects and ensure smoother reuse of configuration.

* **Refactor**
  * Clarified onboarding logic for requests, improving readability and maintainability without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->