### PR TITLE
feat: Set instance endpoint status and endpoint health status

### DIFF
--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -140,7 +140,11 @@ impl EndpointConfigBuilder {
             };
             tracing::debug!(endpoint_name = %endpoint_name, "Registering endpoint health check target");
             let guard = system_health.lock().unwrap();
-            guard.register_health_check_target(&endpoint_name, instance, health_check_payload.clone());
+            guard.register_health_check_target(
+                &endpoint_name,
+                instance,
+                health_check_payload.clone(),
+            );
             if let Some(notifier) = guard.get_endpoint_health_check_notifier(&endpoint_name) {
                 handler.set_endpoint_health_check_notifier(notifier)?;
             }

--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -138,10 +138,10 @@ impl EndpointConfigBuilder {
                 instance_id: lease_id,
                 transport: TransportType::NatsTcp(subject.clone()),
             };
-            tracing::debug!(subject = %subject, "Registering endpoint health check target");
+            tracing::debug!(endpoint_name = %endpoint_name, "Registering endpoint health check target");
             let guard = system_health.lock().unwrap();
-            guard.register_health_check_target(&subject, instance, health_check_payload.clone());
-            if let Some(notifier) = guard.get_endpoint_health_check_notifier(&subject) {
+            guard.register_health_check_target(&endpoint_name, instance, health_check_payload.clone());
+            if let Some(notifier) = guard.get_endpoint_health_check_notifier(&endpoint_name) {
                 handler.set_endpoint_health_check_notifier(notifier)?;
             }
         }

--- a/lib/runtime/src/system_health.rs
+++ b/lib/runtime/src/system_health.rs
@@ -92,7 +92,20 @@ impl SystemHealth {
 
     pub fn set_endpoint_health_status(&self, endpoint: &str, status: HealthStatus) {
         let mut endpoint_health = self.endpoint_health.write().unwrap();
-        endpoint_health.insert(endpoint.to_string(), status);
+        endpoint_health.insert(endpoint.to_string(), status.clone());
+
+        // Parse endpoint name to extract base endpoint name
+        // Format: namespace.component.endpoint-instance_id
+        // Example: sglang-agg_backend.generate-5e7b99a870acae05
+        // We want to extract "generate" and set its status too
+        if let Some(dot_pos) = endpoint.rfind('.') {
+            let endpoint_part = &endpoint[dot_pos + 1..];
+            // Remove instance ID suffix (everything after the last hyphen)
+            if let Some(dash_pos) = endpoint_part.rfind('-') {
+                let base_endpoint = &endpoint_part[..dash_pos];
+                endpoint_health.insert(base_endpoint.to_string(), status.clone());
+            }
+        }
     }
 
     /// Returns the overall health status and endpoint health statuses

--- a/lib/runtime/src/system_health.rs
+++ b/lib/runtime/src/system_health.rs
@@ -92,20 +92,7 @@ impl SystemHealth {
 
     pub fn set_endpoint_health_status(&self, endpoint: &str, status: HealthStatus) {
         let mut endpoint_health = self.endpoint_health.write().unwrap();
-        endpoint_health.insert(endpoint.to_string(), status.clone());
-
-        // Parse endpoint name to extract base endpoint name
-        // Format: namespace.component.endpoint-instance_id
-        // Example: sglang-agg_backend.generate-5e7b99a870acae05
-        // We want to extract "generate" and set its status too
-        if let Some(dot_pos) = endpoint.rfind('.') {
-            let endpoint_part = &endpoint[dot_pos + 1..];
-            // Remove instance ID suffix (everything after the last hyphen)
-            if let Some(dash_pos) = endpoint_part.rfind('-') {
-                let base_endpoint = &endpoint_part[..dash_pos];
-                endpoint_health.insert(base_endpoint.to_string(), status.clone());
-            }
-        }
+        endpoint_health.insert(endpoint.to_string(), status);
     }
 
     /// Returns the overall health status and endpoint health statuses


### PR DESCRIPTION
#### Overview:

This PR enhances the endpoint health status management in the SystemHealth module to automatically set health status for both endpoint instances and their corresponding base endpoints. This ensures that health status is properly propagated for both instance-specific endpoints and their base endpoint names.

Env
```
DYN_SYSTEM_ENABLED=true
DYN_SYSTEM_PORT=9090
DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS="generate"
```
Before:
```
# Check worker health after known failure
$ curl localhost:${DYN_SYSTEM_PORT}/health
...
"generate" - healthy   # ISSUE 1 - we don't update health of 'generate' endpoint, but we check it as the signal
...
"generate_<instance_id>" - not healthy   # ISSUE 2 - we have a separate endpoint that we update but don't check
```
After:
```
# Check worker health after known failure
$ curl localhost:${DYN_SYSTEM_PORT}/health
...
"generate" - NOT healthy  # FIX 1 - we update the health of 'generate' endpoint
# FIX 2 - we remove the extra instance-specific endpoint here since there's only 1 per DRT/pod 
```

#### Details:

The changes modify the set_endpoint_health_status method in lib/runtime/src/system_health.rs to:
1. Parse endpoint names to extract the base endpoint name from the full endpoint identifier
Endpoint format: namespace.component.endpoint-instance_id
Example: sglang-agg_backend.generate-5e7b99a870acae05
2. Set health status for both levels:
Sets health status for the full endpoint instance (with instance ID)
Automatically extracts and sets the same health status for the base endpoint name (e.g., "generate")
3. Handle instance ID suffix removal: The implementation identifies and removes the instance ID suffix (everything after the last hyphen) to derive the base endpoint name
This change ensures that health checks and status queries can work at both the instance level and the base endpoint level, providing more flexibility in health monitoring and status reporting.


#### Where should the reviewer start?

lib/runtime/src/system_health.rs (lines 93-109): Focus on the set_endpoint_health_status method implementation
Review the endpoint name parsing logic
Verify the string manipulation for extracting base endpoint names is robust
Consider edge cases for endpoint naming conventions
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-702


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Health status set for an instance-specific endpoint now also updates the corresponding base endpoint, improving aggregated visibility in health views.
- Bug Fixes
  - Ensures endpoint health updates are consistently reflected across related endpoints, reducing mismatches in monitoring dashboards.
- Chores
  - No changes to the public API; behavior refined to improve status propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->