### PR TITLE
fix(cherry-pick): planner prometheus service url connection

### DIFF
--- a/components/backends/sglang/deploy/disagg_planner.yaml
+++ b/components/backends/sglang/deploy/disagg_planner.yaml
@@ -10,17 +10,19 @@ spec:
     - name: DYNAMO_SERVICE_CONFIG
       value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:9090"]}]},{"job_name":"frontend","static_configs":[{"targets":["sglang-disagg-planner-frontend:8000"]}]}]}}'
     - name: DYNAMO_NAMESPACE
-      value: "dynamo"
+      value: "sglang-disagg-planner"
+    - name: PROMETHEUS_PORT
+      value: "8000"
   services:
     Frontend:
-      dynamoNamespace: dynamo
+      dynamoNamespace: sglang-disagg-planner
       componentType: frontend
       replicas: 1
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1
     Planner:
-      dynamoNamespace: dynamo
+      dynamoNamespace: sglang-disagg-planner
       envFromSecret: hf-token-secret
       componentType: planner
       replicas: 1
@@ -62,7 +64,7 @@ spec:
               --adjustment-interval=60
               --profile-results-dir=/data/profiling_results
     Prometheus: # NOTE: this is set on Prometheus to ensure a service is created for the Prometheus component. This is a workaround and should be managed differently.
-      dynamoNamespace: dynamo
+      dynamoNamespace: sglang-disagg-planner
       componentType: frontend
       replicas: 1
       envs:
@@ -97,7 +99,7 @@ spec:
           args:
             - "python3 -m dynamo.planner.prometheus"
     decode:
-      dynamoNamespace: dynamo
+      dynamoNamespace: sglang-disagg-planner
       envFromSecret: hf-token-secret
       componentType: worker
       replicas: 2
@@ -128,7 +130,7 @@ spec:
             - --disaggregation-transfer-backend
             - nixl
     prefill:
-      dynamoNamespace: dynamo
+      dynamoNamespace: sglang-disagg-planner
       envFromSecret: hf-token-secret
       componentType: worker
       replicas: 2

--- a/components/backends/trtllm/deploy/disagg_planner.yaml
+++ b/components/backends/trtllm/deploy/disagg_planner.yaml
@@ -11,6 +11,8 @@ spec:
       value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:8000"]}]},{"job_name":"frontend","static_configs":[{"targets":["trtllm-disagg-planner-frontend:8000"]}]}]}}'
     - name: DYNAMO_NAMESPACE
       value: "trtllm-disagg-planner"
+    - name: PROMETHEUS_PORT
+      value: "8000"
   services:
     Frontend:
       dynamoNamespace: trtllm-disagg-planner

--- a/deploy/cloud/operator/internal/dynamo/component_planner.go
+++ b/deploy/cloud/operator/internal/dynamo/component_planner.go
@@ -32,7 +32,7 @@ func (p *PlannerDefaults) GetBaseContainer(context ComponentContext) (corev1.Con
 	}
 	container.Env = append(container.Env, []corev1.EnvVar{
 		{
-			Name:  "PROMETHEUS_PORT",
+			Name:  "PLANNER_PROMETHEUS_PORT",
 			Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort),
 		},
 	}...)

--- a/deploy/cloud/operator/internal/dynamo/component_planner_test.go
+++ b/deploy/cloud/operator/internal/dynamo/component_planner_test.go
@@ -55,7 +55,7 @@ func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
 					{Name: "DYN_NAMESPACE", Value: "dynamo-namespace"},
 					{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "name"},
 					{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: "namespace"},
-					{Name: "PROMETHEUS_PORT", Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort)},
+					{Name: "PLANNER_PROMETHEUS_PORT", Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort)},
 				},
 			},
 		},

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -729,7 +729,7 @@ func GenerateBasePodSpec(
 			}
 		}
 	}
-	container.Env = MergeEnvs(component.Envs, container.Env)
+	container.Env = MergeEnvs(container.Env, component.Envs)
 
 	// Merge probes entirely if they are passed (no partial merge)
 	if component.LivenessProbe != nil {

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -623,6 +623,12 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 								},
 							},
 						},
+						Envs: []corev1.EnvVar{
+							{
+								Name:  "TEST_ENV",
+								Value: "test-value",
+							},
+						},
 					},
 				},
 			},
@@ -664,6 +670,12 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 									Args:    []string{"echo hello world", "sleep 99999"},
 								},
 							},
+							Envs: []corev1.EnvVar{
+								{
+									Name:  "TEST_ENV",
+									Value: "test-value",
+								},
+							},
 						},
 					},
 				},
@@ -697,6 +709,12 @@ func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 								},
 							},
 							Autoscaling: nil,
+							Envs: []corev1.EnvVar{
+								{
+									Name:  "TEST_ENV",
+									Value: "test-value",
+								},
+							},
 						},
 					},
 				},
@@ -1497,7 +1515,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: "http://localhost:9090",
 													},
 													{
-														Name:  "PROMETHEUS_PORT",
+														Name:  "PLANNER_PROMETHEUS_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort),
 													},
 												},
@@ -2269,7 +2287,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: "test-namespace",
 													},
 													{
-														Name:  "PROMETHEUS_PORT",
+														Name:  "PLANNER_PROMETHEUS_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort),
 													},
 												},
@@ -3060,7 +3078,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: "test-namespace",
 													},
 													{
-														Name:  "PROMETHEUS_PORT",
+														Name:  "PLANNER_PROMETHEUS_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort),
 													},
 												},
@@ -4338,6 +4356,24 @@ func TestGenerateBasePodSpec_Frontend(t *testing.T) {
 			backendFramework: BackendFrameworkVLLM,
 			wantEnvVars: map[string]string{
 				"DYN_HTTP_PORT": fmt.Sprintf("%d", commonconsts.DynamoServicePort),
+			},
+		},
+		{
+			name: "frontend with overriding env var",
+			component: &v1alpha1.DynamoComponentDeploymentOverridesSpec{
+				DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: commonconsts.ComponentTypeFrontend,
+					Envs: []corev1.EnvVar{
+						{
+							Name:  "DYN_HTTP_PORT",
+							Value: "3000",
+						},
+					},
+				},
+			},
+			backendFramework: BackendFrameworkVLLM,
+			wantEnvVars: map[string]string{
+				"DYN_HTTP_PORT": "3000",
 			},
 		},
 	}


### PR DESCRIPTION
#### Overview:

Fixes issue with planner component connecting to prometheus service url for release 0.5.1

#### Details:

- Cherry picks: [16409ee](https://github.com/ai-dynamo/dynamo/commit/16409eefe43c1120449ebf8437e13ff8d6ac2c8a)
- Updates planner manifests:
  - `PROMETHEUS_PORT` env var must be defined as `8000`
  - for sglang planner manifest we need to ensure the dynamo namespace matches the DGD name

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- fixes NVBug: https://nvbugspro.nvidia.com/bug/5547608
