### PR TITLE
docs: remove base container as it varies, note no support trtllm py 3.11

### DIFF
--- a/docs/support_matrix.md
+++ b/docs/support_matrix.md
@@ -66,14 +66,13 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 
 | **Build Dependency** | **Version**                                                                      |
 | :------------------- | :------------------------------------------------------------------------------- |
-| **Base Container**   | [25.03](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda-dl-base/tags) |
 | **TensorRT-LLM**     | 1.1.0rc5                                                                         |
 | **NIXL**             | 0.4.1                                                                            |
 | **vLLM**             | 0.10.1.1                                                                         |
 | **SGLang**           | 0.5.0rc2                                                                         |
 
 > [!Important]
-> Specific versions of TensorRT-LLM supported by Dynamo are subject to change.
+> Specific versions of TensorRT-LLM supported by Dynamo are subject to change. Currently TensorRT-LLM does not support Python 3.11 so installation of the ai-dynamo[trtllm] will fail.
 
 ## Cloud Service Provider Compatibility
 


### PR DESCRIPTION
#### Overview:

Updates the support matrix to remove the base container dependency as it varies across the container target and, currently, the frameworks. This seems a reasonable step since the previously documented version did not align with any of the presently shipped wheels.

It was also discovered that TRTLLM optional install is not working on Python 3.11 and this is noted in the section where issues with TRTLLM are mentioned.

relates to OPS-1281


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated support matrix: removed the Base Container entry from the Build Dependency table.
  * Added a note that TensorRT-LLM version requirements may change over time.
  * Clarified that TensorRT-LLM does not support Python 3.11, which can cause ai-dynamo[trtllm] installation to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->