### PR TITLE
feat: allow shutdown of orphaned kv consumers on Router startup

### DIFF
--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -649,6 +649,17 @@ impl NatsQueue {
         }
     }
 
+    /// List all consumer names for the stream
+    pub async fn list_consumers(&mut self) -> Result<Vec<String>> {
+        self.ensure_connection().await?;
+
+        if let Some(client) = &self.client {
+            client.list_consumers(&self.stream_name).await
+        } else {
+            Err(anyhow::anyhow!("Client not connected"))
+        }
+    }
+
     /// Enqueue a task using the provided data
     pub async fn enqueue_task(&mut self, task_data: Bytes) -> Result<()> {
         self.ensure_connection().await?;


### PR DESCRIPTION
#### Overview:

This is particularly useful if the last Router replica in the component is ungracefully terminated, so a cleanup on startup is another safeguard to prevent orphaned consumers from hanging around, which would affect snapshotting. A leftover task from #2756 

#### e2e test:

In addition to the existing CI tests, I manually monitored that the orphaned durable consumers in the stream would be removed on a restart after an ungraceful shutdown (nuking the terminal)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic cleanup of orphaned message consumers during startup to prevent stale processing.
- Bug Fixes
  - More robust handling of router deletions to avoid accidental cross-component cleanup and reduce resource leaks.
- Chores
  - Improved logging clarity around router lifecycle and cleanup actions.
  - Startup housekeeping to align active consumers with current router entries for greater reliability.
  - Internal enhancements to support listing queue consumers, enabling better monitoring and maintenance workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->