### PR TITLE
docs: update version picker for 0.6.1

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -5,6 +5,10 @@
         "url": "https://docs.nvidia.com/dynamo/latest/"
     },
     {
+        "version": "0.6.1",
+        "url": "https://docs.nvidia.com/dynamo/archive/0.6.1/"
+    },
+    {
         "version": "0.6.0",
         "url": "https://docs.nvidia.com/dynamo/archive/0.6.0/"
     },


### PR DESCRIPTION
#### Overview:

Add Version 0.6.1 to the docs' version picker; somewhere between a chore and a doc fix

#### Details:

versions1.json updated to include 0.6.1.

#### Where should the reviewer start?

./docs/versions1.json

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added version 0.6.1 documentation reference to the versions list, enabling access to archived documentation for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->