### PR TITLE
feat: add dynamic port allocation to prevent test conflicts (part 2)

### DIFF
--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -71,7 +71,7 @@ jobs:
           docker run -w /workspace \
             --name ${{ env.CONTAINER_ID }}_pytest_parallel \
             ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c "pytest --basetemp=/tmp/pytest-parallel --junitxml=${{ env.PYTEST_PARALLEL_XML_FILE }} -n 4 -m \"${{ env.PYTEST_MARKS }}\""
+            bash -c "pytest --basetemp=/tmp/pytest-parallel --junitxml=${{ env.PYTEST_PARALLEL_XML_FILE }} -n auto -m \"${{ env.PYTEST_MARKS }}\""
       - name: Copy parallel test report from Container
         if: always()
         run: |

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -265,15 +265,19 @@ async def async_main():
     flags = parse_args()
     dump_config(flags.dump_config_to, flags)
 
-    # Warn if DYN_SYSTEM_PORT is set (frontend doesn't use system metrics server)
+    # Warn and unset DYN_SYSTEM_PORT if set (frontend doesn't use system metrics server)
+    # The frontend creates a DRT but should NOT start a system metrics server
+    # Only backend workers should set DYN_SYSTEM_PORT
     if os.environ.get("DYN_SYSTEM_PORT"):
         logger.warning(
             "=" * 80 + "\n"
             "WARNING: DYN_SYSTEM_PORT is set but NOT used by the frontend!\n"
             "The frontend does not expose a system metrics server.\n"
             "Only backend workers should set DYN_SYSTEM_PORT.\n"
-            "Use --http-port to configure the frontend HTTP API port.\n" + "=" * 80
+            "Unsetting DYN_SYSTEM_PORT to prevent DRT from starting system server.\n"
+            + "=" * 80
         )
+        os.environ.pop("DYN_SYSTEM_PORT", None)
 
     # Configure Dynamo frontend HTTP service metrics prefix
     if flags.metrics_prefix is not None:

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -228,7 +228,7 @@ def setup_prometheus_registry(
     SGLang uses multiprocess architecture where metrics are stored in shared memory.
     MultiProcessCollector aggregates metrics from all worker processes. The Prometheus
     registry collects sglang:* metrics which are exposed via the metrics server endpoint
-    (set DYN_SYSTEM_PORT to a positive value to enable, e.g., DYN_SYSTEM_PORT=8081).
+    (typically port 8081) when DYN_SYSTEM_PORT is set to a positive value.
 
     Args:
         engine: The SGLang engine instance.

--- a/examples/backends/sglang/launch/disagg.sh
+++ b/examples/backends/sglang/launch/disagg.sh
@@ -52,7 +52,7 @@ DYNAMO_PID=$!
 #AssertionError: Prefill round robin balance is required when dp size > 1. Please make sure that the prefill instance is launched with `--load-balance-method round_robin` and `--prefill-round-robin-balance` is set for decode server.
 
 # run prefill worker
-OTEL_SERVICE_NAME=dynamo-worker-prefill DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_PREFILL:-8081} \
+OTEL_SERVICE_NAME=dynamo-worker-prefill DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 python3 -m dynamo.sglang \
   --model-path silence09/DeepSeek-R1-Small-2layers \
   --served-model-name silence09/DeepSeek-R1-Small-2layers \
@@ -69,7 +69,7 @@ python3 -m dynamo.sglang \
 PREFILL_PID=$!
 
 # run decode worker
-OTEL_SERVICE_NAME=dynamo-worker-decode DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_DECODE:-8082} \
+OTEL_SERVICE_NAME=dynamo-worker-decode DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 CUDA_VISIBLE_DEVICES=2,3 python3 -m dynamo.sglang \
   --model-path silence09/DeepSeek-R1-Small-2layers \
   --served-model-name silence09/DeepSeek-R1-Small-2layers \

--- a/examples/backends/vllm/launch/disagg_same_gpu.sh
+++ b/examples/backends/vllm/launch/disagg_same_gpu.sh
@@ -48,7 +48,7 @@ DYNAMO_PID=$!
 
 # run decode worker with metrics on port 8081
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag
-DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 CUDA_VISIBLE_DEVICES=0 \
 python3 -m dynamo.vllm \
   --model Qwen/Qwen3-0.6B \
@@ -66,7 +66,7 @@ echo "Waiting for decode worker to initialize..."
 sleep 10
 
 # run prefill worker with metrics on port 8082 (foreground)
-DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_PREFILL:-8082} \
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 DYN_VLLM_KV_EVENT_PORT=20081 \
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=0 \

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -38,7 +38,24 @@ class DistributedRuntime:
     The runtime object for dynamo applications
     """
 
-    ...
+    def __init__(
+        self,
+        event_loop: Any,
+        store_kv: str = "etcd",
+        request_plane: str = "nats",
+        env: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Create a new DistributedRuntime instance.
+
+        Args:
+            event_loop: The asyncio event loop to use
+            store_kv: Storage backend ("etcd", "file", or "memory"). Defaults to "etcd"
+            request_plane: Request plane transport ("nats", "http", or "tcp"). Defaults to "nats"
+            env: Optional dictionary of environment variables to use during initialization.
+                 Common keys: "NATS_SERVER", "ETCD_ENDPOINTS", "NATS_AUTH_*", "ETCD_AUTH_*"
+        """
+        ...
 
     def namespace(self, name: str) -> Namespace:
         """

--- a/lib/runtime/src/config.rs
+++ b/lib/runtime/src/config.rs
@@ -101,6 +101,7 @@ pub struct RuntimeConfig {
     /// Set to 0 to bind to a random available port
     /// Set to a positive port number (e.g. 8081) to bind to a specific port
     /// Set this at runtime with environment variable DYN_SYSTEM_PORT
+    /// TODO: Change type from i16 to u16 to support full port range (0-65535)
     #[builder(default = "DEFAULT_SYSTEM_PORT")]
     #[builder_field_attr(serde(skip_serializing_if = "Option::is_none"))]
     pub system_port: i16,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,8 @@ markers = [
     "model: model id used by a test or parameter",
     "custom_build: marks tests that require custom builds or special setup (e.g., MoE models)",
     "k8s: marks tests as requiring Kubernetes",
-    "fault_tolerance: marks tests as fault tolerance tests"
+    "fault_tolerance: marks tests as fault tolerance tests",
+    "requires_hf_token: marks tests that require HuggingFace authentication token for gated models"
 ]
 
 # Linting/formatting

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 import logging
 import os
@@ -26,6 +14,14 @@ from filelock import FileLock
 
 from tests.utils.constants import TEST_MODELS
 from tests.utils.managed_process import ManagedProcess
+from tests.utils.port_utils import (
+    allocate_free_port,
+    allocate_free_ports,
+    free_port,
+    free_ports,
+)
+
+_logger = logging.getLogger(__name__)
 
 
 def pytest_configure(config):
@@ -248,43 +244,123 @@ def pytest_runtestloop(session):
 
 
 class EtcdServer(ManagedProcess):
-    def __init__(self, request, port=2379, timeout=300):
+    def __init__(self, request, port=None, timeout=300):
+        # Allocate free ports if not specified
+        use_random_port = port is None
+        if use_random_port:
+            # Need two ports: client port and peer port for parallel execution
+            # Start from 2380 (etcd default 2379 + 1)
+            port, peer_port = allocate_free_ports(2, 2380)
+        else:
+            peer_port = None
+
+        self.port = port
+        self.peer_port = peer_port  # Store for cleanup
         port_string = str(port)
         etcd_env = os.environ.copy()
         etcd_env["ALLOW_NONE_AUTHENTICATION"] = "yes"
         data_dir = tempfile.mkdtemp(prefix="etcd_")
+
         command = [
             "etcd",
             "--listen-client-urls",
             f"http://0.0.0.0:{port_string}",
             "--advertise-client-urls",
             f"http://0.0.0.0:{port_string}",
-            "--data-dir",
-            data_dir,
         ]
+
+        # Add peer port configuration only for random ports (parallel execution)
+        if peer_port is not None:
+            peer_port_string = str(peer_port)
+            command.extend(
+                [
+                    "--listen-peer-urls",
+                    f"http://0.0.0.0:{peer_port_string}",
+                    "--initial-advertise-peer-urls",
+                    f"http://localhost:{peer_port_string}",
+                    "--initial-cluster",
+                    f"default=http://localhost:{peer_port_string}",
+                ]
+            )
+
+        command.extend(
+            [
+                "--data-dir",
+                data_dir,
+            ]
+        )
         super().__init__(
             env=etcd_env,
             command=command,
             timeout=timeout,
             display_output=False,
+            terminate_existing=not use_random_port,  # Disabled for parallel test execution with random ports
             health_check_ports=[port],
             data_dir=data_dir,
             log_dir=request.node.name,
         )
 
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Release allocated ports when server exits."""
+        ports_to_release = []
+        try:
+            # Release allocated ports BEFORE calling parent __exit__
+            if hasattr(self, "port") and self.port is not None:
+                ports_to_release.append(self.port)
+            if hasattr(self, "peer_port") and self.peer_port is not None:
+                ports_to_release.append(self.peer_port)
+
+            if ports_to_release:
+                free_ports(ports_to_release)
+        except Exception:
+            # Silently continue if port release fails
+            pass
+        finally:
+            # Always call parent __exit__ to terminate the process
+            return super().__exit__(exc_type, exc_val, exc_tb)
+
 
 class NatsServer(ManagedProcess):
-    def __init__(self, request, port=4222, timeout=300):
+    def __init__(self, request, port=None, timeout=300):
+        # Allocate a free port if not specified
+        use_random_port = port is None
+        if use_random_port:
+            # Start from 4223 (nats-server default 4222 + 1)
+            port = allocate_free_port(4223)
+
+        self.port = port
         data_dir = tempfile.mkdtemp(prefix="nats_")
-        command = ["nats-server", "-js", "--trace", "--store_dir", data_dir]
+        command = [
+            "nats-server",
+            "-js",
+            "--trace",
+            "--store_dir",
+            data_dir,
+            "-p",
+            str(port),
+        ]
         super().__init__(
             command=command,
             timeout=timeout,
             display_output=False,
+            terminate_existing=not use_random_port,  # Disabled for parallel test execution with random ports
             data_dir=data_dir,
             health_check_ports=[port],
             log_dir=request.node.name,
         )
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Release allocated port when server exits."""
+        try:
+            # Release allocated port BEFORE calling parent __exit__
+            if hasattr(self, "port") and self.port is not None:
+                free_port(self.port)
+        except Exception:
+            # Silently continue if port release fails
+            pass
+        finally:
+            # Always call parent __exit__ to terminate the process
+            return super().__exit__(exc_type, exc_val, exc_tb)
 
 
 class SharedManagedProcess:
@@ -414,6 +490,13 @@ class SharedNatsServer(SharedManagedProcess):
 
 @pytest.fixture()
 def runtime_services(request):
+    """Provide NATS and Etcd servers with dynamically allocated ports.
+
+    Returns a tuple of (nats_process, etcd_process) where each has a .port attribute.
+    Tests should set NATS_SERVER and ETCD_ENDPOINTS environment variables in their
+    subprocess environments using these ports.
+    """
+    # Port cleanup is now handled in NatsServer and EtcdServer __exit__ methods
     with NatsServer(request) as nats_process:
         with EtcdServer(request) as etcd_process:
             yield nats_process, etcd_process

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -15,9 +15,9 @@ from tests.fault_tolerance.cancellation.utils import (
     send_cancellable_request,
 )
 from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
-from tests.utils.engine_process import FRONTEND_PORT
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_health_generate, check_models_api
+from tests.utils.port_utils import allocate_free_port
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +33,20 @@ pytestmark = [
 class DynamoWorkerProcess(ManagedProcess):
     """Process manager for Dynamo worker with TensorRT-LLM backend"""
 
-    def __init__(self, request, mode: str = "prefill_and_decode"):
+    def __init__(
+        self,
+        request,
+        system_port: int,
+        frontend_port: int,
+        mode: str = "prefill_and_decode",
+    ):
         """
         Initialize TensorRT-LLM worker process.
 
         Args:
             request: pytest request object
+            system_port: Port for metrics endpoint
+            frontend_port: Port where the frontend is running
             mode: One of "prefill_and_decode", "prefill", "decode"
         """
         # Prefill workers require migration_limit=0 (no KV cache migration support)
@@ -70,20 +78,16 @@ class DynamoWorkerProcess(ManagedProcess):
                 "test_request_cancellation_trtllm_config.yaml",
             ]
 
-        health_check_urls = [
-            (f"http://localhost:{FRONTEND_PORT}/v1/models", check_models_api),
-            (f"http://localhost:{FRONTEND_PORT}/health", check_health_generate),
-        ]
-
-        # Set port based on worker type
-        if mode == "prefill":
-            port = "8082"
-            health_check_urls = [(f"http://localhost:{port}/health", self.is_ready)]
-        elif mode == "decode":
-            port = "8081"
-            health_check_urls = [(f"http://localhost:{port}/health", self.is_ready)]
+        # Set health check URLs based on mode
+        if mode in ["prefill", "decode"]:
+            health_check_urls = [
+                (f"http://localhost:{system_port}/health", self.is_ready)
+            ]
         else:  # prefill_and_decode
-            port = "8081"
+            health_check_urls = [
+                (f"http://localhost:{frontend_port}/v1/models", check_models_api),
+                (f"http://localhost:{frontend_port}/health", check_health_generate),
+            ]
 
         # Set debug logging environment
         env = os.environ.copy()
@@ -94,7 +98,8 @@ class DynamoWorkerProcess(ManagedProcess):
         # intermittent failures
         env["DYN_HEALTH_CHECK_ENABLED"] = "false"
         env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
-        env["DYN_SYSTEM_PORT"] = port
+        env["DYN_SYSTEM_PORT"] = str(system_port)
+        env["DYN_HTTP_PORT"] = str(frontend_port)
 
         # Set log directory based on worker type
         log_dir = f"{request.node.name}_{mode}_worker"
@@ -150,12 +155,21 @@ def test_request_cancellation_trtllm_aggregated(request, runtime_services):
     on the worker side in aggregated (prefill_and_decode) mode.
     """
 
+    # Allocate ports to avoid conflicts with parallel tests
+    frontend_port = allocate_free_port(8100)
+    system_port = allocate_free_port(9100)
+
     # Step 1: Start the frontend
-    with DynamoFrontendProcess(request) as frontend:
+    with DynamoFrontendProcess(request, frontend_port) as frontend:
         logger.info("Frontend started successfully")
 
         # Step 2: Start an aggregated worker
-        with DynamoWorkerProcess(request, mode="prefill_and_decode") as worker:
+        with DynamoWorkerProcess(
+            request,
+            system_port=system_port,
+            frontend_port=frontend_port,
+            mode="prefill_and_decode",
+        ) as worker:
             logger.info(f"Aggregated Worker PID: {worker.get_pid()}")
 
             # TODO: Why wait after worker ready fixes frontend 404 / 500 flakiness?
@@ -177,7 +191,7 @@ def test_request_cancellation_trtllm_aggregated(request, runtime_services):
                 logger.info(f"Testing {description.lower()}...")
 
                 # Send the request (non-blocking)
-                cancellable_req = send_cancellable_request(request_type)
+                cancellable_req = send_cancellable_request(frontend_port, request_type)
 
                 # Poll for "New Request ID" pattern
                 request_id, worker_log_offset = poll_for_pattern(
@@ -222,16 +236,31 @@ def test_request_cancellation_trtllm_decode_cancel(request, runtime_services):
     on the decode worker side in a disaggregated setup.
     """
 
+    # Allocate ports to avoid conflicts with parallel tests
+    frontend_port = allocate_free_port(8100)
+    prefill_system_port = allocate_free_port(9100)
+    decode_system_port = allocate_free_port(9100)
+
     # Step 1: Start the frontend
-    with DynamoFrontendProcess(request) as frontend:
+    with DynamoFrontendProcess(request, frontend_port) as frontend:
         logger.info("Frontend started successfully")
 
         # Step 2: Start the prefill worker
-        with DynamoWorkerProcess(request, mode="prefill") as prefill_worker:
+        with DynamoWorkerProcess(
+            request,
+            system_port=prefill_system_port,
+            frontend_port=frontend_port,
+            mode="prefill",
+        ) as prefill_worker:
             logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
 
             # Step 3: Start the decode worker
-            with DynamoWorkerProcess(request, mode="decode") as decode_worker:
+            with DynamoWorkerProcess(
+                request,
+                system_port=decode_system_port,
+                frontend_port=frontend_port,
+                mode="decode",
+            ) as decode_worker:
                 logger.info(f"Decode Worker PID: {decode_worker.get_pid()}")
 
                 # TODO: Why wait after worker ready fixes frontend 404 / 500 flakiness?
@@ -243,7 +272,9 @@ def test_request_cancellation_trtllm_decode_cancel(request, runtime_services):
                 )
 
                 # Send streaming request (non-blocking)
-                cancellable_req = send_cancellable_request("chat_completion_stream")
+                cancellable_req = send_cancellable_request(
+                    frontend_port, "chat_completion_stream"
+                )
 
                 # Poll for "Prefill Request ID" pattern in prefill worker (frontend routes here first)
                 request_id, prefill_log_offset = poll_for_pattern(
@@ -293,16 +324,31 @@ def test_request_cancellation_trtllm_prefill_cancel(request, runtime_services):
     Since the request is cancelled before prefill completes, the decode worker never receives it.
     """
 
+    # Allocate ports to avoid conflicts with parallel tests
+    frontend_port = allocate_free_port(8100)
+    prefill_system_port = allocate_free_port(9100)
+    decode_system_port = allocate_free_port(9100)
+
     # Step 1: Start the frontend
-    with DynamoFrontendProcess(request) as frontend:
+    with DynamoFrontendProcess(request, frontend_port) as frontend:
         logger.info("Frontend started successfully")
 
         # Step 2: Start the prefill worker
-        with DynamoWorkerProcess(request, mode="prefill") as prefill_worker:
+        with DynamoWorkerProcess(
+            request,
+            system_port=prefill_system_port,
+            frontend_port=frontend_port,
+            mode="prefill",
+        ) as prefill_worker:
             logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
 
             # Step 3: Start the decode worker
-            with DynamoWorkerProcess(request, mode="decode") as decode_worker:
+            with DynamoWorkerProcess(
+                request,
+                system_port=decode_system_port,
+                frontend_port=frontend_port,
+                mode="decode",
+            ) as decode_worker:
                 logger.info(f"Decode Worker PID: {decode_worker.get_pid()}")
 
                 # TODO: Why wait after worker ready fixes frontend 404 / 500 flakiness?
@@ -315,7 +361,7 @@ def test_request_cancellation_trtllm_prefill_cancel(request, runtime_services):
 
                 # Send request with long prompt (non-blocking)
                 cancellable_req = send_cancellable_request(
-                    "completion", use_long_prompt=True
+                    frontend_port, "completion", use_long_prompt=True
                 )
 
                 # Poll for "Prefill Request ID" pattern in prefill worker (frontend routes here first)
@@ -377,16 +423,28 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(request, runtime_service
     the system properly handles the cancellation and cleans up resources on the workers.
     """
 
+    # Allocate dynamic ports to avoid conflicts
+    frontend_port = allocate_free_port(8100)
+    prefill_system_port = allocate_free_port(9100)
+    decode_system_port = allocate_free_port(9101)
+    logger.info(
+        f"Allocated ports - frontend: {frontend_port}, prefill_system: {prefill_system_port}, decode_system: {decode_system_port}"
+    )
+
     # Step 1: Start the frontend
-    with DynamoFrontendProcess(request) as frontend:
+    with DynamoFrontendProcess(request, frontend_port) as frontend:
         logger.info("Frontend started successfully")
 
         # Step 2: Start the prefill worker
-        with DynamoWorkerProcess(request, mode="prefill") as prefill_worker:
+        with DynamoWorkerProcess(
+            request, prefill_system_port, frontend_port, mode="prefill"
+        ) as prefill_worker:
             logger.info(f"Prefill Worker PID: {prefill_worker.get_pid()}")
 
             # Step 3: Start the decode worker
-            with DynamoWorkerProcess(request, mode="decode") as decode_worker:
+            with DynamoWorkerProcess(
+                request, decode_system_port, frontend_port, mode="decode"
+            ) as decode_worker:
                 logger.info(f"Decode Worker PID: {decode_worker.get_pid()}")
 
                 # TODO: Why wait after worker ready fixes frontend 404 / 500 flakiness?
@@ -399,7 +457,7 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(request, runtime_service
 
                 # Send request with long prompt
                 cancellable_req = send_cancellable_request(
-                    "completion", use_long_prompt=True
+                    frontend_port, "completion", use_long_prompt=True
                 )
 
                 # Poll for "Prefill Request ID" pattern in prefill worker
@@ -440,7 +498,9 @@ def test_request_cancellation_trtllm_kv_transfer_cancel(request, runtime_service
                 )
 
                 # Verify the workers are still functional
-                cancellable_req = send_cancellable_request("chat_completion_stream")
+                cancellable_req = send_cancellable_request(
+                    frontend_port, "chat_completion_stream"
+                )
                 _, decode_log_offset = poll_for_pattern(
                     process=decode_worker,
                     pattern="Decode Request ID: ",

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -94,10 +94,6 @@ class DynamoWorkerProcess(ManagedProcess):
             log_dir=log_dir,
         )
 
-    def get_pid(self):
-        """Get the PID of the worker process"""
-        return self.proc.pid if self.proc else None
-
     def is_ready(self, response) -> bool:
         """Check the health of the worker process"""
         try:
@@ -124,6 +120,16 @@ def test_request_migration_sglang_worker_failure(
     the system can handle the failure gracefully and migrate the request to
     another worker.
     """
+
+    # Extract runtime service ports
+    nats_process, etcd_process = runtime_services
+    logger.info(
+        f"Using runtime services - NATS port: {nats_process.port}, Etcd port: {etcd_process.port}"
+    )
+
+    # Set environment variables for runtime services before starting workers
+    os.environ["NATS_SERVER"] = f"nats://localhost:{nats_process.port}"
+    os.environ["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_process.port}"
 
     # Step 1: Start the frontend
     with DynamoFrontendProcess(request) as frontend:
@@ -216,6 +222,16 @@ def test_no_request_migration_sglang_worker_failure(
     is killed during request processing, the request fails as expected without migration.
     This is the opposite behavior of test_request_migration_sglang_worker_failure.
     """
+
+    # Extract runtime service ports
+    nats_process, etcd_process = runtime_services
+    logger.info(
+        f"Using runtime services - NATS port: {nats_process.port}, Etcd port: {etcd_process.port}"
+    )
+
+    # Set environment variables for runtime services before starting workers
+    os.environ["NATS_SERVER"] = f"nats://localhost:{nats_process.port}"
+    os.environ["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_process.port}"
 
     # Step 1: Start the frontend
     with DynamoFrontendProcess(request) as frontend:

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -90,10 +90,6 @@ class DynamoWorkerProcess(ManagedProcess):
             log_dir=log_dir,
         )
 
-    def get_pid(self):
-        """Get the PID of the worker process"""
-        return self.proc.pid if self.proc else None
-
     def is_ready(self, response) -> bool:
         """Check the health of the worker process"""
         try:
@@ -120,6 +116,16 @@ def test_request_migration_trtllm_worker_failure(
     the system can handle the failure gracefully and migrate the request to
     another worker.
     """
+
+    # Extract runtime service ports
+    nats_process, etcd_process = runtime_services
+    logger.info(
+        f"Using runtime services - NATS port: {nats_process.port}, Etcd port: {etcd_process.port}"
+    )
+
+    # Set environment variables for runtime services before starting workers
+    os.environ["NATS_SERVER"] = f"nats://localhost:{nats_process.port}"
+    os.environ["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_process.port}"
 
     # Step 1: Start the frontend
     with DynamoFrontendProcess(request) as frontend:
@@ -212,6 +218,16 @@ def test_no_request_migration_trtllm_worker_failure(
     is killed during request processing, the request fails as expected without migration.
     This is the opposite behavior of test_request_migration_trtllm_worker_failure.
     """
+
+    # Extract runtime service ports
+    nats_process, etcd_process = runtime_services
+    logger.info(
+        f"Using runtime services - NATS port: {nats_process.port}, Etcd port: {etcd_process.port}"
+    )
+
+    # Set environment variables for runtime services before starting workers
+    os.environ["NATS_SERVER"] = f"nats://localhost:{nats_process.port}"
+    os.environ["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_process.port}"
 
     # Step 1: Start the frontend
     with DynamoFrontendProcess(request) as frontend:

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -94,10 +94,6 @@ class DynamoWorkerProcess(ManagedProcess):
             log_dir=log_dir,
         )
 
-    def get_pid(self):
-        """Get the PID of the worker process"""
-        return self.proc.pid if self.proc else None
-
     def is_ready(self, response) -> bool:
         """Check the health of the worker process"""
         try:

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -97,7 +97,7 @@ def start_completion_request() -> tuple:
 
 def determine_request_receiving_worker(
     worker1: ManagedProcess, worker2: ManagedProcess, receiving_pattern: str
-) -> tuple:
+) -> tuple[ManagedProcess, str]:
     """
     Determine which worker received the request using parallel polling.
 
@@ -158,8 +158,10 @@ def determine_request_receiving_worker(
         return worker2, "Worker 2"
     elif worker1_received and worker2_received:
         pytest.fail("Both workers received the request")
+        raise AssertionError("Unreachable")  # For mypy: pytest.fail() raises
     else:
         pytest.fail("Neither worker received the request")
+        raise AssertionError("Unreachable")  # For mypy: pytest.fail() raises
 
 
 def validate_completion_response(

--- a/tests/frontend/grpc/test_tensor_mocker_engine.py
+++ b/tests/frontend/grpc/test_tensor_mocker_engine.py
@@ -112,6 +112,13 @@ def runtime_services(request):
 @pytest.fixture(scope="module")
 def start_services(request, runtime_services):
     """Start frontend and worker processes once for this module's tests."""
+    # Extract runtime service ports
+    nats_process, etcd_process = runtime_services
+
+    # Set environment variables for runtime services before starting workers
+    os.environ["NATS_SERVER"] = f"nats://localhost:{nats_process.port}"
+    os.environ["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_process.port}"
+
     with DynamoFrontendProcess(request):
         logger.info("Frontend started for tests")
         with MockWorkerProcess(request):

--- a/tests/frontend/grpc/test_tensor_parameters.py
+++ b/tests/frontend/grpc/test_tensor_parameters.py
@@ -68,6 +68,13 @@ class EchoTensorWorkerProcess(ManagedProcess):
 @pytest.fixture()
 def start_services(request, runtime_services):
     """Start frontend and worker with fresh etcd/nats."""
+    # Extract runtime service ports
+    nats_process, etcd_process = runtime_services
+
+    # Set environment variables for runtime services before starting workers
+    os.environ["NATS_SERVER"] = f"nats://localhost:{nats_process.port}"
+    os.environ["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_process.port}"
+
     with DynamoFrontendProcess(request):
         with EchoTensorWorkerProcess(request):
             yield

--- a/tests/frontend/test_completion_mocker_engine.py
+++ b/tests/frontend/test_completion_mocker_engine.py
@@ -1,6 +1,50 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""
+Frontend completion tests with mock backend engine.
+
+Parallel Execution:
+-------------------
+Install pytest-xdist for parallel test execution:
+    pip install pytest-xdist
+
+Most tests MUST run serially (default - no marker needed).
+Tests that are safe to run in parallel should use @pytest.mark.parallel.
+
+Usage Examples:
+    # Run all tests serially (safe default)
+    pytest tests/frontend/test_completion_mocker_engine.py -v
+
+    # Run only serial tests (exclude parallel)
+    pytest tests/frontend/test_completion_mocker_engine.py -v -m "not parallel"
+
+    # Run only parallel tests serially
+    pytest tests/frontend/test_completion_mocker_engine.py -v -m parallel
+
+    # Run only parallel tests in parallel with 2 workers
+    pytest tests/frontend/test_completion_mocker_engine.py -v -n 2 -m parallel
+
+    # Run only parallel tests in parallel with auto workers
+    pytest tests/frontend/test_completion_mocker_engine.py -v -n auto -m parallel
+
+Marker Examples:
+    # Serial test (default - most tests, no marker needed)
+    @pytest.mark.e2e
+    def test_needs_serial():
+        pass
+
+    # Parallel test (uses dynamic ports, isolated fixtures)
+    @pytest.mark.e2e
+    @pytest.mark.parallel
+    def test_can_run_parallel():
+        pass
+
+Performance Comparison (32-core machine, parallel tests only):
+    Serial:              101.24s (1:41)
+    Parallel (-n 2):     51.14s  (50% faster)
+    Parallel (-n auto):  27.37s  (73% faster, 24 workers)
+"""
 
 from __future__ import annotations
 
@@ -13,7 +57,6 @@ from typing import Any, Dict
 import pytest
 import requests
 
-from tests.conftest import EtcdServer, NatsServer
 from tests.utils.constants import QWEN
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
@@ -26,6 +69,7 @@ pytestmark = [
     pytest.mark.e2e,
     pytest.mark.gpu_1,
     pytest.mark.post_merge,
+    pytest.mark.parallel,
     pytest.mark.model(TEST_MODEL),
 ]
 
@@ -33,12 +77,19 @@ pytestmark = [
 class DynamoFrontendProcess(ManagedProcess):
     """Process manager for Dynamo frontend"""
 
-    def __init__(self, request):
+    def __init__(self, request, nats_port, etcd_port, http_port):
+        self.http_port = http_port
+
         command = ["python", "-m", "dynamo.frontend", "--router-mode", "round-robin"]
 
         # Unset DYN_SYSTEM_PORT - frontend doesn't use system metrics server
         env = os.environ.copy()
         env.pop("DYN_SYSTEM_PORT", None)
+
+        # pytest-xdist safe: workers are separate processes with isolated os.environ.
+        env["DYN_HTTP_PORT"] = str(http_port)
+        env["NATS_SERVER"] = f"nats://localhost:{nats_port}"
+        env["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_port}"
 
         log_dir = f"{request.node.name}_frontend"
 
@@ -54,14 +105,23 @@ class DynamoFrontendProcess(ManagedProcess):
             command=command,
             env=env,
             display_output=True,
-            terminate_existing=True,
+            terminate_existing=False,  # Disabled for parallel test execution
             log_dir=log_dir,
         )
 
 
 class MockWorkerProcess(ManagedProcess):
-    def __init__(self, request, worker_id: str = "mocker-worker"):
+    def __init__(
+        self,
+        request,
+        nats_port,
+        etcd_port,
+        frontend_http_port,
+        system_port,
+        worker_id: str = "mocker-worker",
+    ):
         self.worker_id = worker_id
+        self.system_port = system_port
 
         command = [
             "python3",
@@ -76,7 +136,11 @@ class MockWorkerProcess(ManagedProcess):
         env = os.environ.copy()
         env["DYN_LOG"] = "debug"
         env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
-        env["DYN_SYSTEM_PORT"] = "8083"
+
+        # pytest-xdist safe: workers are separate processes with isolated os.environ.
+        env["DYN_SYSTEM_PORT"] = str(system_port)
+        env["NATS_SERVER"] = f"nats://localhost:{nats_port}"
+        env["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_port}"
 
         log_dir = f"{request.node.name}_{worker_id}"
 
@@ -89,8 +153,8 @@ class MockWorkerProcess(ManagedProcess):
             command=command,
             env=env,
             health_check_urls=[
-                ("http://localhost:8000/v1/models", check_models_api),
-                ("http://localhost:8083/health", self.is_ready),
+                (f"http://localhost:{frontend_http_port}/v1/models", check_models_api),
+                (f"http://localhost:{system_port}/health", self.is_ready),
             ],
             timeout=300,
             display_output=True,
@@ -117,6 +181,7 @@ class MockWorkerProcess(ManagedProcess):
 
 def _send_completion_request(
     payload: Dict[str, Any],
+    frontend_http_port: int,
     timeout: int = 180,
 ) -> requests.Response:
     """Send a text completion request"""
@@ -125,7 +190,7 @@ def _send_completion_request(
     print(f"Sending request: {time.time()}")
 
     response = requests.post(
-        "http://localhost:8000/v1/completions",
+        f"http://localhost:{frontend_http_port}/v1/completions",
         headers=headers,
         json=payload,
         timeout=timeout,
@@ -133,33 +198,44 @@ def _send_completion_request(
     return response
 
 
-@pytest.fixture(scope="module")
-def runtime_services(request):
-    """Module-scoped runtime services for this test file."""
-    with NatsServer(request) as nats_process:
-        with EtcdServer(request) as etcd_process:
-            yield nats_process, etcd_process
-
-
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def start_services(request, runtime_services):
-    """Start frontend and worker processes once for this module's tests."""
-    with DynamoFrontendProcess(request):
-        logger.info("Frontend started for tests")
-        with MockWorkerProcess(request):
-            logger.info("Worker started for tests")
-            yield
+    """Start frontend and worker processes for each test (for parallel execution)."""
+    from tests.utils.port_utils import allocate_free_port, free_ports
+
+    nats_process, etcd_process = runtime_services
+
+    # Allocate ports for HTTP and system servers
+    # Frontend starts at 8100, worker/backend starts at 9100
+    http_port = allocate_free_port(8100)
+    system_port = allocate_free_port(9100)
+    logger.info(f"Allocated ports - HTTP: {http_port}, System: {system_port}")
+
+    try:
+        with DynamoFrontendProcess(
+            request, nats_process.port, etcd_process.port, http_port
+        ) as frontend:
+            logger.info(f"Frontend started on port {http_port}")
+            with MockWorkerProcess(
+                request, nats_process.port, etcd_process.port, http_port, system_port
+            ):
+                logger.info(f"Worker started with system port {system_port}")
+                yield frontend
+    finally:
+        # Release ports when test completes
+        free_ports([http_port, system_port])
+        logger.info(f"Released ports - HTTP: {http_port}, System: {system_port}")
 
 
 @pytest.mark.usefixtures("start_services")
-def test_completion_string_prompt() -> None:
+def test_completion_string_prompt(start_services) -> None:
     payload: Dict[str, Any] = {
         "model": TEST_MODEL,
         "prompt": "Tell me about Mars",
         "max_tokens": 2000,
     }
 
-    response = _send_completion_request(payload)
+    response = _send_completion_request(payload, start_services.http_port)
 
     assert response.status_code == 200, (
         f"Completion request failed with status "
@@ -168,14 +244,14 @@ def test_completion_string_prompt() -> None:
 
 
 @pytest.mark.usefixtures("start_services")
-def test_completion_empty_array_prompt() -> None:
+def test_completion_empty_array_prompt(start_services) -> None:
     payload: Dict[str, Any] = {
         "model": TEST_MODEL,
         "prompt": [],
         "max_tokens": 2000,
     }
 
-    response = _send_completion_request(payload)
+    response = _send_completion_request(payload, start_services.http_port)
 
     assert response.status_code == 400, (
         f"Completion request should failed with status 400 but got"
@@ -184,14 +260,14 @@ def test_completion_empty_array_prompt() -> None:
 
 
 @pytest.mark.usefixtures("start_services")
-def test_completion_single_element_array_prompt() -> None:
+def test_completion_single_element_array_prompt(start_services) -> None:
     payload: Dict[str, Any] = {
         "model": TEST_MODEL,
         "prompt": ["Tell me about Mars"],
         "max_tokens": 2000,
     }
 
-    response = _send_completion_request(payload)
+    response = _send_completion_request(payload, start_services.http_port)
 
     assert response.status_code == 200, (
         f"Completion request failed with status "
@@ -200,7 +276,7 @@ def test_completion_single_element_array_prompt() -> None:
 
 
 @pytest.mark.usefixtures("start_services")
-def test_completion_multi_element_array_prompt() -> None:
+def test_completion_multi_element_array_prompt(start_services) -> None:
     payload: Dict[str, Any] = {
         "model": TEST_MODEL,
         "prompt": [
@@ -211,7 +287,7 @@ def test_completion_multi_element_array_prompt() -> None:
         "max_tokens": 300,
     }
 
-    response = _send_completion_request(payload)
+    response = _send_completion_request(payload, start_services.http_port)
     response_data = response.json()
 
     assert response.status_code == 200, (

--- a/tests/profiler/test_profile_sla_dryrun.py
+++ b/tests/profiler/test_profile_sla_dryrun.py
@@ -4,8 +4,55 @@
 """
 Test suite for profile_sla dry-run functionality.
 
-This test ensures that the profile_sla script can successfully run in dry-run mode
-for vllm, sglang, and trtllm backends with their respective disagg.yaml configurations.
+These tests verify that the profile_sla script can successfully run in dry-run mode
+for vllm, sglang, and trtllm backends with their respective configurations. All tests
+are marked as @pytest.mark.pre_merge and @pytest.mark.parallel.
+
+Parallel Execution:
+-------------------
+Install pytest-xdist for parallel test execution:
+    pip install pytest-xdist
+
+All tests in this file are designed for parallel execution with isolated namespaces
+and output directories. No network services (NATS/Etcd) or ports are required.
+
+Usage Examples:
+    # Run all tests serially
+    pytest tests/profiler/test_profile_sla_dryrun.py -v
+
+    # Run all tests in parallel with 4 workers
+    pytest tests/profiler/test_profile_sla_dryrun.py -v -n 4
+
+    # Run all tests in parallel with auto workers (recommended)
+    pytest tests/profiler/test_profile_sla_dryrun.py -v -n auto
+
+    # Run specific test
+    pytest tests/profiler/test_profile_sla_dryrun.py::TestProfileSLADryRun::test_vllm_dryrun -v
+
+    # Run only pre-merge tests (all tests in this file)
+    pytest tests/profiler/test_profile_sla_dryrun.py -v -m pre_merge
+
+Test Isolation:
+---------------
+Each test uses unique output directories and namespaces based on the test name:
+    - output_dir: /tmp/test_profiling_results_{test_name}
+    - namespace: test-namespace-{test_name}
+
+This ensures no conflicts when running tests in parallel.
+
+Requirements:
+-------------
+- No GPU required (dry-run mode)
+- No network services required (no NATS/Etcd)
+- No ports required
+- Minimal dependencies (logic/validation only)
+
+Performance:
+------------
+Parallel execution provides significant speedup (32-core machine):
+    Serial:              ~28s
+    Parallel (-n 4):     ~10s (2.8x faster)
+    Parallel (-n auto):  ~8s (3.5x faster, 24 workers)
 """
 
 import sys

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -335,6 +335,10 @@ def test_vllm_kv_router_basic(
         "ETCD_ENDPOINTS": f"http://localhost:{etcd_process.port}",
     }
 
+    # Set environment variables (needed for KVRouterProcess subprocess that gets created in _test_router_basic)
+    # pytest-xdist safe: workers are separate processes with isolated os.environ
+    os.environ.update(runtime_env)
+
     # Allocate dynamic frontend port
     frontend_port = allocate_free_port(8100)
     logger.info(f"Allocated dynamic frontend port: {frontend_port}")
@@ -391,6 +395,11 @@ def test_router_decisions_vllm_multiple_workers(
         "ETCD_ENDPOINTS": f"http://localhost:{etcd_process.port}",
     }
 
+    # Set environment variables (needed for KvPushRouter background task to subscribe to NATS KV events)
+    # KvPushRouter is created directly in _test_router_decisions and reads NATS_SERVER from os.environ
+    # pytest-xdist safe: workers are separate processes with isolated os.environ
+    os.environ.update(runtime_env)
+
     try:
         # Start 2 worker processes on the same GPU
         logger.info("Starting 2 vLLM worker processes on single GPU (gpu_mem=0.4)")
@@ -406,7 +415,7 @@ def test_router_decisions_vllm_multiple_workers(
         # Initialize vLLM workers
         vllm_workers.__enter__()
 
-        # Get runtime and create endpoint (pass env to avoid modifying global os.environ)
+        # Get runtime and create endpoint
         runtime = get_runtime(env=runtime_env)
         namespace = runtime.namespace(vllm_workers.namespace)
         component = namespace.component("backend")
@@ -447,6 +456,11 @@ def test_router_decisions_vllm_dp(
         "ETCD_ENDPOINTS": f"http://localhost:{etcd_process.port}",
     }
 
+    # Set environment variables (needed for KvPushRouter background task to subscribe to NATS KV events)
+    # KvPushRouter is created directly in _test_router_decisions and reads NATS_SERVER from os.environ
+    # pytest-xdist safe: workers are separate processes with isolated os.environ
+    os.environ.update(runtime_env)
+
     try:
         logger.info("Starting 2 vLLM DP ranks (dp_size=2) (gpu_mem=0.4)")
         vllm_workers = VLLMProcess(
@@ -460,7 +474,7 @@ def test_router_decisions_vllm_dp(
         logger.info(f"All vLLM workers using namespace: {vllm_workers.namespace}")
         vllm_workers.__enter__()
 
-        # Get runtime and create endpoint (pass env to avoid modifying global os.environ)
+        # Get runtime and create endpoint
         runtime = get_runtime(env=runtime_env)
         # Use the namespace from the vLLM workers
         namespace = runtime.namespace(vllm_workers.namespace)
@@ -500,6 +514,11 @@ def test_vllm_indexers_sync(
         "NATS_SERVER": f"nats://localhost:{nats_process.port}",
         "ETCD_ENDPOINTS": f"http://localhost:{etcd_process.port}",
     }
+
+    # Set environment variables (needed for KvPushRouter background task to subscribe to NATS KV events)
+    # KvPushRouter is created directly in _test_router_indexers_sync and reads NATS_SERVER from os.environ
+    # pytest-xdist safe: workers are separate processes with isolated os.environ
+    os.environ.update(runtime_env)
 
     try:
         # Start vLLM workers (pass runtime_env so workers can connect to NATS/ETCD)

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -6,6 +6,7 @@
 import logging
 import os
 from collections.abc import Mapping
+from copy import deepcopy
 from typing import Any, Dict, Optional
 
 import pytest
@@ -13,6 +14,8 @@ import pytest
 from dynamo.common.utils.paths import WORKSPACE_DIR
 from tests.utils.client import send_request
 from tests.utils.engine_process import EngineConfig, EngineProcess
+from tests.utils.payloads import MetricsPayload
+from tests.utils.port_utils import allocate_free_port, free_ports
 
 DEFAULT_TIMEOUT = 10
 
@@ -23,12 +26,20 @@ def run_serve_deployment(
     config: EngineConfig,
     request: Any,
     extra_env: Optional[Dict[str, str]] = None,
+    runtime_services: Optional[Any] = None,
 ) -> None:
     """Run a standard serve deployment test for any EngineConfig.
 
     - Launches the engine via EngineProcess.from_script
     - Builds a payload (with optional override/mutator)
     - Iterates configured endpoints and validates responses and logs
+
+    Args:
+        config: EngineConfig with test configuration
+        request: pytest request object
+        extra_env: Optional dict of additional environment variables
+        runtime_services: Optional tuple of (nats_process, etcd_process) from runtime_services fixture.
+                        If provided, NATS_SERVER and ETCD_ENDPOINTS will be set from their ports.
     """
 
     logger = logging.getLogger(request.node.name)
@@ -41,30 +52,119 @@ def run_serve_deployment(
     logger.info("Using model: %s", config.model)
     logger.info("Script: %s", config.script_name)
 
-    with EngineProcess.from_script(
-        config, request, extra_env=extra_env
-    ) as server_process:
-        for payload in config.request_payloads:
-            logger.info("TESTING: Payload: %s", payload.__class__.__name__)
+    # Allocate dynamic HTTP port for frontend (starting from 8100 to avoid conflicts)
+    http_port = allocate_free_port(8100)
+    logger.info(f"Allocated dynamic HTTP port: {http_port}")
 
-            payload_item = payload
-            # inject model
-            if hasattr(payload_item, "with_model"):
-                payload_item = payload_item.with_model(config.model)
+    # Allocate dynamic system metrics ports (starting from 9100 to avoid conflicts)
+    # For disaggregated deployments with multiple workers, allocate multiple ports
+    # TODO: Find a better way to determine num_workers automatically by parsing
+    # the launch script or adding metadata to config instead of pattern matching
+    # Disaggregated scripts (disagg*.sh) launch 2 workers, so need 2 ports
+    num_workers = (
+        2 if config.script_name and config.script_name.startswith("disagg") else 1
+    )
+    system_ports = [allocate_free_port(9100 + i) for i in range(num_workers)]
+    system_port = system_ports[0]
+    logger.info(f"Allocated dynamic system metrics port(s): {system_ports}")
 
-            if payload_item.port != config.models_port:
-                logger.warning(
-                    f"Current payload port: {payload_item.port} doesn't match the model port: {config.models_port}"
+    # Merge environment variables - start with empty dict to avoid inheriting
+    # potentially incorrect NATS_SERVER/ETCD_ENDPOINTS from os.environ
+    env = {}
+
+    # Copy extra_env if provided
+    if extra_env:
+        env.update(extra_env)
+
+    env["DYN_HTTP_PORT"] = str(http_port)
+    # Set DYN_SYSTEM_PORT1, DYN_SYSTEM_PORT2, ... for each worker
+    for i, port in enumerate(system_ports, start=1):
+        env[f"DYN_SYSTEM_PORT{i}"] = str(port)
+    # Also set DYN_SYSTEM_PORT to the first port for aggregated scripts that expect it
+    env["DYN_SYSTEM_PORT"] = str(system_ports[0])
+    # Note: DYN_SYSTEM_PORT1/2/... are set here, but frontend main.py will unset them
+    # to prevent the frontend's DRT from starting a system server
+    # Only the backend workers should start the system metrics server
+
+    # Set NATS_SERVER and ETCD_ENDPOINTS from runtime_services if provided
+    # This MUST override any values from extra_env or os.environ
+    if runtime_services is not None:
+        nats_process, etcd_process = runtime_services
+        env["NATS_SERVER"] = f"nats://localhost:{nats_process.port}"
+        env["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_process.port}"
+        logger.info(
+            f"Using runtime services - NATS: {nats_process.port}, Etcd: {etcd_process.port}, HTTP: {http_port}"
+        )
+    else:
+        # If runtime_services not provided, log warning but don't fail
+        # (some tests might use default ports)
+        logger.warning(
+            "runtime_services not provided - subprocess will use default or os.environ NATS/Etcd ports"
+        )
+
+    # Create a modified config with the allocated HTTP port for health checks
+    # We need to update models_port so health checks use the correct port
+    from dataclasses import replace
+
+    config_with_port = replace(config, models_port=http_port)
+
+    try:
+        with EngineProcess.from_script(
+            config_with_port, request, extra_env=env
+        ) as server_process:
+            for payload in config.request_payloads:
+                logger.info(
+                    "TESTING: Payload: %s (port: %s)",
+                    payload.__class__.__name__,
+                    payload.port,
                 )
 
-            for _ in range(payload_item.repeat_count):
-                response = send_request(
-                    url=payload_item.url(),
-                    payload=payload_item.body,
-                    timeout=payload_item.timeout,
-                    method=payload_item.method,
-                )
-                server_process.check_response(payload_item, response)
+                payload_item = payload
+                # inject model
+                if hasattr(payload_item, "with_model"):
+                    payload_item = payload_item.with_model(config.model)
+
+                # Update payload port to use allocated HTTP port
+                # MetricsPayload uses system metrics port, not HTTP frontend
+                if isinstance(payload_item, MetricsPayload):
+                    # Map default ports (8081, 8082, ...) to allocated system_ports
+                    # Default base port for metrics is 8081
+                    default_metrics_base = 8081
+                    port_index = payload_item.port - default_metrics_base
+                    new_port = (
+                        system_ports[port_index]
+                        if port_index < len(system_ports)
+                        else system_port
+                    )
+
+                    if payload_item.port != new_port:
+                        payload_item = deepcopy(payload_item)
+                        old_port = payload_item.port
+                        payload_item.port = new_port
+                        logger.info(
+                            f"Updated MetricsPayload port from {old_port} to allocated system metrics port: {new_port}"
+                        )
+                elif payload_item.port != http_port:
+                    payload_item = deepcopy(payload_item)
+                    payload_item.port = http_port
+                    logger.info(
+                        f"Updated payload port from {payload.port} to allocated HTTP port: {http_port}"
+                    )
+
+                for _ in range(payload_item.repeat_count):
+                    response = send_request(
+                        url=payload_item.url(),
+                        payload=payload_item.body,
+                        timeout=payload_item.timeout,
+                        method=payload_item.method,
+                    )
+                    server_process.check_response(payload_item, response)
+    finally:
+        # Release allocated ports
+        free_ports([http_port] + system_ports)
+        logger.info(
+            f"Released HTTP port: {http_port}, system metrics port(s): {system_ports}"
+        )
 
 
 def params_with_model_mark(configs: Mapping[str, EngineConfig]):

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -245,7 +245,7 @@ def test_sglang_deployment(
 ):
     """Test SGLang deployment scenarios using common helpers"""
     config = sglang_config_test
-    run_serve_deployment(config, request)
+    run_serve_deployment(config, request, runtime_services=runtime_services)
 
 
 @pytest.mark.e2e

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Run aggregated tests in parallel: pytest tests/serve/test_trtllm.py -k "aggregated and not disagg" -n auto
+# Speedup: ~2x (57s parallel vs 113s serial for 3 tests)
+
 import logging
 import os
 from dataclasses import dataclass, field
@@ -178,7 +181,9 @@ def test_deployment(trtllm_config_test, request, runtime_services, predownload_m
     """
     config = trtllm_config_test
     extra_env = {"MODEL_PATH": config.model, "SERVED_MODEL_NAME": config.model}
-    run_serve_deployment(config, request, extra_env=extra_env)
+    run_serve_deployment(
+        config, request, extra_env=extra_env, runtime_services=runtime_services
+    )
 
 
 # TODO make this a normal guy

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -533,7 +533,7 @@ def test_serve_deployment(
     Test dynamo serve deployments with different graph configurations.
     """
     config = vllm_config_test
-    run_serve_deployment(config, request)
+    run_serve_deployment(config, request, runtime_services=runtime_services)
 
 
 @pytest.mark.vllm

--- a/tests/utils/engine_process.py
+++ b/tests/utils/engine_process.py
@@ -43,7 +43,7 @@ class EngineConfig:
     script_name: Optional[str] = None
     command: Optional[List[str]] = None
     script_args: Optional[List[str]] = None
-    models_port: int = 8000
+    models_port: int = 8000  # default HTTP frontend port, if running serially
     timeout: int = 600
     delayed_start: int = 0
     env: Dict[str, str] = field(default_factory=dict)

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -559,6 +559,10 @@ class ManagedProcess:
             hasattr(self, "proc") and self.proc is not None and self.proc.poll() is None
         )
 
+    def get_pid(self) -> int | None:
+        """Get the PID of the managed process."""
+        return self.proc.pid if self.proc else None
+
     def subprocesses(self) -> list[psutil.Process]:
         """Find child processes of the current process."""
         if (
@@ -604,10 +608,6 @@ class DynamoFrontendProcess(ManagedProcess):
             terminate_existing=True,
             log_dir=log_dir,
         )
-
-    def get_pid(self) -> int | None:
-        """Get the PID of the worker process"""
-        return self.proc.pid if self.proc else None
 
 
 def main():

--- a/tests/utils/port_utils.py
+++ b/tests/utils/port_utils.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Port allocation utilities for tests.
+
+Port allocation with flock-based locking to prevent race conditions in parallel tests.
+"""
+
+import fcntl
+import json
+import os
+import socket
+import tempfile
+import time
+from pathlib import Path
+
+# Port allocation lock file
+_PORT_LOCK_FILE = Path(tempfile.gettempdir()) / "pytest_port_allocations.lock"
+_PORT_REGISTRY_FILE = Path(tempfile.gettempdir()) / "pytest_port_allocations.json"
+
+# Port range for allocation (i16 range for Rust compatibility)
+_PORT_MIN = 30000
+_PORT_MAX = 32767
+
+
+def _load_port_registry() -> dict:
+    """Load the port registry from disk.
+
+    Returns:
+        dict: Port registry mapping port numbers (as strings) to timestamps.
+              Example: {"30001": 1732647123.456, "30002": 1732647123.789}
+    """
+    if not _PORT_REGISTRY_FILE.exists():
+        return {}
+    try:
+        with open(_PORT_REGISTRY_FILE, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_port_registry(registry: dict) -> None:
+    """Save the port registry to disk."""
+    with open(_PORT_REGISTRY_FILE, "w") as f:
+        json.dump(registry, f)
+
+
+def _cleanup_stale_allocations(registry: dict, max_age: float = 900.0) -> dict:
+    """Remove port allocations older than max_age seconds."""
+    current_time = time.time()
+    return {
+        str(port): timestamp
+        for port, timestamp in registry.items()
+        if current_time - timestamp < max_age
+    }
+
+
+def allocate_free_ports(count: int, start_port: int) -> list[int]:
+    """Find and return available ports in i16 range with flock-based locking.
+
+    Uses file locking (flock) to prevent race conditions when multiple test processes
+    allocate ports simultaneously.
+
+    Port range is limited to i16 (30000-32767) due to Rust backend expecting i16.
+
+    Args:
+        count: Number of unique ports to allocate
+        start_port: Starting port number for allocation (required)
+
+    Returns:
+        list[int]: List of available port numbers between start_port and 32767
+    """
+    # Validate start_port is in valid i16 range
+    if start_port < 1024 or start_port > _PORT_MAX:
+        raise ValueError(
+            f"start_port must be between 1024 and {_PORT_MAX}, got {start_port}"
+        )
+
+    # Ensure lock file exists and is writable
+    _PORT_LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _PORT_LOCK_FILE.touch(exist_ok=True)
+
+    if not os.access(_PORT_LOCK_FILE, os.W_OK):
+        raise PermissionError(
+            f"Port allocation lock file is not writable: {_PORT_LOCK_FILE}"
+        )
+
+    with open(_PORT_LOCK_FILE, "r+") as lock_file:
+        # Acquire exclusive lock
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+
+        try:
+            # Load registry and clean up stale allocations
+            registry = _load_port_registry()
+            registry = _cleanup_stale_allocations(registry)
+
+            allocated_ports = set(int(p) for p in registry.keys())
+            ports: list[int] = []
+
+            # Start searching from start_port
+            current_port = start_port
+
+            # Try to find free ports
+            attempts = 0
+            max_attempts = count * 50
+
+            while len(ports) < count and attempts < max_attempts:
+                attempts += 1
+
+                # Try sequential allocation from our range
+                port = current_port
+                current_port += 1
+                if current_port > _PORT_MAX:
+                    current_port = start_port
+
+                # Skip if already allocated or in our current list
+                if port in allocated_ports or port in ports:
+                    continue
+
+                # Try to bind to verify it's actually free
+                try:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    sock.bind(("", port))
+                    sock.close()
+                    ports.append(port)
+                    registry[str(port)] = time.time()
+                except OSError:
+                    continue
+
+            if len(ports) < count:
+                raise RuntimeError(
+                    f"Could not find {count} available ports in range {start_port}-{_PORT_MAX}"
+                )
+
+            # Save updated registry
+            _save_port_registry(registry)
+
+            return ports
+
+        finally:
+            # Release lock
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def allocate_free_port(start_port: int) -> int:
+    """Find and return a single available port in i16 range.
+
+    Args:
+        start_port: Starting port number for allocation (required)
+
+    Returns:
+        int: An available port number between start_port and 32767 (i16 max)
+    """
+    return allocate_free_ports(1, start_port)[0]
+
+
+def free_ports(ports: list[int]) -> None:
+    """Release previously allocated ports back to the pool.
+
+    Args:
+        ports: List of port numbers to release
+    """
+    if not ports:
+        return
+
+    # Ensure lock file exists
+    _PORT_LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _PORT_LOCK_FILE.touch(exist_ok=True)
+
+    with open(_PORT_LOCK_FILE, "r+") as lock_file:
+        # Acquire exclusive lock
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+
+        try:
+            # Load registry
+            registry = _load_port_registry()
+
+            # Remove the specified ports
+            for port in ports:
+                registry.pop(str(port), None)
+
+            # Save updated registry
+            _save_port_registry(registry)
+
+        finally:
+            # Release lock
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def free_port(port: int) -> None:
+    """Release a previously allocated port back to the pool.
+
+    Args:
+        port: Port number to release
+    """
+    free_ports([port])


### PR DESCRIPTION
#### Overview:

Enable parallel test execution in CI with pytest-xdist. Router and frontend tests now run with auto-detected workers, reducing execution time from 336s to 75s (4.5x speedup). Implements dynamic port allocation to prevent conflicts between parallel workers.

#### Details:

- Fix hardcoded NATS ports in router test helpers (`_test_router_indexers_sync`, `check_nats_consumers`)
- Refactor `runtime_services` fixture to `conftest.py` for reuse across test modules
- Create `tests/utils/port_utils.py` for dynamic port allocation with file-based locking
- Update `container-validation-dynamo.yml` to use `-n auto` instead of `-n 4`

#### Where should the reviewer start?

- `tests/utils/port_utils.py` - dynamic port allocation mechanism
- `tests/conftest.py` - shared fixtures for NATS/Etcd services
- `tests/router/common.py` - port parameter updates in test helpers
- `.github/workflows/container-validation-dynamo.yml` - CI configuration change

#### Related Issues:

DIS-1022

/coderabbit profile chill