### PR TITLE
fix: test case  test_endpoint_health_check_notifier_created

### DIFF
--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -554,6 +554,6 @@ mod integration_tests {
             .system_health
             .lock()
             .get_endpoint_health_status(endpoint);
-        assert_eq!(status, Some(HealthStatus::Ready));
+        assert_eq!(status, Some(HealthStatus::NotReady));
     }
 }


### PR DESCRIPTION


#### Overview:

Inital status is NotReady. See RuntimeConfig.starting_health_status

#### Details:

Inital status is NotReady. See RuntimeConfig.starting_health_status

#### Where should the reviewer start?

lib/runtime/src/health_check.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-891


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated health status check assertions to accurately reflect endpoint health state after notifier creation, ensuring correct expected behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->