### PR TITLE
fix: create virtualenv in Dockerfile.sglang dev stage for maturin dev

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -400,6 +400,18 @@ CMD []
 FROM runtime AS dev
 
 ARG WORKSPACE_DIR=/sgl-workspace/dynamo
+ARG PYTHON_VERSION
+
+# NOTE: SGLang uses system Python (not a virtualenv in framework/runtime stages) to align with
+# upstream SGLang Dockerfile: https://github.com/sgl-project/sglang/blob/main/docker/Dockerfile
+# For dev stage, we create a lightweight venv with --system-site-packages to satisfy maturin develop
+# requirements while still accessing all system-installed packages (sglang, torch, deepep, etc.)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+RUN mkdir -p /opt/dynamo/venv && \
+    uv venv /opt/dynamo/venv --python $PYTHON_VERSION --system-site-packages
+
+ENV VIRTUAL_ENV=/opt/dynamo/venv \
+    PATH="/opt/dynamo/venv/bin:${PATH}"
 
 # Install development tools and utilities
 RUN apt-get update -y && \


### PR DESCRIPTION
#### Overview:

Fixes `maturin develop` failing in SGLang dev container due to missing virtual environment. SGLang uses system Python to align with upstream, but `maturin develop` requires a virtualenv.

#### Details:

- Added lightweight virtualenv creation in Dockerfile.sglang dev stage using `uv venv --system-site-packages`
- Virtualenv provides access to all system-installed packages (sglang, torch, deepep, nvshmem4py)
- Satisfies `maturin develop` requirement for VIRTUAL_ENV while avoiding package duplication
- Added documentation explaining SGLang's system Python approach vs. vLLM's virtualenv approach

#### Where should the reviewer start?

container/Dockerfile.sglang lines 405-414 - virtualenv creation and documentation

#### Related to

https://github.com/ai-dynamo/dynamo/pull/3792

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration to include a lightweight Python virtual environment setup for streamlined development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->