### PR TITLE
refactor: remove redundant COPY in dev stage of framework Dockerfiles

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -280,8 +280,6 @@ RUN apt-get update -y && \
     protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=runtime /usr/local/bin /usr/local/bin
-
 # Set workspace directory variable
 ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
     DYNAMO_HOME=${WORKSPACE_DIR} \
@@ -293,8 +291,6 @@ ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
 
 COPY --from=dynamo_base /usr/local/rustup /usr/local/rustup
 COPY --from=dynamo_base /usr/local/cargo /usr/local/cargo
-
-COPY --from=runtime ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 # Install maturin, for maturin develop
 RUN uv pip install maturin[patchelf]

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -325,8 +325,6 @@ RUN apt-get update -y && \
     protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=runtime /usr/local/bin /usr/local/bin
-
 # Set workspace directory variable
 ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
     DYNAMO_HOME=${WORKSPACE_DIR} \
@@ -338,8 +336,6 @@ ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
 
 COPY --from=dynamo_base /usr/local/rustup /usr/local/rustup
 COPY --from=dynamo_base /usr/local/cargo /usr/local/cargo
-
-COPY --from=runtime ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 # Install maturin, for maturin develop
 RUN uv pip install maturin[patchelf]

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -327,8 +327,6 @@ RUN apt-get update -y && \
     protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=runtime /usr/local/bin /usr/local/bin
-
 # Set workspace directory variable
 ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
     DYNAMO_HOME=${WORKSPACE_DIR} \
@@ -340,10 +338,6 @@ ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
 
 COPY --from=dynamo_base /usr/local/rustup /usr/local/rustup
 COPY --from=dynamo_base /usr/local/cargo /usr/local/cargo
-
-# This is a slow operation (~40s on my cpu)
-# Much better than chown -R $USERNAME:$USERNAME /opt/dynamo/venv (~10min on my cpu)
-COPY --from=runtime ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 # Install maturin, for maturin develop
 # Editable install of dynamo


### PR DESCRIPTION
#### Overview:

Remove redundant COPY statements in the dev stage of framework Dockerfiles that were unnecessarily duplicating files already present from the runtime stage, resulting in significant image size reductions.

#### Details:

- Removed `COPY --from=runtime /usr/local/bin /usr/local/bin` from dev stages
- Removed `COPY --from=runtime ${VIRTUAL_ENV} ${VIRTUAL_ENV}` from dev stages
- These copies were redundant because dev stage inherits directly from runtime (`FROM runtime AS dev`)
- All files from runtime are _already present_ in the dev stage, without the explicit COPY

**Image size improvements:**
- **trtllm**: 50.3GB → 37.8GB (12.5GB reduction, 25%)
- **sglang**: 28GB → 17.5GB (10.5GB reduction, 38%)
- **vllm**: 34.4GB → 23.1GB (11.3GB reduction, 33%)

#### Where should the reviewer start?

Review the removed COPY statements in the dev stages of `container/Dockerfile.{vllm,trtllm,sglang}` to confirm they were indeed redundant.

#### Related Issues:


/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Docker build configurations across multiple container images by removing intermediate artifact copying between build stages, resulting in simplified and more efficient container construction processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->