### PR TITLE
ci: Pass CLI Arguments to workers with a pytest fixture

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,6 +8,9 @@ frameworks are not installed in the current container.
 """
 
 import importlib.util
+import sys
+
+import pytest
 
 
 def pytest_ignore_collect(collection_path, config):
@@ -30,3 +33,45 @@ def pytest_ignore_collect(collection_path, config):
                 return True  # Module not available, skip this file
 
     return None  # Not a backend test or module available
+
+
+def make_cli_args_fixture(module_name: str):
+    """Create a pytest fixture for mocking CLI arguments for a backend.
+
+    The returned fixture supports two call styles:
+
+    1. Explicit:
+        mock_vllm_cli("--model", "gpt-2", "--custom-jinja-template", "path.jinja")
+
+    2. Kwargs (auto-converts underscores to hyphens):
+        mock_vllm_cli(model="gpt-2", custom_jinja_template="path.jinja")
+
+    Both produce: ["dynamo.vllm", "--model", "gpt-2", "--custom-jinja-template", "path.jinja"]
+
+    Args:
+        module_name: Module identifier for argv[0] (e.g., "dynamo.vllm")
+
+    Returns:
+        Pytest fixture that mocks sys.argv via monkeypatch
+    """
+
+    @pytest.fixture
+    def mock_cli_args(monkeypatch):
+        """Mock sys.argv with CLI arguments (explicit or kwargs style)."""
+
+        def set_args(*args, **kwargs):
+            if args:
+                # Explicit style: pass argv elements directly
+                argv = [module_name, *args]
+            else:
+                # Kwargs style: convert python arg to CLI arg
+                argv = [module_name]
+                for param_name, param_value in kwargs.items():
+                    cli_flag = f"--{param_name.replace('_', '-')}"
+                    argv.extend([cli_flag, str(param_value)])
+
+            monkeypatch.setattr(sys, "argv", argv)
+
+        return set_args
+
+    return mock_cli_args


### PR DESCRIPTION
#### Overview:

 Instead of relying on a repeated `monkeypatch.setattr(sys, "argv", [<CLI ARGS>])`, this PR makes it easier to provide command line arguments in unit tests. Each backend now declares a single fixture. For example, for vLLM, the workflow would look like this:

```python
from tests.unit.conftest import make_cli_args_fixture
mock_vllm_cli = make_cli_args_fixture("dynamo.vllm")

# Tests can use either explicit style:
mock_vllm_cli("--model", "gpt-2", "--custom-jinja-template", "...")
# Or kwargs style:
mock_vllm_cli(model="Qwen/Qwen3-0.6B", custom_jinja_template=JINJA_TEMPLATE_PATH)
```

#### Details:

A `new make_cli_args_fixture()` factory function in `conftest.py` creates backend-specific fixtures that handle sys.argv monkeypatching internally.

#### Where should the reviewer start?

Take a look at `tests/unit/conftest.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Motivation for PR: [[Ref](https://github.com/ai-dynamo/dynamo/pull/3472#discussion_r2416958510)]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Introduced a reusable fixture to mock CLI arguments in unit tests, supporting both explicit args and keyword styles.
  - Standardized argv handling and reduced direct sys.argv manipulation.
  - Refactored related tests across multiple backends to use the new fixture.
  - Improved coverage for environment variable expansion scenarios.
  - Added clearer docstrings and comments to enhance test readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->