### PR TITLE
fix: Remove flaky doctest

### DIFF
--- a/lib/runtime/src/utils/tasks/tracker.rs
+++ b/lib/runtime/src/utils/tasks/tracker.rs
@@ -492,27 +492,8 @@ impl<T> TaskHandle<T> {
     ///
     /// This token is a child of the tracker's cancellation token and can be used
     /// to cancel just this individual task without affecting other tasks.
-    ///
-    /// # Example
-    /// ```rust
-    /// # use dynamo_runtime::utils::tasks::tracker::*;
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let tracker = TaskTracker::new(UnlimitedScheduler::new(), LogOnlyPolicy::new())?;
-    /// let handle = tracker.spawn(async {
-    ///     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-    ///     Ok("completed")
-    /// });
-    ///
-    /// // Cancel this specific task
-    /// handle.cancellation_token().cancel();
-    ///
-    /// // Task will be cancelled
-    /// let result = handle.await?;
-    /// assert!(result.is_err());
-    /// # Ok(())
-    /// # }
-    /// ```
+    // FIXME: The doctest previously here failed intermittently and may
+    // indicate a bug in either the doctest example or the implementation.
     pub fn cancellation_token(&self) -> &CancellationToken {
         &self.cancel_token
     }


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

This doctest has been failing intermittently, causing rust test failures on various PRs, for example: https://github.com/ai-dynamo/dynamo/actions/runs/18419132132/job/52489609655?pr=3539

It is relatively rare, maybe 1 out of 10-20 runs that it will fail, but it's enough to make the CI test unreliable. This should be revisited and fixed properly to determine if there is an actual bug in the underlying implementation or just an issue with the doctest example.

#### Details:

For future reference: I had an attempt to fix here, but I'm not confident in its correctness: https://github.com/ai-dynamo/dynamo/pull/3414

I'm opting to remove the flakiness for now to stabilize CI, and have this revisited independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated inline documentation by removing an unstable example to prevent intermittent failures in automated checks. No impact on behavior or APIs.
* **Chores**
  * Maintenance to improve reliability of documentation-related validation during builds and tests. No functional changes for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->