### PR TITLE
test: add durable consumer count test to CI using py-nats

### DIFF
--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -15,6 +15,8 @@
 
 # For IFEval dataset loading in kvbm tests
 datasets
+# For NATS object store verification in router tests
+nats-py
 psutil>=5.0.0
 pyright
 pytest

--- a/docs/architecture/kv_cache_routing.md
+++ b/docs/architecture/kv_cache_routing.md
@@ -316,6 +316,9 @@ To manage stream growth, when the message count exceeds `--router-snapshot-thres
 
 Instead of launching the KV Router via command line, you can create a `KvPushRouter` object directly in Python. This allows per-request routing configuration overrides.
 
+>[!Warning]
+> **Multiple Routers in Same Process**: If you need to run multiple `KvPushRouter` instances for fault tolerance or load distribution, you must launch them in **separate processes** (e.g., using `python -m dynamo.frontend` with different ports). Creating multiple `KvPushRouter` objects in the same Python process is not supported - they share the same cancellation token from the component's primary lease, so dropping one router will cancel all routers in that process. For in-process routing, use a single `KvPushRouter` instance.
+
 ### Methods
 
 The `KvPushRouter` provides the following methods:


### PR DESCRIPTION
#### Overview:

As titled, this is necessary to guarantee functionality of Router replicas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying that multiple KvPushRouter instances must run in separate processes due to shared cancellation token behavior.

* **Tests**
  * Enhanced end-to-end router tests with improved consumer lifecycle verification through NATS integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->