### PR TITLE
docs: fail build on warnings and fix existing warns

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,7 +18,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS        ?=
+SPHINXOPTS        ?= -W
 SPHINXBUILD       ?= sphinx-build
 SOURCEDIR          = .
 BUILDDIR           = build

--- a/docs/_includes/dive_in_examples.rst
+++ b/docs/_includes/dive_in_examples.rst
@@ -5,8 +5,8 @@ The examples below assume you build the latest image yourself from source. If us
     :margin: 0
     :padding: 3 4 0 0
 
-    .. grid-item-card:: :doc:`Hello World <../examples/custom_backend/hello_world/README>`
-        :link: ../examples/custom_backend/hello_world/README
+    .. grid-item-card:: :doc:`Hello World <../examples/runtime/hello_world/README>`
+        :link: ../examples/runtime/hello_world/README
         :link-type: doc
 
         Demonstrates the basic concepts of Dynamo by creating a simple GPU-unaware graph

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,9 +76,6 @@ suppress_warnings = [
     "myst.xref_missing",  # Missing cross-references of relative links outside docs folder
 ]
 
-# Make Sphinx treat warnings as errors
-nitpicky = True
-
 # Additional MyST configuration
 myst_heading_anchors = 7  # Generate anchors for headers
 myst_substitutions = {}  # Custom substitutions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,6 +76,9 @@ suppress_warnings = [
     "myst.xref_missing",  # Missing cross-references of relative links outside docs folder
 ]
 
+# Make Sphinx treat warnings as errors
+nitpicky = True
+
 # Additional MyST configuration
 myst_heading_anchors = 7  # Generate anchors for headers
 myst_substitutions = {}  # Custom substitutions

--- a/docs/examples/runtime/hello_world/README.md
+++ b/docs/examples/runtime/hello_world/README.md
@@ -1,1 +1,1 @@
-../../../../examples/runtime/hello_world/README.md
+../../../../examples/custom_backend/hello_world/README.md

--- a/docs/hidden_toctree.rst
+++ b/docs/hidden_toctree.rst
@@ -47,7 +47,7 @@
    components/backends/sglang/docs/multinode-examples.md
 
    examples/README.md
-   examples/custom_backend/hello_world/README.md
+   examples/runtime/hello_world/README.md
 
    architecture/distributed_runtime.md
    architecture/dynamo_flow.md

--- a/docs/kubernetes/metrics.md
+++ b/docs/kubernetes/metrics.md
@@ -137,7 +137,7 @@ Visit http://localhost:9090 and try these example queries:
 - `dynamo_frontend_requests_total`
 - `dynamo_frontend_time_to_first_token_seconds_bucket`
 
-![Prometheus UI showing Dynamo metrics](../../images/prometheus-k8s.png)
+![Prometheus UI showing Dynamo metrics](../images/prometheus-k8s.png)
 
 ### In Grafana
 ```bash
@@ -155,4 +155,4 @@ Visit http://localhost:3000 and log in with the credentials captured above.
 
 Once logged in, find the Dynamo dashboard under General.
 
-![Grafana dashboard showing Dynamo metrics](../../images/grafana-k8s.png)
+![Grafana dashboard showing Dynamo metrics](../images/grafana-k8s.png)


### PR DESCRIPTION
#### Overview:

Fail sphinx build on any warnings. Sample - https://github.com/ai-dynamo/dynamo/actions/runs/18167604976/job/51713859290?pr=3342

Warning fixes - 
* Fix image paths in k8 doc
* Fix hello world readme symlink

closes: OPS-1289


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected links and references for the “Hello World” example to the runtime path.
  * Updated hidden navigation to include the correct example README.
  * Fixed Kubernetes metrics image paths to ensure images render correctly.

* **Chores**
  * Tightened documentation build settings to treat warnings as errors, improving doc quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->