### PR TITLE
fix: Skip kvbm consolidator test if vllm is not installed

### DIFF
--- a/tests/kvbm/test_consolidator_router_e2e.py
+++ b/tests/kvbm/test_consolidator_router_e2e.py
@@ -13,6 +13,7 @@ This test validates that:
 """
 
 import concurrent.futures
+import importlib.util
 import logging
 import os
 import re
@@ -25,12 +26,16 @@ import requests
 from tests.kvbm.common import ApiTester, check_logs_for_patterns
 from tests.utils.managed_process import ManagedProcess
 
+# Check if vLLM is available
+HAS_VLLM = importlib.util.find_spec("vllm") is not None
+
 # Test markers
 pytestmark = [
     pytest.mark.kvbm,
     pytest.mark.e2e,
     pytest.mark.slow,
     pytest.mark.gpu_1,
+    pytest.mark.skipif(not HAS_VLLM, reason="requires vllm"),
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
KVBM tests are running for vllm and trtllm. This  PR added a check so that the kv event consolidator test will not run for trtllm.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite with conditional execution logic to skip tests when optional dependencies are unavailable, improving test reliability across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->