### PR TITLE
fix: adjust kgateway setup

### DIFF
--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: gitlab-master.nvidia.com:5005/dl/ai-dynamo/dynamo/dynamo:vllm-1029
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-agg
@@ -24,12 +24,12 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: gitlab-master.nvidia.com:5005/dl/ai-dynamo/dynamo/dynamo:vllm-1029
           workingDir: /workspace/components/backends/vllm
           command:
-          - python3
-          - -m
-          - dynamo.vllm
+            - python3
+            - -m
+            - dynamo.vllm
           args:
             - --model
             - Qwen/Qwen3-0.6B

--- a/deploy/inference-gateway/README.md
+++ b/deploy/inference-gateway/README.md
@@ -56,25 +56,6 @@ INFERENCE_EXTENSION_VERSION=v0.5.1
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$INFERENCE_EXTENSION_VERSION/manifests.yaml
 ```
 
-c. Install `kgateway` CRDs and kgateway.
-
-```bash
-KGATEWAY_VERSION=v2.0.3
-
-# Install the Kgateway CRDs
-helm upgrade -i --create-namespace --namespace kgateway-system --version $KGATEWAY_VERSION kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
-
-# Install Kgateway
-helm upgrade -i --namespace kgateway-system --version $KGATEWAY_VERSION kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set inferenceExtension.enabled=true
-```
-
-d. Deploy the Gateway Instance
-
-```bash
-kubectl create namespace my-model
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/gateway/kgateway/gateway.yaml -n  my-model
-```
-
 ```bash
 kubectl get gateway inference-gateway -n my-model
 

--- a/deploy/inference-gateway/install_gaie_crd_kgateway.sh
+++ b/deploy/inference-gateway/install_gaie_crd_kgateway.sh
@@ -32,9 +32,11 @@ INFERENCE_EXTENSION_VERSION=v0.5.1
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$INFERENCE_EXTENSION_VERSION/manifests.yaml -n  $MODEL_NAMESPACE
 
 
-# Install the Kgateway CRDs and Kgateway
+# Install and upgrade Kgateway (includes CRDs)
 KGATEWAY_VERSION=v2.0.3
 KGATEWAY_SYSTEM_NAMESPACE=kgateway-system
+kubectl create namespace $KGATEWAY_SYSTEM_NAMESPACE || true
+
 helm upgrade -i --create-namespace --namespace $KGATEWAY_SYSTEM_NAMESPACE --version $KGATEWAY_VERSION kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
 
 helm upgrade -i --namespace $KGATEWAY_SYSTEM_NAMESPACE --version $KGATEWAY_VERSION kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set inferenceExtension.enabled=true

--- a/deploy/inference-gateway/install_gaie_crd_kgateway.sh
+++ b/deploy/inference-gateway/install_gaie_crd_kgateway.sh
@@ -35,10 +35,10 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extens
 # Install the Kgateway CRDs and Kgateway
 KGATEWAY_VERSION=v2.0.3
 KGATEWAY_SYSTEM_NAMESPACE=kgateway-system
-helm repo add kgateway-dev oci://cr.kgateway.dev/kgateway-dev || true
 helm upgrade -i --create-namespace --namespace $KGATEWAY_SYSTEM_NAMESPACE --version $KGATEWAY_VERSION kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
+
 helm upgrade -i --namespace $KGATEWAY_SYSTEM_NAMESPACE --version $KGATEWAY_VERSION kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --set inferenceExtension.enabled=true
 
 
 # Deploy the Gateway Instance
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/main/config/manifests/gateway/kgateway/gateway.yaml -n $MODEL_NAMESPACE
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/raw/v1.0.0/config/manifests/gateway/kgateway/gateway.yaml -n $MODEL_NAMESPACE


### PR DESCRIPTION
#### Overview:

[<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->](https://nvbugspro.nvidia.com/bug/5619210)

kgateway now ships and documents three GatewayClasses: kgateway, kgateway-waypoint, and agentgateway; to use agentgateway you set spec.gatewayClassName: agentgateway. 
Recent kgateway release notes deprecate Envoy-based AI/Inferences features and recommend using agentgateway for AI/MCP and Inference Extension use cases. That’s why the Inference Extension example started referencing agentgateway.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Streamlined Inference Gateway installation guide with simplified setup steps for easier deployment.

* **Chores**
  * Updated Kgateway installation process with enhanced configuration options.
  * Updated Gateway deployment manifest to reference v1.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->