### PR TITLE
fix: default when tools missing and minijinja length handling

### DIFF
--- a/lib/llm/src/preprocessor/prompt/template/formatters.rs
+++ b/lib/llm/src/preprocessor/prompt/template/formatters.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use super::tokcfg::{ChatTemplate, raise_exception, strftime_now, tojson};
 use super::{ContextMixins, HfTokenizerConfigJsonFormatter, JinjaEnvironment};
 use either::Either;
-use minijinja::Environment;
+use minijinja::{Environment, Value};
 use tracing;
 
 impl JinjaEnvironment {
@@ -33,6 +33,14 @@ impl HfTokenizerConfigJsonFormatter {
         let chat_template = config.chat_template.as_ref().ok_or(anyhow::anyhow!(
             "chat_template field is required in the tokenizer_config.json file"
         ))?;
+
+        env.add_filter("length", |value: Value| -> usize {
+            use minijinja::value::ValueKind;
+            match value.kind() {
+                ValueKind::Undefined | ValueKind::None => 0,
+                _ => value.len().unwrap_or(0),
+            }
+        });
 
         // add pycompat
         // todo: should we use this: minijinja_contrib::add_to_environment(&mut env);

--- a/lib/llm/src/preprocessor/prompt/template/formatters.rs
+++ b/lib/llm/src/preprocessor/prompt/template/formatters.rs
@@ -34,6 +34,9 @@ impl HfTokenizerConfigJsonFormatter {
             "chat_template field is required in the tokenizer_config.json file"
         ))?;
 
+        // Safely handle chat templates that check the length of arguments like `tools` even
+        // when `tools=None` when rendered through minijinja. For example:
+        // https://github.com/vllm-project/vllm/blob/d95d0f4b985f28ea381e301490f9d479b34d8980/examples/tool_chat_template_hermes.jinja#L36
         env.add_filter("length", |value: Value| -> usize {
             use minijinja::value::ValueKind;
             match value.kind() {

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -145,11 +145,10 @@ impl OAIChatLikeRequest for NvCreateChatCompletionRequest {
 
     fn tools(&self) -> Option<Value> {
         if self.inner.tools.is_none() {
-            // ISSUE: {%- if tools is iterable and tools | length > 0 %}
-            // For cases like above, minijinja will not error out in calculating the length of tools
-            // as it evaluates both the sides an don't do short circuiting.
-            // Safe to return an empty array here. This will work even if tools are not present as length = 0
-            Some(Value::from_serialize(Vec::<serde_json::Value>::new()))
+            // Should return None instead of empty array
+            // All templates should check for tools being defined but some do not check for length
+            // This results in tool calling behavior when it shouldn't
+            None
         } else {
             // Try to fix the tool schema if it is missing type and properties
             Some(may_be_fix_tool_schema(

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -603,9 +603,9 @@ No tools
 "#;
 
         // Because we return None for tools when there are no tools this scenario should also be evaluate to false
-        // This is similar to the default jinja template behavior seen with llama models
+        // This is similar to the default jinja template behavior seen with llama models which check if tools is not none to activate tool mode
         let no_tool_template = r#"
-{%- if tools %}
+{%- if tools is not none %}
 TOOL MODE
 {%- else %}
 NORMAL MODE
@@ -648,36 +648,7 @@ NORMAL MODE
             "Jinja template with if defined conditional should handle None: {:?}",
             result2
         );
-        assert!(
-            result2.unwrap().contains("TOOL MODE"),
-            "None in context is 'defined', so production uses template selection to avoid this"
-        );
-    }
-
-    #[test]
-    fn test_llama_template_no_tools_no_tool_calling() {
-        // Llama model default templates do not actiavte tool calling when tools is None
-        let template_str = r#"
-{%- if tools is defined %}
-TOOL MODE
-{%- else %}
-NORMAL MODE
-{%- endif %}
-"#;
-
-        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
-            "chat_template": template_str
-        }))
-        .unwrap();
-
-        let formatter =
-            HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
-
-        // Without tools in context, should be NORMAL MODE
-        let ctx = context! {};
-        let result = formatter.env.get_template("default").unwrap().render(&ctx);
-        assert!(result.is_ok());
-        assert!(result.unwrap().contains("NORMAL MODE"));
+        assert!(result2.unwrap().contains("NORMAL MODE"));
     }
 
     /// Tests mixed content type scenarios.

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -617,27 +617,45 @@ NORMAL MODE
                 {"safe_length": length_template},
                 {"no_tool": no_tool_template}
             ]
-        })).unwrap();
+        }))
+        .unwrap();
 
-        let formatter = HfTokenizerConfigJsonFormatter::new(
-            chat_template,
-            ContextMixins::new(&[])
-        ).unwrap();
+        let formatter =
+            HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
 
         let ctx = context! { tools => Option::<Value>::None };
 
-        let result1 = formatter.env.get_template("safe_length").unwrap().render(&ctx);
+        let result1 = formatter
+            .env
+            .get_template("safe_length")
+            .unwrap()
+            .render(&ctx);
         println!("Safe length template with no tools => None: {:?}", result1);
-        assert!(result1.is_ok(), "Jinja template with and conditional and length filter should handle None: {:?}", result1);
-        assert!(result1.unwrap().contains("No tools"), "Should show 'No tools'");
+        assert!(
+            result1.is_ok(),
+            "Jinja template with and conditional and length filter should handle None: {:?}",
+            result1
+        );
+        assert!(
+            result1.unwrap().contains("No tools"),
+            "Should show 'No tools'"
+        );
 
         let result2 = formatter.env.get_template("no_tool").unwrap().render(&ctx);
         println!("Default template with no tools => None: {:?}", result2);
-        assert!(result2.is_ok(), "Jinja template with if defined conditional should handle None: {:?}", result2);
+        assert!(
+            result2.is_ok(),
+            "Jinja template with if defined conditional should handle None: {:?}",
+            result2
+        );
+        assert!(
+            result2.unwrap().contains("TOOL MODE"),
+            "None in context is 'defined', so production uses template selection to avoid this"
+        );
     }
 
-#[test]
-fn test_llama_template_no_tools_no_tool_calling() {
+    #[test]
+    fn test_llama_template_no_tools_no_tool_calling() {
         // Llama 3.1 activates tool calling when tools is defined
         let template_str = r#"
 {%- if tools is defined %}
@@ -649,19 +667,18 @@ NORMAL MODE
 
         let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
             "chat_template": template_str
-        })).unwrap();
+        }))
+        .unwrap();
 
-        let formatter = HfTokenizerConfigJsonFormatter::new(
-            chat_template,
-            ContextMixins::new(&[])
-        ).unwrap();
+        let formatter =
+            HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
 
         // Without tools in context, should be NORMAL MODE
         let ctx = context! {};
         let result = formatter.env.get_template("default").unwrap().render(&ctx);
         assert!(result.is_ok());
         assert!(result.unwrap().contains("NORMAL MODE"));
-}
+    }
 
     /// Tests mixed content type scenarios.
     #[test]

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -645,7 +645,7 @@ NORMAL MODE
         println!("Default template with no tools => None: {:?}", result2);
         assert!(
             result2.is_ok(),
-            "Jinja template with if defined conditional should handle None: {:?}",
+            "Jinja template with if tools is not none conditional should handle None: {:?}",
             result2
         );
         assert!(result2.unwrap().contains("NORMAL MODE"));

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -656,7 +656,7 @@ NORMAL MODE
 
     #[test]
     fn test_llama_template_no_tools_no_tool_calling() {
-        // Llama 3.1 activates tool calling when tools is defined
+        // Llama model default templates do not actiavte tool calling when tools is None
         let template_str = r#"
 {%- if tools is defined %}
 TOOL MODE


### PR DESCRIPTION
#### Overview:

Currently in `lib/llm/src/preprocessor/prompt/template/oai.rs` empty arrays being passed to the template when no tools are provided causes tool calling behavior by default for Llama 3.1 8b (and possibly other llama models).

This was actually an intentional change to fix an issue found in minijinja and conditional handling: see [3340](https://github.com/ai-dynamo/dynamo/pull/3340) for details

This PR preserves safe behavior for minijinja conditional handling by adding a custom `length` filter that handles `None` values. By returning `None` as default we also satisfy conditions in the default Llama 3.1 jinja templates that cause tool calling to remain inactive.

Before fix applied

```
curl http://localhost:8989/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
    "messages": [
      {"role": "user", "content": "Tell me a story"}
    ],
    "max_tokens": 1000
  }'
```
**Observe:** tool calling behavior but no tools given

```
  {
  "id": "chatcmpl-28be38df-f9c7-48a5-a1cb-35e299be84ed",
  "choices": [{
    "index": 0,
    "message": {
      "content": "{\"name\": \"generate_story\", \"parameters\": {\"length\":100, \"genre\": \"fantasy\"}}",
      "role": "assistant"
    },
    "finish_reason": "stop"
  }],
  "created": 1761323480,
  "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
  "object": "chat.completion"
}
```
After fix:

```
ubuntu@lab:~/dynamo$ curl http://localhost:8989/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
    "messages": [
      {"role": "user", "content": "Tell me a story"}
    ],
    "max_tokens": 10
  }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   483  100   325  100   158   3559   1730 --:--:-- --:--:-- --:--:--  5307
{
  "id": "chatcmpl-8900f7cc-51de-484a-8053-f7e5ecdff28b",
  "choices": [
    {
      "index": 0,
      "message": {
        "content": "Once upon a time, in a small village nestled",
        "role": "assistant",
        "reasoning_content": null
      },
      "finish_reason": "length"
    }
  ],
  "created": 1761326745,
  "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
  "object": "chat.completion",
  "usage": null
}
```

Default Llama 3.1 8B jinja template: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/blob/main/tokenizer_config.json#L2053

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
