### PR TITLE
chore: disagg + router k8s recipe minor changes

### DIFF
--- a/examples/backends/vllm/deploy/disagg.yaml
+++ b/examples/backends/vllm/deploy/disagg.yaml
@@ -34,6 +34,7 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-0.6B
+            - --is-decode-worker
     VllmPrefillWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -36,11 +36,12 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-0.6B
+            - --is-decode-worker
     VllmPrefillWorker:
       dynamoNamespace: vllm-v1-disagg-router
       envFromSecret: hf-token-secret
       componentType: worker
-      replicas: 1
+      replicas: 2
       resources:
         limits:
           gpu: "1"


### PR DESCRIPTION
#### Overview:

The recipes already worked as they were, but minor changes
- Use 2 prefill workers to demonstrate prefill routing
- Set `--is-decode-worker` for the decode pods so they don't needlessly emit KV events which would pollute the frontend logs with warnings

DYN-1278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VllmDecodeWorker configuration to enable decode-worker mode
  * Increased VllmPrefillWorker replicas for enhanced scalability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->