### PR TITLE
chore: Replace ServiceConfigBuilder with add_stats_service

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -664,10 +664,11 @@ impl Component {
         })
     }
 
+    /// NATS specific stats/metrics call
     fn create_service<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
-        let builder = self.inner.service_builder();
+        let mut inner = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let _ = builder.create().await.map_err(to_pyerr)?;
+            inner.add_stats_service().await.map_err(to_pyerr)?;
             Ok(())
         })
     }

--- a/lib/llm/src/block_manager/controller.rs
+++ b/lib/llm/src/block_manager/controller.rs
@@ -41,14 +41,15 @@ impl<Locality: LocalityProvider, Metadata: BlockMetadata> Controller<Locality, M
         block_manager: KvBlockManager<Locality, Metadata>,
         component: dynamo_runtime::component::Component,
     ) -> anyhow::Result<Self> {
-        let service = component.service_builder().create().await?;
+        component.add_stats_handler().await?;
 
         let handler = ControllerHandler::new(block_manager.clone());
         let engine = Ingress::for_engine(handler.clone())?;
 
+        let component_clone = component.clone();
         let reset_task = CriticalTaskExecutionHandle::new(
             |_cancel_token| async move {
-                service
+                component_clone
                     .endpoint("controller")
                     .endpoint_builder()
                     .handler(engine)

--- a/lib/llm/src/block_manager/controller.rs
+++ b/lib/llm/src/block_manager/controller.rs
@@ -41,7 +41,7 @@ impl<Locality: LocalityProvider, Metadata: BlockMetadata> Controller<Locality, M
         block_manager: KvBlockManager<Locality, Metadata>,
         component: dynamo_runtime::component::Component,
     ) -> anyhow::Result<Self> {
-        component.add_stats_handler().await?;
+        component.add_stats_service().await?;
 
         let handler = ControllerHandler::new(block_manager.clone());
         let engine = Ingress::for_engine(handler.clone())?;

--- a/lib/llm/src/block_manager/controller.rs
+++ b/lib/llm/src/block_manager/controller.rs
@@ -39,7 +39,7 @@ pub struct Controller<Locality: LocalityProvider, Metadata: BlockMetadata> {
 impl<Locality: LocalityProvider, Metadata: BlockMetadata> Controller<Locality, Metadata> {
     pub async fn new(
         block_manager: KvBlockManager<Locality, Metadata>,
-        component: dynamo_runtime::component::Component,
+        mut component: dynamo_runtime::component::Component,
     ) -> anyhow::Result<Self> {
         component.add_stats_service().await?;
 

--- a/lib/llm/src/entrypoint/input/endpoint.rs
+++ b/lib/llm/src/entrypoint/input/endpoint.rs
@@ -38,8 +38,7 @@ pub async fn run(
 
     // We can only make the NATS service if we have NATS
     if distributed_runtime.nats_client().is_some() {
-        // TODO fix in next PR, ServiceConfigBuilder is silly
-        component = component.service_builder().create().await?;
+        component.add_stats_service().await?;
     }
     let endpoint = component.endpoint(&endpoint_id.name);
 

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -939,11 +939,8 @@ mod tests {
 
         // Create namespace and shared component for both seq_managers
         let namespace = distributed.namespace("test_cross_instance_sync")?;
-        let component = namespace
-            .component("sequences")?
-            .service_builder()
-            .create()
-            .await?;
+        let mut component = namespace.component("sequences")?;
+        component.add_stats_service().await?;
 
         // Create multi-worker sequence managers with:
         // - Worker 0 with dp_size=2 (dp_ranks 0 and 1)
@@ -1108,11 +1105,8 @@ mod tests {
 
         // Create namespace and shared component for both seq_managers
         let namespace = distributed.namespace("test_no_token_seq_sync")?;
-        let component = namespace
-            .component("sequences")?
-            .service_builder()
-            .create()
-            .await?;
+        let mut component = namespace.component("sequences")?;
+        component.add_stats_service().await?;
 
         // Create multi-worker sequence managers with ALL workers [0, 1, 2]
         // Both use the same component to ensure event synchronization works

--- a/lib/llm/src/mocker/engine.rs
+++ b/lib/llm/src/mocker/engine.rs
@@ -539,12 +539,8 @@ mod integration_tests {
         tracing::info!("✓ Runtime and distributed runtime created");
 
         // Create component for MockVllmEngine (needed for publishers)
-        let test_component = distributed
-            .namespace("test")?
-            .component(MOCKER_COMPONENT)?
-            .service_builder()
-            .create()
-            .await?;
+        let mut test_component = distributed.namespace("test")?.component(MOCKER_COMPONENT)?;
+        test_component.add_stats_service().await?;
         tracing::info!("✓ Test component created");
 
         // Create MockVllmEngine WITH component (enables publishers)

--- a/lib/runtime/examples/hello_world/src/bin/server.rs
+++ b/lib/runtime/examples/hello_world/src/bin/server.rs
@@ -54,12 +54,9 @@ async fn backend(runtime: DistributedRuntime) -> Result<()> {
 
     // // make the ingress discoverable via a component service
     // // we must first create a service, then we can attach one more more endpoints
-    runtime
-        .namespace(DEFAULT_NAMESPACE)?
-        .component("backend")?
-        .service_builder()
-        .create()
-        .await?
+    let mut component = runtime.namespace(DEFAULT_NAMESPACE)?.component("backend")?;
+    component.add_stats_service().await?;
+    component
         .endpoint("generate")
         .endpoint_builder()
         .handler(ingress)

--- a/lib/runtime/examples/service_metrics/src/bin/service_server.rs
+++ b/lib/runtime/examples/service_metrics/src/bin/service_server.rs
@@ -56,12 +56,9 @@ async fn backend(runtime: DistributedRuntime) -> Result<()> {
     // make the ingress discoverable via a component service
     // we must first create a service, then we can attach one more more endpoints
 
-    runtime
-        .namespace(DEFAULT_NAMESPACE)?
-        .component("backend")?
-        .service_builder()
-        .create()
-        .await?
+    let mut component = runtime.namespace(DEFAULT_NAMESPACE)?.component("backend")?;
+    component.add_stats_service().await?;
+    component
         .endpoint("generate")
         .endpoint_builder()
         .stats_handler(|stats| {

--- a/lib/runtime/examples/system_metrics/src/lib.rs
+++ b/lib/runtime/examples/system_metrics/src/lib.rs
@@ -88,13 +88,11 @@ impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, Error> for Reques
 pub async fn backend(drt: DistributedRuntime, endpoint_name: Option<&str>) -> Result<()> {
     let endpoint_name = endpoint_name.unwrap_or(DEFAULT_ENDPOINT);
 
-    let endpoint = drt
+    let mut component = drt
         .namespace(DEFAULT_NAMESPACE)?
-        .component(DEFAULT_COMPONENT)?
-        .service_builder()
-        .create()
-        .await?
-        .endpoint(endpoint_name);
+        .component(DEFAULT_COMPONENT)?;
+    component.add_stats_service().await?;
+    let endpoint = component.endpoint(endpoint_name);
 
     // Create custom metrics for system stats
     let system_metrics =

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -615,7 +615,7 @@ mod integration_tests {
 
                 // Now create a namespace, component, and endpoint to make the system healthy
                 let namespace = drt.namespace("ns1234").unwrap();
-                let component = namespace.component("comp1234").unwrap();
+                let mut component = namespace.component("comp1234").unwrap();
 
                 // Create a simple test handler
                 use crate::pipeline::{async_trait, network::Ingress, AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, SingleIn};
@@ -641,12 +641,8 @@ mod integration_tests {
                 // Start the service and endpoint with a health check payload
                 // This will automatically register the endpoint for health monitoring
                 tokio::spawn(async move {
-                    let _ = component
-                        .service_builder()
-                        .create()
-                        .await
-                        .unwrap()
-                        .endpoint(ENDPOINT_NAME)
+                    component.add_stats_service().await.unwrap();
+                    let _ = component.endpoint(ENDPOINT_NAME)
                         .endpoint_builder()
                         .handler(ingress)
                         .health_check_payload(serde_json::json!({

--- a/lib/runtime/tests/soak.rs
+++ b/lib/runtime/tests/soak.rs
@@ -116,12 +116,9 @@ mod integration {
 
         // // make the ingress discoverable via a component service
         // // we must first create a service, then we can attach one more more endpoints
-        runtime
-            .namespace(DEFAULT_NAMESPACE)?
-            .component("backend")?
-            .service_builder()
-            .create()
-            .await?
+        let mut component = runtime.namespace(DEFAULT_NAMESPACE)?.component("backend")?;
+        component.add_stats_service().await?;
+        component
             .endpoint("generate")
             .endpoint_builder()
             .handler(ingress)


### PR DESCRIPTION
It was unnecessarily complicated, likely left over from a prior cleanup.

Now instead of giving the Component to the Builder and getting it back out again, we call `.add_stats_service()` on the `Component` directly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal statistics service registration within the runtime component system to streamline the initialization process, improve error handling for concurrent service creation, and enhance overall component lifecycle management consistency.

* **Tests**
  * Updated comprehensive test suites across multiple runtime components to align with the new asynchronous service initialization patterns and refined component configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->