### PR TITLE
feat: router frees request from slot manager on stopped requests

### DIFF
--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -576,6 +576,13 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 
                     loop {
                         tokio::select! {
+                            biased;
+
+                            _ = context_for_monitoring.stopped() => {
+                                tracing::debug!("Request {context_id} cancelled, ending stream");
+                                break;
+                            }
+
                             item = response_stream.next() => {
                                 let Some(item) = item else {
                                     break;
@@ -588,10 +595,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                                     prefill_marked = true;
                                 }
                                 yield item;
-                            }
-                            _ = context_for_monitoring.stopped() => {
-                                tracing::debug!("Request {context_id} cancelled, ending stream");
-                                break;
                             }
                         }
                     }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -569,17 +569,31 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 let mut response_stream = self.inner.direct(updated_request, instance_id).await?;
                 let stream_context = response_stream.context();
                 let chooser = self.chooser.clone();
+                let context_for_monitoring = stream_context.clone();
 
                 let wrapped_stream = Box::pin(async_stream::stream! {
-                    if let Some(first_item) = response_stream.next().await {
-                        if let Err(e) = chooser.mark_prefill_completed(&context_id).await {
-                            tracing::warn!("Failed to mark prefill completed for request {context_id}: {e:?}");
-                        }
-                        yield first_item;
-                    }
+                    let mut prefill_marked = false;
 
-                    while let Some(item) = response_stream.next().await {
-                        yield item;
+                    loop {
+                        tokio::select! {
+                            item = response_stream.next() => {
+                                let Some(item) = item else {
+                                    break;
+                                };
+
+                                if !prefill_marked {
+                                    if let Err(e) = chooser.mark_prefill_completed(&context_id).await {
+                                        tracing::warn!("Failed to mark prefill completed for request {context_id}: {e:?}");
+                                    }
+                                    prefill_marked = true;
+                                }
+                                yield item;
+                            }
+                            _ = context_for_monitoring.stopped() => {
+                                tracing::debug!("Request {context_id} cancelled, ending stream");
+                                break;
+                            }
+                        }
                     }
 
                     if let Err(e) = chooser.free(&context_id).await {


### PR DESCRIPTION
#### Overview:

as titled, implemented with a biased `tokio::select!` listening on the `stopped` signal, in common with the patterns used in the repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Faster, more responsive streaming of results with reduced initial delay.
  * Smoother handling of prefill, emitting the first chunk as soon as it’s available.

* **Bug Fixes**
  * Request cancellations now stop streams promptly, reducing stuck or lingering responses.
  * Prevents missed or duplicated first streamed items, improving consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->