### PR TITLE
fix: NIXL connect header strip

### DIFF
--- a/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
+++ b/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
@@ -1482,7 +1482,7 @@ class Remote:
         if isinstance(nixl_metadata, str):
             if nixl_metadata.startswith("b64:"):
                 # Decode the b64-encoded string into bytes.
-                nixl_metadata = base64.b64decode(nixl_metadata.lstrip("b64:"))
+                nixl_metadata = base64.b64decode(nixl_metadata[4:])
             else:
                 # fallback for earlier versions of nixl connect
                 nixl_metadata = bytes.fromhex(nixl_metadata)


### PR DESCRIPTION
#### Overview:

`lstrip` does not actually strip the whole string sequence but any character of that sequence. So this causes issues when the actual b64 data starts with `b`, `6` or `4`

#### Details:

<!-- Describe the changes made in this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected base64-encoded metadata decoding logic to prevent unintended character stripping, ensuring proper data handling for remote connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->