### PR TITLE
feat: add startup order for multinode TRTLLM

### DIFF
--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -331,11 +331,11 @@ func applyCliqueStartupDependencies(
 	backendFramework BackendFramework,
 	numberOfNodes int32,
 ) {
-	// deactivated for now.
-	// TODO: reactivate this when we have a better way to handle the readiness probe for the leader.
-	deactivated := true
+	// enabled for TRTLLM multinode deployments only
+	// TODO: reactivate for all backends when we have a better way to handle the readiness probe for the leader.
+	enabled := backendFramework == BackendFrameworkTRTLLM && numberOfNodes > 1
 
-	if deactivated || numberOfNodes <= 1 {
+	if !enabled {
 		return // No dependencies for single-node deployments
 	}
 


### PR DESCRIPTION
#### Overview:

add startup order for multinode TRTLLM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optimized startup sequencing: applies inter-service startup dependencies only for multi-node TRTLLM deployments, improving orchestration for that configuration.
- Bug Fixes
  - Prevents unintended startup dependencies for single-node or non-TRTLLM backends, reducing unnecessary waits and potential boot issues.
- Performance
  - Faster, simpler startup for non-TRTLLM and single-node setups by avoiding unneeded dependency wiring.
- Tests
  - Reactivated and expanded test coverage across backends to validate startup order and modes, improving confidence in deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->