### PR TITLE
fix: etcd bucket delete missing prefix and metrics test range

### DIFF
--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -1593,8 +1593,8 @@ mod test_metricsregistry_nats {
             (
                 build_component_metric_name(nats_service::REQUESTS_TOTAL),
                 0.0,
-                0.0,
-            ), // No work handler requests
+                10.0,
+            ), // NATS service stats requests (may differ from work handler count)
             (
                 build_component_metric_name(nats_service::PROCESSING_MS_TOTAL),
                 0.0,

--- a/lib/runtime/src/storage/key_value_store/etcd.rs
+++ b/lib/runtime/src/storage/key_value_store/etcd.rs
@@ -70,7 +70,7 @@ impl KeyValueBucket for EtcdBucket {
     }
 
     async fn get(&self, key: &Key) -> Result<Option<bytes::Bytes>, StorageError> {
-        let k = format!("{}/{key}", self.bucket_name);
+        let k = make_key(&self.bucket_name, key);
         tracing::trace!("etcd get: {k}");
 
         let mut kvs = self
@@ -86,9 +86,11 @@ impl KeyValueBucket for EtcdBucket {
     }
 
     async fn delete(&self, key: &Key) -> Result<(), StorageError> {
+        let k = make_key(&self.bucket_name, key);
+        tracing::trace!("etcd delete: {k}");
         let _ = self
             .client
-            .kv_delete(key.0.clone(), None)
+            .kv_delete(k, None)
             .await
             .map_err(|e| StorageError::EtcdError(e.to_string()))?;
         Ok(())


### PR DESCRIPTION
#### Overview:

1) Fix bug in etcd storage bucket delete method that caused test keys to accumulate indefinitely. 
2) Also fix integration test expectations for NATS service metrics.

#### Details:

- Fixed `EtcdBucket::delete()` to include bucket prefix via `make_key()` - was silently failing due to missing prefix
- Fixed `EtcdBucket::get()` to use `make_key()` for consistency with other methods
- Updated metrics integration test to allow valid range (0-10) for `nats_service::TOTAL_REQUESTS` instead of requiring exactly 0
- **Bug impact**: Keys accumulated in etcd with each test run:
```
test_concurrent_bucket/concurrent_test_key_72e3120a-3fa4-4d3f-95c3-fede907fab77
test_concurrent_bucket/concurrent_test_key_8c07b44e-c5b6-495d-bcdf-05b0e02f0a8b
test_concurrent_bucket/concurrent_test_key_a9c60d0e-d388-4bff-a7b9-14bdc2f5bec5
(and more with each subsequent test run)
```
- **Verification**: With bug, keys accumulated (2 → 3 → 4...); with fix, etcd is clean after tests

#### Where should the reviewer start?

`lib/runtime/src/storage/key_value_store/etcd.rs`


/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of key-value retrieval and deletion, reducing risks of missing or incorrect entries.
* **Refactor**
  * Standardized key handling in the storage backend and enhanced trace logging for better observability.
* **Tests**
  * Aligned NATS-related metrics expectations with actual service statistics to reduce flaky results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->