### PR TITLE
fix: platform helm chart value etcd preUpgrade not working

### DIFF
--- a/deploy/cloud/helm/platform/values.yaml
+++ b/deploy/cloud/helm/platform/values.yaml
@@ -167,7 +167,7 @@ etcd:
     size: 1Gi
 
   # Pre-upgrade job configuration
-  preUpgrade:
+  preUpgradeJob:
     # Whether to run pre-upgrade validation jobs
     enabled: false
 


### PR DESCRIPTION
#### Overview:

The etcd pre upgrade job is still running on helm installation because the field is `preUpgradeJob` not `preUpgrade`. This PR fixes that

https://github.com/bitnami/charts/tree/main/bitnami/etcd

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed etcd pre-upgrade configuration key in Helm deployment values. Users deploying via Helm should update their configuration files to reflect the new key name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->