### PR TITLE
fix: copy commit info in trtllm build

### DIFF
--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -193,7 +193,7 @@ ARG TENSORRTLLM_INDEX_URL
 
 # Copy only wheel files and commit info from trtllm_wheel stage from build_context
 COPY --from=trtllm_wheel /*.whl /trtllm_wheel/
-COPY --from=trtllm_wheel /commit.txt /trtllm_wheel/
+COPY --from=trtllm_wheel /*.txt /trtllm_wheel/
 
 # Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel
 # because there might be mismatched versions of TensorRT between the NGC PyTorch

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -191,8 +191,10 @@ ARG HAS_TRTLLM_CONTEXT
 ARG TENSORRTLLM_PIP_WHEEL
 ARG TENSORRTLLM_INDEX_URL
 
-# Copy only wheel files from trtllm_wheel stage from build_context
+# Copy only wheel files and commit info from trtllm_wheel stage from build_context
 COPY --from=trtllm_wheel /*.whl /trtllm_wheel/
+COPY --from=trtllm_wheel /commit.txt /trtllm_wheel/
+
 # Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel
 # because there might be mismatched versions of TensorRT between the NGC PyTorch
 # and the TRTLLM wheel.


### PR DESCRIPTION
#### Overview:

copy commit.txt file trtllm_wheel image context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Container images now include commit metadata text files alongside installed wheels for TensorRT-LLM components.
  * Build process updated to copy both wheel and commit info artifacts into the final image, ensuring metadata is available.
  * Inline comment adjusted to reflect the inclusion of commit information.
  * No runtime behavior changes; application functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->