### PR TITLE
fix: Improve Error Messaging for port/address already in use error

### DIFF
--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -267,9 +267,19 @@ impl HttpService {
                 }
             }
         } else {
-            let listener = tokio::net::TcpListener::bind(addr)
-                .await
-                .unwrap_or_else(|_| panic!("could not bind to address: {address}"));
+            let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
+                tracing::error!(
+                    protocol = %protocol,
+                    address = %address,
+                    error = %e,
+                    "Failed to bind server to address"
+                );
+                anyhow::anyhow!(
+                    "Failed to start {} server: port {} already in use. Use --http-port to specify a different port.",
+                    protocol,
+                    self.port
+                )
+            })?;
 
             axum::serve(listener, router)
                 .with_graceful_shutdown(observer.cancelled_owned())

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -274,11 +274,19 @@ impl HttpService {
                     error = %e,
                     "Failed to bind server to address"
                 );
-                anyhow::anyhow!(
-                    "Failed to start {} server: port {} already in use. Use --http-port to specify a different port.",
-                    protocol,
-                    self.port
-                )
+                match e.kind() {
+                    std::io::ErrorKind::AddrInUse => anyhow::anyhow!(
+                        "Failed to start {} server: port {} already in use. Use --http-port to specify a different port.",
+                        protocol,
+                        self.port
+                    ),
+                    _ => anyhow::anyhow!(
+                        "Failed to start {} server on {}: {}",
+                        protocol,
+                        address,
+                        e
+                    ),
+                }
             })?;
 
             axum::serve(listener, router)


### PR DESCRIPTION
#### Overview:
Previously, when the HTTP server failed to bind to port 8000 (due to the address already being in use), it would panic with a more generic message. Goal of this PR is to improve user friendliness if/when this error is encountered.

#### Details:

Previous error Message when port 8000 was occupied looked something like this:
```
> python -m dynamo.frontend --http-port 8000 &
2025-08-19T23:44:39.229420Z INFO dynamo_llm::entrypoint::input::http: Watching for remote model at models
2025-08-19T23:44:39.231286Z INFO dynamo_llm::http::service::service_v2: Starting HTTP service on: 0.0.0.0:8000 address="0.0.0.0:8000" thread 'tokio-runtime-worker' panicked at
/workspace/lib/llm/src/http/service/service_v2.rs:117:33: could not bind to address: 0.0.0.0:8000
...
"/localhome/.../dynamo/frontend/main.py", line 111, in async_main
 await run_input(runtime, "http", engine)
pyo3_async_runtimes.RustPanic: rust future panicked: unknown error
2025-08-19T23:44:45.531400Z INFO main.worker: Signal handlers set up for graceful shutdown
```

With the introduction of these changes, the new error logs will look like this:
```
2025-10-13T18:18:46.927697Z ERROR dynamo_llm::http::service::service_v2: Failed to bind server to address protocol=HTTP address=0.0.0.0:8000 error=Address already in use (os error 98)
Traceback (most recent call last):
...  
File "/opt/dynamo/venv/lib/python3.12/site-packages/dynamo/frontend/main.py", line 328, in async_main
    await run_input(runtime, "http", engine)
Exception: Failed to start HTTP server: port 8000 already in use. Use --http-port to specify a different port.
``` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes on startup when the server cannot bind to a port; now shows a clear error indicating a possible port conflict and suggests using a different port.
  * Improves non‑TLS server startup reliability by properly awaiting the server and canceling startup on errors, leading to cleaner shutdowns and clearer failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->