### PR TITLE
fix: benchmark reinstall includes cve

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -240,13 +240,7 @@ COPY tests /workspace/tests
 COPY benchmarks /workspace/benchmarks
 COPY examples /workspace/examples
 COPY deploy /workspace/deploy
-RUN uv pip install /workspace/benchmarks
 
-# Copy benchmarks, backends and tests for CI
-COPY tests /workspace/tests
-COPY benchmarks /workspace/benchmarks
-COPY deploy /workspace/deploy
-COPY components/backends/sglang /workspace/components/backends/sglang
 # Copy attribution files
 COPY ATTRIBUTION* LICENSE /workspace/
 


### PR DESCRIPTION
#### Overview:

While this was already fixed on [main](https://github.com/ai-dynamo/dynamo/commit/836d74172feaa7b423f235d0c91c9363155b0d3e#diff-b793e5fb7c3b7b470bc209a8a28728858c101da9e4509d5d23975388a3188559) this was missed on the release branch because the cherry-pick from `main` did not see this line as existing.


