### PR TITLE
docs: Adding redirects

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,12 @@ This approach is ideal for CI/CD pipelines or when you want complete isolation f
 - `docs/_extensions/` - Custom Sphinx extensions
 - `docs/build/` - Generated documentation output (not tracked in git)
 
+## Redirect Creation
+
+When moving or renaming files a redirect must be created.
+
+The logic for redirect creation is located [here](https://documatt.com/sphinx-reredirects/usage/#introduction) and should be added to the existing list in the conf.py.
+
 ## Dependency Management
 
 Documentation dependencies are defined in `pyproject.toml` under the `[dependency-groups]` section:

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ This approach is ideal for CI/CD pipelines or when you want complete isolation f
 
 When moving or renaming files a redirect must be created.
 
-The logic for redirect creation is located [here](https://documatt.com/sphinx-reredirects/usage/#introduction) and should be added to the existing list in the conf.py.
+Redirect entries should be added to the `redirects` dictionary in `conf.py`. For detailed information on redirect syntax, see the [sphinx-reredirects usage documentation](https://documatt.com/sphinx-reredirects/usage/#introduction).
 
 ## Dependency Management
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,23 @@ extensions = [
     "sphinx_reredirects",
 ]
 
+# Redirects configuration
+redirects = {
+    "guides/tool-calling.html": "../agents/tool-calling.html",  # relative
+    "architecture/architecture.html": "../design_docs/architecture.html",  # relative
+    "architecture/disagg_serving.html": "../design_docs/disagg_serving.html",  # relative
+    "architecture/distributed_runtime.html": "../design_docs/distributed_runtime.html",  # relative
+    "architecture/dynamo_flow.html": "../design_docs/dynamo_flow.html",  # relative
+    "architecture/request_cancellation.html": "../fault_tolerance/request_cancellation.html",  # relative
+    "architecture/request_migration.html": "../fault_tolerance/request_migration.html",  # relative
+    "kubernetes/create_deployment.html": "../kubernetes/deployment/create_deployment.html",  # relative
+    "kubernetes/minikube.html": "../kubernetes/deployment/minikube.html",  # relative
+    "kubernetes/multinode-deployment.html": "../kubernetes/deployment/multinode-deployment.html",  # relative
+    "kubernetes/logging.html": "../kubernetes/observability/logging.html",  # relative
+    "kubernetes/metrics.html": "../kubernetes/observability/metrics.html",  # relative
+    "architecture/kv_cache_routing.html": "../router/kv_cache_routing.html",  # relative
+}
+
 # Custom extensions
 sys.path.insert(0, os.path.abspath("_extensions"))
 extensions.append("github_alerts")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,19 +35,19 @@ extensions = [
 
 # Redirects configuration
 redirects = {
-    "guides/tool-calling.html": "../agents/tool-calling.html",  # relative
-    "architecture/architecture.html": "../design_docs/architecture.html",  # relative
-    "architecture/disagg_serving.html": "../design_docs/disagg_serving.html",  # relative
-    "architecture/distributed_runtime.html": "../design_docs/distributed_runtime.html",  # relative
-    "architecture/dynamo_flow.html": "../design_docs/dynamo_flow.html",  # relative
-    "architecture/request_cancellation.html": "../fault_tolerance/request_cancellation.html",  # relative
-    "architecture/request_migration.html": "../fault_tolerance/request_migration.html",  # relative
-    "kubernetes/create_deployment.html": "../kubernetes/deployment/create_deployment.html",  # relative
-    "kubernetes/minikube.html": "../kubernetes/deployment/minikube.html",  # relative
-    "kubernetes/multinode-deployment.html": "../kubernetes/deployment/multinode-deployment.html",  # relative
-    "kubernetes/logging.html": "../kubernetes/observability/logging.html",  # relative
-    "kubernetes/metrics.html": "../kubernetes/observability/metrics.html",  # relative
-    "architecture/kv_cache_routing.html": "../router/kv_cache_routing.html",  # relative
+    "guides/tool-calling": "../agents/tool-calling.html",  # key format corrected
+    "architecture/architecture": "../design_docs/architecture.html",
+    "architecture/disagg_serving": "../design_docs/disagg_serving.html",
+    "architecture/distributed_runtime": "../design_docs/distributed_runtime.html",
+    "architecture/dynamo_flow": "../design_docs/dynamo_flow.html",
+    "architecture/request_cancellation": "../fault_tolerance/request_cancellation.html",
+    "architecture/request_migration": "../fault_tolerance/request_migration.html",
+    "kubernetes/create_deployment": "../kubernetes/deployment/create_deployment.html",
+    "kubernetes/minikube": "../kubernetes/deployment/minikube.html",
+    "kubernetes/multinode-deployment": "../kubernetes/deployment/multinode-deployment.html",
+    "kubernetes/logging": "../kubernetes/observability/logging.html",
+    "kubernetes/metrics": "../kubernetes/observability/metrics.html",
+    "architecture/kv_cache_routing": "../router/kv_cache_routing.html",
 }
 
 # Custom extensions


### PR DESCRIPTION
#### Overview:

Creates redirects for pages that were moved in #3802.

#### Details:

Adds 13 redirects to the conf.py and updates README.md with instructions on how to add redirects in the future.

#### Where should the reviewer start?

- docs/README.md
- docs/conf.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added redirect creation guidance to the documentation README with external references and configuration instructions.

* **Chores**
  * Configured URL redirects for guides, architecture, Kubernetes, fault tolerance, and routing documentation paths to maintain accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->