### PR TITLE
test: Remove extra test to kill CoreProcess

### DIFF
--- a/tests/fault_tolerance/deploy/scenarios.py
+++ b/tests/fault_tolerance/deploy/scenarios.py
@@ -288,13 +288,6 @@ def _create_backend_failures(backend, deploy_type="disagg"):
         failures["sglang_prefill_detokenizer"] = [
             Failure(30, prefill_worker, "sglang::detokenizer", "SIGKILL")
         ]
-    elif backend == "trtllm":
-        failures["trtllm_decode_engine_core"] = [
-            Failure(30, decode_worker, "TRTLLM::EngineCore", "SIGKILL")
-        ]
-        failures["trtllm_prefill_engine_core"] = [
-            Failure(30, prefill_worker, "TRTLLM::EngineCore", "SIGKILL")
-        ]
 
     return failures
 


### PR DESCRIPTION
#### Overview:
Remove non-functional TRTLLM fault injection scenarios that target non-existent `TRTLLM::EngineCore` processes.

#### Details:
- Removed `trtllm_decode_engine_core` and `trtllm_prefill_engine_core` fault scenarios from `scenarios.py`
- These scenarios were attempting to kill processes named `TRTLLM::EngineCore`, which don't exist in TRTLLM's architecture
- The existing `decode_worker` and `prefill_worker` scenarios already provide process-level fault injection for TRTLLM

**Root cause:** This scenario were copied from https://github.com/ai-dynamo/dynamo/blob/0c4c4d1de3fc19caf21bf50352e4dd5c0a94139a/tests/serve/test_trtllm.py#L21

#### Where should the reviewer start?
- `tests/fault_tolerance/deploy/scenarios.py` - lines 288-299 (removal of non-functional TRTLLM scenarios)


#### Related Issues:
- Relates to fault tolerance testing for TRTLLM backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated fault-tolerance scenarios for the TRTLLM backend by removing two SIGKILL failure injections related to decode and prefill paths.
  * Streamlines the test suite to better reflect current backend behavior and reduce false negatives.
  * No changes to runtime functionality or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->