### PR TITLE
fix: include request_id and error details in completions stream failure message

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -422,7 +422,10 @@ async fn completions(
                     request_id,
                     e
                 );
-                ErrorMessage::internal_server_error("Failed to fold completions stream")
+                ErrorMessage::internal_server_error(&format!(
+                    "Failed to fold completions stream for {}: {:?}",
+                    request_id, e
+                ))
             })?;
 
         inflight_guard.mark_ok();


### PR DESCRIPTION
#### Overview:

Ad titled; Follow the same practice as chat endpoint
#### Details:
Before
`{"message":"Failed to fold completions stream","type":"Internal Server Error","code":500}`

After

`{"message":"Failed to fold completions stream for 6edcf4b3-07a6-4d37-99dc-4028cd098a2b: a python exception was caught while processing the async generator: ValueError: n must be 1 when using greedy sampling, got 2.","type":"Internal Server Error","code":500}`

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages with request identifiers and detailed error context for improved troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->