### PR TITLE
docs: fix helm install prometheus command

### DIFF
--- a/docs/kubernetes/metrics.md
+++ b/docs/kubernetes/metrics.md
@@ -20,8 +20,8 @@ helm repo update
 # Values allow PodMonitors to be picked up that are outside of the kube-prometheus-stack helm release
 helm install prometheus -n monitoring --create-namespace prometheus-community/kube-prometheus-stack \
   --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
-  --set prometheus.prometheusSpec.podMonitorNamespaceSelector="{}" \
-  --set prometheus.prometheusSpec.probeNamespaceSelector="{}"
+  --set-json prometheus.prometheusSpec.podMonitorNamespaceSelector="{}" \
+  --set-json prometheus.prometheusSpec.probeNamespaceSelector="{}"
 ```
 
 > [!Note]


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Fix Prometheus installation error caused by Helm interpreting `{}` as an array in `--set` parameters. Switched to `--set-json` to ensure `podMonitorNamespaceSelector` and `probeNamespaceSelector` are correctly parsed as objects.

```bash
helm install prometheus -n monitoring --create-namespace prometheus-community/kube-prometheus-stack \
  --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
  --set prometheus.prometheusSpec.podMonitorNamespaceSelector="{}" \
  --set prometheus.prometheusSpec.probeNamespaceSelector="{}"
.....
Error: INSTALLATION FAILED: 1 error occurred:
        * Prometheus.monitoring.coreos.com "prometheus-kube-prometheus-prometheus" is invalid: 
        [spec.probeNamespaceSelector: Invalid value: "array": spec.probeNamespaceSelector in body must be of type object: "array", spec.podMonitorNamespaceSelector: 
       Invalid value: "array": spec.podMonitorNamespaceSelector in body must be of type object: "array"]
```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Kubernetes metrics installation instructions to use --set-json for namespace selectors in monitoring resources.
  - Improves accuracy and reliability of the Helm install command, reducing copy/paste and quoting issues.
  - Clarifies how to pass structured values during installation for smoother setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->