### PR TITLE
chore: Add openssh-server in sglang docker container

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -143,8 +143,6 @@ RUN apt-get update \
         libczmq4 \
         libczmq-dev \
         libfabric-dev \
-        # NVIDIA dependencies
-        nvidia-dkms-550
         # Package building tools
         devscripts \
         debhelper \

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -105,6 +105,7 @@ RUN apt-get update \
         unzip \
         # Network utilities
         netcat-openbsd \
+        openssh-server \
         # SSL and pkg-config
         libssl-dev \
         pkg-config \
@@ -142,6 +143,8 @@ RUN apt-get update \
         libczmq4 \
         libczmq-dev \
         libfabric-dev \
+        # NVIDIA dependencies
+        nvidia-dkms-550
         # Package building tools
         devscripts \
         debhelper \

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -39,7 +39,7 @@ FROM ${DYNAMO_BASE_IMAGE} AS dynamo_base
 # - Develop or debug framework-level components
 # - Create custom builds with specific optimization flags
 #
-FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu24.04 AS framework
+FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu22.04 AS framework
 
 # Declare all ARGs
 ARG BUILD_TYPE=all


### PR DESCRIPTION
#### Overview:

After comparing the sglang Dockerfile, I noticed that there are a few missing libs in the package which could be resulting in the QA bug in 5623639. This PR adds the openssh-server to determine if this could be causing the network timeout.

#### Details:

- Install openssh-server in sglang dockerfile. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled SSH server support in container images, providing remote access and administrative capabilities for container management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->