### PR TITLE
feat: recipe for llama3 70b disagg deployment using sglang

### DIFF
--- a/recipes/llama-3-70b/sglang/disagg/deploy.yaml
+++ b/recipes/llama-3-70b/sglang/disagg/deploy.yaml
@@ -1,0 +1,147 @@
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-disagg
+spec:
+  backendFramework: sglang
+  services:
+    Frontend:
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        initialDelaySeconds: 1800
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        initialDelaySeconds: 1800
+        periodSeconds: 60
+        timeoutSeconds: 30
+        failureThreshold: 10
+      componentType: frontend
+      replicas: 1
+      dynamoNamespace: sglang-disagg
+      pvc:
+        create: false
+        name: model-cache
+        mountPoint: /root/.cache/huggingface
+      resources:
+        requests:
+          cpu: "5"
+          memory: "25Gi"
+        limits:
+          cpu: "5"
+          memory: "25Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
+          workingDir: /workspace/components/backends/sglang
+          command: ["sh", "-c"]
+          args:
+            - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-disagg && python3 -m dynamo.frontend --http-port=8000"
+    SGLangDecodeWorker:
+      envFromSecret: hf-token-secret
+      livenessProbe:
+        httpGet:
+          path: /live
+          port: system
+        timeoutSeconds: 30
+        periodSeconds: 5
+        failureThreshold: 1
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: system
+        initialDelaySeconds: 1800
+        timeoutSeconds: 30
+        periodSeconds: 60
+        failureThreshold: 60
+      dynamoNamespace: sglang-disagg
+      pvc:
+        create: false
+        name: model-cache
+        mountPoint: /root/.cache/huggingface
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "200Gi"
+          gpu: "4"
+        limits:
+          cpu: "10"
+          memory: "200Gi"
+          gpu: "4"
+      extraPodSpec:
+        mainContainer:
+          startupProbe:
+            failureThreshold: 3600
+            httpGet:
+              path: /live
+              port: system
+            periodSeconds: 10
+            timeoutSeconds: 5
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
+          workingDir: /workspace/components/backends/sglang
+          command: ["/bin/bash", "-c"]
+          stdin: true
+          tty: true
+          args:
+            - |
+              set -e
+              exec python3 -m dynamo.sglang \
+                --model-path RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic \
+                --served-model-name RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic \
+                --tp 4 \
+                --trust-remote-code \
+                --skip-tokenizer-init \
+                --disaggregation-mode decode \
+                --disaggregation-transfer-backend nixl \
+                --disaggregation-bootstrap-port 30001 \
+                --host 0.0.0.0 \
+                --port 8000 \
+                --mem-fraction-static 0.82
+    SGLangPrefillWorker:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: sglang-disagg
+      pvc:
+        create: false
+        name: model-cache
+        mountPoint: /root/.cache/huggingface
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          cpu: "10"
+          memory: "200Gi"
+          gpu: "4"
+        limits:
+          cpu: "10"
+          memory: "200Gi"
+          gpu: "4"
+      extraPodSpec:
+        mainContainer:
+          stdin: true
+          tty: true
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
+          workingDir: /workspace/components/backends/sglang
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -e
+              exec python3 -m dynamo.sglang \
+                --model-path RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic \
+                --served-model-name RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic \
+                --tp 4 \
+                --trust-remote-code \
+                --skip-tokenizer-init \
+                --disaggregation-mode prefill \
+                --disaggregation-transfer-backend nixl \
+                --disaggregation-bootstrap-port 30001 \
+                --host 0.0.0.0 \
+                --port 8000 \
+                --mem-fraction-static 0.82

--- a/recipes/llama-3-70b/sglang/disagg/deploy.yaml
+++ b/recipes/llama-3-70b/sglang/disagg/deploy.yaml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/recipes/llama-3-70b/sglang/disagg/deploy.yaml
+++ b/recipes/llama-3-70b/sglang/disagg/deploy.yaml
@@ -47,13 +47,6 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          # startupProbe:
-          #   failureThreshold: 3600
-          #   httpGet:
-          #     path: /live
-          #     port: system
-          #   periodSeconds: 10
-          #   timeoutSeconds: 5
           image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command: ["/bin/bash", "-c"]

--- a/recipes/llama-3-70b/sglang/disagg/deploy.yaml
+++ b/recipes/llama-3-70b/sglang/disagg/deploy.yaml
@@ -6,22 +6,6 @@ spec:
   backendFramework: sglang
   services:
     Frontend:
-      livenessProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        initialDelaySeconds: 1800
-        periodSeconds: 60
-        timeoutSeconds: 30
-        failureThreshold: 10
-      readinessProbe:
-        httpGet:
-          path: /health
-          port: 8000
-        initialDelaySeconds: 1800
-        periodSeconds: 60
-        timeoutSeconds: 30
-        failureThreshold: 10
       componentType: frontend
       replicas: 1
       dynamoNamespace: sglang-disagg
@@ -45,21 +29,6 @@ spec:
             - "python3 -m dynamo.sglang.utils.clear_namespace --namespace sglang-disagg && python3 -m dynamo.frontend --http-port=8000"
     SGLangDecodeWorker:
       envFromSecret: hf-token-secret
-      livenessProbe:
-        httpGet:
-          path: /live
-          port: system
-        timeoutSeconds: 30
-        periodSeconds: 5
-        failureThreshold: 1
-      readinessProbe:
-        httpGet:
-          path: /health
-          port: system
-        initialDelaySeconds: 1800
-        timeoutSeconds: 30
-        periodSeconds: 60
-        failureThreshold: 60
       dynamoNamespace: sglang-disagg
       pvc:
         create: false
@@ -78,13 +47,13 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          startupProbe:
-            failureThreshold: 3600
-            httpGet:
-              path: /live
-              port: system
-            periodSeconds: 10
-            timeoutSeconds: 5
+          # startupProbe:
+          #   failureThreshold: 3600
+          #   httpGet:
+          #     path: /live
+          #     port: system
+          #   periodSeconds: 10
+          #   timeoutSeconds: 5
           image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
           workingDir: /workspace/components/backends/sglang
           command: ["/bin/bash", "-c"]

--- a/recipes/llama-3-70b/sglang/disagg/perf.yaml
+++ b/recipes/llama-3-70b/sglang/disagg/perf.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: llama3-70b-sgl-disagg-perf
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: llama3-70b-sgl-disagg-perf
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: perf
+        image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.0
+        workingDir: /workspace/components/backends/vllm
+        command:
+        - /bin/sh
+        - -c
+        - |
+          # wait for the model to be ready
+          export ENDPOINT=sglang-disagg-frontend:8000
+          export TARGET_MODEL=RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
+          export INTERVAL=5
+          echo "Waiting for model '$TARGET_MODEL' at $ENDPOINT/v1/models (checking every ${INTERVAL}s)..."
+          while ! curl -s "http://$ENDPOINT/v1/models" | jq -e --arg model "$TARGET_MODEL" '.data[]? | select(.id == $model)' >/dev/null 2>&1; do
+              echo "[$(date '+%H:%M:%S')] Model not ready yet, waiting ${INTERVAL}s..."
+              sleep $INTERVAL
+          done
+          echo "✅ Model '$TARGET_MODEL' is now available!"
+          curl -s "http://$ENDPOINT/v1/models" | jq .
+          # now run the benchmark
+          export ARTIFACT_DIR="/tmp/genai-$RANDOM"
+          mkdir -p "$ARTIFACT_DIR"
+          echo "Running benchmark..."
+          export COLUMNS=200
+          genai-perf profile \
+            --model "$TARGET_MODEL" \
+            --tokenizer ~/.cache/huggingface/hub/models--RedHatAI--Llama-3.3-70B-Instruct-FP8-dynamic/snapshots/ddb4128556dfcff99e0c41aee159ea6c3e655dcd  \
+            --endpoint-type chat --url "$ENDPOINT" --streaming \
+            --concurrency 64 \
+            --warmup-request-count 2 \
+            --request-count 320 \
+            --extra-inputs max_tokens:1024 \
+            --synthetic-input-tokens-mean 8192 \
+            --synthetic-input-tokens-stddev 0 \
+            --output-tokens-mean 1024 \
+            --output-tokens-stddev 0 \
+            --extra-inputs min_tokens:1024 \
+            --extra-inputs ignore_eos:true \
+            --extra-inputs "{\"nvext\":{\"ignore_eos\":true}}" \
+            --random-seed 1418186270 \
+            --artifact-dir $ARTIFACT_DIR \
+            --num-dataset-entries=3000 -- \
+            --max-threads 64
+          echo "----------------json----------------"
+          PERF_JSON=$(find $ARTIFACT_DIR -name profile_export_genai_perf.json)
+          cat $PERF_JSON | jq .
+          echo "----------------csv-----------------"
+          PERF_CSV=$(find $ARTIFACT_DIR -name profile_export_genai_perf.csv)
+          cat $PERF_CSV
+          echo "Benchmark completed successfully!"
+        volumeMounts:
+        - name: model-cache
+          mountPath: /root/.cache/huggingface
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache


### PR DESCRIPTION
#### Overview:

add sgl recipe for llama3 70b disagg

closes: DEP-468

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Kubernetes deployment recipe for a disaggregated sglang service with frontend, decode worker, and prefill worker components.
  - Includes health checks, resource requests/limits (including GPU), and persistent storage configuration.
  - Supports secret-based environment configuration and per-service probes for improved reliability.
  - Enables configurable model paths and served model names.
- Chores
  - Introduced a standardized deployment YAML to streamline setup and scaling of the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->