### PR TITLE
fix: Fix sglang imports for v0.5.3rc0 and update Dockerfile.sglang version to match

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/multimodal_encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal_encode_worker_handler.py
@@ -5,7 +5,7 @@ import logging
 from typing import AsyncIterator
 
 import torch
-from sglang.srt.conversation import chat_templates
+from sglang.srt.parser.conversation import chat_templates
 from transformers import AutoImageProcessor, AutoModel, AutoTokenizer
 
 import dynamo.nixl_connect as connect

--- a/components/src/dynamo/sglang/utils/multimodal_chat_processor.py
+++ b/components/src/dynamo/sglang/utils/multimodal_chat_processor.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from sglang.srt.conversation import chat_templates
+from sglang.srt.parser.conversation import chat_templates
 
 logger = logging.getLogger(__name__)
 

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -14,7 +14,7 @@ ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
 
 # Make sure to update the dependency version in pyproject.toml when updating this
-ARG SGLANG_VERSION="0.5.0rc2"
+ARG SGLANG_VERSION="0.5.3rc0"
 
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

(1) Update sglang version in Dockerfile.sglang to v0.5.3rc0 to match [pyproject.toml](https://github.com/ai-dynamo/dynamo/blob/498e6668e798483d3e47ef97199b4394e4d25dfd/pyproject.toml#L63) and [Dockerfile.sglang-wideep](https://github.com/ai-dynamo/dynamo/blob/498e6668e798483d3e47ef97199b4394e4d25dfd/container/Dockerfile.sglang-wideep#L4)
(2) Update import that changed across versions

Fixes this import error on trying `dynamo.sglang`:
```bash
  File "/home/rmccormick/dynamo/venv/sglang/lib/python3.12/site-packages/dynamo/sglang/request_handlers/multimodal_encode_worker_handler.py", line 8, in <module>
    from sglang.srt.conversation import chat_templates
ModuleNotFoundError: No module named 'sglang.srt.conversation'
```

Repro steps on main:
```bash
pushd
cd lib/bindings/python
maturin develop --uv

popd
uv pip install .[sglang]

python -m dynamo.sglang
```

