### PR TITLE
fix: add the proper flag for mooncake benchmarking on router

### DIFF
--- a/benchmarks/router/README.md
+++ b/benchmarks/router/README.md
@@ -184,7 +184,15 @@ python prefix_ratio_benchmark.py --output-dir results/experiment1
 
 ### Step 4 (Alternative): Run Benchmarks with Real Trace Data
 
-Instead of synthetic benchmarks with controlled prefix ratios, you can benchmark using real trace data in [mooncake-style format](https://github.com/kvcache-ai/Mooncake/blob/d21da178bae8db9651cf18a76824c084145fc725/mooncake_trace.jsonl). This approach uses actual request patterns from production traces, potentially modified with synthesis parameters.
+Instead of synthetic benchmarks with controlled prefix ratios, you can benchmark using real trace data. This approach uses actual request patterns from production traces, potentially modified with synthesis parameters.
+
+First, download the mooncake trace dataset:
+
+```bash
+wget https://raw.githubusercontent.com/kvcache-ai/Mooncake/d21da178bae8db9651cf18a76824c084145fc725/mooncake_trace.jsonl
+```
+
+Then run the benchmark:
 
 ```bash
 python real_data_benchmark.py --input-dataset mooncake_trace.jsonl

--- a/benchmarks/router/real_data_benchmark.py
+++ b/benchmarks/router/real_data_benchmark.py
@@ -48,6 +48,8 @@ def get_aiperf_cmd_for_trace(
         url,
         "--input-file",
         f"{input_dataset}",
+        "--custom-dataset-type",
+        "mooncake_trace",
         "--fixed-schedule-auto-offset",
         "--random-seed",
         str(seed),


### PR DESCRIPTION
#### Overview:

`--custom-dataset-type mooncake_trace` to the aiperf CLI arg
