### PR TITLE
feat(frontend): Get model config files (`tokenizer.json` et al.) from MX

### DIFF
--- a/lib/llm/src/common/checked_file.rs
+++ b/lib/llm/src/common/checked_file.rs
@@ -100,6 +100,29 @@ impl CheckedFile {
             }
         }
     }
+
+    /// Is the CheckedFile a path on disk that exists?
+    pub fn is_local(&self) -> bool {
+        match self.path.as_ref() {
+            Either::Left(path) => path.exists(),
+            Either::Right(_) => false, // is a Url
+        }
+    }
+
+    /// Keep the filename but change it's containing directory to `dir`.
+    /// This is used to point at a model file (e.g. `tokenizer.json`) in the HF cache dir.
+    pub fn update_dir(&mut self, dir: &Path) {
+        match self.path.as_mut() {
+            Either::Left(path) => {
+                if let Some(file_name) = path.file_name() {
+                    let mut new_path = PathBuf::from(dir);
+                    new_path.push(file_name);
+                    *path = new_path;
+                }
+            }
+            Either::Right(_) => tracing::warn!("Cannot update directory on URL"),
+        }
+    }
 }
 
 impl Display for CheckedFile {

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -303,7 +303,8 @@ impl ModelWatcher {
         endpoint_id: &EndpointId,
         card: &mut ModelDeploymentCard,
     ) -> anyhow::Result<()> {
-        card.move_from_nats(self.drt.nats_client()).await?;
+        card.download_config().await?;
+
         let component = self
             .drt
             .namespace(&endpoint_id.namespace)?

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -418,10 +418,6 @@ impl LocalModel {
         self.card.model_type = model_type;
         self.card.model_input = model_input;
 
-        // Store model config files in NATS object store
-        let nats_client = endpoint.drt().nats_client();
-        self.card.move_to_nats(nats_client.clone()).await?;
-
         // Publish the Model Deployment Card to KV store
         let kvstore: Box<dyn KeyValueStore> = Box::new(EtcdStore::new(etcd_client.clone()));
         let card_store = Arc::new(KeyValueStoreManager::new(kvstore));


### PR DESCRIPTION
Previously the backend would push all model config files into the NATS object store, to make them available to the frontends. It then changed the ModelDeploymentCard to have the nats URL instead of local path.

Now we do this instead:

Leave the local paths untouched in the model card in etcd. When frontend fetches the model card it first checks if the same path is visible for it too. This is good for local dev, but more importantly the K8s PVC is often mounted on the same path on every pod, so likely the frontend can already see the files.

If the files are not visible locally it downloads them from modelexpress, and changes the local files to point to the new cache directory.

This makes publishing a model faster, because uploading / downloading the ~10 MiB tokenizer took a few seconds. It also reduces our reliance on NATS.

Local (unpublished) models are still supported. They need to be in a PVC shared by all nodes, or at the same local path on all nodes.

# What this changes: 

We now recommend running Modelexpress server (MX) with it's shared PVC mounted at the same location on all nodes. In most cases Dynamo starts faster and does not need NATS, because MX caches the model on the PVC making it immediately visible to all nodes.

1. Agg / single-node:

Starts faster because there's no push-pull to NATS object store. NATS is not required (other parts of Dynamo still need it). MX is not necessary.

2. Disagg / multi-node setup:

- HF model with MX: Starts faster, does not need NATS (but other parts of Dynamo still do).
- HF model without MX: Frontend will need to download the JSON config files (not the weights) from HF once on first run. Starts slower the first time.
- Unreleased local model with MX: Starts faster, does not needs NATS.
- Unreleased local model without MX: This no longer works but is easily fixed. The model must be located on a shared folder (K8s PVC) visible to the frontend. We no longer send the files via the NATS object store. Does not work without that PVC. With the PVC, starts faster, does not need NATS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Detect whether model artifacts are local and update their directory location.
  * Automatically download missing model configuration when loading, reducing manual setup.

* **Refactor**
  * Replaced message-bus-based model config transfer with direct download for simpler, more reliable syncing.
  * Streamlined local-file handling during model attach and load for more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->