### PR TITLE
chore: Fix cuda lock in trtllm dockerfile

### DIFF
--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -195,7 +195,7 @@ ARG TENSORRTLLM_INDEX_URL
 COPY --from=trtllm_wheel /*.whl /trtllm_wheel/
 COPY --from=trtllm_wheel /*.txt /trtllm_wheel/
 
-# NOTE: locking cuda-python version to <13 to avoid breaks with tensorrt-llm 1.0.0rc6. This
+# NOTE: locking cuda-python version to <13 to avoid breaks with tensorrt-llm 1.0.0rc6.
 RUN uv pip install "cuda-python>=12,<13"
 
 # Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -195,6 +195,9 @@ ARG TENSORRTLLM_INDEX_URL
 COPY --from=trtllm_wheel /*.whl /trtllm_wheel/
 COPY --from=trtllm_wheel /*.txt /trtllm_wheel/
 
+# NOTE: locking cuda-python version to <13 to avoid breaks with tensorrt-llm 1.0.0rc6. This
+RUN uv pip install "cuda-python>=12,<13"
+
 # Note: TensorRT needs to be uninstalled before installing the TRTLLM wheel
 # because there might be mismatched versions of TensorRT between the NGC PyTorch
 # and the TRTLLM wheel.


### PR DESCRIPTION
#### Overview:

Fix cuda lock in trtllm dockerfile, by bringing back initial lock

#### Details:

Add `pip install "cuda-python>=12,<13"`

#### Where should the reviewer start?

[container/Dockerfile.trtllm](https://github.com/ai-dynamo/dynamo/compare/main...ibhosale_cuda_lock?expand=1#diff-3c0008b9a58afd297f4703af7b52f1b7b2b60ad4c36755547d1e6943bc9c73b2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build stability by pinning CUDA Python dependencies to prevent compatibility issues with the TensorRT-LLM runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->