### PR TITLE
ci: Try using docker driver instead of docker-container

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -61,8 +61,7 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
       with:
-        # This is not # of CPUs, this is CPU priority, 1024 is the default
-        driver-opts: 'cpu-shares=100'
+        driver: docker
     - name: Install awscli
       shell: bash
       run: |


### PR DESCRIPTION
#### Overview:

Uses the driver `docker` for buildx instead of the default `docker-container`. This simplifies the infrastructure as `docker-container` will run the build inside a container, resulting in a `docker-in-docker` setup which unnecessarily complicates the environment.

`docker` is sufficient, as the main boon of `docker-container` is cross-platform builds. Since we are building containers on their native architectures, we do not need this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration in the CI/CD pipeline to optimize driver selection for improved build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->