### PR TITLE
test: fix dsr1_dep test, adjust the expected response

### DIFF
--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -100,8 +100,8 @@ vllm_configs = {
         ],
         timeout=700,
         request_payloads=[
-            chat_payload_default(),
-            completion_payload_default(),
+            chat_payload_default(expected_response=["joke"]),
+            completion_payload_default(expected_response=["joke"]),
         ],
     ),
     "multimodal_agg_llava": VLLMConfig(


### PR DESCRIPTION
#### Overview:

The failed dsr1_dep test will not produce the response with the key word "AI", but will always response with the word "joke"

#### Details:

Fix for tests failure:
https://gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/-/jobs/227577205
https://gitlab-master.nvidia.com/dl/ai-dynamo/dynamo/-/jobs/227478806

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test configuration for model serving scenarios to better validate expected outcomes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->