### PR TITLE
feat: exclude k8 FT tests that need custom build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,8 @@ markers = [
     "slow: marks tests as known to be slow",
     "h100: marks tests to run on H100",
     "kvbm: marks tests for KV behavior and model determinism",
-    "model: model id used by a test or parameter"
+    "model: model id used by a test or parameter",
+    "custom_build: marks tests that require custom builds or special setup (e.g., MoE models)"
 ]
 
 # Linting/formatting

--- a/tests/fault_tolerance/deploy/README.md
+++ b/tests/fault_tolerance/deploy/README.md
@@ -119,6 +119,17 @@ The following failure types are defined in `scenarios.py`:
 | `sglang_prefill_scheduler`    | Terminate SGLang prefill scheduler process.        | `SIGKILL` to `sglang::scheduler`| sglang only         |
 | `sglang_prefill_detokenizer`  | Terminate SGLang prefill detokenizer process.      | `SIGKILL` to `sglang::detokenizer`| sglang only         |
 
+#### Token Overflow Tests
+
+In addition to process and pod failures, the suite includes tests for **token overflow**, where the model receives an input prompt larger than its configured `max_seq_len`. These tests are crucial for verifying that the system can gracefully reject invalid requests without crashing.
+
+- **Failure Injection**: Unlike other tests, this failure is injected from the **client side**. The `aiperf` client is configured to send a batch of requests with oversized token lengths.
+- **Two-Phase Execution**: These tests run in two distinct phases, creating separate log directories for each:
+  1.  **`overflow` Phase**: Sends oversized requests. The expected outcome is a high rate of failed requests (rejections) as the server correctly identifies and blocks them.
+  2.  **`recovery` Phase**: Immediately after the overflow phase, sends valid, normal-sized requests. The expected outcome is a high success rate, confirming that the system has recovered and remains operational.
+
+The combined results of these two phases demonstrate both the system's ability to reject invalid inputs and its stability after handling them.
+
 #### Example Scenario Breakdown
 
 **Scenario**: `sglang-agg-tp-2-dp-1-decode_worker`
@@ -392,7 +403,6 @@ graph LR
     style DecodePool stroke:#000,stroke-width:2px
 ```
 
-
 #### Summary:
 
 
@@ -596,3 +606,5 @@ Test Group: vllm-agg-tp-1-dp-2
 ╘═══════════════════╧═══════════╧═══════════╧══════════╧═══════════╧══════════╧═══════════╧═══════════╧════════════╛
 
 ```
+
+

--- a/tests/fault_tolerance/deploy/README.md
+++ b/tests/fault_tolerance/deploy/README.md
@@ -141,10 +141,16 @@ The combined results of these two phases demonstrate both the system's ability t
 
 #### Example Scenario Execution:
 
-Run all deployments and failure scenarios
+Run standard deployments and failure scenarios (excludes custom builds by default):
 
 ```bash
 pytest tests/fault_tolerance/deploy/test_deployment.py -s -v --namespace ${NAMESPACE}
+```
+
+To include all scenarios including custom builds (e.g., MoE models):
+
+```bash
+pytest tests/fault_tolerance/deploy/test_deployment.py -s -v --namespace ${NAMESPACE} --include-custom-build
 ```
 
 ### Test Results Directory
@@ -490,9 +496,54 @@ Then run the development container mounting the workspace and your kube config.
 
 ### Run the tests
 
+#### Default: Run Standard Tests Only
+
+By default, tests requiring custom builds (e.g., MoE models) are **automatically excluded**:
+
 ```bash
-pytest tests/fault_tolerance/deploy/test_deployment.py -s -v --namespace ${NAMESPACE} --image ${IMAGE}
+# Standard tests only - no special flags needed
+pytest tests/fault_tolerance/deploy/test_deployment.py -s -v \
+  --namespace ${NAMESPACE} \
+  --image ${IMAGE}
 ```
+
+#### Include Custom Build Tests
+
+To run ALL tests including those requiring custom builds (e.g., MoE models):
+
+```bash
+pytest tests/fault_tolerance/deploy/test_deployment.py -s -v \
+  --namespace ${NAMESPACE} \
+  --image ${IMAGE} \
+  --include-custom-build
+```
+
+#### Run Only Custom Build Tests
+
+To run ONLY tests that require custom builds:
+
+```bash
+pytest tests/fault_tolerance/deploy/test_deployment.py -s -v \
+  --namespace ${NAMESPACE} \
+  --image ${IMAGE} \
+  -m "custom_build" \
+  --include-custom-build
+```
+
+#### List Available Tests
+
+```bash
+# See which tests will run by default (excludes custom_build)
+pytest tests/fault_tolerance/deploy/test_deployment.py --collect-only -q
+
+# See which tests are excluded
+pytest tests/fault_tolerance/deploy/test_deployment.py --collect-only -m "custom_build" -q
+```
+
+> **Note:** Tests requiring custom builds are marked with `@pytest.mark.custom_build` and include:
+> - MoE (Mixture-of-Experts) models like DeepSeek-V2-Lite
+> - Tests requiring special Docker image configurations
+> - Any scenario with `requires_custom_build=True` in scenarios.py
 
 
 ### Note on Running with Additional Credentials

--- a/tests/fault_tolerance/deploy/README.md
+++ b/tests/fault_tolerance/deploy/README.md
@@ -130,10 +130,16 @@ The following failure types are defined in `scenarios.py`:
 
 #### Example Scenario Execution:
 
-Run all deployments and failure scenarios
+Run standard deployments and failure scenarios (excludes custom builds by default):
 
 ```bash
 pytest tests/fault_tolerance/deploy/test_deployment.py -s -v --namespace ${NAMESPACE}
+```
+
+To include all scenarios including custom builds (e.g., MoE models):
+
+```bash
+pytest tests/fault_tolerance/deploy/test_deployment.py -s -v --namespace ${NAMESPACE} --include-custom-build
 ```
 
 ### Test Results Directory
@@ -480,9 +486,54 @@ Then run the development container mounting the workspace and your kube config.
 
 ### Run the tests
 
+#### Default: Run Standard Tests Only
+
+By default, tests requiring custom builds (e.g., MoE models) are **automatically excluded**:
+
 ```bash
-pytest tests/fault_tolerance/deploy/test_deployment.py -s -v --namespace ${NAMESPACE} --image ${IMAGE}
+# Standard tests only - no special flags needed
+pytest tests/fault_tolerance/deploy/test_deployment.py -s -v \
+  --namespace ${NAMESPACE} \
+  --image ${IMAGE}
 ```
+
+#### Include Custom Build Tests
+
+To run ALL tests including those requiring custom builds (e.g., MoE models):
+
+```bash
+pytest tests/fault_tolerance/deploy/test_deployment.py -s -v \
+  --namespace ${NAMESPACE} \
+  --image ${IMAGE} \
+  --include-custom-build
+```
+
+#### Run Only Custom Build Tests
+
+To run ONLY tests that require custom builds:
+
+```bash
+pytest tests/fault_tolerance/deploy/test_deployment.py -s -v \
+  --namespace ${NAMESPACE} \
+  --image ${IMAGE} \
+  -m "custom_build" \
+  --include-custom-build
+```
+
+#### List Available Tests
+
+```bash
+# See which tests will run by default (excludes custom_build)
+pytest tests/fault_tolerance/deploy/test_deployment.py --collect-only -q
+
+# See which tests are excluded
+pytest tests/fault_tolerance/deploy/test_deployment.py --collect-only -m "custom_build" -q
+```
+
+> **Note:** Tests requiring custom builds are marked with `@pytest.mark.custom_build` and include:
+> - MoE (Mixture-of-Experts) models like DeepSeek-V2-Lite
+> - Tests requiring special Docker image configurations
+> - Any scenario with `requires_custom_build=True` in scenarios.py
 
 
 ### Note on Running with Additional Credentials

--- a/tests/fault_tolerance/deploy/conftest.py
+++ b/tests/fault_tolerance/deploy/conftest.py
@@ -15,6 +15,10 @@
 
 import pytest
 
+from tests.fault_tolerance.deploy.scenarios import (
+    scenarios,  # Used by pytest_generate_tests
+)
+
 
 def pytest_addoption(parser):
     parser.addoption("--image", type=str, default=None)
@@ -26,6 +30,75 @@ def pytest_addoption(parser):
         choices=["aiperf", "legacy"],
         help="Client type for load generation: 'aiperf' (default) or 'legacy'",
     )
+    parser.addoption(
+        "--include-custom-build",
+        action="store_true",
+        default=False,
+        help="Include tests that require custom builds (e.g., MoE models). "
+        "By default, these tests are excluded.",
+    )
+
+
+def pytest_generate_tests(metafunc):
+    """Dynamically parametrize tests and apply markers based on scenario properties.
+
+    This hook applies markers to individual test instances based on their scenario:
+    - @pytest.mark.custom_build: For MoE models and other tests requiring custom builds
+    """
+    if "scenario" in metafunc.fixturenames:
+        scenario_names = list(scenarios.keys())
+        argvalues = []
+        ids = []
+
+        for scenario_name in scenario_names:
+            scenario_obj = scenarios[scenario_name]
+            marks = []
+
+            if getattr(scenario_obj, "requires_custom_build", False):
+                marks.append(pytest.mark.custom_build)
+
+            if marks:
+                param = pytest.param(scenario_name, marks=marks)
+            else:
+                param = scenario_name
+
+            argvalues.append(param)
+            ids.append(scenario_name)
+
+        metafunc.parametrize("scenario_name", argvalues, ids=ids)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Automatically deselect custom_build tests unless --include-custom-build is specified.
+
+    This allows users to run tests without any special flags and automatically excludes
+    tests that require custom builds. To include them, use --include-custom-build.
+
+    Note: If user explicitly uses -m marker filtering, we respect that and don't
+    auto-deselect, allowing them to run custom_build tests with -m "custom_build".
+    """
+    # If --include-custom-build flag is set, include all tests
+    if config.getoption("--include-custom-build"):
+        return
+
+    # If user explicitly used -m marker filtering, let pytest handle it
+    # Don't auto-deselect in this case
+    if config.option.markexpr:
+        return
+
+    # Default case: auto-deselect custom_build tests
+    deselected = []
+    selected = []
+
+    for item in items:
+        if "custom_build" in item.keywords:
+            deselected.append(item)
+        else:
+            selected.append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected
 
 
 @pytest.fixture

--- a/tests/fault_tolerance/deploy/legacy_parse_results.py
+++ b/tests/fault_tolerance/deploy/legacy_parse_results.py
@@ -418,7 +418,7 @@ def process_test_directory(test_dir, sla):
     }
 
 
-def main(logs_dir, tablefmt, log_paths=None, sla=None):
+def main(logs_dir, tablefmt, log_paths=None, sla=None, print_output=True):
     """Main entry point for parsing legacy client results.
 
     Args:
@@ -426,6 +426,7 @@ def main(logs_dir, tablefmt, log_paths=None, sla=None):
         tablefmt: Table format for output (e.g., "fancy_grid")
         log_paths: Optional list of specific log paths to process
         sla: Optional SLA threshold for latency violations
+        print_output: If True, print tables and summaries. If False, only return results.
     """
     results = []
 
@@ -542,19 +543,21 @@ def main(logs_dir, tablefmt, log_paths=None, sla=None):
                 ]
             rows.append(row)
 
-        print(f"\nTest Group: {test_prefix}")
-        print(
-            tabulate(
-                rows,
-                headers,
-                tablefmt=tablefmt,
-                floatfmt=".2f",
-                missingval="N/A",
-                numalign="right",
-                stralign="center",
+        if print_output:
+            logging.info(f"\nTest Group: {test_prefix}")
+            logging.info(
+                "\n"
+                + tabulate(
+                    rows,
+                    headers,
+                    tablefmt=tablefmt,
+                    floatfmt=".2f",
+                    missingval="N/A",
+                    numalign="right",
+                    stralign="center",
+                )
             )
-        )
-        print("\n" + "=" * 80)
+            logging.info("\n" + "=" * 80)
 
 
 if __name__ == "__main__":

--- a/tests/fault_tolerance/deploy/parse_factory.py
+++ b/tests/fault_tolerance/deploy/parse_factory.py
@@ -103,7 +103,9 @@ def parse_test_results(
     log_paths: Optional[List[str]] = None,
     tablefmt: str = "grid",
     sla: Optional[float] = None,
+    success_threshold: float = 90.0,
     force_parser: Optional[str] = None,
+    print_output: bool = True,
 ) -> Any:
     """Auto-detect and parse test results using the appropriate parser.
 
@@ -116,8 +118,10 @@ def parse_test_results(
         log_paths: List of log directories to process (for multiple directories)
         tablefmt: Table format for output (e.g., "fancy_grid", "pipe")
         sla: Optional SLA threshold for latency violations
+        success_threshold: Success rate threshold for pass/fail (default: 90.0)
         force_parser: Optional override to force using a specific parser
                      ("aiperf" or "legacy"). If not provided, auto-detection is used.
+        print_output: If True, print tables and summaries. If False, only return results.
 
     Returns:
         Results from the appropriate parser
@@ -189,6 +193,8 @@ def parse_test_results(
                 log_paths=log_paths,
                 tablefmt=tablefmt,
                 sla=sla,
+                success_threshold=success_threshold,
+                print_output=print_output,
             )
         else:
             return parse_aiperf(
@@ -196,6 +202,8 @@ def parse_test_results(
                 log_paths=None,
                 tablefmt=tablefmt,
                 sla=sla,
+                success_threshold=success_threshold,
+                print_output=print_output,
             )
 
     elif parser_type == "legacy":
@@ -209,6 +217,7 @@ def parse_test_results(
                 log_paths=log_paths,
                 tablefmt=tablefmt,
                 sla=sla,
+                print_output=print_output,
             )
         else:
             return parse_legacy(
@@ -216,6 +225,7 @@ def parse_test_results(
                 log_paths=None,
                 tablefmt=tablefmt,
                 sla=sla,
+                print_output=print_output,
             )
 
     else:
@@ -294,18 +304,18 @@ def print_result_info(log_dir: str) -> None:
     """
     info = get_result_info(log_dir)
 
-    print(f"\nTest Results Information: {log_dir}")
-    print("=" * 60)
-    print(f"Result Type: {info['type'] or 'Unknown'}")
-    print(f"Client Count: {info['client_count']}")
-    print(f"Has Test Log: {info['has_test_log']}")
+    logging.info(f"\nTest Results Information: {log_dir}")
+    logging.info("=" * 60)
+    logging.info(f"Result Type: {info['type'] or 'Unknown'}")
+    logging.info(f"Client Count: {info['client_count']}")
+    logging.info(f"Has Test Log: {info['has_test_log']}")
 
     if info["details"]:
-        print("\nDetails:")
+        logging.info("\nDetails:")
         for key, value in info["details"].items():
-            print(f"  {key}: {value}")
+            logging.info(f"  {key}: {value}")
 
-    print("=" * 60)
+    logging.info("=" * 60)
 
 
 if __name__ == "__main__":
@@ -354,7 +364,7 @@ if __name__ == "__main__":
             for log_path in args.log_paths:
                 print_result_info(log_path)
         else:
-            print("Error: Must provide log_dir or --log-paths")
+            logging.error("Must provide log_dir or --log-paths")
     else:
         # Parse mode
         try:

--- a/tests/fault_tolerance/deploy/scenarios.py
+++ b/tests/fault_tolerance/deploy/scenarios.py
@@ -15,9 +15,41 @@
 
 import re
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Dict, Optional, Pattern
 
+from typing_extensions import TypedDict
+
 from tests.utils.managed_deployment import DeploymentSpec
+
+
+class TestPhase(Enum):
+    """Enum representing different test phases in fault tolerance testing."""
+
+    STANDARD = auto()
+    OVERFLOW = auto()
+    RECOVERY = auto()
+
+
+class DeploymentInfo(TypedDict, total=False):
+    """Information about a deployment configuration.
+
+    Attributes:
+        spec: DeploymentSpec object defining the deployment configuration
+        backend: Backend type - "vllm", "sglang", or "trtllm"
+        model: Optional model identifier (e.g., "deepseek-ai/DeepSeek-V2-Lite")
+        is_moe: Optional flag indicating if this is a Mixture-of-Experts model
+    """
+
+    spec: DeploymentSpec
+    backend: str
+    model: str
+    is_moe: bool
+
+
+# Test phase suffixes derived from TestPhase enum
+OVERFLOW_SUFFIX = f"_{TestPhase.OVERFLOW.name.lower()}"
+RECOVERY_SUFFIX = f"_{TestPhase.RECOVERY.name.lower()}"
 
 # Worker name mapping for different backends
 WORKER_MAP = {
@@ -102,6 +134,13 @@ class Load:
     sla: Optional[float] = None
     client_type: str = "aiperf"  # "aiperf" or "legacy"
     max_request_rate: float = 1.0  # Rate limiting for legacy client (requests/sec)
+    success_threshold: float = 90.0  # Success rate threshold for tests
+
+    # For mixed token testing (overflow + recovery)
+    mixed_token_test: bool = False
+    overflow_token_length: Optional[int] = None  # Tokens for overflow requests
+    overflow_request_count: int = 15  # Number of overflow requests
+    normal_request_count: int = 15  # Number of normal requests after overflow
 
 
 @dataclass
@@ -114,6 +153,31 @@ class Failure:
 
 
 @dataclass
+class TokenOverflowFailure(Failure):
+    """
+    Failure type for injecting token overflow (prompt > max_seq_len)
+    """
+
+    overflow_multiplier: float = 2.0  # How much to exceed max_seq_len (e.g., 2.0 = 2x)
+    max_seq_len: int = 1024
+
+    def __init__(
+        self,
+        time: int,
+        max_seq_len: int = 1024,
+        overflow_multiplier: float = 2.0,
+    ):
+        super().__init__(
+            time=time,
+            pod_name="Client",
+            command="token_overflow",
+        )
+        self.max_seq_len = max_seq_len
+        self.overflow_multiplier = overflow_multiplier
+        self.overflow_token_count = int(max_seq_len * overflow_multiplier)
+
+
+@dataclass
 class Scenario:
     deployment: DeploymentSpec
     load: Load
@@ -123,9 +187,17 @@ class Scenario:
 
 
 # Helper functions to create deployment specs
-def _create_deployment_spec(backend, deploy_type, yaml_path):
-    """Create a deployment spec with backend information."""
-    return {"spec": DeploymentSpec(yaml_path), "backend": backend}
+def _create_deployment_spec(backend: str, yaml_path: str) -> DeploymentInfo:
+    """Create a deployment spec with backend information.
+
+    Args:
+        backend: Backend type ("vllm", "sglang", or "trtllm")
+        yaml_path: Path to the deployment YAML file
+
+    Returns:
+        DeploymentInfo dictionary with spec and backend
+    """
+    return DeploymentInfo(spec=DeploymentSpec(yaml_path), backend=backend)
 
 
 def _set_replicas(deployment_spec, backend, deploy_type, replicas):
@@ -171,9 +243,16 @@ def _set_tensor_parallel(deployment_spec, backend, deploy_type, tp_size):
             spec[decode_worker].tensor_parallel_size = tp_size
 
 
-def _create_deployments_for_backend(backend):
-    """Create all deployment specifications for a given backend."""
-    deployments = {}
+def _create_deployments_for_backend(backend: str) -> Dict[str, DeploymentInfo]:
+    """Create all deployment specifications for a given backend.
+
+    Args:
+        backend: Backend type ("vllm", "sglang", or "trtllm")
+
+    Returns:
+        Dictionary mapping deployment names to DeploymentInfo objects
+    """
+    deployments: Dict[str, DeploymentInfo] = {}
 
     # Define the yaml files for agg and disagg deployments
     yaml_files = {
@@ -210,9 +289,7 @@ def _create_deployments_for_backend(backend):
             scenario_name = "-".join(name_parts)
 
             # Create and configure the deployment
-            deployment = _create_deployment_spec(
-                backend, deploy_type, yaml_files[deploy_type]
-            )
+            deployment = _create_deployment_spec(backend, yaml_files[deploy_type])
             if tp_size > 1:
                 _set_tensor_parallel(deployment, backend, deploy_type, tp_size)
             if dp_replicas > 1:
@@ -223,9 +300,18 @@ def _create_deployments_for_backend(backend):
     return deployments
 
 
-def _create_moe_deployments_for_backend(backend="vllm"):
-    """Create MoE-specific deployment configurations for DeepSeek-V2-Lite."""
-    deployments = {}
+def _create_moe_deployments_for_backend(
+    backend: str = "vllm",
+) -> Dict[str, DeploymentInfo]:
+    """Create MoE-specific deployment configurations for DeepSeek-V2-Lite.
+
+    Args:
+        backend: Backend type (default: "vllm")
+
+    Returns:
+        Dictionary mapping deployment names to DeploymentInfo objects
+    """
+    deployments: Dict[str, DeploymentInfo] = {}
 
     # Only test tp=1, dp=2 for now
     tp_size = 1
@@ -241,12 +327,12 @@ def _create_moe_deployments_for_backend(backend="vllm"):
 
     for deploy_type in ["agg", "disagg"]:
         scenario_name = f"{backend}-moe-{deploy_type}-tp-{tp_size}-dp-{dp_replicas}"
-        deployment = {
-            "spec": DeploymentSpec(yaml_files[deploy_type]),
-            "backend": backend,
-            "model": "deepseek-ai/DeepSeek-V2-Lite",
-            "is_moe": True,
-        }
+        deployment = DeploymentInfo(
+            spec=DeploymentSpec(yaml_files[deploy_type]),
+            backend=backend,
+            model="deepseek-ai/DeepSeek-V2-Lite",
+            is_moe=True,
+        )
 
         deployments[scenario_name] = deployment
 
@@ -254,13 +340,13 @@ def _create_moe_deployments_for_backend(backend="vllm"):
 
 
 # Create all deployment specifications
-deployment_specs = {}
-deployment_specs.update(_create_deployments_for_backend("vllm"))
-deployment_specs.update(_create_deployments_for_backend("sglang"))
-deployment_specs.update(_create_deployments_for_backend("trtllm"))
+DEPLOYMENT_SPECS: Dict[str, DeploymentInfo] = {}
+DEPLOYMENT_SPECS.update(_create_deployments_for_backend("vllm"))
+DEPLOYMENT_SPECS.update(_create_deployments_for_backend("sglang"))
+DEPLOYMENT_SPECS.update(_create_deployments_for_backend("trtllm"))
 
 # Add MoE deployments for vLLM only
-deployment_specs.update(_create_moe_deployments_for_backend("vllm"))
+DEPLOYMENT_SPECS.update(_create_moe_deployments_for_backend("vllm"))
 
 
 # Each failure scenaro contains a list of failure injections
@@ -340,6 +426,7 @@ def create_aiperf_load(
     max_retries: int = 3,
     sla: Optional[float] = None,
     max_request_rate: float = 1.0,
+    success_threshold: float = 90.0,
 ) -> Load:
     """Create a Load configuration for AI-Perf client.
 
@@ -351,6 +438,7 @@ def create_aiperf_load(
         max_retries: Maximum retry attempts - AI-Perf retries entire test (default: 3)
         sla: Optional SLA threshold for latency (default: None)
         max_request_rate: Rate limiting for requests/sec (default: 1.0)
+        success_threshold: Success rate threshold for pass/fail (default: 90.0)
 
     Returns:
         Load instance configured for AI-Perf client
@@ -367,6 +455,7 @@ def create_aiperf_load(
         sla=sla,
         client_type="aiperf",
         max_request_rate=max_request_rate,
+        success_threshold=success_threshold,
     )
 
 
@@ -378,6 +467,7 @@ def create_legacy_load(
     max_retries: int = 1,
     sla: Optional[float] = None,
     max_request_rate: float = 1.0,
+    success_threshold: float = 90.0,
 ) -> Load:
     """Create a Load configuration for legacy custom client.
 
@@ -389,6 +479,7 @@ def create_legacy_load(
         max_retries: Maximum retry attempts - legacy retries per request (default: 1)
         sla: Optional SLA threshold for latency (default: None)
         max_request_rate: Rate limiting for requests/sec (default: 1.0)
+        success_threshold: Success rate threshold for pass/fail (default: 90.0)
 
     Returns:
         Load instance configured for legacy client
@@ -405,6 +496,7 @@ def create_legacy_load(
         sla=sla,
         client_type="legacy",
         max_request_rate=max_request_rate,
+        success_threshold=success_threshold,
     )
 
 
@@ -439,7 +531,7 @@ for backend in ["vllm", "sglang", "trtllm"]:
         backend, "disagg"
     )
 
-for deployment_name, deployment_info in deployment_specs.items():
+for deployment_name, deployment_info in DEPLOYMENT_SPECS.items():
     backend = deployment_info["backend"]
 
     # Check if this is an MoE deployment
@@ -481,3 +573,140 @@ for deployment_name, deployment_info in deployment_specs.items():
             model=scenario_model,
             backend=backend,
         )
+
+
+# Add token overflow test scenarios
+def add_token_overflow_scenarios():
+    """
+    Add test scenarios for token overflow (prompt > max_seq_len) failures
+    """
+    overflow_test_configs = [
+        # vLLM tests
+        {
+            "name": "vllm_agg_token_overflow_2x",
+            "deployment_key": "vllm-agg-tp-1-dp-1",
+            "backend": "vllm",
+        },
+        {
+            "name": "vllm_disagg_token_overflow_2x",
+            "deployment_key": "vllm-disagg-prefill-tp-2-decode-tp-2-dp-1",
+            "backend": "vllm",
+        },
+        # TRT-LLM tests
+        {
+            "name": "trtllm_agg_token_overflow_2x",
+            "deployment_key": "trtllm-agg-tp-1-dp-1",
+            "backend": "trtllm",
+        },
+        {
+            "name": "trtllm_disagg_token_overflow_2x",
+            "deployment_key": "trtllm-disagg-prefill-tp-2-decode-tp-2-dp-1",
+            "backend": "trtllm",
+        },
+        # SGLang tests
+        {
+            "name": "sglang_agg_token_overflow_2x",
+            "deployment_key": "sglang-agg-tp-1-dp-1",
+            "backend": "sglang",
+        },
+        {
+            "name": "sglang_disagg_token_overflow_2x",
+            "deployment_key": "sglang-disagg-prefill-tp-2-decode-tp-2-dp-1",
+            "backend": "sglang",
+        },
+    ]
+
+    # Common configuration for all tests
+    MAX_SEQ_LEN = 1024
+    OVERFLOW_MULTIPLIER = 2.0
+    OVERFLOW_REQUESTS = 15  # Number of oversized requests to send
+    NORMAL_REQUESTS = 15  # Number of normal requests to send after overflow
+
+    for config in overflow_test_configs:
+        # Skip if deployment doesn't exist
+        if config["deployment_key"] not in DEPLOYMENT_SPECS:
+            continue
+
+        overflow_scenario_name = config["name"]
+        deployment_info = DEPLOYMENT_SPECS[config["deployment_key"]]
+
+        scenario_model = deployment_info.get("model", model)
+
+        deployment_spec = deployment_info["spec"]
+
+        backend = config["backend"]
+        is_agg = (
+            "disagg" not in config["deployment_key"]
+        )  # If not disaggregated, then it's aggregated
+
+        workers = WORKER_MAP[backend]
+
+        # Get the correct decode worker name
+        if backend == "trtllm" and is_agg:
+            decode_worker = workers["decode_agg"]
+        else:
+            decode_worker = workers["decode"]
+
+        prefill_worker = workers["prefill"]
+
+        # Determine argument name based on backend
+        if backend == "trtllm":
+            arg_name = "--max-seq-len"
+        elif backend == "sglang":
+            arg_name = "--context-length"
+        else:  # vllm
+            arg_name = "--max-model-len"
+
+        # Add arguments to appropriate workers
+        if is_agg:
+            # For aggregated, add only to decode worker
+            deployment_spec.add_arg_to_service(
+                decode_worker, arg_name, str(MAX_SEQ_LEN)
+            )
+        else:
+            # For disaggregated, add to both prefill and decode workers
+            deployment_spec.add_arg_to_service(
+                prefill_worker, arg_name, str(MAX_SEQ_LEN)
+            )
+            deployment_spec.add_arg_to_service(
+                decode_worker, arg_name, str(MAX_SEQ_LEN)
+            )
+
+        # Create overflow failure
+        overflow_failure = TokenOverflowFailure(
+            time=30,  # Start after 30 seconds
+            max_seq_len=MAX_SEQ_LEN,
+            overflow_multiplier=OVERFLOW_MULTIPLIER,
+        )
+
+        # Create mixed load configuration for overflow + recovery testing
+        overflow_tokens = int(MAX_SEQ_LEN * OVERFLOW_MULTIPLIER)
+        normal_tokens = 512  # Well within MAX_SEQ_LEN
+
+        # Total requests = overflow + normal
+        total_requests = OVERFLOW_REQUESTS + NORMAL_REQUESTS
+
+        # Mixed load that tests both rejection and recovery
+        mixed_load = Load(
+            clients=3,
+            requests_per_client=total_requests,
+            input_token_length=normal_tokens,
+            output_token_length=50,
+            # Mixed token test configuration
+            mixed_token_test=True,
+            overflow_token_length=overflow_tokens,
+            overflow_request_count=OVERFLOW_REQUESTS,
+            normal_request_count=NORMAL_REQUESTS,
+        )
+
+        scenarios[overflow_scenario_name] = Scenario(
+            deployment=deployment_spec,
+            load=mixed_load,
+            failures=[overflow_failure],
+            model=scenario_model,
+            backend=backend,
+        )
+
+
+# Add the token overflow scenarios
+add_token_overflow_scenarios()

--- a/tests/fault_tolerance/deploy/scenarios.py
+++ b/tests/fault_tolerance/deploy/scenarios.py
@@ -184,6 +184,9 @@ class Scenario:
     failures: list[Failure]
     model: Optional[str] = None
     backend: str = "vllm"  # Backend type for tracking
+    # When set to True, the test will be automatically marked with @pytest.mark.custom_build
+    # and excluded from default test runs unless --include-custom-build flag is used
+    requires_custom_build: bool = False  # Flag for tests needing custom builds/setup
 
 
 # Helper functions to create deployment specs
@@ -572,6 +575,7 @@ for deployment_name, deployment_info in DEPLOYMENT_SPECS.items():
             failures=failure,
             model=scenario_model,
             backend=backend,
+            requires_custom_build=is_moe,  # MoE models require custom builds
         )
 
 

--- a/tests/fault_tolerance/deploy/scenarios.py
+++ b/tests/fault_tolerance/deploy/scenarios.py
@@ -120,6 +120,9 @@ class Scenario:
     failures: list[Failure]
     model: Optional[str] = None
     backend: str = "vllm"  # Backend type for tracking
+    # When set to True, the test will be automatically marked with @pytest.mark.custom_build
+    # and excluded from default test runs unless --include-custom-build flag is used
+    requires_custom_build: bool = False  # Flag for tests needing custom builds/setup
 
 
 # Helper functions to create deployment specs
@@ -480,4 +483,5 @@ for deployment_name, deployment_info in deployment_specs.items():
             failures=failure,
             model=scenario_model,
             backend=backend,
+            requires_custom_build=is_moe,  # MoE models require custom builds
         )

--- a/tests/fault_tolerance/deploy/test_deployment.py
+++ b/tests/fault_tolerance/deploy/test_deployment.py
@@ -3,6 +3,7 @@
 
 import logging
 import multiprocessing
+import re
 import time
 from contextlib import contextmanager
 
@@ -10,7 +11,14 @@ import pytest
 
 from tests.fault_tolerance.deploy.client_factory import get_client_function
 from tests.fault_tolerance.deploy.parse_factory import parse_test_results
-from tests.fault_tolerance.deploy.scenarios import Load, scenarios
+from tests.fault_tolerance.deploy.parse_results import process_overflow_recovery_test
+from tests.fault_tolerance.deploy.scenarios import (
+    OVERFLOW_SUFFIX,
+    RECOVERY_SUFFIX,
+    Load,
+    TokenOverflowFailure,
+    scenarios,
+)
 from tests.utils.managed_deployment import ManagedDeployment
 
 
@@ -80,26 +88,89 @@ def _clients(
         # AI-Perf client uses retry_delay between attempts (default 5s)
         retry_delay_or_rate = 5
 
-    for i in range(load_config.clients):
-        procs.append(
-            ctx.Process(
+    # Check if this is a mixed token test (overflow + recovery)
+    # If mixed_token_test is True, run two phases; otherwise run normally
+    if hasattr(load_config, "mixed_token_test") and load_config.mixed_token_test:
+        logger.info(
+            f"Mixed token test: {load_config.overflow_request_count} overflow requests "
+            f"({load_config.overflow_token_length} tokens) + "
+            f"{load_config.normal_request_count} normal requests "
+            f"({load_config.input_token_length} tokens)"
+        )
+
+        # First phase: Send overflow requests
+        for i in range(load_config.clients):
+            proc_overflow = ctx.Process(
                 target=client_func,
                 args=(
                     deployment_spec,
                     namespace,
                     model,
-                    request.node.name,
+                    request.node.name + OVERFLOW_SUFFIX,
                     i,
-                    load_config.requests_per_client,
-                    load_config.input_token_length,
+                    load_config.overflow_request_count,  # 15 overflow requests
+                    load_config.overflow_token_length,  # 2x max_seq_len tokens
                     load_config.output_token_length,
                     load_config.max_retries,
                     retry_delay_or_rate,
                 ),
             )
-        )
-        procs[-1].start()
-        logger.debug(f"Started client {i} (PID: {procs[-1].pid})")
+            proc_overflow.start()
+            procs.append(proc_overflow)
+            logger.debug(f"Started overflow client {i} (PID: {proc_overflow.pid})")
+
+        # Wait for overflow requests to complete
+        for proc in procs:
+            proc.join()
+
+        logger.info("Overflow requests completed. Starting recovery phase...")
+
+        # Second phase: Send normal requests to test recovery
+        procs_recovery = []
+        for i in range(load_config.clients):
+            proc_normal = ctx.Process(
+                target=client_func,
+                args=(
+                    deployment_spec,
+                    namespace,
+                    model,
+                    request.node.name + RECOVERY_SUFFIX,
+                    i,
+                    load_config.normal_request_count,  # 15 normal requests
+                    load_config.input_token_length,  # Normal token count
+                    load_config.output_token_length,
+                    load_config.max_retries,
+                    retry_delay_or_rate,
+                ),
+            )
+            proc_normal.start()
+            procs_recovery.append(proc_normal)
+            logger.debug(f"Started recovery client {i} (PID: {proc_normal.pid})")
+
+        # Add recovery processes to main list
+        procs.extend(procs_recovery)
+    else:
+        # Normal test - single phase
+        for i in range(load_config.clients):
+            procs.append(
+                ctx.Process(
+                    target=client_func,
+                    args=(
+                        deployment_spec,
+                        namespace,
+                        model,
+                        request.node.name,
+                        i,
+                        load_config.requests_per_client,
+                        load_config.input_token_length,
+                        load_config.output_token_length,
+                        load_config.max_retries,
+                        retry_delay_or_rate,
+                    ),
+                )
+            )
+            procs[-1].start()
+            logger.debug(f"Started client {i} (PID: {procs[-1].pid})")
 
     yield procs
 
@@ -112,6 +183,13 @@ def _clients(
 def _inject_failures(failures, logger, deployment: ManagedDeployment):  # noqa: F811
     for failure in failures:
         time.sleep(failure.time)
+
+        # Handle TokenOverflowFailure differently - it's a client-side injection
+        if isinstance(failure, TokenOverflowFailure):
+            # The actual overflow is handled by the client configuration
+            # which uses the input_token_length from the Load config
+            # This is just logging for visibility
+            continue
 
         pods = deployment.get_pods(failure.pod_name)[failure.pod_name]
 
@@ -155,41 +233,109 @@ def results_table(request, scenario):  # noqa: F811
     """
     yield
 
+    # Determine log paths based on whether this is a mixed token test
+    log_paths = []
+    if hasattr(scenario.load, "mixed_token_test") and scenario.load.mixed_token_test:
+        # For mixed token tests, we have separate overflow and recovery directories
+        overflow_dir = f"{request.node.name}{OVERFLOW_SUFFIX}"
+        recovery_dir = f"{request.node.name}{RECOVERY_SUFFIX}"
+        log_paths = [overflow_dir, recovery_dir]
+
+        logging.info("Mixed token test detected. Looking for results in:")
+        logging.info(f"  - Overflow phase: {overflow_dir}")
+        logging.info(f"  - Recovery phase: {recovery_dir}")
+    else:
+        # Standard test with single directory
+        log_paths = [request.node.name]
+
     # Use factory to auto-detect and parse results
     try:
         parse_test_results(
             log_dir=None,
-            log_paths=[request.node.name],
+            log_paths=log_paths,
             tablefmt="fancy_grid",
             sla=scenario.load.sla,
+            success_threshold=scenario.load.success_threshold,
+            print_output=True,
             # force_parser can be set based on client_type if needed
             # force_parser=scenario.load.client_type,
         )
-    except Exception as e:
-        logging.error(f"Failed to parse results for {request.node.name}: {e}")
+    except Exception:
+        logging.exception("Failed to parse results for %s", request.node.name)
 
-    global_result_list.append(request.node.name)
+    # Add all directories to global list for session summary
+    global_result_list.extend(log_paths)
 
 
 @pytest.fixture(autouse=True, scope="session")
 def results_summary():
-    """Parse and display combined results for all tests in session.
-
-    Automatically detects result types and uses appropriate parsers.
+    """
+    Session summary that processes all tests but only prints paired tests.
     """
     yield
 
     if not global_result_list:
-        logging.info("No test results to summarize")
         return
 
-    # Use factory to auto-detect and parse combined results
+    # Step 1: Group directories
+    test_groups: dict[str, dict[str, str]] = {}
+
+    for log_path in global_result_list:
+        if log_path.endswith(OVERFLOW_SUFFIX):
+            base_name = log_path[: -len(OVERFLOW_SUFFIX)]
+            if base_name not in test_groups:
+                test_groups[base_name] = {}
+            test_groups[base_name]["overflow"] = log_path
+        elif log_path.endswith(RECOVERY_SUFFIX):
+            base_name = log_path[: -len(RECOVERY_SUFFIX)]
+            if base_name not in test_groups:
+                test_groups[base_name] = {}
+            test_groups[base_name]["recovery"] = log_path
+
+    # Step 2: Process all tests (get results) but only print paired ones
     try:
+        # First, silently parse all tests to get results (for any downstream processing)
         parse_test_results(
             log_dir=None,
             log_paths=global_result_list,
             tablefmt="fancy_grid",
+            print_output=False,  # Don't print anything
         )
+
+        for base_name, paths in test_groups.items():
+            if "overflow" in paths and "recovery" in paths:
+                # Extract scenario from test name to pass configs
+                scenario_obj = None
+                match = re.search(r"\[(.*)\]", base_name)
+                if match:
+                    scenario_name = match.group(1)
+                    if scenario_name in scenarios:
+                        scenario_obj = scenarios[scenario_name]
+                        logging.info(
+                            f"Found scenario '{scenario_name}' for combined results."
+                        )
+
+                if not scenario_obj:
+                    logging.warning(
+                        f"Could not find scenario for '{base_name}'. Using default thresholds."
+                    )
+
+                success_threshold = (
+                    scenario_obj.load.success_threshold if scenario_obj else 90.0
+                )
+                logging.info(
+                    f"Using success_threshold: {success_threshold} for combined summary of '{base_name}'"
+                )
+
+                # This function will print the combined summary
+                process_overflow_recovery_test(
+                    overflow_path=paths["overflow"],
+                    recovery_path=paths["recovery"],
+                    tablefmt="fancy_grid",
+                    sla=scenario_obj.load.sla if scenario_obj else None,
+                    success_threshold=success_threshold,
+                )
+
     except Exception as e:
         logging.error(f"Failed to parse combined results: {e}")
 

--- a/tests/fault_tolerance/deploy/test_deployment.py
+++ b/tests/fault_tolerance/deploy/test_deployment.py
@@ -22,13 +22,13 @@ from tests.fault_tolerance.deploy.scenarios import (
 from tests.utils.managed_deployment import ManagedDeployment
 
 
-@pytest.fixture(params=scenarios.keys())
-def scenario(request, client_type):
+@pytest.fixture
+def scenario(scenario_name, client_type):
     """Get scenario and optionally override client type from command line.
 
     If --client-type is specified, it overrides the scenario's default client type.
     """
-    scenario_obj = scenarios[request.param]
+    scenario_obj = scenarios[scenario_name]
 
     # Override client type if specified on command line
     if client_type is not None:

--- a/tests/fault_tolerance/deploy/test_deployment.py
+++ b/tests/fault_tolerance/deploy/test_deployment.py
@@ -14,13 +14,13 @@ from tests.fault_tolerance.deploy.scenarios import Load, scenarios
 from tests.utils.managed_deployment import ManagedDeployment
 
 
-@pytest.fixture(params=scenarios.keys())
-def scenario(request, client_type):
+@pytest.fixture
+def scenario(scenario_name, client_type):
     """Get scenario and optionally override client type from command line.
 
     If --client-type is specified, it overrides the scenario's default client type.
     """
-    scenario_obj = scenarios[request.param]
+    scenario_obj = scenarios[scenario_name]
 
     # Override client type if specified on command line
     if client_type is not None:

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -316,6 +316,59 @@ class DeploymentSpec:
     def spec(self):
         return self._deployment_spec
 
+    def add_arg_to_service(self, service_name: str, arg_name: str, arg_value: str):
+        """
+        Add or override a command-line argument for a specific service
+
+        Args:
+            service_name: Name of the service (e.g., "VllmDecodeWorker", "TRTLLMWorker")
+            arg_name: Argument name (e.g., "--max-model-len", "--max-seq-len")
+            arg_value: Argument value (e.g., "1024")
+        """
+        # Get the service
+        if service_name not in self._deployment_spec["spec"]["services"]:
+            raise ValueError(f"Service '{service_name}' not found in deployment spec")
+
+        service = self._deployment_spec["spec"]["services"][service_name]
+
+        # Ensure args list exists
+        if "extraPodSpec" not in service:
+            service["extraPodSpec"] = {"mainContainer": {}}
+        if "mainContainer" not in service["extraPodSpec"]:
+            service["extraPodSpec"]["mainContainer"] = {}
+        if "args" not in service["extraPodSpec"]["mainContainer"]:
+            service["extraPodSpec"]["mainContainer"]["args"] = []
+
+        args_list = service["extraPodSpec"]["mainContainer"]["args"]
+
+        # Convert to list if needed (sometimes it's a single string)
+        if isinstance(args_list, str):
+            import shlex
+
+            args_list = shlex.split(args_list)
+            service["extraPodSpec"]["mainContainer"]["args"] = args_list
+
+        # Find existing argument
+        arg_index = None
+        for i, arg in enumerate(args_list):
+            if arg == arg_name:
+                arg_index = i
+                break
+
+        if arg_index is not None:
+            # Argument found, check if it has a value
+            if arg_index + 1 < len(args_list) and not args_list[
+                arg_index + 1
+            ].startswith("-"):
+                # Has a value, replace it
+                args_list[arg_index + 1] = arg_value
+            else:
+                # No value after the argument, insert the value
+                args_list.insert(arg_index + 1, arg_value)
+        else:
+            # Add new argument
+            args_list.extend([arg_name, arg_value])
+
     def save(self, out_file: str):
         """Save updated deployment to file"""
         with open(out_file, "w") as f:


### PR DESCRIPTION
#### Overview:

Auto-exclude tests requiring custom builds (e.g., MoE models) by default using pytest markers. Users can run standard tests without special flags, while custom build tests can be explicitly included when needed.

#### Details:

**Problem:** MoE model tests and other tests requiring custom builds were mixed with standard tests, requiring manual filtering to avoid running tests without proper setup.

**Solution:** Implement automatic test filtering using pytest markers:
- Added `custom_build` marker and `requires_custom_build` field to `Scenario` dataclass
- MoE scenarios automatically tagged with `@pytest.mark.custom_build`
- Custom build tests auto-excluded by default during test collection
- Tests can be explicitly included with `--include-custom-build` flag or `-m` marker filtering
#### Where should the reviewer start?

- tests/fault_tolerance/deploy/conftest.py - Core logic: pytest hooks for dynamic marker application and auto-filtering
- tests/fault_tolerance/deploy/scenarios.py - Added requires_custom_build field 
- pyproject.toml - Registered custom_build marker 
- tests/fault_tolerance/deploy/README.md - Updated usage documentation

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-949


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a custom_build marker to identify tests requiring special setups.
  * Added --include-custom-build flag to selectively run marked tests.
  * Default test execution now excludes custom build tests.

* **Documentation**
  * Updated test guidance with new execution options and examples for including or excluding custom build tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->