### PR TITLE
feat: add Context class to Python type stubs

### DIFF
--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -228,6 +228,93 @@ def compute_block_hash_for_seq_py(tokens: List[int], kv_block_size: int) -> List
 
     ...
 
+class Context:
+    """
+    Context wrapper around AsyncEngineContext for Python bindings.
+    Provides tracing and cancellation capabilities for request handling.
+    """
+
+    def __init__(self, id: Optional[str] = None) -> None:
+        """
+        Create a new Context instance.
+
+        Args:
+            id: Optional request ID. If None, a default ID will be generated.
+        """
+        ...
+
+    def is_stopped(self) -> bool:
+        """
+        Check if the context has been stopped (synchronous).
+
+        Returns:
+            True if the context is stopped, False otherwise.
+        """
+        ...
+
+    def is_killed(self) -> bool:
+        """
+        Check if the context has been killed (synchronous).
+
+        Returns:
+            True if the context is killed, False otherwise.
+        """
+        ...
+
+    def stop_generating(self) -> None:
+        """
+        Issue a stop generating signal to the context.
+        """
+        ...
+
+    def id(self) -> str:
+        """
+        Get the context ID.
+
+        Returns:
+            The context identifier string.
+        """
+        ...
+
+    async def async_killed_or_stopped(self) -> bool:
+        """
+        Asynchronously wait until the context is killed or stopped.
+
+        Returns:
+            True when the context is killed or stopped.
+        """
+        ...
+
+    @property
+    def trace_id(self) -> Optional[str]:
+        """
+        Get the distributed trace ID if available.
+
+        Returns:
+            The trace ID string, or None if no trace context.
+        """
+        ...
+
+    @property
+    def span_id(self) -> Optional[str]:
+        """
+        Get the distributed span ID if available.
+
+        Returns:
+            The span ID string, or None if no trace context.
+        """
+        ...
+
+    @property
+    def parent_span_id(self) -> Optional[str]:
+        """
+        Get the parent span ID if available.
+
+        Returns:
+            The parent span ID string, or None if no trace context.
+        """
+        ...
+
 class WorkerStats:
     """
     Worker stats.

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -267,12 +267,12 @@ class Context:
         """
         ...
 
-    def id(self) -> str:
+    def id(self) -> Optional[str]:
         """
         Get the context ID.
 
         Returns:
-            The context identifier string.
+            The context identifier string, or None if not set.
         """
         ...
 


### PR DESCRIPTION
#### Overview:

Add missing Context class to Python type stubs for IDE support.

#### Details:

- Add Context class definition to `_core.pyi` with all methods and properties
- Fixes IDE type checking for Context usage in TensorRT-LLM backend

#### Where should the reviewer start?

`lib/bindings/python/src/dynamo/_core.pyi` - new Context class definition

#### Related Issues:

Relates to #3296 - adds type definitions for Context class used in TRT-LLM cancellation logic

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Context object to the Python API for managing request lifecycles. It lets you check if generation is stopped or killed, signal a stop, and await cancellation asynchronously. It also exposes optional tracing identifiers (trace/span/parent span) to correlate logs and traces. You can provide and retrieve an optional id for easier tracking, improving control and observability for requests and long-running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->