### PR TITLE
fix: Reduce memory usage to avoid vLLM dsr1 OOM

### DIFF
--- a/components/backends/vllm/launch/dsr1_dep.sh
+++ b/components/backends/vllm/launch/dsr1_dep.sh
@@ -101,10 +101,10 @@ for ((i=0; i<GPUS_PER_NODE; i++)); do
         --data_parallel_size $DATA_PARALLEL_SIZE \
         --data-parallel-rank $dp_rank \
         --enable-expert-parallel \
-        --max-model-len 10240 \
+        --max-model-len 4096 \
         --data-parallel-address $MASTER_ADDR \
         --data-parallel-rpc-port 13345 \
-        --gpu-memory-utilization 0.95 \
+        --gpu-memory-utilization 0.9 \
         --enforce-eager 2>&1 | tee $LOG_DIR/dsr1_dep_${dp_rank}.log &
 done
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Lower the value of max-model-len and gpu-memory-utilization to avoid OOM for dsr1.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default runtime parameters for the vLLM launcher: reduced maximum model context length from 10240 to 4096 and slightly lowered GPU memory utilization from 0.95 to 0.9.

* **Impact**
  * Improves runtime stability under typical workloads and reduces risk of GPU memory overcommit.
  * May limit maximum token context per request compared to previous defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->