### PR TITLE
fix: add usage field to non-streaming responses by default

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -833,11 +833,10 @@ impl
         if !original_stream_flag {
             // If stream_options doesn't exist, create it
             if request.inner.stream_options.is_none() {
-                request.inner.stream_options = Some(
-                    dynamo_async_openai::types::ChatCompletionStreamOptions {
+                request.inner.stream_options =
+                    Some(dynamo_async_openai::types::ChatCompletionStreamOptions {
                         include_usage: true,
-                    }
-                );
+                    });
             } else if let Some(ref mut opts) = request.inner.stream_options {
                 // If stream_options exists, ensure include_usage is true for non-streaming
                 opts.include_usage = true;
@@ -979,11 +978,10 @@ impl
         if !original_stream_flag {
             // If stream_options doesn't exist, create it
             if request.inner.stream_options.is_none() {
-                request.inner.stream_options = Some(
-                    dynamo_async_openai::types::ChatCompletionStreamOptions {
+                request.inner.stream_options =
+                    Some(dynamo_async_openai::types::ChatCompletionStreamOptions {
                         include_usage: true,
-                    }
-                );
+                    });
             } else if let Some(ref mut opts) = request.inner.stream_options {
                 // If stream_options exists, ensure include_usage is true for non-streaming
                 opts.include_usage = true;

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -830,18 +830,7 @@ impl
         // For non-streaming requests (stream=false), enable usage by default
         // This ensures compliance with OpenAI API spec where non-streaming responses
         // always include usage statistics
-        if !original_stream_flag {
-            // If stream_options doesn't exist, create it
-            if request.inner.stream_options.is_none() {
-                request.inner.stream_options =
-                    Some(dynamo_async_openai::types::ChatCompletionStreamOptions {
-                        include_usage: true,
-                    });
-            } else if let Some(ref mut opts) = request.inner.stream_options {
-                // If stream_options exists, ensure include_usage is true for non-streaming
-                opts.include_usage = true;
-            }
-        }
+        request.enable_usage_for_nonstreaming(original_stream_flag);
 
         // Set stream=true for internal processing (after audit capture)
         request.inner.stream = Some(true);
@@ -975,18 +964,7 @@ impl
         // For non-streaming requests (stream=false), enable usage by default
         // This ensures compliance with OpenAI API spec where non-streaming responses
         // always include usage statistics
-        if !original_stream_flag {
-            // If stream_options doesn't exist, create it
-            if request.inner.stream_options.is_none() {
-                request.inner.stream_options =
-                    Some(dynamo_async_openai::types::ChatCompletionStreamOptions {
-                        include_usage: true,
-                    });
-            } else if let Some(ref mut opts) = request.inner.stream_options {
-                // If stream_options exists, ensure include_usage is true for non-streaming
-                opts.include_usage = true;
-            }
-        }
+        request.enable_usage_for_nonstreaming(original_stream_flag);
 
         request.inner.stream = Some(true);
 


### PR DESCRIPTION
#### Overview:

This PR enables usage field to present for all non-streaming responses by default.

#### Details:

Test Plan

Input request
```
curl -sk -X POST http://localhost:8001/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "Qwen/Qwen3-0.6B",
    "messages": [
      {"role": "user", "content": "Write a short poem about AI in 4 lines."}
    ],
    "max_tokens": 500,
    "temperature": 0.7
  }' | jq
```

Response
```
{
  "id": "chatcmpl-a4c1b260-dde7-42a7-9799-b1f958b3cc4f",
  "choices": [
    {
      "index": 0,
      "message": {
        "content": "<think>Okay, the user wants a short poem about AI in four lines. Let me start by thinking about the key aspects of AI. Maybe something about its impact, the challenges, and the future.First line could introduce AI as a transformative force. \"In a world where machines learn to think,\" that sets the stage. Then, maybe mention the blend of humans and machines. \"We blend our minds with algorithms bright.\"Next, I need to address the challenges. \"But they can't replace the human spark that drives them.\" That shows both the potential and the limitations. The fourth line could highlight the future possibilities. \"So let us build a future where AI learns to dream.\"Wait, does that flow well? Let me check. Each line is a couplet, and the themes are consistent. The challenges and future are balanced. Yeah, this should work. I'll make sure it's concise and captures the essence without being too verbose.</think>In a world where machines learn to think,We blend our minds with algorithms bright.But they can't replace the human spark that drives them.So let us build a future where AI learns to dream.",
        "role": "assistant",
        "reasoning_content": null
      },
      "finish_reason": "stop"
    }
  ],
  "created": 1761620597,
  "model": "Qwen/Qwen3-0.6B",
  "object": "chat.completion",
  "usage": {
    "prompt_tokens": 19,
    "completion_tokens": 241,
    "total_tokens": 260
  }
}
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Non-streaming API requests now automatically include comprehensive usage metrics in responses, providing improved visibility into API consumption and resource allocation patterns.
  * Enhanced request processing to preserve original streaming configuration preferences while ensuring compliance with usage reporting requirements across both chat and completion-based endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->