### PR TITLE
fix: avoid offload redundant prefill blocks | fix cuda graph hanging

### DIFF
--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader.rs
@@ -386,10 +386,6 @@ impl Leader for KvConnectorLeader {
                 .get(request_id)
                 .unwrap_or(&0);
 
-            tracing::info!(
-                "Applying scheduler output for num_computed_tokens: {}, scheduled_tokens: {}",
-                new_req.num_computed_tokens, scheduled_tokens
-            );
             slot.apply_scheduler_output(&[], &[], new_req.num_computed_tokens, scheduled_tokens)?;
 
             if let Some(pending_ops) = slot.take_pending_operations() {

--- a/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader.rs
+++ b/lib/bindings/python/rust/llm/block_manager/vllm/connector/leader.rs
@@ -386,6 +386,10 @@ impl Leader for KvConnectorLeader {
                 .get(request_id)
                 .unwrap_or(&0);
 
+            tracing::info!(
+                "Applying scheduler output for num_computed_tokens: {}, scheduled_tokens: {}",
+                new_req.num_computed_tokens, scheduled_tokens
+            );
             slot.apply_scheduler_output(&[], &[], new_req.num_computed_tokens, scheduled_tokens)?;
 
             if let Some(pending_ops) = slot.take_pending_operations() {


### PR DESCRIPTION
#### Overview:

By moving `current_position` and `evaluated_blocks` to the correct position, this PR will

- avoid offload redundant prefill blocks
- fix cuda graph hanging

Before this PR, when sending the same request twice (e.g. ISL 196, OSL 50), the expected behavior is - in the first request, we offload 12 blocks (16 x 12 = 192) and no blocks should be offloaded in the second request. This is due to all 12 blocks would be prefix cache hit and we do not offload decode blocks for vllm.

However, the actual behavior is in the second request, we would offload 3 blocks, since we do not advance `current_position` and `evaluated_blocks` with the `num_computed_tokens` accordingly and current_position and evaluated_blocks will start with 0

closes [DIS-824](https://linear.app/nvidia/issue/DIS-824/debug-issues-with-cuda-graph-in-vllm-kvbm)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed a parameter in a public interface for clarity and consistency; custom integrations implementing this interface may need minor updates.

* **Chores**
  * Added an info-level log before applying scheduler output, reporting computed and scheduled token counts to aid observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->