### PR TITLE
fix: two node disaggreated serving

### DIFF
--- a/deploy/cloud/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/cloud/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -244,7 +244,7 @@ func (s *DynamoComponentDeployment) SetDynamoDeploymentConfig(config []byte) {
 }
 
 func (s *DynamoComponentDeployment) IsMultinode() bool {
-	return s.GetNumberOfNodes() > 1
+	return s.Spec.Multinode != nil
 }
 
 func (s *DynamoComponentDeployment) GetNumberOfNodes() int32 {

--- a/deploy/cloud/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/cloud/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -109,8 +109,9 @@ type MultinodeSpec struct {
 	// +kubebuilder:default=2
 	// Indicates the number of nodes to deploy for multinode components.
 	// Total number of GPUs is NumberOfNodes * GPU limit.
-	// Must be greater than 1.
-	// +kubebuilder:validation:Minimum=2
+	// Must be at least 1. For disaggregated serving, each service (e.g., prefill, decode)
+	// can have nodeCount=1 while still requiring multinode/distributed initialization.
+	// +kubebuilder:validation:Minimum=1
 	NodeCount int32 `json:"nodeCount"`
 }
 

--- a/deploy/cloud/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/cloud/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -10144,9 +10144,10 @@ spec:
                             description: |-
                               Indicates the number of nodes to deploy for multinode components.
                               Total number of GPUs is NumberOfNodes * GPU limit.
-                              Must be greater than 1.
+                              Must be at least 1. For disaggregated serving, each service (e.g., prefill, decode)
+                              can have nodeCount=1 while still requiring multinode/distributed initialization.
                             format: int32
-                            minimum: 2
+                            minimum: 1
                             type: integer
                         required:
                           - nodeCount

--- a/deploy/cloud/operator/internal/dynamo/backend_sglang.go
+++ b/deploy/cloud/operator/internal/dynamo/backend_sglang.go
@@ -41,8 +41,10 @@ func (b *SGLangBackend) UpdateContainer(container *corev1.Container, numberOfNod
 		}
 	}
 
-	// For single node, nothing to do
-	if numberOfNodes <= 1 {
+	// Check if multinode is explicitly configured
+	// For disaggregated serving, multinode section can be present with nodeCount=1
+	// and still needs distributed initialization flags
+	if component.Multinode == nil {
 		return
 	}
 

--- a/deploy/cloud/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/cloud/operator/internal/dynamo/backend_vllm.go
@@ -22,7 +22,10 @@ const (
 type VLLMBackend struct{}
 
 func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1alpha1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
-	isMultinode := numberOfNodes > 1
+	// Check if multinode is explicitly configured
+	// For disaggregated serving, multinode section can be present with nodeCount=1
+	// and still needs distributed initialization flags
+	isMultinode := component.Multinode != nil
 
 	if isMultinode {
 		// Apply multinode-specific argument modifications


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multinode deployments now support single-node configurations for disaggregated serving scenarios, enabling individual services (e.g., prefill, decode) to operate independently on a single node.

* **Refactor**
  * Updated validation rules to allow single-node multinode deployments. Backend logic now uses explicit multinode configuration instead of inferring from node count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->