### PR TITLE
test: Allow prefill cancellation tests to fail

### DIFF
--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -344,6 +344,11 @@ def test_request_cancellation_trtllm_decode_first_decode_cancel(
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
+@pytest.mark.xfail(
+    reason="Time-sensitive test: Relies on request timeout (0.1s) to cancel during remote prefill phase. "
+    "May fail if prefill completes too quickly or timeout triggers at a different phase.",
+    strict=False,
+)
 def test_request_cancellation_trtllm_decode_first_remote_prefill_cancel(
     request, runtime_services, predownload_models
 ):
@@ -403,6 +408,11 @@ def test_request_cancellation_trtllm_decode_first_remote_prefill_cancel(
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
+@pytest.mark.xfail(
+    reason="Time-sensitive test: Relies on request timeout (0.1s) to cancel during prefill phase. "
+    "May fail if prefill completes too quickly or timeout triggers at a different phase.",
+    strict=False,
+)
 def test_request_cancellation_trtllm_prefill_first_prefill_cancel(
     request, runtime_services, predownload_models
 ):

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -316,6 +316,11 @@ def test_request_cancellation_vllm_decode(
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
+@pytest.mark.xfail(
+    reason="Time-sensitive test: Relies on request timeout (0.1s) to cancel during prefill phase. "
+    "May fail if prefill completes too quickly or timeout triggers at a different phase.",
+    strict=False,
+)
 def test_request_cancellation_vllm_prefill(
     request, runtime_services, predownload_models
 ):


### PR DESCRIPTION
#### Overview:

Before the testing steps are updated, mark all prefill cancellation tests to allow to fail.

#### Details:

N/A

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Marked several time-sensitive request cancellation tests as expected to fail to reduce flakiness during prefill and remote decode phases across multiple backends. Uses non-strict expectations and does not alter test logic.
  - No changes to runtime behavior, features, or public APIs; end users are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->