### PR TITLE
docs: Add version 0.6.0 to versions1.json (#3795)

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -5,6 +5,10 @@
         "url": "https://docs.nvidia.com/dynamo/latest/"
     },
     {
+        "version": "0.6.0",
+        "url": "https://docs.nvidia.com/dynamo/archive/0.6.0/"
+    },
+    {
         "version": "0.5.1",
         "url": "https://docs.nvidia.com/dynamo/archive/0.5.1/"
     },


### PR DESCRIPTION
# docs: Add version 0.6.0 to versions1.json

## Overview
Cherry-picking PR #3795 from main to release/0.6.0. This adds version 0.6.0 to the version picker configuration, which is needed for the new version picker in the Dynamo User Guide.

## Details
This is a cherry-pick of the merge commit `8ad3b9a` from PR #3795 which was merged to main on October 21, 2025.

**Original PR:** https://github.com/ai-dynamo/dynamo/pull/3795  
**Change:** One-line addition to `docs/versions1.json` to add version 0.6.0 entry

## Where should the reviewer start?
`docs/versions1.json`

## Related Issues
N/A - Required for 0.6.0 release documentation

## Type
**docs** (documentation change)

---

### Cherry Pick Process Notes
- ✅ Original PR merged to main: https://github.com/ai-dynamo/dynamo/pull/3795
- ✅ Cherry-picked with DCO sign-off: `git cherry-pick --signoff 8ad3b9a`
- ✅ Branch pushed: `dagil/cherrypick-pr3795-versions-json`
- 📋 Next: Open PR to `release/0.6.0` and update Cherry Pick table in #swdl-dynamo-release

