### PR TITLE
feat: Update Dynamo k8s deployment example to use ModelExpress

### DIFF
--- a/examples/backends/sglang/deploy/README.md
+++ b/examples/backends/sglang/deploy/README.md
@@ -99,7 +99,7 @@ Note: If your cluster requires a specific storage class, edit `model_cache_pvc.y
 We have public images available on [NGC Catalog](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo/artifacts). If you'd prefer to use your own registry, build and push your own image:
 
 ```bash
-./container/build.sh --framework SGLANG
+./container/build.sh --framework sglang
 # Tag and push to your container registry
 # Update the image references in the YAML files
 ```

--- a/examples/backends/sglang/deploy/agg.yaml
+++ b/examples/backends/sglang/deploy/agg.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://sglang-agg-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: sglang-agg
@@ -47,10 +54,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -81,18 +84,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://sglang-agg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/sglang/deploy/agg.yaml
+++ b/examples/backends/sglang/deploy/agg.yaml
@@ -6,6 +6,9 @@ kind: DynamoGraphDeployment
 metadata:
   name: sglang-agg
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: sglang-agg
@@ -14,6 +17,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: sglang-agg
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -22,10 +81,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://sglang-agg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -41,4 +108,7 @@ spec:
             - "1"
             - --trust-remote-code
             - --skip-tokenizer-init
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
 

--- a/examples/backends/sglang/deploy/agg_logging.yaml
+++ b/examples/backends/sglang/deploy/agg_logging.yaml
@@ -9,6 +9,12 @@ spec:
   envs:
   - name: DYN_LOGGING_JSONL
     value: "1"
+  - name: MODEL_EXPRESS_CACHE_DIRECTORY
+    value: "/model/.model-express/cache"
+  - name: HF_HUB_CACHE
+    value: "/model/.model-express/cache"
+  - name: MODEL_EXPRESS_URL
+    value: "http://sglang-agg-modelexpress:8000"
   pvcs:
     - name: model-cache-pvc
       create: false
@@ -50,10 +56,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -84,18 +86,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://sglang-agg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/sglang/deploy/agg_logging.yaml
+++ b/examples/backends/sglang/deploy/agg_logging.yaml
@@ -9,6 +9,9 @@ spec:
   envs:
   - name: DYN_LOGGING_JSONL
     value: "1"
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: sglang-agg
@@ -17,6 +20,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: sglang-agg
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -25,10 +84,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://sglang-agg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -44,3 +111,6 @@ spec:
             - "1"
             - --trust-remote-code
             - --skip-tokenizer-init
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/sglang/deploy/agg_router.yaml
+++ b/examples/backends/sglang/deploy/agg_router.yaml
@@ -6,6 +6,9 @@ kind: DynamoGraphDeployment
 metadata:
   name: sglang-agg-router
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: sglang-agg-router
@@ -17,6 +20,62 @@ spec:
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: sglang-agg-router
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg-router
@@ -25,10 +84,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://sglang-agg-router-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -44,3 +111,6 @@ spec:
             - "1"
             - --trust-remote-code
             - --skip-tokenizer-init
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/sglang/deploy/agg_router.yaml
+++ b/examples/backends/sglang/deploy/agg_router.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://sglang-agg-router-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: sglang-agg-router
@@ -50,10 +57,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -84,18 +87,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://sglang-agg-router-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/sglang/deploy/disagg-multinode.yaml
+++ b/examples/backends/sglang/deploy/disagg-multinode.yaml
@@ -15,6 +15,9 @@ spec:
   - name: GLOO_SOCKET_IFNAME
     value: "eth0"
   backendFramework: sglang
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: sglang-disagg-multinode
@@ -23,6 +26,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: sglang-disagg-multinode
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     decode:
       multinode:
         nodeCount: 2
@@ -37,6 +96,13 @@ spec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://sglang-disagg-multinode-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -60,6 +126,9 @@ spec:
             - "0.0.0.0"
             - --mem-fraction-static
             - "0.82"
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     prefill:
       multinode:
         nodeCount: 2
@@ -74,6 +143,13 @@ spec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://sglang-disagg-multinode-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -97,3 +173,6 @@ spec:
             - "0.82"
             - --host
             - "0.0.0.0"
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/sglang/deploy/disagg-multinode.yaml
+++ b/examples/backends/sglang/deploy/disagg-multinode.yaml
@@ -14,6 +14,12 @@ spec:
         key: HF_TOKEN
   - name: GLOO_SOCKET_IFNAME
     value: "eth0"
+  - name: MODEL_EXPRESS_CACHE_DIRECTORY
+    value: "/model/.model-express/cache"
+  - name: HF_HUB_CACHE
+    value: "/model/.model-express/cache"
+  - name: MODEL_EXPRESS_URL
+    value: "http://sglang-disagg-multinode-modelexpress:8000"
   backendFramework: sglang
   pvcs:
     - name: model-cache-pvc
@@ -56,10 +62,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -96,13 +98,6 @@ spec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://sglang-disagg-multinode-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -143,13 +138,6 @@ spec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://sglang-disagg-multinode-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/sglang/deploy/disagg.yaml
+++ b/examples/backends/sglang/deploy/disagg.yaml
@@ -6,6 +6,9 @@ kind: DynamoGraphDeployment
 metadata:
   name: sglang-disagg
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: sglang-disagg
@@ -14,6 +17,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: sglang-disagg
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -23,10 +82,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://sglang-disagg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -50,6 +117,9 @@ spec:
             - "12345"
             - --host
             - "0.0.0.0"
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     prefill:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -59,10 +129,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://sglang-disagg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -86,3 +164,6 @@ spec:
             - "12345"
             - --host
             - "0.0.0.0"
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/sglang/deploy/disagg.yaml
+++ b/examples/backends/sglang/deploy/disagg.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://sglang-disagg-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: sglang-disagg
@@ -47,10 +54,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -82,18 +85,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://sglang-disagg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -129,18 +124,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://sglang-disagg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
           workingDir: /workspace/examples/backends/sglang
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/sglang/deploy/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/disagg_planner.yaml
@@ -11,6 +11,13 @@ spec:
       create: false # Must be pre-created before deployment and SLA profiler must have been run
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://sglang-disagg-planner-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: dynamo
@@ -49,10 +56,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -132,14 +135,6 @@ spec:
             - "12345"
             - --host
             - "0.0.0.0"
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://sglang-disagg-planner-modelexpress:8000
       volumeMounts:
         - name: model-cache-pvc
           mountPoint: /model
@@ -179,14 +174,6 @@ spec:
             - "12345"
             - --host
             - "0.0.0.0"
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://sglang-disagg-planner-modelexpress:8000
       volumeMounts:
         - name: model-cache-pvc
           mountPoint: /model

--- a/examples/backends/sglang/deploy/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/disagg_planner.yaml
@@ -9,6 +9,8 @@ spec:
   pvcs:
     - name: dynamo-pvc
       create: false # Must be pre-created before deployment and SLA profiler must have been run
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: dynamo
@@ -17,6 +19,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: dynamo
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     Planner:
       dynamoNamespace: dynamo
       envFromSecret: hf-token-secret
@@ -74,6 +132,17 @@ spec:
             - "12345"
             - --host
             - "0.0.0.0"
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://sglang-disagg-planner-modelexpress:8000
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     prefill:
       dynamoNamespace: dynamo
       envFromSecret: hf-token-secret
@@ -110,3 +179,14 @@ spec:
             - "12345"
             - --host
             - "0.0.0.0"
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://sglang-disagg-planner-modelexpress:8000
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/sglang/deploy/model_cache_pvc.yaml
+++ b/examples/backends/sglang/deploy/model_cache_pvc.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+
+

--- a/examples/backends/sglang/deploy/model_cache_pvc.yaml
+++ b/examples/backends/sglang/deploy/model_cache_pvc.yaml
@@ -8,11 +8,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
+  storageClassName: csi-mounted-fs-path-sc
   resources:
     requests:
       storage: 256Gi
     limits:
       storage: 256Gi
-
-
-

--- a/examples/backends/trtllm/deploy/agg-with-config.yaml
+++ b/examples/backends/trtllm/deploy/agg-with-config.yaml
@@ -30,6 +30,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://trtllm-agg-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: trtllm-agg
@@ -68,10 +75,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -111,13 +114,6 @@ spec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
           workingDir: /workspace/examples/backends/trtllm
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://trtllm-agg-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           # mount the configmap as a volume
           volumeMounts:
           - name: nvidia-config

--- a/examples/backends/trtllm/deploy/agg-with-config.yaml
+++ b/examples/backends/trtllm/deploy/agg-with-config.yaml
@@ -27,6 +27,9 @@ kind: DynamoGraphDeployment
 metadata:
   name: trtllm-agg
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: trtllm-agg
@@ -35,6 +38,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: trtllm-agg
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: trtllm-agg
@@ -52,6 +111,13 @@ spec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
           workingDir: /workspace/examples/backends/trtllm
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://trtllm-agg-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           # mount the configmap as a volume
           volumeMounts:
           - name: nvidia-config
@@ -68,3 +134,6 @@ spec:
             - Qwen/Qwen3-0.6B
             - --extra-engine-args
             - ./recipes/qwen3/trtllm/agg.yaml
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/trtllm/deploy/agg.yaml
+++ b/examples/backends/trtllm/deploy/agg.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://trtllm-agg-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: trtllm-agg
@@ -47,10 +54,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -85,13 +88,6 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://trtllm-agg-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/trtllm/deploy/agg.yaml
+++ b/examples/backends/trtllm/deploy/agg.yaml
@@ -6,6 +6,9 @@ kind: DynamoGraphDeployment
 metadata:
   name: trtllm-agg
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: trtllm-agg
@@ -14,6 +17,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: trtllm-agg
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: trtllm-agg
@@ -26,6 +85,13 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://trtllm-agg-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -37,3 +103,6 @@ spec:
             - Qwen/Qwen3-0.6B
             - --extra-engine-args
             - ./recipes/qwen3/trtllm/agg.yaml
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/trtllm/deploy/agg_router.yaml
+++ b/examples/backends/trtllm/deploy/agg_router.yaml
@@ -6,6 +6,9 @@ kind: DynamoGraphDeployment
 metadata:
   name: trtllm-agg-router
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: trtllm-agg-router
@@ -17,6 +20,62 @@ spec:
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: trtllm-agg-router
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: trtllm-agg-router
@@ -25,10 +84,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://trtllm-agg-router-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -41,3 +108,6 @@ spec:
             - --extra-engine-args
             - ./recipes/qwen3/trtllm/agg.yaml
             - --publish-events-and-metrics
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/trtllm/deploy/agg_router.yaml
+++ b/examples/backends/trtllm/deploy/agg_router.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://trtllm-agg-router-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: trtllm-agg-router
@@ -50,10 +57,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -84,18 +87,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://trtllm-agg-router-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/trtllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/trtllm/deploy/disagg-multinode.yaml
@@ -76,6 +76,12 @@ spec:
       value: "1"
     - name: OMPI_ALLOW_RUN_AS_ROOT_CONFIRM
       value: "1"
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://trtllm-disagg-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: trtllm-disagg
@@ -122,10 +128,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -167,13 +169,6 @@ spec:
             configMap:
               name: nvidia-config
         mainContainer:
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://trtllm-disagg-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           volumeMounts:
             - name: nvidia-config
               mountPath: /workspace/
@@ -214,13 +209,6 @@ spec:
             configMap:
               name: nvidia-config
         mainContainer:
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://trtllm-disagg-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           volumeMounts:
             - name: nvidia-config
               mountPath: /workspace/

--- a/examples/backends/trtllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/trtllm/deploy/disagg-multinode.yaml
@@ -62,17 +62,6 @@ data:
     cache_transceiver_config:
       backend: DEFAULT
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: models
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 100Gi
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
@@ -80,14 +69,13 @@ metadata:
 spec:
   backendFramework: trtllm
   pvcs:
-    - name: models
+    - name: model-cache-pvc
+      create: false
   envs:
     - name: OMPI_ALLOW_RUN_AS_ROOT
       value: "1"
     - name: OMPI_ALLOW_RUN_AS_ROOT_CONFIRM
       value: "1"
-    - name: HF_HOME
-      value: "/models"
   services:
     Frontend:
       dynamoNamespace: trtllm-disagg
@@ -104,10 +92,66 @@ spec:
           args:
             - --http-port
             - "8000"
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: trtllm-disagg
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     prefill:
       volumeMounts:
-        - name: models
-          mountPoint: /models
+        - name: model-cache-pvc
+          mountPoint: /model
       dynamoNamespace: trtllm-disagg
       envFromSecret: hf-token-secret
       componentType: worker
@@ -123,6 +167,13 @@ spec:
             configMap:
               name: nvidia-config
         mainContainer:
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://trtllm-disagg-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           volumeMounts:
             - name: nvidia-config
               mountPath: /workspace/
@@ -146,8 +197,8 @@ spec:
             - decode_first
     decode:
       volumeMounts:
-        - name: models
-          mountPoint: /models
+        - name: model-cache-pvc
+          mountPoint: /model
       dynamoNamespace: trtllm-disagg
       envFromSecret: hf-token-secret
       componentType: worker
@@ -163,6 +214,13 @@ spec:
             configMap:
               name: nvidia-config
         mainContainer:
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://trtllm-disagg-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           volumeMounts:
             - name: nvidia-config
               mountPath: /workspace/

--- a/examples/backends/trtllm/deploy/disagg.yaml
+++ b/examples/backends/trtllm/deploy/disagg.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://trtllm-disagg-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: trtllm-disagg
@@ -47,10 +54,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -86,13 +89,6 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://trtllm-disagg-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -124,13 +120,6 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://trtllm-disagg-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/trtllm/deploy/disagg.yaml
+++ b/examples/backends/trtllm/deploy/disagg.yaml
@@ -6,6 +6,9 @@ kind: DynamoGraphDeployment
 metadata:
   name: trtllm-disagg
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: trtllm-disagg
@@ -14,6 +17,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: trtllm-disagg
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     TRTLLMPrefillWorker:
       dynamoNamespace: trtllm-disagg
       envFromSecret: hf-token-secret
@@ -27,6 +86,13 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://trtllm-disagg-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -42,6 +108,9 @@ spec:
             - prefill
             - --disaggregation-strategy
             - decode_first
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     TRTLLMDecodeWorker:
       dynamoNamespace: trtllm-disagg
       envFromSecret: hf-token-secret
@@ -55,6 +124,13 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://trtllm-disagg-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -70,3 +146,6 @@ spec:
             - decode
             - --disaggregation-strategy
             - decode_first
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/trtllm/deploy/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/disagg_planner.yaml
@@ -11,6 +11,13 @@ spec:
       create: false
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://trtllm-disagg-planner-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: trtllm-disagg-planner
@@ -66,10 +73,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -145,13 +148,6 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://trtllm-disagg-planner-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - python3
           args:
@@ -184,13 +180,6 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://trtllm-disagg-planner-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - python3
           args:

--- a/examples/backends/trtllm/deploy/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/disagg_planner.yaml
@@ -9,6 +9,8 @@ spec:
   pvcs:
     - name: dynamo-pvc
       create: false
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: trtllm-disagg-planner
@@ -34,6 +36,62 @@ spec:
             - --router-temperature
             - "0.0"
             - --no-kv-events
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: trtllm-disagg-planner
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     Planner:
       dynamoNamespace: trtllm-disagg-planner
       envFromSecret: hf-token-secret
@@ -87,6 +145,13 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://trtllm-disagg-planner-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
             - python3
           args:
@@ -102,6 +167,9 @@ spec:
             - decode
             - --disaggregation-strategy
             - decode_first
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     TRTLLMPrefillWorker:
       dynamoNamespace: trtllm-disagg-planner
       envFromSecret: hf-token-secret
@@ -116,6 +184,13 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://trtllm-disagg-planner-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
             - python3
           args:
@@ -131,3 +206,6 @@ spec:
             - prefill
             - --disaggregation-strategy
             - decode_first
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/trtllm/deploy/disagg_router.yaml
+++ b/examples/backends/trtllm/deploy/disagg_router.yaml
@@ -6,6 +6,9 @@ kind: DynamoGraphDeployment
 metadata:
   name: trtllm-v1-disagg-router
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: trtllm-v1-disagg-router
@@ -17,6 +20,62 @@ spec:
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: trtllm-v1-disagg-router
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     TRTLLMPrefillWorker:
       dynamoNamespace: trtllm-v1-disagg-router
       envFromSecret: hf-token-secret
@@ -29,6 +88,13 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://trtllm-v1-disagg-router-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -45,6 +111,9 @@ spec:
             - --disaggregation-strategy
             - prefill_first
             - --publish-events-and-metrics
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     TRTLLMDecodeWorker:
       dynamoNamespace: trtllm-v1-disagg-router
       envFromSecret: hf-token-secret
@@ -57,6 +126,13 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://trtllm-v1-disagg-router-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -72,3 +148,6 @@ spec:
             - decode
             - --disaggregation-strategy
             - prefill_first
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/trtllm/deploy/disagg_router.yaml
+++ b/examples/backends/trtllm/deploy/disagg_router.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://trtllm-v1-disagg-router-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: trtllm-v1-disagg-router
@@ -50,10 +57,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -88,13 +91,6 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://trtllm-v1-disagg-router-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -126,13 +122,6 @@ spec:
         mainContainer:
           image: my-registry/trtllm-runtime:my-tag
           workingDir: /workspace/
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://trtllm-v1-disagg-router-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/trtllm/deploy/model_cache_pvc.yaml
+++ b/examples/backends/trtllm/deploy/model_cache_pvc.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: csi-mounted-fs-path-sc
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+

--- a/examples/backends/vllm/deploy/agg.yaml
+++ b/examples/backends/vllm/deploy/agg.yaml
@@ -1,11 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-agg
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: vllm-agg
@@ -13,7 +31,63 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: gitlab-master.nvidia.com:5005/dl/ai-dynamo/dynamo/dynamo:vllm-1029
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-agg
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-agg
@@ -22,10 +96,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-agg-modelexpress:8000
       extraPodSpec:
         mainContainer:
-          image: gitlab-master.nvidia.com:5005/dl/ai-dynamo/dynamo/dynamo:vllm-1029
-          workingDir: /workspace/examples/backends/vllm
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
             - python3
             - -m
@@ -33,3 +115,6 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-0.6B
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/vllm/deploy/agg.yaml
+++ b/examples/backends/vllm/deploy/agg.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://vllm-agg-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: vllm-agg
@@ -47,10 +54,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -81,18 +84,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-agg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - python3
             - -m

--- a/examples/backends/vllm/deploy/agg.yaml
+++ b/examples/backends/vllm/deploy/agg.yaml
@@ -1,21 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 256Gi
-    limits:
-      storage: 256Gi
-
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/examples/backends/vllm/deploy/agg.yaml
+++ b/examples/backends/vllm/deploy/agg.yaml
@@ -87,7 +87,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
             - python3
             - -m

--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -95,7 +95,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -1,11 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-agg-kvbm
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: vllm-agg-kvbm
@@ -14,6 +32,67 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-agg-kvbm
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.2.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+              # mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              # cat > /model/.model-express/config.yaml << EOF
+              # local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              # server_endpoint: http://localhost:8000
+              # timeout_secs: null
+              # EOF
+
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-agg-kvbm
@@ -29,10 +108,17 @@ spec:
       envs:
         - name: DYN_KVBM_CPU_CACHE_GB
           value: "100"
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-agg-kvbm-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -48,3 +134,6 @@ spec:
             - --enforce-eager
             - --connector
             - kvbm
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -53,7 +53,7 @@ spec:
           memory: "16Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.2.0
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
           imagePullPolicy: IfNotPresent
           env:
             - name: MODEL_EXPRESS_SERVER_PORT
@@ -72,13 +72,8 @@ spec:
           args:
             - |
               echo "Setting up Model Express configuration..."
-              # mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
-              # cat > /model/.model-express/config.yaml << EOF
-              # local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
-              # server_endpoint: http://localhost:8000
-              # timeout_secs: null
-              # EOF
 
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
               cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
               local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
               server_endpoint: http://localhost:8000

--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -1,21 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 256Gi
-    limits:
-      storage: 256Gi
-
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://vllm-agg-kvbm-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: vllm-agg-kvbm
@@ -47,10 +54,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -88,17 +91,11 @@ spec:
       envs:
         - name: DYN_KVBM_CPU_CACHE_GB
           value: "100"
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-agg-kvbm-modelexpress:8000
+
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/agg_router.yaml
+++ b/examples/backends/vllm/deploy/agg_router.yaml
@@ -90,7 +90,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/agg_router.yaml
+++ b/examples/backends/vllm/deploy/agg_router.yaml
@@ -1,11 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-agg-router
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: vllm-agg-router
@@ -17,6 +35,62 @@ spec:
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-agg-router
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-agg-router
@@ -25,10 +99,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-agg-router-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -36,3 +118,6 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-0.6B
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/vllm/deploy/agg_router.yaml
+++ b/examples/backends/vllm/deploy/agg_router.yaml
@@ -1,21 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 256Gi
-    limits:
-      storage: 256Gi
-
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/examples/backends/vllm/deploy/agg_router.yaml
+++ b/examples/backends/vllm/deploy/agg_router.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://vllm-agg-router-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: vllm-agg-router
@@ -50,10 +57,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -84,18 +87,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-agg-router-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/disagg-multinode.yaml
@@ -97,7 +97,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m
@@ -123,7 +123,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/disagg-multinode.yaml
@@ -1,11 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-disagg
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: vllm-disagg
@@ -22,6 +40,62 @@ spec:
           args:
             - --http-port
             - "8000"
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-disagg
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     decode:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -35,7 +109,14 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://vllm-disagg-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -45,6 +126,9 @@ spec:
             - Qwen/Qwen3-0.6B
             - --tensor-parallel-size
             - "2"
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     prefill:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -58,7 +142,14 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_URL
+              value: http://vllm-disagg-modelexpress:8000
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -69,3 +160,6 @@ spec:
             - --is-prefill-worker
             - --tensor-parallel-size
             - "2"
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/vllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/disagg-multinode.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://vllm-disagg-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: vllm-disagg
@@ -55,10 +62,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -95,13 +98,6 @@ spec:
         mainContainer:
           image: my-registry/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://vllm-disagg-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -128,13 +124,6 @@ spec:
         mainContainer:
           image: my-registry/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_URL
-              value: http://vllm-disagg-modelexpress:8000
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/disagg-multinode.yaml
@@ -1,21 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 256Gi
-    limits:
-      storage: 256Gi
-
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/examples/backends/vllm/deploy/disagg.yaml
+++ b/examples/backends/vllm/deploy/disagg.yaml
@@ -87,7 +87,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m
@@ -111,7 +111,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg.yaml
+++ b/examples/backends/vllm/deploy/disagg.yaml
@@ -1,11 +1,30 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: csi-mounted-fs-path-sc
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-disagg
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: vllm-disagg
@@ -14,6 +33,61 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-disagg
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -23,10 +97,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-disagg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -35,6 +117,9 @@ spec:
             - --model
             - Qwen/Qwen3-0.6B
             - --is-decode-worker
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmPrefillWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -44,10 +129,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-disagg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -56,3 +149,6 @@ spec:
             - --model
             - Qwen/Qwen3-0.6B
             - --is-prefill-worker
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/vllm/deploy/disagg.yaml
+++ b/examples/backends/vllm/deploy/disagg.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://vllm-disagg-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: vllm-disagg
@@ -46,10 +53,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -81,18 +84,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-disagg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -113,18 +108,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-disagg-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg.yaml
+++ b/examples/backends/vllm/deploy/disagg.yaml
@@ -1,22 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  storageClassName: csi-mounted-fs-path-sc
-  resources:
-    requests:
-      storage: 256Gi
-    limits:
-      storage: 256Gi
-
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/examples/backends/vllm/deploy/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm.yaml
@@ -87,7 +87,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m
@@ -122,7 +122,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://vllm-disagg-kvbm-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: vllm-disagg-kvbm
@@ -47,10 +54,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -81,18 +84,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-disagg-kvbm-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -124,17 +119,10 @@ spec:
       envs:
         - name: DYN_KVBM_CPU_CACHE_GB
           value: "100"
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-disagg-kvbm-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm.yaml
@@ -1,21 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 256Gi
-    limits:
-      storage: 256Gi
-
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/examples/backends/vllm/deploy/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm.yaml
@@ -1,11 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-disagg-kvbm
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: vllm-disagg-kvbm
@@ -14,6 +32,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-disagg-kvbm
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg-kvbm
       envFromSecret: hf-token-secret
@@ -22,10 +96,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-disagg-kvbm-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -39,6 +121,9 @@ spec:
             - --max-model-len
             - "32000"
             - --enforce-eager
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmPrefillWorker:
       dynamoNamespace: vllm-disagg-kvbm
       envFromSecret: hf-token-secret
@@ -54,10 +139,17 @@ spec:
       envs:
         - name: DYN_KVBM_CPU_CACHE_GB
           value: "100"
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-disagg-kvbm-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -75,3 +167,6 @@ spec:
             - --connector
             - kvbm
             - nixl
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
@@ -1,11 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-disagg-kvbm-2p2d
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: vllm-disagg-kvbm-2p2d
@@ -14,6 +32,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-disagg-kvbm-2p2d
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg-kvbm-2p2d
       envFromSecret: hf-token-secret
@@ -22,10 +96,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-disagg-kvbm-2p2d-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -39,6 +121,9 @@ spec:
             - --max-model-len
             - "32000"
             - --enforce-eager
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmPrefillWorker:
       dynamoNamespace: vllm-disagg-kvbm-2p2d
       envFromSecret: hf-token-secret
@@ -54,10 +139,17 @@ spec:
       envs:
         - name: DYN_KVBM_CPU_CACHE_GB
           value: "100"
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-disagg-kvbm-2p2d-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -75,3 +167,6 @@ spec:
             - --connector
             - kvbm
             - nixl
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
@@ -87,7 +87,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m
@@ -122,7 +122,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
@@ -1,21 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 256Gi
-    limits:
-      storage: 256Gi
-
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://vllm-disagg-kvbm-2p2d-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: vllm-disagg-kvbm-2p2d
@@ -47,10 +54,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -81,18 +84,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-disagg-kvbm-2p2d-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -124,17 +119,10 @@ spec:
       envs:
         - name: DYN_KVBM_CPU_CACHE_GB
           value: "100"
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-disagg-kvbm-2p2d-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
@@ -89,7 +89,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m
@@ -126,7 +126,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
@@ -1,21 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 256Gi
-    limits:
-      storage: 256Gi
-
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
@@ -1,11 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-disagg-kvbm-tp2
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: vllm-disagg-kvbm-tp2
@@ -14,6 +32,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-disagg-kvbm-tp2
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg-kvbm-tp2
       envFromSecret: hf-token-secret
@@ -24,10 +98,18 @@ spec:
           gpu: "2"
         limits:
           gpu: "2"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-disagg-kvbm-tp2-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -43,6 +125,9 @@ spec:
             - --enforce-eager
             - --tensor-parallel-size
             - "2"
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmPrefillWorker:
       dynamoNamespace: vllm-disagg-kvbm-tp2
       envFromSecret: hf-token-secret
@@ -58,10 +143,17 @@ spec:
       envs:
         - name: DYN_KVBM_CPU_CACHE_GB
           value: "100"
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-disagg-kvbm-tp2-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -81,3 +173,6 @@ spec:
             - nixl
             - --tensor-parallel-size
             - "2"
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://vllm-disagg-kvbm-tp2-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: vllm-disagg-kvbm-tp2
@@ -47,10 +54,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -83,18 +86,10 @@ spec:
           gpu: "2"
         limits:
           gpu: "2"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-disagg-kvbm-tp2-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -128,17 +123,10 @@ spec:
       envs:
         - name: DYN_KVBM_CPU_CACHE_GB
           value: "100"
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-disagg-kvbm-tp2-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/disagg_planner.yaml
@@ -1,6 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
@@ -9,6 +24,8 @@ spec:
   pvcs:
     - name: dynamo-pvc
       create: false # Must be pre-created before deployment and SLA profiler must have been run
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: vllm-disagg-planner
@@ -17,6 +34,62 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-disagg-planner
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     Planner:
       dynamoNamespace: vllm-disagg-planner
       componentType: planner
@@ -46,10 +119,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-disagg-planner-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
             - python3
           args:
@@ -57,6 +138,9 @@ spec:
             - dynamo.vllm
             - --model
             - Qwen/Qwen3-0.6B
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmPrefillWorker:
       dynamoNamespace: vllm-disagg-planner
       envFromSecret: hf-token-secret
@@ -66,10 +150,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-disagg-planner-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
             - python3
           args:
@@ -78,3 +170,6 @@ spec:
             - --model
             - Qwen/Qwen3-0.6B
             - --is-prefill-worker
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/vllm/deploy/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/disagg_planner.yaml
@@ -1,21 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 256Gi
-    limits:
-      storage: 256Gi
-
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/examples/backends/vllm/deploy/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/disagg_planner.yaml
@@ -11,6 +11,13 @@ spec:
       create: false # Must be pre-created before deployment and SLA profiler must have been run
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://vllm-disagg-planner-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: vllm-disagg-planner
@@ -49,10 +56,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -104,18 +107,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-disagg-planner-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - python3
           args:
@@ -135,18 +130,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-disagg-planner-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - python3
           args:

--- a/examples/backends/vllm/deploy/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/disagg_planner.yaml
@@ -110,7 +110,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
             - python3
           args:
@@ -133,7 +133,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
             - python3
           args:

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -90,7 +90,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m
@@ -113,7 +113,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/components/backends/vllm
+          workingDir: /workspace/examples/backends/vllm
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -9,6 +9,13 @@ spec:
   pvcs:
     - name: model-cache-pvc
       create: false
+  envs:
+    - name: MODEL_EXPRESS_CACHE_DIRECTORY
+      value: "/model/.model-express/cache"
+    - name: HF_HUB_CACHE
+      value: "/model/.model-express/cache"
+    - name: MODEL_EXPRESS_URL
+      value: "http://vllm-v1-disagg-router-modelexpress:8000"
   services:
     Frontend:
       dynamoNamespace: vllm-v1-disagg-router
@@ -50,10 +57,6 @@ spec:
               value: "info"
             - name: MODEL_EXPRESS_DATABASE_PATH
               value: "/model/models.db"
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
             - /bin/sh
             - -c
@@ -84,18 +87,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-v1-disagg-router-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -115,18 +110,10 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: MODEL_EXPRESS_URL
-          value: http://vllm-v1-disagg-router-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/components/backends/vllm
-          env:
-            - name: MODEL_EXPRESS_CACHE_DIRECTORY
-              value: "/model/.model-express/cache"
-            - name: HF_HUB_CACHE
-              value: "/model/.model-express/cache"
           command:
           - python3
           - -m

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -1,21 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: model-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 256Gi
-    limits:
-      storage: 256Gi
-
----
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -1,11 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: vllm-v1-disagg-router
 spec:
+  pvcs:
+    - name: model-cache-pvc
+      create: false
   services:
     Frontend:
       dynamoNamespace: vllm-v1-disagg-router
@@ -17,6 +35,62 @@ spec:
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
+    ModelExpress:
+      envFromSecret: hf-token-secret
+      dynamoNamespace: vllm-v1-disagg-router
+      componentType: frontend
+      readinessProbe:
+        tcpSocket:
+          port: 8000
+        initialDelaySeconds: 10
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "16Gi"
+        limits:
+          cpu: "4"
+          memory: "16Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:my-tag
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: "info"
+            - name: MODEL_EXPRESS_DATABASE_PATH
+              value: "/model/models.db"
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo "Setting up Model Express configuration..."
+
+              mkdir -p $MODEL_EXPRESS_CACHE_DIRECTORY
+              cat > $MODEL_EXPRESS_CACHE_DIRECTORY/config.yaml << EOF
+              local_path: $MODEL_EXPRESS_CACHE_DIRECTORY
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              ./modelexpress-server &
+
+              SERVER_PID=$!
+              echo "Server started with PID: $SERVER_PID"
+              wait $SERVER_PID
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmDecodeWorker:
       dynamoNamespace: vllm-v1-disagg-router
       envFromSecret: hf-token-secret
@@ -25,10 +99,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-v1-disagg-router-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -37,6 +119,9 @@ spec:
             - --model
             - Qwen/Qwen3-0.6B
             - --is-decode-worker
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model
     VllmPrefillWorker:
       dynamoNamespace: vllm-v1-disagg-router
       envFromSecret: hf-token-secret
@@ -45,10 +130,18 @@ spec:
       resources:
         limits:
           gpu: "1"
+      envs:
+        - name: MODEL_EXPRESS_URL
+          value: http://vllm-v1-disagg-router-modelexpress:8000
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
-          workingDir: /workspace/examples/backends/vllm
+          workingDir: /workspace/components/backends/vllm
+          env:
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: "/model/.model-express/cache"
+            - name: HF_HUB_CACHE
+              value: "/model/.model-express/cache"
           command:
           - python3
           - -m
@@ -57,3 +150,6 @@ spec:
             - --model
             - Qwen/Qwen3-0.6B
             - --is-prefill-worker
+      volumeMounts:
+        - name: model-cache-pvc
+          mountPoint: /model

--- a/examples/backends/vllm/deploy/model_cache_pvc.yaml
+++ b/examples/backends/vllm/deploy/model_cache_pvc.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
+  storageClassName: csi-mounted-fs-path-sc
   resources:
     requests:
       storage: 256Gi
     limits:
       storage: 256Gi
-

--- a/examples/backends/vllm/deploy/model_cache_pvc.yaml
+++ b/examples/backends/vllm/deploy/model_cache_pvc.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 256Gi
+    limits:
+      storage: 256Gi
+


### PR DESCRIPTION
### Summary

As the title says, the PR integrates ModelExpress into Dynamo k8s deployments. Deployment now starts ModelExpress server with PVC attached (shared with the Dynamo workers) so that models are managed in a central location and shared across different workers. This avoids duplicate model download happening on each worker.

#### Details:
- Start modelexpress server along with frontend and workers for model management
- Add PVC manifest shared across modelexpress server and workers
- Update README docs with the new workflow 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated ModelExpress service for shared model caching across all deployment architectures.
  * Added persistent volume support with 256Gi model cache storage allocation.
  * Implemented cache sharing across inference workers and backend services.

* **Documentation**
  * Updated deployment guides for SGLang, TensorRT-LLM, and vLLM backends.
  * Added PVC creation instructions to deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->