### PR TITLE
feat: Add --custom-jinja-template argument to pass a custom chat template for TRTLLM

### DIFF
--- a/components/backends/trtllm/src/dynamo/trtllm/main.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/main.py
@@ -335,6 +335,7 @@ async def init(runtime: DistributedRuntime, config: Config):
                 kv_cache_block_size=config.kv_block_size,
                 migration_limit=config.migration_limit,
                 runtime_config=runtime_config,
+                custom_template_path=config.custom_jinja_template,
             )
 
         # Get health check payload (checks env var and falls back to TensorRT-LLM default)

--- a/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/backends/trtllm/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -59,6 +59,7 @@ class Config:
         self.max_file_size_mb: int = 50
         self.reasoning_parser: Optional[str] = None
         self.tool_call_parser: Optional[str] = None
+        self.custom_jinja_template: Optional[str] = None
 
     def __str__(self) -> str:
         return (
@@ -89,7 +90,8 @@ class Config:
             f"allowed_local_media_path={self.allowed_local_media_path}, "
             f"max_file_size_mb={self.max_file_size_mb}, "
             f"reasoning_parser={self.reasoning_parser}, "
-            f"tool_call_parser={self.tool_call_parser}"
+            f"tool_call_parser={self.tool_call_parser}, "
+            f"custom_jinja_template={self.custom_jinja_template}"
         )
 
 
@@ -296,6 +298,12 @@ def cmd_line_args():
         choices=get_reasoning_parser_names(),
         help="Reasoning parser name for the model. If not specified, no reasoning parsing is performed.",
     )
+    parser.add_argument(
+        "--custom-jinja-template",
+        type=str,
+        default=None,
+        help="Path to a custom Jinja template file to override the model's default chat template. This template will take precedence over any template found in the model repository.",
+    )
 
     args = parser.parse_args()
 
@@ -366,6 +374,15 @@ def cmd_line_args():
 
     config.reasoning_parser = args.dyn_reasoning_parser
     config.tool_call_parser = args.dyn_tool_call_parser
+
+    # Handle custom jinja template path expansion (environment variables and home directory)
+    if args.custom_jinja_template:
+        expanded_template_path = os.path.expandvars(
+            os.path.expanduser(args.custom_jinja_template)
+        )
+        config.custom_jinja_template = expanded_template_path
+    else:
+        config.custom_jinja_template = None
 
     return config
 


### PR DESCRIPTION
#### Overview:
This PR adds support for custom chat templates in Dynamo's TRTLLM backend, allowing users to override a model's default chat template with a custom Jinja template file. This feature enables fine-grained control over prompt formatting without modifying the model repository.

Example Workflow:
```
#Assuming nats & etcd are up and running.
> python -m dynamo.frontend --http-port 8000 &
> python -m dynamo.trtllm --model Qwen/Qwen2.5-0.5B-Instruct \
    --custom-jinja-template ~/custom_chat_template.jinja 
```

#### Details:
- Added a CLI Argument `--custom-jinja-template`
- Added path expansion so users can pass file paths strings. Ex: `--custom-jinja-template "~/template.jinja"` will still get converted to `--custom-jinja-template "/home/<user>/template.jinja"` [[Link to Context](https://github.com/ai-dynamo/dynamo/pull/3165#discussion_r2372685902)]
- Passes this custom chat template to register_llm so that it can stored/reflected in the MDC and ingested by the frontend pre-processor.

#### Related PRs: 
- vLLM Backend: #2829 
- SGLang Backend: #3165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI option --custom-jinja-template to supply a custom Jinja template file.
  * Configuration now supports a custom_jinja_template field; paths expand ~ and environment variables.
  * Custom templates are propagated to model registration, enabling tailored prompt formatting without affecting existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->