### PR TITLE
fix: start separate runtime for span exporter

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -118,6 +118,9 @@ fn create_request_context(
 /// import the module.
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Initialize logging early - it will create its own runtime if needed
+    rs::logging::init();
+
     m.add_function(wrap_pyfunction!(llm::kv::compute_block_hash_for_seq_py, m)?)?;
     m.add_function(wrap_pyfunction!(log_message, m)?)?;
     m.add_function(wrap_pyfunction!(register_llm, m)?)?;
@@ -422,12 +425,6 @@ impl DistributedRuntime {
         .map_err(to_pyerr)?;
 
         let runtime = worker.runtime().clone();
-
-        // Initialize logging in context where tokio runtime is available
-        // otel exporter requires it
-        runtime.secondary().block_on(async {
-            rs::logging::init();
-        });
 
         let inner =
             if is_static {


### PR DESCRIPTION
As part of the introduction of OTEL, I relocated the logging::init() to happen after the tokio runtime is available ([Location](https://github.com/ai-dynamo/dynamo/commit/1f92dd547e77a66cfe0970844a2afd22e7a154d7#diff-f93642a9a7225c72dea97d02336c04bae46a94b55b59f3ea089c01e97f22c579L130)). The reason for this is that the export of spans happens async in the event loop. This however caused a regression where logs emitted initially are dropped since the logging stack is initialized further down.

This change reversts the init of the logging stack and creates a dedicated thread to manage the exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Logging is now initialized eagerly when the module is imported rather than during runtime construction.
  * Logging setup now ensures it runs within an appropriate runtime context when OTLP/exporting is enabled, improving compatibility in distributed scenarios.
  * No public APIs or exported signatures were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->