### PR TITLE
docs: Add cancellation docs for vLLM, TRT-LLM and SGLang backends

### DIFF
--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -75,13 +75,13 @@ When a user cancels a request (e.g., by disconnecting from the frontend), the re
 
 #### Cancellation Support Matrix
 
-| | Local Prefill | Remote Prefill | Decode |
-|-|--------------|----------------|--------|
-| **Aggregated** | ✅ | - | ✅ |
-| **Disaggregated** | - | ⚠️ | ✅ |
+| | Prefill | Decode |
+|-|---------|--------|
+| **Aggregated** | ✅ | ✅ |
+| **Disaggregated** | ⚠️ | ✅ |
 
 > [!WARNING]
-> ⚠️ SGLang currently does not support cancellation during the remote prefill phase.
+> ⚠️ SGLang backend currently does not support cancellation during remote prefill phase in disaggregated mode.
 
 For more details, see the [Request Cancellation Architecture](../../architecture/request_cancellation.md) documentation.
 

--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -69,6 +69,22 @@ Dynamo SGLang uses SGLang's native argument parser, so **most SGLang engine argu
 > [!NOTE]
 > When using `--use-sglang-tokenizer`, only `v1/chat/completions` is available through Dynamo's frontend.
 
+### Request Cancellation
+
+When a user cancels a request (e.g., by disconnecting from the frontend), the request is automatically cancelled across all workers, freeing compute resources for other requests.
+
+#### Cancellation Support Matrix
+
+| | Local Prefill | Remote Prefill | Decode |
+|-|--------------|----------------|--------|
+| **Aggregated** | ✅ | - | ✅ |
+| **Disaggregated** | - | ⚠️ | ✅ |
+
+> [!WARNING]
+> ⚠️ SGLang currently does not support cancellation during the remote prefill phase.
+
+For more details, see the [Request Cancellation Architecture](../../architecture/request_cancellation.md) documentation.
+
 ## Installation
 
 ### Install latest release

--- a/docs/backends/trtllm/README.md
+++ b/docs/backends/trtllm/README.md
@@ -228,6 +228,20 @@ python3 -m dynamo.trtllm ... --migration-limit=3
 
 This allows a request to be migrated up to 3 times before failing. See the [Request Migration Architecture](../../../docs/architecture/request_migration.md) documentation for details on how this works.
 
+## Request Cancellation
+
+When a user cancels a request (e.g., by disconnecting from the frontend), the request is automatically cancelled across all workers, freeing compute resources for other requests.
+
+### Cancellation Support Matrix
+
+| | Local Prefill | Remote Prefill | Local Decode | Remote Decode |
+|-|--------------|----------------|--------------|---------------|
+| **Aggregated** | ✅ | - | ✅ | - |
+| **Disaggregated (Decode-First)** | - | ✅ | ✅ | - |
+| **Disaggregated (Prefill-First)** | ✅ | - | - | ✅ |
+
+For more details, see the [Request Cancellation Architecture](../../../docs/architecture/request_cancellation.md) documentation.
+
 ## Client
 
 See [client](../../../docs/backends/sglang/README.md#testing-the-deployment) section to learn how to send request to the deployment.

--- a/docs/backends/trtllm/README.md
+++ b/docs/backends/trtllm/README.md
@@ -234,11 +234,11 @@ When a user cancels a request (e.g., by disconnecting from the frontend), the re
 
 ### Cancellation Support Matrix
 
-| | Local Prefill | Remote Prefill | Local Decode | Remote Decode |
-|-|--------------|----------------|--------------|---------------|
-| **Aggregated** | ✅ | - | ✅ | - |
-| **Disaggregated (Decode-First)** | - | ✅ | ✅ | - |
-| **Disaggregated (Prefill-First)** | ✅ | - | - | ✅ |
+| | Prefill | Decode |
+|-|---------|--------|
+| **Aggregated** | ✅ | ✅ |
+| **Disaggregated (Decode-First)** | ✅ | ✅ |
+| **Disaggregated (Prefill-First)** | ✅ | ✅ |
 
 For more details, see the [Request Cancellation Architecture](../../../docs/architecture/request_cancellation.md) documentation.
 

--- a/docs/backends/vllm/README.md
+++ b/docs/backends/vllm/README.md
@@ -189,3 +189,16 @@ python3 -m dynamo.vllm ... --migration-limit=3
 ```
 
 This allows a request to be migrated up to 3 times before failing. See the [Request Migration Architecture](../../../docs/architecture/request_migration.md) documentation for details on how this works.
+
+## Request Cancellation
+
+When a user cancels a request (e.g., by disconnecting from the frontend), the request is automatically cancelled across all workers, freeing compute resources for other requests.
+
+### Cancellation Support Matrix
+
+| | Local Prefill | Remote Prefill | Decode |
+|-|--------------|----------------|--------|
+| **Aggregated** | ✅ | - | ✅ |
+| **Disaggregated** | - | ✅ | ✅ |
+
+For more details, see the [Request Cancellation Architecture](../../../docs/architecture/request_cancellation.md) documentation.

--- a/docs/backends/vllm/README.md
+++ b/docs/backends/vllm/README.md
@@ -196,9 +196,9 @@ When a user cancels a request (e.g., by disconnecting from the frontend), the re
 
 ### Cancellation Support Matrix
 
-| | Local Prefill | Remote Prefill | Decode |
-|-|--------------|----------------|--------|
-| **Aggregated** | ✅ | - | ✅ |
-| **Disaggregated** | - | ✅ | ✅ |
+| | Prefill | Decode |
+|-|---------|--------|
+| **Aggregated** | ✅ | ✅ |
+| **Disaggregated** | ✅ | ✅ |
 
 For more details, see the [Request Cancellation Architecture](../../../docs/architecture/request_cancellation.md) documentation.


### PR DESCRIPTION
#### Overview:

Add cancellation docs for vLLM, TRT-LLM and SGLang backends.

#### Details:

* Cancellation is supported for all 3 backends.
* Matrix on the mode and phase where cancellation is supported.

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Request Cancellation documentation sections to SGLang, TRTLLM, and vLLM backend README files.
  * Includes Cancellation Support Matrices showing availability across prefill and decode execution phases for Aggregated and Disaggregated deployment modes.
  * Added links to Request Cancellation Architecture documentation for additional details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->