### PR TITLE
feat: KV layout conversions in G1<->G3 offloading and onboarding

### DIFF
--- a/lib/llm/src/block_manager/distributed/worker.rs
+++ b/lib/llm/src/block_manager/distributed/worker.rs
@@ -215,6 +215,10 @@ async fn perform_allocation_and_build_handler(
             max_transfer_batch_size: MAX_TRANSFER_BATCH_SIZE,
             num_outer_components: device_layout.config().outer_dim,
             num_layers: device_layout.config().num_layers,
+            enable_temp_device_buffer_pool: true,
+            page_size: device_layout.config().page_size,
+            inner_dim: device_layout.config().inner_dim,
+            dtype_width_bytes: device_layout.config().dtype_width_bytes,
         };
         let transfer_context = Arc::new(TransferContext::new(
             Arc::new(Some(agent)),


### PR DESCRIPTION
Add support for temporary device buffers to handle layout conversion during
G1<->G3 direct transfers when source and target have different contiguity:

This optimization avoids small NIXL transfers and improves performance for G1<->G3 direct transfers by batching layout conversions through GPU memory.

 - Detect layout mismatches between non-contiguous GPU blocks and contiguous disk blocks
 - Create temporary GPU buffer pool for layout conversion when bypassing CPU cache
 - Use consolidation kernel for GPU->disk transfers (non-contig to contig)
 - Use scattering kernel for disk->GPU transfers (contig to non-contig)
 - Fall back to direct transfers when temp buffers unavailable or layouts match
  - Add temp device buffer pool configuration to PoolConfig
  - Refactor CUDA kernel functions to support address pair operations, as we cannot hold the references in the async function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized GPU memory transfer paths with layout-aware data consolidation for improved throughput and reduced latency.
  * Enhanced temporary device buffer pool management to minimize memory fragmentation and boost transfer efficiency.

* **Features**
  * Added configurable temporary device buffer pooling to support more flexible memory allocation strategies during data transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->