### PR TITLE
chore: use aic 0.2.0 instead of commit hash

### DIFF
--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 accelerate==1.6.0
-aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@e46d9089ffe4f5dd62c46914489c55b6dfdbc903
+aiconfigurator==0.2.0
 aiofiles
 aiperf @ git+https://github.com/ai-dynamo/aiperf.git@e8f69abf180ff9ea96de9f9a8c955df8c024625b
 av==15.0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized a dependency to a pinned release from the public package index, replacing a Git-based reference. This improves installation consistency, repeatable builds, and simplifies environment setup.
  * Reduced risk of unexpected upstream changes and improved reliability of deployments and CI pipelines.
  * No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->