### PR TITLE
fix: minor robustness improvement for datagen analyze

### DIFF
--- a/benchmarks/burstgpt_loadgen/convert.py
+++ b/benchmarks/burstgpt_loadgen/convert.py
@@ -7,9 +7,8 @@ import os
 import random
 
 import pandas as pd
-from tqdm import tqdm
-
 from prefix_data_generator.hasher import RollingHasher
+from tqdm import tqdm
 
 
 def parse_args():

--- a/benchmarks/burstgpt_loadgen/convert.py
+++ b/benchmarks/burstgpt_loadgen/convert.py
@@ -9,6 +9,8 @@ import random
 import pandas as pd
 from tqdm import tqdm
 
+from prefix_data_generator.hasher import RollingHasher
+
 
 def parse_args():
     """Parse command line arguments."""
@@ -154,8 +156,9 @@ def convert_to_mooncake(df, block_size, num_hash_blocks):
         DataFrame in mooncake format with columns: timestamp, input_length, output_length, hash_ids
     """
     mooncake_data = []
+    hasher = RollingHasher()  # Initialize once to maintain global state
 
-    for _, row in tqdm(df.iterrows(), total=len(df)):
+    for idx, row in tqdm(df.iterrows(), total=len(df)):
         # Convert timestamp from seconds to milliseconds (integer)
         timestamp_ms = int(row["Timestamp"] * 1000)
 
@@ -166,10 +169,14 @@ def convert_to_mooncake(df, block_size, num_hash_blocks):
         # Calculate hash array length based on block size
         hash_array_length = math.ceil(input_length / block_size)
 
-        # Generate random hash IDs
-        hash_ids = [
-            random.randint(0, num_hash_blocks) for _ in range(hash_array_length)
+        # Generate random content blocks (each block is a tuple of random integers)
+        # Using request index as seed for reproducibility
+        random.seed(idx)
+        content_blocks = [
+            (random.randint(0, num_hash_blocks),) for _ in range(hash_array_length)
         ]
+
+        hash_ids = hasher(content_blocks)
 
         mooncake_data.append(
             {


### PR DESCRIPTION
#### Overview:

- `prefix_analyze.py`: Consider (hash_ids, position) instead of just hash_ids. This is technically redundant if hash_ids are a sequence hashes, but (maybe) needed if hash_ids are local block hashes
- `hasher.py`: added `RollingHasher` util
- `convert.py`: use `RollingHasher` to generate the globally increasing hash ids (mooncake)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More accurate benchmarking reports by considering position-specific repeated entries in prefix analysis.
- Bug Fixes
  - Corrected detection of repeated entries, ensuring prefix lengths and summary metrics reflect true repetitions.
- Documentation
  - Clarified output messages to match the updated analysis semantics.
- Refactor
  - Streamlined analysis logic to operate on position-aware entries for improved consistency across datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->