### PR TITLE
fix: update crate lib/runtime README to one that exists

### DIFF
--- a/lib/runtime/README.md
+++ b/lib/runtime/README.md
@@ -1,1 +1,1 @@
-../../docs/runtime/README.md
+../../docs/development/runtime-guide.md


### PR DESCRIPTION
#### Overview:

The crates are not publishable because the runtime crate readme does not exist, this directs it to the correct location


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation references to point to the latest resource location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->