### PR TITLE
chore: remove deprecated nvext parameters for 0.6.0

### DIFF
--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -8,7 +8,7 @@ use super::{
     ContentProvider,
     common::{self, OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider},
 };
-use crate::protocols::openai::common_ext::{CommonExtProvider, choose_with_deprecation};
+use crate::protocols::openai::common_ext::CommonExtProvider;
 
 pub mod chat_completions;
 pub mod common_ext;
@@ -65,14 +65,9 @@ trait OpenAIStopConditionsProvider {
         None
     }
 
-    /// Get the effective ignore_eos value, considering both CommonExt and NvExt.
-    /// CommonExt (root-level) takes precedence over NvExt.
+    /// Get the effective ignore_eos value from CommonExt.
     fn get_ignore_eos(&self) -> Option<bool> {
-        choose_with_deprecation(
-            "ignore_eos",
-            self.get_common_ignore_eos().as_ref(),
-            self.nvext().and_then(|nv| nv.ignore_eos.as_ref()),
-        )
+        self.get_common_ignore_eos()
     }
 
     /// Get max_thinking_tokens from nvext

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -9,9 +9,7 @@ use crate::engines::ValidateRequest;
 
 use super::{
     OpenAIOutputOptionsProvider, OpenAISamplingOptionsProvider, OpenAIStopConditionsProvider,
-    common_ext::{
-        CommonExt, CommonExtProvider, choose_with_deprecation, emit_nvext_deprecation_warning,
-    },
+    common_ext::{CommonExt, CommonExtProvider},
     nvext::NvExt,
     nvext::NvExtProvider,
     validate,
@@ -158,88 +156,39 @@ impl CommonExtProvider for NvCreateChatCompletionRequest {
 
     /// Guided Decoding Options
     fn get_guided_json(&self) -> Option<&serde_json::Value> {
-        // Note: This one needs special handling since it returns a reference
-        if let Some(nvext) = &self.nvext
-            && nvext.guided_json.is_some()
-        {
-            emit_nvext_deprecation_warning("guided_json", true, self.common.guided_json.is_some());
-        }
-        self.common
-            .guided_json
-            .as_ref()
-            .or_else(|| self.nvext.as_ref().and_then(|nv| nv.guided_json.as_ref()))
+        self.common.guided_json.as_ref()
     }
 
     fn get_guided_regex(&self) -> Option<String> {
-        choose_with_deprecation(
-            "guided_regex",
-            self.common.guided_regex.as_ref(),
-            self.nvext.as_ref().and_then(|nv| nv.guided_regex.as_ref()),
-        )
+        self.common.guided_regex.clone()
     }
 
     fn get_guided_grammar(&self) -> Option<String> {
-        choose_with_deprecation(
-            "guided_grammar",
-            self.common.guided_grammar.as_ref(),
-            self.nvext
-                .as_ref()
-                .and_then(|nv| nv.guided_grammar.as_ref()),
-        )
+        self.common.guided_grammar.clone()
     }
 
     fn get_guided_choice(&self) -> Option<Vec<String>> {
-        choose_with_deprecation(
-            "guided_choice",
-            self.common.guided_choice.as_ref(),
-            self.nvext.as_ref().and_then(|nv| nv.guided_choice.as_ref()),
-        )
+        self.common.guided_choice.clone()
     }
 
     fn get_guided_decoding_backend(&self) -> Option<String> {
-        choose_with_deprecation(
-            "guided_decoding_backend",
-            self.common.guided_decoding_backend.as_ref(),
-            self.nvext
-                .as_ref()
-                .and_then(|nv| nv.guided_decoding_backend.as_ref()),
-        )
+        self.common.guided_decoding_backend.clone()
     }
 
     fn get_guided_whitespace_pattern(&self) -> Option<String> {
-        choose_with_deprecation(
-            "guided_whitespace_pattern",
-            self.common.guided_whitespace_pattern.as_ref(),
-            self.nvext
-                .as_ref()
-                .and_then(|nv| nv.guided_whitespace_pattern.as_ref()),
-        )
+        self.common.guided_whitespace_pattern.clone()
     }
 
     fn get_top_k(&self) -> Option<i32> {
-        choose_with_deprecation(
-            "top_k",
-            self.common.top_k.as_ref(),
-            self.nvext.as_ref().and_then(|nv| nv.top_k.as_ref()),
-        )
+        self.common.top_k
     }
 
     fn get_min_p(&self) -> Option<f32> {
-        choose_with_deprecation(
-            "min_p",
-            self.common.min_p.as_ref(),
-            self.nvext.as_ref().and_then(|nv| nv.min_p.as_ref()),
-        )
+        self.common.min_p
     }
 
     fn get_repetition_penalty(&self) -> Option<f32> {
-        choose_with_deprecation(
-            "repetition_penalty",
-            self.common.repetition_penalty.as_ref(),
-            self.nvext
-                .as_ref()
-                .and_then(|nv| nv.repetition_penalty.as_ref()),
-        )
+        self.common.repetition_penalty
     }
 
     fn get_include_stop_str_in_output(&self) -> Option<bool> {
@@ -287,14 +236,9 @@ impl OpenAIStopConditionsProvider for NvCreateChatCompletionRequest {
         self.common.ignore_eos
     }
 
-    /// Get the effective ignore_eos value, considering both CommonExt and NvExt.
-    /// CommonExt (root-level) takes precedence over NvExt.
+    /// Get the effective ignore_eos value from CommonExt.
     fn get_ignore_eos(&self) -> Option<bool> {
-        choose_with_deprecation(
-            "ignore_eos",
-            self.get_common_ignore_eos().as_ref(),
-            NvExtProvider::nvext(self).and_then(|nv| nv.ignore_eos.as_ref()),
-        )
+        self.common.ignore_eos
     }
 }
 

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -101,35 +101,6 @@ pub trait CommonExtProvider {
     fn get_include_stop_str_in_output(&self) -> Option<bool>;
 }
 
-/// Helper function to emit deprecation warnings for nvext parameters
-pub fn emit_nvext_deprecation_warning(
-    field_name: &str,
-    nvext_has_value: bool,
-    common_has_value: bool,
-) {
-    if nvext_has_value && !common_has_value {
-        tracing::warn!(
-            "DEPRECATION WARNING: 'nvext.{field_name}' is deprecated and will be removed in a future release. Use '{field_name}' at the top level or in 'extra_body' instead."
-        );
-    } else if nvext_has_value && common_has_value {
-        tracing::warn!(
-            "DEPRECATION WARNING: 'nvext.{field_name}' is deprecated and will be removed in a future release. Top-level '{field_name}' takes precedence. Use '{field_name}' at the top level or in 'extra_body' instead."
-        );
-    }
-}
-
-/// Helper function to choose between common and nvext values with deprecation warnings
-pub fn choose_with_deprecation<T: Clone>(
-    field: &'static str,
-    common: Option<&T>,
-    nv: Option<&T>,
-) -> Option<T> {
-    if nv.is_some() {
-        emit_nvext_deprecation_warning(field, true, common.is_some());
-    }
-    common.cloned().or_else(|| nv.cloned())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -247,24 +218,5 @@ mod tests {
         assert_eq!(common_ext.repetition_penalty, None);
         assert_eq!(common_ext.include_stop_str_in_output, None);
         assert!(common_ext.validate().is_ok());
-    }
-
-    #[test]
-    fn test_choose_with_deprecation() {
-        // Common takes precedence
-        let result = choose_with_deprecation(
-            "test_field",
-            Some(&"common_value".to_string()),
-            Some(&"nvext_value".to_string()),
-        );
-        assert_eq!(result, Some("common_value".to_string()));
-
-        // Fallback to nvext
-        let result = choose_with_deprecation("test_field", None, Some(&"nvext_value".to_string()));
-        assert_eq!(result, Some("nvext_value".to_string()));
-
-        // Both None
-        let result: Option<String> = choose_with_deprecation("test_field", None, None);
-        assert_eq!(result, None);
     }
 }

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -12,9 +12,7 @@ use super::{
     ContentProvider, OpenAIOutputOptionsProvider, OpenAISamplingOptionsProvider,
     OpenAIStopConditionsProvider,
     common::{self, OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider},
-    common_ext::{
-        CommonExt, CommonExtProvider, choose_with_deprecation, emit_nvext_deprecation_warning,
-    },
+    common_ext::{CommonExt, CommonExtProvider},
     nvext::{NvExt, NvExtProvider},
     validate,
 };
@@ -149,88 +147,39 @@ impl CommonExtProvider for NvCreateCompletionRequest {
 
     /// Guided Decoding Options
     fn get_guided_json(&self) -> Option<&serde_json::Value> {
-        // Note: This one needs special handling since it returns a reference
-        if let Some(nvext) = &self.nvext
-            && nvext.guided_json.is_some()
-        {
-            emit_nvext_deprecation_warning("guided_json", true, self.common.guided_json.is_some());
-        }
-        self.common
-            .guided_json
-            .as_ref()
-            .or_else(|| self.nvext.as_ref().and_then(|nv| nv.guided_json.as_ref()))
+        self.common.guided_json.as_ref()
     }
 
     fn get_guided_regex(&self) -> Option<String> {
-        choose_with_deprecation(
-            "guided_regex",
-            self.common.guided_regex.as_ref(),
-            self.nvext.as_ref().and_then(|nv| nv.guided_regex.as_ref()),
-        )
+        self.common.guided_regex.clone()
     }
 
     fn get_guided_grammar(&self) -> Option<String> {
-        choose_with_deprecation(
-            "guided_grammar",
-            self.common.guided_grammar.as_ref(),
-            self.nvext
-                .as_ref()
-                .and_then(|nv| nv.guided_grammar.as_ref()),
-        )
+        self.common.guided_grammar.clone()
     }
 
     fn get_guided_choice(&self) -> Option<Vec<String>> {
-        choose_with_deprecation(
-            "guided_choice",
-            self.common.guided_choice.as_ref(),
-            self.nvext.as_ref().and_then(|nv| nv.guided_choice.as_ref()),
-        )
+        self.common.guided_choice.clone()
     }
 
     fn get_guided_decoding_backend(&self) -> Option<String> {
-        choose_with_deprecation(
-            "guided_decoding_backend",
-            self.common.guided_decoding_backend.as_ref(),
-            self.nvext
-                .as_ref()
-                .and_then(|nv| nv.guided_decoding_backend.as_ref()),
-        )
+        self.common.guided_decoding_backend.clone()
     }
 
     fn get_guided_whitespace_pattern(&self) -> Option<String> {
-        choose_with_deprecation(
-            "guided_whitespace_pattern",
-            self.common.guided_whitespace_pattern.as_ref(),
-            self.nvext
-                .as_ref()
-                .and_then(|nv| nv.guided_whitespace_pattern.as_ref()),
-        )
+        self.common.guided_whitespace_pattern.clone()
     }
 
     fn get_top_k(&self) -> Option<i32> {
-        choose_with_deprecation(
-            "top_k",
-            self.common.top_k.as_ref(),
-            self.nvext.as_ref().and_then(|nv| nv.top_k.as_ref()),
-        )
+        self.common.top_k
     }
 
     fn get_min_p(&self) -> Option<f32> {
-        choose_with_deprecation(
-            "min_p",
-            self.common.min_p.as_ref(),
-            self.nvext.as_ref().and_then(|nv| nv.min_p.as_ref()),
-        )
+        self.common.min_p
     }
 
     fn get_repetition_penalty(&self) -> Option<f32> {
-        choose_with_deprecation(
-            "repetition_penalty",
-            self.common.repetition_penalty.as_ref(),
-            self.nvext
-                .as_ref()
-                .and_then(|nv| nv.repetition_penalty.as_ref()),
-        )
+        self.common.repetition_penalty
     }
 
     fn get_include_stop_str_in_output(&self) -> Option<bool> {
@@ -259,14 +208,9 @@ impl OpenAIStopConditionsProvider for NvCreateCompletionRequest {
         self.common.ignore_eos
     }
 
-    /// Get the effective ignore_eos value, considering both CommonExt and NvExt.
-    /// CommonExt (root-level) takes precedence over NvExt.
+    /// Get the effective ignore_eos value from CommonExt.
     fn get_ignore_eos(&self) -> Option<bool> {
-        choose_with_deprecation(
-            "ignore_eos",
-            self.get_common_ignore_eos().as_ref(),
-            NvExtProvider::nvext(self).and_then(|nv| nv.ignore_eos.as_ref()),
-        )
+        self.common.ignore_eos
     }
 }
 

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -14,25 +14,6 @@ pub trait NvExtProvider {
 #[derive(Serialize, Deserialize, Builder, Validate, Debug, Clone)]
 #[validate(schema(function = "validate_nv_ext"))]
 pub struct NvExt {
-    /// If true, the model will ignore the end of string token and generate to max_tokens.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(strip_option))]
-    pub ignore_eos: Option<bool>,
-
-    #[builder(default, setter(strip_option))] // NIM LLM might default to -1
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub top_k: Option<i32>,
-
-    /// Relative probability floor
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(strip_option))]
-    pub min_p: Option<f32>,
-
-    /// How much to penalize tokens based on how frequently they occur in the text.
-    /// A value of 1 means no penalty, while values larger than 1 discourage and values smaller encourage.
-    #[builder(default, setter(strip_option))]
-    pub repetition_penalty: Option<f32>,
-
     /// If true, sampling will be forced to be greedy.
     /// The backend is responsible for selecting the correct backend-specific options to
     /// implement this.
@@ -66,36 +47,6 @@ pub struct NvExt {
     #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_data: Option<Vec<u32>>,
-    /// Guided Decoding Options
-    /// If specified, the output will be a JSON object. Can be a string, an object, or null.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(strip_option))]
-    pub guided_json: Option<serde_json::Value>,
-
-    /// If specified, the output will follow the regex pattern. Can be a string or null.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(strip_option))]
-    pub guided_regex: Option<String>,
-
-    /// If specified, the output will follow the context-free grammar. Can be a string or null.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(strip_option))]
-    pub guided_grammar: Option<String>,
-
-    /// If specified, the output will be exactly one of the choices.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(strip_option))]
-    pub guided_choice: Option<Vec<String>>,
-
-    /// If specified, the backend to use for guided decoding, can be backends like xgrammar or custom guided decoding backend
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(strip_option))]
-    pub guided_decoding_backend: Option<String>,
-
-    /// If specified, the output will follow the whitespace pattern. Can be a string or null.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(strip_option))]
-    pub guided_whitespace_pattern: Option<String>,
 
     /// Maximum number of thinking tokens allowed
     /// NOTE: Currently passed through to backends as a no-op for future implementation
@@ -141,15 +92,11 @@ mod tests {
     #[test]
     fn test_nv_ext_builder_default() {
         let nv_ext = NvExt::builder().build().unwrap();
-        assert_eq!(nv_ext.ignore_eos, None);
-        assert_eq!(nv_ext.top_k, None);
-        assert_eq!(nv_ext.repetition_penalty, None);
         assert_eq!(nv_ext.greed_sampling, None);
-        assert_eq!(nv_ext.guided_json, None);
-        assert_eq!(nv_ext.guided_regex, None);
-        assert_eq!(nv_ext.guided_grammar, None);
-        assert_eq!(nv_ext.guided_choice, None);
-        assert_eq!(nv_ext.guided_whitespace_pattern, None);
+        assert_eq!(nv_ext.use_raw_prompt, None);
+        assert_eq!(nv_ext.annotations, None);
+        assert_eq!(nv_ext.backend_instance_id, None);
+        assert_eq!(nv_ext.token_data, None);
         assert_eq!(nv_ext.max_thinking_tokens, None);
     }
 
@@ -157,37 +104,18 @@ mod tests {
     #[test]
     fn test_nv_ext_builder_custom() {
         let nv_ext = NvExt::builder()
-            .ignore_eos(true)
-            .top_k(10)
-            .repetition_penalty(1.5)
             .greed_sampling(true)
-            .guided_json(serde_json::json!({"type": "object"}))
-            .guided_regex("^[0-9]+$".to_string())
-            .guided_grammar("S -> 'a' S 'b' | 'c'".to_string())
-            .guided_choice(vec!["choice1".to_string(), "choice2".to_string()])
-            .guided_decoding_backend("xgrammar".to_string())
+            .use_raw_prompt(true)
+            .backend_instance_id(42)
+            .token_data(vec![1, 2, 3, 4])
             .max_thinking_tokens(1024)
             .build()
             .unwrap();
 
-        assert_eq!(nv_ext.ignore_eos, Some(true));
-        assert_eq!(nv_ext.top_k, Some(10));
-        assert_eq!(nv_ext.repetition_penalty, Some(1.5));
         assert_eq!(nv_ext.greed_sampling, Some(true));
-        assert_eq!(
-            nv_ext.guided_json,
-            Some(serde_json::json!({"type": "object"}))
-        );
-        assert_eq!(nv_ext.guided_regex, Some("^[0-9]+$".to_string()));
-        assert_eq!(
-            nv_ext.guided_grammar,
-            Some("S -> 'a' S 'b' | 'c'".to_string())
-        );
-        assert_eq!(
-            nv_ext.guided_choice,
-            Some(vec!["choice1".to_string(), "choice2".to_string()])
-        );
-        assert_eq!(nv_ext.guided_decoding_backend, Some("xgrammar".to_string()));
+        assert_eq!(nv_ext.use_raw_prompt, Some(true));
+        assert_eq!(nv_ext.backend_instance_id, Some(42));
+        assert_eq!(nv_ext.token_data, Some(vec![1, 2, 3, 4]));
         assert_eq!(nv_ext.max_thinking_tokens, Some(1024));
         // Validate the built struct
         assert!(nv_ext.validate().is_ok());


### PR DESCRIPTION
#### Overview:

Remove the request parameters that were deprecated in 0.5.0. These deprecated parameters are passed in under the `nvext` field. The parameters that are being removed still exist at the top level of the request. These parameters are being removed to simplify the API surface and remove confusion around duplicate parameters that serve the exact same functionality.

#### Details:

Removes parameters from `nvext` that exist at the top level for both completions and chat completions.

#### Where should the reviewer start?


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #2781 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added options for use raw prompt, annotations, and backend instance ID. Token data remains supported.

- Refactor
  - Streamlined configuration: guidance and sampling settings now come from a single source for consistent behavior.
  - Removed legacy override paths and deprecation handling for older NV-specific fields.
  - Consistent handling of end-of-sequence behavior.

- Tests
  - Updated test coverage to align with the new configuration model and available options.

- Chores
  - Removed deprecated helpers and related warnings to reduce noise and maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->