### PR TITLE
feat: Add custom preprocessor support for LLM frontend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ modelexpress-common = { git = "https://github.com/ai-dynamo/modelexpress.git", r
 
 humantime = { version = "2.2.0" }
 libc = { version = "0.2" }
+once_cell = { version = "1.20" }
 oneshot = { version = "0.1.11", features = ["std", "async"] }
 prometheus = { version = "0.14" }
 rand = { version = "0.9.0" }

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -129,11 +129,16 @@ fn get_span_for_direct_context(
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     logging::init();
+
+    // Initialize the custom preprocessor factory
+    llm::custom_preprocessor::init_python_preprocessor_factory();
     m.add_function(wrap_pyfunction!(llm::kv::compute_block_hash_for_seq_py, m)?)?;
     m.add_function(wrap_pyfunction!(log_message, m)?)?;
     m.add_function(wrap_pyfunction!(register_llm, m)?)?;
     m.add_function(wrap_pyfunction!(llm::entrypoint::make_engine, m)?)?;
     m.add_function(wrap_pyfunction!(llm::entrypoint::run_input, m)?)?;
+    m.add_function(wrap_pyfunction!(llm::custom_preprocessor::register_custom_formatter, m)?)?;
+    m.add_function(wrap_pyfunction!(llm::custom_preprocessor::register_custom_tokenizer, m)?)?;
 
     m.add_class::<DistributedRuntime>()?;
     m.add_class::<CancellationToken>()?;

--- a/lib/bindings/python/rust/llm.rs
+++ b/lib/bindings/python/rust/llm.rs
@@ -27,6 +27,7 @@
 use super::*;
 
 pub mod backend;
+pub mod custom_preprocessor;
 pub mod disagg_router;
 pub mod entrypoint;
 pub mod kv;

--- a/lib/bindings/python/rust/llm/custom_preprocessor.rs
+++ b/lib/bindings/python/rust/llm/custom_preprocessor.rs
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Python-based custom preprocessor implementations
+//!
+//! This module implements the CustomPreprocessorFactory trait using Python functions
+//! for formatting and tokenization. It bridges the gap between the Python-free core
+//! library and Python-based custom implementations.
+
+use super::*;
+use anyhow::Result;
+use std::sync::Arc;
+use std::collections::HashMap;
+use pyo3::{PyObject, PyResult, Python, pyfunction};
+use pyo3::types::PyDict;
+use parking_lot::RwLock;
+
+use llm_rs::preprocessor::custom::CustomPreprocessorFactory;
+use llm_rs::preprocessor::prompt::{OAIPromptFormatter, OAIChatLikeRequest};
+use llm_rs::tokenizers::{Encoding, traits::Tokenizer};
+
+/// Global registry for Python preprocessor functions
+static PYTHON_PREPROCESSOR_REGISTRY: once_cell::sync::Lazy<Arc<RwLock<PythonPreprocessorRegistry>>> =
+    once_cell::sync::Lazy::new(|| Arc::new(RwLock::new(PythonPreprocessorRegistry::new())));
+
+/// Registry for managing Python preprocessor functions
+#[derive(Debug, Default)]
+pub struct PythonPreprocessorRegistry {
+    formatters: HashMap<String, PyObject>,
+    tokenizers: HashMap<String, PyObject>,
+}
+
+impl PythonPreprocessorRegistry {
+    pub fn new() -> Self {
+        Self {
+            formatters: HashMap::new(),
+            tokenizers: HashMap::new(),
+        }
+    }
+
+    pub fn register_formatter(&mut self, name: String, formatter: PyObject) {
+        self.formatters.insert(name, formatter);
+    }
+
+    pub fn register_tokenizer(&mut self, name: String, tokenizer: PyObject) {
+        self.tokenizers.insert(name, tokenizer);
+    }
+
+    pub fn get_formatter(&self, name: &str) -> Option<PyObject> {
+        self.formatters.get(name).cloned()
+    }
+
+    pub fn get_tokenizer(&self, name: &str) -> Option<PyObject> {
+        self.tokenizers.get(name).cloned()
+    }
+
+    pub fn has_formatter(&self, name: &str) -> bool {
+        self.formatters.contains_key(name)
+    }
+
+    pub fn has_tokenizer(&self, name: &str) -> bool {
+        self.tokenizers.contains_key(name)
+    }
+}
+
+/// Python-based prompt formatter implementation
+pub struct PythonPromptFormatter {
+    formatter_fn: PyObject,
+    name: String,
+}
+
+impl PythonPromptFormatter {
+    pub fn new(name: String, formatter_fn: PyObject) -> Self {
+        Self { formatter_fn, name }
+    }
+}
+
+impl OAIPromptFormatter for PythonPromptFormatter {
+    fn supports_add_generation_prompt(&self) -> bool {
+        // For now, assume Python formatters support this
+        // Could be made configurable in the future
+        true
+    }
+
+    fn render(&self, req: &dyn OAIChatLikeRequest) -> Result<String> {
+        Python::with_gil(|py| {
+            // Convert the request to a Python dict
+            let request_dict = PyDict::new(py);
+            request_dict.set_item("model", req.model())?;
+
+            // Convert minijinja::Value to string for Python consumption
+            let messages_str = req.messages().to_string();
+            request_dict.set_item("messages", messages_str)?;
+
+            if let Some(tools) = req.tools() {
+                request_dict.set_item("tools", tools.to_string())?;
+            }
+
+            if let Some(tool_choice) = req.tool_choice() {
+                request_dict.set_item("tool_choice", tool_choice.to_string())?;
+            }
+
+            request_dict.set_item("add_generation_prompt", req.should_add_generation_prompt())?;
+
+            if let Some(chat_template_args) = req.chat_template_args() {
+                // Convert HashMap<String, serde_json::Value> to Python dict
+                let py_dict = PyDict::new(py);
+                for (k, v) in chat_template_args.iter() {
+                    py_dict.set_item(k, v.to_string())?;
+                }
+                request_dict.set_item("chat_template_args", py_dict)?;
+            }
+
+            // For now, assume all Python functions are synchronous to keep it simple
+            // TODO: Add async support in the future if needed
+            let result = self.formatter_fn.call1(py, (request_dict,))?;
+
+            let formatted: String = result.extract(py)?;
+            Ok(formatted)
+        }).map_err(|e: PyErr| anyhow::anyhow!("Python formatter '{}' failed: {}", self.name, e))
+    }
+}
+
+/// Python-based tokenizer implementation
+pub struct PythonTokenizer {
+    tokenizer_obj: PyObject,
+    name: String,
+}
+
+impl PythonTokenizer {
+    pub fn new(name: String, tokenizer_obj: PyObject) -> Self {
+        Self { tokenizer_obj, name }
+    }
+}
+
+impl llm_rs::tokenizers::traits::Encoder for PythonTokenizer {
+    fn encode(&self, input: &str) -> Result<Encoding> {
+        Python::with_gil(|py| {
+            // Call the encode method - assume synchronous for simplicity
+            let result = self.tokenizer_obj.call_method1(py, "encode", (input,))?;
+            let token_ids: Vec<u32> = result.extract(py)?;
+            // Return as Sp (SentencePiece) encoding since we don't have HF tokenizer object
+            Ok(Encoding::Sp(token_ids))
+        }).map_err(|e: PyErr| anyhow::anyhow!("Python tokenizer '{}' encode failed: {}", self.name, e))
+    }
+
+    fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
+        // Try batch encode first, fall back to individual encodes
+        let batch_result = Python::with_gil(|py| -> Result<Vec<Vec<u32>>, PyErr> {
+            if let Ok(result) = self.tokenizer_obj.call_method1(py, "encode_batch", (inputs,)) {
+                let batch_token_ids: Vec<Vec<u32>> = result.extract(py)?;
+                Ok(batch_token_ids)
+            } else {
+                Err(PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
+                    "encode_batch method not available"
+                ))
+            }
+        });
+
+        match batch_result {
+            Ok(batch_token_ids) => {
+                Ok(batch_token_ids.into_iter().map(Encoding::Sp).collect())
+            }
+            Err(_) => {
+                // Fall back to individual encoding
+                let mut results = Vec::new();
+                for input in inputs {
+                    results.push(self.encode(input)?);
+                }
+                Ok(results)
+            }
+        }
+    }
+}
+
+impl llm_rs::tokenizers::traits::Decoder for PythonTokenizer {
+    fn decode(&self, token_ids: &[u32], skip_special_tokens: bool) -> Result<String> {
+        Python::with_gil(|py| {
+            // Call the decode method - assume synchronous for simplicity
+            let result = self.tokenizer_obj.call_method1(
+                py,
+                "decode",
+                (token_ids.to_vec(), skip_special_tokens),
+            )?;
+            let decoded: String = result.extract(py)?;
+            Ok(decoded)
+        }).map_err(|e: PyErr| anyhow::anyhow!("Python tokenizer '{}' decode failed: {}", self.name, e))
+    }
+}
+
+impl llm_rs::tokenizers::traits::Tokenizer for PythonTokenizer {}
+
+/// Factory implementation for creating Python-based preprocessors
+pub struct PythonPreprocessorFactory;
+
+impl CustomPreprocessorFactory for PythonPreprocessorFactory {
+    fn create_formatter(&self, name: &str) -> Result<Option<Arc<dyn OAIPromptFormatter>>> {
+        let registry = PYTHON_PREPROCESSOR_REGISTRY.read();
+        if let Some(formatter_fn) = registry.get_formatter(name) {
+            Ok(Some(Arc::new(PythonPromptFormatter::new(
+                name.to_string(),
+                formatter_fn,
+            ))))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn create_tokenizer(&self, name: &str) -> Result<Option<Arc<dyn Tokenizer>>> {
+        let registry = PYTHON_PREPROCESSOR_REGISTRY.read();
+        if let Some(tokenizer_obj) = registry.get_tokenizer(name) {
+            Ok(Some(Arc::new(PythonTokenizer::new(
+                name.to_string(),
+                tokenizer_obj,
+            ))))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn has_formatter(&self, name: &str) -> bool {
+        let registry = PYTHON_PREPROCESSOR_REGISTRY.read();
+        registry.has_formatter(name)
+    }
+
+    fn has_tokenizer(&self, name: &str) -> bool {
+        let registry = PYTHON_PREPROCESSOR_REGISTRY.read();
+        registry.has_tokenizer(name)
+    }
+}
+
+/// Register a Python formatter function
+#[pyfunction]
+pub fn register_custom_formatter(name: String, formatter: PyObject) -> PyResult<()> {
+    let mut registry = PYTHON_PREPROCESSOR_REGISTRY.write();
+    registry.register_formatter(name, formatter);
+    Ok(())
+}
+
+/// Register a Python tokenizer object
+#[pyfunction]
+pub fn register_custom_tokenizer(name: String, tokenizer: PyObject) -> PyResult<()> {
+    let mut registry = PYTHON_PREPROCESSOR_REGISTRY.write();
+    registry.register_tokenizer(name, tokenizer);
+    Ok(())
+}
+
+/// Initialize the Python preprocessor factory (called once at startup)
+pub fn init_python_preprocessor_factory() {
+    llm_rs::preprocessor::custom::register_factory(Arc::new(PythonPreprocessorFactory));
+}

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -57,6 +57,7 @@ hf-hub = { workspace = true }
 humantime = { workspace = true }                           # input/batch
 rand = { workspace = true }
 oneshot = { workspace = true }
+once_cell = { workspace = true }
 parking_lot = "0.12.4"
 prometheus = { workspace = true }
 serde = { workspace = true }

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use crate::common::checked_file::CheckedFile;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 use crate::model_type::{ModelInput, ModelType};
+use crate::preprocessor::custom::CustomPreprocessorConfig;
 use anyhow::{Context, Result};
 use derive_builder::Builder;
 use dynamo_runtime::DistributedRuntime;
@@ -142,6 +143,10 @@ pub struct ModelDeploymentCard {
 
     #[serde(default)]
     pub runtime_config: ModelRuntimeConfig,
+
+    /// Custom preprocessor configuration
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_preprocessor: Option<CustomPreprocessorConfig>,
 
     #[serde(skip)]
     cache_dir: Option<Arc<tempfile::TempDir>>,
@@ -486,6 +491,7 @@ impl ModelDeploymentCard {
             model_input: Default::default(), // set later
             user_data: None,
             runtime_config: ModelRuntimeConfig::default(),
+            custom_preprocessor: None,
             cache_dir: None,
         })
     }
@@ -550,6 +556,7 @@ impl ModelDeploymentCard {
             model_input: Default::default(), // set later
             user_data: None,
             runtime_config: ModelRuntimeConfig::default(),
+            custom_preprocessor: None,
             cache_dir: None,
         })
     }

--- a/lib/llm/src/preprocessor/custom.rs
+++ b/lib/llm/src/preprocessor/custom.rs
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Custom preprocessors with external implementations
+//!
+//! This module provides trait-based interfaces for custom preprocessors that can be
+//! implemented externally (e.g., in the Python bindings crate). The core LLM library
+//! remains Python-free while allowing custom implementations to be injected.
+
+use anyhow::Result;
+use std::sync::Arc;
+use std::collections::HashMap;
+
+use super::prompt::OAIPromptFormatter;
+use crate::tokenizers::traits::Tokenizer;
+
+/// Factory trait for creating custom preprocessors
+///
+/// This trait allows external crates (like bindings) to provide factories
+/// that create custom formatters and tokenizers without the core library
+/// needing to know about the implementation details.
+pub trait CustomPreprocessorFactory: Send + Sync + 'static {
+    /// Create a custom formatter by name
+    fn create_formatter(&self, name: &str) -> Result<Option<Arc<dyn OAIPromptFormatter>>>;
+
+    /// Create a custom tokenizer by name
+    fn create_tokenizer(&self, name: &str) -> Result<Option<Arc<dyn Tokenizer>>>;
+
+    /// Check if a formatter is available
+    fn has_formatter(&self, name: &str) -> bool;
+
+    /// Check if a tokenizer is available
+    fn has_tokenizer(&self, name: &str) -> bool;
+}
+
+/// Configuration for custom preprocessors in ModelDeploymentCard
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CustomPreprocessorConfig {
+    /// Name of the custom formatter (if any)
+    pub formatter_name: Option<String>,
+
+    /// Name of the custom tokenizer (if any)
+    pub tokenizer_name: Option<String>,
+
+    /// Additional configuration parameters
+    pub config: HashMap<String, serde_json::Value>,
+}
+
+impl Default for CustomPreprocessorConfig {
+    fn default() -> Self {
+        Self {
+            formatter_name: None,
+            tokenizer_name: None,
+            config: HashMap::new(),
+        }
+    }
+}
+
+/// Global factory registry
+static FACTORY_REGISTRY: once_cell::sync::Lazy<parking_lot::RwLock<Option<Arc<dyn CustomPreprocessorFactory>>>> =
+    once_cell::sync::Lazy::new(|| parking_lot::RwLock::new(None));
+
+/// Register a global custom preprocessor factory
+///
+/// This should be called once at startup by the bindings crate to register
+/// its factory implementation.
+pub fn register_factory(factory: Arc<dyn CustomPreprocessorFactory>) {
+    let mut registry = FACTORY_REGISTRY.write();
+    *registry = Some(factory);
+}
+
+/// Get the registered factory
+pub fn get_factory() -> Option<Arc<dyn CustomPreprocessorFactory>> {
+    FACTORY_REGISTRY.read().clone()
+}
+
+/// Create a custom formatter if available
+pub fn create_custom_formatter(name: &str) -> Result<Option<Arc<dyn OAIPromptFormatter>>> {
+    if let Some(factory) = get_factory() {
+        factory.create_formatter(name)
+    } else {
+        Ok(None)
+    }
+}
+
+/// Create a custom tokenizer if available
+pub fn create_custom_tokenizer(name: &str) -> Result<Option<Arc<dyn Tokenizer>>> {
+    if let Some(factory) = get_factory() {
+        factory.create_tokenizer(name)
+    } else {
+        Ok(None)
+    }
+}
+
+/// Check if a custom formatter is available
+pub fn has_custom_formatter(name: &str) -> bool {
+    if let Some(factory) = get_factory() {
+        factory.has_formatter(name)
+    } else {
+        false
+    }
+}
+
+/// Check if a custom tokenizer is available
+pub fn has_custom_tokenizer(name: &str) -> bool {
+    if let Some(factory) = get_factory() {
+        factory.has_tokenizer(name)
+    } else {
+        false
+    }
+}


### PR DESCRIPTION
This implementation allows Python-based custom prompt formatting and
tokenization functions to be registered and used per-model, while
maintaining a Python-free core Rust library.

Key features:
- Factory pattern with dependency injection for custom preprocessors
- Per-model configuration via ModelDeploymentCard
- Python registration API for formatters and tokenizers
- Global registry system with thread-safe access
- Integration with existing OAI preprocessor architecture

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
