### PR TITLE
fix vllm stop token

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -45,9 +45,10 @@ def build_sampling_params(
     # Apply stop_conditions
     for key, value in request["stop_conditions"].items():
         if value is not None and hasattr(sampling_params, key):
-            # Do not add stop key to sampling params - dynamo handles stop conditions directly
             if key == "stop":
-                continue
+                sampling_params.detokenize = True
+                request["stop_conditions"]['stop'] = None
+
             setattr(sampling_params, key, value)
 
     return sampling_params


### PR DESCRIPTION
#### Overview:

This PR fixes the vLLM worker stop token issue, in current main branch, whenever user put stop token, it fails, and on debugging found out,that there is stop id in sampling params or stop_token_ids_hidden is there. This PR fixes that

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: https://github.com/ai-dynamo/dynamo/issues/3014


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced stop token condition handling in text generation to prevent duplication and improve termination behavior. Stop conditions are now properly processed with improved detokenization support, ensuring more consistent and reliable control over generated text output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->