### PR TITLE
fix: json strings should remain intact through profiler arg processing

### DIFF
--- a/benchmarks/profiler/utils/config.py
+++ b/benchmarks/profiler/utils/config.py
@@ -127,7 +127,11 @@ def break_arguments(args: list[str] | None) -> list[str]:
             if arg is not None:
                 # If the arg looks like it might be JSON (starts with { or [) or is already a single token,
                 # don't split it further. Only split if it contains spaces AND doesn't look like JSON.
-                if isinstance(arg, str) and (" " in arg or "\t" in arg) and not (arg.strip().startswith(("{", "["))):
+                if (
+                    isinstance(arg, str)
+                    and (" " in arg or "\t" in arg)
+                    and not (arg.strip().startswith(("{", "[")))
+                ):
                     # Use shlex.split to properly handle quoted arguments
                     ans.extend(shlex.split(arg))
                 else:

--- a/benchmarks/profiler/utils/config.py
+++ b/benchmarks/profiler/utils/config.py
@@ -125,8 +125,13 @@ def break_arguments(args: list[str] | None) -> list[str]:
     else:
         for arg in args:
             if arg is not None:
-                # Use shlex.split to properly handle quoted arguments
-                ans.extend(shlex.split(arg))
+                # If the arg looks like it might be JSON (starts with { or [) or is already a single token,
+                # don't split it further. Only split if it contains spaces AND doesn't look like JSON.
+                if isinstance(arg, str) and (" " in arg or "\t" in arg) and not (arg.strip().startswith(("{", "["))):
+                    # Use shlex.split to properly handle quoted arguments
+                    ans.extend(shlex.split(arg))
+                else:
+                    ans.append(arg)
     return ans
 
 

--- a/benchmarks/profiler/utils/config_modifiers/trtllm.py
+++ b/benchmarks/profiler/utils/config_modifiers/trtllm.py
@@ -95,7 +95,7 @@ class TrtllmConfigModifier:
             # - Disable enable_block_reuse (no KV reuse for prefill-only)
             # - Enable overlap scheduler (disabled in prefill.yaml but needed for agg)
             # - Remove cache_transceiver_config (not needed in agg mode)
-            if "kv_cache_config" not in override_dict:
+            if "kv_cache_config" not in override_dict or not isinstance(override_dict["kv_cache_config"], dict):
                 override_dict["kv_cache_config"] = {}
             override_dict["kv_cache_config"]["enable_block_reuse"] = False
             override_dict[
@@ -146,7 +146,7 @@ class TrtllmConfigModifier:
             # Merge our overrides for converting decode-only disagg to aggregated:
             # - Enable enable_block_reuse (to skip prefill in decode-only)
             # - Remove cache_transceiver_config (not needed in agg mode)
-            if "kv_cache_config" not in override_dict:
+            if "kv_cache_config" not in override_dict or not isinstance(override_dict["kv_cache_config"], dict):
                 override_dict["kv_cache_config"] = {}
             override_dict["kv_cache_config"]["enable_block_reuse"] = True
             override_dict[

--- a/benchmarks/profiler/utils/config_modifiers/trtllm.py
+++ b/benchmarks/profiler/utils/config_modifiers/trtllm.py
@@ -95,7 +95,9 @@ class TrtllmConfigModifier:
             # - Disable enable_block_reuse (no KV reuse for prefill-only)
             # - Enable overlap scheduler (disabled in prefill.yaml but needed for agg)
             # - Remove cache_transceiver_config (not needed in agg mode)
-            if "kv_cache_config" not in override_dict or not isinstance(override_dict["kv_cache_config"], dict):
+            if "kv_cache_config" not in override_dict or not isinstance(
+                override_dict["kv_cache_config"], dict
+            ):
                 override_dict["kv_cache_config"] = {}
             override_dict["kv_cache_config"]["enable_block_reuse"] = False
             override_dict[
@@ -146,7 +148,9 @@ class TrtllmConfigModifier:
             # Merge our overrides for converting decode-only disagg to aggregated:
             # - Enable enable_block_reuse (to skip prefill in decode-only)
             # - Remove cache_transceiver_config (not needed in agg mode)
-            if "kv_cache_config" not in override_dict or not isinstance(override_dict["kv_cache_config"], dict):
+            if "kv_cache_config" not in override_dict or not isinstance(
+                override_dict["kv_cache_config"], dict
+            ):
                 override_dict["kv_cache_config"] = {}
             override_dict["kv_cache_config"]["enable_block_reuse"] = True
             override_dict[


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument parsing in benchmark profiler configurations to correctly handle JSON-formatted values and single tokens. Arguments resembling JSON structures or single tokens are now properly preserved during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->