### PR TITLE
chore: bump ai-configurator version in container to make gradio install optional

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@e46d9089ffe4f5dd62c46914489c55b6dfdbc903",
+    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@11b6d821f1fbb34300bb0ed4945f647e89fb411a",
     "networkx",
     "pandas",
     "pydantic>=2",

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 accelerate==1.6.0
-aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@e46d9089ffe4f5dd62c46914489c55b6dfdbc903
+aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@11b6d821f1fbb34300bb0ed4945f647e89fb411a
 aiofiles
 aiperf @ git+https://github.com/ai-dynamo/aiperf.git@e8f69abf180ff9ea96de9f9a8c955df8c024625b
 av==15.0.0


### PR DESCRIPTION
#### Overview:

PR for our containers to pick up the following change from AIC: https://github.com/ai-dynamo/aiconfigurator/commit/11b6d821f1fbb34300bb0ed4945f647e89fb411a

#### Details:

- Bump AIC commit

#### Where should the reviewer start?

- container/deps/requirements.txt



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest compatible versions for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->