### PR TITLE
feat(etcd): Version the etcd keys

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -594,7 +594,7 @@ fn bind_tcp_port(port: u16) -> std::io::Result<socket2::Socket> {
 }
 
 fn make_port_key(namespace: &str, node_ip: IpAddr, port: u16) -> anyhow::Result<String> {
-    Ok(format!("dyn://{namespace}/ports/{node_ip}/{port}"))
+    Ok(format!("v1/{namespace}/ports/{node_ip}/{port}"))
 }
 
 fn local_ip() -> Result<IpAddr, local_ip_address::Error> {

--- a/lib/bindings/python/rust/planner.rs
+++ b/lib/bindings/python/rust/planner.rs
@@ -102,7 +102,7 @@ impl VirtualConnectorCoordinator {
         let prefix = root_key(&self.0.namespace);
         let inner = self.0.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let kv_cache = KvCache::new(inner.etcd_client.clone(), prefix, HashMap::new())
+            let kv_cache = KvCache::new(inner.etcd_client.clone(), "v1", prefix, HashMap::new())
                 .await
                 .map_err(to_pyerr)?;
             *inner.kv_cache.lock() = Some(Arc::new(kv_cache));

--- a/lib/bindings/python/rust/planner.rs
+++ b/lib/bindings/python/rust/planner.rs
@@ -497,5 +497,5 @@ fn load(a: &AtomicUsize) -> usize {
 }
 
 fn root_key(namespace: &str) -> String {
-    format!("/{namespace}/planner/")
+    format!("{namespace}/planner/")
 }

--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -8,4 +8,4 @@ mod watcher;
 pub use watcher::{ModelUpdate, ModelWatcher};
 
 /// The root etcd path for KV Router registrations
-pub const KV_ROUTERS_ROOT_PATH: &str = "kv_routers";
+pub const KV_ROUTERS_ROOT_PATH: &str = "v1/kv_routers";

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -584,16 +584,6 @@ mod tests {
     #[test]
     fn test_etcd_key_extract() {
         let input = format!(
-            "v1/{}/dynamo/backend/generate/694d9981145a61ad",
-            model_card::ROOT_PATH
-        );
-        let (endpoint_id, instance_id) = etcd_key_extract(&input).unwrap();
-        assert_eq!(endpoint_id.namespace, "dynamo");
-        assert_eq!(endpoint_id.component, "backend");
-        assert_eq!(endpoint_id.name, "generate");
-        assert_eq!(instance_id, "694d9981145a61ad");
-
-        let input = format!(
             "{}/dynamo/backend/generate/694d9981145a61ad",
             model_card::ROOT_PATH
         );

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -318,7 +318,6 @@ impl ModelWatcher {
                 namespace = endpoint_id.namespace,
                 "New endpoint for existing model"
             );
-            //self.notify_on_model.notify_waiters();
             return Ok(());
         }
 
@@ -413,7 +412,7 @@ impl ModelWatcher {
             .await?;
             let engine = Arc::new(push_router);
             self.manager
-                .add_embeddings_model(&model_entry.name, engine)?;
+                .add_embeddings_model(card.name(), checksum, engine)?;
         } else if card.model_input == ModelInput::Text && card.model_type.supports_chat() {
             // Case 3: Text + Chat
             let push_router = PushRouter::<
@@ -560,26 +559,20 @@ impl ModelWatcher {
 /// The ModelDeploymentCard is published in etcd with a key like "v1/mdc/dynamo/backend/generate/694d9981145a61ad".
 /// Extract the EndpointId and instance_id from that.
 fn etcd_key_extract(s: &str) -> anyhow::Result<(EndpointId, String)> {
+    if !s.starts_with(model_card::ROOT_PATH) {
+        anyhow::bail!("Invalid format: expected model card ROOT_PATH segment in {s}");
+    }
     let parts: Vec<&str> = s.split('/').collect();
-    let start_idx = if !parts.is_empty() && parts[0] == "v1" {
-        1
-    } else {
-        0
-    };
 
-    // Need at least prefix model_card::ROOT_PATH + 3 parts: namespace, component, name
-    if parts.len() <= start_idx + 3 {
+    // Need at least prefix model_card::ROOT_PATH (2 parts) + namespace, component, name (3 parts)
+    if parts.len() <= 5 {
         anyhow::bail!("Invalid format: not enough path segments in {s}");
     }
 
-    if parts.get(start_idx) != Some(&model_card::ROOT_PATH) {
-        anyhow::bail!("Invalid format: expected model card ROOT_PATH segment in {s}");
-    }
-
     let endpoint_id = EndpointId {
-        namespace: parts[start_idx + 1].to_string(),
-        component: parts[start_idx + 2].to_string(),
-        name: parts[start_idx + 3].to_string(),
+        namespace: parts[2].to_string(),
+        component: parts[3].to_string(),
+        name: parts[4].to_string(),
     };
     Ok((endpoint_id, parts[parts.len() - 1].to_string()))
 }

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -34,7 +34,7 @@ use crate::gguf::{Content, ContentConfig, ModelConfigLike};
 use crate::protocols::TokenIdType;
 
 /// Identify model deployment cards in the key-value store
-pub const ROOT_PATH: &str = "mdc";
+pub const ROOT_PATH: &str = "v1/mdc";
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case")]

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -34,7 +34,7 @@ use crate::{
     discovery::Lease,
     metrics::{MetricsRegistry, prometheus_names},
     service::ServiceSet,
-    transports::etcd::EtcdPath,
+    transports::etcd::{ETCD_ROOT_PATH, EtcdPath},
 };
 
 use super::{
@@ -72,10 +72,7 @@ pub use client::{Client, InstanceSource};
 
 /// The root etcd path where each instance registers itself in etcd.
 /// An instance is namespace+component+endpoint+lease_id and must be unique.
-pub const INSTANCE_ROOT_PATH: &str = "instances";
-
-/// The root etcd path where each namespace is registered in etcd.
-pub const ETCD_ROOT_PATH: &str = "dynamo://";
+pub const INSTANCE_ROOT_PATH: &str = "v1/instances";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -601,7 +598,7 @@ impl Namespace {
     }
 
     pub fn etcd_path(&self) -> String {
-        format!("{}{}", ETCD_ROOT_PATH, self.name())
+        format!("{ETCD_ROOT_PATH}{}", self.name())
     }
 
     pub fn name(&self) -> String {

--- a/lib/runtime/src/storage/key_value_store.rs
+++ b/lib/runtime/src/storage/key_value_store.rs
@@ -252,7 +252,7 @@ mod tests {
     use super::*;
     use futures::{StreamExt, pin_mut};
 
-    const BUCKET_NAME: &str = "mdc";
+    const BUCKET_NAME: &str = "v1/mdc";
 
     /// Convert the value returned by `watch()` into a broadcast stream that multiple
     /// clients can listen to.

--- a/lib/runtime/src/storage/key_value_store/etcd.rs
+++ b/lib/runtime/src/storage/key_value_store/etcd.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::time::Duration;
 
-use crate::{slug::Slug, storage::key_value_store::Key, transports::etcd::Client};
+use crate::{storage::key_value_store::Key, transports::etcd::Client};
 use async_stream::stream;
 use async_trait::async_trait;
 use etcd_client::{Compare, CompareOp, EventType, PutOptions, Txn, TxnOp, WatchOptions};
@@ -240,7 +240,7 @@ impl EtcdBucket {
 }
 
 fn make_key(bucket_name: &str, key: &Key) -> String {
-    [Slug::slugify(bucket_name).to_string(), key.to_string()].join("/")
+    [bucket_name.to_string(), key.to_string()].join("/")
 }
 
 #[cfg(feature = "integration")]

--- a/lib/runtime/src/utils/pool.rs
+++ b/lib/runtime/src/utils/pool.rs
@@ -669,7 +669,7 @@ mod tests {
 
         // Should be fast (< 10ms on most systems)
         // Update(grahamk): Takes 144ms on my box which is much faster than CI, so something
-        // is add about claim above.
+        // is odd about claim above.
         assert!(duration < Duration::from_millis(200));
     }
 }

--- a/lib/runtime/src/utils/pool.rs
+++ b/lib/runtime/src/utils/pool.rs
@@ -668,6 +668,8 @@ mod tests {
         println!("1000 sync pool operations took {:?}", duration);
 
         // Should be fast (< 10ms on most systems)
-        assert!(duration < Duration::from_millis(50));
+        // Update(grahamk): Takes 144ms on my box which is much faster than CI, so something
+        // is add about claim above.
+        assert!(duration < Duration::from_millis(200));
     }
 }

--- a/lib/runtime/src/utils/typed_prefix_watcher.rs
+++ b/lib/runtime/src/utils/typed_prefix_watcher.rs
@@ -70,7 +70,7 @@ where
 /// // Watch for ModelDeploymentCard objects and extract runtime_config field
 /// let watcher = watch_prefix_with_extraction(
 ///     etcd_client,
-///     "mdc/",
+///     "v1/mdc/",
 ///     |kv| Some(kv.lease()),  // Use lease_id as key
 ///     |card: ModelDeploymentCard| card.runtime_config,  // Extract runtime_config field
 ///     cancellation_token,

--- a/lib/runtime/src/utils/worker_monitor.rs
+++ b/lib/runtime/src/utils/worker_monitor.rs
@@ -94,7 +94,7 @@ impl WorkerMonitor {
         // That means we cannot use ModelDeploymentCard, so use serde_json::Value for now .
         let runtime_configs_watcher = watch_prefix_with_extraction(
             etcd_client,
-            "mdc/", // should be model_card::ROOT_PREFIX but wrong crate
+            "v1/mdc/", // should be model_card::ROOT_PREFIX but wrong crate
             key_extractors::lease_id,
             |card: serde_json::Value| {
                 card.get("runtime_config")


### PR DESCRIPTION
Prefix all our etcd keys with `v1/` to give us upgrade options in the future.

Note there is no effort to manage versions centrally, we aren't enforcing all keys upgrade in lockstep, or even implementing an upgrade feature. We're giving future-us space to work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced versioned keyspace (v1/…) for configurations, ports, instances, models, and routers to improve namespacing and future compatibility.
- Refactor
  - Standardized path parsing and validation for etcd keys; simplified prefix handling.
- Observability
  - Reduced log noise: cache update/delete logs lowered to trace; watcher stop logs to debug.
- Documentation
  - Updated examples to reflect v1-prefixed paths.
- Tests
  - Adjusted timing threshold for pool performance test to reduce flakiness; updated test constants to v1-prefixed buckets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->