### PR TITLE
fix: retry DGD status update when failing because of conflicts

### DIFF
--- a/deploy/cloud/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/cloud/operator/internal/controller/dynamographdeployment_controller.go
@@ -179,12 +179,14 @@ func (r *DynamoGraphDeploymentReconciler) setStatusConditions(ctx context.Contex
 		}
 
 		// Update Ready condition
+		// Note: LastTransitionTime is intentionally omitted - meta.SetStatusCondition
+		// will automatically set it only when the Status field changes, which is the
+		// correct Kubernetes behavior for tracking actual state transitions
 		condition := metav1.Condition{
-			Type:               "Ready",
-			Status:             readyStatus,
-			Reason:             string(reason),
-			Message:            string(message),
-			LastTransitionTime: metav1.Now(),
+			Type:    "Ready",
+			Status:  readyStatus,
+			Reason:  string(reason),
+			Message: string(message),
 		}
 		meta.SetStatusCondition(&dynamoDeployment.Status.Conditions, condition)
 


### PR DESCRIPTION
#### Overview:

retry DGD status update when failing because of conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability and reliability of DynamoGraphDeployment resource status updates to better handle operational scenarios
  * Improved resource deletion handling to ensure complete cleanup operations and accurate state tracking
  * Better resilience and consistency for deployment condition reporting and status synchronization
  * Reduced operational failures during concurrent deployment reconciliation processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->