### PR TITLE
feat: add trtllm env variables + gpu part numbers to config dump

### DIFF
--- a/components/src/dynamo/common/config_dump/environment.py
+++ b/components/src/dynamo/common/config_dump/environment.py
@@ -21,6 +21,20 @@ DEFAULT_ENV_PREFIXES = [
     "UCX_",  # UCX
     "NIXL_",  # NIXL
     "OMPI_",  # OpenMPI
+    "LLM_",  # Misc trtllm variables
+    "TLLM_",
+    "TRT_LLM_",
+    "TRTLLM_",
+    "NVIDIA_",
+    "NSYS_",
+    "GENERATE_CU_",
+    "OVERRIDE_",
+    "TOKENIZERS_",
+    "DISABLE_TORCH_",
+    "PYTORCH_",
+    "ENABLE_PERFECT_ROUTER",
+    "FLA_",
+    "NEMOTRON_",
 ]
 
 # Sensitive variable patterns to redact (case-insensitive)


### PR DESCRIPTION
#### Overview:

Adds gpu/board part numbers and trtllm environment varibales to config dump. 

#### Details:

- Uses nvidia-smi -q xml format to grab part numbers in addition to driver version, memory size, etc.
- Adds a bunch of environment prefixes used in trtllm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced environment variable capture for system configuration diagnostics, now tracking additional configuration parameters across multiple system components
  * Improved GPU information detection and system diagnostics, providing more reliable hardware identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->