### PR TITLE
docs: Adding redirects (#3965)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,12 @@ This approach is ideal for CI/CD pipelines or when you want complete isolation f
 - `docs/_extensions/` - Custom Sphinx extensions
 - `docs/build/` - Generated documentation output (not tracked in git)
 
+## Redirect Creation
+
+When moving or renaming files a redirect must be created.
+
+Redirect entries should be added to the `redirects` dictionary in `conf.py`. For detailed information on redirect syntax, see the [sphinx-reredirects usage documentation](https://documatt.com/sphinx-reredirects/usage/#introduction).
+
 ## Dependency Management
 
 Documentation dependencies are defined in `pyproject.toml` under the `[dependency-groups]` section:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,23 @@ extensions = [
     "sphinxcontrib.mermaid",
 ]
 
+# Redirects configuration
+redirects = {
+    "guides/tool-calling": "../agents/tool-calling.html",  # key format corrected
+    "architecture/architecture": "../design_docs/architecture.html",
+    "architecture/disagg_serving": "../design_docs/disagg_serving.html",
+    "architecture/distributed_runtime": "../design_docs/distributed_runtime.html",
+    "architecture/dynamo_flow": "../design_docs/dynamo_flow.html",
+    "architecture/request_cancellation": "../fault_tolerance/request_cancellation.html",
+    "architecture/request_migration": "../fault_tolerance/request_migration.html",
+    "kubernetes/create_deployment": "../kubernetes/deployment/create_deployment.html",
+    "kubernetes/minikube": "../kubernetes/deployment/minikube.html",
+    "kubernetes/multinode-deployment": "../kubernetes/deployment/multinode-deployment.html",
+    "kubernetes/logging": "../kubernetes/observability/logging.html",
+    "kubernetes/metrics": "../kubernetes/observability/metrics.html",
+    "architecture/kv_cache_routing": "../router/kv_cache_routing.html",
+}
+
 # Custom extensions
 sys.path.insert(0, os.path.abspath("_extensions"))
 extensions.append("github_alerts")


### PR DESCRIPTION
# Cherry-pick: docs: Adding redirects

## Overview

This PR cherry-picks PR #3965 (merged to main) to `release/0.6.1` to add redirects for documentation pages that were moved in PR #3802.

## Details

Adds 13 redirects to `docs/conf.py` to maintain accessibility of documentation URLs after the reorganization. Also updates `docs/README.md` with instructions on how to add redirects in the future.

### Redirects Added

The following redirects were added to preserve access to moved documentation pages:

- `guides/tool-calling` → `../agents/tool-calling.html`
- `architecture/architecture` → `../design_docs/architecture.html`
- `architecture/disagg_serving` → `../design_docs/disagg_serving.html`
- `architecture/distributed_runtime` → `../design_docs/distributed_runtime.html`
- `architecture/dynamo_flow` → `../design_docs/dynamo_flow.html`
- `architecture/request_cancellation` → `../fault_tolerance/request_cancellation.html`
- `architecture/request_migration` → `../fault_tolerance/request_migration.html`
- `kubernetes/create_deployment` → `../kubernetes/deployment/create_deployment.html`
- `kubernetes/minikube` → `../kubernetes/deployment/minikube.html`
- `kubernetes/multinode-deployment` → `../kubernetes/deployment/multinode-deployment.html`
- `kubernetes/logging` → `../kubernetes/observability/logging.html`
- `kubernetes/metrics` → `../kubernetes/observability/metrics.html`
- `architecture/kv_cache_routing` → `../router/kv_cache_routing.html`

## Related PRs

- Original PR: #3965
- Related reorganization: #3802

## Where should the reviewer start?

- `docs/conf.py` - Review redirect mappings
- `docs/README.md` - Review redirect creation guidance

## Testing

- Verified cherry-pick applies cleanly to `release/0.6.1`
- No merge conflicts
- Redirects configuration matches the original PR

