### PR TITLE
fix: pin flashinfer version for vllm arm builds

### DIFF
--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -195,7 +195,7 @@ python setup.py install
 
 # Install Flash Infer
 if [ "$ARCH" = "arm64" ]; then
-    uv pip install flashinfer-python
+    uv pip install flashinfer-python==0.3.1.post1
 else
     cd $INSTALLATION_DIR
     git clone https://github.com/flashinfer-ai/flashinfer.git --recursive


### PR DESCRIPTION
#### Overview:

`flashinfer-python` was floating on ARM builds and overnight it moved from `0.3.1.post1` to `0.4.0` which broke inferencing in the vLLM container.
