### PR TITLE
fix: fix devcontainer build to work across shells

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -426,7 +426,8 @@ If you see errors like "container is not running" or "An error occurred setting 
    # If missing, build the dev image first, then build local-dev
    export FRAMEWORK=VLLM  # Replace with VLLM, SGLANG, or TRTLLM
    ./container/build.sh --framework $FRAMEWORK
-   ./container/build.sh --dev-image dynamo:latest-${FRAMEWORK,,} --framework $FRAMEWORK
+   # change to lower case portable way across shells
+   ./container/build.sh --dev-image dynamo:latest-$(echo "$FRAMEWORK" | tr '[:upper:]' '[:lower:]') --framework "$FRAMEWORK"
    # Now you have dynamo:latest-vllm-local-dev
    ```
 


### PR DESCRIPTION
#### Overview:

fix devcontainer build to work across shells (zsh, bash..)

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Improved dev container README by replacing the build command with a shell-portable expression that lowercases the framework suffix, and added explanatory comments. This ensures consistent image target naming across different shells and clarifies the transformation steps. No runtime or product behavior changes; developers benefit from clearer, more reliable setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->