### PR TITLE
fix: Send last token batch when finish_reason is set

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -171,18 +171,19 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         num_output_tokens_so_far = 0
 
         async for res in stream_source:
+            out = {}
             finish_reason = res["meta_info"]["finish_reason"]
             if finish_reason:
-                out = {"token_ids": [], "finish_reason": finish_reason["type"]}
-            else:
-                try:
-                    next_total_toks = len(res["output_ids"])
-                except KeyError:
-                    raise ValueError(
-                        f"Missing 'output_ids' in response. Response keys: {list(res.keys())}"
-                    )
-                out = {"token_ids": res["output_ids"][num_output_tokens_so_far:]}
-                num_output_tokens_so_far = next_total_toks
+                out["finish_reason"] = finish_reason["type"]
+
+            try:
+                next_total_toks = len(res["output_ids"])
+            except KeyError:
+                raise ValueError(
+                    f"Missing 'output_ids' in response. Response keys: {list(res.keys())}"
+                )
+            out["token_ids"] = res["output_ids"][num_output_tokens_so_far:]
+            num_output_tokens_so_far = next_total_toks
 
             yield out
 

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -164,9 +164,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         Yields:
             Dict with token_ids and optional finish_reason.
-
-        Raises:
-            ValueError: If response missing output_ids.
         """
         num_output_tokens_so_far = 0
 
@@ -176,15 +173,15 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             if finish_reason:
                 out["finish_reason"] = finish_reason["type"]
 
-            try:
-                next_total_toks = len(res["output_ids"])
-            except KeyError:
-                raise ValueError(
-                    f"Missing 'output_ids' in response. Response keys: {list(res.keys())}"
-                )
-            out["token_ids"] = res["output_ids"][num_output_tokens_so_far:]
-            num_output_tokens_so_far = next_total_toks
+            output_ids = res.get("output_ids", [])
+            # If request is not finished yet, but there are no outputs, return an error.
+            if not output_ids and not finish_reason:
+                yield {"finish_reason": "error", "token_ids": []}
+                break
 
+            next_total_toks = len(output_ids)
+            out["token_ids"] = output_ids[num_output_tokens_so_far:]
+            num_output_tokens_so_far = next_total_toks
             yield out
 
     async def _process_text_stream(


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Fixes SGLang worker to include last token(s) in response when a finish reason is set. Before when finish_reason is set, it would hard-code the response to have no tokens. But there are scenarios where finish_reason is set _and_ there are tokens to send back with it.

Note this edge case isn't just for the "last" token, it's the last "batch" of tokens - so if you set something like `--stream-interval 50` where each iteration returns 50 tokens at a time, without this change you'd be excluding up to the last 50 tokens as well.

#### Details:

<!-- Describe the changes made in this PR. -->

Before (`content=null` - no token returned):
```
$ curl localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '
{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [{"role": "user", "content": "Write me a DND campaign"}],
  "stream": true,
  "max_tokens": 1,
  "ignore_eos": false,
  "stream_options": {"include_usage": false}
}'
data: {"id":"chatcmpl-2dae09bb-1ed3-409f-9ad1-2f2e2c5e15d0","choices":[{"index":0,"delta":{"content":null,"function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null},"finish_reason":"length"}],"created":1759510713,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

data: [DONE]
``` 

After (`<think>` token returned in `content` field):
```
$ curl localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '
{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [{"role": "user", "content": "Write me a DND campaign"}],
  "stream": true,
  "max_tokens": 1,
  "ignore_eos": false,
  "stream_options": {"include_usage": false}
}'
data: {"id":"chatcmpl-a5747b00-1cb8-4062-8cf2-7ddf899b9a15","choices":[{"index":0,"delta":{"content":"<think>","function_call":null,"tool_calls":null,"role":"assistant","refusal":null,"reasoning_content":null},"finish_reason":"length"}],"created":1760037414,"model":"Qwen/Qwen3-0.6B","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}

data: [DONE]
```

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes #3443 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined token streaming logic for more consistent handling of generated tokens and completion signals.
  - Consolidated control flow to always read and slice output tokens, improving clarity and reducing edge-case inconsistencies.
  - Enhanced robustness with clearer error behavior when token outputs are missing.
  - No changes to user-facing APIs; behavior remains consistent while improving reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->