### PR TITLE
refactor: standardize HF_CACHE to HF_HOME across codebase (use Hugging Face convention)

### DIFF
--- a/components/backends/trtllm/multinode/multinode-examples.md
+++ b/components/backends/trtllm/multinode/multinode-examples.md
@@ -111,7 +111,7 @@ export MOUNTS="${PWD}/../:/mnt"
 
 # NOTE: In general, Deepseek R1 is very large, so it is recommended to
 # pre-download the model weights and save them in some shared location,
-# NFS storage, HF_CACHE, etc. and modify the `--model-path` below
+# NFS storage, HF_HOME, etc. and modify the `--model-path` below
 # to reuse the pre-downloaded weights instead.
 #
 # On Blackwell systems (ex: GB200), it is recommended to use the FP4 weights:

--- a/components/backends/trtllm/performance_sweeps/README.md
+++ b/components/backends/trtllm/performance_sweeps/README.md
@@ -74,7 +74,7 @@ export IMAGE="<dynamo_trtllm_image>"
 
 # NOTE: In general, Deepseek R1 is very large, so it is recommended to
 # pre-download the model weights and save them in some shared location,
-# NFS storage, HF_CACHE, etc. and modify the `--model-path` below
+# NFS storage, HF_HOME, etc. and modify the `--model-path` below
 # to reuse the pre-downloaded weights instead.
 #
 # On Blackwell systems (ex: GB200), it is recommended to use the FP4 weights:


### PR DESCRIPTION
#### Overview:

This PR standardizes the use of `HF_HOME` instead of `HF_CACHE` across the codebase to align with Hugging Face's standard environment variable naming conventions. The changes maintain backward compatibility while updating the container run script and documentation.

#### Details:

- Update `container/run.sh` to use `HF_HOME` variable instead of `HF_CACHE`
- Add `--hf-home` command line option while maintaining `--hf-cache` for backward compatibility
- Update help text to reference both options
- Use `${HF_HOME:-}` parameter expansion for safe environment variable initialization
- Update documentation references in multinode and performance sweep examples
- Align with existing Kubernetes configurations that already use `HF_HOME`

#### Where should the reviewer start?

- `container/run.sh` - Main changes to variable names, command line options, and logic
- `components/backends/trtllm/multinode/multinode-examples.md` - Documentation update
- `components/backends/trtllm/performance_sweeps/README.md` - Documentation update

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HF_HOME as the primary cache location, with a combined --hf-home|--hf-cache option.
  * Improved defaulting: when mounting a workspace, HF_HOME auto-populates if unset.
  * Updated NONE handling to clear HF_HOME appropriately.
  * Ensured volume mounting creates and mounts HF_HOME to the expected cache path.
  * Help text updated to reflect new option and semantics.

* **Documentation**
  * Updated guides to reference HF_HOME instead of HF_CACHE for model weight caching and pre-download instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->