### PR TITLE
fix: mocker engines should ignore downloading weights from hf (again)

### DIFF
--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -37,7 +37,9 @@ pub async fn run(
         }
         Some(p) => {
             // model_path might be an HF repo, not a local path. Resolve it by downloading.
-            Some(LocalModel::fetch(&p.display().to_string(), false).await?)
+            // Mocker only needs tokenizer, not weights
+            let ignore_weights = matches!(out_opt, Some(Output::Mocker));
+            Some(LocalModel::fetch(&p.display().to_string(), ignore_weights).await?)
         }
     };
 

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -215,7 +215,9 @@ pub fn make_engine<'p>(
             let local_path = if model_path.exists() {
                 model_path
             } else {
-                LocalModel::fetch(&model_path.display().to_string(), false)
+                // Mocker only needs tokenizer, not weights
+                let ignore_weights = matches!(args.engine_type, EngineType::Mocker);
+                LocalModel::fetch(&model_path.display().to_string(), ignore_weights)
                     .await
                     .map_err(to_pyerr)?
             };


### PR DESCRIPTION
#### Overview:

as titled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized mock engine initialization by skipping unnecessary weight downloads in mock mode, reducing startup time and bandwidth usage, especially when model files are absent.

* **Bug Fixes**
  * Prevents spurious errors during initialization in mock mode by correctly handling cases where only the tokenizer is needed without weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->