### PR TITLE
fix: add prefill load balance args for deepseek-r1

### DIFF
--- a/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
@@ -48,7 +48,7 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 600
           image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.6.1
-          workingDir: /workspace/components/backends/sglang
+          workingDir: /sgl-workspace/dynamo
           command:
             - python3
             - -m
@@ -77,6 +77,7 @@ spec:
             - "0.75"
             - --host
             - 0.0.0.0
+            - --prefill-round-robin-balance
     prefill:
       dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
@@ -101,7 +102,7 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 600
           image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.6.1
-          workingDir: /workspace/components/backends/sglang
+          workingDir: /sgl-workspace/dynamo
           command:
             - python3
             - -m
@@ -127,3 +128,5 @@ spec:
             - "0.75"
             - --host
             - 0.0.0.0
+            - --load-balance-method
+            - round_robin

--- a/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
@@ -46,7 +46,7 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 600
           image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.6.1
-          workingDir: /workspace/components/backends/sglang
+          workingDir: /sgl-workspace/dynamo
           command:
             - python3
             - -m
@@ -73,6 +73,7 @@ spec:
             - "30001"
             - --host
             - 0.0.0.0
+            - --prefill-round-robin-balance
     prefill:
       dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
@@ -95,7 +96,7 @@ spec:
             timeoutSeconds: 10
             failureThreshold: 600
           image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.6.1
-          workingDir: /workspace/components/backends/sglang
+          workingDir: /sgl-workspace/dynamo
           command:
             - python3
             - -m
@@ -119,3 +120,5 @@ spec:
             - "30001"
             - --host
             - 0.0.0.0
+            - --load-balance-method
+            - round_robin


### PR DESCRIPTION
#### Overview:

Cherry-pick PR: https://github.com/ai-dynamo/dynamo/pull/4051
- fix deepseek-r1 recipe for Hopper
- add arguments for prefill round-robin load-balancing


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
