### PR TITLE
fix(nats): NATs queue should use streaming API otherwise KV events drop

### DIFF
--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -560,19 +560,9 @@ impl NatsQueue {
 
             // Create persistent subscriber only if consumer_name is set
             if let Some(ref consumer_name) = self.consumer_name {
-                // Set ack_wait to 5 minutes to give plenty of time for message processing
-                // before NATS redelivers. This prevents spurious redeliveries when messages
-                // are being processed but haven't been ack'd yet.
-                let ack_wait = std::env::var("DYN_NATS_ACK_WAIT")
-                    .ok()
-                    .and_then(|s| s.parse::<u64>().ok())
-                    .map(time::Duration::from_secs)
-                    .unwrap_or_else(|| time::Duration::from_secs(300)); // 5 minutes default
-
                 let consumer_config = jetstream::consumer::pull::Config {
                     durable_name: Some(consumer_name.clone()),
                     inactive_threshold: std::time::Duration::from_secs(3600), // 1 hour
-                    ack_wait,
                     ..Default::default()
                 };
 

--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -439,6 +439,8 @@ pub struct NatsQueue {
     subscriber: Option<jetstream::consumer::PullConsumer>,
     /// Optional consumer name for broadcast pattern (if None, uses "worker-group")
     consumer_name: Option<String>,
+    /// Message stream for efficient message consumption
+    message_stream: Option<jetstream::consumer::pull::Stream>,
 }
 
 impl NatsQueue {
@@ -457,6 +459,7 @@ impl NatsQueue {
             subject,
             subscriber: None,
             consumer_name: Some("worker-group".to_string()),
+            message_stream: None,
         }
     }
 
@@ -477,6 +480,7 @@ impl NatsQueue {
             subject,
             subscriber: None,
             consumer_name: None,
+            message_stream: None,
         }
     }
 
@@ -499,6 +503,7 @@ impl NatsQueue {
             subject,
             subscriber: None,
             consumer_name: Some(consumer_name),
+            message_stream: None,
         }
     }
 
@@ -555,14 +560,29 @@ impl NatsQueue {
 
             // Create persistent subscriber only if consumer_name is set
             if let Some(ref consumer_name) = self.consumer_name {
+                // Set ack_wait to 5 minutes to give plenty of time for message processing
+                // before NATS redelivers. This prevents spurious redeliveries when messages
+                // are being processed but haven't been ack'd yet.
+                let ack_wait = std::env::var("DYN_NATS_ACK_WAIT")
+                    .ok()
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .map(time::Duration::from_secs)
+                    .unwrap_or_else(|| time::Duration::from_secs(300)); // 5 minutes default
+
                 let consumer_config = jetstream::consumer::pull::Config {
                     durable_name: Some(consumer_name.clone()),
                     inactive_threshold: std::time::Duration::from_secs(3600), // 1 hour
+                    ack_wait,
                     ..Default::default()
                 };
 
                 let subscriber = stream.create_consumer(consumer_config).await?;
+
+                // Create the message stream for efficient consumption
+                let message_stream = subscriber.messages().await?;
+
                 self.subscriber = Some(subscriber);
+                self.message_stream = Some(message_stream);
             }
 
             self.client = Some(client);
@@ -581,6 +601,7 @@ impl NatsQueue {
 
     /// Close the connection when done
     pub async fn close(&mut self) -> Result<()> {
+        self.message_stream = None;
         self.subscriber = None;
         self.client = None;
         Ok(())
@@ -677,28 +698,29 @@ impl NatsQueue {
     pub async fn dequeue_task(&mut self, timeout: Option<time::Duration>) -> Result<Option<Bytes>> {
         self.ensure_connection().await?;
 
-        if let Some(subscriber) = &self.subscriber {
-            let timeout_duration = timeout.unwrap_or(self.dequeue_timeout);
-            let mut batch = subscriber
-                .fetch()
-                .expires(timeout_duration)
-                .max_messages(1)
-                .messages()
-                .await?;
+        let Some(ref mut stream) = self.message_stream else {
+            return Err(anyhow::anyhow!("Message stream not initialized"));
+        };
 
-            if let Some(message) = batch.next().await {
-                let message =
-                    message.map_err(|e| anyhow::anyhow!("Failed to get message: {}", e))?;
-                message
-                    .ack()
+        let timeout_duration = timeout.unwrap_or(self.dequeue_timeout);
+
+        // Try to get next message from the stream with timeout
+        let message = tokio::time::timeout(timeout_duration, stream.next()).await;
+
+        match message {
+            Ok(Some(Ok(msg))) => {
+                msg.ack()
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to ack message: {}", e))?;
-                Ok(Some(message.payload.clone()))
-            } else {
-                Ok(None)
+                Ok(Some(msg.payload.clone()))
             }
-        } else {
-            Err(anyhow::anyhow!("Subscriber not initialized"))
+
+            Ok(Some(Err(e))) => Err(anyhow::anyhow!("Failed to get message from stream: {}", e)),
+
+            Ok(None) => Err(anyhow::anyhow!("Message stream ended unexpectedly")),
+
+            // Timeout - no messages available
+            Err(_) => Ok(None),
         }
     }
 


### PR DESCRIPTION
#### Problem
`parent block not found` errors were triggered sporadically by the `KvIndexer`. Turns out it was a NATs queue issue.

#### Root Cause
Each `dequeue_task()` call created a **new fetch batch with a new inbox**. If a batch timed out before yielding messages, its inbox was abandoned - but NATS had already delivered messages there. These unacked messages triggered redelivery after 30s.

```rust
// ❌ Old: new batch/inbox every call
let batch = subscriber.fetch().messages().await?;
batch.next().await  // might timeout, abandoning delivered messages
```

#### Solution
Use the **streaming API** which maintains a single long-lived stream:

```rust
// ✅ New: one persistent stream, no abandoned messages
let stream = subscriber.messages().await?;
stream.next().await  // same stream every time
```

Note that this does not change at all the public methods or functionalities of the NATs queue, and the queue itself can still be used by external components in a pull-based fashion

#### Outcome

This completely eliminates the `parent block not found` when testing with the mockers over a long benchmarking run. So it looks like both the mocker and indexer are working fine.