### PR TITLE
fix: add hf secret to guide

### DIFF
--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -53,6 +53,12 @@ Each backend has deployment examples and configuration options:
 export NAMESPACE=dynamo-cloud
 kubectl create namespace ${NAMESPACE}
 
+# to pull model from HF
+export HF_TOKEN=<Token-Here>
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="$HF_TOKEN" \
+  -n ${NAMESPACE};
+
 # Deploy any example (this uses vLLM with Qwen model using aggregated serving)
 kubectl apply -f components/backends/vllm/deploy/agg.yaml -n ${NAMESPACE}
 


### PR DESCRIPTION
#### Overview:

Adding secret that failed my pod when I was following the instructions. 
#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added instructions to Kubernetes docs for configuring Hugging Face access: create a Kubernetes secret named hf-token-secret containing HF_TOKEN and ensure it’s available in the target namespace.
  * Included steps to export the secret in the deployment namespace for use by workloads pulling models.
  * No changes to the “Model Caching with Fluid” section; content remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->