### PR TITLE
fix: remove CVE introduced by aiconfigurator to runtime containers

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "aiconfigurator==0.2.0",
     "networkx",
     "pandas",
     "pydantic>=2",
@@ -58,6 +59,11 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.uv]
+override-dependencies = [
+    "gradio==5.47.1"
+]
 
 [tool.setuptools]
 packages = ["prefix_data_generator"]

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -376,8 +376,10 @@ RUN uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*cp312*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl \
-    /opt/dynamo/benchmarks && \
-    rm -rf /opt/dynamo/benchmarks
+    && cd /opt/dynamo/benchmarks \
+    && uv pip install . \
+    && cd / \
+    && rm -rf /opt/dynamo/benchmarks
 
 # Setup launch banner
 RUN --mount=type=bind,source=./container/launch_message.txt,target=/opt/dynamo/launch_message.txt \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -378,7 +378,7 @@ RUN uv pip install \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl \
     && cd /opt/dynamo/benchmarks \
     && uv pip install . \
-    && cd / \
+    && cd - \
     && rm -rf /opt/dynamo/benchmarks
 
 # Setup launch banner

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -205,7 +205,7 @@ RUN uv pip install \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl \
     && cd /opt/dynamo/benchmarks \
     && uv pip install . \
-    && cd / \
+    && cd - \
     && rm -rf /opt/dynamo/benchmarks
 
 # Install common and test dependencies

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -203,8 +203,10 @@ RUN uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*cp312*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl \
-    /opt/dynamo/benchmarks && \
-    rm -rf /opt/dynamo/benchmarks
+    && cd /opt/dynamo/benchmarks \
+    && uv pip install . \
+    && cd / \
+    && rm -rf /opt/dynamo/benchmarks
 
 # Install common and test dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -234,8 +234,10 @@ RUN uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*cp312*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl \
-    /opt/dynamo/benchmarks && \
-    rm -rf /opt/dynamo/benchmarks
+    && cd /opt/dynamo/benchmarks \
+    && uv pip install . \
+    && cd / \
+    && rm -rf /opt/dynamo/benchmarks
 
 # Install common and test dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -236,7 +236,7 @@ RUN uv pip install \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl \
     && cd /opt/dynamo/benchmarks \
     && uv pip install . \
-    && cd / \
+    && cd - \
     && rm -rf /opt/dynamo/benchmarks
 
 # Install common and test dependencies

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -252,7 +252,7 @@ RUN uv pip install \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl \
     && cd /opt/dynamo/benchmarks \
     && uv pip install . \
-    && cd / \
+    && cd - \
     && rm -rf /opt/dynamo/benchmarks
 
 # Install common and test dependencies

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -250,8 +250,10 @@ RUN uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*cp312*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl \
-    /opt/dynamo/benchmarks && \
-    rm -rf /opt/dynamo/benchmarks
+    && cd /opt/dynamo/benchmarks \
+    && uv pip install . \
+    && cd / \
+    && rm -rf /opt/dynamo/benchmarks
 
 # Install common and test dependencies
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 accelerate==1.6.0
-aiconfigurator==0.2.0
 aiofiles
 av==15.0.0
 fastapi==0.115.12


### PR DESCRIPTION
#### Overview:
Fixes [CVE](https://github.com/advisories/GHSA-5cpq-9538-jm2j)                                                                          discovered in containers.


The dependency on aiconfigurator brought in `gradio` which we are now overriding using the `tool.uv` section to a version which does not have this cve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated runtime images to install the benchmarks package from local source during build for consistent environments.
  - Adjusted dependencies: added aiconfigurator to the benchmarks package, removed it from base container deps, and pinned gradio to 5.47.1.
  - Outcome: more reliable builds, leaner images, and aligned dependencies across container variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->