### PR TITLE
fix: limit the number of build jobs on sglang-wideep

### DIFF
--- a/container/Dockerfile.sglang-wideep
+++ b/container/Dockerfile.sglang-wideep
@@ -3,6 +3,7 @@
 
 ARG SGLANG_IMAGE_TAG="v0.5.3.post2"
 ARG BRANCH_TYPE
+ARG CARGO_BUILD_JOBS
 
 FROM scratch AS local_src
 COPY . /src
@@ -16,12 +17,16 @@ WORKDIR /sgl-workspace
 # Providing --build-arg BRANCH_TYPE=remote will editable install the remote dynamo repo
 # Default is to install the latest published dynamo version
 ARG BRANCH_TYPE
+ARG CARGO_BUILD_JOBS
+
 COPY --from=local_src /src /tmp/local_src
 RUN if [ "$BRANCH_TYPE" = "local" ]; then \
         cp -r /tmp/local_src /sgl-workspace/dynamo; \
     elif [ "$BRANCH_TYPE" = "remote" ]; then \
         git clone https://github.com/ai-dynamo/dynamo.git /sgl-workspace/dynamo; \
     fi
+
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-16}
 
 # SGLang does not use a venv in their container
 RUN if [ "$BRANCH_TYPE" = "local" ]; then \


### PR DESCRIPTION
#### Overview:

The SGLang-wideep container occasionally runs into the `to many files open` error. By introducing the `CARGO_BUILD_JOBS` environment variable if the user runs into this issue they can decrease the number of concurrent jobs so the build succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made build parallelism configurable with a customizable job count parameter (default: 16 jobs).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->