### PR TITLE
fix: update distroless go container for operator to fix openssl

### DIFF
--- a/deploy/cloud/operator/Dockerfile
+++ b/deploy/cloud/operator/Dockerfile
@@ -47,7 +47,7 @@ FROM base AS builder
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o manager ./cmd/main.go
 
 # Runtime stage
-FROM nvcr.io/nvidia/distroless/go:v3.1.12
+FROM nvcr.io/nvidia/distroless/go:v3.1.13
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/deploy/cloud/operator/Earthfile
+++ b/deploy/cloud/operator/Earthfile
@@ -48,7 +48,7 @@ docker:
     ARG DOCKER_SERVER=my-registry
     ARG IMAGE_TAG=latest
     ARG IMAGE_SUFFIX=dynamo-operator
-    FROM nvcr.io/nvidia/distroless/go:v3.1.12
+    FROM nvcr.io/nvidia/distroless/go:v3.1.13
     WORKDIR /
     COPY +build/manager .
     USER 65532:65532


### PR DESCRIPTION
#### Overview:

Bumps the version of the runtime base distroless container to fix [CVE-2025-9230](https://security-tracker.debian.org/tracker/CVE-2025-9230)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded the operator container base image to the latest patch release for the distroless Go runtime used in deployments. This brings upstream security and stability updates with no expected behavior changes.
  - Aligned build and deployment configurations to the same base image version for consistency across environments and reduced supply-chain variance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->