### PR TITLE
docs: Add note about NGC login required for TRTLLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ You can pass any sglang flags directly to this worker, see https://docs.sglang.a
 It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch) for running the TensorRT-LLM engine.
 
 > [!Note]
+> To use the PyTorch container from NVIDIA NGC, you must log in to NGC with Docker. If you do not have an NGC account, create one at [ngc.nvidia.com/signin](https://ngc.nvidia.com/signin). Obtain your API key from [ngc.nvidia.com/setup/api-key](https://ngc.nvidia.com/setup/api-key), then log in with:
+> ```
+> docker login nvcr.io
+> ```
+> When prompted for a username, enter your NGC email or `$oauthtoken` (without quotes). When prompted for a password, enter your NGC API key.
+
+> [!Note]
 > Ensure that you select a PyTorch container image version that matches the version of TensorRT-LLM you are using.
 > For example, if you are using `tensorrt-llm==1.1.0rc5`, use the PyTorch container image version `25.06`.
 > To find the correct PyTorch container version for your desired `tensorrt-llm` release, visit the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) on GitHub. Switch to the branch that matches your `tensorrt-llm` version, and look for the `BASE_TAG` line to identify the recommended PyTorch container tag.

--- a/components/backends/trtllm/README.md
+++ b/components/backends/trtllm/README.md
@@ -85,6 +85,20 @@ docker compose -f deploy/docker-compose.yml up -d
 # TensorRT-LLM uses git-lfs, which needs to be installed in advance.
 apt-get update && apt-get -y install git git-lfs
 
+# You need to login to NVIDIA NGC to pull the PyTorch NGC container during the build process.
+# If you do not have an NGC account, you can create one for free at https://ngc.nvidia.com/signin
+# Once you have an account, obtain your NGC API key from https://ngc.nvidia.com/setup/api-key
+
+# Login to NGC using Docker:
+docker login nvcr.io
+
+# When prompted for a username, enter your NGC email or "$oauthtoken" (without quotes).
+# When prompted for a password, enter your NGC API key.
+
+# Example:
+# Username: $oauthtoken
+# Password: <your NGC API key>
+
 # On an x86 machine:
 ./container/build.sh --framework trtllm
 


### PR DESCRIPTION
#### Overview:

Include NGC login instructions for TRTLLM backend.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded TensorRT-LLM setup instructions with a step-by-step guide for NVIDIA NGC access, including account creation, API key generation, and Docker login to the registry.
  - Added guidance on choosing the correct PyTorch container version for a given TensorRT-LLM release.
  - Clarified Quick Start build instructions to improve usability on x86 environments.
  - Improved readability and completeness of setup guidance; no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->