### PR TITLE
fix: allow tolerations and affinity to be set in jobs that run during helm install

### DIFF
--- a/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
@@ -30,6 +30,17 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "dynamo-operator.fullname" . }}-ssh-keygen
+      # use controller manager tolerations and affinity or mpiRun sepcific or none
+      {{- $tolerations := .Values.dynamo.mpiRun.sshKeygen.tolerations | default .Values.controllerManager.tolerations -}}
+      {{- if $tolerations }}
+      tolerations:
+        {{- toYaml $tolerations | nindent 8 }}
+      {{- end }}
+      {{- $affinity := .Values.dynamo.mpiRun.sshKeygen.affinity | default .Values.controllerManager.affinity -}}
+      {{- if $affinity }}
+      affinity:
+        {{- toYaml $affinity | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
@@ -31,12 +31,14 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{ include "dynamo-operator.fullname" . }}-ssh-keygen
       # use controller manager tolerations and affinity or mpiRun sepcific or none
-      {{- $tolerations := .Values.dynamo.mpiRun.sshKeygen.tolerations | default .Values.controllerManager.tolerations -}}
+      {{- $sshKeygen := .Values.dynamo.mpiRun.sshKeygen | default dict -}}
+      {{- $controller := .Values.controllerManager | default dict -}}
+      {{- $tolerations := ternary $sshKeygen.tolerations $controller.tolerations (hasKey $sshKeygen "tolerations") -}}
       {{- if $tolerations }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       {{- end }}
-      {{- $affinity := .Values.dynamo.mpiRun.sshKeygen.affinity | default .Values.controllerManager.affinity -}}
+      {{- $affinity := ternary $sshKeygen.affinity $controller.affinity (hasKey $sshKeygen "affinity") -}}
       {{- if $affinity }}
       affinity:
         {{- toYaml $affinity | nindent 8 }}

--- a/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
@@ -30,7 +30,6 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "dynamo-operator.fullname" . }}-ssh-keygen
-      # use controller manager tolerations and affinity or mpiRun sepcific or none
       {{- $sshKeygen := .Values.dynamo.mpiRun.sshKeygen | default dict -}}
       {{- $controller := .Values.controllerManager | default dict -}}
       {{- $tolerations := ternary $sshKeygen.tolerations $controller.tolerations (hasKey $sshKeygen "tolerations") -}}

--- a/deploy/cloud/helm/platform/components/operator/values.yaml
+++ b/deploy/cloud/helm/platform/components/operator/values.yaml
@@ -116,8 +116,6 @@ dynamo:
     secretName: "mpi-run-ssh-secret"
     sshKeygen:
       enabled: true
-      tolerations: []
-      affinity: []
 
 
 #imagePullSecrets: []

--- a/deploy/cloud/helm/platform/components/operator/values.yaml
+++ b/deploy/cloud/helm/platform/components/operator/values.yaml
@@ -116,6 +116,8 @@ dynamo:
     secretName: "mpi-run-ssh-secret"
     sshKeygen:
       enabled: true
+      tolerations: []
+      affinity: []
 
 
 #imagePullSecrets: []


### PR DESCRIPTION
#### Overview:

allow tolerations and affinity to be set in jobs that run during helm install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable scheduling options for the mpiRun sshKeygen job: tolerations and affinity can now be set via chart values.
  * When these options are not provided, the job inherits defaults from the controller manager.
  * Behavior remains unchanged unless values are specified; corresponding sections are only applied when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->