### PR TITLE
test: fix KV Router and KVBM tests in CI

### DIFF
--- a/tests/kvbm/test_determinism_disagg.py
+++ b/tests/kvbm/test_determinism_disagg.py
@@ -223,8 +223,10 @@ class LLMServerManager:
         )
         print(f"Decoder process started with PID: {self.process_decoder.pid}")
 
-        # Give decoder time to start up
-        time.sleep(5)
+        # The prefiller and decoder cannot download the model simultaneously,
+        # because the Hugging Face rust library (invoked by fetch_llm) needs to hold an exclusive lock on the model files.
+        print("Sleeping for 60 seconds to allow the decoder to download the model. ")
+        time.sleep(60)
 
         # Launch prefiller
         self.process_prefiller = subprocess.Popen(

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -71,7 +71,7 @@ sglang_configs = {
         request_payloads=[
             chat_payload_default(
                 expected_log=[
-                    r"ZMQ listener .* received batch with \d+ events \(seq=\d+\)",
+                    r"ZMQ listener .* received batch with \d+ events \(seq=\d+(?:, [^)]*)?\)",
                     r"Event processor for worker_id \d+ processing event: Stored\(",
                     r"Selected worker: worker_id=\d+ dp_rank=.*?, logit: ",
                 ]

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -51,7 +51,7 @@ vllm_configs = {
         request_payloads=[
             chat_payload_default(
                 expected_log=[
-                    r"ZMQ listener .* received batch with \d+ events \(seq=\d+\)",
+                    r"ZMQ listener .* received batch with \d+ events \(seq=\d+(?:, [^)]*)?\)",
                     r"Event processor for worker_id \d+ processing event: Stored\(",
                     r"Selected worker: worker_id=\d+ dp_rank=.*?, logit: ",
                 ]


### PR DESCRIPTION
#### Overview:

Fix two kv router tests and one KVBM disagg test

#### Details:

1. kv router tests:
The log of the event listener has been updated to
```
"ZMQ listener on {} received batch with {} events (seq={}, dp_rank={})",
```
we need to update the regex to include the "dp_rank" field

2. KVBM disagg test

The prefiller and decoder will start at the same time in the same OS and they will download the same model, which will cause a race condition to get the lock on the file.
```
Exception: Failed to download file 'model-00001-of-000002.safetensors' from model 'deepseek-ai/DeepSeek-R1-Distill-Llama-8B': Lock acquisition failed: /root/.cache/huggingface/hub/models--deepseek-ai--DeepSeek-R1-Distill-Llama-8B/blobs/7e6b24744354ef4ba547547cc758339090f46ba2da917845cfc69f7d4ded9edb.lock
```
Adding a time.sleep after decoder started, to give decoder some time to download the file alone. 

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted system startup timing verification tests to properly account for sequential model loading constraints that occur during the initialization process
  * Extended system initialization timeout thresholds to accommodate longer startup duration sequences across all service components
  * Updated event log pattern validation assertions in service tests to flexibly support variable log formats that include optional additional event details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->