### PR TITLE
docs: move SGLang and vLLM Prometheus metrics documentation to docs path

### DIFF
--- a/docs/backends/sglang/prometheus.md
+++ b/docs/backends/sglang/prometheus.md
@@ -10,7 +10,7 @@ When running SGLang through Dynamo, SGLang engine metrics are automatically pass
 
 For the complete and authoritative list of all SGLang metrics, always refer to the official documentation linked above.
 
-Dynamo runtime metrics are documented in [docs/guides/metrics.md](../../../docs/guides/metrics.md).
+Dynamo runtime metrics are documented in [docs/guides/metrics.md](../../guides/metrics.md).
 
 ## Metric Reference
 

--- a/docs/backends/vllm/prometheus.md
+++ b/docs/backends/vllm/prometheus.md
@@ -10,7 +10,7 @@ When running vLLM through Dynamo, vLLM engine metrics are automatically passed t
 
 For the complete and authoritative list of all vLLM metrics, always refer to the official documentation linked above.
 
-Dynamo runtime metrics are documented in [docs/guides/metrics.md](../../../docs/guides/metrics.md).
+Dynamo runtime metrics are documented in [docs/guides/metrics.md](../../guides/metrics.md).
 
 ## Metric Reference
 

--- a/docs/hidden_toctree.rst
+++ b/docs/hidden_toctree.rst
@@ -60,6 +60,7 @@
    backends/sglang/multimodal_epd.md
    backends/sglang/sgl-hicache-example.md
    backends/sglang/sglang-disaggregation.md
+   backends/sglang/prometheus.md
 
    examples/README.md
    examples/runtime/hello_world/README.md
@@ -70,6 +71,7 @@
    backends/vllm/deepseek-r1.md
    backends/vllm/gpt-oss.md
    backends/vllm/multi-node.md
+   backends/vllm/prometheus.md
 
 
 ..   TODO: architecture/distributed_runtime.md and architecture/dynamo_flow.md


### PR DESCRIPTION
#### Overview:

Move prometheus.md documentation files from `components/backends/{sglang,vllm}/` to `docs/backends/{sglang,vllm}/` per Maksim's notice.

#### Details:

- Rename `components/backends/sglang/prometheus.md` → `docs/backends/sglang/prometheus.md`
- Rename `components/backends/vllm/prometheus.md` → `docs/backends/vllm/prometheus.md`
- TRT-LLM isn't implemented yet, but will follow the same convention in a separate PR. See DIS-442 for more details.
- Update internal relative paths from `../../../docs/guides/metrics.md` to `../../guides/metrics.md`

#### Where should the reviewer start?

The changes are self-contained file moves with path updates.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Relates to DIS-833

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected internal documentation links in the Prometheus configuration guides for backend services to ensure proper navigation to related metrics documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->