### PR TITLE
feat: disable kv events in vLLM when lora is enabled

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -328,8 +328,15 @@ def create_kv_events_config(config: Config) -> Optional[KVEventsConfig]:
 
     # There is a bug with KV events publishing when LORA is enabled.
     # This is fixed in https://github.com/vllm-project/vllm/pull/27728 but not released yet.
-    # remove below check once newcomponents/src/dynamo/vllm/args.py vLLM version is released with the fix.
+    # remove below check once new vLLM version is released with the fix.
     if config.engine_args.enable_lora:
+        # Explicitly clear any user-provided kv_events_config to prevent upstream bug
+        logger.info(
+            "KV events disabled due to LoRA being enabled (upstream bug). "
+            "User-provided kv_events_config will be ignored. "
+            "See https://github.com/vllm-project/vllm/pull/27728"
+        )
+        config.engine_args.kv_events_config = None
         return None
 
     # If user provided their own config, use that

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -329,18 +329,20 @@ def create_kv_events_config(config: Config) -> Optional[KVEventsConfig]:
     # There is a bug with KV events publishing when LORA is enabled.
     # This is fixed in https://github.com/vllm-project/vllm/pull/27728 but not released yet.
     # remove below check once new vLLM version is released with the fix.
-    if (
-        config.engine_args.enable_lora
-        and config.engine_args.kv_events_config is not None
-    ):
-        message = (
-            "KV events doesn't work when LoRA is enabled due to upstream vLLM bug. "
-            "Please see https://github.com/vllm-project/vllm/pull/27728."
-            "For now, either disable lora or dont use explicit kv envents config."
-            "Dont set both --kv-events-config and --enable-lora in vllm command line args."
-        )
-        logger.error(message)
-        raise ValueError(message)
+    if config.engine_args.enable_lora:
+        if config.engine_args.kv_events_config is None:
+            # No explicit kv events config provided by user, we'll disable kv cache because LoRA is enabled and its not supported yet.
+            return None
+        else:
+            # User provided their own kv events config and it'll not work when LoRA is enabled.
+            message = (
+                "KV events doesn't work when LoRA is enabled due to upstream vLLM bug. "
+                "Please see https://github.com/vllm-project/vllm/pull/27728."
+                "For now, either disable lora or dont use explicit kv envents config."
+                "Dont set both --kv-events-config and --enable-lora in vllm command line args."
+            )
+            logger.error(message)
+            raise ValueError(message)
 
     # If user provided their own config, use that
     if c := getattr(config.engine_args, "kv_events_config"):

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -335,7 +335,9 @@ def create_kv_events_config(config: Config) -> Optional[KVEventsConfig]:
     ):
         message = (
             "KV events doesn't work when LoRA is enabled due to upstream vLLM bug. "
-            "See https://github.com/vllm-project/vllm/pull/27728"
+            "Please see https://github.com/vllm-project/vllm/pull/27728."
+            "For now, either disable lora or dont use explicit kv envents config "
+            "(dont set both --kv-events-config and --enable-lora in vllm command line args )."
         )
         logger.error(message)
         raise ValueError(message)

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -336,8 +336,8 @@ def create_kv_events_config(config: Config) -> Optional[KVEventsConfig]:
         message = (
             "KV events doesn't work when LoRA is enabled due to upstream vLLM bug. "
             "Please see https://github.com/vllm-project/vllm/pull/27728."
-            "For now, either disable lora or dont use explicit kv envents config "
-            "(dont set both --kv-events-config and --enable-lora in vllm command line args )."
+            "For now, either disable lora or dont use explicit kv envents config."
+            "Dont set both --kv-events-config and --enable-lora in vllm command line args."
         )
         logger.error(message)
         raise ValueError(message)

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -326,6 +326,12 @@ def create_kv_events_config(config: Config) -> Optional[KVEventsConfig]:
     if not config.engine_args.enable_prefix_caching:
         return None
 
+    # There is a bug with KV events publishing when LORA is enabled.
+    # This is fixed in https://github.com/vllm-project/vllm/pull/27728 but not released yet.
+    # remove below check once newcomponents/src/dynamo/vllm/args.py vLLM version is released with the fix.
+    if config.engine_args.enable_lora:
+        return None
+
     # If user provided their own config, use that
     if c := getattr(config.engine_args, "kv_events_config"):
         logger.info(f"Using user-provided kv_events_config {c}")

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -153,6 +153,9 @@ def setup_kv_event_publisher(
         logger.info("Skipping KV event publisher setup for decode worker")
         return None
 
+    if config.engine_args.kv_events_config is None:
+        return None
+
     # Get data_parallel_size to create publishers for all dp_ranks
     data_parallel_size = getattr(vllm_config.parallel_config, "data_parallel_size", 1)
     kv_publishers = []


### PR DESCRIPTION
#### Overview:

Disable kv events in vLLM when lora is enabled.

There is a bug in the KV cache block storage system where the code was incorrectly trying to access request.lora_request.id instead of the correct request.lora_request.adapter_id property.

Bug is fixed in https://github.com/vllm-project/vllm/pull/27728 but not released yet.

DEP-588

#### Details:

- Fixed KV events with LoRA: Added upstream bug workaround that disables KV events when LoRA is enabled, preventing crashes until vLLM PR #27728 is released
- Improved KV publisher setup: Added null check to prevent setup when kv_events_config is None


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KV events publishing configuration handling to prevent incompatible feature combinations.
  * KV events publishing is now properly disabled when both prefix caching and LORA features are enabled simultaneously.
  * Added proper handling for cases where KV events configuration is not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->