### PR TITLE
ci: OPS-980: Add operator build and push per-commit

### DIFF
--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         run: |
           cd deploy/cloud/operator
-          docker build -f Dockerfile -t dynamo-operator:latest .
+          docker buildx build --platform linux/${{ matrix.platform.arch }} -f Dockerfile -t dynamo-operator:latest .
       - name: Docker Tag and Push
         uses: ./.github/actions/docker-tag-push
         with:

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -37,6 +37,41 @@ jobs:
         run: |
           echo '${{ toJson(needs) }}' | jq -e 'to_entries | map(.value.result) | all(. as $result | ["success", "skipped"] | any($result == .))'
 
+  operator:
+    needs: changed-files
+    if: needs.changed-files.outputs.has_code_changes == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { arch: amd64, runner: cpu-amd-m5-2xlarge }
+          - { arch: arm64, runner: cpu-arm-r8g-4xlarge }
+    name: operator (${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Container
+        id: build-image
+        shell: bash
+        run: |
+          cd deploy/cloud/operator
+          docker build -f Dockerfile -t dynamo-operator:latest .
+      - name: Docker Tag and Push
+        uses: ./.github/actions/docker-tag-push
+        with:
+          local_image: dynamo-operator:latest
+          push_tag: ai-dynamo/dynamo:${{ github.sha }}-operator-${{ matrix.platform.arch }}
+          aws_push: 'false'
+          azure_push: 'true'
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+
   vllm:
     needs: changed-files
     if: needs.changed-files.outputs.has_code_changes == 'true'

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -58,7 +58,10 @@ jobs:
         shell: bash
         run: |
           cd deploy/cloud/operator
-          docker buildx build --platform linux/${{ matrix.platform.arch }} -f Dockerfile -t dynamo-operator:latest .
+          docker buildx build --load \
+              --platform linux/${{ matrix.platform.arch }} \
+              -f Dockerfile \
+              -t dynamo-operator:latest .
       - name: Docker Tag and Push
         uses: ./.github/actions/docker-tag-push
         with:

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -30,7 +30,7 @@ jobs:
 
   backend-status-check:
     runs-on: ubuntu-latest
-    needs: [vllm, sglang, trtllm]
+    needs: [vllm, sglang, trtllm, operator]
     if: always()
     steps:
       - name: "Check all dependent jobs"

--- a/deploy/cloud/operator/Dockerfile
+++ b/deploy/cloud/operator/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.24 AS base
 
 # Docker buildx automatically provides these
 ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 
 RUN echo "Building for ${TARGETOS}/${TARGETARCH}"
 


### PR DESCRIPTION
#### Overview:

- Fixes `TARGETARCH` in operator `Dockerfile`, this variable is set automatically by `docker buildx`, hard-coding the variable made invocations of `--platform linux/arm64` build with `linux/amd64` instead, resulting in incorrect images.
- Adds workflow job to build the dynamo operator image, and push to ACR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - CI workflow expanded to build and publish the operator container image for multiple architectures (amd64, arm64), improving multi-platform coverage.
  - Workflow runs only when relevant code changes are detected, reducing unnecessary executions.
  - Docker build now honors the provided target architecture (no default), ensuring accurate platform-specific builds and clearer build logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->