### PR TITLE
fix: update router standalone to use updated vLLM API

### DIFF
--- a/examples/deployments/router_standalone/api.py
+++ b/examples/deployments/router_standalone/api.py
@@ -223,7 +223,6 @@ class ServiceAPI:
             base_metrics_port=self.init_params.base_metrics_port,
             num_workers=self.init_params.num_workers,
         )
-        await self.workers.initialize()
 
         # Initialize HTTP client for router communication
         self.http_client = httpx.AsyncClient()
@@ -267,6 +266,10 @@ class ServiceAPI:
 
     async def start(self):
         """Start the API server"""
+        # Initialize services first
+        await self.initialize_services()
+
+        # Start the API server
         logger.info(f"Starting API server on port {self.init_params.http_port}")
         config = uvicorn.Config(
             self.app, host="0.0.0.0", port=self.init_params.http_port, log_level="info"
@@ -345,10 +348,7 @@ def main():
 
     async def run_with_shutdown():
         try:
-            # Initialize API services first
-            await api.initialize_services()
-
-            # Now start both servers concurrently
+            # Start both services concurrently
             await asyncio.gather(
                 api.start(), router_api.start(), return_exceptions=True
             )

--- a/examples/deployments/router_standalone/api.py
+++ b/examples/deployments/router_standalone/api.py
@@ -35,6 +35,7 @@ from vllm.entrypoints.openai.protocol import (
 )
 from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
 from vllm.entrypoints.openai.serving_models import BaseModelPath, OpenAIServingModels
+from vllm.inputs.data import TokensPrompt
 from vllm.transformers_utils.tokenizer import get_tokenizer
 from worker import VllmWorkers
 
@@ -78,9 +79,7 @@ class ServiceAPI:
                 or self.http_client is None
             ):
                 return ErrorResponse(
-                    message="Service not ready",
-                    type="service_unavailable",
-                    code=503,
+                    error={"message": "Service not ready", "type": "service_unavailable", "code": 503}
                 )
 
             try:
@@ -95,9 +94,7 @@ class ServiceAPI:
                     max_tokens_value = request.max_tokens
                 else:
                     return ErrorResponse(
-                        message="Either max_tokens or max_completion_tokens must be specified",
-                        type="invalid_request_error",
-                        code=400,
+                        error={"message": "Either max_tokens or max_completion_tokens must be specified", "type": "invalid_request_error", "code": 400}
                     )
 
                 # Use vLLM's preprocessing to convert chat to prompt
@@ -119,9 +116,9 @@ class ServiceAPI:
 
                 # Convert request to sampling parameters with our determined max_tokens
                 sampling_params = request.to_sampling_params(
-                    default_max_tokens=max_tokens_value,
+                    max_tokens=max_tokens_value,
                     logits_processor_pattern=None,
-                    default_sampling_params=None,
+                    default_sampling_params={},
                 )
 
                 # Get best worker using HTTP request to router
@@ -129,9 +126,7 @@ class ServiceAPI:
                 num_tokens = len(tokens)
                 if num_tokens == 0:
                     return ErrorResponse(
-                        message="Input prompt is empty",
-                        type="invalid_request_error",
-                        code=400,
+                        error={"message": "Input prompt is empty", "type": "invalid_request_error", "code": 400}
                     )
 
                 # It is much preferred to communicate block hashes to the router instead of
@@ -161,9 +156,7 @@ class ServiceAPI:
                 except (httpx.RequestError, httpx.HTTPStatusError) as e:
                     logger.error(f"Router request failed: {e}")
                     return ErrorResponse(
-                        message="Router service unavailable",
-                        type="service_unavailable",
-                        code=503,
+                        error={"message": "Router service unavailable", "type": "service_unavailable", "code": 503}
                     )
 
                 logger.info(f"Selected worker {best_worker_id} for request")
@@ -172,9 +165,13 @@ class ServiceAPI:
                 request_id = f"chatcmpl-{uuid.uuid4()}"
                 request_metadata = RequestResponseMetadata(request_id=request_id)
 
+                # Convert engine_prompt dict to TokensPrompt object
+                tokens_prompt = TokensPrompt(prompt_token_ids=tokens)
+                logger.info(f"Created TokensPrompt with {len(tokens)} tokens")
+
                 # Get the generator from the selected worker with sampling params
                 result_generator = self.workers.direct(
-                    engine_prompt, best_worker_id, sampling_params
+                    tokens_prompt, best_worker_id, sampling_params
                 )
                 assert request.stream
 
@@ -188,6 +185,7 @@ class ServiceAPI:
                         conversation,
                         self.tokenizer,
                         request_metadata,
+                        enable_force_include_usage=False,
                     ),
                     media_type="text/event-stream",
                     headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
@@ -195,7 +193,9 @@ class ServiceAPI:
 
             except Exception as e:
                 logger.error(f"Error processing request: {e}")
-                return ErrorResponse(message=str(e), type="internal_error", code=500)
+                return ErrorResponse(
+                    error={"message": str(e), "type": "internal_error", "code": 500}
+                )
 
     async def initialize_services(self):
         """Initialize workers, HTTP client, and OpenAI serving components"""
@@ -207,6 +207,7 @@ class ServiceAPI:
             base_metrics_port=self.init_params.base_metrics_port,
             num_workers=self.init_params.num_workers,
         )
+        await self.workers.initialize()
 
         # Initialize HTTP client for router communication
         self.http_client = httpx.AsyncClient()
@@ -250,10 +251,6 @@ class ServiceAPI:
 
     async def start(self):
         """Start the API server"""
-        # Initialize services first
-        await self.initialize_services()
-
-        # Start the API server
         logger.info(f"Starting API server on port {self.init_params.http_port}")
         config = uvicorn.Config(
             self.app, host="0.0.0.0", port=self.init_params.http_port, log_level="info"
@@ -332,7 +329,10 @@ def main():
 
     async def run_with_shutdown():
         try:
-            # Start both services concurrently
+            # Initialize API services first
+            await api.initialize_services()
+            
+            # Now start both servers concurrently
             await asyncio.gather(
                 api.start(), router_api.start(), return_exceptions=True
             )

--- a/examples/deployments/router_standalone/api.py
+++ b/examples/deployments/router_standalone/api.py
@@ -79,7 +79,11 @@ class ServiceAPI:
                 or self.http_client is None
             ):
                 return ErrorResponse(
-                    error={"message": "Service not ready", "type": "service_unavailable", "code": 503}
+                    error={
+                        "message": "Service not ready",
+                        "type": "service_unavailable",
+                        "code": 503,
+                    },
                 )
 
             try:
@@ -94,7 +98,11 @@ class ServiceAPI:
                     max_tokens_value = request.max_tokens
                 else:
                     return ErrorResponse(
-                        error={"message": "Either max_tokens or max_completion_tokens must be specified", "type": "invalid_request_error", "code": 400}
+                        error={
+                            "message": "Either max_tokens or max_completion_tokens must be specified",
+                            "type": "invalid_request_error",
+                            "code": 400,
+                        },
                     )
 
                 # Use vLLM's preprocessing to convert chat to prompt
@@ -126,7 +134,11 @@ class ServiceAPI:
                 num_tokens = len(tokens)
                 if num_tokens == 0:
                     return ErrorResponse(
-                        error={"message": "Input prompt is empty", "type": "invalid_request_error", "code": 400}
+                        error={
+                            "message": "Input prompt is empty",
+                            "type": "invalid_request_error",
+                            "code": 400,
+                        }
                     )
 
                 # It is much preferred to communicate block hashes to the router instead of
@@ -156,7 +168,11 @@ class ServiceAPI:
                 except (httpx.RequestError, httpx.HTTPStatusError) as e:
                     logger.error(f"Router request failed: {e}")
                     return ErrorResponse(
-                        error={"message": "Router service unavailable", "type": "service_unavailable", "code": 503}
+                        error={
+                            "message": "Router service unavailable",
+                            "type": "service_unavailable",
+                            "code": 503,
+                        }
                     )
 
                 logger.info(f"Selected worker {best_worker_id} for request")
@@ -331,7 +347,7 @@ def main():
         try:
             # Initialize API services first
             await api.initialize_services()
-            
+
             # Now start both servers concurrently
             await asyncio.gather(
                 api.start(), router_api.start(), return_exceptions=True

--- a/examples/deployments/router_standalone/router.py
+++ b/examples/deployments/router_standalone/router.py
@@ -41,7 +41,7 @@ class RouterResponse(BaseModel):
 
 
 class LoadMetrics(BaseModel):
-    gpu_cache_usage: float
+    kv_cache_usage: float
     num_waiting_reqs: int
 
 
@@ -101,7 +101,7 @@ class KvRouter:
                 try:
                     metrics_dict = self.load_listeners[worker_id].recv_json(zmq.NOBLOCK)
                     metrics = LoadMetrics.model_validate(metrics_dict)
-                    self.kv_usages[worker_id] = metrics.gpu_cache_usage
+                    self.kv_usages[worker_id] = metrics.kv_cache_usage
                     self.waitings[worker_id] = metrics.num_waiting_reqs
                 except zmq.Again:
                     pass

--- a/examples/deployments/router_standalone/worker.py
+++ b/examples/deployments/router_standalone/worker.py
@@ -20,7 +20,13 @@ import uuid
 from typing import AsyncGenerator, Optional
 
 import zmq
-from vllm.config import CacheConfig, ModelConfig, ObservabilityConfig, SchedulerConfig, VllmConfig
+from vllm.config import (
+    CacheConfig,
+    ModelConfig,
+    ObservabilityConfig,
+    SchedulerConfig,
+    VllmConfig,
+)
 from vllm.distributed.kv_events import KVEventsConfig
 from vllm.inputs.data import TokensPrompt
 from vllm.outputs import RequestOutput
@@ -132,7 +138,7 @@ class VllmWorkers:
                     stat_loggers=[LoggerFactory(port=metrics_port)],
                 )
             )
-        
+
         logger.info(f"All {self.num_workers} workers initialized")
 
     async def direct(


### PR DESCRIPTION
#### Overview:

The changes to the standalone router example fix API compatibility issues and correct metric attribute names to ensure the deployment works properly with the latest vLLM version.

#### Details:

**API Compatibility:**
- Updated `to_sampling_params()` to pass empty dict `{}` instead of `None` for `default_sampling_params`
- Added required `enable_force_include_usage=False` parameter to `chat_completion_stream_generator()`
- Convert engine_prompt dict to `TokensPrompt` object before passing to worker
- Added `ObservabilityConfig` to `VllmConfig` to fix AttributeError during engine initialization

**Metrics Updates:**
- Changed `gpu_cache_usage` → `kv_cache_usage` in `worker.py` MetricsPublisher
- Updated corresponding field in `router.py` LoadMetrics model and usage

**Error Handling:**
- Updated all ErrorResponse calls to use proper nested structure: `ErrorResponse(error={"message": "...", "type": "...", "code": ...})`


#### Where should the reviewer start?

- `examples/deployments/router_standalone/api.py` - Updated sampling params, updated ErrorResponse, and properly passing TokensPrompt to workers
- `examples/deployments/router_standalone/worker.py` - metrics change and ObservabilityConfig added
- `examples/deployments/router_standalone/router.py` - metrics field name change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unified error response format for improved consistency and reliability.

* **New Features**
  * Enhanced observability configuration for better worker monitoring and diagnostics.

* **Improvements**
  * Refactored server initialization flow for improved startup process.
  * Updated cache metrics tracking to use KV cache monitoring instead of GPU cache metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->