### PR TITLE
docs: Adding instruction to install python3-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ The Dynamo team recommends the `uv` Python package manager, although any way wor
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
+### Install Python development headers
+
+Backend engines require Python development headers for JIT compilation. Install them with:
+
+```bash
+sudo apt install python3-dev
+```
+
 ### Install etcd and NATS (required)
 
 To coordinate across a data center, Dynamo relies on etcd and NATS. To run Dynamo locally, these need to be available.


### PR DESCRIPTION
#### Overview:

For initial setup, added a step to install system package `python3-dev` because it is required at runtime by certain backends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Install Python development headers” subsection to the Installation guide, explaining the requirement for Python headers to enable JIT compilation.
  * Provided a ready-to-use command for Debian/Ubuntu systems (sudo apt install python3-dev) to help users set up the necessary dependencies and avoid build issues during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->