### PR TITLE
chore(build): Silence unused variable warnings in dynamo-run

### DIFF
--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -83,6 +83,7 @@ pub async fn run(
 
 /// Create the engine matching `out_opt`
 /// Note validation happens in Flags::validate. In here assume everything is going to work.
+#[allow(unused_variables)]
 async fn engine_for(
     out_opt: Output,
     flags: Flags,


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

This PR cleans up the `dynamo-run` build process by silencing `unused_variables` warnings.


#### Details:

``` 
warning: unused variable: `local_model`
   --> launch/dynamo-run/src/flags.rs:152:9
    |
152 |         local_model: &LocalModel,
    |         ^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_local_model`
```

These warnings occur for parameters like `local_model` which are only used when optional features (e.g., `llamacpp`) are enabled.

Adding `#[allow(unused_variables)]` resolves the warnings while maintaining a consistent API across different build configurations.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Suppressed compile-time warnings for unused variables in select internal methods to keep builds clean and reduce noise during development. No changes to functionality or behavior.
- Notes
  - No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->