### PR TITLE
Draft: Enable vLLM calls to MX in Dynamo

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -186,6 +186,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     engine::add_to_module(m)?;
     parsers::add_to_module(m)?;
     prometheus_names::add_to_module(m)?;
+    llm::hub::add_to_module(m)?;
 
     #[cfg(feature = "block-manager")]
     llm::block_manager::add_to_module(m)?;

--- a/lib/bindings/python/rust/llm.rs
+++ b/lib/bindings/python/rust/llm.rs
@@ -29,6 +29,7 @@ use super::*;
 pub mod backend;
 pub mod disagg_router;
 pub mod entrypoint;
+pub mod hub;
 pub mod kv;
 pub mod local_model;
 pub mod model_card;

--- a/lib/bindings/python/rust/llm/hub.rs
+++ b/lib/bindings/python/rust/llm/hub.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use std::path::PathBuf;
+
+/// Download a model from HuggingFace using ModelExpress client.
+/// 
+/// This function attempts to download the model through the ModelExpress server first.
+/// If the server is unavailable or fails, it falls back to direct download.
+/// 
+/// Args:
+///     model_name: The HuggingFace model identifier (e.g., "meta-llama/Llama-3.3-70B-Instruct")
+///     ignore_weights: If True, skip downloading model weight files
+/// 
+/// Returns:
+///     The local filesystem path to the downloaded model
+#[pyfunction]
+#[pyo3(signature = (model_name, ignore_weights=false))]
+fn from_hf<'p>(
+    py: Python<'p>,
+    model_name: String,
+    ignore_weights: bool,
+) -> PyResult<Bound<'p, PyAny>> {
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let path = dynamo_llm::hub::from_hf(&model_name, ignore_weights)
+            .await
+            .map_err(to_pyerr)?;
+        
+        Ok(path.to_string_lossy().to_string())
+    })
+}
+
+pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(from_hf, m)?)?;
+    Ok(())
+}
+


### PR DESCRIPTION
#### Overview:

Moved MX downloads to before vLLM worker init occurs to prevent double model pulls.

#### Details:

**Dynamo ModelExpress Integration Summary**

The changes integrate ModelExpress as a model caching layer into the VLLM worker startup process, enabling centralized model caching on a shared PVC. This results in significant speedups for subsequent workers (34 minutes → 3.4 minutes in testing) while maintaining robust fallback behavior.

**New File: lib/bindings/python/rust/llm/hub.rs**

Created a Rust-to-Python binding that exposes the from_hf() function to Python code. This function downloads models from HuggingFace using the ModelExpress client library, supports an ignore_weights parameter for partial downloads, and returns the local filesystem path to the cached model. It serves as the bridge between Python VLLM code and the Rust ModelExpress client.

**Modified: components/src/dynamo/vllm/main.py**

Added a new async pull_model() function that pre-downloads models via ModelExpress before VLLM engine initialization. The function uses a 30-minute timeout for large model downloads and updates the VLLM config to use the resolved local cached path if successful. On timeout or failure, it keeps the original HuggingFace model name, allowing VLLM to leverage the shared HF_HUB_CACHE directory that ModelExpress populates. The function is called in the worker startup flow immediately after port configuration.

**Modified: lib/bindings/python/rust/lib.rs**

Added the module registration llm::hub::add_to_module(m)? to expose the new hub functionality to Python, making the from_hf() function available for import in Python code.

**Modified: lib/bindings/python/rust/llm.rs**

Added the module declaration pub mod hub; to enable the Rust compiler to include the new hub module in the build process.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Models are now pre-resolved and cached before VLLM starts, reducing cold-start time and using local paths when available.
  * Automatic fallback to standard downloads on timeouts or failures, with clear warnings to aid troubleshooting.
  * Added a Python-accessible helper to download Hugging Face models via an optimized hub service, returning the local model path.
  * Works transparently with existing configurations; no changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->