### PR TITLE
feat: add prefill workers to discovery

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -203,7 +203,7 @@ fn log_message(level: &str, message: &str, module: &str, file: &str, line: u32) 
 /// Create an engine and attach it to an endpoint to make it visible to the frontend.
 /// This is the main way you create a Dynamo worker / backend.
 #[pyfunction]
-#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_mode=None, migration_limit=0, runtime_config=None, user_data=None, custom_template_path=None))]
+#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_mode=None, migration_limit=0, is_prefill=false, runtime_config=None, user_data=None, custom_template_path=None))]
 #[allow(clippy::too_many_arguments)]
 fn register_llm<'p>(
     py: Python<'p>,
@@ -216,10 +216,25 @@ fn register_llm<'p>(
     kv_cache_block_size: Option<u32>,
     router_mode: Option<RouterMode>,
     migration_limit: u32,
+    is_prefill: bool,
     runtime_config: Option<ModelRuntimeConfig>,
     user_data: Option<&Bound<'p, PyDict>>,
     custom_template_path: Option<&str>,
 ) -> PyResult<Bound<'p, PyAny>> {
+    // Validate is_prefill constraints
+    if is_prefill {
+        if !matches!(model_input, ModelInput::Tokens) {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "When is_prefill=True, model_input must be ModelInput::Tokens",
+            ));
+        }
+        if model_type.inner != llm_rs::model_type::ModelType::Prefill {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "When is_prefill=True, model_type must be ModelType::Prefill",
+            ));
+        }
+    }
+
     let model_input = match model_input {
         ModelInput::Text => llm_rs::model_type::ModelInput::Text,
         ModelInput::Tokens => llm_rs::model_type::ModelInput::Tokens,
@@ -372,6 +387,10 @@ impl ModelType {
     #[classattr]
     const TensorBased: Self = ModelType {
         inner: llm_rs::model_type::ModelType::TensorBased,
+    };
+    #[classattr]
+    const Prefill: Self = ModelType {
+        inner: llm_rs::model_type::ModelType::Prefill,
     };
 
     fn __or__(&self, other: &Self) -> Self {

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -220,13 +220,18 @@ fn register_llm<'p>(
     user_data: Option<&Bound<'p, PyDict>>,
     custom_template_path: Option<&str>,
 ) -> PyResult<Bound<'p, PyAny>> {
-    // Validate that Prefill model type requires Tokens input
-    if model_type.inner == llm_rs::model_type::ModelType::Prefill
-        && !matches!(model_input, ModelInput::Tokens)
-    {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "ModelType::Prefill requires model_input to be ModelInput::Tokens",
-        ));
+    // Validate Prefill model type requirements
+    if model_type.inner == llm_rs::model_type::ModelType::Prefill {
+        if !matches!(model_input, ModelInput::Tokens) {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "ModelType::Prefill requires model_input to be ModelInput::Tokens",
+            ));
+        }
+        if migration_limit != 0 {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "ModelType::Prefill requires migration_limit to be 0",
+            ));
+        }
     }
 
     let model_input = match model_input {

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -908,7 +908,6 @@ async def register_llm(
     kv_cache_block_size: Optional[int] = None,
     migration_limit: int = 0,
     router_mode: Optional[RouterMode] = None,
-    is_prefill: bool = False,
     user_data: Optional[Dict[str, Any]] = None,
     custom_template_path: Optional[str] = None,
 ) -> None:

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -878,7 +878,12 @@ class ModelInput:
     ...
 
 class ModelType:
-    """What type of request this model needs: Chat, Completions, Embedding or Tensor"""
+    """What type of request this model needs: Chat, Completions, Embedding, Tensor or Prefill"""
+    Chat: ModelType
+    Completions: ModelType
+    Embedding: ModelType
+    TensorBased: ModelType
+    Prefill: ModelType
     ...
 
 class RouterMode:
@@ -903,6 +908,7 @@ async def register_llm(
     kv_cache_block_size: Optional[int] = None,
     migration_limit: int = 0,
     router_mode: Optional[RouterMode] = None,
+    is_prefill: bool = False,
     user_data: Optional[Dict[str, Any]] = None,
     custom_template_path: Optional[str] = None,
 ) -> None:

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -906,8 +906,9 @@ async def register_llm(
     model_name: Optional[str] = None,
     context_length: Optional[int] = None,
     kv_cache_block_size: Optional[int] = None,
-    migration_limit: int = 0,
     router_mode: Optional[RouterMode] = None,
+    migration_limit: int = 0,
+    runtime_config: Optional[ModelRuntimeConfig] = None,
     user_data: Optional[Dict[str, Any]] = None,
     custom_template_path: Optional[str] = None,
 ) -> None:

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -41,6 +41,7 @@ pub struct ModelManager {
     chat_completion_engines: RwLock<ModelEngines<OpenAIChatCompletionsStreamingEngine>>,
     embeddings_engines: RwLock<ModelEngines<OpenAIEmbeddingsStreamingEngine>>,
     tensor_engines: RwLock<ModelEngines<TensorStreamingEngine>>,
+    prefill_engines: RwLock<ModelEngines<TensorStreamingEngine>>,
 
     // These are Mutex because we read and write rarely and equally
     cards: Mutex<HashMap<String, ModelDeploymentCard>>,
@@ -60,6 +61,7 @@ impl ModelManager {
             chat_completion_engines: RwLock::new(ModelEngines::default()),
             embeddings_engines: RwLock::new(ModelEngines::default()),
             tensor_engines: RwLock::new(ModelEngines::default()),
+            prefill_engines: RwLock::new(ModelEngines::default()),
             cards: Mutex::new(HashMap::new()),
             kv_choosers: Mutex::new(HashMap::new()),
         }
@@ -78,6 +80,7 @@ impl ModelManager {
                 ModelType::Completions => self.completion_engines.read().checksum(model_name),
                 ModelType::Embedding => self.embeddings_engines.read().checksum(model_name),
                 ModelType::TensorBased => self.tensor_engines.read().checksum(model_name),
+                ModelType::Prefill => self.prefill_engines.read().checksum(model_name),
                 _ => {
                     continue;
                 }
@@ -117,6 +120,7 @@ impl ModelManager {
             .chain(self.list_completions_models())
             .chain(self.list_embeddings_models())
             .chain(self.list_tensor_models())
+            .chain(self.list_prefill_models())
             .collect()
     }
 
@@ -134,6 +138,10 @@ impl ModelManager {
 
     pub fn list_tensor_models(&self) -> Vec<String> {
         self.tensor_engines.read().list()
+    }
+
+    pub fn list_prefill_models(&self) -> Vec<String> {
+        self.prefill_engines.read().list()
     }
 
     pub fn add_completions_model(
@@ -176,6 +184,16 @@ impl ModelManager {
         clients.add(model, card_checksum, engine)
     }
 
+    pub fn add_prefill_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: TensorStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let mut clients = self.prefill_engines.write();
+        clients.add(model, card_checksum, engine)
+    }
+
     pub fn remove_completions_model(&self, model: &str) -> Result<(), ModelManagerError> {
         let mut clients = self.completion_engines.write();
         clients.remove(model)
@@ -193,6 +211,11 @@ impl ModelManager {
 
     pub fn remove_tensor_model(&self, model: &str) -> Result<(), ModelManagerError> {
         let mut clients = self.tensor_engines.write();
+        clients.remove(model)
+    }
+
+    pub fn remove_prefill_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let mut clients = self.prefill_engines.write();
         clients.remove(model)
     }
 
@@ -234,6 +257,17 @@ impl ModelManager {
         model: &str,
     ) -> Result<TensorStreamingEngine, ModelManagerError> {
         self.tensor_engines
+            .read()
+            .get(model)
+            .cloned()
+            .ok_or(ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn get_prefill_engine(
+        &self,
+        model: &str,
+    ) -> Result<TensorStreamingEngine, ModelManagerError> {
+        self.prefill_engines
             .read()
             .get(model)
             .cloned()

--- a/lib/llm/src/model_type.rs
+++ b/lib/llm/src/model_type.rs
@@ -36,6 +36,7 @@ bitflags! {
         const Completions = 1 << 1;
         const Embedding = 1 << 2;
         const TensorBased = 1 << 3;
+        const Prefill = 1 << 4;
     }
 }
 
@@ -56,6 +57,9 @@ impl ModelType {
     pub fn supports_tensor(&self) -> bool {
         self.contains(ModelType::TensorBased)
     }
+    pub fn supports_prefill(&self) -> bool {
+        self.contains(ModelType::Prefill)
+    }
 
     pub fn as_vec(&self) -> Vec<&'static str> {
         let mut result = Vec::new();
@@ -70,6 +74,9 @@ impl ModelType {
         }
         if self.supports_tensor() {
             result.push("tensor");
+        }
+        if self.supports_prefill() {
+            result.push("prefill");
         }
         result
     }
@@ -89,6 +96,9 @@ impl ModelType {
         }
         if self.supports_tensor() {
             result.push(ModelType::TensorBased);
+        }
+        if self.supports_prefill() {
+            result.push(ModelType::Prefill);
         }
         result
     }


### PR DESCRIPTION
#### Overview:

This change allows prefill workers to be registered via `register_llm(..., is_preifll=True)`, which would allow it to be discovered as the `Prefill` model type. 

However, currently, this does not do the following to keep the change atomic
1. No prefill router + pipeline creation. (This would likely require a prefill router operator linked to the pipeline)
2. Naturally, it would not make network calls to the prefill workers.
These require more discussion before scoping for future PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for Prefill model type as a new model category alongside Chat, Completions, Embedding, and TensorBased
* Extended `register_llm` with optional `is_prefill` parameter to enable prefill model registration
* Added prefill model management capabilities including listing, adding, removing, and retrieving prefill models
* Implemented validation ensuring prefill models use token-based input

<!-- end of auto-generated comment: release notes by coderabbit.ai -->