### PR TITLE
feat: prefill routing for trtllm

### DIFF
--- a/benchmarks/router/README.md
+++ b/benchmarks/router/README.md
@@ -38,17 +38,22 @@ This will start both etcd and NATS with the required configurations in the backg
 
 ## Usage Instructions
 
-### Step 1: Launch vLLM Workers
+### Step 1: Launch Workers
 
-Make sure you have 8 GPUs for these examples, unless you are using mockers (see below). First, start the vLLM worker engines in a terminal.
+Make sure you have 8 GPUs for these examples, unless you are using mockers (see below). First, start the worker engines in a terminal.
+
+The script supports three modes:
+- **`agg` (default)**: Aggregated/monolithic workers that handle both prefill and decode
+- **`decode`**: Workers dedicated to decode (token generation) phase
+- **`prefill`**: Workers dedicated to prefill (prompt processing) phase
 
 ```bash
-# Default: 8 vLLM workers with DeepSeek model (explicitly sets --block-size 64)
+# Default: 8 aggregated workers with DeepSeek model (handles both prefill and decode)
 ./run_engines.sh \
     --num-workers 8 \
     --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 
-# Example: 4 vLLM workers with larger model using tensor parallelism (2 GPUs per worker)
+# Example: 4 workers with larger model using tensor parallelism (2 GPUs per worker)
 # NOTE: this requires having Hopper or later GPU SKUs to support MXFP4 precision.
 ./run_engines.sh \
     --num-workers 4 \
@@ -56,19 +61,20 @@ Make sure you have 8 GPUs for these examples, unless you are using mockers (see 
     --tensor-parallel-size 2
 ```
 
-#### Prefill Workers
+#### Disaggregated Serving (Decode + Prefill Workers)
 
-You can also launch separate decode and prefill workers for disaggregated serving. This allows you to dedicate specific GPUs to prefill (prompt processing) and decode (token generation) tasks:
+You can launch separate decode and prefill workers for disaggregated serving. This allows you to dedicate specific GPUs to prefill (prompt processing) and decode (token generation) tasks:
 
 ```bash
 # Launch 4 decode workers (GPUs 0-3)
 ./run_engines.sh \
+    --decode \
     --num-workers 4 \
     --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 
 # Launch 4 prefill workers (GPUs 4-7)
 ./run_engines.sh \
-    --prefills \
+    --prefill \
     --num-workers 4 \
     --base-gpu-offset 4 \
     --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B

--- a/benchmarks/router/run_engines.sh
+++ b/benchmarks/router/run_engines.sh
@@ -75,12 +75,10 @@ if [ ${#EXTRA_ARGS[@]} -eq 0 ]; then
         )
     elif [ "$USE_TRTLLM" = true ]; then
         # Default args for TensorRT-LLM engine
-        # Build override args based on prefill vs decode mode
-        # Configuration follows components/backends/trtllm/engine_configs/{prefill,decode}.yaml
         if [ "$USE_PREFILLS" = true ]; then
-            OVERRIDE_ARGS='{"enable_chunked_prefill": true, "disable_overlap_scheduler": true, "cuda_graph_config": {"max_batch_size": 16}, "cache_transceiver_config": {"backend": "DEFAULT"}}'
+            OVERRIDE_ARGS='{"enable_chunked_prefill": true, "disable_overlap_scheduler": true, "cuda_graph_config": {"max_batch_size": 16}, "cache_transceiver_config": {"backend": "DEFAULT"}, "kv_cache_config": {"event_buffer_max_size": 1024}}'
         else
-            OVERRIDE_ARGS='{"enable_chunked_prefill": true, "disable_overlap_scheduler": false, "cuda_graph_config": {"max_batch_size": 16}, "cache_transceiver_config": {"backend": "DEFAULT"}}'
+            OVERRIDE_ARGS='{"enable_chunked_prefill": true, "disable_overlap_scheduler": false, "cuda_graph_config": {"max_batch_size": 16}, "cache_transceiver_config": {"backend": "DEFAULT"}, "kv_cache_config": {"event_buffer_max_size": 1024}}'
         fi
 
         EXTRA_ARGS=(
@@ -88,6 +86,7 @@ if [ ${#EXTRA_ARGS[@]} -eq 0 ]; then
             "--max-seq-len" "32768"
             "--kv-block-size" "64"
             "--override-engine-args" "$OVERRIDE_ARGS"
+            "--publish-events-and-metrics"
         )
     else
         # Default args for vLLM engine (explicitly include block-size)

--- a/benchmarks/router/run_engines.sh
+++ b/benchmarks/router/run_engines.sh
@@ -88,7 +88,6 @@ if [ ${#EXTRA_ARGS[@]} -eq 0 ]; then
             "--max-seq-len" "32768"
             "--kv-block-size" "64"
             "--override-engine-args" "$OVERRIDE_ARGS"
-            "--publish-events-and-metrics"
         )
     else
         # Default args for vLLM engine (explicitly include block-size)

--- a/benchmarks/router/run_engines.sh
+++ b/benchmarks/router/run_engines.sh
@@ -74,18 +74,16 @@ if [ ${#EXTRA_ARGS[@]} -eq 0 ]; then
             "--block-size" "64"
         )
     elif [ "$USE_TRTLLM" = true ]; then
-        # Default args for TensorRT-LLM engine
+        # Default args for TensorRT-LLM engine using predefined YAML configs
+        # Config files located at: ../../components/backends/trtllm/engine_configs/{prefill,decode}.yaml
         if [ "$USE_PREFILLS" = true ]; then
-            OVERRIDE_ARGS='{"enable_chunked_prefill": true, "disable_overlap_scheduler": true, "cuda_graph_config": {"max_batch_size": 16}, "cache_transceiver_config": {"backend": "DEFAULT"}, "kv_cache_config": {"event_buffer_max_size": 1024}}'
+            ENGINE_CONFIG="../../components/backends/trtllm/engine_configs/prefill.yaml"
         else
-            OVERRIDE_ARGS='{"enable_chunked_prefill": true, "disable_overlap_scheduler": false, "cuda_graph_config": {"max_batch_size": 16}, "cache_transceiver_config": {"backend": "DEFAULT"}, "kv_cache_config": {"event_buffer_max_size": 1024}}'
+            ENGINE_CONFIG="../../components/backends/trtllm/engine_configs/decode.yaml"
         fi
 
         EXTRA_ARGS=(
-            "--max-num-tokens" "16384"
-            "--max-seq-len" "32768"
-            "--kv-block-size" "64"
-            "--override-engine-args" "$OVERRIDE_ARGS"
+            "--extra-engine-args" "$ENGINE_CONFIG"
             "--publish-events-and-metrics"
         )
     else

--- a/benchmarks/router/run_engines.sh
+++ b/benchmarks/router/run_engines.sh
@@ -78,18 +78,8 @@ if [ ${#EXTRA_ARGS[@]} -eq 0 ]; then
         # Build override args based on prefill vs decode mode
         # Configuration follows components/backends/trtllm/engine_configs/{prefill,decode}.yaml
         if [ "$USE_PREFILLS" = true ]; then
-            # Prefill worker configuration:
-            # - enable_chunked_prefill: true (better prefill performance)
-            # - disable_overlap_scheduler: true (overlap not supported in prefill-only)
-            # - cuda_graph_config: optimization for CUDA graph execution
-            # - cache_transceiver_config: required for disaggregated serving KV transfer
             OVERRIDE_ARGS='{"enable_chunked_prefill": true, "disable_overlap_scheduler": true, "cuda_graph_config": {"max_batch_size": 16}, "cache_transceiver_config": {"backend": "DEFAULT"}}'
         else
-            # Decode worker configuration:
-            # - enable_chunked_prefill: true (supports mixed workloads)
-            # - disable_overlap_scheduler: false (overlap enabled for decode efficiency)
-            # - cuda_graph_config: optimization for CUDA graph execution
-            # - cache_transceiver_config: required for disaggregated serving KV transfer
             OVERRIDE_ARGS='{"enable_chunked_prefill": true, "disable_overlap_scheduler": false, "cuda_graph_config": {"max_batch_size": 16}, "cache_transceiver_config": {"backend": "DEFAULT"}}'
         fi
 

--- a/benchmarks/router/run_engines.sh
+++ b/benchmarks/router/run_engines.sh
@@ -88,6 +88,7 @@ if [ ${#EXTRA_ARGS[@]} -eq 0 ]; then
             "--max-seq-len" "32768"
             "--kv-block-size" "64"
             "--override-engine-args" "$OVERRIDE_ARGS"
+            "--publish-events-and-metrics"
         )
     else
         # Default args for vLLM engine (explicitly include block-size)

--- a/benchmarks/router/run_engines.sh
+++ b/benchmarks/router/run_engines.sh
@@ -172,7 +172,7 @@ for i in $(seq 1 $NUM_WORKERS); do
                 "${EXTRA_ARGS[@]}"
         elif [ "$USE_TRTLLM" = true ]; then
             echo "[${WORKER_TYPE^} Worker-$i] Using GPUs: $GPU_DEVICES"
-            # Run TensorRT-LLM engine
+            # Run TensorRT-LLM engine with trtllm-llmapi-launch for proper initialization
             TRTLLM_ARGS=()
             TRTLLM_ARGS+=("--model-path" "$MODEL_PATH")
             TRTLLM_ARGS+=("--tensor-parallel-size" "$TENSOR_PARALLEL_SIZE")
@@ -183,7 +183,7 @@ for i in $(seq 1 $NUM_WORKERS); do
             fi
             TRTLLM_ARGS+=("${EXTRA_ARGS[@]}")
 
-            exec env CUDA_VISIBLE_DEVICES=$GPU_DEVICES python -m dynamo.trtllm \
+            exec env CUDA_VISIBLE_DEVICES=$GPU_DEVICES trtllm-llmapi-launch python -m dynamo.trtllm \
                 "${TRTLLM_ARGS[@]}"
         else
             echo "[${WORKER_TYPE^} Worker-$i] Using GPUs: $GPU_DEVICES"

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -98,6 +98,7 @@ class StandaloneRouterHandler:
             "output_options": request.get("output_options", {}),
             "eos_token_ids": request.get("eos_token_ids", []),
             "annotations": request.get("annotations", []),
+            "disaggregated_params": request.get("disaggregated_params"),
             "extra_args": request.get("extra_args", {}),
         }
 
@@ -116,6 +117,7 @@ class StandaloneRouterHandler:
                 "top_logprobs": worker_output.get("top_logprobs"),
                 "finish_reason": worker_output.get("finish_reason"),
                 "index": worker_output.get("index"),
+                "disaggregated_params": worker_output.get("disaggregated_params"),
                 "extra_args": worker_output.get("extra_args"),
             }
             yield llm_engine_output

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -103,28 +103,24 @@ class StandaloneRouterHandler:
         }
 
         # Route and process through KvPushRouter
-        try:
-            async for worker_output in await self.kv_push_router.generate_from_request(
-                preprocessed_request
-            ):
-                # Wrap worker output into LLMEngineOutput format
-                # Worker should return dict with at minimum kv_transfer_params in extra_args
-                llm_engine_output = {
-                    "token_ids": worker_output.get("token_ids", []),
-                    "tokens": worker_output.get("tokens"),
-                    "text": worker_output.get("text"),
-                    "cum_log_probs": worker_output.get("cum_log_probs"),
-                    "log_probs": worker_output.get("log_probs"),
-                    "top_logprobs": worker_output.get("top_logprobs"),
-                    "finish_reason": worker_output.get("finish_reason"),
-                    "index": worker_output.get("index"),
-                    "disaggregated_params": worker_output.get("disaggregated_params"),
-                    "extra_args": worker_output.get("extra_args"),
-                }
-                yield llm_engine_output
-        except Exception as e:
-            logger.error(f"Error during request routing: {e}", exc_info=True)
-            raise
+        async for worker_output in await self.kv_push_router.generate_from_request(
+            preprocessed_request
+        ):
+            # Wrap worker output into LLMEngineOutput format
+            # Worker should return dict with at minimum kv_transfer_params in extra_args
+            llm_engine_output = {
+                "token_ids": worker_output.get("token_ids", []),
+                "tokens": worker_output.get("tokens"),
+                "text": worker_output.get("text"),
+                "cum_log_probs": worker_output.get("cum_log_probs"),
+                "log_probs": worker_output.get("log_probs"),
+                "top_logprobs": worker_output.get("top_logprobs"),
+                "finish_reason": worker_output.get("finish_reason"),
+                "index": worker_output.get("index"),
+                "disaggregated_params": worker_output.get("disaggregated_params"),
+                "extra_args": worker_output.get("extra_args"),
+            }
+            yield llm_engine_output
 
     async def best_worker_id(self, token_ids, router_config_override=None):
         """

--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -369,7 +369,9 @@ async def init(runtime: DistributedRuntime, config: Config):
             kv_listener = runtime.namespace(config.namespace).component(
                 config.component
             )
-            metrics_labels = [("model", config.served_model_name)]
+            # Use model_path as fallback if served_model_name is not provided
+            model_name_for_metrics = config.served_model_name or config.model_path
+            metrics_labels = [("model", model_name_for_metrics)]
             async with get_publisher(
                 component,
                 engine,

--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -363,7 +363,7 @@ async def init(runtime: DistributedRuntime, config: Config):
         # Get health check payload (checks env var and falls back to TensorRT-LLM default)
         health_check_payload = TrtllmHealthCheckPayload(tokenizer=tokenizer).to_dict()
 
-        if config.publish_events_and_metrics and is_first_worker(config):
+        if config.publish_events_and_metrics:
             # Initialize and pass in the publisher to the request handler to
             # publish events and metrics.
             kv_listener = runtime.namespace(config.namespace).component(

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -68,6 +68,7 @@ class RequestHandlerConfig:
     disaggregation_mode: DisaggregationMode
     disaggregation_strategy: DisaggregationStrategy
     next_client: object
+    next_router_client: Optional[object] = None
     encode_client: Optional[object] = None
     multimodal_processor: Optional[
         MultimodalRequestProcessor
@@ -88,6 +89,7 @@ class HandlerBase:
         self.disaggregation_mode = config.disaggregation_mode
         self.disaggregation_strategy = config.disaggregation_strategy
         self.next_client = config.next_client
+        self.next_router_client = config.next_router_client
         self.encode_client = config.encode_client
         self.multimodal_processor = config.multimodal_processor
         self.first_generation = True

--- a/lib/engines/llamacpp/src/lib.rs
+++ b/lib/engines/llamacpp/src/lib.rs
@@ -271,6 +271,7 @@ fn run_request(
             top_logprobs: None,
             finish_reason: None,
             index: None,
+            disaggregated_params: None,
             extra_args: None,
         };
         work_request

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -302,7 +302,16 @@ pub async fn start_kv_router_background(
                     let key = String::from_utf8_lossy(kv.key());
                     tracing::info!("Router deleted: {}", key);
 
-                    // Extract the router UUID from the key (format: kv_routers/<model>/<uuid>)
+                    // Only process deletions for routers on the same component
+                    if !key.contains(component.path().as_str()) {
+                        tracing::trace!(
+                            "Skipping router deletion from different component (key: {key}, subscriber component: {})",
+                            component.path()
+                        );
+                        continue;
+                    }
+
+                    // Extract the router UUID from the key
                     let Some(router_uuid) = key.split('/').next_back() else {
                         tracing::warn!("Could not extract UUID from router key: {}", key);
                         continue;

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -210,6 +210,7 @@ mod tests {
             top_logprobs: None,
             finish_reason: None,
             index: None,
+            disaggregated_params: None,
             extra_args: None,
         })
     }

--- a/lib/llm/src/mocker/engine.rs
+++ b/lib/llm/src/mocker/engine.rs
@@ -392,6 +392,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                             top_logprobs: None,
                             finish_reason: None,
                             index: None,
+                            disaggregated_params: None,
                             extra_args: None,
                         };
 

--- a/lib/llm/src/protocols/common/llm_backend.rs
+++ b/lib/llm/src/protocols/common/llm_backend.rs
@@ -85,6 +85,10 @@ pub struct LLMEngineOutput {
     // Index field for batch requests to match OpenAI format
     pub index: Option<u32>,
 
+    /// Disaggregated execution parameters (for prefill/decode separation)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disaggregated_params: Option<serde_json::Value>,
+
     /// Additional arguments for extensibility
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra_args: Option<serde_json::Value>,
@@ -101,6 +105,7 @@ impl LLMEngineOutput {
             top_logprobs: None,
             finish_reason: Some(FinishReason::Cancelled),
             index: None,
+            disaggregated_params: None,
             extra_args: None,
         }
     }
@@ -115,6 +120,7 @@ impl LLMEngineOutput {
             finish_reason: Some(FinishReason::Stop),
             top_logprobs: None,
             index: None,
+            disaggregated_params: None,
             extra_args: None,
         }
     }
@@ -129,6 +135,7 @@ impl LLMEngineOutput {
             top_logprobs: None,
             finish_reason: Some(FinishReason::Length),
             index: None,
+            disaggregated_params: None,
             extra_args: None,
         }
     }
@@ -143,6 +150,7 @@ impl LLMEngineOutput {
             top_logprobs: None,
             finish_reason: Some(FinishReason::Error(err_msg)),
             index: None,
+            disaggregated_params: None,
             extra_args: None,
         }
     }

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -60,6 +60,11 @@ pub struct PreprocessedRequest {
     #[builder(default)]
     pub router_config_override: Option<RouterConfigOverride>,
 
+    /// Disaggregated execution parameters (for prefill/decode separation)
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disaggregated_params: Option<serde_json::Value>,
+
     /// Additional arguments for extensibility
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
#### Overview:

- added `disaggregated_params` field to `PreprocessedRequest` and `LLMEngineOutput` so it supports trtllm natively
- allowed `remote_prefill` in the trtllm decode handler to use the prefill router

#### Tests

- e2e tested serving with and without the prefill routers. 
- There seems to be a bug with the KV events emitted by trtllm engines (for agg, prefill, and decode) causing the blocks to be received as empty by the indexer, so cannot benchmark (outside the scope of this PR)
- Did not observe regression with vllm prefill routing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Prefill requests can route through a standalone router in decode-disaggregation mode, with automatic fallback to direct workers and warning logs on failures for improved resilience.
  - Added an optional disaggregated_params field to requests and responses to carry separated execution parameters; omitted when empty to maintain backward compatibility.

- Tests
  - Updated test helpers and mock engines to reflect the new optional disaggregated_params field in outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->