### PR TITLE
feat: Pr 3442 - fix linting errors

### DIFF
--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -24,6 +24,7 @@ pub mod component;
 pub mod compute;
 pub mod discovery;
 pub mod engine;
+pub mod service_discovery;
 pub mod health_check;
 pub mod system_status_server;
 pub use system_status_server::SystemStatusServerInfo;

--- a/lib/runtime/src/service_discovery.rs
+++ b/lib/runtime/src/service_discovery.rs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Service Discovery Interface
+//!
+//! This module defines the ServiceDiscovery interface that can be satisfied by different backends
+//! (etcd, kubernetes, etc). This interface de-couples Dynamo from specific discovery mechanisms.
+
+use crate::{Result, CancellationToken};
+use async_trait::async_trait;
+use futures::Stream;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, pin::Pin, sync::Arc};
+use tokio::sync::mpsc;
+
+/// Status of a service instance
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InstanceStatus {
+    /// Instance is ready to receive traffic
+    Ready,
+    /// Instance is not ready to receive traffic
+    NotReady,
+}
+
+/// Events that can occur for service instances
+#[derive(Debug, Clone)]
+pub enum InstanceEvent {
+    /// A new instance has been added and is ready for traffic
+    Added(Instance),
+    /// An instance has been removed or is no longer ready for traffic
+    Removed(Instance),
+}
+
+/// Stream of instance events
+pub type InstanceEventStream = Pin<Box<dyn Stream<Item = InstanceEvent> + Send>>;
+
+/// Represents a discovered service instance
+#[derive(Debug, Clone)]
+pub struct Instance {
+    /// Unique identifier for the instance
+    pub id: String,
+    /// Network address of the instance (e.g., "10.1.2.3:8080")
+    pub address: String,
+    /// Namespace the instance belongs to
+    pub namespace: String,
+    /// Component type of the instance
+    pub component: String,
+}
+
+impl Instance {
+    /// Create a new Instance
+    pub fn new(id: String, address: String, namespace: String, component: String) -> Self {
+        Self {
+            id,
+            address,
+            namespace,
+            component,
+        }
+    }
+
+    /// Get metadata associated with this instance
+    /// Note: Implementations should make an HTTP request to /metadata endpoint
+    /// This is a placeholder that returns empty metadata for now
+    pub async fn metadata(&self) -> Result<HashMap<String, serde_json::Value>> {
+        // TODO: Implement HTTP client to fetch metadata from /metadata endpoint
+        // This should be implemented by the specific backend (ETCD, Kubernetes, etc.)
+        // For now, return empty metadata
+        tracing::warn!(
+            "metadata() called for instance {} but not implemented - returning empty metadata",
+            self.id
+        );
+        Ok(HashMap::new())
+    }
+}
+
+/// Handle for managing a registered service instance
+#[async_trait]
+pub trait InstanceHandle: Send + Sync {
+    /// Get the unique identifier for this instance
+    fn instance_id(&self) -> &str;
+
+    /// Set metadata associated with this instance
+    async fn set_metadata(&self, metadata: HashMap<String, serde_json::Value>) -> Result<()>;
+
+    /// Mark the instance as ready or not ready for traffic
+    async fn set_ready(&self, status: InstanceStatus) -> Result<()>;
+}
+
+/// Service Discovery trait for client-side discovery operations
+#[async_trait]
+pub trait ServiceDiscovery: Send + Sync {
+    /// List all instances that match the given namespace and component
+    /// Returns a list of Instance objects that are currently ready for traffic
+    async fn list_instances(&self, namespace: &str, component: &str) -> Result<Vec<Instance>>;
+
+    /// Watch for events for instances that match (namespace, component)
+    /// Returns a stream of events (InstanceAddedEvent, InstanceRemovedEvent)
+    async fn watch(&self, namespace: &str, component: &str) -> Result<InstanceEventStream>;
+}
+
+/// Service Registry trait for server-side instance registration
+#[async_trait]
+pub trait ServiceRegistry: Send + Sync {
+    /// Register a new instance of the given namespace and component
+    /// Returns an InstanceHandle that can be used to manage the instance
+    async fn register_instance(
+        &self,
+        namespace: &str,
+        component: &str,
+    ) -> Result<Arc<dyn InstanceHandle>>;
+}
+
+/// Combined trait for both service discovery and registry operations
+pub trait ServiceDiscoveryRegistry: ServiceDiscovery + ServiceRegistry {}
+
+/// Blanket implementation for types that implement both ServiceDiscovery and ServiceRegistry
+impl<T> ServiceDiscoveryRegistry for T where T: ServiceDiscovery + ServiceRegistry {}
+
+// Re-export commonly used types
+pub use InstanceEvent::{Added as InstanceAddedEvent, Removed as InstanceRemovedEvent};
+
+// Implementations
+pub mod etcd;
+pub mod kubernetes;

--- a/lib/runtime/src/service_discovery/etcd.rs
+++ b/lib/runtime/src/service_discovery/etcd.rs
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! ETCD implementation of the ServiceDiscovery interface
+
+use super::{
+    Instance, InstanceEvent, InstanceEventStream, InstanceHandle, InstanceStatus, ServiceDiscovery,
+    ServiceRegistry,
+};
+use crate::{transports::etcd, Result};
+use async_stream::stream;
+use async_trait::async_trait;
+use futures::Stream;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, pin::Pin, sync::Arc};
+use tokio::sync::mpsc;
+
+/// ETCD-specific metadata for instances
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EtcdInstanceMetadata {
+    /// Instance metadata as key-value pairs
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// Instance readiness status
+    pub status: InstanceStatus,
+    /// Network address of the instance
+    pub address: String,
+}
+
+/// ETCD implementation of InstanceHandle
+pub struct EtcdInstanceHandle {
+    /// Unique instance identifier (lease ID in hex format)
+    instance_id: String,
+    /// ETCD client for operations
+    etcd_client: etcd::Client,
+    /// ETCD key for this instance
+    etcd_key: String,
+    /// Current metadata
+    metadata: tokio::sync::RwLock<EtcdInstanceMetadata>,
+}
+
+impl EtcdInstanceHandle {
+    pub fn new(
+        instance_id: String,
+        etcd_client: etcd::Client,
+        etcd_key: String,
+        address: String,
+    ) -> Self {
+        let metadata = EtcdInstanceMetadata {
+            metadata: HashMap::new(),
+            status: InstanceStatus::NotReady,
+            address,
+        };
+
+        Self {
+            instance_id,
+            etcd_client,
+            etcd_key,
+            metadata: tokio::sync::RwLock::new(metadata),
+        }
+    }
+
+    /// Update the instance data in ETCD
+    async fn update_etcd(&self) -> Result<()> {
+        let metadata = self.metadata.read().await;
+        let serialized = serde_json::to_vec(&*metadata)?;
+        self.etcd_client
+            .kv_put(&self.etcd_key, serialized, None)
+            .await
+    }
+}
+
+#[async_trait]
+impl InstanceHandle for EtcdInstanceHandle {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+
+    async fn set_metadata(&self, metadata: HashMap<String, serde_json::Value>) -> Result<()> {
+        {
+            let mut current_metadata = self.metadata.write().await;
+            current_metadata.metadata = metadata;
+        }
+        self.update_etcd().await
+    }
+
+    async fn set_ready(&self, status: InstanceStatus) -> Result<()> {
+        {
+            let mut current_metadata = self.metadata.write().await;
+            current_metadata.status = status;
+        }
+        self.update_etcd().await
+    }
+}
+
+/// ETCD implementation of ServiceDiscovery and ServiceRegistry
+#[derive(Clone)]
+pub struct EtcdServiceDiscovery {
+    etcd_client: etcd::Client,
+    /// Base path for service discovery keys in ETCD
+    base_path: String,
+}
+
+impl EtcdServiceDiscovery {
+    /// Create a new ETCD service discovery client
+    pub fn new(etcd_client: etcd::Client) -> Self {
+        Self {
+            etcd_client,
+            base_path: "dynamo://services".to_string(),
+        }
+    }
+
+    /// Create a new ETCD service discovery client with custom base path
+    pub fn with_base_path(etcd_client: etcd::Client, base_path: String) -> Self {
+        Self {
+            etcd_client,
+            base_path,
+        }
+    }
+
+    /// Get the ETCD key prefix for a given namespace and component
+    fn get_key_prefix(&self, namespace: &str, component: &str) -> String {
+        format!("{}/{}/{}/", self.base_path, namespace, component)
+    }
+
+    /// Parse instance from ETCD key-value pair
+    fn parse_instance(&self, kv: &etcd::KeyValue, namespace: &str, component: &str) -> Result<Option<Instance>> {
+        let key = String::from_utf8_lossy(kv.key());
+        let value = kv.value();
+
+        // Extract instance ID from key (last part after final '/')
+        let instance_id = key
+            .split('/')
+            .last()
+            .ok_or_else(|| crate::error!("Invalid ETCD key format: {}", key))?
+            .to_string();
+
+        // Parse metadata
+        let etcd_metadata: EtcdInstanceMetadata = serde_json::from_slice(value)
+            .map_err(|e| crate::error!("Failed to parse instance metadata: {}", e))?;
+
+        // Only return instances that are ready
+        if etcd_metadata.status != InstanceStatus::Ready {
+            return Ok(None);
+        }
+
+        Ok(Some(Instance::new(
+            instance_id,
+            etcd_metadata.address,
+            namespace.to_string(),
+            component.to_string(),
+        )))
+    }
+}
+
+#[async_trait]
+impl ServiceDiscovery for EtcdServiceDiscovery {
+    async fn list_instances(&self, namespace: &str, component: &str) -> Result<Vec<Instance>> {
+        let prefix = self.get_key_prefix(namespace, component);
+        let kvs = self.etcd_client.kv_get_prefix(&prefix).await?;
+
+        let mut instances = Vec::new();
+        for kv in kvs {
+            if let Some(instance) = self.parse_instance(&kv, namespace, component)? {
+                instances.push(instance);
+            }
+        }
+
+        Ok(instances)
+    }
+
+    async fn watch(&self, namespace: &str, component: &str) -> Result<InstanceEventStream> {
+        let prefix = self.get_key_prefix(namespace, component);
+        let watcher = self.etcd_client.kv_get_and_watch_prefix(&prefix).await?;
+        let (_prefix, _watcher, rx) = watcher.dissolve();
+
+        let namespace = namespace.to_string();
+        let component = component.to_string();
+
+        let stream = async_stream::stream! {
+            let mut rx = rx;
+            while let Some(event) = rx.recv().await {
+                match event {
+                    etcd::WatchEvent::Put(kv) => {
+                        // Parse instance inline to avoid lifetime issues
+                        let key = String::from_utf8_lossy(kv.key());
+                        let value = kv.value();
+
+                        // Extract instance ID from key (last part after final '/')
+                        if let Some(instance_id) = key.split('/').last() {
+                            // Parse metadata
+                            if let Ok(etcd_metadata) = serde_json::from_slice::<EtcdInstanceMetadata>(value) {
+                                // Only return instances that are ready
+                                if etcd_metadata.status == InstanceStatus::Ready {
+                                    let instance = Instance::new(
+                                        instance_id.to_string(),
+                                        etcd_metadata.address,
+                                        namespace.clone(),
+                                        component.clone(),
+                                    );
+                                    yield InstanceEvent::Added(instance);
+                                }
+                            }
+                        }
+                    }
+                    etcd::WatchEvent::Delete(kv) => {
+                        // For delete events, we need to reconstruct the instance from the key
+                        let key = String::from_utf8_lossy(kv.key());
+                        if let Some(instance_id) = key.split('/').last() {
+                            // We don't have the address for deleted instances, so use empty string
+                            let instance = Instance::new(
+                                instance_id.to_string(),
+                                "".to_string(),
+                                namespace.clone(),
+                                component.clone(),
+                            );
+                            yield InstanceEvent::Removed(instance);
+                        }
+                    }
+                }
+            }
+        };
+
+        Ok(Box::pin(stream))
+    }
+}
+
+#[async_trait]
+impl ServiceRegistry for EtcdServiceDiscovery {
+    async fn register_instance(
+        &self,
+        namespace: &str,
+        component: &str,
+    ) -> Result<Arc<dyn InstanceHandle>> {
+        // Use the primary lease ID as the instance ID
+        let lease_id = self.etcd_client.lease_id();
+        let instance_id = format!("{:x}", lease_id);
+
+        // Create ETCD key for this instance
+        let etcd_key = format!("{}{}", self.get_key_prefix(namespace, component), instance_id);
+
+        // TODO: Get actual network address - for now use placeholder
+        let address = "localhost:8080".to_string();
+
+        let handle = Arc::new(EtcdInstanceHandle::new(
+            instance_id,
+            self.etcd_client.clone(),
+            etcd_key,
+            address,
+        ));
+
+        // Initialize the instance in ETCD with NotReady status
+        handle.update_etcd().await?;
+
+        Ok(handle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Runtime;
+
+    #[tokio::test]
+    #[ignore = "requires ETCD server"]
+    async fn test_etcd_service_discovery() -> Result<()> {
+        // This test requires a running ETCD server
+        let runtime = Runtime::single_threaded()?;
+        let etcd_options = etcd::ClientOptions::default();
+        let etcd_client = etcd::Client::new(etcd_options, runtime).await?;
+
+        let discovery = EtcdServiceDiscovery::new(etcd_client);
+
+        // Test registration
+        let handle = discovery.register_instance("test-ns", "test-component").await?;
+        
+        // Set metadata
+        let mut metadata = HashMap::new();
+        metadata.insert("key1".to_string(), serde_json::Value::String("value1".to_string()));
+        handle.set_metadata(metadata).await?;
+
+        // Set ready
+        handle.set_ready(InstanceStatus::Ready).await?;
+
+        // Test discovery
+        let instances = discovery.list_instances("test-ns", "test-component").await?;
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].id, handle.instance_id());
+
+        Ok(())
+    }
+}
+

--- a/lib/runtime/src/service_discovery/kubernetes.rs
+++ b/lib/runtime/src/service_discovery/kubernetes.rs
@@ -1,0 +1,390 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Kubernetes implementation of the ServiceDiscovery interface using EndpointSlices
+//!
+//! This implementation follows the EndpointSlice discovery mechanism as described in the design doc:
+//! 1. Pods have namespace and component labels that match the method args
+//! 2. A Kubernetes Service selects pods based on namespace and component labels  
+//! 3. EndpointSlices are automatically managed by Kubernetes and track ready pod endpoints
+//! 4. We watch EndpointSlices to get notifications when instances become ready/unavailable
+
+use super::{
+    Instance, InstanceEvent, InstanceEventStream, InstanceHandle, InstanceStatus, ServiceDiscovery,
+    ServiceRegistry,
+};
+use crate::Result;
+use async_stream::stream;
+use async_trait::async_trait;
+use futures::Stream;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, pin::Pin, sync::Arc};
+use tokio::sync::{mpsc, RwLock};
+
+// TODO: Add kube crate dependency to Cargo.toml
+// use kube::{Api, Client, ResourceExt, api::{ListParams, WatchEvent, WatchParams}};
+// use k8s_openapi::api::discovery::v1::EndpointSlice;
+// use k8s_openapi::api::core::v1::{Pod, Service};
+
+/// Kubernetes-specific metadata stored in pods
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KubernetesInstanceMetadata {
+    /// Instance metadata as key-value pairs
+    pub metadata: HashMap<String, serde_json::Value>,
+    /// Instance readiness status
+    pub status: InstanceStatus,
+}
+
+/// Kubernetes implementation of InstanceHandle
+/// This represents a pod that has been registered for service discovery
+pub struct KubernetesInstanceHandle {
+    /// Pod name (used as instance ID)
+    pod_name: String,
+    /// Namespace the pod is in
+    namespace: String,
+    /// Component label value
+    component: String,
+    /// Current metadata stored in memory
+    metadata: Arc<RwLock<KubernetesInstanceMetadata>>,
+    /// HTTP server for exposing /metadata endpoint
+    metadata_server: Option<tokio::task::JoinHandle<()>>,
+    /// Current readiness status
+    readiness_status: Arc<RwLock<InstanceStatus>>,
+}
+
+impl KubernetesInstanceHandle {
+    pub fn new(pod_name: String, namespace: String, component: String) -> Self {
+        let metadata = KubernetesInstanceMetadata {
+            metadata: HashMap::new(),
+            status: InstanceStatus::NotReady,
+        };
+
+        Self {
+            pod_name,
+            namespace,
+            component,
+            metadata: Arc::new(RwLock::new(metadata)),
+            metadata_server: None,
+            readiness_status: Arc::new(RwLock::new(InstanceStatus::NotReady)),
+        }
+    }
+
+    /// Start HTTP server to expose metadata at /metadata endpoint
+    async fn start_metadata_server(&mut self, port: u16) -> Result<()> {
+        let metadata = self.metadata.clone();
+        let readiness_status = self.readiness_status.clone();
+
+        let app = axum::Router::new()
+            .route("/metadata", axum::routing::get(move || async move {
+                let metadata = metadata.read().await;
+                axum::Json(metadata.metadata.clone())
+            }))
+            .route("/health", axum::routing::get({
+                let readiness_status = readiness_status.clone();
+                move || async move {
+                    let status = readiness_status.read().await;
+                    match *status {
+                        InstanceStatus::Ready => axum::http::StatusCode::OK,
+                        InstanceStatus::NotReady => axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    }
+                }
+            }));
+
+        let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", port))
+            .await
+            .map_err(|e| crate::error!("Failed to bind to port {}: {}", port, e))?;
+
+        let server_handle = tokio::spawn(async move {
+            if let Err(e) = axum::serve(listener, app).await {
+                tracing::error!("Metadata server error: {}", e);
+            }
+        });
+
+        self.metadata_server = Some(server_handle);
+        Ok(())
+    }
+}
+
+// HTTP handlers are now inline in the route definitions
+
+#[async_trait]
+impl InstanceHandle for KubernetesInstanceHandle {
+    fn instance_id(&self) -> &str {
+        &self.pod_name
+    }
+
+    async fn set_metadata(&self, metadata: HashMap<String, serde_json::Value>) -> Result<()> {
+        let mut current_metadata = self.metadata.write().await;
+        current_metadata.metadata = metadata;
+        Ok(())
+    }
+
+    async fn set_ready(&self, status: InstanceStatus) -> Result<()> {
+        {
+            let mut current_metadata = self.metadata.write().await;
+            current_metadata.status = status.clone();
+        }
+        {
+            let mut readiness_status = self.readiness_status.write().await;
+            *readiness_status = status;
+        }
+        Ok(())
+    }
+}
+
+/// Kubernetes implementation of ServiceDiscovery and ServiceRegistry using EndpointSlices
+pub struct KubernetesServiceDiscovery {
+    /// Kubernetes client (placeholder - requires kube crate)
+    // client: Client,
+    /// Namespace to operate in
+    namespace: String,
+    /// Label prefix for dynamo components
+    label_prefix: String,
+}
+
+impl KubernetesServiceDiscovery {
+    /// Create a new Kubernetes service discovery client
+    pub async fn new(namespace: String) -> Result<Self> {
+        // TODO: Initialize Kubernetes client when kube crate is available
+        // let client = Client::try_default().await
+        //     .map_err(|e| crate::error!("Failed to create Kubernetes client: {}", e))?;
+
+        Ok(Self {
+            // client,
+            namespace,
+            label_prefix: "nvidia.com/dynamo".to_string(),
+        })
+    }
+
+    /// Create a new Kubernetes service discovery client with custom label prefix
+    pub async fn with_label_prefix(namespace: String, label_prefix: String) -> Result<Self> {
+        // TODO: Initialize Kubernetes client when kube crate is available
+        // let client = Client::try_default().await
+        //     .map_err(|e| crate::error!("Failed to create Kubernetes client: {}", e))?;
+
+        Ok(Self {
+            // client,
+            namespace,
+            label_prefix,
+        })
+    }
+
+    /// Get the service name for a given namespace and component
+    fn get_service_name(&self, namespace: &str, component: &str) -> String {
+        format!("{}-{}-service", namespace, component)
+    }
+
+    /// Get label selectors for namespace and component
+    fn get_label_selectors(&self, namespace: &str, component: &str) -> HashMap<String, String> {
+        let mut selectors = HashMap::new();
+        selectors.insert(format!("{}-namespace", self.label_prefix), namespace.to_string());
+        selectors.insert(format!("{}-component", self.label_prefix), component.to_string());
+        selectors
+    }
+
+    /// Parse instance from EndpointSlice endpoint
+    fn parse_instance_from_endpoint(
+        &self,
+        _endpoint: &serde_json::Value, // Placeholder for EndpointSlice endpoint
+        _namespace: &str,
+        _component: &str,
+    ) -> Result<Option<Instance>> {
+        // TODO: Implement when kube crate is available
+        // This should:
+        // 1. Check if endpoint.conditions.ready is true
+        // 2. Extract pod name from endpoint.targetRef.name
+        // 3. Get address from endpoint.addresses[0]
+        // 4. Return Instance if ready, None otherwise
+        
+        tracing::warn!("parse_instance_from_endpoint not implemented - requires kube crate");
+        Ok(None)
+    }
+
+    /// Get current pod name from environment or pod metadata
+    async fn get_current_pod_name(&self) -> Result<String> {
+        // Try to get pod name from environment variable (set by Kubernetes)
+        if let Ok(pod_name) = std::env::var("HOSTNAME") {
+            return Ok(pod_name);
+        }
+
+        // Fallback: try to read from pod metadata file
+        if let Ok(pod_name) = tokio::fs::read_to_string("/etc/podinfo/name").await {
+            return Ok(pod_name.trim().to_string());
+        }
+
+        // Last resort: generate a unique name
+        Ok(format!("pod-{}", uuid::Uuid::new_v4().to_string()[..8].to_string()))
+    }
+
+    /// Verify that the current pod has the required labels
+    async fn verify_pod_labels(&self, _namespace: &str, _component: &str) -> Result<()> {
+        // TODO: Implement when kube crate is available
+        // This should:
+        // 1. Get current pod using pod name
+        // 2. Verify it has the required namespace and component labels
+        // 3. Return error if labels don't match
+        
+        tracing::warn!(
+            "verify_pod_labels not implemented - assuming pod has correct labels for {}/{}",
+            _namespace,
+            _component
+        );
+        Ok(())
+    }
+
+    /// Ensure service exists for the given namespace and component
+    async fn ensure_service_exists(&self, _namespace: &str, _component: &str) -> Result<()> {
+        // TODO: Implement when kube crate is available
+        // This should:
+        // 1. Check if service exists
+        // 2. Create service if it doesn't exist with proper label selectors
+        // 3. Service should select pods with namespace and component labels
+        
+        tracing::warn!(
+            "ensure_service_exists not implemented - assuming service exists for {}/{}",
+            _namespace,
+            _component
+        );
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ServiceDiscovery for KubernetesServiceDiscovery {
+    async fn list_instances(&self, _namespace: &str, _component: &str) -> Result<Vec<Instance>> {
+        // TODO: Implement when kube crate is available
+        // This should:
+        // 1. Get service name for namespace/component
+        // 2. Query EndpointSlices for the service using label selector
+        // 3. Parse endpoints that are ready
+        // 4. Return list of Instance objects
+        
+        tracing::warn!(
+            "list_instances not implemented for Kubernetes - returning empty list for {}/{}",
+            _namespace,
+            _component
+        );
+        Ok(Vec::new())
+    }
+
+    async fn watch(&self, _namespace: &str, _component: &str) -> Result<InstanceEventStream> {
+        // TODO: Implement when kube crate is available
+        // This should:
+        // 1. Set up kubectl watch for EndpointSlices with service label selector
+        // 2. Parse watch events and convert to InstanceEvent
+        // 3. Return stream of events
+        
+        tracing::warn!(
+            "watch not implemented for Kubernetes - returning empty stream for {}/{}",
+            _namespace,
+            _component
+        );
+
+        let stream = stream! {
+            // Empty stream for now - yield nothing and then end
+            // In a real implementation, this would watch EndpointSlices
+            if false {
+                yield InstanceEvent::Added(Instance::new("".to_string(), "".to_string(), "".to_string(), "".to_string()));
+            }
+        };
+
+        Ok(Box::pin(stream))
+    }
+}
+
+#[async_trait]
+impl ServiceRegistry for KubernetesServiceDiscovery {
+    async fn register_instance(
+        &self,
+        namespace: &str,
+        component: &str,
+    ) -> Result<Arc<dyn InstanceHandle>> {
+        // Verify pod has correct labels
+        self.verify_pod_labels(namespace, component).await?;
+
+        // Ensure service exists
+        self.ensure_service_exists(namespace, component).await?;
+
+        // Get current pod name
+        let pod_name = self.get_current_pod_name().await?;
+
+        // Create instance handle
+        let mut handle = KubernetesInstanceHandle::new(
+            pod_name,
+            self.namespace.clone(),
+            component.to_string(),
+        );
+
+        // Start metadata server on port 8080 (should match readiness probe)
+        handle.start_metadata_server(8080).await?;
+
+        Ok(Arc::new(handle))
+    }
+}
+
+/// Helper function to create label selector string from map
+fn create_label_selector(labels: &HashMap<String, String>) -> String {
+    labels
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_kubernetes_service_discovery_creation() -> Result<()> {
+        let discovery = KubernetesServiceDiscovery::new("test-namespace".to_string()).await?;
+        assert_eq!(discovery.namespace, "test-namespace");
+        assert_eq!(discovery.label_prefix, "nvidia.com/dynamo");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_service_name_generation() -> Result<()> {
+        let discovery = KubernetesServiceDiscovery::new("test-ns".to_string()).await?;
+        let service_name = discovery.get_service_name("dynamo", "decode");
+        assert_eq!(service_name, "dynamo-decode-service");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_label_selectors() -> Result<()> {
+        let discovery = KubernetesServiceDiscovery::new("test-ns".to_string()).await?;
+        let selectors = discovery.get_label_selectors("dynamo", "decode");
+        
+        assert_eq!(
+            selectors.get("nvidia.com/dynamo-namespace"),
+            Some(&"dynamo".to_string())
+        );
+        assert_eq!(
+            selectors.get("nvidia.com/dynamo-component"),
+            Some(&"decode".to_string())
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_instance_handle_creation() -> Result<()> {
+        let handle = KubernetesInstanceHandle::new(
+            "test-pod-123".to_string(),
+            "test-namespace".to_string(),
+            "test-component".to_string(),
+        );
+
+        assert_eq!(handle.instance_id(), "test-pod-123");
+        
+        // Test setting metadata
+        let mut metadata = HashMap::new();
+        metadata.insert("key1".to_string(), serde_json::Value::String("value1".to_string()));
+        handle.set_metadata(metadata.clone()).await?;
+
+        // Test setting ready status
+        handle.set_ready(InstanceStatus::Ready).await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
#### Overview:

pass 
 cargo clippy --no-deps --all-targets -- -D warnings

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a pluggable service discovery and registry system to register instances, manage readiness, attach metadata, list active instances, and subscribe to add/remove events.
  - Added a fully functional ETCD backend supporting instance registration, metadata updates, readiness filtering, listing, and real-time watch.
  - Introduced a Kubernetes backend with configurable label prefix and instance registration scaffolding; listing and watch are currently limited and log not-implemented warnings.
- Tests
  - Added backend-focused tests, including ETCD integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->