### PR TITLE
chore: Improve NATS connection error message

### DIFF
--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -326,7 +326,7 @@ impl ClientOptions {
                 client
                     .connect(self.server)
                     .await
-                    .map_err(|e| anyhow::anyhow!("Failed to connect to NATS: {e}"))
+                    .map_err(|e| anyhow::anyhow!("Failed to connect to NATS: {e}. Verify NATS server is running and accessible."))
             },
             NATS_WORKER_THREADS,
         )


### PR DESCRIPTION
#### Overview:

Goal of this PR is to prove error messaging, when a worker/frontend cannot access NATS.

If we start etcd and try starting a worker/frontend, the current error message looks like:
```
(venv) root@4845aa7-lcedt:/workspace# python -m dynamo.frontend
...
...
...  
 File "/workspace/components/src/dynamo/frontend/main.py", line 256, in async_main
    runtime = DistributedRuntime(loop, is_static)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Exception: Failed to connect to NATS: IO error: Connection refused (os error 111)
```

With the introduction of this PR, the new error message will look like:
```
venv) root@4845aa7-lcedt:/workspace# python -m dynamo.frontend
...
...
...  
  File "/workspace/components/src/dynamo/frontend/main.py", line 256, in async_main
    runtime = DistributedRuntime(loop, is_static)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Exception: Failed to connect to NATS: IO error: Connection refused (os error 111). Verify NATS server is running and accessible.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clarity of NATS connection error messages by adding actionable guidance to verify the server is running and reachable. This helps diagnose connectivity issues more quickly and reduces ambiguity during setup or when network access is misconfigured. No changes to connection behavior or recovery flow; only the displayed error message was enhanced to better inform next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->