### PR TITLE
fix: hf cli exclusions

### DIFF
--- a/docs/backends/trtllm/gpt-oss.md
+++ b/docs/backends/trtllm/gpt-oss.md
@@ -42,7 +42,7 @@ export HF_TOKEN=<INSERT_TOKEN_HERE>
 
 pip install -U "huggingface_hub[cli]"
 
-huggingface-cli download openai/gpt-oss-120b --exclude "original/*" --exclude "metal/*" --local-dir $MODEL_PATH
+huggingface-cli download openai/gpt-oss-120b --exclude "original/*" "metal/*" --local-dir $MODEL_PATH
 ```
 
 ### 2. Run the Container

--- a/recipes/gpt-oss-120b/model-cache/model-download.yaml
+++ b/recipes/gpt-oss-120b/model-cache/model-download.yaml
@@ -34,7 +34,7 @@ spec:
             - |
               set -eux
               pip install --no-cache-dir huggingface_hub hf_transfer
-              hf download $MODEL_NAME --revision $MODEL_REVISION --exclude "original/*" --exclude "metal/*"
+              hf download $MODEL_NAME --revision $MODEL_REVISION --exclude "original/*" "metal/*"
           volumeMounts:
             - name: model-cache
               mountPath: /model-store


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

multiple `--exclude` arguments doesn't work, and it ends up over the requested pvc size for gpt-oss 120b

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified HuggingFace CLI instructions for downloading models, showing how to pass multiple exclusion patterns correctly. Improves copy-paste reliability and reduces download errors.

* **Chores**
  * Standardized the model download recipe by consolidating exclusion patterns into a single command invocation, ensuring consistent behavior across environments and smoother downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->