### PR TITLE
fix: Fix vllm multimodal qwen cuda oom issue 

### DIFF
--- a/examples/multimodal/launch/agg.sh
+++ b/examples/multimodal/launch/agg.sh
@@ -58,9 +58,15 @@ python -m dynamo.frontend --http-port=8000 &
 # run processor
 python3 components/processor.py --model $MODEL_NAME --prompt-template "$PROMPT_TEMPLATE" &
 
+# To make Qwen2.5-VL fit in A100 40GB, set the following extra arguments
+EXTRA_ARGS=""
+if [[ "$MODEL_NAME" == "Qwen/Qwen2.5-VL-7B-Instruct" ]]; then
+    EXTRA_ARGS="--gpu-memory-utilization 0.85 --max-model-len 2048"
+fi
+
 # run E/P/D workers
 CUDA_VISIBLE_DEVICES=0 python3 components/encode_worker.py --model $MODEL_NAME &
-CUDA_VISIBLE_DEVICES=1 python3 components/worker.py --model $MODEL_NAME --worker-type prefill &
+CUDA_VISIBLE_DEVICES=1 python3 components/worker.py --model $MODEL_NAME --worker-type prefill $EXTRA_ARGS &
 
 # Wait for all background processes to complete
 wait


### PR DESCRIPTION
#### Overview:

Set max model len and gpu memory utilization for qwen model to avoid OOM on A100 40GB.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multimodal launcher now auto-tunes settings when using Qwen/Qwen2.5-VL-7B-Instruct. It applies GPU memory utilization of 0.85 and a maximum model length of 2048 to the prefill worker, improving stability and performance on limited hardware. These adjustments are applied only for this model; behavior for other models remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->