### PR TITLE
fix: only log config on `debug` log level, fix trtllm warnings

### DIFF
--- a/components/src/dynamo/common/config_dump/config_dumper.py
+++ b/components/src/dynamo/common/config_dump/config_dumper.py
@@ -98,9 +98,9 @@ def dump_config(dump_config_to: Optional[str], config: Any) -> None:
     Raises:
         Logs errors but does not raise exceptions to ensure graceful degradation.
     """
-    config_dump_payload = get_config_dump(config)
 
     if dump_config_to:
+        config_dump_payload = get_config_dump(config)
         try:
             dump_path = pathlib.Path(dump_config_to)
             dump_path.parent.mkdir(parents=True, exist_ok=True)
@@ -108,13 +108,17 @@ def dump_config(dump_config_to: Optional[str], config: Any) -> None:
                 f.write(config_dump_payload)
             logger.info(f"Dumped config to {dump_path.resolve()}")
         except (OSError, IOError):
-            logger.exception(f"Failed to dump config to {dump_config_to}")
+            logger.exception(
+                f"Failed to dump config to {dump_config_to}, dropping to stdout"
+            )
             logger.info(f"CONFIG_DUMP: {config_dump_payload}")
         except Exception:
-            logger.exception("Unexpected error dumping config")
+            logger.exception("Unexpected error dumping config, dropping to stdout")
             logger.info(f"CONFIG_DUMP: {config_dump_payload}")
-    else:
-        logger.info(f"CONFIG_DUMP: {config_dump_payload}")
+    elif logger.getEffectiveLevel() <= logging.DEBUG:
+        # only collect/dump config if the logger is at DEBUG level or lower
+        config_dump_payload = get_config_dump(config)
+        logger.debug(f"CONFIG_DUMP: {config_dump_payload}")
 
 
 def get_config_dump(config: Any, extra_info: Optional[Dict[str, Any]] = None) -> str:

--- a/components/src/dynamo/common/config_dump/config_dumper.py
+++ b/components/src/dynamo/common/config_dump/config_dumper.py
@@ -194,6 +194,7 @@ try:
     def try_process_pydantic(obj: Any) -> Optional[dict]:
         if isinstance(obj, pydantic.BaseModel):
             return obj.model_dump()
+        return None
 
 except ImportError:
 

--- a/components/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -8,7 +8,7 @@ from typing import Optional
 from tensorrt_llm.llmapi import BuildConfig
 
 from dynamo._core import get_reasoning_parser_names, get_tool_parser_names
-from dynamo.common.config_dump import add_config_dump_args
+from dynamo.common.config_dump import add_config_dump_args, register_encoder
 from dynamo.trtllm import __version__
 from dynamo.trtllm.request_handlers.handler_base import (
     DisaggregationMode,
@@ -96,6 +96,13 @@ class Config:
             f"dump_config_to={self.dump_config_to},"
             f"custom_jinja_template={self.custom_jinja_template}"
         )
+
+
+@register_encoder(Config)
+def _preprocess_for_encode_config(
+    obj: Config,
+) -> dict:  # pyright: ignore[reportUnusedFunction]
+    return obj.__dict__
 
 
 def is_first_worker(config):


### PR DESCRIPTION
Small fix that
1. only grabs/logs the config on debug or when the `--dump-config-to` flag is specified
2. properly dumps some trtllm objects that use `pydantic`, avoiding some warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional support for serializing Pydantic models in config dumps.
  * New encoder hook for Config objects to ensure consistent serialization.
  * Config dump now available in DEBUG logs without writing to a file.

* **Bug Fixes**
  * More robust config dump writing: on file errors, automatically falls back to stdout with clear logging.
  * Ensures config payload is computed before attempting file output to prevent partial or missing dumps.

* **Refactor**
  * Expanded internal preprocessing to better handle diverse config object types without changing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->