### PR TITLE
fix: add `--host` to k8s and bump sgl version

### DIFF
--- a/components/backends/sglang/deploy/disagg-multinode.yaml
+++ b/components/backends/sglang/deploy/disagg-multinode.yaml
@@ -56,6 +56,8 @@ spec:
             - nixl
             - --disaggregation-bootstrap-port
             - "30001"
+            - --host
+            - "0.0.0.0"
             - --mem-fraction-static
             - "0.82"
     prefill:
@@ -93,3 +95,5 @@ spec:
             - "30001"
             - --mem-fraction-static
             - "0.82"
+            - --host
+            - "0.0.0.0"

--- a/components/backends/sglang/deploy/disagg.yaml
+++ b/components/backends/sglang/deploy/disagg.yaml
@@ -46,7 +46,10 @@ spec:
             - decode
             - --disaggregation-transfer-backend
             - nixl
-
+            - --disaggregation-bootstrap-port
+            - "12345"
+            - --host
+            - "0.0.0.0"
     prefill:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -79,3 +82,7 @@ spec:
             - prefill
             - --disaggregation-transfer-backend
             - nixl
+            - --disaggregation-bootstrap-port
+            - "12345"
+            - --host
+            - "0.0.0.0"

--- a/components/backends/sglang/deploy/disagg_planner.yaml
+++ b/components/backends/sglang/deploy/disagg_planner.yaml
@@ -70,6 +70,10 @@ spec:
             - decode
             - --disaggregation-transfer-backend
             - nixl
+            - --disaggregation-bootstrap-port
+            - "12345"
+            - --host
+            - "0.0.0.0"
     prefill:
       dynamoNamespace: dynamo
       envFromSecret: hf-token-secret
@@ -102,3 +106,7 @@ spec:
             - prefill
             - --disaggregation-transfer-backend
             - nixl
+            - --disaggregation-bootstrap-port
+            - "12345"
+            - --host
+            - "0.0.0.0"

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -14,7 +14,7 @@ ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
 
 # Make sure to update the dependency version in pyproject.toml when updating this
-ARG SGLANG_VERSION="0.5.3.post1"
+ARG SGLANG_VERSION="0.5.3.post2"
 
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.

--- a/container/Dockerfile.sglang-wideep
+++ b/container/Dockerfile.sglang-wideep
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG SGLANG_IMAGE_TAG="v0.5.3.post1"
+ARG SGLANG_IMAGE_TAG="v0.5.3.post2"
 ARG BRANCH_TYPE
 
 FROM scratch AS local_src

--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -104,8 +104,8 @@ cd $DYNAMO_HOME
 # installs sglang supported version along with dynamo
 # include the prerelease flag to install flashinfer rc versions
 uv pip install -e .
-# install any sglang version >= 0.5.3
-uv pip install "sglang[all]==0.5.3.post1"
+# install any sglang version >= 0.5.3.post2
+uv pip install "sglang[all]==0.5.3.post2"
 ```
 
 </details>

--- a/docs/backends/sglang/dsr1-wideep-h100.md
+++ b/docs/backends/sglang/dsr1-wideep-h100.md
@@ -58,6 +58,7 @@ python3 -m dynamo.sglang \
   --skip-tokenizer-init \
   --disaggregation-mode prefill \
   --disaggregation-transfer-backend nixl \
+  --host 0.0.0.0 \
   --disaggregation-bootstrap-port 30001 \
   --dist-init-addr ${HEAD_PREFILL_NODE_IP}:29500 \
   --nnodes 4 \
@@ -95,6 +96,7 @@ python3 -m dynamo.sglang \
   --disaggregation-mode decode \
   --disaggregation-transfer-backend nixl \
   --disaggregation-bootstrap-port 30001 \
+  --host 0.0.0.0 \
   --dist-init-addr ${HEAD_DECODE_NODE_IP}:29500 \
   --nnodes 4 \
   --node-rank 0 \

--- a/docs/backends/sglang/multinode-examples.md
+++ b/docs/backends/sglang/multinode-examples.md
@@ -39,6 +39,7 @@ python3 -m dynamo.sglang \
   --disaggregation-mode prefill \
   --disaggregation-transfer-backend nixl \
   --disaggregation-bootstrap-port 30001 \
+  --host 0.0.0.0 \
   --mem-fraction-static 0.82
 ```
 
@@ -58,6 +59,7 @@ python3 -m dynamo.sglang \
   --disaggregation-mode prefill \
   --disaggregation-transfer-backend nixl \
   --disaggregation-bootstrap-port 30001 \
+  --host 0.0.0.0 \
   --mem-fraction-static 0.82
 ```
 
@@ -77,6 +79,7 @@ python3 -m dynamo.sglang \
   --disaggregation-mode decode \
   --disaggregation-transfer-backend nixl \
   --disaggregation-bootstrap-port 30001 \
+  --host 0.0.0.0 \
   --mem-fraction-static 0.82
 ```
 
@@ -96,6 +99,7 @@ python3 -m dynamo.sglang \
   --disaggregation-mode decode \
   --disaggregation-transfer-backend nixl \
   --disaggregation-bootstrap-port 30001 \
+  --host 0.0.0.0 \
   --mem-fraction-static 0.82
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ vllm = [
 sglang = [
     "uvloop",
     "nixl<=0.6.0",
-    "sglang[all]==0.5.3.post1",
+    "sglang[all]==0.5.3.post2",
 ]
 
 [dependency-groups]

--- a/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep16p-dep16d-disagg.yaml
@@ -67,6 +67,7 @@ spec:
               --disaggregation-transfer-backend nixl
               --disaggregation-bootstrap-port 30001
               --mem-fraction-static 0.8
+              --host 0.0.0.0
     prefill:
       dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
@@ -108,3 +109,4 @@ spec:
               --disaggregation-transfer-backend nixl
               --disaggregation-bootstrap-port 30001
               --mem-fraction-static 0.8
+              --host 0.0.0.0

--- a/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
+++ b/recipes/deepseek-r1/sglang-wideep/tep8p-dep8d-disagg.yaml
@@ -64,6 +64,7 @@ spec:
               --disaggregation-mode decode
               --disaggregation-transfer-backend nixl
               --disaggregation-bootstrap-port 30001
+              --host 0.0.0.0
     prefill:
       dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
@@ -102,3 +103,4 @@ spec:
               --disaggregation-mode prefill
               --disaggregation-transfer-backend nixl
               --disaggregation-bootstrap-port 30001
+              --host 0.0.0.0


### PR DESCRIPTION
SGLang recently switched up their disaggregation ip logic in https://github.com/sgl-project/sglang/pull/10081. We updated  this ourself in https://github.com/ai-dynamo/dynamo/pull/3498. 

Due to my oversight I forgot to update the K8s YAMLs. This should have raised a ⏰ but it did not. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations to bind services to 0.0.0.0 and set the disaggregation bootstrap port to 12345 for both decode and prefill in multi-node and planner setups.
  * Upgraded sglang to version 0.5.3.post2 across images and runtime to ensure consistency.

* **Documentation**
  * Revised setup instructions to require and install sglang 0.5.3.post2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->