### PR TITLE
chore: move worker_monitor to the llm crate

### DIFF
--- a/docs/architecture/kv_cache_routing.md
+++ b/docs/architecture/kv_cache_routing.md
@@ -31,6 +31,8 @@ The main KV-aware routing arguments:
 
 - `--no-track-active-blocks`: Disables tracking of active blocks (blocks being used for ongoing generation/decode phases). By default, the router tracks active blocks for load balancing. Disable this when routing to workers that only perform prefill (no decode phase), as tracking decode load is not relevant. This reduces router overhead and simplifies state management.
 
+- `--busy-threshold`: Threshold (0.0-1.0) for determining when a worker is considered busy based on KV cache usage. When a worker's KV cache active blocks exceed this percentage of total blocks, it will be marked as busy and excluded from routing. If not set, busy detection is disabled. This feature works with all routing modes (`--router-mode kv|round-robin|random`) as long as backend engines emit `ForwardPassMetrics`.
+
 >[!Note]
 > State persistence is only available when KV events are enabled (default). When using `--no-kv-events` with `ApproxKvIndexer`, state persistence is not currently supported.
 >

--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -7,5 +7,8 @@ pub use model_manager::{ModelManager, ModelManagerError};
 mod watcher;
 pub use watcher::{ModelUpdate, ModelWatcher};
 
+mod worker_monitor;
+pub use worker_monitor::{KvWorkerMonitor, WorkerLoadState};
+
 /// The root etcd path for KV Router registrations
 pub const KV_ROUTERS_ROOT_PATH: &str = "v1/kv_routers";

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -403,7 +403,6 @@ impl ModelWatcher {
             }
         } else if card.model_input == ModelInput::Text && card.model_type.supports_embedding() {
             // Case: Text + Embeddings
-            // No preprocessing or KV monitoring - backend handles everything
             let push_router = PushRouter::<
                 NvCreateEmbeddingRequest,
                 Annotated<NvCreateEmbeddingResponse>,
@@ -416,7 +415,6 @@ impl ModelWatcher {
                 .add_embeddings_model(card.name(), checksum, engine)?;
         } else if card.model_input == ModelInput::Text && card.model_type.supports_chat() {
             // Case 3: Text + Chat
-            // No preprocessing or KV monitoring - backend handles everything
             let push_router =
                 PushRouter::<
                     NvCreateChatCompletionRequest,
@@ -428,7 +426,6 @@ impl ModelWatcher {
                 .add_chat_completions_model(card.name(), checksum, engine)?;
         } else if card.model_input == ModelInput::Text && card.model_type.supports_completions() {
             // Case 2: Text + Completions
-            // No preprocessing or KV monitoring - backend handles everything
             let push_router = PushRouter::<
                 NvCreateCompletionRequest,
                 Annotated<NvCreateCompletionResponse>,

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -1,49 +1,23 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO: Make load comparisons and runtime metrics a generic trait so this monitoring
-// system is not tied to KV cache concepts, which are LLM-specific. This would allow
-// different types of workers to define their own load metrics and busy thresholds.
-
-use crate::component::{Client, InstanceSource};
-use crate::traits::DistributedRuntimeProvider;
-use crate::traits::events::EventSubscriber;
-use crate::utils::typed_prefix_watcher::{key_extractors, watch_prefix_with_extraction};
+use crate::kv_router::KV_METRICS_SUBJECT;
+use crate::kv_router::protocols::ForwardPassMetrics;
+use crate::model_card;
+use dynamo_runtime::component::Client;
+use dynamo_runtime::pipeline::{WorkerLoadMonitor, async_trait};
+use dynamo_runtime::traits::DistributedRuntimeProvider;
+use dynamo_runtime::traits::events::EventSubscriber;
+use dynamo_runtime::utils::typed_prefix_watcher::{key_extractors, watch_prefix_with_extraction};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use tokio::sync::watch;
 use tokio_stream::StreamExt;
 
-// Constants for monitoring configuration
-const KV_METRICS_SUBJECT: &str = "kv_metrics";
-
-// Internal structs for deserializing metrics events
+/// Event structure for KV metrics
 #[derive(serde::Deserialize)]
 struct LoadEvent {
     worker_id: i64,
     data: ForwardPassMetrics,
-}
-
-#[derive(serde::Deserialize)]
-struct ForwardPassMetrics {
-    worker_stats: WorkerStats,
-    kv_stats: KvStats,
-}
-
-#[derive(serde::Deserialize)]
-struct WorkerStats {
-    data_parallel_rank: Option<u32>,
-}
-
-#[derive(serde::Deserialize)]
-struct KvStats {
-    kv_active_blocks: u64,
-}
-
-#[derive(serde::Deserialize, Clone)]
-struct RuntimeConfig {
-    total_kv_blocks: Option<u64>,
-    data_parallel_size: u32,
 }
 
 /// Worker load monitoring state per dp_rank
@@ -83,15 +57,15 @@ impl WorkerLoadState {
 }
 
 /// Worker monitor for tracking KV cache usage and busy states
-pub struct WorkerMonitor {
+pub struct KvWorkerMonitor {
     client: Arc<Client>,
     worker_load_states: Arc<RwLock<HashMap<i64, WorkerLoadState>>>,
     busy_threshold: f64,
 }
 
-impl WorkerMonitor {
+impl KvWorkerMonitor {
     /// Create a new worker monitor with custom threshold
-    pub fn new_with_threshold(client: Arc<Client>, busy_threshold: f64) -> Self {
+    pub fn new(client: Arc<Client>, busy_threshold: f64) -> Self {
         Self {
             client,
             worker_load_states: Arc::new(RwLock::new(HashMap::new())),
@@ -103,9 +77,12 @@ impl WorkerMonitor {
     pub fn load_states(&self) -> Arc<RwLock<HashMap<i64, WorkerLoadState>>> {
         self.worker_load_states.clone()
     }
+}
 
+#[async_trait]
+impl WorkerLoadMonitor for KvWorkerMonitor {
     /// Start background monitoring of worker KV cache usage
-    pub async fn start_monitoring(&self) -> anyhow::Result<()> {
+    async fn start_monitoring(&self) -> anyhow::Result<()> {
         let endpoint = &self.client.endpoint;
         let component = endpoint.component();
 
@@ -114,19 +91,12 @@ impl WorkerMonitor {
             return Ok(());
         };
 
-        // WorkerMonitor is in the wrong crate. It deals with LLM things (KV) so it should be in
-        // dynamo-llm not dynamo-runtime.
-        // That means we cannot use ModelDeploymentCard, so use serde_json::Value for now .
+        // Watch for runtime config updates from model deployment cards
         let runtime_configs_watcher = watch_prefix_with_extraction(
             etcd_client,
-            "v1/mdc/", // should be model_card::ROOT_PREFIX but wrong crate
+            model_card::ROOT_PATH,
             key_extractors::lease_id,
-            |card: serde_json::Value| {
-                let runtime_config: Option<RuntimeConfig> = card
-                    .get("runtime_config")
-                    .and_then(|rc| serde_json::from_value(rc.clone()).ok());
-                runtime_config
-            },
+            |card: crate::model_card::ModelDeploymentCard| Some(card.runtime_config),
             component.drt().child_token(),
         )
         .await?;
@@ -138,7 +108,7 @@ impl WorkerMonitor {
         let worker_load_states = self.worker_load_states.clone();
         let client = self.client.clone();
         let cancellation_token = component.drt().child_token();
-        let busy_threshold = self.busy_threshold; // Capture threshold for the closure
+        let busy_threshold = self.busy_threshold;
 
         // Spawn background monitoring task
         tokio::spawn(async move {
@@ -151,7 +121,7 @@ impl WorkerMonitor {
                         break;
                     }
 
-                    // Handle runtime config updates - now receives full HashMap
+                    // Handle runtime config updates
                     _ = config_events_rx.changed() => {
                         let runtime_configs = config_events_rx.borrow().clone();
 
@@ -163,7 +133,6 @@ impl WorkerMonitor {
                             let state = states.entry(*lease_id).or_default();
 
                             // Populate total_blocks for all dp_ranks (they share the same total)
-                            // data_parallel_size defaults to 1 via serde in ModelRuntimeConfig
                             if let Some(total_blocks) = runtime_config.total_kv_blocks {
                                 for dp_rank in 0..runtime_config.data_parallel_size {
                                     state.kv_total_blocks.insert(dp_rank, total_blocks);

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::kv_router::KV_METRICS_SUBJECT;
-use crate::kv_router::protocols::ForwardPassMetrics;
-use crate::model_card;
+use crate::kv_router::scoring::LoadEvent;
+use crate::model_card::{self, ModelDeploymentCard};
 use dynamo_runtime::component::Client;
 use dynamo_runtime::pipeline::{WorkerLoadMonitor, async_trait};
 use dynamo_runtime::traits::DistributedRuntimeProvider;
@@ -12,13 +12,6 @@ use dynamo_runtime::utils::typed_prefix_watcher::{key_extractors, watch_prefix_w
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use tokio_stream::StreamExt;
-
-/// Event structure for KV metrics
-#[derive(serde::Deserialize)]
-struct LoadEvent {
-    worker_id: i64,
-    data: ForwardPassMetrics,
-}
 
 /// Worker load monitoring state per dp_rank
 #[derive(Clone, Debug, Default)]
@@ -96,7 +89,7 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
             etcd_client,
             model_card::ROOT_PATH,
             key_extractors::lease_id,
-            |card: crate::model_card::ModelDeploymentCard| Some(card.runtime_config),
+            |card: ModelDeploymentCard| Some(card.runtime_config),
             component.drt().child_token(),
         )
         .await?;

--- a/lib/runtime/src/pipeline.rs
+++ b/lib/runtime/src/pipeline.rs
@@ -15,7 +15,7 @@ pub mod context;
 pub mod error;
 pub mod network;
 pub use network::egress::addressed_router::{AddressedPushRouter, AddressedRequest};
-pub use network::egress::push_router::{PushRouter, RouterMode};
+pub use network::egress::push_router::{PushRouter, RouterMode, WorkerLoadMonitor};
 pub mod registry;
 
 pub use crate::engine::{

--- a/lib/runtime/src/utils.rs
+++ b/lib/runtime/src/utils.rs
@@ -10,6 +10,5 @@ pub mod stream;
 pub mod task;
 pub mod tasks;
 pub mod typed_prefix_watcher;
-pub mod worker_monitor;
 
 pub use graceful_shutdown::GracefulShutdownTracker;


### PR DESCRIPTION
#### Overview:

closes #3602. 

- `PushRouter::from_client_with_threshold` would take in `worker_monitor: Option<Arc<dyn WorkerLoadMonitor>>` as a generic arg, which would be specified in the llm crate with the actual KV load metrics during the `build_routed_pipeline_with_preprocessor` stage

Tests
- Manually served the mocker with the frontend (with the router), and verified that the `WorkerMonitor` did in fact receive the load events. 
- Scope e2e test with non-flaky request rejection in future PRs
