### PR TITLE
Lease keepalive retry

### DIFF
--- a/lib/runtime/src/transports/etcd/lease.rs
+++ b/lib/runtime/src/transports/etcd/lease.rs
@@ -18,10 +18,10 @@ pub async fn create_lease(
 
     tokio::spawn(async move {
         let mut retry_count = 0;
-        const MAX_RETRIES: u32 = 10;
-        const RETRY_DELAY: Duration = Duration_from_millisecs(500);
+        const MAX_RETRIES: u32 = 12;
+        const RETRY_DELAY: Duration = Duration::from_millis(500);
         loop {
-                match keep_alive(lease_client, id, ttl, child).await {
+                match keep_alive(lease_client.clone(), id, ttl, child.clone()).await {
                     Ok(_) => {
                         tracing::trace!("keep alive task exited successfully");
                         retry_count = 0;

--- a/lib/runtime/src/transports/etcd/lease.rs
+++ b/lib/runtime/src/transports/etcd/lease.rs
@@ -18,7 +18,7 @@ pub async fn create_lease(
 
     tokio::spawn(async move {
         let mut retry_count = 0;
-        const MAX_RETRIES: u32 = 12;
+        const MAX_RETRIES: u32 = 24;
         const RETRY_DELAY: Duration = Duration::from_millis(500);
         loop {
                 match keep_alive(lease_client.clone(), id, ttl, child.clone()).await {


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

This adds retry logic to the etcd lease keep-alive loop.

#### Details:

<!-- Describe the changes made in this PR. -->

Simply changes the loop to a basic retry loop. No exponential back-off or anything. Just two constants; number of retries and delays.

In my test setup (https://github.com/eskil/dynamo-etcd-kerfuffle) I found that 24 retries with 500ms apart (12s total) gives reasonable resiliency. It's not impervious to failures. But can run for 10+ minutes with the etcd leader getting killed every 30s. 

Without this retry loop, it typically fails before 2 minutes.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
