### PR TITLE
feat: support multiple connections for nats

### DIFF
--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -28,7 +28,6 @@ use crate::kv_router::{
     protocols::*,
     scoring::LoadEvent,
 };
-use dynamo_runtime::config::environment_names::nats as env_nats;
 
 // -------------------------------------------------------------------------
 // KV Event Publishers -----------------------------------------------------
@@ -125,12 +124,15 @@ impl KvEventPublisher {
         let stream_name = Slug::slugify(&format!("{}.{}", component.subject(), KV_EVENT_SUBJECT))
             .to_string()
             .replace("_", "-");
-        let nats_server = std::env::var(env_nats::NATS_SERVER)
-            .unwrap_or_else(|_| "nats://localhost:4222".to_string());
+        let nats_servers = std::env::var("NATS_SERVER")
+            .unwrap_or_else(|_| "nats://localhost:4222".to_string())
+            .split(',')
+            .map(|s| s.to_owned())
+            .collect();
         // Create NatsQueue without consumer since we're only publishing
         let mut nats_queue = NatsQueue::new_without_consumer(
             stream_name,
-            nats_server,
+            nats_servers,
             std::time::Duration::from_secs(60), // 1 minute timeout
         );
 

--- a/lib/llm/tests/audit_nats_integration.rs
+++ b/lib/llm/tests/audit_nats_integration.rs
@@ -40,7 +40,7 @@ mod tests {
     /// Helper to create a test NATS client
     async fn create_test_nats_client() -> nats::Client {
         nats::ClientOptions::builder()
-            .server("nats://localhost:4222")
+            .servers(vec!["nats://localhost:4222".to_string()])
             .build()
             .expect("Failed to build NATS client options")
             .connect()


### PR DESCRIPTION
#### Overview:

Supporting multiple nats connections is useful for building HA clusters. This is done for etcd but not for nats for some reason. Both etcd and nats connections are implemented through external libraries and they support several endpoints, so it was not much work to implement it. Please tell me if this is unwanted and why

#### Details:

I changed NATS_SERVER -> NATS_SERVERS through out all project and add support for multiple endpoints in rust wrapper of nats. Also added env var NATS_JETSTREAM_REPLICAS to set number of replicas for jetstreams that is used by NatsQueue.

#### Where should the reviewer start?

Please start at nats wrapper in dynamo/lib/runtime/src/transports/nats.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support multiple NATS endpoints via NATS_SERVERS (comma-separated).
  * Added NATS_JETSTREAM_REPLICAS to configure JetStream replica count.

* **Refactor**
  * Renamed NATS_SERVER to NATS_SERVERS across jobs, scripts, operators, Helm templates, and task definitions for consistent configuration.

* **Documentation**
  * Updated guides, examples, and diagrams to use NATS_SERVERS and reflect multi-endpoint support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->