### PR TITLE
chore: add ucx binaries to path

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -205,7 +205,7 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
 
 # UCX environment variables
 ENV CPATH=/usr/include:$CPATH \
-    PATH=/usr/bin:$PATH \
+    PATH=/usr/bin:/usr/local/ucx/bin:$PATH \
     PKG_CONFIG_PATH=/usr/lib/pkgconfig:$PKG_CONFIG_PATH
 
 ##################################

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -116,12 +116,16 @@ COPY --from=framework /usr/local/lib/lib* /usr/local/lib/
 # Copy nats and etcd from dynamo_base image
 COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
+# Add ETCD and CUDA binaries to PATH so cicc and other CUDA tools are accessible
+ENV PATH=/usr/local/bin/etcd/:/usr/local/cuda/nvvm/bin:$PATH
 
 # Copy UCX from framework image as plugin for NIXL
 # Copy NIXL source from framework image
 # Copy dynamo wheels for gitlab artifacts
 COPY --from=dynamo_base /usr/local/ucx /usr/local/ucx
 COPY --from=dynamo_base $NIXL_PREFIX $NIXL_PREFIX
+ENV PATH=/usr/local/ucx/bin:$PATH
+
 # Copy OpenMPI from framework image
 COPY --from=framework /opt/hpcx/ompi /opt/hpcx/ompi
 # Copy NUMA library from framework image

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -221,6 +221,7 @@ ENV PATH=/usr/local/bin/etcd/:/usr/local/cuda/nvvm/bin:$PATH
 # Copy dynamo wheels for gitlab artifacts
 COPY --from=dynamo_base /usr/local/ucx /usr/local/ucx
 COPY --from=dynamo_base $NIXL_PREFIX $NIXL_PREFIX
+ENV PATH=/usr/local/ucx/bin:$PATH
 
 # Copies vllm, DeepEP, DeepGEMM, PPLX repos (all editable installs) and nvshmem binaries
 COPY --from=framework /opt/vllm /opt/vllm


### PR DESCRIPTION
#### Overview:

Adding missing binaries to path so they can be used. Technically, these are more development related tools but they already exist in the container and can help diagnose runtime problems. Its also very lightweight to add something to path so I am adding it to runtime.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Expanded PATH in container images to include /usr/local/ucx/bin, /usr/local/bin/etcd, and /usr/local/cuda/nvvm/bin, making UCX and CUDA tools readily available at runtime.
  - Standardized PATH precedence to prefer UCX binaries from /usr/local for consistent behavior across environments.

- Style
  - Ensured final CMD lines end with newline characters to prevent formatting warnings and improve tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->