### PR TITLE
feat: Add PoC of sglang metrics server (default port 30000)

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -6,10 +6,10 @@ import logging
 import signal
 import sys
 
-import sglang as sgl
 import uvloop
-from sglang.srt.utils import get_ip, launch_dummy_health_check_server
+from sglang.srt.utils import launch_dummy_health_check_server
 
+import sglang as sgl
 from dynamo.llm import ModelInput, ModelType
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -8,6 +8,7 @@ import sys
 
 import sglang as sgl
 import uvloop
+from sglang.srt.utils import get_ip, launch_dummy_health_check_server
 
 from dynamo.llm import ModelInput, ModelType
 from dynamo.runtime import DistributedRuntime, dynamo_worker
@@ -66,6 +67,10 @@ async def init(runtime: DistributedRuntime, config: Config):
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
     engine = sgl.Engine(server_args=server_args)
+    if server_args.enable_metrics:
+        launch_dummy_health_check_server(
+            server_args.host, server_args.port, server_args.enable_metrics
+        )
 
     component = runtime.namespace(dynamo_args.namespace).component(
         dynamo_args.component


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

@keivenchang is looking at exposing full set of SGLang metrics when running through dynamo (`python -m dynamo.sglang ...`), and ideally without having to 1:1 map and redefine every single metric SGLang has, and constantly maintain/update everytime a new metric is added.

This exposes the built-in sglang metrics server when running dynamo+sglang.

#### Details:

Build with these local changes
```
pushd lib/bindings/python
maturin develop --uv

popd
uv pip install .[sglang]
```

Run with these changes
```
python -m dynamo.frontend &

# KEY: Set --enable-metrics
python -m dynamo.sglang --model-path Qwen/Qwen3-0.6B --enable-metrics &

# See server come up in sglang worker log output
# 2025-10-03T17:19:07.084539Z  INFO utils.launch_dummy_health_check_server: Dummy health check server scheduled on existing loop at 127.0.0.1:30000   

# Send inference request
curl localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '
{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [{"role": "user", "content": "Write me a DND campaign"}],
  "stream": true,
  "max_tokens": 2,
  "ignore_eos": true
}'

# Check metrics
curl localhost:30000/metrics
```

NOTE: The metrics server output seems to be empty until a single inference request has been received.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically starts a lightweight health check server when metrics are enabled.
  * Uses the configured host and port from existing settings for the health check server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->