### PR TITLE
fix: sglang srt parser

### DIFF
--- a/docs/backends/sglang/dsr1-wideep-gb200.md
+++ b/docs/backends/sglang/dsr1-wideep-gb200.md
@@ -29,7 +29,7 @@ docker build \
   -f container/Dockerfile.sglang-wideep \
   -t dynamo-wideep-gb200 \
   --build-arg MODE=blackwell \
-  --build-arg SGLANG_IMAGE_TAG=v0.5.3rc0-cu129-gb200 \
+  --build-arg SGLANG_IMAGE_TAG=v0.5.3-cu129-gb200 \
   --build-arg ARCH=arm64 \
   --build-arg ARCH_ALT=aarch64 \
   .


### PR DESCRIPTION
We don't need this change on main since we've already updated how we build this container

---

Fixes 

```
[Dynamo][release/0.6.0][sglang][slurm]sglang-deepep-arm64:  No module named 'sglang.srt.parser
```

---

After building container with this fix, I can do 

```bash
root@869b724f19d1:/sgl-workspace/dynamo/components/backends/sglang# python3
Python 3.12.11 (main, Jun  4 2025, 08:56:18) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sglang.srt.parser
>>>
```