### PR TITLE
fix: Polling from exhausted stream in preprocessor

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -543,11 +543,14 @@ impl OpenAIPreprocessor {
 
                     Some((response, inner))
                 } else {
-                    // Stream has ended - check if we need to send a usage chunk
+                    // Stream has ended - must set finished to true to prevent unfold from polling
+                    // again. The stream is exhausted and will panic if polled after None.
+                    inner.finished = true;
+
+                    // Check if we need to send a usage chunk
                     if inner.response_generator.is_usage_enabled()
                         && inner.finish_reason_sent
                         && !inner.usage_chunk_sent
-                        && !inner.finished
                     {
                         inner.usage_chunk_sent = true;
 
@@ -568,7 +571,6 @@ impl OpenAIPreprocessor {
                         Some((annotated_usage, inner))
                     } else {
                         // stream closed
-                        inner.finished = true; // Mark as finished
                         None
                     }
                 }


### PR DESCRIPTION
#### Overview:

Fix a logic error at preprocessor when manually handling response_stream.next()

#### Details:

After response_stream.next() responds None, the next() method may not be called.

Before fix:
```
$ curl localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
    "messages": [
      {
        "role": "user",
        "content": "Tell me anything short in 5 words"
      }
    ],
    "stream": true,
    "stream_options": {
      "include_usage": true 
    }
  }'
...
curl: (18) transfer closed with outstanding read data remaining

thread 'tokio-runtime-worker' panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/stream/unfold.rs:108:21:
Unfold must not be polled after it returned `Poll::Ready(None)`
```

After fix:
```
$ curl localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
    "messages": [
      {
        "role": "user",
        "content": "Tell me anything short in 5 words"
      }
    ],
    "stream": true,
    "stream_options": {
      "include_usage": true 
    }
  }'
...
data: {"id":"chatcmpl-c4d35d1c-9dab-415f-b6bf-3e3f539c6c86","choices":[],"created":1759345113,"model":"deepseek-ai/DeepSeek-R1-Distill-Llama-8B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":13,"completion_tokens":16,"total_tokens":29}}
event: llm_metrics

data: [DONE]
```

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

fixes https://github.com/ai-dynamo/dynamo/issues/3247
