### PR TITLE
docs: update wideep documentation to precompile DeepGemm kernels beforehand

### DIFF
--- a/docs/backends/sglang/dsr1-wideep-gb200.md
+++ b/docs/backends/sglang/dsr1-wideep-gb200.md
@@ -50,27 +50,6 @@ docker run \
 
 In each container, you should be in the /sgl-workspace/dynamo/examples/backends/sglang directory.
 
-> [!IMPORTANT]
-> If you encounter random CPU recv timeout issues during the warm-up phase in multi-GPU or multi-node setups, they are likely caused by DeepGEMM kernel compilation overhead.
-> To avoid these non-deterministic timeouts, it's strongly recommended to precompile the DeepGEMM kernels before launching the SGLang engine. This ensures all kernels are cached and ready, preventing long initialization delays or distributed timeout errors.
-
-> Steps to precompile and use cached kernels:
-
-```bash
-# 1. Precompile DeepGEMM kernels
-export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
-python3 -m sglang.compile_deep_gemm <ServerArgs>
-
-# 2. Launch the engine with the same cache directory
-export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
-python3 -m dynamo.frontend <ServerArgs>
-```
-
-> [!NOTE]
-> There's a known issue where the compile request may fail due to missing bootstrap information, but the kernels are still successfully cached.
-> Using a gradual warm-up phase and enabling caching for FlashInfer (similar to DeepGEMM) can further improve stability and reduce startup time.
-
-
 3. Run the ingress and prefill worker
 
 ```bash
@@ -126,6 +105,24 @@ python3 -m dynamo.sglang \
 ```
 
 On the other prefill nodes (this example has 2 total prefill nodes), run the same command but change `--node-rank` to 1
+
+> [!IMPORTANT]
+> If you encounter random CPU recv timeout issues during the warm-up phase in multi-GPU or multi-node setups, they are likely caused by DeepGEMM kernel compilation overhead.
+> To avoid these non-deterministic timeouts, it's strongly recommended to precompile the DeepGEMM kernels before launching the SGLang engine. This ensures all kernels are cached and ready, preventing long initialization delays or distributed timeout errors. To precompile and use cached kernels, please execute the following commands:
+
+```bash
+# 1. Precompile DeepGEMM kernels
+export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
+python3 -m sglang.compile_deep_gemm <ServerArgs>
+
+# 2. Launch the engine with the same cache directory
+export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
+python3 -m dynamo.frontend <ServerArgs>
+```
+
+> [!NOTE]
+> There's a known issue where the compile request may fail due to missing bootstrap information, but the kernels are still successfully cached.
+> Using a gradual warm-up phase and enabling caching for FlashInfer (similar to DeepGEMM) can further improve stability and reduce startup time.
 
 4. Run the decode worker on the head decode node
 

--- a/docs/backends/sglang/dsr1-wideep-gb200.md
+++ b/docs/backends/sglang/dsr1-wideep-gb200.md
@@ -50,6 +50,13 @@ docker run \
 
 3. Run the ingress and prefill worker
 
+> [!IMPORTANT]
+> We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
+```bash
+export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
+python3 -m sglang.compile_deep_gemm <ServerArgs>
+````
+
 ```bash
 # run ingress
 python3 -m dynamo.frontend --http-port=8000 &

--- a/docs/backends/sglang/dsr1-wideep-gb200.md
+++ b/docs/backends/sglang/dsr1-wideep-gb200.md
@@ -123,6 +123,7 @@ python3 -m dynamo.frontend <ServerArgs>
 > [!NOTE]
 > There's a known issue where the compile request may fail due to missing bootstrap information, but the kernels are still successfully cached.
 > Using a gradual warm-up phase and enabling caching for FlashInfer (similar to DeepGEMM) can further improve stability and reduce startup time.
+> See https://github.com/sgl-project/sglang/issues/9867#issuecomment-3336551174 for more details.
 
 4. Run the decode worker on the head decode node
 

--- a/docs/backends/sglang/dsr1-wideep-gb200.md
+++ b/docs/backends/sglang/dsr1-wideep-gb200.md
@@ -48,6 +48,7 @@ docker run \
     dynamo-wideep-gb200:latest
 ```
 
+In each container, you should be in the /sgl-workspace/dynamo/examples/backends/sglang directory.
 > [!IMPORTANT]
 > We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
 ```bash

--- a/docs/backends/sglang/dsr1-wideep-gb200.md
+++ b/docs/backends/sglang/dsr1-wideep-gb200.md
@@ -49,12 +49,27 @@ docker run \
 ```
 
 In each container, you should be in the /sgl-workspace/dynamo/examples/backends/sglang directory.
+
 > [!IMPORTANT]
-> We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
+> If you encounter random CPU recv timeout issues during the warm-up phase in multi-GPU or multi-node setups, they are likely caused by DeepGEMM kernel compilation overhead.
+> To avoid these non-deterministic timeouts, it's strongly recommended to precompile the DeepGEMM kernels before launching the SGLang engine. This ensures all kernels are cached and ready, preventing long initialization delays or distributed timeout errors.
+
+> Steps to precompile and use cached kernels:
+
 ```bash
+# 1. Precompile DeepGEMM kernels
 export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
 python3 -m sglang.compile_deep_gemm <ServerArgs>
-````
+
+# 2. Launch the engine with the same cache directory
+export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
+python3 -m dynamo.frontend <ServerArgs>
+```
+
+> [!NOTE]
+> There's a known issue where the compile request may fail due to missing bootstrap information, but the kernels are still successfully cached.
+> Using a gradual warm-up phase and enabling caching for FlashInfer (similar to DeepGEMM) can further improve stability and reduce startup time.
+
 
 3. Run the ingress and prefill worker
 

--- a/docs/backends/sglang/dsr1-wideep-gb200.md
+++ b/docs/backends/sglang/dsr1-wideep-gb200.md
@@ -48,14 +48,14 @@ docker run \
     dynamo-wideep-gb200:latest
 ```
 
-3. Run the ingress and prefill worker
-
 > [!IMPORTANT]
 > We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
 ```bash
 export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
 python3 -m sglang.compile_deep_gemm <ServerArgs>
 ````
+
+3. Run the ingress and prefill worker
 
 ```bash
 # run ingress

--- a/docs/backends/sglang/dsr1-wideep-h100.md
+++ b/docs/backends/sglang/dsr1-wideep-h100.md
@@ -45,7 +45,8 @@ docker run \
 ```
 
 In each container, you should be in the `/sgl-workspace/dynamo/examples/backends/sglang` directory.
-> [!IMPORTANT] We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
+> [!IMPORTANT]
+> We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
 ```bash
 export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
 python3 -m sglang.compile_deep_gemm <ServerArgs>

--- a/docs/backends/sglang/dsr1-wideep-h100.md
+++ b/docs/backends/sglang/dsr1-wideep-h100.md
@@ -46,10 +46,10 @@ docker run \
 
 In each container, you should be in the `/sgl-workspace/dynamo/examples/backends/sglang` directory.
 
-3. Run the ingress and prefill worker
-
 > [!IMPORTANT]
 > We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
+
+3. Run the ingress and prefill worker
 
 ```bash
 # run ingress

--- a/docs/backends/sglang/dsr1-wideep-h100.md
+++ b/docs/backends/sglang/dsr1-wideep-h100.md
@@ -46,26 +46,6 @@ docker run \
 
 In each container, you should be in the `/sgl-workspace/dynamo/examples/backends/sglang` directory.
 
-> [!IMPORTANT]
-> If you encounter random CPU recv timeout issues during the warm-up phase in multi-GPU or multi-node setups, they are likely caused by DeepGEMM kernel compilation overhead.
-> To avoid these non-deterministic timeouts, it's strongly recommended to precompile the DeepGEMM kernels before launching the SGLang engine. This ensures all kernels are cached and ready, preventing long initialization delays or distributed timeout errors.
-
-> Steps to precompile and use cached kernels:
-
-```bash
-# 1. Precompile DeepGEMM kernels
-export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
-python3 -m sglang.compile_deep_gemm <ServerArgs>
-
-# 2. Launch the engine with the same cache directory
-export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
-python3 -m dynamo.frontend <ServerArgs>
-```
-
-> [!NOTE]
-> There's a known issue where the compile request may fail due to missing bootstrap information, but the kernels are still successfully cached.
-> Using a gradual warm-up phase and enabling caching for FlashInfer (similar to DeepGEMM) can further improve stability and reduce startup time.
-
 3. Run the ingress and prefill worker
 
 ```bash
@@ -105,6 +85,24 @@ python3 -m dynamo.sglang \
 ```
 
 On the other prefill node (since this example has 4 total prefill nodes), run the same command but change `--node-rank` to 1,2, and 3
+
+> [!IMPORTANT]
+> If you encounter random CPU recv timeout issues during the warm-up phase in multi-GPU or multi-node setups, they are likely caused by DeepGEMM kernel compilation overhead.
+> To avoid these non-deterministic timeouts, it's strongly recommended to precompile the DeepGEMM kernels before launching the SGLang engine. This ensures all kernels are cached and ready, preventing long initialization delays or distributed timeout errors. To precompile and use cached kernels, please execute the following commands:
+
+```bash
+# 1. Precompile DeepGEMM kernels
+export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
+python3 -m sglang.compile_deep_gemm <ServerArgs>
+
+# 2. Launch the engine with the same cache directory
+export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
+python3 -m dynamo.frontend <ServerArgs>
+```
+
+> [!NOTE]
+> There's a known issue where the compile request may fail due to missing bootstrap information, but the kernels are still successfully cached.
+> Using a gradual warm-up phase and enabling caching for FlashInfer (similar to DeepGEMM) can further improve stability and reduce startup time.
 
 4. Run the decode worker on the head decode node
 

--- a/docs/backends/sglang/dsr1-wideep-h100.md
+++ b/docs/backends/sglang/dsr1-wideep-h100.md
@@ -45,14 +45,15 @@ docker run \
 ```
 
 In each container, you should be in the `/sgl-workspace/dynamo/examples/backends/sglang` directory.
+
+3. Run the ingress and prefill worker
+
 > [!IMPORTANT]
 > We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
 ```bash
 export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
 python3 -m sglang.compile_deep_gemm <ServerArgs>
 ````
-
-3. Run the ingress and prefill worker
 
 ```bash
 # run ingress

--- a/docs/backends/sglang/dsr1-wideep-h100.md
+++ b/docs/backends/sglang/dsr1-wideep-h100.md
@@ -47,7 +47,24 @@ docker run \
 In each container, you should be in the `/sgl-workspace/dynamo/examples/backends/sglang` directory.
 
 > [!IMPORTANT]
-> We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
+> If you encounter random CPU recv timeout issues during the warm-up phase in multi-GPU or multi-node setups, they are likely caused by DeepGEMM kernel compilation overhead.
+> To avoid these non-deterministic timeouts, it's strongly recommended to precompile the DeepGEMM kernels before launching the SGLang engine. This ensures all kernels are cached and ready, preventing long initialization delays or distributed timeout errors.
+
+> Steps to precompile and use cached kernels:
+
+```bash
+# 1. Precompile DeepGEMM kernels
+export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
+python3 -m sglang.compile_deep_gemm <ServerArgs>
+
+# 2. Launch the engine with the same cache directory
+export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
+python3 -m dynamo.frontend <ServerArgs>
+```
+
+> [!NOTE]
+> There's a known issue where the compile request may fail due to missing bootstrap information, but the kernels are still successfully cached.
+> Using a gradual warm-up phase and enabling caching for FlashInfer (similar to DeepGEMM) can further improve stability and reduce startup time.
 
 3. Run the ingress and prefill worker
 

--- a/docs/backends/sglang/dsr1-wideep-h100.md
+++ b/docs/backends/sglang/dsr1-wideep-h100.md
@@ -45,6 +45,11 @@ docker run \
 ```
 
 In each container, you should be in the `/sgl-workspace/dynamo/examples/backends/sglang` directory.
+> [!IMPORTANT] We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
+```bash
+export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
+python3 -m sglang.compile_deep_gemm <ServerArgs>
+````
 
 3. Run the ingress and prefill worker
 

--- a/docs/backends/sglang/dsr1-wideep-h100.md
+++ b/docs/backends/sglang/dsr1-wideep-h100.md
@@ -103,6 +103,7 @@ python3 -m dynamo.frontend <ServerArgs>
 > [!NOTE]
 > There's a known issue where the compile request may fail due to missing bootstrap information, but the kernels are still successfully cached.
 > Using a gradual warm-up phase and enabling caching for FlashInfer (similar to DeepGEMM) can further improve stability and reduce startup time.
+> See https://github.com/sgl-project/sglang/issues/9867#issuecomment-3336551174 for more details.
 
 4. Run the decode worker on the head decode node
 

--- a/docs/backends/sglang/dsr1-wideep-h100.md
+++ b/docs/backends/sglang/dsr1-wideep-h100.md
@@ -50,10 +50,6 @@ In each container, you should be in the `/sgl-workspace/dynamo/examples/backends
 
 > [!IMPORTANT]
 > We recommend precompiling the DeepGemm kernels once before starting the workers. Doing so significantly reduces initialization delays and helps avoid timeout errors when starting the SGLang engine. To precompile DeepGemm kernels, please execute the following commands:
-```bash
-export SGLANG_DG_CACHE_DIR="/configs/dgcache/3p1dcache"
-python3 -m sglang.compile_deep_gemm <ServerArgs>
-````
 
 ```bash
 # run ingress


### PR DESCRIPTION
#### Overview:

update wideep documentation to precompile DeepGemm kernels beforehand to prevent CPU timeout issues. See: https://github.com/sgl-project/sglang/issues/9867#issuecomment-3336551174

#### Details:

- docs/backends/sglang/dsr1-wideep-h100.md



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend configuration documentation with essential precompilation instructions for DeepGemm kernels. Added detailed setup recommendations including environment variable configuration and command sequences required before starting workers. Critical setup notes have been prominently inserted in multiple documentation sections to ensure proper configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->