### PR TITLE
feat: add prefill worker metrics support for vLLM

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -12,6 +12,7 @@ from vllm.inputs import TokensPrompt
 from vllm.sampling_params import SamplingParams
 from vllm.v1.engine.exceptions import EngineDeadError
 
+from dynamo.llm import ZmqKvEventPublisher
 from dynamo.runtime.logging import configure_dynamo_logging
 
 from .engine_monitor import VllmEngineMonitor
@@ -62,7 +63,7 @@ class BaseWorkerHandler(ABC):
         self.component = component
         self.engine_client = engine
         self.default_sampling_params = default_sampling_params
-        self.kv_publishers = None
+        self.kv_publishers: list[ZmqKvEventPublisher] | None = None
         self.engine_monitor = VllmEngineMonitor(runtime, engine)
 
     @abstractmethod

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -274,6 +274,11 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
     if kv_publishers:
         handler.kv_publishers = kv_publishers
 
+    if config.engine_args.disable_log_stats is False:
+        register_engine_metrics_callback(
+            endpoint=generate_endpoint, registry=REGISTRY, metric_prefix_filter="vllm:"
+        )
+
     # Register prefill model with ModelType.Prefill
     if not config.engine_args.data_parallel_rank:  # if rank is 0 or None then register
         await register_vllm_model(


### PR DESCRIPTION
#### Overview:

Prometheus metrics support for vLLM prefill workers in disaggregated serving mode

#### Details:

- Register `register_engine_metrics_callback` for prefill worker when `disable_log_stats` is False
- Expose vLLM metrics with `vllm:` prefix filter through Dynamo's metrics endpoint
- Minor: add `ZmqKvEventPublisher` type hint in `handlers.py` for proper type inference in IDE

#### Where should the reviewer start?

- `components/src/dynamo/vllm/main.py` lines 277-280: New metrics callback registration logic

#### Related Issues:

DIS-911

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced engine metrics collection for Prometheus/NReg during prefill operations when stats logging is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->