### PR TITLE
fix: dynamo.common import failing on non-editable installs

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -12,6 +12,15 @@ Main submodules:
 """
 
 from dynamo.common import config_dump
-from dynamo.common._version import __version__
+
+try:
+    from ._version import __version__
+except Exception:
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        __version__ = _pkg_version("ai-dynamo")
+    except Exception:
+        __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump"]

--- a/components/src/dynamo/common/config_dump/config_dumper.py
+++ b/components/src/dynamo/common/config_dump/config_dumper.py
@@ -212,9 +212,9 @@ def _preprocess_for_encode_set(
 
 
 @register_encoder(argparse.Namespace)
-def _preprocess_for_encode_set(
+def _preprocess_for_encode_namespace(
     obj: argparse.Namespace,
-) -> list:  # pyright: ignore[reportUnusedFunction]
+) -> dict:  # pyright: ignore[reportUnusedFunction]
     return obj.__dict__
 
 

--- a/components/src/dynamo/common/config_dump/config_dumper.py
+++ b/components/src/dynamo/common/config_dump/config_dumper.py
@@ -211,6 +211,13 @@ def _preprocess_for_encode_set(
     return sorted(list(obj))
 
 
+@register_encoder(argparse.Namespace)
+def _preprocess_for_encode_set(
+    obj: argparse.Namespace,
+) -> list:  # pyright: ignore[reportUnusedFunction]
+    return obj.__dict__
+
+
 @register_encoder(Enum)
 def _preprocess_for_encode_enum(
     obj: Enum,


### PR DESCRIPTION
Fix issue with `dynamo.common._version` not being importable for editable installs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Config dump now supports argparse.Namespace objects, automatically serializing them for export.

- Bug Fixes
  - Improved version retrieval robustness: if package metadata is unavailable, the application falls back to a safe version value instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->