### PR TITLE
chore: Use KeyValueStoreManager instead of etcd::Client

### DIFF
--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -334,7 +334,7 @@ use std::pin::Pin;
 const GENERATE_ENDPOINT: &str = "generate";
 
 use anyhow::Context;
-use dynamo_runtime::{Runtime, distributed::DistributedConfig};
+use dynamo_runtime::{Runtime, distributed::DistributedConfig, traits::DistributedRuntimeProvider};
 
 use dynamo_llm::discovery::ModelManager;
 use dynamo_llm::entrypoint::build_routed_pipeline;

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -136,7 +136,7 @@ fn dynamo_create_kv_publisher(
     {
         Ok(drt) => {
             let backend = drt.namespace(namespace)?.component(component)?;
-            KvEventPublisher::new(backend, worker_id, kv_block_size, None)
+            KvEventPublisher::new(backend, worker_id as u64, kv_block_size, None)
         }
         Err(e) => Err(e),
     }

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -334,7 +334,7 @@ use std::pin::Pin;
 const GENERATE_ENDPOINT: &str = "generate";
 
 use anyhow::Context;
-use dynamo_runtime::{Runtime, distributed::DistributedConfig, traits::DistributedRuntimeProvider};
+use dynamo_runtime::{Runtime, distributed::DistributedConfig};
 
 use dynamo_llm::discovery::ModelManager;
 use dynamo_llm::entrypoint::build_routed_pipeline;

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -771,7 +771,7 @@ impl Endpoint {
         })
     }
 
-    fn lease_id(&self) -> i64 {
+    fn lease_id(&self) -> u64 {
         self.inner
             .drt()
             .primary_lease()
@@ -807,7 +807,7 @@ impl Namespace {
 impl Client {
     /// Get list of current instances.
     /// Replaces endpoint_ids.
-    fn instance_ids(&self) -> Vec<i64> {
+    fn instance_ids(&self) -> Vec<u64> {
         self.router.client.instance_ids()
     }
 
@@ -819,7 +819,7 @@ impl Client {
             inner
                 .wait_for_instances()
                 .await
-                .map(|v| v.into_iter().map(|cei| cei.id()).collect::<Vec<i64>>())
+                .map(|v| v.into_iter().map(|cei| cei.id()).collect::<Vec<u64>>())
                 .map_err(to_pyerr)
         })
     }
@@ -920,7 +920,7 @@ impl Client {
         &self,
         py: Python<'p>,
         request: PyObject,
-        instance_id: i64,
+        instance_id: u64,
         annotated: Option<bool>,
         context: Option<context::Context>,
     ) -> PyResult<Bound<'p, PyAny>> {

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -322,7 +322,7 @@ pub(crate) struct OverlapScores {
 #[pymethods]
 impl OverlapScores {
     #[getter]
-    fn scores(&self) -> HashMap<(i64, u32), u32> {
+    fn scores(&self) -> HashMap<(u64, u32), u32> {
         // Return scores with full WorkerWithDpRank granularity as (worker_id, dp_rank) tuples
         self.inner
             .scores

--- a/lib/llm/src/block_manager/controller/client.rs
+++ b/lib/llm/src/block_manager/controller/client.rs
@@ -59,7 +59,10 @@ impl ControlClient {
     }
 
     async fn execute<T: DeserializeOwned>(&self, message: ControlMessage) -> Result<T> {
-        let mut stream = self.client.direct(message.into(), self.instance_id).await?;
+        let mut stream = self
+            .client
+            .direct(message.into(), self.instance_id as u64)
+            .await?;
         let resp = stream
             .next()
             .await

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -52,7 +52,7 @@ impl WorkerLoadState {
 /// Worker monitor for tracking KV cache usage and busy states
 pub struct KvWorkerMonitor {
     client: Arc<Client>,
-    worker_load_states: Arc<RwLock<HashMap<i64, WorkerLoadState>>>,
+    worker_load_states: Arc<RwLock<HashMap<u64, WorkerLoadState>>>,
     busy_threshold: f64,
 }
 
@@ -67,7 +67,7 @@ impl KvWorkerMonitor {
     }
 
     /// Get the worker load states for external access
-    pub fn load_states(&self) -> Arc<RwLock<HashMap<i64, WorkerLoadState>>> {
+    pub fn load_states(&self) -> Arc<RwLock<HashMap<u64, WorkerLoadState>>> {
         self.worker_load_states.clone()
     }
 }
@@ -154,7 +154,7 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
 
                             // Recalculate all busy instances and update
                             let states = worker_load_states.read().unwrap();
-                            let busy_instances: Vec<i64> = states
+                            let busy_instances: Vec<u64> = states
                                 .iter()
                                 .filter_map(|(&id, state)| {
                                     state.is_busy(busy_threshold).then_some(id)

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -163,6 +163,7 @@ pub struct HttpServiceConfig {
     #[builder(default = "None")]
     request_template: Option<RequestTemplate>,
 
+    #[builder(default)]
     store: KeyValueStoreManager,
 
     // DEPRECATED: To be removed after custom backends migrate to Dynamo backend.

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -20,10 +20,7 @@ use axum_server::tls_rustls::RustlsConfig;
 use derive_builder::Builder;
 use dynamo_runtime::logging::make_request_span;
 use dynamo_runtime::metrics::prometheus_names::name_prefix;
-use dynamo_runtime::storage::key_value_store::EtcdStore;
-use dynamo_runtime::storage::key_value_store::KeyValueStore;
-use dynamo_runtime::storage::key_value_store::MemoryStore;
-use dynamo_runtime::transports::etcd;
+use dynamo_runtime::storage::key_value_store::KeyValueStoreManager;
 use std::net::SocketAddr;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -33,8 +30,7 @@ use tower_http::trace::TraceLayer;
 pub struct State {
     metrics: Arc<Metrics>,
     manager: Arc<ModelManager>,
-    etcd_client: Option<etcd::Client>,
-    store: Arc<dyn KeyValueStore>,
+    store: KeyValueStoreManager,
     flags: StateFlags,
 }
 
@@ -75,12 +71,11 @@ impl StateFlags {
 }
 
 impl State {
-    pub fn new(manager: Arc<ModelManager>) -> Self {
+    pub fn new(manager: Arc<ModelManager>, store: KeyValueStoreManager) -> Self {
         Self {
             manager,
             metrics: Arc::new(Metrics::default()),
-            etcd_client: None,
-            store: Arc::new(MemoryStore::new()),
+            store,
             flags: StateFlags {
                 chat_endpoints_enabled: AtomicBool::new(false),
                 cmpl_endpoints_enabled: AtomicBool::new(false),
@@ -90,20 +85,6 @@ impl State {
         }
     }
 
-    pub fn new_with_etcd(manager: Arc<ModelManager>, etcd_client: etcd::Client) -> Self {
-        Self {
-            manager,
-            metrics: Arc::new(Metrics::default()),
-            store: Arc::new(EtcdStore::new(etcd_client.clone())),
-            etcd_client: Some(etcd_client),
-            flags: StateFlags {
-                chat_endpoints_enabled: AtomicBool::new(false),
-                cmpl_endpoints_enabled: AtomicBool::new(false),
-                embeddings_endpoints_enabled: AtomicBool::new(false),
-                responses_endpoints_enabled: AtomicBool::new(false),
-            },
-        }
-    }
     /// Get the Prometheus [`Metrics`] object which tracks request counts and inflight requests
     pub fn metrics_clone(&self) -> Arc<Metrics> {
         self.metrics.clone()
@@ -117,12 +98,8 @@ impl State {
         self.manager.clone()
     }
 
-    pub fn etcd_client(&self) -> Option<&etcd::Client> {
-        self.etcd_client.as_ref()
-    }
-
-    pub fn store(&self) -> Arc<dyn KeyValueStore> {
-        self.store.clone()
+    pub fn store(&self) -> &KeyValueStoreManager {
+        &self.store
     }
 
     // TODO
@@ -186,8 +163,7 @@ pub struct HttpServiceConfig {
     #[builder(default = "None")]
     request_template: Option<RequestTemplate>,
 
-    #[builder(default = "None")]
-    etcd_client: Option<etcd::Client>,
+    store: KeyValueStoreManager,
 
     // DEPRECATED: To be removed after custom backends migrate to Dynamo backend.
     #[builder(default = "None")]
@@ -335,10 +311,7 @@ impl HttpServiceConfigBuilder {
         let config: HttpServiceConfig = self.build_internal()?;
 
         let model_manager = Arc::new(ModelManager::new());
-        let state = match config.etcd_client {
-            Some(etcd_client) => Arc::new(State::new_with_etcd(model_manager, etcd_client)),
-            None => Arc::new(State::new(model_manager)),
-        };
+        let state = Arc::new(State::new(model_manager, config.store));
         state
             .flags
             .set(&EndpointType::Chat, config.enable_chat_endpoints);
@@ -419,11 +392,6 @@ impl HttpServiceConfigBuilder {
 
     pub fn with_request_template(mut self, request_template: Option<RequestTemplate>) -> Self {
         self.request_template = Some(request_template);
-        self
-    }
-
-    pub fn with_etcd_client(mut self, etcd_client: Option<etcd::Client>) -> Self {
-        self.etcd_client = Some(etcd_client);
         self
     }
 

--- a/lib/llm/src/kv_router/protocols.rs
+++ b/lib/llm/src/kv_router/protocols.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// A worker identifier.
-pub type WorkerId = i64;
+pub type WorkerId = u64;
 
 /// A data parallel rank identifier.
 pub type DpRank = u32;

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -97,7 +97,7 @@ pub struct KvEventPublisher {
 impl KvEventPublisher {
     pub fn new(
         component: Component,
-        worker_id: i64,
+        worker_id: u64,
         kv_block_size: u32,
         source_config: Option<KvEventSourceConfig>,
     ) -> Result<Self> {
@@ -174,7 +174,7 @@ impl Drop for KvEventPublisher {
 
 async fn start_event_processor<P: EventPublisher + Send + Sync + 'static>(
     publisher: P,
-    worker_id: i64,
+    worker_id: u64,
     cancellation_token: CancellationToken,
     mut rx: mpsc::UnboundedReceiver<KvCacheEvent>,
 ) {
@@ -801,7 +801,7 @@ impl WorkerMetricsPublisher {
     ///
     /// This task monitors metric changes (specifically kv_active_blocks and num_requests_waiting)
     /// and publishes stable metrics to NATS after they've been unchanged for 1ms.
-    fn start_nats_metrics_publishing(&self, namespace: Namespace, worker_id: i64) {
+    fn start_nats_metrics_publishing(&self, namespace: Namespace, worker_id: u64) {
         let nats_rx = self.rx.clone();
 
         tokio::spawn(async move {

--- a/lib/llm/src/kv_router/scoring.rs
+++ b/lib/llm/src/kv_router/scoring.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LoadEvent {
-    pub worker_id: i64,
+    pub worker_id: u64,
     pub data: ForwardPassMetrics,
 }
 
@@ -23,8 +23,8 @@ pub struct Endpoint {
 }
 
 impl Endpoint {
-    pub fn worker_id(&self) -> i64 {
-        i64::from_str_radix(
+    pub fn worker_id(&self) -> u64 {
+        u64::from_str_radix(
             self.subject
                 .split("-")
                 .last()
@@ -39,7 +39,7 @@ impl Endpoint {
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ProcessedEndpoints {
-    pub endpoints: HashMap<i64, Endpoint>,
+    pub endpoints: HashMap<u64, Endpoint>,
     pub load_avg: f64,
     pub load_std: f64,
 }
@@ -68,11 +68,11 @@ impl ProcessedEndpoints {
         }
     }
 
-    pub fn worker_ids(&self) -> Vec<i64> {
+    pub fn worker_ids(&self) -> Vec<u64> {
         self.endpoints.keys().copied().collect()
     }
 
-    pub fn active_blocks(&self) -> HashMap<i64, usize> {
+    pub fn active_blocks(&self) -> HashMap<u64, usize> {
         self.endpoints
             .iter()
             .map(|(&worker_id, endpoint)| (worker_id, endpoint.data.kv_active_blocks() as usize))

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -293,7 +293,7 @@ impl ActiveSequencesMultiWorker {
     pub fn new(
         component: Component,
         block_size: usize,
-        workers_with_configs: HashMap<i64, Option<ModelRuntimeConfig>>,
+        workers_with_configs: HashMap<u64, Option<ModelRuntimeConfig>>,
         replica_sync: bool,
         router_uuid: String,
     ) -> Self {
@@ -557,7 +557,7 @@ impl ActiveSequencesMultiWorker {
     /// Update the set of workers, adding and removing as needed
     pub fn update_workers(
         &self,
-        new_workers_with_configs: HashMap<i64, Option<ModelRuntimeConfig>>,
+        new_workers_with_configs: HashMap<u64, Option<ModelRuntimeConfig>>,
     ) {
         let current_workers: HashSet<WorkerWithDpRank> =
             self.senders.iter().map(|entry| *entry.key()).collect();

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -63,7 +63,7 @@ impl SnapshotResources {
         // Clean up stale workers before snapshot
         // Get current worker IDs from instances_rx
         let current_instances = self.instances_rx.borrow().clone();
-        let current_worker_ids: std::collections::HashSet<i64> = current_instances
+        let current_worker_ids: std::collections::HashSet<u64> = current_instances
             .iter()
             .map(|instance| instance.instance_id)
             .collect();
@@ -312,7 +312,7 @@ pub async fn start_kv_router_background(
                     };
 
                     // Parse as hexadecimal (base 16)
-                    let Ok(worker_id) = i64::from_str_radix(worker_id_str, 16) else {
+                    let Ok(worker_id) = u64::from_str_radix(worker_id_str, 16) else {
                         tracing::warn!("Could not parse worker ID from instance key: {key}");
                         continue;
                     };

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -50,7 +50,7 @@ pub struct PreprocessedRequest {
 
     /// Targeted backend instance ID for the request
     #[builder(default)]
-    pub backend_instance_id: Option<i64>,
+    pub backend_instance_id: Option<u64>,
 
     /// Router configuration overrides for this specific request
     #[builder(default)]

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -39,7 +39,7 @@ pub struct NvExt {
     /// If not set, the request will be routed to the best matching instance.
     #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub backend_instance_id: Option<i64>,
+    pub backend_instance_id: Option<u64>,
 
     /// Pre-tokenized data to use instead of tokenizing the prompt
     /// If provided along with backend_instance_id, these tokens will be used directly

--- a/lib/llm/tests/block_manager.rs
+++ b/lib/llm/tests/block_manager.rs
@@ -216,7 +216,7 @@ pub mod llm_kvbm {
     impl DynamoKvbmRuntimeConfigBuilder {
         pub fn build(self) -> Result<kvbm::config::KvManagerRuntimeConfig> {
             let (runtime, nixl) = self.build_internal()?.dissolve();
-            let worker_id = runtime.primary_lease().unwrap().id() as u64;
+            let worker_id = runtime.primary_lease().unwrap().id();
             Ok(kvbm::config::KvManagerRuntimeConfig::builder()
                 .worker_id(worker_id)
                 .cancellation_token(runtime.primary_token().child_token())
@@ -247,7 +247,7 @@ pub mod llm_kvbm {
     impl DynamoEventManager {
         pub fn new(component: Arc<KVBMDynamoRuntimeComponent>) -> Self {
             let (tx, rx) = mpsc::unbounded_channel();
-            let worker_id = component.drt().primary_lease().unwrap().id() as u64;
+            let worker_id = component.drt().primary_lease().unwrap().id();
             component.drt().runtime().secondary().spawn(async move {
                 worker_task(component, rx).await;
             });

--- a/lib/llm/tests/block_manager.rs
+++ b/lib/llm/tests/block_manager.rs
@@ -296,7 +296,7 @@ pub mod llm_kvbm {
                         event_id: event_id_counter,
                         dp_rank: 0,
                     };
-                    let router_event = RouterEvent::new(worker_identifier as i64, event);
+                    let router_event = RouterEvent::new(worker_identifier, event);
                     event_id_counter += 1;
                     if let Err(e) = component_clone
                         .batch_tx
@@ -316,7 +316,7 @@ pub mod llm_kvbm {
                         event_id: event_id_counter,
                         dp_rank: 0,
                     };
-                    let router_event = RouterEvent::new(worker_identifier as i64, event);
+                    let router_event = RouterEvent::new(worker_identifier, event);
                     event_id_counter += 1;
                     if let Err(e) = component_clone
                         .batch_tx

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -98,12 +98,12 @@ pub struct Instance {
     pub component: String,
     pub endpoint: String,
     pub namespace: String,
-    pub instance_id: i64,
+    pub instance_id: u64,
     pub transport: TransportType,
 }
 
 impl Instance {
-    pub fn id(&self) -> i64 {
+    pub fn id(&self) -> u64 {
         self.instance_id
     }
     pub fn endpoint_id(&self) -> EndpointId {
@@ -525,8 +525,8 @@ impl Endpoint {
     }
 
     /// The fully path of an instance in etcd
-    pub fn etcd_path_with_lease_id(&self, lease_id: i64) -> String {
-        format!("{INSTANCE_ROOT_PATH}/{}", self.unique_path(lease_id as u64))
+    pub fn etcd_path_with_lease_id(&self, lease_id: u64) -> String {
+        format!("{INSTANCE_ROOT_PATH}/{}", self.unique_path(lease_id))
     }
 
     /// Full path of this endpoint with forward slash separators, including lease id
@@ -552,7 +552,7 @@ impl Endpoint {
         }
     }
 
-    pub fn name_with_id(&self, lease_id: i64) -> String {
+    pub fn name_with_id(&self, lease_id: u64) -> String {
         if self.is_static {
             self.name.clone()
         } else {
@@ -565,7 +565,7 @@ impl Endpoint {
     }
 
     /// Subject to an instance of the [Endpoint] with a specific lease id
-    pub fn subject_to(&self, lease_id: i64) -> String {
+    pub fn subject_to(&self, lease_id: u64) -> String {
         format!(
             "{}.{}",
             self.component.service_name(),

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -526,11 +526,11 @@ impl Endpoint {
 
     /// The fully path of an instance in etcd
     pub fn etcd_path_with_lease_id(&self, lease_id: i64) -> String {
-        format!("{INSTANCE_ROOT_PATH}/{}", self.unique_path(lease_id))
+        format!("{INSTANCE_ROOT_PATH}/{}", self.unique_path(lease_id as u64))
     }
 
     /// Full path of this endpoint with forward slash separators, including lease id
-    pub fn unique_path(&self, lease_id: i64) -> String {
+    pub fn unique_path(&self, lease_id: u64) -> String {
         let ns = self.component.namespace().name();
         let cp = self.component.name();
         let ep = self.name();

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -32,7 +32,7 @@ enum MapState {
 }
 
 enum EndpointEvent {
-    Put(String, i64),
+    Put(String, u64),
     Delete(String),
 }
 
@@ -43,9 +43,9 @@ pub struct Client {
     // These are the remotes I know about from watching etcd
     pub instance_source: Arc<InstanceSource>,
     // These are the instance source ids less those reported as down from sending rpc
-    instance_avail: Arc<ArcSwap<Vec<i64>>>,
+    instance_avail: Arc<ArcSwap<Vec<u64>>>,
     // These are the instance source ids less those reported as busy (above threshold)
-    instance_free: Arc<ArcSwap<Vec<i64>>>,
+    instance_free: Arc<ArcSwap<Vec<u64>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -104,15 +104,15 @@ impl Client {
         }
     }
 
-    pub fn instance_ids(&self) -> Vec<i64> {
+    pub fn instance_ids(&self) -> Vec<u64> {
         self.instances().into_iter().map(|ep| ep.id()).collect()
     }
 
-    pub fn instance_ids_avail(&self) -> arc_swap::Guard<Arc<Vec<i64>>> {
+    pub fn instance_ids_avail(&self) -> arc_swap::Guard<Arc<Vec<u64>>> {
         self.instance_avail.load()
     }
 
-    pub fn instance_ids_free(&self) -> arc_swap::Guard<Arc<Vec<i64>>> {
+    pub fn instance_ids_free(&self) -> arc_swap::Guard<Arc<Vec<u64>>> {
         self.instance_free.load()
     }
 
@@ -139,7 +139,7 @@ impl Client {
     }
 
     /// Mark an instance as down/unavailable
-    pub fn report_instance_down(&self, instance_id: i64) {
+    pub fn report_instance_down(&self, instance_id: u64) {
         let filtered = self
             .instance_ids_avail()
             .iter()
@@ -151,9 +151,9 @@ impl Client {
     }
 
     /// Update the set of free instances based on busy instance IDs
-    pub fn update_free_instances(&self, busy_instance_ids: &[i64]) {
+    pub fn update_free_instances(&self, busy_instance_ids: &[u64]) {
         let all_instance_ids = self.instance_ids();
-        let free_ids: Vec<i64> = all_instance_ids
+        let free_ids: Vec<u64> = all_instance_ids
             .into_iter()
             .filter(|id| !busy_instance_ids.contains(id))
             .collect();
@@ -173,7 +173,7 @@ impl Client {
                 InstanceSource::Dynamic(rx) => rx.clone(),
             };
             while !cancel_token.is_cancelled() {
-                let instance_ids: Vec<i64> = rx
+                let instance_ids: Vec<u64> = rx
                     .borrow_and_update()
                     .iter()
                     .map(|instance| instance.id())

--- a/lib/runtime/src/discovery.rs
+++ b/lib/runtime/src/discovery.rs
@@ -27,48 +27,13 @@ impl DiscoveryClient {
     }
 
     /// Get the primary lease ID
-    pub fn primary_lease_id(&self) -> i64 {
+    pub fn primary_lease_id(&self) -> u64 {
         self.etcd_client.lease_id()
     }
 
     /// Create a [`Lease`] with a given time-to-live (TTL).
     /// This [`Lease`] will be tied to the [`crate::Runtime`], but has its own independent [`crate::CancellationToken`].
-    pub async fn create_lease(&self, ttl: i64) -> Result<Lease> {
+    pub async fn create_lease(&self, ttl: u64) -> Result<Lease> {
         self.etcd_client.create_lease(ttl).await
     }
-
-    // the following two commented out codes are not implemented, but are placeholders for proposed ectd usage patterns
-
-    // /// Create an ephemeral key/value pair tied to a lease_id.
-    // /// This is an atomic create. If the key already exists, this will fail.
-    // /// The [`etcd_client::KeyValue`] will be removed when the lease expires or is revoked.
-    // pub async fn create_ephemerial_key(&self, key: &str, value: &str, lease_id: i64) -> Result<()> {
-    //     // self.etcd_client.create_ephemeral_key(key, value, lease_id).await
-    //     unimplemented!()
-    // }
-
-    // /// Create a shared [`etcd_client::KeyValue`] which behaves similar to a C++ `std::shared_ptr` or a
-    // /// Rust [std::sync::Arc]. Instead of having one owner of the lease, multiple owners participate in
-    // /// maintaining the lease. In this manner, when the last member of the group sharing the lease is gone,
-    // /// the lease will be expired.
-    // ///
-    // /// Implementation notes: At the time of writing, it is unclear if we have atomics that control leases,
-    // /// so in our initial implementation, the last member of the group will not revoke the lease, so the object
-    // /// will live for upto the TTL after the last member is gone.
-    // ///
-    // /// Notes
-    // /// -----
-    // ///
-    // /// - Multiple members sharing the lease and contributing to the heartbeat might cause some overheads.
-    // ///   The implementation will try to randomize the heartbeat intervals to avoid thundering herd problem,
-    // ///   and with any luck, the heartbeat watchers will be able to detect when if a external member triggered
-    // ///   the heartbeat checking this interval and skip unnecessary heartbeat messages.
-    // ///
-    // /// A new lease will be created for this object. If you wish to add an object to a shared group s
-    // ///
-    // /// The [`etcd_client::KeyValue`] will be removed when the lease expires or is revoked.
-    // pub async fn create_shared_key(&self, key: &str, value: &str, lease_id: i64) -> Result<()> {
-    //     // self.etcd_client.create_ephemeral_key(key, value, lease_id).await
-    //     unimplemented!()
-    // }
 }

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -278,7 +278,8 @@ impl DistributedRuntime {
         self.etcd_client.clone()
     }
 
-    // Do not use. This is for the last few bits of the codebase that need upgrading.
+    // Deprecated but our CI blocks us using the feature currently.
+    //#[deprecated(note = "Use KeyValueStoreManager via store(); this will be removed")]
     pub fn deprecated_etcd_client(&self) -> Option<etcd::Client> {
         self.etcd_client.clone()
     }

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use crate::component::Component;
-use crate::storage::key_value_store::{EtcdStore, KeyValueStore, MemoryStore};
+use crate::storage::key_value_store::{
+    EtcdStore, KeyValueStore, KeyValueStoreEnum, KeyValueStoreManager, MemoryStore,
+};
 use crate::transports::nats::DRTNatsClientPrometheusMetrics;
 use crate::{
     ErrorContext, PrometheusUpdateCallback,
@@ -46,12 +48,10 @@ impl DistributedRuntime {
         let runtime_clone = runtime.clone();
 
         let (etcd_client, store) = if is_static {
-            let store: Arc<dyn KeyValueStore> = Arc::new(MemoryStore::new());
-            (None, store)
+            (None, KeyValueStoreManager::memory())
         } else {
             let etcd_client = etcd::Client::new(etcd_config.clone(), runtime_clone).await?;
-            let store: Arc<dyn KeyValueStore> = Arc::new(EtcdStore::new(etcd_client.clone()));
-
+            let store = KeyValueStoreManager::etcd(etcd_client.clone());
             (Some(etcd_client), store)
         };
 
@@ -278,10 +278,15 @@ impl DistributedRuntime {
         self.etcd_client.clone()
     }
 
+    // Do not use. This is for the last few bits of the codebase that need upgrading.
+    pub fn deprecated_etcd_client(&self) -> Option<etcd::Client> {
+        self.etcd_client.clone()
+    }
+
     /// An interface to store things. Will eventually replace `etcd_client`.
     /// Currently does key-value, but will grow to include whatever we need to store.
-    pub fn store(&self) -> Arc<dyn KeyValueStore> {
-        self.store.clone()
+    pub fn store(&self) -> &KeyValueStoreManager {
+        &self.store
     }
 
     pub fn child_token(&self) -> CancellationToken {

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -484,7 +484,7 @@ mod integration_tests {
                     component: "test_component".to_string(),
                     endpoint: format!("test_endpoint_{}", i),
                     namespace: "test_namespace".to_string(),
-                    instance_id: i as i64,
+                    instance_id: i,
                     transport: crate::component::TransportType::NatsTcp(endpoint.clone()),
                 },
                 payload,

--- a/lib/runtime/src/instances.rs
+++ b/lib/runtime/src/instances.rs
@@ -10,10 +10,10 @@
 use std::sync::Arc;
 
 use crate::component::{INSTANCE_ROOT_PATH, Instance};
-use crate::storage::key_value_store::KeyValueStore;
+use crate::storage::key_value_store::{KeyValueStore, KeyValueStoreManager};
 use crate::transports::etcd::Client as EtcdClient;
 
-pub async fn list_all_instances(client: Arc<dyn KeyValueStore>) -> anyhow::Result<Vec<Instance>> {
+pub async fn list_all_instances(client: &KeyValueStoreManager) -> anyhow::Result<Vec<Instance>> {
     let Some(bucket) = client.get_bucket(INSTANCE_ROOT_PATH).await? else {
         return Ok(vec![]);
     };

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -52,7 +52,8 @@ pub use tokio_util::sync::CancellationToken;
 pub use worker::Worker;
 
 use crate::{
-    metrics::prometheus_names::distributed_runtime, storage::key_value_store::KeyValueStore,
+    metrics::prometheus_names::distributed_runtime,
+    storage::key_value_store::{KeyValueStore, KeyValueStoreManager},
 };
 
 use component::{Endpoint, InstanceSource};
@@ -188,7 +189,7 @@ pub struct DistributedRuntime {
     // we might consider a unifed transport manager here
     etcd_client: Option<transports::etcd::Client>,
     nats_client: Option<transports::nats::Client>,
-    store: Arc<dyn KeyValueStore>,
+    store: KeyValueStoreManager,
     tcp_server: Arc<OnceCell<Arc<transports::tcp::server::TcpStreamServer>>>,
     system_status_server: Arc<OnceLock<Arc<system_status_server::SystemStatusServerInfo>>>,
 

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -310,7 +310,7 @@ pub fn make_handle_payload_span(
     component: &str,
     endpoint: &str,
     namespace: &str,
-    instance_id: i64,
+    instance_id: u64,
 ) -> Span {
     let (otel_context, trace_id, parent_span_id) = extract_otel_context_from_nats_headers(headers);
     let trace_parent = TraceParent::from_headers(headers);

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -77,7 +77,7 @@ pub enum RouterMode {
     #[default]
     RoundRobin,
     Random,
-    Direct(i64),
+    Direct(u64),
     // Marker value, KV routing itself is in dynamo-llm
     KV,
 }
@@ -181,7 +181,7 @@ where
     pub async fn direct(
         &self,
         request: SingleIn<T>,
-        instance_id: i64,
+        instance_id: u64,
     ) -> anyhow::Result<ManyOut<U>> {
         let found = self.client.instance_ids_avail().contains(&instance_id);
 
@@ -206,7 +206,7 @@ where
 
     async fn generate_with_fault_detection(
         &self,
-        instance_id: i64,
+        instance_id: u64,
         request: SingleIn<T>,
     ) -> anyhow::Result<ManyOut<U>> {
         // Check if all workers are busy (only if busy threshold is set)

--- a/lib/runtime/src/pipeline/network/ingress/push_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_endpoint.rs
@@ -39,7 +39,7 @@ impl PushEndpoint {
         namespace: String,
         component_name: String,
         endpoint_name: String,
-        instance_id: i64,
+        instance_id: u64,
         system_health: Arc<Mutex<SystemHealth>>,
     ) -> Result<()> {
         let mut endpoint = endpoint;

--- a/lib/runtime/src/storage/key_value_store/etcd.rs
+++ b/lib/runtime/src/storage/key_value_store/etcd.rs
@@ -25,25 +25,24 @@ impl EtcdStore {
 
 #[async_trait]
 impl KeyValueStore for EtcdStore {
+    type Bucket = EtcdBucket;
+
     /// A "bucket" in etcd is a path prefix
     async fn get_or_create_bucket(
         &self,
         bucket_name: &str,
         _ttl: Option<Duration>, // TODO ttl not used yet
-    ) -> Result<Box<dyn KeyValueBucket>, StoreError> {
+    ) -> Result<Self::Bucket, StoreError> {
         Ok(self.get_bucket(bucket_name).await?.unwrap())
     }
 
     /// A "bucket" in etcd is a path prefix. This creates an EtcdBucket object without doing
     /// any network calls.
-    async fn get_bucket(
-        &self,
-        bucket_name: &str,
-    ) -> Result<Option<Box<dyn KeyValueBucket>>, StoreError> {
-        Ok(Some(Box::new(EtcdBucket {
+    async fn get_bucket(&self, bucket_name: &str) -> Result<Option<Self::Bucket>, StoreError> {
+        Ok(Some(EtcdBucket {
             client: self.client.clone(),
             bucket_name: bucket_name.to_string(),
-        })))
+        }))
     }
 
     fn connection_id(&self) -> u64 {

--- a/lib/runtime/src/storage/key_value_store/etcd.rs
+++ b/lib/runtime/src/storage/key_value_store/etcd.rs
@@ -49,9 +49,7 @@ impl KeyValueStore for EtcdStore {
     }
 
     fn connection_id(&self) -> u64 {
-        // This conversion from i64 to u64 is safe because etcd lease IDs are u64 internally.
-        // They present as i64 because of the limitations of the etcd grpc/HTTP JSON API.
-        self.client.lease_id() as u64
+        self.client.lease_id()
     }
 }
 

--- a/lib/runtime/src/storage/key_value_store/nats.rs
+++ b/lib/runtime/src/storage/key_value_store/nats.rs
@@ -23,25 +23,24 @@ pub struct NATSBucket {
 
 #[async_trait]
 impl KeyValueStore for NATSStore {
+    type Bucket = NATSBucket;
+
     async fn get_or_create_bucket(
         &self,
         bucket_name: &str,
         ttl: Option<Duration>,
-    ) -> Result<Box<dyn KeyValueBucket>, StoreError> {
+    ) -> Result<Self::Bucket, StoreError> {
         let name = Slug::slugify(bucket_name);
         let nats_store = self
             .get_or_create_key_value(&self.endpoint.namespace, &name, ttl)
             .await?;
-        Ok(Box::new(NATSBucket { nats_store }))
+        Ok(NATSBucket { nats_store })
     }
 
-    async fn get_bucket(
-        &self,
-        bucket_name: &str,
-    ) -> Result<Option<Box<dyn KeyValueBucket>>, StoreError> {
+    async fn get_bucket(&self, bucket_name: &str) -> Result<Option<Self::Bucket>, StoreError> {
         let name = Slug::slugify(bucket_name);
         match self.get_key_value(&self.endpoint.namespace, &name).await? {
-            Some(nats_store) => Ok(Some(Box::new(NATSBucket { nats_store }))),
+            Some(nats_store) => Ok(Some(NATSBucket { nats_store })),
             None => Ok(None),
         }
     }

--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -39,6 +39,12 @@ pub struct Client {
     rt: Arc<tokio::runtime::Runtime>,
 }
 
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "etcd::Client primary_lease={}", self.primary_lease)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Lease {
     /// ETCD lease ID

--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -34,7 +34,7 @@ use super::utils::build_in_runtime;
 #[derive(Clone)]
 pub struct Client {
     client: etcd_client::Client,
-    primary_lease: i64,
+    primary_lease: u64,
     runtime: Runtime,
     rt: Arc<tokio::runtime::Runtime>,
 }
@@ -48,7 +48,8 @@ impl std::fmt::Debug for Client {
 #[derive(Debug, Clone)]
 pub struct Lease {
     /// ETCD lease ID
-    id: i64,
+    /// Delivered as i64 by etcd because of documented gRPC limitations.
+    id: u64,
 
     /// [`CancellationToken`] associated with the lease
     cancel_token: CancellationToken,
@@ -56,7 +57,7 @@ pub struct Lease {
 
 impl Lease {
     /// Get the lease ID
-    pub fn id(&self) -> i64 {
+    pub fn id(&self) -> u64 {
         self.id
     }
 
@@ -152,7 +153,7 @@ impl Client {
     }
 
     /// Get the primary lease ID.
-    pub fn lease_id(&self) -> i64 {
+    pub fn lease_id(&self) -> u64 {
         self.primary_lease
     }
 
@@ -166,7 +167,7 @@ impl Client {
 
     /// Create a [`Lease`] with a given time-to-live (TTL).
     /// This [`Lease`] will be tied to the [`Runtime`], specifically a child [`CancellationToken`].
-    pub async fn create_lease(&self, ttl: i64) -> Result<Lease> {
+    pub async fn create_lease(&self, ttl: u64) -> Result<Lease> {
         let token = self.runtime.child_token();
         let lease_client = self.client.lease_client();
         self.rt
@@ -175,14 +176,14 @@ impl Client {
     }
 
     // Revoke an etcd lease given its lease id. A wrapper over etcd_client::LeaseClient::revoke
-    pub async fn revoke_lease(&self, lease_id: i64) -> Result<()> {
+    pub async fn revoke_lease(&self, lease_id: u64) -> Result<()> {
         let lease_client = self.client.lease_client();
         self.rt.spawn(revoke_lease(lease_client, lease_id)).await?
     }
 
-    pub async fn kv_create(&self, key: &str, value: Vec<u8>, lease_id: Option<i64>) -> Result<()> {
+    pub async fn kv_create(&self, key: &str, value: Vec<u8>, lease_id: Option<u64>) -> Result<()> {
         let id = lease_id.unwrap_or(self.lease_id());
-        let put_options = PutOptions::new().with_lease(id);
+        let put_options = PutOptions::new().with_lease(id as i64);
 
         // Build the transaction
         let txn = Txn::new()
@@ -209,10 +210,10 @@ impl Client {
         &self,
         key: String,
         value: Vec<u8>,
-        lease_id: Option<i64>,
+        lease_id: Option<u64>,
     ) -> Result<()> {
         let id = lease_id.unwrap_or(self.lease_id());
-        let put_options = PutOptions::new().with_lease(id);
+        let put_options = PutOptions::new().with_lease(id as i64);
 
         // Build the transaction that either creates the key if it doesn't exist,
         // or validates the existing value matches what we expect
@@ -260,10 +261,10 @@ impl Client {
         &self,
         key: impl AsRef<str>,
         value: impl AsRef<[u8]>,
-        lease_id: Option<i64>,
+        lease_id: Option<u64>,
     ) -> Result<()> {
         let id = lease_id.unwrap_or(self.lease_id());
-        let put_options = PutOptions::new().with_lease(id);
+        let put_options = PutOptions::new().with_lease(id as i64);
         let _ = self
             .client
             .kv_client()
@@ -280,7 +281,7 @@ impl Client {
     ) -> Result<PutResponse> {
         let options = options
             .unwrap_or_default()
-            .with_lease(self.primary_lease().id());
+            .with_lease(self.primary_lease().id() as i64);
         self.client
             .kv_client()
             .put(key.as_ref(), value.as_ref(), Some(options))
@@ -301,12 +302,12 @@ impl Client {
         &self,
         key: impl Into<Vec<u8>>,
         options: Option<DeleteOptions>,
-    ) -> Result<i64> {
+    ) -> Result<u64> {
         self.client
             .kv_client()
             .delete(key, options)
             .await
-            .map(|del_response| del_response.deleted())
+            .map(|del_response| del_response.deleted() as u64)
             .map_err(|err| err.into())
     }
 
@@ -325,11 +326,11 @@ impl Client {
     pub async fn lock(
         &self,
         key: impl Into<Vec<u8>>,
-        lease_id: Option<i64>,
+        lease_id: Option<u64>,
     ) -> Result<LockResponse> {
         let mut lock_client = self.client.lock_client();
         let id = lease_id.unwrap_or(self.lease_id());
-        let options = LockOptions::new().with_lease(id);
+        let options = LockOptions::new().with_lease(id as i64);
         lock_client
             .lock(key, Some(options))
             .await
@@ -635,7 +636,7 @@ impl KvCache {
     }
 
     /// Update a value in both the cache and etcd
-    pub async fn put(&self, key: &str, value: Vec<u8>, lease_id: Option<i64>) -> Result<()> {
+    pub async fn put(&self, key: &str, value: Vec<u8>, lease_id: Option<u64>) -> Result<()> {
         let full_key = format!("{}{}", self.prefix, key);
 
         // Update etcd first

--- a/lib/runtime/src/transports/etcd/lease.rs
+++ b/lib/runtime/src/transports/etcd/lease.rs
@@ -118,8 +118,5 @@ pub async fn keep_alive(
 
 /// Create a deadline for a given time-to-live (TTL).
 fn create_deadline(ttl: u64) -> Result<std::time::Instant> {
-    if ttl <= 0 {
-        return Err(error!("invalid ttl: {}", ttl));
-    }
     Ok(std::time::Instant::now() + std::time::Duration::from_secs(ttl))
 }

--- a/lib/runtime/src/transports/etcd/lease.rs
+++ b/lib/runtime/src/transports/etcd/lease.rs
@@ -6,13 +6,13 @@ use super::*;
 /// Create a [`Lease`] with a given time-to-live (TTL) attached to the [`CancellationToken`].
 pub async fn create_lease(
     mut lease_client: LeaseClient,
-    ttl: i64,
+    ttl: u64,
     token: CancellationToken,
 ) -> Result<Lease> {
-    let lease = lease_client.grant(ttl, None).await?;
+    let lease = lease_client.grant(ttl as i64, None).await?;
 
-    let id = lease.id();
-    let ttl = lease.ttl();
+    let id = lease.id() as u64;
+    let ttl = lease.ttl() as u64;
     let child = token.child_token();
     let clone = token.clone();
 
@@ -36,8 +36,8 @@ pub async fn create_lease(
 }
 
 /// Revoke a lease given its lease id. A wrapper over etcd_client::LeaseClient::revoke
-pub async fn revoke_lease(mut lease_client: LeaseClient, lease_id: i64) -> Result<()> {
-    match lease_client.revoke(lease_id).await {
+pub async fn revoke_lease(mut lease_client: LeaseClient, lease_id: u64) -> Result<()> {
+    match lease_client.revoke(lease_id as i64).await {
         Ok(_) => Ok(()),
         Err(e) => {
             tracing::warn!("failed to revoke lease: {:?}", e);
@@ -52,15 +52,15 @@ pub async fn revoke_lease(mut lease_client: LeaseClient, lease_id: i64) -> Resul
 /// If
 pub async fn keep_alive(
     client: LeaseClient,
-    lease_id: i64,
-    ttl: i64,
+    lease_id: u64,
+    ttl: u64,
     token: CancellationToken,
 ) -> Result<()> {
     let mut ttl = ttl;
     let mut deadline = create_deadline(ttl)?;
 
     let mut client = client;
-    let (mut heartbeat_sender, mut heartbeat_receiver) = client.keep_alive(lease_id).await?;
+    let (mut heartbeat_sender, mut heartbeat_receiver) = client.keep_alive(lease_id as i64).await?;
 
     loop {
         // if the deadline is exceeded, then we have failed to issue a heartbeat in time
@@ -79,7 +79,7 @@ pub async fn keep_alive(
                     tracing::trace!(lease_id, "keep alive response received: {:?}", resp);
 
                     // update ttl and deadline
-                    ttl = resp.ttl();
+                    ttl = resp.ttl() as u64;
                     deadline = create_deadline(ttl)?;
 
                     if resp.ttl() == 0 {
@@ -91,11 +91,11 @@ pub async fn keep_alive(
 
             _ = token.cancelled() => {
                 tracing::trace!(lease_id, "cancellation token triggered; revoking lease");
-                let _ = client.revoke(lease_id).await?;
+                let _ = client.revoke(lease_id as i64).await?;
                 return Ok(());
             }
 
-            _ = tokio::time::sleep(tokio::time::Duration::from_secs(ttl as u64 / 2)) => {
+            _ = tokio::time::sleep(tokio::time::Duration::from_secs(ttl / 2)) => {
                 tracing::trace!(lease_id, "sending keep alive");
 
                 // if we get a error issuing the heartbeat, set the ttl to 0
@@ -117,9 +117,9 @@ pub async fn keep_alive(
 }
 
 /// Create a deadline for a given time-to-live (TTL).
-fn create_deadline(ttl: i64) -> Result<std::time::Instant> {
+fn create_deadline(ttl: u64) -> Result<std::time::Instant> {
     if ttl <= 0 {
         return Err(error!("invalid ttl: {}", ttl));
     }
-    Ok(std::time::Instant::now() + std::time::Duration::from_secs(ttl as u64))
+    Ok(std::time::Instant::now() + std::time::Duration::from_secs(ttl))
 }

--- a/lib/runtime/src/transports/etcd/lock.rs
+++ b/lib/runtime/src/transports/etcd/lock.rs
@@ -112,7 +112,7 @@ impl DistributedRWLock {
     ) -> Option<WriteLockGuard<'a>> {
         let write_key = format!("v1/{}/writer", self.lock_prefix);
         let lease_id = etcd_client.lease_id();
-        let put_options = PutOptions::new().with_lease(lease_id);
+        let put_options = PutOptions::new().with_lease(lease_id as i64);
 
         // Step 1: Atomically create write lock only if it doesn't exist
         let txn = Txn::new()
@@ -204,7 +204,7 @@ impl DistributedRWLock {
 
             // Try to atomically acquire read lock
             // The transaction checks that no writer exists and creates reader key atomically
-            let put_options = PutOptions::new().with_lease(lease_id);
+            let put_options = PutOptions::new().with_lease(lease_id as i64);
 
             // Build atomic transaction: create reader key only if write_key doesn't exist
             let txn = Txn::new()

--- a/lib/runtime/src/utils/leader_worker_barrier.rs
+++ b/lib/runtime/src/utils/leader_worker_barrier.rs
@@ -85,7 +85,7 @@ async fn create_barrier_key<T: Serialize>(
     client: &Client,
     key: &str,
     data: T,
-    lease_id: Option<i64>,
+    lease_id: Option<u64>,
 ) -> Result<(), LeaderWorkerBarrierError> {
     let serialized_data =
         serde_json::to_vec(&data).map_err(LeaderWorkerBarrierError::SerdeError)?;
@@ -178,7 +178,7 @@ impl<LeaderData: Serialize + DeserializeOwned, WorkerData: Serialize + Deseriali
         &self,
         client: &Client,
         data: &LeaderData,
-        lease_id: i64,
+        lease_id: u64,
     ) -> Result<(), LeaderWorkerBarrierError> {
         let key = barrier_key(&self.barrier_id, BARRIER_DATA);
         create_barrier_key(client, &key, data, Some(lease_id)).await
@@ -197,7 +197,7 @@ impl<LeaderData: Serialize + DeserializeOwned, WorkerData: Serialize + Deseriali
         &self,
         client: &Client,
         worker_result: &Result<HashMap<String, WorkerData>, LeaderWorkerBarrierError>,
-        lease_id: i64,
+        lease_id: u64,
     ) -> Result<(), LeaderWorkerBarrierError> {
         if let Ok(worker_result) = worker_result {
             let key = barrier_key(&self.barrier_id, BARRIER_COMPLETE);
@@ -284,7 +284,7 @@ impl<LeaderData: Serialize + DeserializeOwned, WorkerData: Serialize + Deseriali
         &self,
         client: &Client,
         data: &WorkerData,
-        lease_id: i64,
+        lease_id: u64,
     ) -> Result<String, LeaderWorkerBarrierError> {
         let key = barrier_key(
             &self.barrier_id,

--- a/lib/runtime/src/utils/leader_worker_barrier.rs
+++ b/lib/runtime/src/utils/leader_worker_barrier.rs
@@ -151,7 +151,7 @@ impl<LeaderData: Serialize + DeserializeOwned, WorkerData: Serialize + Deseriali
         data: &LeaderData,
     ) -> anyhow::Result<HashMap<String, WorkerData>, LeaderWorkerBarrierError> {
         let etcd_client = rt
-            .etcd_client()
+            .deprecated_etcd_client()
             .ok_or(LeaderWorkerBarrierError::EtcdClientNotFound)?;
 
         let lease_id = etcd_client.lease_id();
@@ -245,7 +245,7 @@ impl<LeaderData: Serialize + DeserializeOwned, WorkerData: Serialize + Deseriali
         data: &WorkerData,
     ) -> anyhow::Result<LeaderData, LeaderWorkerBarrierError> {
         let etcd_client = rt
-            .etcd_client()
+            .deprecated_etcd_client()
             .ok_or(LeaderWorkerBarrierError::EtcdClientNotFound)?;
 
         let lease_id = etcd_client.lease_id();

--- a/lib/runtime/src/utils/typed_prefix_watcher.rs
+++ b/lib/runtime/src/utils/typed_prefix_watcher.rs
@@ -208,8 +208,8 @@ pub mod key_extractors {
     use etcd_client::KeyValue;
 
     /// Extract the lease ID as the key
-    pub fn lease_id(kv: &KeyValue) -> Option<i64> {
-        Some(kv.lease())
+    pub fn lease_id(kv: &KeyValue) -> Option<u64> {
+        Some(kv.lease() as u64)
     }
 
     /// Extract the key as a string (without prefix)


### PR DESCRIPTION
Gradually move etcd behind an interface.

This PR includes three things:
- Rework the KeyValueStoreManager object and traits so the KeyValueStore has an associated Bucket trait, which models the data better.
- Use that KeyValueStoreManager in more places. There will be several more PRs to keep doing this gradually.
- Normalize the etcd lease, worker id and instance ids to u64. They can never be negative.
 
Places I can't update (KVBM / block-manager) switch to using `deprecated_etcd_client`, and will be fix by relevant team later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal storage abstraction to support multiple backend types flexibly.
  * Enhanced watch operations with cancellation support for improved resource management and graceful shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->