### PR TITLE
docs: add gpu details for model recipes

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -2,9 +2,9 @@
 
 | Model family  | Backend | Mode                | GPU   | Deployment | Benchmark |
 |---------------|---------|---------------------|-------|------------|-----------|
-| llama-3-70b   | vllm    | agg                 | H200  |     ✓      |     ✓     |
-| llama-3-70b   | vllm    | disagg-multi-node   | H200  |     ✓      |     ✓     |
-| llama-3-70b   | vllm    | disagg-single-node  | H200  |     ✓      |     ✓     |
+| llama-3-70b   | vllm    | agg                 | H100, H200  |     ✓      |     ✓     |
+| llama-3-70b   | vllm    | disagg-multi-node   | H100, H200  |     ✓      |     ✓     |
+| llama-3-70b   | vllm    | disagg-single-node  | H100, H200  |     ✓      |     ✓     |
 | DeepSeek-R1   | sglang  | disaggregated       | H200  |     ✓      |    🚧     |
 | oss-gpt       | trtllm  | aggregated          | GB200 |     ✓      |     ✓     |
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,12 +1,12 @@
 # Dynamo model serving recipes
 
-| Model family  | Backend | Mode                | Deployment | Benchmark |
-|---------------|---------|---------------------|------------|-----------|
-| llama-3-70b   | vllm    | agg                 |     ✓      |     ✓     |
-| llama-3-70b   | vllm    | disagg-multi-node   |     ✓      |     ✓     |
-| llama-3-70b   | vllm    | disagg-single-node  |     ✓      |     ✓     |
-| oss-gpt       | trtllm  | aggregated          |     ✓      |     ✓     |
-| DeepSeek-R1   | sglang  | disaggregated       |     ✓      |    🚧     |
+| Model family  | Backend | Mode                | GPU   | Deployment | Benchmark |
+|---------------|---------|---------------------|-------|------------|-----------|
+| llama-3-70b   | vllm    | agg                 | H200  |     ✓      |     ✓     |
+| llama-3-70b   | vllm    | disagg-multi-node   | H200  |     ✓      |     ✓     |
+| llama-3-70b   | vllm    | disagg-single-node  | H200  |     ✓      |     ✓     |
+| DeepSeek-R1   | sglang  | disaggregated       | H200  |     ✓      |    🚧     |
+| oss-gpt       | trtllm  | aggregated          | GB200 |     ✓      |     ✓     |
 
 
 ## Prerequisites


### PR DESCRIPTION
#### Overview:

add gpu details for model recipes

closes DEP-503


| Model family  | Backend | Mode                | GPU   | Deployment | Benchmark |
|---------------|---------|---------------------|-------|------------|-----------|
| llama-3-70b   | vllm    | agg                 | H200  |     ✓      |     ✓     |
| llama-3-70b   | vllm    | disagg-multi-node   | H200  |     ✓      |     ✓     |
| llama-3-70b   | vllm    | disagg-single-node  | H200  |     ✓      |     ✓     |
| DeepSeek-R1   | sglang  | disaggregated       | H200  |     ✓      |    🚧     |
| oss-gpt       | trtllm  | aggregated          | GB200 |     ✓      |     ✓     |



## Summary by CodeRabbit

* **Documentation**
  * Updated the model recipes table with a new GPU column and populated GPU details across entries (e.g., H200, GB200).
  * Revised table headers and aligned row data to reflect the additional column while retaining existing columns (Model family, Backend, Mode, Deployment, Benchmark).
  * Preserves existing statuses (e.g., DeepSeek-R1) with GPU information added.
  * No functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->