### PR TITLE
feat: add model downloader for ds r1 recipe

### DIFF
--- a/recipes/deepseek-r1/model_cache/model-download.yaml
+++ b/recipes/deepseek-r1/model_cache/model-download.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: MODEL_NAME
+              value: deepseek-ai/DeepSeek-R1
+            - name: HF_HOME
+              value: /root/.cache/huggingface
+            - name: MODEL_REVISION
+              value: 56d4cbbb4d29f4355bab4b9a39ccb717a14ad5ad
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub
+              hf download $MODEL_NAME --revision $MODEL_REVISION
+          volumeMounts:
+            - name: model-cache
+              mountPath: /root/.cache/huggingface
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

adds model downloader for deepseek r1 recipe

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added a Kubernetes Job to pre-cache the DeepSeek-R1 model in a shared volume using secure credentials.
  - Downloads a specific model revision and runs once with automatic retries.
- Impact
  - Faster first-run performance and reduced cold starts for model-dependent features.
  - Improved reliability of model availability across deployments.
  - No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->