### PR TITLE
fix: remove metric publisher tight loop

### DIFF
--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -860,6 +860,12 @@ impl WorkerMetricsPublisher {
                             {
                                 tracing::warn!("Failed to publish metrics over NATS: {}", e);
                             }
+
+                            // Reset timer to pending state to avoid tight loop
+                            // It will be reset to 1ms when metrics actually change
+                            publish_timer.as_mut().reset(
+                                tokio::time::Instant::now() + tokio::time::Duration::from_secs(3600)
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
#### Overview:

as titled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the metrics publishing system by reducing excessive re-publishing cycles. The system now implements a delayed retry mechanism to prevent rapid publish loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->