### PR TITLE
fix (cherrypick): remove metric publisher tight loop (#4028)

### DIFF
--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -866,6 +866,12 @@ impl WorkerMetricsPublisher {
                             {
                                 tracing::warn!("Failed to publish metrics over NATS: {}", e);
                             }
+
+                            // Reset timer to pending state to avoid tight loop
+                            // It will be reset to 1ms when metrics actually change
+                            publish_timer.as_mut().reset(
+                                tokio::time::Instant::now() + tokio::time::Duration::from_secs(3600)
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
#### Overview:

as titled
