### PR TITLE
chore: don't error on failure to download snapshot

### DIFF
--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -228,7 +228,7 @@ pub async fn start_kv_router_background(
                 }
                 Err(e) => {
                     tracing::info!(
-                        "Did not initialize radix state from NATS object store (likely no snapshots yet): {e:?}"
+                        "Failed to download snapshots. This is normal for freshly started Router replicas."
                     );
                 }
             }

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -227,7 +227,7 @@ pub async fn start_kv_router_background(
                     tracing::info!("Successfully sent all initial events to indexer");
                 }
                 Err(_) => {
-                    tracing::info!(
+                    tracing::debug!(
                         "Failed to download snapshots. This is normal for freshly started Router replicas."
                     );
                 }

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -226,7 +226,7 @@ pub async fn start_kv_router_background(
                     }
                     tracing::info!("Successfully sent all initial events to indexer");
                 }
-                Err(e) => {
+                Err(_) => {
                     tracing::info!(
                         "Failed to download snapshots. This is normal for freshly started Router replicas."
                     );


### PR DESCRIPTION
#### Overview:

Quick fix to improve logging. It is normal for a new router to fail downloading a snapshot. 
Will consider making error handling more robust in a future PR. This is fine for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved clarity of log messaging during router initialization to better indicate that initial snapshot download failures during fresh router startup is expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->