### PR TITLE
feat: added support for multi-modal fields in pre-processor

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -217,6 +217,8 @@ impl OpenAIPreprocessor {
         if let Some(nvext) = request.nvext() {
             builder.backend_instance_id(nvext.backend_instance_id);
         }
+        // Extract multimodal content (images, videos) if present
+        builder.multimodal_data(request.extract_multimodal_content());
 
         Ok(builder)
     }

--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -76,6 +76,14 @@ pub trait OAIChatLikeRequest {
     fn extract_text(&self) -> Option<TextInput> {
         None
     }
+
+    /// Extract multimodal content (images, videos) from the request
+    /// Returns None if no multimodal content is present
+    fn extract_multimodal_content(
+        &self,
+    ) -> Option<Vec<crate::protocols::common::preprocessor::MultiModalContentItem>> {
+        None
+    }
 }
 
 pub trait OAIPromptFormatter: Send + Sync + 'static {

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -8,6 +8,21 @@ use super::{OutputOptions, SamplingOptions, StopConditions};
 use crate::kv_router::RouterConfigOverride;
 use crate::protocols::TokenIdType;
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum MultiModalContentType {
+    ImageUrl,
+    VideoUrl,
+    AudioUrl,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MultiModalContentItem {
+    // content type can be image_url, video_url
+    pub content_type: MultiModalContentType,
+    // data is the actual data for the content type
+    pub data: serde_json::Value,
+}
+
 /// [`PreprocessedRequest`] is the internal representation of an LLM request. The [`dynamo.llm-preprocessor`]
 /// crate is responsible for converting request from the public APIs to this internal representation.
 #[derive(Serialize, Deserialize, Debug, Clone, Builder)]
@@ -69,6 +84,11 @@ pub struct PreprocessedRequest {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra_args: Option<serde_json::Value>,
+
+    /// Multimodal data from original request (image_urls, video_urls, audio_urls)
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub multimodal_data: Option<Vec<MultiModalContentItem>>,
 }
 
 impl PreprocessedRequest {


### PR DESCRIPTION
#### Overview:

Current State: Pre-Processor is unaware of multi-modal requests coming  from user. The API support is there as it is openai compatible but pre-processor do nothing with that. 

To support multi-modal flow in the current state, we need a separate processor worker that can read user request and parse multi-modal inputs. 

This PR makes rust pre-processor aware of multi-modal inputs and extracts them and passes them via PreProcessed Request to the worker. Now the worker just needs to use those inputs and do some loading which is happening anyways there. The follow up PR will contain work on the vLLM worker side. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
