### PR TITLE
feat: Connect DYN_LOG level to TLLM_LOG_LEVEL

### DIFF
--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -10,14 +10,16 @@ import sys
 
 # Configure TLLM_LOG_LEVEL before importing tensorrt_llm
 # This must happen before any tensorrt_llm imports
-if "TLLM_LOG_LEVEL" not in os.environ:
+if (
+    "TLLM_LOG_LEVEL" not in os.environ
+    and os.getenv("DYN_SKIP_TRTLLM_LOG_FORMATTING") not in ("1", "true", "TRUE")
+):
     # This import is safe because it doesn't trigger tensorrt_llm imports
     from dynamo.runtime.logging import map_dyn_log_to_tllm_level
 
     dyn_log = os.environ.get("DYN_LOG", "info")
     tllm_level = map_dyn_log_to_tllm_level(dyn_log)
     os.environ["TLLM_LOG_LEVEL"] = tllm_level
-
 import uvloop
 from tensorrt_llm.llmapi import (
     BuildConfig,

--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -8,6 +8,16 @@ import os
 import signal
 import sys
 
+# Configure TLLM_LOG_LEVEL before importing tensorrt_llm
+# This must happen before any tensorrt_llm imports
+if "TLLM_LOG_LEVEL" not in os.environ:
+    # This import is safe because it doesn't trigger tensorrt_llm imports
+    from dynamo.runtime.logging import map_dyn_log_to_tllm_level
+    
+    dyn_log = os.environ.get("DYN_LOG", "info")
+    tllm_level = map_dyn_log_to_tllm_level(dyn_log)
+    os.environ["TLLM_LOG_LEVEL"] = tllm_level
+
 import uvloop
 from tensorrt_llm.llmapi import (
     BuildConfig,

--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -10,10 +10,9 @@ import sys
 
 # Configure TLLM_LOG_LEVEL before importing tensorrt_llm
 # This must happen before any tensorrt_llm imports
-if (
-    "TLLM_LOG_LEVEL" not in os.environ
-    and os.getenv("DYN_SKIP_TRTLLM_LOG_FORMATTING") not in ("1", "true", "TRUE")
-):
+if "TLLM_LOG_LEVEL" not in os.environ and os.getenv(
+    "DYN_SKIP_TRTLLM_LOG_FORMATTING"
+) not in ("1", "true", "TRUE"):
     # This import is safe because it doesn't trigger tensorrt_llm imports
     from dynamo.runtime.logging import map_dyn_log_to_tllm_level
 

--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -13,7 +13,7 @@ import sys
 if "TLLM_LOG_LEVEL" not in os.environ:
     # This import is safe because it doesn't trigger tensorrt_llm imports
     from dynamo.runtime.logging import map_dyn_log_to_tllm_level
-    
+
     dyn_log = os.environ.get("DYN_LOG", "info")
     tllm_level = map_dyn_log_to_tllm_level(dyn_log)
     os.environ["TLLM_LOG_LEVEL"] = tllm_level

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -223,16 +223,6 @@ def map_dyn_log_to_tllm_level(dyn_log_value: str) -> str:
 
 
 def configure_trtllm_logging(dyn_level: int):
-    """
-    TensorRT-LLM uses the TLLM_LOG_LEVEL environment variable to control logging.
-    This function maps the DYN_LOG level to the appropriate TLLM_LOG_LEVEL value.
-
-    Note: This function sets the environment variable, but TensorRT-LLM reads it
-    during import. The TensorRT-LLM backend main.py sets TLLM_LOG_LEVEL before
-    importing tensorrt_llm to ensure it takes effect. This function is kept for
-    consistency with other backend logging configuration.
-    """
-def configure_trtllm_logging(dyn_level: int):
     # Only set TLLM_LOG_LEVEL if it's not already set
     # This allows users to override it explicitly if needed
     if "TLLM_LOG_LEVEL" not in os.environ:

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -210,13 +210,13 @@ def map_dyn_log_to_tllm_level(dyn_log_value: str) -> str:
 
     # Map DYN_LOG levels to TLLM_LOG_LEVEL
     level_mapping = {
-        "debug": "VERBOSE",
+        "debug": "DEBUG",
         "info": "INFO",
         "warn": "WARNING",
         "warning": "WARNING",
         "error": "ERROR",
         "critical": "ERROR",
-        "trace": "INFO",
+        "trace": "TRACE",
     }
 
     return level_mapping.get(base_level, "INFO")

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -232,11 +232,12 @@ def configure_trtllm_logging(dyn_level: int):
     importing tensorrt_llm to ensure it takes effect. This function is kept for
     consistency with other backend logging configuration.
     """
+def configure_trtllm_logging(dyn_level: int):
     # Only set TLLM_LOG_LEVEL if it's not already set
     # This allows users to override it explicitly if needed
     if "TLLM_LOG_LEVEL" not in os.environ:
-        dyn_log = os.environ.get("DYN_LOG", "info")
-        tllm_level = map_dyn_log_to_tllm_level(dyn_log)
+        dyn_level_name = logging.getLevelName(dyn_level)
+        tllm_level = map_dyn_log_to_tllm_level(dyn_level_name)
         os.environ["TLLM_LOG_LEVEL"] = tllm_level
         logging.debug(f"Set TLLM_LOG_LEVEL to {tllm_level} based on DYN_LOG")
 

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -198,16 +198,16 @@ def configure_vllm_logging(dyn_level: int):
 def map_dyn_log_to_tllm_level(dyn_log_value: str) -> str:
     """
     Map DYN_LOG string value to TensorRT-LLM log level.
-    
+
     Args:
         dyn_log_value: The DYN_LOG environment variable value (e.g., "debug", "info,module::path=trace")
-    
+
     Returns:
         The corresponding TLLM_LOG_LEVEL value (e.g., "VERBOSE", "INFO")
     """
     # Extract the base level (handle cases like "debug,module::path=trace")
     base_level = dyn_log_value.lower().split(",")[0].strip()
-    
+
     # Map DYN_LOG levels to TLLM_LOG_LEVEL
     level_mapping = {
         "debug": "VERBOSE",
@@ -218,7 +218,7 @@ def map_dyn_log_to_tllm_level(dyn_log_value: str) -> str:
         "critical": "ERROR",
         "trace": "INFO",
     }
-    
+
     return level_mapping.get(base_level, "INFO")
 
 
@@ -226,7 +226,7 @@ def configure_trtllm_logging(dyn_level: int):
     """
     TensorRT-LLM uses the TLLM_LOG_LEVEL environment variable to control logging.
     This function maps the DYN_LOG level to the appropriate TLLM_LOG_LEVEL value.
-    
+
     Note: This function sets the environment variable, but TensorRT-LLM reads it
     during import. The TensorRT-LLM backend main.py sets TLLM_LOG_LEVEL before
     importing tensorrt_llm to ensure it takes effect. This function is kept for

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -97,6 +97,8 @@ def configure_dynamo_logging(
         configure_vllm_logging(dyn_level)
     if not get_bool_env_var("DYN_SKIP_SGLANG_LOG_FORMATTING"):
         configure_sglang_logging(dyn_level)
+    if not get_bool_env_var("DYN_SKIP_TRTLLM_LOG_FORMATTING"):
+        configure_trtllm_logging(dyn_level)
 
     # loggers that should be configured to ERROR
     error_loggers = ["tag"]
@@ -191,6 +193,52 @@ def configure_vllm_logging(dyn_level: int):
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
         json.dump(vllm_config, f)
         os.environ["VLLM_LOGGING_CONFIG_PATH"] = f.name
+
+
+def map_dyn_log_to_tllm_level(dyn_log_value: str) -> str:
+    """
+    Map DYN_LOG string value to TensorRT-LLM log level.
+    
+    Args:
+        dyn_log_value: The DYN_LOG environment variable value (e.g., "debug", "info,module::path=trace")
+    
+    Returns:
+        The corresponding TLLM_LOG_LEVEL value (e.g., "VERBOSE", "INFO")
+    """
+    # Extract the base level (handle cases like "debug,module::path=trace")
+    base_level = dyn_log_value.lower().split(",")[0].strip()
+    
+    # Map DYN_LOG levels to TLLM_LOG_LEVEL
+    level_mapping = {
+        "debug": "VERBOSE",
+        "info": "INFO",
+        "warn": "WARNING",
+        "warning": "WARNING",
+        "error": "ERROR",
+        "critical": "ERROR",
+        "trace": "INFO",
+    }
+    
+    return level_mapping.get(base_level, "INFO")
+
+
+def configure_trtllm_logging(dyn_level: int):
+    """
+    TensorRT-LLM uses the TLLM_LOG_LEVEL environment variable to control logging.
+    This function maps the DYN_LOG level to the appropriate TLLM_LOG_LEVEL value.
+    
+    Note: This function sets the environment variable, but TensorRT-LLM reads it
+    during import. The TensorRT-LLM backend main.py sets TLLM_LOG_LEVEL before
+    importing tensorrt_llm to ensure it takes effect. This function is kept for
+    consistency with other backend logging configuration.
+    """
+    # Only set TLLM_LOG_LEVEL if it's not already set
+    # This allows users to override it explicitly if needed
+    if "TLLM_LOG_LEVEL" not in os.environ:
+        dyn_log = os.environ.get("DYN_LOG", "info")
+        tllm_level = map_dyn_log_to_tllm_level(dyn_log)
+        os.environ["TLLM_LOG_LEVEL"] = tllm_level
+        logging.debug(f"Set TLLM_LOG_LEVEL to {tllm_level} based on DYN_LOG")
 
 
 def get_bool_env_var(name: str, default: str = "false") -> bool:


### PR DESCRIPTION
#### Overview:

This fixes the logging within TRTLLM engine. The code will set TLLM_LOG_LEVEL=INFO by default which would allow the print_iter_log to appear. 

Without this TRTLLM logs will not appear during inference. 

### Before

```

data: {"id":"chatcmpl-d043cc61-c996-4baf-b2cb-7b9b323f59b9","choices":[{"index":0,"delta":{"content":" me","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null}}],"created":1759789572,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

data: {"id":"chatcmpl-d043cc61-c996-4baf-b2cb-7b9b323f59b9","choices":[{"index":0,"delta":{"content":" start","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null}}],"created":1759789572,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

data: {"id":"chatcmpl-d043cc61-c996-4baf-b2cb-7b9b323f59b9","choices":[{"index":0,"delta":{"content":" by","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null}}],"created":1759789572,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

data: {"id":"chatcmpl-d043cc61-c996-4baf-b2cb-7b9b323f59b9","choices":[{"index":0,"delta":{"content":" recalling","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null},"finish_reason":"length"}],"created":1759789572,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

data: [DONE]
```

### After

```
[10/07/2025-00:29:01] [TRT-LLM] [I] iter = 94, global_rank = 0, rank = 0, currank_total_requests = 0/0, host_step_time = 2.382040023803711ms, prev_device_step_time = 2.4019839763641357ms, timestamp = 2025-10-07 00:29:01, num_scheduled_requests: 1, states = {'num_ctx_requests': 0, 'num_ctx_tokens': 0, 'num_generation_tokens': 1}
data: {"id":"chatcmpl-51e76f86-db3a-4092-bf60-94372ccaf7b4","choices":[{"index":0,"delta":{"content":".","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null}}],"created":1759796941,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

[10/07/2025-00:29:01] [TRT-LLM] [I] iter = 95, global_rank = 0, rank = 0, currank_total_requests = 0/0, host_step_time = 2.3653507232666016ms, prev_device_step_time = 2.436768054962158ms, timestamp = 2025-10-07 00:29:01, num_scheduled_requests: 1, states = {'num_ctx_requests': 0, 'num_ctx_tokens': 0, 'num_generation_tokens': 1}
data: {"id":"chatcmpl-51e76f86-db3a-4092-bf60-94372ccaf7b4","choices":[{"index":0,"delta":{"content":" Let","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null}}],"created":1759796941,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

[10/07/2025-00:29:01] [TRT-LLM] [I] iter = 96, global_rank = 0, rank = 0, currank_total_requests = 0/0, host_step_time = 2.4323463439941406ms, prev_device_step_time = 2.398848056793213ms, timestamp = 2025-10-07 00:29:01, num_scheduled_requests: 1, states = {'num_ctx_requests': 0, 'num_ctx_tokens': 0, 'num_generation_tokens': 1}
data: {"id":"chatcmpl-51e76f86-db3a-4092-bf60-94372ccaf7b4","choices":[{"index":0,"delta":{"content":" me","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null}}],"created":1759796941,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

[10/07/2025-00:29:01] [TRT-LLM] [I] iter = 97, global_rank = 0, rank = 0, currank_total_requests = 0/0, host_step_time = 2.274036407470703ms, prev_device_step_time = 2.4051520824432373ms, timestamp = 2025-10-07 00:29:01, num_scheduled_requests: 1, states = {'num_ctx_requests': 0, 'num_ctx_tokens': 0, 'num_generation_tokens': 1}
data: {"id":"chatcmpl-51e76f86-db3a-4092-bf60-94372ccaf7b4","choices":[{"index":0,"delta":{"content":" start","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null}}],"created":1759796941,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

[10/07/2025-00:29:01] [TRT-LLM] [I] iter = 98, global_rank = 0, rank = 0, currank_total_requests = 0/0, host_step_time = 2.378702163696289ms, prev_device_step_time = 2.430624008178711ms, timestamp = 2025-10-07 00:29:01, num_scheduled_requests: 1, states = {'num_ctx_requests': 0, 'num_ctx_tokens': 0, 'num_generation_tokens': 1}
data: {"id":"chatcmpl-51e76f86-db3a-4092-bf60-94372ccaf7b4","choices":[{"index":0,"delta":{"content":" by","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null}}],"created":1759796941,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

[10/07/2025-00:29:01] [TRT-LLM] [I] iter = 99, global_rank = 0, rank = 0, currank_total_requests = 0/0, host_step_time = 2.4247169494628906ms, prev_device_step_time = 2.4163520336151123ms, timestamp = 2025-10-07 00:29:01, num_scheduled_requests: 1, states = {'num_ctx_requests': 0, 'num_ctx_tokens': 0, 'num_generation_tokens': 1}
data: {"id":"chatcmpl-51e76f86-db3a-4092-bf60-94372ccaf7b4","choices":[{"index":0,"delta":{"content":" recalling","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null},"finish_reason":"length"}],"created":1759796941,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

data: [DONE]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically aligns TensorRT-LLM logging level with your existing DYN_LOG setting at startup for consistent logs.
  - Respects any pre-set TLLM_LOG_LEVEL and falls back to sensible defaults when unspecified.
  - Supports comma-delimited DYN_LOG values and maps them to appropriate TensorRT-LLM levels.
  - Integrates with the runtime logging setup by default; can be disabled via an environment flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->