### PR TITLE
chore(etcd): Making connecting to etcd optional

### DIFF
--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1464,15 +1464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dynamo-kvbm-kernels"
-version = "0.6.0"
-dependencies = [
- "cc",
- "cudarc",
- "once_cell",
-]
-
-[[package]]
 name = "dynamo-llm"
 version = "0.6.1"
 dependencies = [
@@ -1501,7 +1492,6 @@ dependencies = [
  "derive_builder",
  "dialoguer",
  "dynamo-async-openai",
- "dynamo-kvbm-kernels",
  "dynamo-parsers",
  "dynamo-runtime",
  "either",

--- a/lib/bindings/python/rust/llm/disagg_router.rs
+++ b/lib/bindings/python/rust/llm/disagg_router.rs
@@ -32,7 +32,7 @@ impl DisaggregatedRouter {
         })?;
 
         let router = runtime.block_on(async {
-            dynamo_llm::disagg_router::DisaggregatedRouter::new_with_etcd_and_default(
+            dynamo_llm::disagg_router::DisaggregatedRouter::new_with_config_watcher(
                 drt_arc,
                 model_name,
                 default_max_local_prefill_length,

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -51,12 +51,20 @@ impl DistributedRuntime {
 
         let runtime_clone = runtime.clone();
 
+        // TODO: Here is where we will later select the KeyValueStore impl
         let (etcd_client, store) = if is_static {
             (None, KeyValueStoreManager::memory())
         } else {
-            let etcd_client = etcd::Client::new(etcd_config.clone(), runtime_clone).await?;
-            let store = KeyValueStoreManager::etcd(etcd_client.clone());
-            (Some(etcd_client), store)
+            match etcd::Client::new(etcd_config.clone(), runtime_clone).await {
+                Ok(etcd_client) => {
+                    let store = KeyValueStoreManager::etcd(etcd_client.clone());
+                    (Some(etcd_client), store)
+                }
+                Err(err) => {
+                    tracing::info!(%err, "Did not connect to etcd. Using memory storage.");
+                    (None, KeyValueStoreManager::memory())
+                }
+            }
         };
 
         let nats_client = Some(nats_config.clone().connect().await?);
@@ -251,13 +259,10 @@ impl DistributedRuntime {
     }
 
     // todo(ryan): deprecate this as we move to Discovery traits and Component Identifiers
+    //
+    // Try to use `store()` instead of this. Only use this if you have not been able to migrate
+    // yet, or if you require etcd-specific features like distributed locking (rare).
     pub fn etcd_client(&self) -> Option<etcd::Client> {
-        self.etcd_client.clone()
-    }
-
-    // Deprecated but our CI blocks us using the feature currently.
-    //#[deprecated(note = "Use KeyValueStoreManager via store(); this will be removed")]
-    pub fn deprecated_etcd_client(&self) -> Option<etcd::Client> {
         self.etcd_client.clone()
     }
 

--- a/lib/runtime/src/storage/key_value_store.rs
+++ b/lib/runtime/src/storage/key_value_store.rs
@@ -305,7 +305,6 @@ impl KeyValueStoreManager {
 }
 
 /// An online storage for key-value config values.
-/// Usually backed by `nats-server`.
 #[async_trait]
 pub trait KeyValueBucket: Send + Sync {
     /// A bucket is a collection of key/value pairs.

--- a/lib/runtime/src/utils/leader_worker_barrier.rs
+++ b/lib/runtime/src/utils/leader_worker_barrier.rs
@@ -151,7 +151,7 @@ impl<LeaderData: Serialize + DeserializeOwned, WorkerData: Serialize + Deseriali
         data: &LeaderData,
     ) -> anyhow::Result<HashMap<String, WorkerData>, LeaderWorkerBarrierError> {
         let etcd_client = rt
-            .deprecated_etcd_client()
+            .etcd_client()
             .ok_or(LeaderWorkerBarrierError::EtcdClientNotFound)?;
 
         let lease_id = etcd_client.lease_id();
@@ -245,7 +245,7 @@ impl<LeaderData: Serialize + DeserializeOwned, WorkerData: Serialize + Deseriali
         data: &WorkerData,
     ) -> anyhow::Result<LeaderData, LeaderWorkerBarrierError> {
         let etcd_client = rt
-            .deprecated_etcd_client()
+            .etcd_client()
             .ok_or(LeaderWorkerBarrierError::EtcdClientNotFound)?;
 
         let lease_id = etcd_client.lease_id();


### PR DESCRIPTION
Dynamo frontend and backend both now run without needing etcd. The next step is making them talk to each other.

Some features such as KV routing still require etcd.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Enhanced system resilience: etcd connection failures now gracefully fall back to in-memory storage instead of causing failures, ensuring continued operation.

* **Architecture Updates**
  * Modernized configuration management: router configuration now uses flexible key-value store backend, replacing etcd-specific implementation for better portability.

* **API Changes**
  * Removed deprecated public API accessor to streamline the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->