### PR TITLE
fix: gb200 nixl instructions and max cuda graph bs on h100 instructions

### DIFF
--- a/docs/backends/sglang/dsr1-wideep-gb200.md
+++ b/docs/backends/sglang/dsr1-wideep-gb200.md
@@ -98,7 +98,8 @@ python3 -m dynamo.sglang \
   --chunked-prefill-size 16384 \
   --max-total-tokens 32768 \
   --mem-fraction-static 0.82 \
-  --log-level debug
+  --log-level debug \
+  --disaggregation-transfer-backend nixl
 ```
 
 On the other prefill nodes (this example has 2 total prefill nodes), run the same command but change `--node-rank` to 1
@@ -151,7 +152,8 @@ python3 -m dynamo.sglang \
   --watchdog-timeout 1000000 \
   --chunked-prefill-size 36864 \
   --mem-fraction-static 0.82 \
-  --log-level debug
+  --log-level debug \
+  --disaggregation-transfer-backend nixl
 ```
 
 On the other decode nodes (this example has 2 total decode nodes), run the same command but change `--node-rank` to 1.

--- a/docs/backends/sglang/multinode-examples.md
+++ b/docs/backends/sglang/multinode-examples.md
@@ -83,7 +83,8 @@ python3 -m dynamo.sglang \
   --disaggregation-bootstrap-port 30001 \
   --host 0.0.0.0 \
   --prefill-round-robin-balance \
-  --mem-fraction-static 0.82
+  --mem-fraction-static 0.82 \
+  --cuda-graph-max-bs 8
 ```
 
 Node 4: Run the remaining 8 shards of the decode worker
@@ -104,7 +105,8 @@ python3 -m dynamo.sglang \
   --disaggregation-bootstrap-port 30001 \
   --host 0.0.0.0 \
   --prefill-round-robin-balance \
-  --mem-fraction-static 0.82
+  --mem-fraction-static 0.82 \
+  --cuda-graph-max-bs 8
 ```
 
 **Step 2**: Run inference


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SGLang backend configuration documentation with new command-line flags for disaggregation transfer backend and CUDA graph batch size parameters in multi-node deployment examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->