### PR TITLE
fix: fix the lmcache args in the agg_lmcache.sh script

### DIFF
--- a/components/backends/vllm/launch/agg_lmcache.sh
+++ b/components/backends/vllm/launch/agg_lmcache.sh
@@ -12,4 +12,4 @@ ENABLE_LMCACHE=1 \
 LMCACHE_CHUNK_SIZE=256 \
 LMCACHE_LOCAL_CPU=True \
 LMCACHE_MAX_LOCAL_CPU_SIZE=20 \
-  python -m dynamo.vllm --model Qwen/Qwen3-0.6B
+  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector lmcache


### PR DESCRIPTION
#### Overview:

Add the required args to the agg_lmcache.sh script to truly activate the lmcache in the vllm engine

#### Details:

attach the "--connector lmcache" to the "python -m dynamo.vllm" command

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled LMCache integration for the vLLM backend when running the Qwen 0.6B model, allowing reusable prompt caching.
- Performance
  - Faster response times and improved throughput for repeated or similar prompts due to caching.
  - Potentially lower compute usage and costs under cache-friendly workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->