### PR TITLE
fix: Add jq to sglang wideeep dockerfile

### DIFF
--- a/container/Dockerfile.sglang-wideep
+++ b/container/Dockerfile.sglang-wideep
@@ -12,6 +12,13 @@ FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG}
 
 WORKDIR /sgl-workspace
 
+# Install jq for JSON processing
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        jq \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install dynamo
 # Providing --build-arg BRANCH_TYPE=local will editable install the local dynamo repo
 # Providing --build-arg BRANCH_TYPE=remote will editable install the remote dynamo repo


### PR DESCRIPTION
#### Overview:

Fix release 0.6.0 blocker to install jq in sglang dockerfile. profile_sla_moe_job.yaml deployment fails due to frontend not ready and decode pod CrashLoopBackOff. This seems to be because the jq package is missing in the container. This should resolve the issue on the frontend pod which is causing it to never be ready. It seems to be unhealthy and its readiness probe failed seemingly because jq cannot be found. This PR installs jq.

#### Details:

- Install jq in Dockerfile.sglang-wideep

#### Where should the reviewer start?

- container/Dockerfile.sglang-wideep

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment configuration to include JSON processing utilities for improved system capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->