### PR TITLE
ci: Add --prerelease=allow flag to sglang installation

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -103,7 +103,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     cd sglang && \
     git checkout v${SGLANG_VERSION} && \
     # Install in editable mode for development
-    uv pip install -e "python[all]"
+    uv pip install --prerelease=allow -e "python[all]"
 
 # Set env var that allows for forceful shutdown of inflight requests in SGL's TokenizerManager
 ENV SGL_FORCE_SHUTDOWN=1


### PR DESCRIPTION
#### Overview:

Recent PR's have been blocked due to an installation issue when installing editable sglang:
````
[framework 6/6] RUN --mount=type=cache,target=/root/.cache/uv     cd /opt &&     git clone https://github.com/sgl-project/sglang.git &&     cd sglang &&     git checkout v0.5.3.post2 &&     uv pip install -e "python[all]":
5.212       flashinfer-python==0.4.0 depends on apache-tvm-ffi==0.1.0b15, we can
5.212       conclude that flashinfer-python==0.4.0 cannot be used.
5.212       And because sglang==0.5.3.post2 depends on flashinfer-python==0.4.0, we
5.212       can conclude that sglang==0.5.3.post2 cannot be used.
5.212       And because only sglang[all]==0.5.3.post2 is available and you require
5.212       sglang[all], we can conclude that your requirements are unsatisfiable.
5.212 
5.212       hint: `apache-tvm-ffi` was requested with a pre-release marker (e.g.,
5.212       apache-tvm-ffi==0.1.0b15), but pre-releases weren't enabled (try:
5.212       `--prerelease=allow`)
------
Dockerfile.sglang:100
--------------------
  99 |     ARG SGLANG_VERSION
 100 | >>> RUN --mount=type=cache,target=/root/.cache/uv \
 101 | >>>     cd /opt && \
 102 | >>>     git clone https://github.com/sgl-project/sglang.git && \
 103 | >>>     cd sglang && \
 104 | >>>     git checkout v${SGLANG_VERSION} && \
 105 | >>>     # Install in editable mode for development
 106 | >>>     uv pip install -e "python[all]"
 107 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c cd /opt &&     git clone https://github.com/sgl-project/sglang.git &&     cd sglang &&     git checkout v${SGLANG_VERSION} &&     uv pip install -e \"python[all]\"" did not complete successfully: exit code: 1
````
This PR applies the suggestion to pass a  `--prerelease=allow` flag as a pip flag for the sglang installation. https://pypi.org/project/apache-tvm-ffi/#history

#### Details:

- Add --prerelease=allow to sglang editable installation. 

#### Where should the reviewer start?

- container/Dockerfile.sglang

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to support pre-release package versions during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->