### PR TITLE
test: fix frontend tests to make sure openai/gpt-oss-20b can be loaded on A100

### DIFF
--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -95,6 +95,8 @@ class VllmWorkerProcess(ManagedProcess):
             "harmony",
             "--dyn-reasoning-parser",
             "gpt_oss",
+            "--connector",
+            "none",
         ]
 
         env = os.environ.copy()


### PR DESCRIPTION
#### Overview:

there is some issue with openai/gpt-oss-20b + nixl connector to be loaded together on A100,
The process will hang without any error message

Some constant test failure:
https://gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/-/jobs/224501974
https://gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/-/jobs/224497968

eliminate the nixl connector from loading in those frontend tests to unlock the CI

#### Details:



#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
