### PR TITLE
fix(cherry-pick): KV Router bindings docs

### DIFF
--- a/docs/architecture/kv_cache_routing.md
+++ b/docs/architecture/kv_cache_routing.md
@@ -330,8 +330,8 @@ from dynamo._core import DistributedRuntime, KvPushRouter, KvRouterConfig
 async def main():
     # Get runtime and create endpoint
     runtime = DistributedRuntime.detached()
-    namespace = runtime.namespace("inference")
-    component = namespace.component("vllm")
+    namespace = runtime.namespace("dynamo")
+    component = namespace.component("backend")
     endpoint = component.endpoint("generate")
 
     # Create KV router
@@ -396,8 +396,8 @@ from dynamo._core import DistributedRuntime, KvPushRouter, KvRouterConfig
 async def minimize_ttft_routing():
     # Setup router
     runtime = DistributedRuntime.detached()
-    namespace = runtime.namespace("inference")
-    component = namespace.component("vllm")
+    namespace = runtime.namespace("dynamo")
+    component = namespace.component("backend")
     endpoint = component.endpoint("generate")
 
     router = KvPushRouter(


### PR DESCRIPTION
#### Overview:

as titled, main PR in #3308 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Benchmark data synthesizer adds min/max input/output length controls and dataset-based inputs.
  - Deployment manifests add health checks and support for tolerations/affinity in SSH keygen job.
- Bug Fixes
  - More robust generation streaming: ensures finish_reason is set and errors on empty outputs.
- Chores
  - Bumped container images and Helm charts to 0.5.1 across backends and examples.
  - Updated build scripts and registry references.
  - Increased default router snapshot threshold to 1,000,000.
- Documentation
  - Revised guides, examples, and support matrix to reflect 0.5.1, new flags, and updated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->