### PR TITLE
fix: Make planner VirtualConnectorClient also use v1/ prefix.

### DIFF
--- a/lib/bindings/python/rust/planner.rs
+++ b/lib/bindings/python/rust/planner.rs
@@ -102,7 +102,7 @@ impl VirtualConnectorCoordinator {
         let prefix = root_key(&self.0.namespace);
         let inner = self.0.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let kv_cache = KvCache::new(inner.etcd_client.clone(), "v1", prefix, HashMap::new())
+            let kv_cache = KvCache::new(inner.etcd_client.clone(), prefix, HashMap::new())
                 .await
                 .map_err(to_pyerr)?;
             *inner.kv_cache.lock() = Some(Arc::new(kv_cache));
@@ -497,5 +497,5 @@ fn load(a: &AtomicUsize) -> usize {
 }
 
 fn root_key(namespace: &str) -> String {
-    format!("{namespace}/planner/")
+    format!("v1/{namespace}/planner/")
 }

--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -515,13 +515,10 @@ impl KvCache {
     /// Create a new KV cache for the given prefix
     pub async fn new(
         client: Client,
-        version: &str,
         prefix: String,
         initial_values: HashMap<String, Vec<u8>>,
     ) -> Result<Self> {
         let mut cache = HashMap::new();
-
-        let prefix = format!("{version}/{prefix}");
 
         // First get all existing keys with this prefix
         let existing_kvs = client.kv_get_prefix(&prefix).await?;
@@ -712,7 +709,7 @@ mod tests {
 
         // Create a unique test prefix to avoid conflicts with other tests
         let test_id = uuid::Uuid::new_v4().to_string();
-        let prefix = format!("test_kv_cache_{}/", test_id);
+        let prefix = format!("v1/test_kv_cache_{}/", test_id);
 
         // Initial values
         let mut initial_values = HashMap::new();
@@ -720,7 +717,7 @@ mod tests {
         initial_values.insert("key2".to_string(), b"value2".to_vec());
 
         // Create the KV cache
-        let kv_cache = KvCache::new(client.clone(), "v1", prefix.clone(), initial_values).await?;
+        let kv_cache = KvCache::new(client.clone(), prefix.clone(), initial_values).await?;
 
         // Test get
         let value1 = kv_cache.get("key1").await;


### PR DESCRIPTION
Codex caught the bug! Thanks @paulhendricks for doing a review with it.

Follow-up to https://github.com/ai-dynamo/dynamo/pull/3458 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standardized key/value storage namespace to use a v1/ prefix for planner data.
- Refactor
  - Simplified configuration by consolidating versioning into the provided prefix (no separate version parameter).
- Notes
  - Existing setups referencing previous prefixes may need to update configurations or reindex keys to align with the new v1/ path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->