### PR TITLE
fix: namespace not being considered on model delete

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -161,7 +161,7 @@ impl ModelWatcher {
                         }
                     }
                 }
-                WatchEvent::Delete(kv) => match self.handle_delete(&kv).await {
+                WatchEvent::Delete(kv) => match self.handle_delete(&kv, target_namespace, global_namespace).await {
                     Ok(Some(model_name)) => {
                         tracing::info!(model_name, "removed model");
                     }
@@ -178,7 +178,12 @@ impl ModelWatcher {
 
     /// If the last instance running this model has gone delete it.
     /// Returns the name of the model we just deleted, if any.
-    async fn handle_delete(&self, kv: &KeyValue) -> anyhow::Result<Option<String>> {
+    async fn handle_delete(
+        &self,
+        kv: &KeyValue,
+        target_namespace: Option<&str>,
+        global_namespace: bool,
+    ) -> anyhow::Result<Option<String>> {
         let key = kv.key_str()?;
         let card = match self.manager.remove_model_card(key) {
             Some(card) => card,
@@ -188,10 +193,16 @@ impl ModelWatcher {
         };
         let model_name = card.display_name.clone();
         let active_instances = self
-            .entries_for_model(&model_name)
+            .entries_for_model(&model_name, target_namespace, global_namespace)
             .await
             .with_context(|| model_name.clone())?;
         if !active_instances.is_empty() {
+            tracing::debug!(
+                model_name,
+                target_namespace = ?target_namespace,
+                active_instance_count = active_instances.len(),
+                "Model has other active instances, not removing"
+            );
             return Ok(None);
         }
 
@@ -483,9 +494,22 @@ impl ModelWatcher {
         Ok(entries)
     }
 
-    pub async fn entries_for_model(&self, model_name: &str) -> anyhow::Result<Vec<ModelEntry>> {
+    pub async fn entries_for_model(
+        &self,
+        model_name: &str,
+        target_namespace: Option<&str>,
+        global_namespace: bool,
+    ) -> anyhow::Result<Vec<ModelEntry>> {
         let mut all = self.all_entries().await?;
-        all.retain(|entry| entry.name == model_name);
+        all.retain(|entry| {
+            let matches_name = entry.name == model_name;
+            let matches_namespace = global_namespace
+                || target_namespace.is_none()
+                || target_namespace
+                    .map(|target_ns| entry.endpoint_id.namespace == target_ns)
+                    .unwrap_or(true);
+            matches_name && matches_namespace
+        });
         Ok(all)
     }
 }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -161,7 +161,10 @@ impl ModelWatcher {
                         }
                     }
                 }
-                WatchEvent::Delete(kv) => match self.handle_delete(&kv, target_namespace, global_namespace).await {
+                WatchEvent::Delete(kv) => match self
+                    .handle_delete(&kv, target_namespace, global_namespace)
+                    .await
+                {
                     Ok(Some(model_name)) => {
                         tracing::info!(model_name, "removed model");
                     }

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -514,7 +514,7 @@ mod integration_tests {
             );
 
             // Get all model entries for our test model
-            let model_entries = watcher.entries_for_model("test-mdc-model").await.unwrap();
+            let model_entries = watcher.entries_for_model("test-mdc-model", None, true).await.unwrap();
 
             if !model_entries.is_empty() {
                 // For each model entry, we need to find its etcd key and remove it

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -514,7 +514,10 @@ mod integration_tests {
             );
 
             // Get all model entries for our test model
-            let model_entries = watcher.entries_for_model("test-mdc-model", None, true).await.unwrap();
+            let model_entries = watcher
+                .entries_for_model("test-mdc-model", None, true)
+                .await
+                .unwrap();
 
             if !model_entries.is_empty() {
                 // For each model entry, we need to find its etcd key and remove it


### PR DESCRIPTION
#### Overview:

Fixes namespace scoping bug in model deletion where deleting the last instance in one namespace would fail to remove the model if instances existed in other namespaces.

#### Details:

- Updated `handle_delete()` to accept and use `target_namespace` and `global_namespace` parameters
- Modified `entries_for_model()` to filter model instances by namespace
- Updated `watch()` to pass namespace context to `handle_delete()`

#### Where should the reviewer start?

- [lib/llm/src/discovery/watcher.rs](lib/llm/src/discovery/watcher.rs#L164) - namespace parameter passing in `watch()`
- [lib/llm/src/discovery/watcher.rs](lib/llm/src/discovery/watcher.rs#L491-L508) - namespace filtering logic in `entries_for_model()`

#### Related Issues:

- Addresses #3353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Namespace-aware model discovery and deletion, ensuring actions respect target and global namespaces.
- Bug Fixes
  - Prevents removing a model when other active instances still exist, improving reliability in multi-instance setups.
- Tests
  - Updated tests to cover namespace-scoped discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->