### PR TITLE
docs: Adding MDC to glossary

### DIFF
--- a/docs/dynamo_glossary.md
+++ b/docs/dynamo_glossary.md
@@ -44,7 +44,7 @@
 
 
 ## M
-**Model Deployment Card (MDC)** - A configuration structure containing all information needed for distributed model serving. When a worker loads a model, it creates an MDC containing references to the tokenizer, templates, runtime config, etc. Workers publish their MDC to make the model discoverable to frontends. Frontends use the MDC to configure request preprocessing (tokenization, prompt formatting).
+**Model Deployment Card (MDC)** - A configuration structure containing all information required for distributed model serving. When a worker loads a model, it creates an MDC containing references to components such as the tokenizer, templates, runtime config. Workers publish their MDC to make the model discoverable to frontends. Frontends use the MDC to configure request preprocessing (tokenization, prompt formatting).
 
 ## N
 **Namespace** - Dynamo's logical grouping mechanism for related components. Similar to directories in a file system, they prevent collisions between different deployments.

--- a/docs/dynamo_glossary.md
+++ b/docs/dynamo_glossary.md
@@ -44,7 +44,7 @@
 
 
 ## M
-**Model Deployment Card (MDC)** - A configuration structure containing all information needed for distributed model serving. When a worker loads a model, it creates an MDC containing references to tokenizer, templates, runtime config, etc. Workers publish their MDC to make the model discoverable to frontends. Frontends use the MDC to configure request preprocessing (tokenization, prompt formatting).
+**Model Deployment Card (MDC)** - A configuration structure containing all information needed for distributed model serving. When a worker loads a model, it creates an MDC containing references to the tokenizer, templates, runtime config, etc. Workers publish their MDC to make the model discoverable to frontends. Frontends use the MDC to configure request preprocessing (tokenization, prompt formatting).
 
 ## N
 **Namespace** - Dynamo's logical grouping mechanism for related components. Similar to directories in a file system, they prevent collisions between different deployments.

--- a/docs/dynamo_glossary.md
+++ b/docs/dynamo_glossary.md
@@ -42,6 +42,10 @@
 
 **KVPublisher** - Dynamo component that emits KV cache events (stored/removed) from individual workers to the global KVIndexer.
 
+
+## M
+**Model Deployment Card (MDC)** - A configuration structure containing all information needed for distributed model serving. When a worker loads a model, it creates an MDC containing references to tokenizer, templates, runtime config, etc. Workers publish their MDC to make the model discoverable to frontends. Frontends use the MDC to configure request preprocessing (tokenization, prompt formatting).
+
 ## N
 **Namespace** - Dynamo's logical grouping mechanism for related components. Similar to directories in a file system, they prevent collisions between different deployments.
 


### PR DESCRIPTION
#### Overview:

Adding minimal definition for MDC without referencing etcd/NATS. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded glossary with two new entries:
    * Model Deployment Card (MDC): Defines a configuration artifact used in distributed model serving, including how it’s created, published for discovery, and used for request preprocessing.
    * NIXL (NVIDIA Inference tranXfer Library): Describes a high-performance data transfer library optimized for inference workloads.
  * No changes to existing glossary definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->