### PR TITLE
feat: filter out invalid GPU counts for MOE models

### DIFF
--- a/benchmarks/profiler/utils/gpu_count_filters.py
+++ b/benchmarks/profiler/utils/gpu_count_filters.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPU count filtering utilities for MoE model profiling.
+
+These filters ensure that GPU configurations are compatible with model constraints:
+- Expert parallelism requires num_experts % ep_size == 0
+- FP8 quantization requires partition_size % block_size == 0
+"""
+
+from typing import List, Optional, Tuple
+
+# SGLang FP8 quantization block size
+FP8_BLOCK_SIZE = 128
+
+
+def filter_gpu_counts_by_expert_divisibility(
+    gpu_counts: List[int],
+    num_experts: int,
+    min_gpus: int,
+    max_gpus: int,
+) -> Tuple[List[int], Optional[str], Optional[str]]:
+    """
+    Filter GPU counts to only include divisors of num_experts.
+    SGLang requires num_physical_experts % ep_size == 0 for proper expert distribution.
+    """
+    original_counts = gpu_counts.copy()
+    filtered = [count for count in gpu_counts if num_experts % count == 0]
+
+    if not filtered:
+        # No valid counts
+        valid_divisors = [
+            d for d in range(min_gpus, max_gpus + 1) if num_experts % d == 0
+        ]
+        error_msg = (
+            f"No valid GPU counts found that divide evenly into num_experts={num_experts}. "
+            f"Original candidates were {original_counts}. "
+            f"Valid divisors in range would be: {valid_divisors}"
+        )
+        return [], None, error_msg
+
+    if len(filtered) < len(original_counts):
+        # Some counts filtered
+        info_msg = (
+            f"Filtered GPU counts from {original_counts} to {filtered} "
+            f"(only divisors of num_experts={num_experts})"
+        )
+        return filtered, info_msg, None
+
+    # No filtering needed
+    return filtered, None, None
+
+
+def filter_gpu_counts_by_fp8_alignment(
+    gpu_counts: List[int],
+    intermediate_size: int,
+    block_size: int = FP8_BLOCK_SIZE,
+) -> Tuple[List[int], Optional[str], Optional[str]]:
+    """
+    Filter GPU counts for FP8 quantization alignment.
+
+    FP8 quantization requires partition sizes to be divisible by block_n.
+    When a model layer with intermediate_size is partitioned across tp_size GPUs,
+    the partition size (intermediate_size / tp_size) must be divisible by block_size.
+    """
+    original_counts = gpu_counts.copy()
+    filtered = [
+        count for count in gpu_counts if (intermediate_size // count) % block_size == 0
+    ]
+
+    if not filtered:
+        # No valid counts
+        warning_msg = (
+            f"No GPU counts satisfy FP8 alignment constraint "
+            f"(intermediate_size={intermediate_size}, block_size={block_size}). "
+            f"Keeping original counts {original_counts} - profiling may fail for some configurations."
+        )
+        return original_counts, None, warning_msg
+
+    if len(filtered) < len(original_counts):
+        # Some counts filtered
+        removed = set(original_counts) - set(filtered)
+        info_msg = (
+            f"Filtered GPU counts from {original_counts} to {filtered} for FP8 alignment "
+            f"(removed {removed}: intermediate_size={intermediate_size} not divisible by "
+            f"{block_size} when partitioned)"
+        )
+        return filtered, info_msg, None
+
+    # No filtering needed
+    return filtered, None, None

--- a/benchmarks/profiler/utils/model_info.py
+++ b/benchmarks/profiler/utils/model_info.py
@@ -145,11 +145,15 @@ def get_model_info(
                     num_experts = value
                     break
 
+    # Extract intermediate_size for FP8 quantization alignment check that partition sizes are compatible with FP8 block sizes
+    intermediate_size = getattr(config, "intermediate_size", None)
+
     return {
         "model_size": model_size,
         "is_moe": config.is_moe,
         "max_context_length": max_context_length,
         "num_experts": num_experts,
+        "intermediate_size": intermediate_size,
     }
 
 

--- a/benchmarks/profiler/utils/search_space_autogen.py
+++ b/benchmarks/profiler/utils/search_space_autogen.py
@@ -65,8 +65,13 @@ def auto_generate_search_space(args: argparse.Namespace) -> None:
             if model_info.get("num_experts")
             else ""
         )
+        intermediate_size_str = (
+            f", intermediate_size={model_info['intermediate_size']}"
+            if model_info.get("intermediate_size")
+            else ""
+        )
         logger.info(
-            f"Model {args.model} has size {model_info['model_size']}, is_moe={model_info['is_moe']}, and max_context_length={model_info['max_context_length']}{num_experts_str}"
+            f"Model {args.model} has size {model_info['model_size']}, is_moe={model_info['is_moe']}, max_context_length={model_info['max_context_length']}{num_experts_str}{intermediate_size_str}"
         )
         logger.info(
             f"Cluster has {gpu_info['gpus_per_node']}x{gpu_info['model']} GPUs per node with {gpu_info['vram']} VRAM"
@@ -94,5 +99,6 @@ def auto_generate_search_space(args: argparse.Namespace) -> None:
         args.max_context_length = model_info["max_context_length"]  # type: ignore[assignment]
         args.num_gpus_per_node = gpu_info["gpus_per_node"]  # type: ignore[assignment]
         args.num_experts = model_info.get("num_experts")  # type: ignore[assignment]
+        args.intermediate_size = model_info.get("intermediate_size")  # type: ignore[assignment]
 
     return


### PR DESCRIPTION
#### Overview:

Filter out GPU counts where `intermediate_size / gpu_count` is not divisible by FP8 block size (128). Also move other GPU count validation into helper function. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GPU count filtering for mixture-of-experts models to ensure GPU counts properly divide expert counts.
  * Introduced FP8 alignment checks during profiling to optimize GPU memory allocation.
  * Enhanced model profiling to capture and track intermediate layer sizes for more accurate performance predictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->