### PR TITLE
fix: oss-gpt-120b model path in recipe

### DIFF
--- a/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
@@ -92,7 +92,7 @@ spec:
           - name: ENGINE_ARGS
             value: "/opt/dynamo/configs/config.yaml"
           - name: MODEL_PATH
-            value: "/model-store/hub/models--openai--gpt-oss-120b/snapshots/b5c939de8f754692c1647ca79fbf85e8c1e70f8a"
+            value: "/root/.cache/huggingface/hub/models--openai--gpt-oss-120b/snapshots/b5c939de8f754692c1647ca79fbf85e8c1e70f8a"
           volumeMounts:
           - mountPath: /opt/dynamo/configs
             name: llm-config


### PR DESCRIPTION
#### Overview:

This PR fixes oss-gpt-120b path on PVC. 

This was incorrectly introduced during a rebase

fixes: nvbug: [5609103](https://nvbugspro.nvidia.com/bug/5609103)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated model loading configuration for gpt-oss-120b deployment to use an alternative model source

<!-- end of auto-generated comment: release notes by coderabbit.ai -->