### PR TITLE
docs: add sphinx reredirects extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.extlinks",
     "sphinxcontrib.mermaid",
+    "sphinx_reredirects",
 ]
 
 # Custom extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ docs = [
     "sphinx-book-theme>=1.1",
     "sphinxcontrib-mermaid>=1.0",
     "sphinxcontrib-bibtex>=2.6",
+    "sphinx-reredirects>=1.0.0",
     # Markdown and notebook support
     "myst-parser>=4.0",
     "myst-nb>=1.2",


### PR DESCRIPTION
#### Overview:

add sphinx reredirects extension for docs build

ref: #3961


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enabled redirect support for documentation pages to ensure old links continue to work.

* **Chores**
  * Updated documentation build dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->