### PR TITLE
fix: removing PYTHONPATH in sglang Dockerfile, no need for it anymore

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -226,7 +226,7 @@ COPY components/ /workspace/components/
 # Copy attribution files
 COPY ATTRIBUTION* LICENSE /workspace/
 
-ENV PYTHONPATH=/workspace/examples/sglang/utils:$PYTHONPATH
+ENV PYTHONPATH=/workspace/components/src/dynamo/sglang/utils:$PYTHONPATH
 
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -226,8 +226,6 @@ COPY components/ /workspace/components/
 # Copy attribution files
 COPY ATTRIBUTION* LICENSE /workspace/
 
-ENV PYTHONPATH=/workspace/components/src/dynamo/sglang/utils:$PYTHONPATH
-
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []
 


### PR DESCRIPTION
#### Overview:

Remove PYTHONPATH in the sglang Dockerfile

#### Details:

No longer needed

#### Where should the reviewer start?

container/Dockerfile.sglang line 229

#### Related Issues:

836d74172feaa7b423f235d0c91c9363155b0d3e
