### PR TITLE
fix: force infiniband libraries reinstall when building container

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -122,21 +122,25 @@ RUN apt-get update -y \
         net-tools \
         ninja-build \
         pybind11-dev \
-        # These headers are missing with the hpcx installer, required
-        # by UCX to find RDMA devices
-        ibverbs-providers \
-        ibverbs-utils \
-        libibumad-dev \
-        libibverbs-dev \
-        librdmacm-dev \
-        libnuma-dev \
-        rdma-core \
         # Rust build dependencies
         clang \
         libclang-dev \
         protobuf-compiler \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# These headers are missing with the hpcx installer, required
+# by UCX to build and use RDMA devices. Reinstall to make sure to recreate
+# symlink .so to .so.1 in case some packages are already found.
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install --reinstall \
+        libibverbs-dev \
+        rdma-core \
+        ibverbs-utils \
+        libibumad-dev \
+        libnuma-dev \
+        librdmacm-dev \
+        ibverbs-providers
 
 ##################################
 ########## External Services #####

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -140,7 +140,9 @@ RUN apt-get update -y \
         libibumad-dev \
         libnuma-dev \
         librdmacm-dev \
-        ibverbs-providers
+        ibverbs-providers \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ##################################
 ########## External Services #####

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -133,7 +133,7 @@ RUN apt-get update -y \
 # by UCX to build and use RDMA devices. Reinstall to make sure to recreate
 # symlink .so to .so.1 in case some packages are already found.
 RUN apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y install --reinstall \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install --reinstall --no-install-recommends \
         libibverbs-dev \
         rdma-core \
         ibverbs-utils \


### PR DESCRIPTION
#### Overview:
Fix UCX missing IB/EFA support on `dynamo-base` image and TRTLLM image.

#### Details:
UCX configure does not enable IB and EFA modules because of missing symlink `libibverbs.so`. Adding option `--reinstall` to `apt` command makes sure to recreate any missing files when a package is already installed.

#### Tested:
```
./container/build.sh --framework trtllm

docker run --ulimit memlock=-1:-1 --device=/dev/infiniband \
    --net=host --ipc=host -it dynamo:latest-trtllm /usr/local/ucx/bin/ucx_info -d
<infiniband devices>

docker run --ulimit memlock=-1:-1 --device=/dev/infiniband \
    --net=host --ipc=host -it dynamo-base:v0.1.0.dev.02c822d6b ucx_info -d
<infiniband devices>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved intermittent missing or mislinked RDMA libraries/headers in container environments, improving compatibility for RDMA-enabled workloads.

* **Chores**
  * Updated container build to reinstall RDMA-related system packages, ensuring consistent symlink and header setup across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->