### PR TITLE
fix: add a note for users to use VSWA feature after 0.5.1 release

### DIFF
--- a/components/backends/trtllm/gemma3_sliding_window_attention.md
+++ b/components/backends/trtllm/gemma3_sliding_window_attention.md
@@ -23,6 +23,23 @@ VSWA is a mechanism in which a model’s layers alternate between multiple slidi
 > [!Note]
 > - Ensure that required services such as `nats` and `etcd` are running before starting.
 > - Request access to `google/gemma-3-1b-it` on Hugging Face and set your `HF_TOKEN` environment variable for authentication.
+> - It’s recommended to continue using the VSWA feature with the Dynamo 0.5.0 release and the TensorRT-LLM dynamo runtime image nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.5.0. The 0.5.1 release bundles TensorRT-LLM v1.1.0rc5, which has a regression that breaks VSWA.
+>
+>   To try the latest TensorRT-LLM v1.2.0rc0 with VSWA, apply this patch to main or the latest release branch.
+>   ```bash
+>   # go to the dynamo repo
+>   cd dynamo
+>
+>   # apply the patch from the "vswa-patch-0.5.1" branch
+>   git fetch
+>   git cherry-pick -n 27dbaa19b2f4574bbfb55122661d58437d01de8e
+>
+>   # build the container with the
+>   ./container/build.sh --framework trtllm --tensorrtllm-pip-wheel tensorrt-llm==1.2.0rc0
+>
+>   # run the container after build
+>   ./container/run.sh --framework trtllm -it
+>   ```
 
 ### Aggregated Serving
 ```bash

--- a/components/backends/trtllm/gemma3_sliding_window_attention.md
+++ b/components/backends/trtllm/gemma3_sliding_window_attention.md
@@ -34,7 +34,7 @@ VSWA is a mechanism in which a model’s layers alternate between multiple slidi
 >   git fetch
 >   git cherry-pick -n 27dbaa19b2f4574bbfb55122661d58437d01de8e
 >
->   # build the container with the
+>   # build the container with tensorrt-llm==1.2.0rc0
 >   ./container/build.sh --framework trtllm --tensorrtllm-pip-wheel tensorrt-llm==1.2.0rc0
 >
 >   # run the container after build


### PR DESCRIPTION
#### Overview:

1. add a note for users to be able to use the VSWA feature
2. Provide an temporary WRN for users to try out the latest TRTLLM VSWA feature

#### Details:

 TensorRT-LLM 1.1.0rc5 breaks the VSWA, which is fixed in the 1.2.0rc0.

But 1.2.0rc0 has some issue with the installation: https://nvidia.slack.com/archives/C059LSY62BT/p1759258990143679
and there are some breaking changes introduced into the TensorRT-LLM 1.2.0rc0 
So we will provide a patch for the user to be able to use VSWA with the TensorRT-LLM 1.2.0rc0, so they can use other new dynamo features.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded deployment guidance for Sliding Window Attention with TensorRT-LLM, including version recommendations (0.5.0 recommended; 0.5.1 regression noted).
  - Added step-by-step patch instructions for 1.2.0rc0.
  - Provided a concrete workflow to apply patches, build images, and run the container with example shell commands.
  - Clarified environment setup and version-specific notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->