### PR TITLE
fix: update dynamo namespace env var usage

### DIFF
--- a/components/backends/sglang/deploy/disagg_planner.yaml
+++ b/components/backends/sglang/deploy/disagg_planner.yaml
@@ -7,7 +7,7 @@ metadata:
   name: sglang-disagg-planner
 spec:
   envs:
-    - name: DYNAMO_NAMESPACE
+    - name: DYN_NAMESPACE
       value: "dynamo"
   pvcs:
     - name: dynamo-pvc

--- a/components/backends/sglang/deploy/disagg_planner.yaml
+++ b/components/backends/sglang/deploy/disagg_planner.yaml
@@ -6,9 +6,6 @@ kind: DynamoGraphDeployment
 metadata:
   name: sglang-disagg-planner
 spec:
-  envs:
-    - name: DYN_NAMESPACE
-      value: "dynamo"
   pvcs:
     - name: dynamo-pvc
       create: false # Must be pre-created before deployment and SLA profiler must have been run

--- a/components/backends/trtllm/deploy/disagg_planner.yaml
+++ b/components/backends/trtllm/deploy/disagg_planner.yaml
@@ -9,9 +9,6 @@ spec:
   pvcs:
     - name: dynamo-pvc
       create: false
-  envs:
-    - name: DYN_NAMESPACE
-      value: "trtllm-disagg-planner"
   services:
     Frontend:
       dynamoNamespace: trtllm-disagg-planner

--- a/components/backends/trtllm/deploy/disagg_planner.yaml
+++ b/components/backends/trtllm/deploy/disagg_planner.yaml
@@ -10,7 +10,7 @@ spec:
     - name: dynamo-pvc
       create: false
   envs:
-    - name: DYNAMO_NAMESPACE
+    - name: DYN_NAMESPACE
       value: "trtllm-disagg-planner"
   services:
     Frontend:

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -10,7 +10,7 @@ spec:
     - name: dynamo-pvc
       create: false # Must be pre-created before deployment and SLA profiler must have been run
   envs:
-    - name: DYNAMO_NAMESPACE
+    - name: DYN_NAMESPACE
       value: "vllm-disagg-planner"
   services:
     Frontend:

--- a/components/backends/vllm/deploy/disagg_planner.yaml
+++ b/components/backends/vllm/deploy/disagg_planner.yaml
@@ -9,9 +9,6 @@ spec:
   pvcs:
     - name: dynamo-pvc
       create: false # Must be pre-created before deployment and SLA profiler must have been run
-  envs:
-    - name: DYN_NAMESPACE
-      value: "vllm-disagg-planner"
   services:
     Frontend:
       dynamoNamespace: vllm-disagg-planner

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -45,7 +45,7 @@ from dynamo.runtime import DistributedRuntime
 
 from . import __version__
 
-DYNAMO_NAMESPACE_ENV_VAR = "DYN_NAMESPACE"
+DYN_NAMESPACE_ENV_VAR = "DYN_NAMESPACE"
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +147,7 @@ def parse_args():
     parser.add_argument(
         "--namespace",
         type=str,
-        default=os.environ.get(DYNAMO_NAMESPACE_ENV_VAR),
+        default=os.environ.get(DYN_NAMESPACE_ENV_VAR),
         help="Dynamo namespace for model discovery scoping. If specified, models will only be discovered from this namespace. If not specified, discovers models from all namespaces (global discovery).",
     )
     parser.add_argument(

--- a/components/src/dynamo/planner/defaults.py
+++ b/components/src/dynamo/planner/defaults.py
@@ -84,7 +84,7 @@ def _get_default_prometheus_endpoint(port: str, namespace: str):
 
 class SLAPlannerDefaults(BasePlannerDefaults):
     port = os.environ.get("PROMETHEUS_PORT", "9090")
-    namespace = os.environ.get("DYNAMO_NAMESPACE", "vllm-disagg-planner")
+    namespace = os.environ.get("DYN_NAMESPACE", "vllm-disagg-planner")
     prometheus_endpoint = _get_default_prometheus_endpoint(port, namespace)
     profile_results_dir = "profiling_results"
     isl = 3000  # in number of tokens

--- a/deploy/inference-gateway/README.md
+++ b/deploy/inference-gateway/README.md
@@ -191,7 +191,7 @@ export EPP_IMAGE=<the-epp-image-you-built>
 
 **Configuration**
 You can configure the plugin by setting environment vars in your [values-epp-aware.yaml].
-- Overwrite the `DYNAMO_NAMESPACE` env var if needed to match your model's dynamo namespace.
+- Overwrite the `DYN_NAMESPACE` env var if needed to match your model's dynamo namespace.
 - Set `DYNAMO_BUSY_THRESHOLD` to configure the upper bound on how “full” a worker can be (often derived from kv_active_blocks or other load metrics) before the router skips it. If the selected worker exceeds this value, routing falls back to the next best candidate. By default the value is negative meaning this is not enabled.
 - Set `DYNAMO_ROUTER_REPLICA_SYNC=true` to enable a background watcher to keep multiple router instances in sync (important if you run more than one KV router per component).
 - By default the Dynamo plugin uses KV routing. You can expose `DYNAMO_USE_KV_ROUTING=false`  in your [values-epp-aware.yaml] if you prefer to route in the round-robin fashion.

--- a/deploy/inference-gateway/epp-patches/epp-v0.5.1-2/epp-v0.5.1-dyn2.patch
+++ b/deploy/inference-gateway/epp-patches/epp-v0.5.1-2/epp-v0.5.1-dyn2.patch
@@ -647,7 +647,7 @@ index 0000000..1f6a41f
 +)
 +
 +func loadDynamoConfig() {
-+	ffiNamespace = getEnvOrDefault("DYNAMO_NAMESPACE", "vllm-agg")
++	ffiNamespace = getEnvOrDefault("DYN_NAMESPACE", "vllm-agg")
 +	ffiComponent = getEnvOrDefault("DYNAMO_COMPONENT", "backend")
 +	ffiModel = getEnvOrDefault("DYNAMO_MODEL", "Qwen/Qwen3-0.6B")
 +	ffiWorkerID = getEnvInt64OrDefault("DYNAMO_WORKER_ID", 1)

--- a/deploy/inference-gateway/helm/dynamo-gaie/templates/dynamo-epp.yaml
+++ b/deploy/inference-gateway/helm/dynamo-gaie/templates/dynamo-epp.yaml
@@ -84,7 +84,7 @@ spec:
             value: "{{ $platformName }}-etcd.{{ $platformNs }}:2379"
           - name: NATS_SERVER
             value: "nats://{{ $platformName }}-nats.{{ $platformNs }}:4222"
-          - name: DYNAMO_NAMESPACE
+          - name: DYN_NAMESPACE
             value: "{{ $ns }}"
           - name: DYNAMO_COMPONENT
             value: "{{ $comp }}"

--- a/deploy/logging/values/alloy-values.yaml
+++ b/deploy/logging/values/alloy-values.yaml
@@ -35,7 +35,7 @@ podLogs:
   structuredMetadata:
     pod: pod  # Set structured metadata "pod" from label "pod"
   namespaces:
-    - $DYNAMO_NAMESPACE
+    - $DYN_NAMESPACE
 
 # Collectors
 alloy-singleton:

--- a/docs/kubernetes/logging.md
+++ b/docs/kubernetes/logging.md
@@ -27,11 +27,11 @@ While this guide does not use Prometheus, it assumes Grafana is pre-installed wi
 
 The following env variables are set:
 - `MONITORING_NAMESPACE`: The namespace where Loki is installed
-- `DYNAMO_NAMESPACE`: The namespace where Dynamo Cloud Operator is installed
+- `DYN_NAMESPACE`: The namespace where Dynamo Cloud Operator is installed
 
 ```bash
 export MONITORING_NAMESPACE=monitoring
-export DYNAMO_NAMESPACE=dynamo-system
+export DYN_NAMESPACE=dynamo-system
 ```
 
 ## Installation Steps
@@ -99,7 +99,7 @@ podLogs:
   - "nvidia_com_dynamo_component_type" # extract this label from the dynamo graph deployment
   - "nvidia_com_dynamo_graph_deployment_name" # extract this label from the dynamo graph deployment
   namespaces:
-  - $DYNAMO_NAMESPACE
+  - $DYN_NAMESPACE
 ```
 
 ### 3. Configure Grafana with the Loki datasource and Dynamo Logs dashboard
@@ -126,7 +126,7 @@ At this point, we should have everything in place to collect and view logs in ou
 To enable structured logs in a DynamoGraphDeployment, we need to set the `DYN_LOGGING_JSONL` environment variable to `1`. This is done for us in the `agg_logging.yaml` setup for the Sglang backend. We can now deploy the DynamoGraphDeployment with:
 
 ```bash
-kubectl apply -n $DYNAMO_NAMESPACE -f components/backends/sglang/deploy/agg_logging.yaml
+kubectl apply -n $DYN_NAMESPACE -f components/backends/sglang/deploy/agg_logging.yaml
 ```
 
 Send a few chat completions requests to generate structured logs across the frontend and worker pods across the DynamoGraphDeployment. We are now all set to view the logs in Grafana.

--- a/tests/planner/perf_test_configs/disagg_8b_planner.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_planner.yaml
@@ -9,8 +9,6 @@ spec:
   envs:
     - name: DYNAMO_SERVICE_CONFIG
       value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:8000"]}]},{"job_name":"frontend","static_configs":[{"targets":["vllm-disagg-planner-frontend:8000"]}]}]}}'
-    - name: DYN_NAMESPACE
-      value: "vllm-disagg-planner"
   services:
     Frontend:
       dynamoNamespace: vllm-disagg-planner

--- a/tests/planner/perf_test_configs/disagg_8b_planner.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_planner.yaml
@@ -9,7 +9,7 @@ spec:
   envs:
     - name: DYNAMO_SERVICE_CONFIG
       value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:8000"]}]},{"job_name":"frontend","static_configs":[{"targets":["vllm-disagg-planner-frontend:8000"]}]}]}}'
-    - name: DYNAMO_NAMESPACE
+    - name: DYN_NAMESPACE
       value: "vllm-disagg-planner"
   services:
     Frontend:

--- a/tests/planner/scaling/disagg_planner.yaml
+++ b/tests/planner/scaling/disagg_planner.yaml
@@ -9,7 +9,7 @@ spec:
   envs:
     - name: DYNAMO_SERVICE_CONFIG
       value: '{"Prometheus":{"global":{"scrape_interval":"5s"},"scrape_configs":[{"job_name":"prometheus","static_configs":[{"targets":["localhost:9090"]}]},{"job_name":"frontend","static_configs":[{"targets":["vllm-disagg-planner-frontend:8000"]}]}]}}'
-    - name: DYNAMO_NAMESPACE
+    - name: DYN_NAMESPACE
       value: "vllm-disagg-planner"
   services:
     Frontend:


### PR DESCRIPTION
#### Overview:

update dynamo namespace env var usage

replace `DYNAMO_NAMESPACE` with `DYN_NAMESPACE` (correct env variable)


[Dynamo namespace usage proposal](https://github.com/ai-dynamo/enhancements/blob/bis/multi-tenancy/deps/000N-mutlitenancy-support.md)


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes: dep-346



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standardized configuration uses the DYN_NAMESPACE environment variable across planners and related services.
- Documentation
  - Updated guides and examples to reference DYN_NAMESPACE, including setup, logging, and kubectl commands.
- Chores
  - Aligned deployment configs, Helm templates, and logging values to DYN_NAMESPACE for consistency.
- Tests
  - Updated test configurations to use DYN_NAMESPACE.

Note: If you previously set DYNAMO_NAMESPACE, switch to DYN_NAMESPACE to maintain your existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->