### PR TITLE
fix: python bindings for router should register to etcd as well

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -214,7 +214,7 @@ impl ModelManager {
         kv_cache_block_size: u32,
         kv_router_config: Option<KvRouterConfig>,
     ) -> anyhow::Result<Arc<KvRouter>> {
-        if let Some(kv_chooser) = self.kv_choosers.lock().get(model_name).cloned() {
+        if let Some(kv_chooser) = self.get_kv_chooser(model_name) {
             // Check if the existing router has a different block size
             if kv_chooser.block_size() != kv_cache_block_size {
                 tracing::warn!(
@@ -262,6 +262,10 @@ impl ModelManager {
             .lock()
             .insert(model_name.to_string(), new_kv_chooser.clone());
         Ok(new_kv_chooser)
+    }
+
+    fn get_kv_chooser(&self, model_name: &str) -> Option<Arc<KvRouter>> {
+        self.kv_choosers.lock().get(model_name).cloned()
     }
 
     pub fn get_model_tool_call_parser(&self, model: &str) -> Option<String> {


### PR DESCRIPTION
#### Overview:

As titled. Two minor changes:

- Merged `create_kv_chooser` into `kv_chooser_for`. No reason to have the former if it's only used by the latter and nowhere else
- In the python bindings for `KvPushRouter`, use `kv_chooser_for` to register, so the Router (replica) is discoverable in etcd (needed to detect and remove durable consumers of KV events)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic discovery and registration of key-value routing, reducing manual setup.
- Bug Fixes
  - Prevents duplicate router creation and mitigates configuration mismatches for more consistent routing behavior.
- Refactor
  - Centralized routing management through a unified manager, simplifying how routers are obtained and shared.
- Chores
  - Streamlined internal plumbing to rely on a single source of truth for routing, improving reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->