### PR TITLE
build: Add prometheus_client dependency for pip install without container

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "typer",
     "click<8.2.0",
     "setuptools",
+    "prometheus_client>=0.23.1,<1.0",
 ]
 
 classifiers = [


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

- https://github.com/ai-dynamo/dynamo/pull/3539 added a dependency on `prometheus_client` to `dynamo.common` which is automatically imported when trying to run `python -m dynamo.frontend`
- The dependency was only added to the container dependencies here: https://github.com/ai-dynamo/dynamo/blob/237e978f1a3ff5c610e972063f0284603e5699d4/container/deps/requirements.txt#L27
- So `pip install` for local development outside of container was now missing this dependency.
- This PR adds the dependency to the package pyproject.toml so it can't be missed

#### Details:

<!-- Describe the changes made in this PR. -->

Error before this change when following local development pip install steps: https://github.com/ai-dynamo/dynamo?tab=readme-ov-file#developing-locally

<img width="836" height="554" alt="image" src="https://github.com/user-attachments/assets/971e6878-5769-443a-a554-e9f68178b788" />


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added monitoring dependency to project requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->