### PR TITLE
fix: KV Router bindings docs

### DIFF
--- a/docs/architecture/kv_cache_routing.md
+++ b/docs/architecture/kv_cache_routing.md
@@ -330,8 +330,8 @@ from dynamo._core import DistributedRuntime, KvPushRouter, KvRouterConfig
 async def main():
     # Get runtime and create endpoint
     runtime = DistributedRuntime.detached()
-    namespace = runtime.namespace("inference")
-    component = namespace.component("vllm")
+    namespace = runtime.namespace("dynamo")
+    component = namespace.component("backend")
     endpoint = component.endpoint("generate")
 
     # Create KV router
@@ -396,8 +396,8 @@ from dynamo._core import DistributedRuntime, KvPushRouter, KvRouterConfig
 async def minimize_ttft_routing():
     # Setup router
     runtime = DistributedRuntime.detached()
-    namespace = runtime.namespace("inference")
-    component = namespace.component("vllm")
+    namespace = runtime.namespace("dynamo")
+    component = namespace.component("backend")
     endpoint = component.endpoint("generate")
 
     router = KvPushRouter(


### PR DESCRIPTION
#### Overview:

changed to the correct component and endpoint names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture guide examples to use the “dynamo” namespace and “backend” component when calling the “generate” endpoint.
  * Refreshed Python examples to reflect the new routing path while keeping the endpoint name unchanged.
  * Clarified usage so developers can follow the current routing scheme without code changes to their generate calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->