### PR TITLE
Update groveTerminationDelay to ensure it doesn't trigger for now

### DIFF
--- a/deploy/cloud/helm/platform/values.yaml
+++ b/deploy/cloud/helm/platform/values.yaml
@@ -74,7 +74,7 @@ dynamo-operator:
   # Core Dynamo platform configuration
   dynamo:
     # -- How long to wait before forcefully terminating Grove instances
-    groveTerminationDelay: 15m
+    groveTerminationDelay: 24h
 
     # Internal utility images used by the platform
     internalImages:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

This pr updates the groveTermination delay to 24h so that the user has to "opt in" to it. This is to ensure the default setting matches existing behavior for k8s, see equivalent [pr in Grove ](https://github.com/NVIDIA/grove/pull/199) for more details


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased Grove instance termination grace period from 15 minutes to 24 hours. This extends the wait time before forced shutdowns, reducing disruptions during deployments and maintenance.
  * Users may experience improved session persistence and fewer unexpected interruptions.
  * Operators should expect longer teardown windows and adjust scaling and cleanup workflows accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->