### PR TITLE
fix: Operator defaults for liveness and readiness probes

### DIFF
--- a/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -862,7 +862,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 													Port: intstr.FromString(commonconsts.DynamoSystemPortName),
 												},
 											},
-											TimeoutSeconds:   30,
+											TimeoutSeconds:   4,
 											PeriodSeconds:    5,
 											SuccessThreshold: 0,
 											FailureThreshold: 1,
@@ -874,10 +874,10 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 													Port: intstr.FromString(commonconsts.DynamoSystemPortName),
 												},
 											},
-											TimeoutSeconds:   30,
+											TimeoutSeconds:   4,
 											PeriodSeconds:    10,
 											SuccessThreshold: 0,
-											FailureThreshold: 60,
+											FailureThreshold: 3,
 										},
 										StartupProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{

--- a/deploy/cloud/operator/internal/dynamo/component_frontend.go
+++ b/deploy/cloud/operator/internal/dynamo/component_frontend.go
@@ -47,10 +47,10 @@ func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Co
 				Port: intstr.FromString(commonconsts.DynamoContainerPortName),
 			},
 		},
-		InitialDelaySeconds: 60,
-		PeriodSeconds:       60,
-		TimeoutSeconds:      30,
-		FailureThreshold:    10,
+		InitialDelaySeconds: 15, // Frontend ready to serve requests in ~5-10 seconds
+		PeriodSeconds:       10,
+		TimeoutSeconds:      1, // live endpoint performs no i/o
+		FailureThreshold:    3,
 	}
 
 	container.ReadinessProbe = &corev1.Probe{
@@ -60,10 +60,10 @@ func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Co
 				Port: intstr.FromString(commonconsts.DynamoContainerPortName),
 			},
 		},
-		InitialDelaySeconds: 60,
-		PeriodSeconds:       60,
-		TimeoutSeconds:      30,
-		FailureThreshold:    10,
+		InitialDelaySeconds: 10, // Frontend ready to serve requests in ~5-10 seconds
+		PeriodSeconds:       10,
+		TimeoutSeconds:      3,
+		FailureThreshold:    3,
 	}
 
 	// Add standard environment variables

--- a/deploy/cloud/operator/internal/dynamo/component_frontend.go
+++ b/deploy/cloud/operator/internal/dynamo/component_frontend.go
@@ -43,7 +43,7 @@ func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Co
 	container.LivenessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Path: "/health",
+				Path: "/live",
 				Port: intstr.FromString(commonconsts.DynamoContainerPortName),
 			},
 		},
@@ -55,12 +55,9 @@ func (f *FrontendDefaults) GetBaseContainer(context ComponentContext) (corev1.Co
 
 	container.ReadinessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{
-					"/bin/sh",
-					"-c",
-					"curl -s http://localhost:${DYNAMO_PORT}/health | jq -e \".status == \\\"healthy\\\"\"",
-				},
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/health",
+				Port: intstr.FromString(commonconsts.DynamoContainerPortName),
 			},
 		},
 		InitialDelaySeconds: 60,

--- a/deploy/cloud/operator/internal/dynamo/component_worker.go
+++ b/deploy/cloud/operator/internal/dynamo/component_worker.go
@@ -42,10 +42,13 @@ func (w *WorkerDefaults) GetBaseContainer(context ComponentContext) (corev1.Cont
 			},
 		},
 		PeriodSeconds:    5,
-		TimeoutSeconds:   30,
-		FailureThreshold: 1,
+		TimeoutSeconds:   4, // TimeoutSeconds should be < PeriodSeconds
+		FailureThreshold: 1, // Note this default FailureThreshold is 3, with 1 a single failure will restart Pod
 	}
 
+	// ReadinessProbe in Dynamo worker context doesn't determine that the worker is ready to receive traffic
+	// Since worker registration is done through external KvStore and Transport does not use Kubernetes Service
+	// Still important for external depencies that rely on Pod Readiness
 	container.ReadinessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -54,8 +57,8 @@ func (w *WorkerDefaults) GetBaseContainer(context ComponentContext) (corev1.Cont
 			},
 		},
 		PeriodSeconds:    10,
-		TimeoutSeconds:   30,
-		FailureThreshold: 60,
+		TimeoutSeconds:   4,
+		FailureThreshold: 3,
 	}
 
 	container.StartupProbe = &corev1.Probe{

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -1874,7 +1874,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 															Port: intstr.FromString(commonconsts.DynamoSystemPortName),
 														},
 													},
-													TimeoutSeconds:   30,
+													TimeoutSeconds:   4,
 													PeriodSeconds:    5,
 													SuccessThreshold: 0,
 													FailureThreshold: 1,
@@ -1886,10 +1886,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 															Port: intstr.FromString(commonconsts.DynamoSystemPortName),
 														},
 													},
-													TimeoutSeconds:   30,
+													TimeoutSeconds:   4,
 													PeriodSeconds:    10,
 													SuccessThreshold: 0,
-													FailureThreshold: 60,
+													FailureThreshold: 3,
 												},
 												StartupProbe: &corev1.Probe{
 													ProbeHandler: corev1.ProbeHandler{
@@ -4549,7 +4549,7 @@ func TestGenerateBasePodSpec_Worker(t *testing.T) {
 								},
 							},
 							PeriodSeconds:    5,
-							TimeoutSeconds:   30,
+							TimeoutSeconds:   4,
 							FailureThreshold: 1,
 						},
 						ReadinessProbe: &corev1.Probe{
@@ -4560,8 +4560,8 @@ func TestGenerateBasePodSpec_Worker(t *testing.T) {
 								},
 							},
 							PeriodSeconds:    10,
-							TimeoutSeconds:   30,
-							FailureThreshold: 60,
+							TimeoutSeconds:   4,
+							FailureThreshold: 3,
 						},
 						StartupProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
#### Overview:

Updates the Operator defaulted liveness and readiness probes configuration for Frontend and Worker Pods

#### Details:

- `component_frontend.go`: 
  - `LivenessProbe`: use the `/live` endpoint exposed by Frontend since it doesn't performs I/O (standard k8s aliveness check)
  - `ReadinessProbe`: use `HTTPGet` directly since endpoint returns returns 200 when healthy - no longer relies on curl/jq dependencies in frontend container. Also, cuts down `InitialIntervalSeconds` from 60s to 10s (Frontend consistently starting in 5-10s)
- `component_worker.go`: better reasonable defaults for liveness/readiness probes

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes [DEP-437](https://linear.app/nvidia/issue/DEP-437/fix-dynamo-core-health-check-to-return-503-when-not-healthy)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized health monitoring configuration for improved service reliability and responsiveness. Adjusted detection timings to enable faster recovery from transient failures and streamlined health check mechanisms across deployment components for better operational efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->