### PR TITLE
fix: manager exits when plannerClusterRoleName is not defined

### DIFF
--- a/deploy/cloud/operator/cmd/main.go
+++ b/deploy/cloud/operator/cmd/main.go
@@ -186,11 +186,6 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	if restrictedNamespace == "" && plannerClusterRoleName == "" {
-		setupLog.Error(nil, "planner-cluster-role-name is required in cluster-wide mode")
-		os.Exit(1)
-	}
-
 	// Validate modelExpressURL if provided
 	if modelExpressURL != "" {
 		if _, err := url.Parse(modelExpressURL); err != nil {


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

I am not sure what the intend of this code is but manager will exit if plannerClusterRoleName is not defined which is not defined in any recipes

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster-wide deployments no longer fail on startup due to a missing planner ClusterRole name, reducing configuration friction.
  * Improves reliability by preventing unnecessary validation errors and allowing deployments to proceed with default or existing RBAC settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->