### PR TITLE
fix: remove VSWA user prompts, since we need a lot more updates to get it working 

### DIFF
--- a/components/backends/trtllm/gemma3_sliding_window_attention.md
+++ b/components/backends/trtllm/gemma3_sliding_window_attention.md
@@ -24,22 +24,6 @@ VSWA is a mechanism in which a model’s layers alternate between multiple slidi
 > - Ensure that required services such as `nats` and `etcd` are running before starting.
 > - Request access to `google/gemma-3-1b-it` on Hugging Face and set your `HF_TOKEN` environment variable for authentication.
 > - It’s recommended to continue using the VSWA feature with the Dynamo 0.5.0 release and the TensorRT-LLM dynamo runtime image nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.5.0. The 0.5.1 release bundles TensorRT-LLM v1.1.0rc5, which has a regression that breaks VSWA.
->
->   To try the latest TensorRT-LLM v1.2.0rc0 with VSWA, apply this patch to main or the latest release branch.
->   ```bash
->   # go to the dynamo repo
->   cd dynamo
->
->   # apply the patch from the "vswa-patch-0.5.1" branch
->   git fetch
->   git cherry-pick -n 27dbaa19b2f4574bbfb55122661d58437d01de8e
->
->   # build the container with tensorrt-llm==1.2.0rc0
->   ./container/build.sh --framework trtllm --tensorrtllm-pip-wheel tensorrt-llm==1.2.0rc0
->
->   # run the container after build
->   ./container/run.sh --framework trtllm -it
->   ```
 
 ### Aggregated Serving
 ```bash


### PR DESCRIPTION
#### Overview:

after this PR, https://github.com/ai-dynamo/dynamo/pull/3218 , trtllm will need to run install tensorrt script, 
In the TensorRT-LLM 1.2.0rc0 install tensorrt script, the tensorrt's CUDA version has bumped to 13.0 

dynamo image need to upgrade base image to cuda 13.0 to be able to install TensorRT-LLM 1.2.0rc0. 

#### Details:

remove the user prompt, since that would not really work now.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Streamlined Gemma 3 VSWA guide by removing upgrade/patch steps and build/run commands tied to a prior TensorRT-LLM version.
  - Retained and clarified Aggregated Serving sections for continuity.
  - Users now see a shorter page focused on current serving information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->