### PR TITLE
chore: Add Key abstraction in our KeyValueStore

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -14,6 +14,7 @@ use dynamo_runtime::{
         network::egress::push_router::PushRouter,
     },
     protocols::annotated::Annotated,
+    storage::key_value_store::Key,
     transports::etcd::{KeyValue, WatchEvent},
 };
 
@@ -258,7 +259,12 @@ impl ModelWatcher {
             .component(&endpoint_id.component)?;
         let client = component.endpoint(&endpoint_id.name).client().await?;
         let model_slug = model_entry.slug();
-        let card = match ModelDeploymentCard::load_from_store(&model_slug, &self.drt).await {
+        let card = match ModelDeploymentCard::load_from_store(
+            &Key::from_raw(model_slug.to_string()),
+            &self.drt,
+        )
+        .await
+        {
             Ok(Some(mut card)) => {
                 tracing::debug!(card.display_name, "adding model");
                 // Ensure runtime_config is populated

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -239,10 +239,7 @@ async fn run_watcher(
     // Spawn a task to watch for model type changes and update HTTP service endpoints and metrics
     let _endpoint_enabler_task = tokio::spawn(async move {
         while let Some(model_update) = rx.recv().await {
-            // Update HTTP endpoints (existing functionality)
             update_http_endpoints(http_service.clone(), model_update.clone());
-
-            // Update metrics (only for added models)
             update_model_metrics(model_update, metrics.clone());
         }
     });

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -225,8 +225,8 @@ impl Component {
         &self.namespace
     }
 
-    pub fn name(&self) -> String {
-        self.name.clone()
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn labels(&self) -> &[(String, String)] {
@@ -457,7 +457,7 @@ impl Endpoint {
     pub fn etcd_path(&self) -> EtcdPath {
         EtcdPath::new_endpoint(
             &self.component.namespace().name(),
-            &self.component.name(),
+            self.component.name(),
             &self.name,
         )
         .expect("Endpoint name and component name should be valid")
@@ -465,12 +465,15 @@ impl Endpoint {
 
     /// The fully path of an instance in etcd
     pub fn etcd_path_with_lease_id(&self, lease_id: i64) -> String {
-        let endpoint_root = self.etcd_root();
-        if self.is_static {
-            endpoint_root
-        } else {
-            format!("{endpoint_root}:{lease_id:x}")
-        }
+        format!("{INSTANCE_ROOT_PATH}/{}", self.unique_path(lease_id))
+    }
+
+    /// Full path of this endpoint with forward slash separators, including lease id
+    pub fn unique_path(&self, lease_id: i64) -> String {
+        let ns = self.component.namespace().name();
+        let cp = self.component.name();
+        let ep = self.name();
+        format!("{ns}/{cp}/{ep}/{lease_id:x}")
     }
 
     /// The endpoint as an EtcdPath object with lease ID
@@ -480,7 +483,7 @@ impl Endpoint {
         } else {
             EtcdPath::new_endpoint_with_lease(
                 &self.component.namespace().name(),
-                &self.component.name(),
+                self.component.name(),
                 &self.name,
                 lease_id,
             )

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -425,8 +425,8 @@ mod integration_tests {
         let request_timeout = Duration::from_secs(3);
 
         let config = HealthCheckConfig {
-            canary_wait_time: canary_wait_time,
-            request_timeout: request_timeout,
+            canary_wait_time,
+            request_timeout,
         };
 
         let manager = HealthCheckManager::new(drt.clone(), config);


### PR DESCRIPTION
That allows us to control whether it gets Slug-ified or not. For etcd we want to preserve the `/` characters and not replace with `_`.

Another step towards merging `ModelEntry` and `ModelDeploymentCard`.
