### PR TITLE
fix: char boundary panic jail

### DIFF
--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -457,11 +457,7 @@ impl Decoder {
                 }
             }
 
-            if self.jail.len() > self.jail_max_bytes {
-                // truncate the jail
-                let drain_len = self.jail.len() - self.jail_max_bytes;
-                self.jail.drain(0..drain_len);
-            }
+            Self::maybe_drain_to_max_bytes(&mut self.jail, self.jail_max_bytes);
         }
 
         Ok(StepResult::ok(token))
@@ -529,5 +525,29 @@ impl Decoder {
         } else {
             None
         }
+    }
+
+    fn maybe_drain_to_max_bytes(s: &mut String, max_bytes: usize) {
+        if s.len() > max_bytes {
+            let mut drain_len = s.len() - max_bytes;
+            while !s.is_char_boundary(drain_len) {
+                drain_len -= 1;
+            }
+            s.drain(0..drain_len);
+        }
+    }
+}
+
+mod tests {
+
+    #[test]
+    fn test_char_boundary_drain() {
+        use super::Decoder;
+        let mut s = String::from("helloñworld"); // 12 bytes total ñ is 2 bytes
+        let max_bytes = 6; // 12 - 6 = 6 which is inside ñ
+        assert!(!s.is_char_boundary(s.len() - max_bytes)); // initially we are not on a char boundary
+        Decoder::maybe_drain_to_max_bytes(&mut s, max_bytes);
+        assert!(s.is_char_boundary(0)); // front of jail string on valid char boundary
+        assert_eq!(s, "ñworld");
     }
 }


### PR DESCRIPTION
#### Overview:

The LLM NIM team has observed the following error signature in testing:

```
thread 'tokio-runtime-worker' panicked at /home/code/dynamo/lib/llm/src/backend.rs:463:27:
assertion failed: self.is_char_boundary(end)
2025-10-15T21:42:32.064749Z ERROR http-request: dynamo_llm::http::service::openai: Internal server error: Failed to await chat completions task: JoinError::Panic(Id(2632), "assertion failed: self.is_char_boundary(end)", ...) method=POST uri=/v1/chat/completions version=HTTP/1.1
2025-10-15T21:42:32.064817Z ERROR http-request: tower_http::trace::on_failure: response failed classification=Status code: 500 Internal Server Error latency=3209 ms method=POST uri=/v1/chat/completions version=HTTP/1.1
2025-10-15T21:42:32.065175Z ERROR dynamo_runtime::pipeline::network::tcp::client: failed to join writer task: I/O error: Broken pipe (os error 32)
```

The cause of this error is due to how `Decoder` is currently truncating the `jail` string. Current behavior is to simply truncate the first `drain_len` bytes from the front of the `jail` string. This is not safe however, as there is no guarantee the truncation end point is a valid character boundary. A non-valid character boundary causes the `drain` method to panic.

#### Details:

- Add a boundary safe drain function `maybe_drain_to_max_bytes`
- Test the new logic via unit test

#### Where should the reviewer start?



#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 character boundary handling during string truncation to prevent potential text corruption.

* **Tests**
  * Added validation for proper UTF-8 boundary preservation in string trimming operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->