### PR TITLE
docs: Adding elements required for version switcher

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ import sys
 project = "NVIDIA Dynamo"
 copyright = "2024-2025, NVIDIA CORPORATION & AFFILIATES"
 author = "NVIDIA"
+release = "0.5.0"
 
 # -- General configuration ---------------------------------------------------
 
@@ -58,9 +59,30 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "build"]
 # -- Options for HTML output -------------------------------------------------
 html_theme = "nvidia_sphinx_theme"
 html_static_path = ["_static"]
+html_extra_path = ["project.json", "versions1.json"]
 html_theme_options = {
     "collapse_navigation": False,
-    "github_url": "https://github.com/ai-dynamo/dynamo",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/ai-dynamo/dynamo",
+            "icon": "fa-brands fa-github",
+        }
+    ],
+    "switcher": {
+        "json_url": "../versions1.json",
+        "version_match": release,
+    },
+    "extra_head": {
+        """
+    <script src="https://assets.adobedtm.com/5d4962a43b79/c1061d2c5e7b/launch-191c2462b890.min.js" ></script>
+    """
+    },
+    "extra_footer": {
+        """
+    <script type="text/javascript">if (typeof _satellite !== "undefined") {_satellite.pageBottom();}</script>
+    """
+    },
     "navbar_start": ["navbar-logo"],
     "primary_sidebar_end": [],
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ import sys
 project = "NVIDIA Dynamo"
 copyright = "2024-2025, NVIDIA CORPORATION & AFFILIATES"
 author = "NVIDIA"
-release = "0.5.0"
+release = "latest"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "NVIDIA Dynamo", "version": "0.5.0"}
+{"name": "NVIDIA Dynamo", "version": "latest"}

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,0 +1,1 @@
+{"name": "NVIDIA Dynamo", "version": "0.5.0"}

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,8 +1,12 @@
 [
     {
         "preferred": true,
+        "version": "latest",
+        "url": "https://docs.nvidia.com/dynamo/latest/"
+    },
+    {
         "version": "0.5.0",
-        "url": "https://docs.nvidia.com/dynamo/0.5.0/"
+        "url": "https://docs.nvidia.com/dynamo/archive/0.5.0/"
     },
     {
         "name": "0.4.1",

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,0 +1,42 @@
+[
+    {
+        "preferred": true,
+        "version": "0.5.0",
+        "url": "https://docs.nvidia.com/dynamo/0.5.0/"
+    },
+    {
+        "name": "0.4.1",
+        "version": "0.4.1",
+        "url": "https://docs.nvidia.com/dynamo/archive/0.4.1/"
+    },
+    {
+        "name": "0.4.0",
+        "version": "0.4.0",
+        "url": "https://docs.nvidia.com/dynamo/archive/0.4.0/"
+    },
+    {
+        "name": "0.3.2",
+        "version": "0.3.2",
+        "url": "https://docs.nvidia.com/dynamo/archive/0.3.2/"
+    },
+    {
+        "name": "0.3.1",
+        "version": "0.3.1",
+        "url": "https://docs.nvidia.com/dynamo/archive/0.3.1/"
+    },
+    {
+        "name": "0.3.0",
+        "version": "0.3.0",
+        "url": "https://docs.nvidia.com/dynamo/archive/0.3.0/"
+    },
+    {
+        "name": "0.2.1",
+        "version": "0.2.1",
+        "url": "https://docs.nvidia.com/dynamo/archive/0.2.1/"
+    },
+    {
+        "name": "0.2.0",
+        "version": "0.2.0",
+        "url": "https://docs.nvidia.com/dynamo/archive/0.2.0/"
+    }
+]

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -5,6 +5,10 @@
         "url": "https://docs.nvidia.com/dynamo/latest/"
     },
     {
+        "version": "0.5.1",
+        "url": "https://docs.nvidia.com/dynamo/archive/0.5.1/"
+    },
+    {
         "version": "0.5.0",
         "url": "https://docs.nvidia.com/dynamo/archive/0.5.0/"
     },


### PR DESCRIPTION
#### Overview:

This PR enables the version switcher drop-down for Dynamo docs. It adds the versions1.json and project.json to aid the drop-down when deployed. It also adds the Adobe Launch script, which is used for analytics. Finally, it swaps the GitHub icon to be more in line with the NVIDIA PyPi theme.

#### Details:

Changes made to docs/conf.py and versions1.json and project.json files created.

#### Where should the reviewer start?

docs/ folder and conf.py.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a documentation version switcher with links to “latest” and historical releases.
  * Enhanced header and footer with support for additional scripts and a GitHub icon link.
  * Designated the current docs as “latest” for clearer version labeling.
  * Added project metadata to improve the docs UI and version awareness.
  * Refined HTML theme options and asset handling while preserving existing navigation layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->