### PR TITLE
test: add backend-specific metrics validation for E2E tests (part 1/3, vLLM only)

### DIFF
--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -42,7 +42,11 @@ sglang_configs = {
         model="deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
         env={},
         models_port=8000,
-        request_payloads=[chat_payload_default(), completion_payload_default()],
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+            # TODO: Add metric_payload_default(min_num_requests=N, backend="sglang")
+        ],
     ),
     "disaggregated": SGLangConfig(
         name="disaggregated",

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -35,6 +35,7 @@ trtllm_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+            # TODO: Add metric_payload_default(min_num_requests=N, backend="trtllm")
         ],
     ),
     "disaggregated": TRTLLMConfig(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -39,7 +39,7 @@ vllm_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
-            metric_payload_default(min_num_requests=6),
+            metric_payload_default(min_num_requests=6, backend="vllm"),
         ],
     ),
     "agg-router": VLLMConfig(

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -66,6 +66,7 @@ def metric_payload_default(
     min_num_requests: int,
     repeat_count: int = 1,
     expected_log: Optional[List[str]] = None,
+    backend: Optional[str] = None,
 ) -> MetricsPayload:
     return MetricsPayload(
         body={},
@@ -73,6 +74,7 @@ def metric_payload_default(
         expected_log=expected_log or [],
         expected_response=[],
         min_num_requests=min_num_requests,
+        backend=backend,
     )
 
 


### PR DESCRIPTION
#### Overview:

Add metrics validation to E2E tests for Dynamo framework and backend-specific metrics (vLLM)

#### Details:

- Add backend parameter to MetricsPayload for conditional validation
- Implement MetricCheck dataclass for structured metric definitions
- Validate Dynamo framework metrics (dynamo_component_*)
- Validate vLLM-specific metrics (vllm:*) when backend="vllm"
- Filter _bucket metrics to avoid histogram inflation
- Support metrics with/without labels in regex pattern
- Add TODOs for SGLang and TensorRT-LLM, in the next part.

#### Where should the reviewer start?

- tests/utils/payloads.py - MetricsPayload.validate() method
- tests/serve/test_vllm.py - Example usage with backend="vllm"

#### Related Issues:

DIS-807

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced metrics validation infrastructure with structured multi-check system for test configurations.
  * Added backend-specific metric validation to support vLLM and other inference engine backends.
  * Improved test setup to provide more comprehensive and configurable metric assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->