### PR TITLE
fix(dynamo-run): Fix naming the model in single-process mode

### DIFF
--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -174,8 +174,8 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
             let engine = Arc::new(StreamingEngineAdapter::new(engine));
             let manager = http_service.model_manager();
             let checksum = model.card().mdcsum();
-            manager.add_completions_model(model.service_name(), checksum, engine.clone())?;
-            manager.add_chat_completions_model(model.service_name(), checksum, engine)?;
+            manager.add_completions_model(model.display_name(), checksum, engine.clone())?;
+            manager.add_chat_completions_model(model.display_name(), checksum, engine)?;
 
             // Enable all endpoints
             for endpoint_type in EndpointType::all() {
@@ -199,14 +199,14 @@ pub async fn run(runtime: Runtime, engine_config: EngineConfig) -> anyhow::Resul
                     NvCreateChatCompletionStreamResponse,
                 >(model.card(), inner_engine.clone(), tokenizer_hf.clone())
                 .await?;
-            manager.add_chat_completions_model(model.service_name(), checksum, chat_pipeline)?;
+            manager.add_chat_completions_model(model.display_name(), checksum, chat_pipeline)?;
 
             let cmpl_pipeline = common::build_pipeline::<
                 NvCreateCompletionRequest,
                 NvCreateCompletionResponse,
             >(model.card(), inner_engine, tokenizer_hf)
             .await?;
-            manager.add_completions_model(model.service_name(), checksum, cmpl_pipeline)?;
+            manager.add_completions_model(model.display_name(), checksum, cmpl_pipeline)?;
             // Enable all endpoints
             for endpoint_type in EndpointType::all() {
                 http_service.enable_model_endpoint(endpoint_type, true);


### PR DESCRIPTION
`dynamo-run` in `StaticFull` or `StaticCore` mode
(`dynamo-run in=http out=mistralrs Qwen/Qwen3-0.6B`) was slugifying the display name. Instead we want to preserve the name as the user passed it, particularly for HF IDs (e.g. `Qwen/Qwen3-0.6B`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected model identification mechanism to use display names instead of service identifiers when registering models, ensuring consistent and accurate model labeling throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->