### PR TITLE
fix: dynamo-run model name should default to remote path i.e. HFID

### DIFF
--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -29,6 +29,10 @@ pub async fn run(
         .model_path_pos
         .clone()
         .or_else(|| flags.model_path_flag.clone());
+
+    // Preserve the original model identifier before downloading (for default model name)
+    let original_model_identifier = maybe_remote_repo.as_ref().map(|p| p.display().to_string());
+
     let model_path = match maybe_remote_repo {
         None => None,
         Some(p) if p.exists() => {
@@ -49,7 +53,7 @@ pub async fn run(
 
     let mut builder = LocalModelBuilder::default();
     builder
-        .model_name(flags.model_name.clone())
+        .model_name(flags.model_name.clone().or(original_model_identifier))
         .kv_cache_block_size(flags.kv_cache_block_size)
         // Only set if user provides. Usually loaded from tokenizer_config.json
         .context_length(flags.context_length)


### PR DESCRIPTION
#### Overview:

We may have unintentionally introduced a bug where the model name defaulted to the local cached path instead of the more expected HFID

Even though `dynamo-run` is in the process of deprecation, this issue has been brought up, so this small fix is probably worth it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Model naming now automatically uses the remote repository identifier as a default when no explicit model name is provided, improving the user experience with intelligent naming defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->