### PR TITLE
feat: Enable cancellation during or before a stream is established

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -135,7 +135,7 @@ fn create_request_context(
             if context.inner().is_stopped() || context.inner().is_killed() {
                 // Let the server handle the cancellation for now since not all backends are
                 // properly handling request exceptions
-                // TODO: (DIS-829) Return an error if context is cancelled
+                // TODO: (DIS-830) Return an error if context is cancelled
                 request_ctx.context().stop_generating();
             }
             request_ctx

--- a/lib/bindings/python/tests/cancellation/test_cancellation.py
+++ b/lib/bindings/python/tests/cancellation/test_cancellation.py
@@ -289,3 +289,44 @@ async def test_server_raise_cancelled(server, client):
     # TODO: Server to gracefully stop the stream?
     assert not handler.context_is_stopped
     assert not handler.context_is_killed
+
+
+@pytest.mark.forked
+@pytest.mark.asyncio
+async def test_client_context_already_cancelled(server, client):
+    _, handler = server
+    context = Context()
+    context.stop_generating()
+    # TODO: (DIS-829) The outgoing call should raise if context is cancelled
+    stream = await client.generate("_generate_until_context_cancelled", context=context)
+
+    # Give server a moment to process anything
+    await asyncio.sleep(0.2)
+
+    async for _ in stream:
+        raise AssertionError("Request should be cancelled when generate begins")
+
+    # Verify server context cancellation status
+    assert handler.context_is_stopped
+    assert not handler.context_is_killed
+
+
+@pytest.mark.forked
+@pytest.mark.asyncio
+async def test_client_context_cancel_before_await_request(server, client):
+    _, handler = server
+    context = Context()
+    request = client.generate("_generate_until_context_cancelled", context=context)
+    context.stop_generating()
+    # TODO: (DIS-829) The outgoing call should raise if context is cancelled
+    stream = await request
+
+    # Give server a moment to process anything
+    await asyncio.sleep(0.2)
+
+    async for _ in stream:
+        raise AssertionError("Request should be cancelled when generate begins")
+
+    # Verify server context cancellation status
+    assert handler.context_is_stopped
+    assert not handler.context_is_killed

--- a/lib/bindings/python/tests/cancellation/test_cancellation.py
+++ b/lib/bindings/python/tests/cancellation/test_cancellation.py
@@ -300,11 +300,13 @@ async def test_client_context_already_cancelled(server, client):
     # TODO: (DIS-830) The outgoing call should raise if context is cancelled
     stream = await client.generate("_generate_until_context_cancelled", context=context)
 
-    # Give server a moment to process anything
-    await asyncio.sleep(0.2)
-
     async for _ in stream:
-        raise AssertionError("Request should be cancelled when generate begins")
+        raise AssertionError(
+            "Request should be cancelled before any responses are generated"
+        )
+
+    # Give server a moment to update status
+    await asyncio.sleep(0.2)
 
     # Verify server context cancellation status
     assert handler.context_is_stopped
@@ -321,11 +323,13 @@ async def test_client_context_cancel_before_await_request(server, client):
     # TODO: (DIS-830) The outgoing call should raise if context is cancelled
     stream = await request
 
-    # Give server a moment to process anything
-    await asyncio.sleep(0.2)
-
     async for _ in stream:
-        raise AssertionError("Request should be cancelled when generate begins")
+        raise AssertionError(
+            "Request should be cancelled before any responses are generated"
+        )
+
+    # Give server a moment to update status
+    await asyncio.sleep(0.2)
 
     # Verify server context cancellation status
     assert handler.context_is_stopped

--- a/lib/bindings/python/tests/cancellation/test_cancellation.py
+++ b/lib/bindings/python/tests/cancellation/test_cancellation.py
@@ -297,7 +297,7 @@ async def test_client_context_already_cancelled(server, client):
     _, handler = server
     context = Context()
     context.stop_generating()
-    # TODO: (DIS-829) The outgoing call should raise if context is cancelled
+    # TODO: (DIS-830) The outgoing call should raise if context is cancelled
     stream = await client.generate("_generate_until_context_cancelled", context=context)
 
     # Give server a moment to process anything
@@ -318,7 +318,7 @@ async def test_client_context_cancel_before_await_request(server, client):
     context = Context()
     request = client.generate("_generate_until_context_cancelled", context=context)
     context.stop_generating()
-    # TODO: (DIS-829) The outgoing call should raise if context is cancelled
+    # TODO: (DIS-830) The outgoing call should raise if context is cancelled
     stream = await request
 
     # Give server a moment to process anything

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -135,7 +135,10 @@ impl RetryManager {
             self.context.link_child(request.context());
             if self.context.is_stopped() || self.context.is_killed() {
                 tracing::debug!("Abort creating new stream after context is stopped or killed");
-                return Err(Error::msg("Context is stopped or killed"));
+                return Err(Error::msg(format!(
+                    "Context id {} is stopped or killed",
+                    self.context.id()
+                )));
             }
             response_stream = Some(self.next_generate.generate(request).await);
             if let Some(err) = response_stream.as_ref().unwrap().as_ref().err()
@@ -748,7 +751,11 @@ mod tests {
 
         assert!(retry_manager_result.is_err());
         if let Err(error) = retry_manager_result {
-            assert!(error.to_string().contains("Context is stopped or killed"));
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("Context id {} is stopped or killed", context_id))
+            );
         }
     }
 }

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -133,6 +133,10 @@ impl RetryManager {
             self.retries_left -= 1;
             let request = Context::with_id(self.request.clone(), self.context.id().to_string());
             self.context.link_child(request.context());
+            if self.context.is_stopped() || self.context.is_killed() {
+                tracing::debug!("Abort creating new stream after context is stopped or killed");
+                return Err(Error::msg("Context is stopped or killed"));
+            }
             response_stream = Some(self.next_generate.generate(request).await);
             if let Some(err) = response_stream.as_ref().unwrap().as_ref().err()
                 && let Some(req_err) = err.downcast_ref::<NatsRequestError>()
@@ -713,6 +717,38 @@ mod tests {
         assert!(error_response.err().is_some());
         if let Some(error) = error_response.err() {
             assert!(error.to_string().contains(STREAM_ERR_MSG));
+        }
+    }
+
+    /// Test case 7: Request cancelled when creating new stream
+    /// Tests the scenario where context.stop_generating() is called when creating a new stream.
+    /// The RetryManager should detect that the context is stopped and abort creating new streams.
+    /// Expected behavior: Should fail to build RetryManager with "Context is stopped or killed" error.
+    #[tokio::test]
+    async fn test_retry_manager_context_stopped_before_stream() {
+        dynamo_runtime::logging::init();
+        let context_id = uuid::Uuid::new_v4().to_string();
+        let request = create_mock_request(10);
+        let mock_engine = Arc::new(MockEngine::new(
+            MockBehavior::Success,
+            10,
+            100,
+            context_id.clone(),
+        ));
+        let next_generate: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
+            mock_engine;
+
+        let ctx = Arc::new(Controller::new(context_id.clone()));
+
+        // Stop the context before building RetryManager
+        ctx.stop_generating();
+
+        // Should fail to build due to stopped context
+        let retry_manager_result = RetryManager::build(ctx, request, next_generate, 3).await;
+
+        assert!(retry_manager_result.is_err());
+        if let Err(error) = retry_manager_result {
+            assert!(error.to_string().contains("Context is stopped or killed"));
         }
     }
 }

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -9,7 +9,6 @@ use super::*;
 use crate::logging::DistributedTraceContext;
 use crate::logging::get_distributed_tracing_context;
 use crate::{Result, protocols::maybe_error::MaybeError};
-use tokio::task::JoinSet;
 use tokio_stream::{StreamExt, StreamNotifyClose, wrappers::ReceiverStream};
 use tracing::Instrument;
 
@@ -67,68 +66,6 @@ impl AddressedPushRouter {
             req_transport,
             resp_transport,
         }))
-    }
-
-    /// Helper method to send a request with cancellation support.
-    /// If the engine context is stopped before the request completes, the request is detached and
-    /// allowed to complete in the background, since NATS is not cancellation safe.
-    async fn send_request_with_cancellation(
-        &self,
-        address: String,
-        headers: HeaderMap,
-        buffer: Bytes,
-        engine_ctx: Arc<dyn AsyncEngineContext>,
-        request_id: &str,
-    ) -> Result<async_nats::Message> {
-        // Define the result type for the concurrent tasks
-        enum TaskResult {
-            RequestCompleted(
-                Result<
-                    async_nats::Message,
-                    async_nats::error::Error<async_nats::client::RequestErrorKind>,
-                >,
-            ),
-            Cancelled,
-        }
-
-        let mut join_set = JoinSet::new();
-
-        // Spawn the request task
-        let req_transport = self.req_transport.clone();
-        let engine_ctx_ = engine_ctx.clone();
-        join_set.spawn(async move {
-            let result = req_transport
-                .request_with_headers(address, headers, buffer.into())
-                .await;
-            if engine_ctx_.is_stopped() {
-                // Replay the stop signal to ensure the request is explicitly cancelled
-                engine_ctx_.stop_generating();
-            }
-            TaskResult::RequestCompleted(result)
-        });
-
-        // Spawn the cancellation monitor tasks
-        join_set.spawn(async move {
-            engine_ctx.stopped().await;
-            TaskResult::Cancelled
-        });
-
-        // Wait for the first task to complete
-        let result = join_set
-            .join_next()
-            .await
-            .ok_or_else(|| anyhow::anyhow!("JoinSet unexpectedly empty"))?
-            .map_err(|e| anyhow::anyhow!("Join task failed: {}", e))?;
-
-        // Check if it was the request or the cancellation
-        match result {
-            TaskResult::RequestCompleted(response) => response.map_err(|e| e.into()),
-            TaskResult::Cancelled => {
-                log::debug!(request_id, "Request cancelled before stream is established");
-                join_set.detach_all();
-                Err(PipelineError::DetachedStreamReceiver.into())
-            }
-        }
     }
 }
 
@@ -225,13 +162,8 @@ where
         // we might need to add a timeout on this if there is no subscriber to the subject; however, I think nats
         // will handle this for us
         let _response = self
-            .send_request_with_cancellation(
-                address,
-                headers,
-                buffer,
-                engine_ctx.clone(),
-                &request_id,
-            )
+            .req_transport
+            .request_with_headers(address.to_string(), headers, buffer)
             .await?;
 
         log::trace!(request_id, "awaiting transport handshake");


### PR DESCRIPTION
#### Overview:

* Python binding will cancel the outgoing request if cancellation happens before the stream is established.
* Migration will abort creating new streams if the request is cancelled.

#### Details:

* Python binding update to allow context to be linked before making the outgoing request.
* New unit test checking the cancellation behavior with Python binding.
* Migration logic enhancement to support aborting new stream construction if request is cancelled.
* New unit test checking the Migration new stream construction abort logic.

#### Where should the reviewer start?

Start with the Python binding unit tests, and then the Python binding changes, and finish off with the Migration layer.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified request context handling across all request paths for more consistent behavior.
- Bug Fixes
  - Cancellation is now reliably propagated and honored across all request types.
  - Requests no longer start if the context is already stopped or cancelled, returning a clear error.
  - Standardized instrumentation for improved observability.
- Tests
  - Added scenarios verifying cancellation when a context is already cancelled.
  - Added scenarios verifying cancellation triggered before awaiting a request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->