### PR TITLE
feat: standardize http deserialization error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serial_test",
  "strum",
  "temp-env",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ reqwest = { version = "0.12.22", default-features = false, features = [
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
+serde_path_to_error = { version = "0.1" }
 strum = { version = "0.27", features = ["derive"] }
 tempfile = "3"
 thiserror = { version = "2.0.11" }

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -61,6 +61,7 @@ parking_lot = { workspace = true }
 prometheus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_path_to_error = { workspace = true }
 strum = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -19,6 +19,7 @@
 //! The [`service_v2::HttpService`] can be further extended to host any [`axum::Router`] using the [`service_v2::HttpServiceConfigBuilder`].
 
 mod openai;
+mod json_path;
 
 pub mod custom_backend_metrics;
 pub mod disconnect;

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -18,8 +18,8 @@
 //!
 //! The [`service_v2::HttpService`] can be further extended to host any [`axum::Router`] using the [`service_v2::HttpServiceConfigBuilder`].
 
-mod openai;
 mod json_path;
+mod openai;
 
 pub mod custom_backend_metrics;
 pub mod disconnect;

--- a/lib/llm/src/http/service/json_path.rs
+++ b/lib/llm/src/http/service/json_path.rs
@@ -1,0 +1,100 @@
+use axum::{
+    body::{to_bytes, Body},
+    extract::FromRequest,
+    http::{Request, StatusCode},
+    response::IntoResponse,
+};
+use serde::de::DeserializeOwned;
+use serde_json::Deserializer;
+
+#[derive(Debug)]
+pub struct JsonPath<T>(pub T);
+
+impl<S, T> FromRequest<S, Body> for JsonPath<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = axum::response::Response;
+
+    async fn from_request(req: Request<Body>, _state: &S) -> Result<Self, Self::Rejection> {
+        let bytes = to_bytes(req.into_body(), usize::MAX)
+            .await
+            .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()).into_response())?;
+
+        match serde_path_to_error::deserialize(&mut Deserializer::from_slice(&bytes)) {
+            Ok(v) => Ok(JsonPath(v)),
+            Err(e) => {
+                let field = e.path().to_string().trim_start_matches('.').to_string();
+                let msg = format!(
+                    "Invalid argument for parameter '{}': {}",
+                    if field.is_empty() { "request body" } else { &field },
+                    e.inner()
+                );
+
+                Err((
+                    StatusCode::BAD_REQUEST,
+                    axum::Json(serde_json::json!({
+                        "message": msg,
+                        "type": "Bad Request",
+                        "code": 400
+                    })),
+                )
+                    .into_response())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize, Debug)]
+    struct TestRequest {
+        model: String,
+        temperature: Option<f32>,
+        echo: Option<bool>,
+    }
+
+    #[tokio::test]
+    async fn test_valid_request() {
+        let body = r#"{"model": "gpt-4", "temperature": 0.7, "echo": true}"#;
+        let req = Request::builder().body(Body::from(body)).unwrap();
+
+        let result = JsonPath::<TestRequest>::from_request(req, &()).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_echo_as_number_shows_field_path() {
+        let body = r#"{"model": "gpt-4", "echo": 1}"#;
+        let req = Request::builder().body(Body::from(body)).unwrap();
+
+        let result = JsonPath::<TestRequest>::from_request(req, &()).await;
+        assert!(result.is_err());
+
+        let response = result.unwrap_err();
+        let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+        assert!(body_str.contains("echo"));
+        assert!(body_str.contains("Invalid argument for parameter"));
+    }
+
+    #[tokio::test]
+    async fn test_temperature_as_string_shows_field_path() {
+        let body = r#"{"model": "gpt-4", "temperature": "hot"}"#;
+        let req = Request::builder().body(Body::from(body)).unwrap();
+
+        let result = JsonPath::<TestRequest>::from_request(req, &()).await;
+        assert!(result.is_err());
+
+        let response = result.unwrap_err();
+        let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+        assert!(body_str.contains("temperature"));
+    }
+}

--- a/lib/llm/src/http/service/json_path.rs
+++ b/lib/llm/src/http/service/json_path.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{
     body::{Body, to_bytes},
     extract::FromRequest,

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -31,12 +31,12 @@ use super::{
     RouteDoc,
     disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
     error::HttpError,
+    json_path::JsonPath,
     metrics::{
         Endpoint, EventConverter, process_response_and_observe_metrics,
         process_response_using_event_converter_and_observe_metrics,
     },
     service_v2,
-    json_path::JsonPath,
 };
 use crate::engines::ValidateRequest;
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -36,6 +36,7 @@ use super::{
         process_response_using_event_converter_and_observe_metrics,
     },
     service_v2,
+    json_path::JsonPath,
 };
 use crate::engines::ValidateRequest;
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
@@ -280,7 +281,7 @@ fn get_or_create_request_id(primary: Option<&str>, headers: &HeaderMap) -> Strin
 async fn handler_completions(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateCompletionRequest>,
+    JsonPath(request): JsonPath<NvCreateCompletionRequest>,
 ) -> Result<Response, ErrorResponse> {
     // return a 503 if the service is not ready
     check_ready(&state)?;


### PR DESCRIPTION
#### Overview:

Replace Axum’s default `Json<T>` extractor with a custom `JsonPath<T>` to improve JSON error messages.

#### Details:

- Added `JsonPath<T>` extractor (`lib/llm/src/http/json_path.rs`).
- Swapped incoming request extractors from `Json<T>` -> `JsonPath<T>`.
- `JsonPath` wraps Serde’s deserializer with `serde_path_to_error`, providing full field paths.
- Standardized 400 error responses in the format.

#### Where should the reviewer start?

`lib/llm/src/http/json_path.rs`

Relevant docs

[axum::extract::FromRequest trait](https://docs.rs/axum/latest/axum/extract/trait.FromRequest.html): shows the definition and bounds required.

[axum::extract::Json<T> struct](https://docs.rs/axum/latest/axum/struct.Json.html): shows how Axum’s built-in JSON extractor works.

[serde_path_to_error crate docs](https://docs.rs/serde_path_to_error/latest/serde_path_to_error/): shows how to wrap a Deserializer to get full JSON paths.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to PR #3813 as an alternative to handling deserialization errors that should work across all parameters
