### PR TITLE
fix: allow tolerations and affinity to be set in jobs that run during helm install (#3324)

### DIFF
--- a/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
@@ -30,6 +30,18 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "dynamo-operator.fullname" . }}-ssh-keygen
+      {{- $sshKeygen := .Values.dynamo.mpiRun.sshKeygen | default dict -}}
+      {{- $controller := .Values.controllerManager | default dict -}}
+      {{- $tolerations := ternary $sshKeygen.tolerations $controller.tolerations (hasKey $sshKeygen "tolerations") -}}
+      {{- if $tolerations }}
+      tolerations:
+        {{- toYaml $tolerations | nindent 8 }}
+      {{- end }}
+      {{- $affinity := ternary $sshKeygen.affinity $controller.affinity (hasKey $sshKeygen "affinity") -}}
+      {{- if $affinity }}
+      affinity:
+        {{- toYaml $affinity | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534


### PR DESCRIPTION
cherry-pick of #3324 