### PR TITLE
refactor: remove hardcoded /workspace paths across tests

### DIFF
--- a/benchmarks/profiler/utils/config.py
+++ b/benchmarks/profiler/utils/config.py
@@ -23,6 +23,7 @@ import yaml
 from pydantic import BaseModel
 
 from benchmarks.profiler.utils.planner_utils import build_planner_args_from_namespace
+from dynamo.common.utils.paths import get_workspace_dir
 from dynamo.planner.defaults import WORKER_COMPONENT_NAMES, SubComponentType
 
 logger = logging.getLogger(__name__)
@@ -107,7 +108,7 @@ class DgdPlannerServiceConfig(BaseModel):
     extraPodSpec: PodSpec = PodSpec(
         mainContainer=Container(
             image="my-registry/dynamo-runtime:my-tag",  # placeholder
-            workingDir="/workspace/components/src/dynamo/planner",
+            workingDir=f"{get_workspace_dir()}/components/src/dynamo/planner",
             command=["python3", "-m", "planner_sla"],
             args=[],
         )

--- a/components/src/dynamo/common/utils/__init__.py
+++ b/components/src/dynamo/common/utils/__init__.py
@@ -8,9 +8,10 @@ This module contains shared utility functions used across multiple
 Dynamo backends and components.
 
 Submodules:
+    - paths: Workspace directory detection and path utilities
     - prometheus: Prometheus metrics collection and logging utilities
 """
 
-from dynamo.common.utils import prometheus
+from dynamo.common.utils import paths, prometheus
 
-__all__ = ["prometheus"]
+__all__ = ["paths", "prometheus"]

--- a/components/src/dynamo/common/utils/paths.py
+++ b/components/src/dynamo/common/utils/paths.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Path utilities for Dynamo workspace detection.
+
+This module provides utilities for determining the workspace directory
+across different environments (development, container, CI).
+"""
+
+import os
+
+
+def get_workspace_dir() -> str:
+    """
+    Determine the Dynamo workspace directory.
+
+    Returns the workspace directory with the following precedence:
+    1. Current working directory if it contains Cargo.toml (running from repo root)
+    2. WORKSPACE_DIR environment variable (user-provided override)
+    3. /workspace (default container path)
+    4. Current working directory (fallback)
+
+    Returns:
+        str: Absolute path to the workspace directory
+
+    Examples:
+        >>> # Running from repo root
+        >>> get_workspace_dir()
+        '/home/ubuntu/dynamo'
+
+        >>> # With environment variable override
+        >>> os.environ['WORKSPACE_DIR'] = '/custom/path'
+        >>> get_workspace_dir()
+        '/custom/path'
+
+        >>> # In container default
+        >>> get_workspace_dir()
+        '/workspace'
+    """
+    # Check if running from repo root (contains Cargo.toml)
+    if os.path.exists(os.path.join(os.getcwd(), "Cargo.toml")):
+        return os.getcwd()
+
+    # Check environment variable
+    workspace_dir = os.environ.get("WORKSPACE_DIR")
+    if workspace_dir:
+        return workspace_dir
+
+    # Check container default
+    if os.path.exists("/workspace"):
+        return "/workspace"
+
+    # Fallback to current directory
+    return os.getcwd()
+
+
+# Global constant for convenience
+WORKSPACE_DIR = get_workspace_dir()
+
+__all__ = ["get_workspace_dir", "WORKSPACE_DIR"]

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -10,22 +10,11 @@ from typing import Any, Dict, Optional
 
 import pytest
 
+from dynamo.common.utils.paths import WORKSPACE_DIR
 from tests.utils.client import send_request
 from tests.utils.engine_process import EngineConfig, EngineProcess
 
 DEFAULT_TIMEOUT = 10
-
-# Determine WORKSPACE_DIR with precedence: current path -> env WORKSPACE_DIR -> /workspace
-if os.path.exists(os.path.join(os.getcwd(), "Cargo.toml")):
-    WORKSPACE_DIR = os.getcwd()
-else:
-    _workspace_dir = os.environ.get("WORKSPACE_DIR")
-    if _workspace_dir:
-        WORKSPACE_DIR = _workspace_dir
-    elif os.path.exists("/workspace"):
-        WORKSPACE_DIR = "/workspace"
-    else:
-        WORKSPACE_DIR = os.getcwd()
 
 SERVE_TEST_DIR = os.path.join(WORKSPACE_DIR, "tests/serve")
 

--- a/tests/serve/launch/template_verifier.py
+++ b/tests/serve/launch/template_verifier.py
@@ -1,16 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 from pathlib import Path
 
 import uvloop
 from transformers import AutoTokenizer
 
+from dynamo.common.utils.paths import WORKSPACE_DIR
 from dynamo.llm import ModelInput, ModelType, register_llm
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
-SERVE_TEST_DIR = "/workspace/tests/serve"  # do not import from tests.serve.common because on CI, PYTHONPATH is not set and it'll fail
+SERVE_TEST_DIR = os.path.join(WORKSPACE_DIR, "tests/serve")
 
 
 class TemplateVerificationHandler:

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -9,6 +9,7 @@ import pytest
 
 from tests.serve.common import (
     SERVE_TEST_DIR,
+    WORKSPACE_DIR,
     params_with_model_mark,
     run_serve_deployment,
 )
@@ -32,7 +33,9 @@ class SGLangConfig(EngineConfig):
     stragglers: list[str] = field(default_factory=lambda: ["SGLANG:EngineCore"])
 
 
-sglang_dir = os.environ.get("SGLANG_DIR", "/workspace/components/backends/sglang")
+sglang_dir = os.environ.get("SGLANG_DIR") or os.path.join(
+    WORKSPACE_DIR, "components/backends/sglang"
+)
 
 sglang_configs = {
     "aggregated": SGLangConfig(

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -30,7 +30,7 @@ class TRTLLMConfig(EngineConfig):
 
 
 trtllm_dir = os.environ.get("TRTLLM_DIR") or os.path.join(
-    WORKSPACE_DIR, "components", "backends", "trtllm"
+    WORKSPACE_DIR, "components/backends/trtllm"
 )
 
 # trtllm test configurations

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -31,7 +31,7 @@ class VLLMConfig(EngineConfig):
 
 
 vllm_dir = os.environ.get("VLLM_DIR") or os.path.join(
-    WORKSPACE_DIR, "components", "backends", "vllm"
+    WORKSPACE_DIR, "components/backends/vllm"
 )
 
 # vLLM test configurations
@@ -106,7 +106,7 @@ vllm_configs = {
     ),
     "multimodal_agg_llava": VLLMConfig(
         name="multimodal_agg_llava",
-        directory=os.path.join(WORKSPACE_DIR, "examples", "multimodal"),
+        directory=os.path.join(WORKSPACE_DIR, "examples/multimodal"),
         script_name="agg.sh",
         marks=[pytest.mark.gpu_2],
         model="llava-hf/llava-1.5-7b-hf",
@@ -130,7 +130,7 @@ vllm_configs = {
     ),
     "multimodal_agg_qwen": VLLMConfig(
         name="multimodal_agg_qwen",
-        directory=os.path.join(WORKSPACE_DIR, "examples", "multimodal"),
+        directory=os.path.join(WORKSPACE_DIR, "examples/multimodal"),
         script_name="agg.sh",
         marks=[pytest.mark.gpu_2],
         model="Qwen/Qwen2.5-VL-7B-Instruct",
@@ -155,7 +155,7 @@ vllm_configs = {
     ),
     "multimodal_video_agg": VLLMConfig(
         name="multimodal_video_agg",
-        directory=os.path.join(WORKSPACE_DIR, "examples", "multimodal"),
+        directory=os.path.join(WORKSPACE_DIR, "examples/multimodal"),
         script_name="video_agg.sh",
         marks=[pytest.mark.gpu_2],
         model="llava-hf/LLaVA-NeXT-Video-7B-hf",
@@ -182,7 +182,7 @@ vllm_configs = {
     # TODO: Enable this test case when we have 4 GPUs runners.
     # "multimodal_disagg": VLLMConfig(
     #     name="multimodal_disagg",
-    #     directory="/workspace/examples/multimodal",
+    #     directory=os.path.join(WORKSPACE_DIR, "examples/multimodal"),
     #     script_name="disagg.sh",
     #     marks=[pytest.mark.gpu_4, pytest.mark.vllm],
     #     model="llava-hf/llava-1.5-7b-hf",

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -18,6 +18,8 @@ from kr8s.objects import Pod as kr8s_Pod
 from kr8s.objects import Service as kr8s_Service
 from kubernetes_asyncio import client, config
 
+from dynamo.common.utils.paths import get_workspace_dir
+
 
 class ServiceSpec:
     """Wrapper around a single service in the deployment spec."""
@@ -822,8 +824,11 @@ async def main():
         datefmt=DATE_FORMAT,  # ISO 8601 UTC format
     )
 
+    # Get workspace directory using centralized logic
+    workspace_dir = get_workspace_dir()
+
     deployment_spec = DeploymentSpec(
-        "/workspace/components/backends/vllm/deploy/agg.yaml"
+        os.path.join(workspace_dir, "components/backends/vllm/deploy/agg.yaml")
     )
 
     deployment_spec.disable_grove()


### PR DESCRIPTION
#### Overview:

This PR removes all hardcoded `/workspace` paths from test and profiler code. This enables tests and profiler utilities to work correctly both inside various Docker containers (dev vs. local-dev) and in native development environments.

#### Details:

- Centralized workspace path detection using `dynamo.common.utils.paths.get_workspace_dir()`
- Updated test files to use `WORKSPACE_DIR` constant instead of hardcoded paths
- Removed duplicate workspace detection logic in `tests/serve/common.py`
- Fixed profiler config to use dynamic paths for planner working directory

#### Where should the reviewer start?

- `tests/serve/common.py` - Simplified workspace detection by importing from paths module
- `benchmarks/profiler/utils/config.py` - Dynamic path usage in DgdPlannerServiceConfig
- Test files for consistent usage pattern: `tests/serve/test_vllm.py`, `tests/serve/test_sglang.py`, `tests/serve/test_trtllm.py`


/coderabbit profile chill