### PR TITLE
fix: add additional tool call end tokens for deepseek_parser.rs

### DIFF
--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -155,7 +155,10 @@ impl ToolCallConfig {
                     "<｜tool▁calls▁begin｜>".to_string(),
                     "<｜tool▁call▁begin｜>".to_string(),
                 ],
-                tool_call_end_tokens: vec!["<｜tool▁calls▁end｜>".to_string()],
+                tool_call_end_tokens: vec![
+                    "<｜tool▁call▁end｜>".to_string(),
+                    "<｜tool▁calls▁end｜>".to_string(),
+                ],
                 parser_type: JsonParserType::DeepseekV31,
                 ..Default::default()
             },


### PR DESCRIPTION
refs: #3599

#### Overview:

Fix DeepSeek V3.1 tool calling parser to correctly handle individual tool call end tokens according to the official format specification.

#### Details:

The DeepSeek V3.1 tool calling format uses two distinct end tokens:
- `<｜tool▁call▁end｜>` - closes each individual tool call
- `<｜tool▁calls▁end｜>` - closes the entire tool calls block

The official format from DeepSeek's Hugging Face documentation is:
```
<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>tool_call_name<｜tool▁sep｜>tool_call_arguments<｜tool▁call▁end｜>{additional_tool_calls}<｜tool▁calls▁end｜>
```

Previously, the parser configuration only included `<｜tool▁calls▁end｜>` in `tool_call_end_tokens`, which meant it couldn't properly detect the boundaries between multiple tool calls in a single response.

This PR adds `<｜tool▁call▁end｜>` to the end tokens array, creating symmetry with the start tokens and enabling correct parsing of both single and multiple tool call scenarios.

#### Where should the reviewer start?

- `lib/parsers/src/tool_calling/config.rs` - specifically the `deepseek_v3_1()` function (lines 150-166)
- Verify that the order of end tokens (`tool_call_end` before `tool_calls_end`) is correct for the parser logic

#### Related Issues:

- Fixes #3599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved tool-call parsing reliability for DeepSeek v3.1 by recognizing multiple valid end markers, reducing parsing errors and missed tool calls across varied responses.
  - Prevents premature termination during tool-call processing, leading to more consistent execution of automations and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->