### PR TITLE
feat: changing SIGKILL to SIGINT for graceful shutdown

### DIFF
--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -336,6 +336,15 @@ class PodProcess:
                 signal = "SIGINT"
             else:
                 signal = "SIGKILL"
+        # Python processes need signal handlers for graceful shutdown
+        if self.pid == 1 and signal == "SIGKILL" and "python" in self.command.lower():
+            logging.info(
+                f"PID 1 is a Python process ({self.command[:50]}...), "
+                "changing SIGKILL to SIGINT for graceful shutdown"
+            )
+            signal = "SIGINT"
+
+        logging.info("Killing PID %s with %s", self.pid, signal)
 
         return self._pod.exec(["kill", f"-{signal}", str(self.pid)])
 


### PR DESCRIPTION
#### Overview:

This PR improves the signal handling for PID 1 Python processes in Kubernetes pods during test execution. It ensures graceful shutdown by using SIGINT instead of SIGKILL for Python processes running as PID 1, allowing them to properly clean up resources and handle shutdown signals.

#### Details:

The changes address a specific issue with killing processes in containerized environments:
Problem: PID 1 processes in containers require special signal handling. When Python processes run as PID 1, sending SIGKILL prevents graceful shutdown and proper cleanup. The dynamo worker wasn't terminated with SIGKILL.
Solution: Added logic to automatically convert SIGKILL to SIGINT when:

1. The process is PID 1
2. The signal is SIGKILL
3. The process is a Python process (detected by checking the command string)


#### Where should the reviewer start?

tests/utils/managed_deployment.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-703


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves shutdown behavior for services running as PID 1: Python-based processes now receive a graceful SIGINT instead of SIGKILL, reducing abrupt exits and potential data loss. Existing behavior for other processes remains unchanged.

* **Chores**
  * Adds clearer informational logs before termination, including the target PID and signal used, to aid troubleshooting and make shutdown actions more transparent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->