### PR TITLE
chore: post code freeze activity: update dynamo operator version

### DIFF
--- a/deploy/cloud/helm/platform/Chart.yaml
+++ b/deploy/cloud/helm/platform/Chart.yaml
@@ -23,7 +23,7 @@ version: 0.6.0
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator
-    version: 0.5.0
+    version: 0.6.1
     repository: file://components/operator
     condition: dynamo-operator.enabled
   - name: nats


### PR DESCRIPTION
#### Overview:

Update dynamo operator version to point to 0.6.1 instead of 0.5.0. 

- closes GitHub issue: #xxx
