### PR TITLE
ci: fix variable processing into internal pipeline

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -30,6 +30,7 @@ vllm: &vllm
   - 'container/deps/vllm/**'
   - 'components/backends/vllm/**'
   - 'components/src/dynamo/vllm/**'
+  - 'container/build.sh'
   - 'tests/serve/test_vllm.py'
 
 sglang: &sglang

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -118,12 +118,13 @@ jobs:
         ci_variables["ENABLE_SECURITY_SCAN"]="false"
         ci_variables["RELEASE_BUILD"]="false"
 
-        ci_args=""
+        ci_args=()
         for key in "${!ci_variables[@]}"; do
-          ci_args+="--form variables[$key]=\"${ci_variables[$key]}\" "
+          value="${ci_variables[$key]}"
+          ci_args+=(--form "variables[$key]=${value}")
         done
 
-        echo "Running Pipeline with Variables: $ci_args"
+        echo "Running Pipeline with Variables: ${ci_args[*]}"
 
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           REF="${{ github.event.pull_request.head.ref }}"
@@ -134,5 +135,5 @@ jobs:
           --request POST \
           --form token=${{ secrets.PIPELINE_TOKEN }} \
           --form ref=${REF} \
-          $ci_args \
+          "${ci_args[@]}" \
           "${{ secrets.PIPELINE_URL }}"

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -120,7 +120,7 @@ jobs:
 
         ci_args=""
         for key in "${!ci_variables[@]}"; do
-          ci_args+="--form variables[$key]=${ci_variables[$key]} "
+          ci_args+="--form variables[$key]=\"${ci_variables[$key]}\" "
         done
 
         echo "Running Pipeline with Variables: $ci_args"


### PR DESCRIPTION
#### Overview:

The Trigger Pipeline workflow is called with the following variables:

````
Running Pipeline with Variables: --form variables[FRAMEWORKS]=trtllm sglang --form variables[ENABLE_SECURITY_SCAN]=false --form variables[BUILD_ARCHS]= --form variables[ENABLE_E2E_TEST]=true --form variables[RELEASE_BUILD]=false --form variables[ENABLE_JET_BENCHMARKS]=false --form variables[ENABLE_PREMERGE]=true 
````

This was resulting in not all the framework jobs running since bash was only picking up the first word (in this case framework) as the value if space was used as a delimiter.

Bash was splitting the command on whitespaces which was resulting in the frameworks not being properly delimited on space. This PR addresses this by seperating each ci arg into arrays of form ci_args=(--form "variables[x]=value"). This approach ensures that variables can be delimited on space. Example of workflow running: https://github.com/ai-dynamo/dynamo/actions/runs/18891081188/job/53918744258?pr=3936

Along with this change, we are adding container/build.sh as a file to check for when triggering CI since we often have SHAS for all of our Dockerfiles defined here.

#### Details:

- Use arrays for ci_args instead of relying on spaces to ensure bash interpreter is able to pick up the value of a particular CI variable
- Add container/build.sh as a file to check for code changes for vllm jobs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to enhance argument handling in build automation.
  * Expanded container build support in automated deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->