### PR TITLE
feat: b64 encoding for nixl_connect metadata

### DIFF
--- a/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
+++ b/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
@@ -1186,7 +1186,7 @@ class PassiveOperation(AbstractOperation):
                 case _:
                     return
 
-    def metadata(self) -> RdmaMetadata:
+    def metadata(self, hex_encode: bool = False) -> RdmaMetadata:
         """
         Gets the request descriptor for the operation.
         """
@@ -1210,9 +1210,14 @@ class PassiveOperation(AbstractOperation):
                     f"dynamo.nixl_connect.{self.__class__.__name__}: Compressed NIXL metadata is larger than original ({compressed_len} > {original_len})."
                 )
 
+            if not hex_encode:
+                encoded_metadata = base64.b64encode(nixl_metadata).decode("utf-8")
+                encoded_metadata = "b64:" + encoded_metadata
+            else:
+                encoded_metadata = nixl_metadata.hex()
             self._serialized_request = RdmaMetadata(
                 descriptors=descriptors,
-                nixl_metadata=base64.b64encode(nixl_metadata).decode("utf-8"),
+                nixl_metadata=encoded_metadata,
                 notification_key=self._notification_key,
                 operation_kind=int(self._operation_kind),
             )
@@ -1475,8 +1480,12 @@ class Remote:
         # via a `RdmaMetadata` object and therefore can assumed be a b64-encoded, compressed
         # representation of the NIXL metadata.
         if isinstance(nixl_metadata, str):
-            # Decode the b64-encoded string into bytes.
-            nixl_metadata = base64.b64decode(nixl_metadata)
+            if nixl_metadata.startswith("b64:"):
+                # Decode the b64-encoded string into bytes.
+                nixl_metadata = base64.b64decode(nixl_metadata.lstrip("b64:"))
+            else:
+                # fallback for earlier versions of nixl connect
+                nixl_metadata = bytes.fromhex(nixl_metadata)
             # Decompress the NIXL metadata.
             nixl_metadata = zlib.decompress(nixl_metadata)
 

--- a/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
+++ b/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import socket
 import uuid
@@ -1211,7 +1212,7 @@ class PassiveOperation(AbstractOperation):
 
             self._serialized_request = RdmaMetadata(
                 descriptors=descriptors,
-                nixl_metadata=nixl_metadata.hex(),
+                nixl_metadata=base64.b64encode(nixl_metadata).decode("utf-8"),
                 notification_key=self._notification_key,
                 operation_kind=int(self._operation_kind),
             )
@@ -1471,11 +1472,11 @@ class Remote:
         self._connector = connector
 
         # When `nixl_metadata` is a string, it is assumed to have come from a remote worker
-        # via a `RdmaMetadata` object and therefore can assumed be a hex-encoded, compressed
+        # via a `RdmaMetadata` object and therefore can assumed be a b64-encoded, compressed
         # representation of the NIXL metadata.
         if isinstance(nixl_metadata, str):
-            # Decode the hex-encoded string into bytes.
-            nixl_metadata = bytes.fromhex(nixl_metadata)
+            # Decode the b64-encoded string into bytes.
+            nixl_metadata = base64.b64decode(nixl_metadata)
             # Decompress the NIXL metadata.
             nixl_metadata = zlib.decompress(nixl_metadata)
 


### PR DESCRIPTION
#### Overview:

Changes the encoding of the compressed NIXL agent metadata


#### Details:

`hex` encoding has an overhead of 100%, doubling the size of the actual data. This means that if the zlib compression ratio is less than 2x (which it seems to be in many cases), then the metadata send over the network after compression+encoding is even larger than the original metadata size.

Base64 has a 33% overhead and mitigates this while keeping the payload JSON-safe. Base85 could be another option with 25% overhead but I feel like base64 has more support for external integration and compatibility.

Example:

```
NIXL raw metadata: 670 bytes
After zlib:  366 bytes

Main: After hex: 732 bytes
This MR: After b64: 488 bytes
```

@whoisj 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data encoding mechanism for improved compatibility and transport efficiency. No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->