### PR TITLE
fix: frontend component handles graceful shutdown

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -243,8 +243,6 @@ async def async_main():
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, signal_handler)
 
-    logging.debug("Signal handlers will trigger a graceful shutdown of the runtime")
-
     if flags.router_mode == "kv":
         router_mode = RouterMode.KV
         kv_router_config = KvRouterConfig(
@@ -307,9 +305,7 @@ async def async_main():
 
 
 async def graceful_shutdown(runtime):
-    logging.info("Received shutdown signal, shutting down DistributedRuntime")
     runtime.shutdown()
-    logging.info("DistributedRuntime shutdown complete")
 
 
 def main():

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -243,7 +243,7 @@ async def async_main():
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, signal_handler)
 
-    logging.info("Signal handlers will trigger a graceful shutdown of the runtime")
+    logging.debug("Signal handlers will trigger a graceful shutdown of the runtime")
 
     if flags.router_mode == "kv":
         router_mode = RouterMode.KV


### PR DESCRIPTION
#### Overview:

In the testing of Rolling Updates for the frontend within Kubernetes, I observed that the frontend never respected the SIGTERM from Pod termination -  the Frontend would continue processing requests from persistent connections. These requests would be dropped when the Pod was finally killed.

#### Details:

This PR adds a signal handler to trigger graceful shutdown when SIGTERM is received - in line with how workers handle signals. Results in proper graceful shutdown of frontend during Rolling Updates.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds graceful shutdown for the frontend runtime on termination signals (SIGTERM/SIGINT), ensuring a controlled stop of services.
  - Provides clearer logging before, during, and after shutdown to aid observability.

- Chores
  - Improves signal handling setup to make shutdown behavior more predictable and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->