### PR TITLE
docs: removed all TODOs from public facing docs within repo

### DIFF
--- a/deploy/metrics/README.md
+++ b/deploy/metrics/README.md
@@ -163,8 +163,6 @@ $ python -m dynamo.vllm --model Qwen/Qwen3-0.6B  \
 - **HTTP Queue**: Measures queuing time before processing begins (including prefill time)
 - **HTTP Queue ≤ Inflight** (HTTP queue is a subset of inflight time)
 
-¹ **TODO**: Implement the "actual" HTTP queue metric that tracks from request start until first token generation begins, rather than the current implementation that tracks until first token is received by the frontend
-
 ### Required Files
 
 The following configuration files should be present in this directory:

--- a/docs/backends/vllm/multi-node.md
+++ b/docs/backends/vllm/multi-node.md
@@ -95,9 +95,6 @@ python -m dynamo.vllm \
   --is-prefill-worker
 ```
 
-
-## TODO
-
 ## Large Model Deployment
 
 For models requiring more GPUs than available on a single node such as tensor-parallel-size 16:


### PR DESCRIPTION
#### Overview:

docs: removed all TODOs from public facing docs within repo




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Cleaned up multi-node backend docs by removing unused TODO subheaders and extra blank lines, improving readability and flow into the Large Model Deployment section.
  * Updated metrics documentation by clarifying the “actual HTTP queue” label (removed footnote marker) and deleting an obsolete TODO footnote about a pending metric.
  * Overall, improves clarity and reduces clutter in docs; no functional, deployment, or metric behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->