### PR TITLE
chore(discovery): Use Store interface instead of etcd

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -105,6 +105,28 @@ impl ModelWatcher {
         while let Some(event) = events_rx.recv().await {
             match event {
                 WatchEvent::Put(kv) => {
+                    let key = kv.key_str();
+                    let endpoint_id = match key_extract(key) {
+                        Ok((eid, _)) => eid,
+                        Err(err) => {
+                            tracing::error!(%key, %err, "Failed extracting EndpointId from key. Ignoring instance.");
+                            continue;
+                        }
+                    };
+
+                    // Filter by namespace if target_namespace is specified
+                    if !global_namespace
+                        && let Some(target_ns) = target_namespace
+                        && endpoint_id.namespace != target_ns
+                    {
+                        tracing::debug!(
+                            model_namespace = endpoint_id.namespace,
+                            target_namespace = target_ns,
+                            "Skipping model from different namespace"
+                        );
+                        continue;
+                    }
+
                     let mut card = match serde_json::from_slice::<ModelDeploymentCard>(kv.value()) {
                         Ok(card) => card,
                         Err(err) => {
@@ -119,28 +141,6 @@ impl ModelWatcher {
                             continue;
                         }
                     };
-                    let key = kv.key_str();
-                    let endpoint_id = match etcd_key_extract(key) {
-                        Ok((eid, _)) => eid,
-                        Err(err) => {
-                            tracing::error!(%key, model_name = card.name(), %err, "Failed extracting EndpointId from key. Ignoring instance.");
-                            continue;
-                        }
-                    };
-
-                    // Filter by namespace if target_namespace is specified
-                    if !global_namespace
-                        && let Some(target_ns) = target_namespace
-                        && endpoint_id.namespace != target_ns
-                    {
-                        tracing::debug!(
-                            model_namespace = endpoint_id.namespace,
-                            target_namespace = target_ns,
-                            model_name = card.name(),
-                            "Skipping model from different namespace"
-                        );
-                        continue;
-                    }
 
                     // If we already have a worker for this model, and the ModelDeploymentCard
                     // cards don't match, alert, and don't add the new instance
@@ -295,7 +295,7 @@ impl ModelWatcher {
         Ok(Some(model_name))
     }
 
-    // Handles a PUT event from etcd, this usually means adding a new model to the list of served
+    // Handles a PUT event from store, this usually means adding a new model to the list of served
     // models.
     async fn handle_put(
         &self,
@@ -560,8 +560,6 @@ impl ModelWatcher {
     /// All the registered ModelDeploymentCard with the EndpointId they are attached to, one per instance
     async fn all_cards(&self) -> anyhow::Result<Vec<(EndpointId, ModelDeploymentCard)>> {
         let store = self.drt.store();
-
-        //let kvs = etcd_client.kv_get_prefix(model_card::ROOT_PATH).await?;
         let Some(card_bucket) = store.get_bucket(model_card::ROOT_PATH).await? else {
             // no cards
             return Ok(vec![]);
@@ -573,11 +571,11 @@ impl ModelWatcher {
             let r = match serde_json::from_slice::<ModelDeploymentCard>(&card_bytes) {
                 Ok(card) => {
                     let maybe_endpoint_id =
-                        etcd_key_extract(&key).map(|(endpoint_id, _instance_id)| endpoint_id);
+                        key_extract(&key).map(|(endpoint_id, _instance_id)| endpoint_id);
                     let endpoint_id = match maybe_endpoint_id {
                         Ok(eid) => eid,
                         Err(err) => {
-                            tracing::error!(%err, "Skipping invalid etcd key, not string or not EndpointId");
+                            tracing::error!(%err, "Skipping invalid key, not string or not EndpointId");
                             continue;
                         }
                     };
@@ -614,9 +612,9 @@ impl ModelWatcher {
     }
 }
 
-/// The ModelDeploymentCard is published in etcd with a key like "v1/mdc/dynamo/backend/generate/694d9981145a61ad".
+/// The ModelDeploymentCard is published in store with a key like "v1/mdc/dynamo/backend/generate/694d9981145a61ad".
 /// Extract the EndpointId and instance_id from that.
-fn etcd_key_extract(s: &str) -> anyhow::Result<(EndpointId, String)> {
+fn key_extract(s: &str) -> anyhow::Result<(EndpointId, String)> {
     if !s.starts_with(model_card::ROOT_PATH) {
         anyhow::bail!("Invalid format: expected model card ROOT_PATH segment in {s}");
     }
@@ -640,12 +638,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_etcd_key_extract() {
+    fn test_key_extract() {
         let input = format!(
             "{}/dynamo/backend/generate/694d9981145a61ad",
             model_card::ROOT_PATH
         );
-        let (endpoint_id, _) = etcd_key_extract(&input).unwrap();
+        let (endpoint_id, _) = key_extract(&input).unwrap();
         assert_eq!(endpoint_id.namespace, "dynamo");
         assert_eq!(endpoint_id.component, "backend");
         assert_eq!(endpoint_id.name, "generate");

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -83,7 +83,6 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
                 distributed_runtime,
                 http_service.state().manager_clone(),
                 store,
-                model_card::ROOT_PATH,
                 router_config.router_mode,
                 Some(router_config.kv_router_config),
                 router_config.busy_threshold,
@@ -268,14 +267,13 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
     Ok(())
 }
 
-/// Spawns a task that watches for new models in etcd at network_prefix,
+/// Spawns a task that watches for new models in store,
 /// and registers them with the ModelManager so that the HTTP service can use them.
 #[allow(clippy::too_many_arguments)]
 async fn run_watcher(
     runtime: DistributedRuntime,
     model_manager: Arc<ModelManager>,
     store: Arc<KeyValueStoreManager>,
-    network_prefix: &str,
     router_mode: RouterMode,
     kv_router_config: Option<KvRouterConfig>,
     busy_threshold: Option<f64>,
@@ -291,7 +289,7 @@ async fn run_watcher(
         kv_router_config,
         busy_threshold,
     );
-    tracing::info!("Watching for remote model at {network_prefix}");
+    tracing::debug!("Waiting for remote model");
     let (_, receiver) = store.watch(model_card::ROOT_PATH, None, cancellation_token);
 
     // Create a channel to receive model type updates

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -17,7 +17,7 @@ use crate::{
         completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
     },
 };
-use dynamo_runtime::transports::etcd;
+use dynamo_runtime::storage::key_value_store::KeyValueStoreManager;
 use dynamo_runtime::{DistributedRuntime, Runtime};
 use dynamo_runtime::{distributed::DistributedConfig, pipeline::RouterMode};
 
@@ -64,40 +64,34 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
     let http_service = match engine_config {
         EngineConfig::Dynamic(_) => {
             let distributed_runtime = DistributedRuntime::from_settings(runtime.clone()).await?;
-            // This allows the /health endpoint to query etcd for active instances
+            // This allows the /health endpoint to query store for active instances
             http_service_builder = http_service_builder.store(distributed_runtime.store().clone());
             let http_service = http_service_builder.build()?;
-            let etcd_client = distributed_runtime.etcd_client();
-            match etcd_client {
-                Some(ref etcd_client) => {
-                    let router_config = engine_config.local_model().router_config();
-                    // Listen for models registering themselves in etcd, add them to HTTP service
-                    // Check if we should filter by namespace (based on the local model's namespace)
-                    // Get namespace from the model, fallback to endpoint_id namespace if not set
-                    let namespace = engine_config.local_model().namespace().unwrap_or("");
-                    let target_namespace = if is_global_namespace(namespace) {
-                        None
-                    } else {
-                        Some(namespace.to_string())
-                    };
-                    run_watcher(
-                        distributed_runtime,
-                        http_service.state().manager_clone(),
-                        etcd_client.clone(),
-                        model_card::ROOT_PATH,
-                        router_config.router_mode,
-                        Some(router_config.kv_router_config),
-                        router_config.busy_threshold,
-                        target_namespace,
-                        Arc::new(http_service.clone()),
-                        http_service.state().metrics_clone(),
-                    )
-                    .await?;
-                }
-                None => {
-                    // Static endpoints don't need discovery
-                }
-            }
+            let store = Arc::new(distributed_runtime.store().clone());
+
+            let router_config = engine_config.local_model().router_config();
+            // Listen for models registering themselves, add them to HTTP service
+            // Check if we should filter by namespace (based on the local model's namespace)
+            // Get namespace from the model, fallback to endpoint_id namespace if not set
+            let namespace = engine_config.local_model().namespace().unwrap_or("");
+            let target_namespace = if is_global_namespace(namespace) {
+                None
+            } else {
+                Some(namespace.to_string())
+            };
+            run_watcher(
+                distributed_runtime,
+                http_service.state().manager_clone(),
+                store,
+                model_card::ROOT_PATH,
+                router_config.router_mode,
+                Some(router_config.kv_router_config),
+                router_config.busy_threshold,
+                target_namespace,
+                Arc::new(http_service.clone()),
+                http_service.state().metrics_clone(),
+            )
+            .await?;
             http_service
         }
         EngineConfig::StaticRemote(local_model) => {
@@ -280,7 +274,7 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
 async fn run_watcher(
     runtime: DistributedRuntime,
     model_manager: Arc<ModelManager>,
-    etcd_client: etcd::Client,
+    store: Arc<KeyValueStoreManager>,
     network_prefix: &str,
     router_mode: RouterMode,
     kv_router_config: Option<KvRouterConfig>,
@@ -289,6 +283,7 @@ async fn run_watcher(
     http_service: Arc<HttpService>,
     metrics: Arc<crate::http::service::metrics::Metrics>,
 ) -> anyhow::Result<()> {
+    let cancellation_token = runtime.primary_token();
     let mut watch_obj = ModelWatcher::new(
         runtime,
         model_manager,
@@ -297,12 +292,10 @@ async fn run_watcher(
         busy_threshold,
     );
     tracing::info!("Watching for remote model at {network_prefix}");
-    let models_watcher = etcd_client.kv_get_and_watch_prefix(network_prefix).await?;
-    let (_prefix, _watcher, receiver) = models_watcher.dissolve();
+    let (_, receiver) = store.watch(model_card::ROOT_PATH, None, cancellation_token);
 
     // Create a channel to receive model type updates
     let (tx, mut rx) = tokio::sync::mpsc::channel(32);
-
     watch_obj.set_notify_on_model_update(tx);
 
     // Spawn a task to watch for model type changes and update HTTP service endpoints and metrics

--- a/lib/llm/src/grpc/service/kserve.rs
+++ b/lib/llm/src/grpc/service/kserve.rs
@@ -15,7 +15,6 @@ use crate::protocols::tensor::{NvCreateTensorRequest, NvCreateTensorResponse};
 use crate::request_template::RequestTemplate;
 use anyhow::Result;
 use derive_builder::Builder;
-use dynamo_runtime::transports::etcd;
 use futures::pin_mut;
 use tokio::task::JoinHandle;
 use tokio_stream::{Stream, StreamExt};
@@ -45,7 +44,6 @@ use inference::{
 pub struct State {
     metrics: Arc<Metrics>,
     manager: Arc<ModelManager>,
-    etcd_client: Option<etcd::Client>,
 }
 
 impl State {
@@ -53,15 +51,6 @@ impl State {
         Self {
             manager,
             metrics: Arc::new(Metrics::default()),
-            etcd_client: None,
-        }
-    }
-
-    pub fn new_with_etcd(manager: Arc<ModelManager>, etcd_client: etcd::Client) -> Self {
-        Self {
-            manager,
-            metrics: Arc::new(Metrics::default()),
-            etcd_client: Some(etcd_client),
         }
     }
 
@@ -76,10 +65,6 @@ impl State {
 
     pub fn manager_clone(&self) -> Arc<ModelManager> {
         self.manager.clone()
-    }
-
-    pub fn etcd_client(&self) -> Option<&etcd::Client> {
-        self.etcd_client.as_ref()
     }
 
     fn is_tensor_model(&self, model: &String) -> bool {
@@ -108,9 +93,6 @@ pub struct KserveServiceConfig {
 
     #[builder(default = "None")]
     request_template: Option<RequestTemplate>,
-
-    #[builder(default = "None")]
-    etcd_client: Option<etcd::Client>,
 }
 
 impl KserveService {
@@ -155,10 +137,7 @@ impl KserveServiceConfigBuilder {
         let config: KserveServiceConfig = self.build_internal()?;
 
         let model_manager = Arc::new(ModelManager::new());
-        let state = match config.etcd_client {
-            Some(etcd_client) => Arc::new(State::new_with_etcd(model_manager, etcd_client)),
-            None => Arc::new(State::new(model_manager)),
-        };
+        let state = Arc::new(State::new(model_manager));
 
         // enable prometheus metrics
         let registry = metrics::Registry::new();
@@ -174,11 +153,6 @@ impl KserveServiceConfigBuilder {
 
     pub fn with_request_template(mut self, request_template: Option<RequestTemplate>) -> Self {
         self.request_template = Some(request_template);
-        self
-    }
-
-    pub fn with_etcd_client(mut self, etcd_client: Option<etcd::Client>) -> Self {
-        self.etcd_client = Some(etcd_client);
         self
     }
 }


### PR DESCRIPTION
Discovery watcher now uses `KeyValueStoreManager` instead of directly etcd. That allows us to switch to other backends.

Remove unused `etcd_client` from grpc entrypoint.

Part of larger project to make etcd optional.