### PR TITLE
docs: Add deprecation notices for unused Docker build arguments (no code change at all)

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -591,6 +591,13 @@ if [[ $TARGET == "local-dev" ]]; then
     TARGET_STR="--target dev"
 fi
 
+# DEPRECATION: The following build args are not currently used by any Dockerfile and will be removed soon:
+#   - FRAMEWORK
+#   - VLLM_FRAMEWORK (or TRTLLM_FRAMEWORK, SGLANG_FRAMEWORK, etc.)
+#   - VERSION
+#   - PYTHON_PACKAGE_VERSION
+#   - HF_TOKEN
+
 # BUILD DEV IMAGE
 
 BUILD_ARGS+=" --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG --build-arg FRAMEWORK=$FRAMEWORK --build-arg ${FRAMEWORK}_FRAMEWORK=1 --build-arg VERSION=$VERSION --build-arg PYTHON_PACKAGE_VERSION=$PYTHON_PACKAGE_VERSION"
@@ -752,11 +759,27 @@ if [[ -z "${DEV_IMAGE_INPUT:-}" ]]; then
         echo "======================================"
         echo "Starting Build 1: Base Image"
         echo "======================================"
+        # Build 1 (container/Dockerfile) does NOT use (will be removed soon):
+        #   - FRAMEWORK
+        #   - VLLM_FRAMEWORK (or TRTLLM_FRAMEWORK, SGLANG_FRAMEWORK, etc.)
+        #   - VERSION
+        #   - PYTHON_PACKAGE_VERSION
+        #   - HF_TOKEN
+        #   - MAX_JOBS
         $RUN_PREFIX docker build -f "${SOURCE_DIR}/Dockerfile" --target dev $PLATFORM $BUILD_ARGS $CACHE_FROM $CACHE_TO --tag $DYNAMO_BASE_IMAGE $BUILD_CONTEXT_ARG $BUILD_CONTEXT $NO_CACHE
         # Start framework build
         echo "======================================"
         echo "Starting Build 2: Framework Image"
         echo "======================================"
+        # Build 2 (container/Dockerfile.vllm or .trtllm, .sglang) does NOT use (will be removed soon):
+        #   - FRAMEWORK
+        #   - VLLM_FRAMEWORK (or TRTLLM_FRAMEWORK, SGLANG_FRAMEWORK, etc.)
+        #   - VERSION
+        #   - PYTHON_PACKAGE_VERSION
+        #   - HF_TOKEN
+        #   - NIXL_REF
+        #   - NIXL_UCX_REF
+        #   - ENABLE_KVBM
         BUILD_ARGS+=" --build-arg DYNAMO_BASE_IMAGE=${DYNAMO_BASE_IMAGE}"
         $RUN_PREFIX docker build -f $DOCKERFILE $TARGET_STR $PLATFORM $BUILD_ARGS $CACHE_FROM $CACHE_TO $TAG $LATEST_TAG $BUILD_CONTEXT_ARG $BUILD_CONTEXT $NO_CACHE
     else


### PR DESCRIPTION
## Summary

Document unused Docker build arguments in `container/build.sh` with deprecation notices. These args will be removed in a future PR.

## Unused Arguments

**Build 1 (base image):**
- `FRAMEWORK`, `VLLM_FRAMEWORK`, `VERSION`, `PYTHON_PACKAGE_VERSION`, `HF_TOKEN`, `MAX_JOBS`

**Build 2 (framework image):**
- `FRAMEWORK`, `VLLM_FRAMEWORK`, `VERSION`, `PYTHON_PACKAGE_VERSION`, `HF_TOKEN`, `NIXL_REF`, `NIXL_UCX_REF`, `ENABLE_KVBM`

## Impact

Documentation only. No functional changes to build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added deprecation notes in the container build process for several unused build arguments, clarifying they will be removed in a future release.
  - Notes are present across relevant build steps to improve visibility for users customizing builds.
  - No changes to build logic, control flow, or error handling; build behavior and outputs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->