### PR TITLE
fix: ignore stop key in vllm sampling params

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -44,6 +44,9 @@ def build_sampling_params(
     # Apply stop_conditions
     for key, value in request["stop_conditions"].items():
         if value is not None and hasattr(sampling_params, key):
+            # Do not add stop key to sampling params - dynamo handles stop conditions directly
+            if key == "stop":
+                continue
             setattr(sampling_params, key, value)
 
     return sampling_params


### PR DESCRIPTION
#### Overview:

When using the stop parameter with the vLLM backend the following errror occurs

```
curl http://localhost:8989/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\": \"$MODEL\", \"messages\": [{\"role\": \"user\", \"content\": \"You are helpful\"}], \"max_tokens\": "1000",\"stop\": \"ok\"}"

{"message":"Failed to fold chat completions stream: a python exception was caught while processing the async generator: ValueError: stop strings are only supported when detokenize is True. Set detokenize=True to use stop.","type":"Internal Server Error","code":500}
```

Dynamo handles stop conditions in [/lib/llm/src/backend.rs (line 165)](https://github.com/ai-dynamo/dynamo/blob/main/lib/llm/src/backend.rs#L165)

With the fix in this PR applied

```
(venv) ubuntu@inst-sdvtf-infe-labs-h100:~/dynamo$ curl http://localhost:8989/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
    "messages": [
      {"role": "user", "content": "Count from 1 to 10"}
    ],
    "max_tokens": 100,
    "stop": "5"        
  }'
{"id":"chatcmpl-1ddde63f-1471-48b6-aab1-87e6d17de71a","choices":[{"index":0,"message":{"content":"1,2,3,4,","role":"assistant","reasoning_content":null},"finish_reason":"stop"}],"created":1761325343,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct","object":"chat.completion","usage":null}(venv) ubuntu@inst-sdvtf-infe-labs-h100:~/dynamo$ 
```

#### Details:

Update the vLLM dynamo worker logic to ignore the stop parameter.

#### Where should the reviewer start?


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #3877 