### PR TITLE
feat(keyvalue): Filesystem backed KeyValueStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,6 +2391,7 @@ dependencies = [
  "figment",
  "futures",
  "humantime",
+ "inotify",
  "jsonschema",
  "local-ip-address",
  "log",
@@ -3991,6 +3992,28 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.4",
+ "futures-core",
+ "inotify-sys",
+ "libc",
+ "tokio",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "insta"

--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -204,6 +204,12 @@ def parse_args():
         default=False,
         help="Mark this as a decode worker which does not publish KV events and skips prefill cost estimation (default: False)",
     )
+    parser.add_argument(
+        "--store-kv",
+        type=str,
+        default=os.environ.get("DYN_STORE_KV", "etcd"),
+        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+    )
 
     args = parser.parse_args()
     validate_worker_type_args(args)

--- a/components/src/dynamo/mocker/main.py
+++ b/components/src/dynamo/mocker/main.py
@@ -72,7 +72,7 @@ async def launch_workers(args, extra_engine_args_path):
         logger.info(f"Creating mocker worker {worker_id + 1}/{args.num_workers}")
 
         # Create a separate DistributedRuntime for this worker (on same event loop)
-        runtime = DistributedRuntime(loop, False)
+        runtime = DistributedRuntime(loop, args.store_kv, False)
         runtimes.append(runtime)
 
         # Create EntrypointArgs for this worker

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -93,6 +93,12 @@ DYNAMO_ARGS: Dict[str, Dict[str, Any]] = {
         "default": None,
         "help": "Dump debug config to the specified file path. If not specified, the config will be dumped to stdout at INFO level.",
     },
+    "store-kv": {
+        "flags": ["--store-kv"],
+        "type": str,
+        "default": os.environ.get("DYN_STORE_KV", "etcd"),
+        "help": "Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+    },
 }
 
 
@@ -102,6 +108,7 @@ class DynamoArgs:
     component: str
     endpoint: str
     migration_limit: int
+    store_kv: str
 
     # tool and reasoning parser options
     tool_call_parser: Optional[str] = None
@@ -329,6 +336,7 @@ async def parse_args(args: list[str]) -> Config:
         component=parsed_component_name,
         endpoint=parsed_endpoint_name,
         migration_limit=parsed_args.migration_limit,
+        store_kv=parsed_args.store_kv,
         tool_call_parser=tool_call_parser,
         reasoning_parser=reasoning_parser,
         custom_jinja_template=expanded_template_path,

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -11,7 +11,7 @@ import uvloop
 
 from dynamo.common.config_dump import dump_config
 from dynamo.llm import ModelInput, ModelType
-from dynamo.runtime import DistributedRuntime, dynamo_worker
+from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sglang.args import Config, DisaggregationMode, parse_args
 from dynamo.sglang.health_check import (
@@ -33,9 +33,12 @@ from dynamo.sglang.request_handlers import (
 configure_dynamo_logging()
 
 
-@dynamo_worker(static=False)
-async def worker(runtime: DistributedRuntime):
+async def worker():
+    config = await parse_args(sys.argv[1:])
+    dump_config(config.dynamo_args.dump_config_to, config)
+
     loop = asyncio.get_running_loop()
+    runtime = DistributedRuntime(loop, config.dynamo_args.store_kv, False)
 
     def signal_handler():
         asyncio.create_task(graceful_shutdown(runtime))
@@ -44,9 +47,6 @@ async def worker(runtime: DistributedRuntime):
         loop.add_signal_handler(sig, signal_handler)
 
     logging.info("Signal handlers will trigger a graceful shutdown of the runtime")
-
-    config = await parse_args(sys.argv[1:])
-    dump_config(config.dynamo_args.dump_config_to, config)
 
     if config.dynamo_args.embedding_worker:
         await init_embedding(runtime, config)

--- a/components/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -58,6 +58,7 @@ class Config:
         self.tool_call_parser: Optional[str] = None
         self.dump_config_to: Optional[str] = None
         self.custom_jinja_template: Optional[str] = None
+        self.store_kv: str = ""
 
     def __str__(self) -> str:
         return (
@@ -87,8 +88,9 @@ class Config:
             f"max_file_size_mb={self.max_file_size_mb}, "
             f"reasoning_parser={self.reasoning_parser}, "
             f"tool_call_parser={self.tool_call_parser}, "
-            f"dump_config_to={self.dump_config_to},"
-            f"custom_jinja_template={self.custom_jinja_template}"
+            f"dump_config_to={self.dump_config_to}, "
+            f"custom_jinja_template={self.custom_jinja_template}, "
+            f"store_kv={self.store_kv}"
         )
 
 
@@ -278,6 +280,12 @@ def cmd_line_args():
         default=None,
         help="Path to a custom Jinja template file to override the model's default chat template. This template will take precedence over any template found in the model repository.",
     )
+    parser.add_argument(
+        "--store-kv",
+        type=str,
+        default=os.environ.get("DYN_STORE_KV", "etcd"),
+        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+    )
 
     args = parser.parse_args()
 
@@ -337,6 +345,7 @@ def cmd_line_args():
     config.reasoning_parser = args.dyn_reasoning_parser
     config.tool_call_parser = args.dyn_tool_call_parser
     config.dump_config_to = args.dump_config_to
+    config.store_kv = args.store_kv
 
     # Handle custom jinja template path expansion (environment variables and home directory)
     if args.custom_jinja_template:

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -38,6 +38,7 @@ class Config:
     migration_limit: int = 0
     kv_port: Optional[int] = None
     custom_jinja_template: Optional[str] = None
+    store_kv: str
 
     # mirror vLLM
     model: str
@@ -164,6 +165,12 @@ def parse_args() -> Config:
             "'USER: <image> please describe the image ASSISTANT:'."
         ),
     )
+    parser.add_argument(
+        "--store-kv",
+        type=str,
+        default=os.environ.get("DYN_STORE_KV", "etcd"),
+        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+    )
     add_config_dump_args(parser)
 
     parser = AsyncEngineArgs.add_cli_args(parser)
@@ -233,6 +240,7 @@ def parse_args() -> Config:
     config.multimodal_worker = args.multimodal_worker
     config.multimodal_encode_prefill_worker = args.multimodal_encode_prefill_worker
     config.mm_prompt_template = args.mm_prompt_template
+    config.store_kv = args.store_kv
 
     # Validate custom Jinja template file exists if provided
     if config.custom_jinja_template is not None:

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -25,7 +25,7 @@ from dynamo.llm import (
     fetch_llm,
     register_llm,
 )
-from dynamo.runtime import DistributedRuntime, dynamo_worker
+from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.vllm.multimodal_handlers import (
     EncodeWorkerHandler,
@@ -70,16 +70,16 @@ async def graceful_shutdown(runtime):
     logging.info("DistributedRuntime shutdown complete")
 
 
-@dynamo_worker(static=False)
-async def worker(runtime: DistributedRuntime):
+async def worker():
     config = parse_args()
+
+    loop = asyncio.get_running_loop()
+    runtime = DistributedRuntime(loop, config.store_kv, False)
 
     await configure_ports(config)
     overwrite_args(config)
 
     # Set up signal handler for graceful shutdown
-    loop = asyncio.get_running_loop()
-
     def signal_handler():
         asyncio.create_task(graceful_shutdown(runtime))
 

--- a/examples/custom_backend/cancellation/client.py
+++ b/examples/custom_backend/cancellation/client.py
@@ -50,7 +50,7 @@ async def main():
             return
 
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "etcd", False)
+    runtime = DistributedRuntime(loop, "mem", True)
 
     # Connect to middle server or direct server based on argument
     if use_middle_server:

--- a/examples/custom_backend/cancellation/client.py
+++ b/examples/custom_backend/cancellation/client.py
@@ -50,7 +50,7 @@ async def main():
             return
 
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "file", True)
+    runtime = DistributedRuntime(loop, "etcd", True)
 
     # Connect to middle server or direct server based on argument
     if use_middle_server:

--- a/examples/custom_backend/cancellation/client.py
+++ b/examples/custom_backend/cancellation/client.py
@@ -50,7 +50,7 @@ async def main():
             return
 
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, True)
+    runtime = DistributedRuntime(loop, "file", True)
 
     # Connect to middle server or direct server based on argument
     if use_middle_server:

--- a/examples/custom_backend/cancellation/client.py
+++ b/examples/custom_backend/cancellation/client.py
@@ -50,7 +50,7 @@ async def main():
             return
 
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "etcd", True)
+    runtime = DistributedRuntime(loop, "etcd", False)
 
     # Connect to middle server or direct server based on argument
     if use_middle_server:

--- a/examples/custom_backend/cancellation/middle_server.py
+++ b/examples/custom_backend/cancellation/middle_server.py
@@ -50,7 +50,7 @@ class MiddleServer:
 async def main():
     """Start the middle server"""
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, True)
+    runtime = DistributedRuntime(loop, "file", True)
 
     # Create middle server handler
     handler = MiddleServer(runtime)

--- a/examples/custom_backend/cancellation/middle_server.py
+++ b/examples/custom_backend/cancellation/middle_server.py
@@ -50,7 +50,7 @@ class MiddleServer:
 async def main():
     """Start the middle server"""
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "etcd", True)
+    runtime = DistributedRuntime(loop, "etcd", False)
 
     # Create middle server handler
     handler = MiddleServer(runtime)

--- a/examples/custom_backend/cancellation/middle_server.py
+++ b/examples/custom_backend/cancellation/middle_server.py
@@ -50,7 +50,7 @@ class MiddleServer:
 async def main():
     """Start the middle server"""
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "etcd", False)
+    runtime = DistributedRuntime(loop, "mem", True)
 
     # Create middle server handler
     handler = MiddleServer(runtime)

--- a/examples/custom_backend/cancellation/middle_server.py
+++ b/examples/custom_backend/cancellation/middle_server.py
@@ -50,7 +50,7 @@ class MiddleServer:
 async def main():
     """Start the middle server"""
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "file", True)
+    runtime = DistributedRuntime(loop, "etcd", True)
 
     # Create middle server handler
     handler = MiddleServer(runtime)

--- a/examples/custom_backend/cancellation/server.py
+++ b/examples/custom_backend/cancellation/server.py
@@ -31,7 +31,7 @@ class DemoServer:
 async def main():
     """Start the demo server"""
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "file", True)
+    runtime = DistributedRuntime(loop, "etcd", True)
 
     # Create server component
     component = runtime.namespace("demo").component("server")

--- a/examples/custom_backend/cancellation/server.py
+++ b/examples/custom_backend/cancellation/server.py
@@ -31,7 +31,7 @@ class DemoServer:
 async def main():
     """Start the demo server"""
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, True)
+    runtime = DistributedRuntime(loop, "file", True)
 
     # Create server component
     component = runtime.namespace("demo").component("server")

--- a/examples/custom_backend/cancellation/server.py
+++ b/examples/custom_backend/cancellation/server.py
@@ -31,7 +31,7 @@ class DemoServer:
 async def main():
     """Start the demo server"""
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "etcd", True)
+    runtime = DistributedRuntime(loop, "etcd", False)
 
     # Create server component
     component = runtime.namespace("demo").component("server")

--- a/examples/custom_backend/cancellation/server.py
+++ b/examples/custom_backend/cancellation/server.py
@@ -31,7 +31,7 @@ class DemoServer:
 async def main():
     """Start the demo server"""
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "etcd", False)
+    runtime = DistributedRuntime(loop, "mem", True)
 
     # Create server component
     component = runtime.namespace("demo").component("server")

--- a/examples/custom_backend/nim/mock_nim_frontend.py
+++ b/examples/custom_backend/nim/mock_nim_frontend.py
@@ -123,7 +123,7 @@ async def async_main():
 
     # Create DistributedRuntime - similar to frontend/main.py line 246
     is_static = True  # Use static mode (no etcd)
-    runtime = DistributedRuntime(loop, is_static)  # type: ignore[call-arg]
+    runtime = DistributedRuntime(loop, "mem", is_static)  # type: ignore[call-arg]
 
     # Setup signal handlers for graceful shutdown
     def signal_handler():

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -127,6 +127,12 @@ pub struct Flags {
     #[arg(long, default_value = "false")]
     pub static_worker: bool,
 
+    /// Which key-value backend to use: etcd, mem, file.
+    /// Etcd uses the ETCD_* env vars (e.g. ETCD_ENPOINTS) for connection details.
+    /// File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.
+    #[arg(long, default_value = "etcd")]
+    pub store_kv: String,
+
     /// Everything after a `--`.
     /// These are the command line arguments to the python engine when using `pystr` or `pytok`.
     #[arg(index = 2, last = true, hide = true, allow_hyphen_values = true)]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1606,6 +1606,7 @@ dependencies = [
  "figment",
  "futures",
  "humantime",
+ "inotify",
  "local-ip-address",
  "log",
  "nid",
@@ -2856,6 +2857,28 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.3",
+ "futures-core",
+ "inotify-sys",
+ "libc",
+ "tokio",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "instant"

--- a/lib/bindings/python/examples/cli/cli.py
+++ b/lib/bindings/python/examples/cli/cli.py
@@ -115,7 +115,7 @@ def parse_args():
 
 async def run():
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, False)
+    runtime = DistributedRuntime(loop, "etcd", False)
 
     args = parse_args()
 

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -299,7 +299,7 @@ pub fn run_input<'p>(
     let input_enum: Input = input.parse().map_err(to_pyerr)?;
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         dynamo_llm::entrypoint::input::run_input(
-            either::Either::Right(distributed_runtime.inner.clone()),
+            distributed_runtime.inner.clone(),
             input_enum,
             engine_config.inner,
         )

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -25,7 +25,7 @@ def dynamo_worker(static=False):
         @wraps(func)
         async def wrapper(*args, **kwargs):
             loop = asyncio.get_running_loop()
-            runtime = DistributedRuntime(loop, static)
+            runtime = DistributedRuntime(loop, "etcd", static)
 
             await func(runtime, *args, **kwargs)
 

--- a/lib/bindings/python/tests/cancellation/test_cancellation.py
+++ b/lib/bindings/python/tests/cancellation/test_cancellation.py
@@ -256,7 +256,7 @@ async def test_server_context_cancel(server, client):
     except ValueError as e:
         # Verify the expected cancellation exception is received
         # TODO: Should this be a asyncio.CancelledError?
-        assert str(e) == "Stream ended before generation completed"
+        assert str(e).startswith("Stream ended before generation completed")
 
     # Verify server context cancellation status
     assert handler.context_is_stopped

--- a/lib/bindings/python/tests/cancellation/test_example.py
+++ b/lib/bindings/python/tests/cancellation/test_example.py
@@ -82,25 +82,21 @@ def run_client(example_dir, use_middle=False):
     )
 
     # Wait for client to complete
-    stdout, _ = client_proc.communicate(timeout=1)
-
-    if client_proc.returncode != 0:
-        pytest.fail(
-            f"Client failed with return code {client_proc.returncode}. Output: {stdout}"
-        )
+    stdout, _ = client_proc.communicate(timeout=2)
+    print(f"Client stdout: {stdout}")
 
     return stdout
 
 
-def stop_process(process):
+def stop_process(name, process):
     """Stop a running process and capture its output"""
     process.terminate()
     stdout, _ = process.communicate(timeout=1)
+    print(f"{name}: {stdout}")
     return stdout
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Graham working on it")
 async def test_direct_connection_cancellation(example_dir, server_process):
     """Test cancellation with direct client-server connection"""
     # Run the client (direct connection)
@@ -110,7 +106,7 @@ async def test_direct_connection_cancellation(example_dir, server_process):
     await asyncio.sleep(1)
 
     # Capture server output
-    server_output = stop_process(server_process)
+    server_output = stop_process("server_process", server_process)
 
     # Assert expected messages
     assert (
@@ -122,7 +118,6 @@ async def test_direct_connection_cancellation(example_dir, server_process):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Graham working on it")
 async def test_middle_server_cancellation(
     example_dir, server_process, middle_server_process
 ):
@@ -134,8 +129,8 @@ async def test_middle_server_cancellation(
     await asyncio.sleep(1)
 
     # Capture output from all processes
-    server_output = stop_process(server_process)
-    middle_output = stop_process(middle_server_process)
+    server_output = stop_process("server_process", server_process)
+    middle_output = stop_process("middle_server_process", middle_server_process)
 
     # Assert expected messages
     assert (

--- a/lib/bindings/python/tests/cancellation/test_example.py
+++ b/lib/bindings/python/tests/cancellation/test_example.py
@@ -100,6 +100,7 @@ def stop_process(process):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Graham working on it")
 async def test_direct_connection_cancellation(example_dir, server_process):
     """Test cancellation with direct client-server connection"""
     # Run the client (direct connection)
@@ -121,6 +122,7 @@ async def test_direct_connection_cancellation(example_dir, server_process):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Graham working on it")
 async def test_middle_server_cancellation(
     example_dir, server_process, middle_server_process
 ):

--- a/lib/bindings/python/tests/conftest.py
+++ b/lib/bindings/python/tests/conftest.py
@@ -153,7 +153,7 @@ def start_nats_and_etcd_default_ports():
     print(f"Using ETCD on default client port {etcd_client_port}")
 
     # Start services with default ports
-    nats_server = subprocess.Popen(["nats-server", "-js"])
+    nats_server = subprocess.Popen(["nats-server", "-js", "--trace"])
     etcd = subprocess.Popen(["etcd"])
 
     return nats_server, etcd, nats_port, etcd_client_port, nats_data_dir, etcd_data_dir
@@ -181,6 +181,8 @@ def start_nats_and_etcd_random_ports():
     etcd = subprocess.Popen(
         [
             "etcd",
+            "--logger",
+            "zap",
             "--data-dir",
             str(etcd_data_dir),
             "--listen-client-urls",
@@ -221,7 +223,11 @@ def start_nats_and_etcd_random_ports():
             msg = log.get("msg", "")
 
             # Look for the client port
-            if "serving client traffic" in msg or "serving client" in msg:
+            if (
+                "serving client traffic" in msg
+                or "serving client" in msg
+                or "serving insecure client" in msg
+            ):
                 address = log.get("address", "")
                 match = re.search(r":(\d+)$", address)
                 if match:
@@ -430,6 +436,6 @@ This is required because DistributedRuntime is a process-level singleton.
             )
 
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "file", True)
+    runtime = DistributedRuntime(loop, "etcd", False)
     yield runtime
     runtime.shutdown()

--- a/lib/bindings/python/tests/conftest.py
+++ b/lib/bindings/python/tests/conftest.py
@@ -430,6 +430,6 @@ This is required because DistributedRuntime is a process-level singleton.
             )
 
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, True)
+    runtime = DistributedRuntime(loop, "file", True)
     yield runtime
     runtime.shutdown()

--- a/lib/bindings/python/tests/conftest.py
+++ b/lib/bindings/python/tests/conftest.py
@@ -436,6 +436,6 @@ This is required because DistributedRuntime is a process-level singleton.
             )
 
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "etcd", False)
+    runtime = DistributedRuntime(loop, "mem", True)
     yield runtime
     runtime.shutdown()

--- a/lib/bindings/python/tests/test_kv_bindings.py
+++ b/lib/bindings/python/tests/test_kv_bindings.py
@@ -34,7 +34,7 @@ async def distributed_runtime():
     Each test gets its own runtime in a forked process to avoid singleton conflicts.
     """
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, False)
+    runtime = DistributedRuntime(loop, "etcd", False)
     yield runtime
     runtime.shutdown()
 

--- a/lib/llm/src/audit/sink.rs
+++ b/lib/llm/src/audit/sink.rs
@@ -89,8 +89,8 @@ fn parse_sinks_from_env(
 }
 
 /// spawn one worker per sink; each subscribes to the bus (off hot path)
-pub fn spawn_workers_from_env(drt: Option<&dynamo_runtime::DistributedRuntime>) {
-    let nats_client = drt.and_then(|d| d.nats_client());
+pub fn spawn_workers_from_env(drt: &dynamo_runtime::DistributedRuntime) {
+    let nats_client = drt.nats_client();
     let sinks = parse_sinks_from_env(nats_client);
     for sink in sinks {
         let name = sink.name();

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -183,8 +183,8 @@ impl ModelWatcher {
                         }
                     }
                 }
-                WatchEvent::Delete(kv) => {
-                    let deleted_key = kv.key_str();
+                WatchEvent::Delete(key) => {
+                    let deleted_key = key.as_ref();
                     match self
                         .handle_delete(deleted_key, target_namespace, global_namespace)
                         .await

--- a/lib/llm/tests/audit_nats_integration.rs
+++ b/lib/llm/tests/audit_nats_integration.rs
@@ -167,7 +167,7 @@ mod tests {
 
                 bus::init(100);
                 let drt = create_test_drt().await;
-                sink::spawn_workers_from_env(Some(&drt));
+                sink::spawn_workers_from_env(&drt);
                 time::sleep(Duration::from_millis(100)).await;
 
                 // Emit audit record
@@ -224,7 +224,7 @@ mod tests {
 
                 bus::init(100);
                 let drt = create_test_drt().await;
-                sink::spawn_workers_from_env(Some(&drt));
+                sink::spawn_workers_from_env(&drt);
                 time::sleep(Duration::from_millis(100)).await;
 
                 // Request with store=true (should be audited)

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -63,6 +63,7 @@ bincode = { version = "1" }
 console-subscriber = { version = "0.4", optional = true }
 educe = { version = "0.6.0" }
 figment = { version = "0.10.19", features = ["env", "json", "toml", "test"] }
+inotify = { version = "0.11" }
 local-ip-address = { version = "0.6.3" }
 log = { version = "0.4" }
 nid = { version = "3.0.0", features = ["serde"] }

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -679,6 +679,7 @@ dependencies = [
  "figment",
  "futures",
  "humantime",
+ "inotify",
  "local-ip-address",
  "log",
  "nid",
@@ -1353,6 +1354,28 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.0",
+ "futures-core",
+ "inotify-sys",
+ "libc",
+ "tokio",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "iovec"

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -3,7 +3,8 @@
 
 pub use crate::component::Component;
 use crate::storage::key_value_store::{
-    EtcdStore, KeyValueStore, KeyValueStoreEnum, KeyValueStoreManager, MemoryStore,
+    EtcdStore, KeyValueStore, KeyValueStoreEnum, KeyValueStoreManager, KeyValueStoreSelect,
+    MemoryStore,
 };
 use crate::transports::nats::DRTNatsClientPrometheusMetrics;
 use crate::{
@@ -48,24 +49,21 @@ impl std::fmt::Debug for DistributedRuntime {
 
 impl DistributedRuntime {
     pub async fn new(runtime: Runtime, config: DistributedConfig) -> Result<Self> {
-        let (etcd_config, nats_config, is_static) = config.dissolve();
+        let (selected_kv_store, nats_config, is_static) = config.dissolve();
 
         let runtime_clone = runtime.clone();
 
-        // TODO: Here is where we will later select the KeyValueStore impl
-        let (etcd_client, store) = if is_static {
-            (None, KeyValueStoreManager::memory())
-        } else {
-            match etcd::Client::new(etcd_config.clone(), runtime_clone).await {
-                Ok(etcd_client) => {
-                    let store = KeyValueStoreManager::etcd(etcd_client.clone());
-                    (Some(etcd_client), store)
-                }
-                Err(err) => {
-                    tracing::info!(%err, "Did not connect to etcd. Using memory storage.");
-                    (None, KeyValueStoreManager::memory())
-                }
+        let (etcd_client, store) = match selected_kv_store {
+            KeyValueStoreSelect::Etcd(etcd_config) => {
+                let etcd_client = etcd::Client::new(*etcd_config, runtime_clone).await.inspect_err(|err|
+                    // The returned error doesn't show because of a dropped runtime error, so
+                    // log it first.
+                    tracing::error!(%err, "Could not connect to etcd. Pass `--store-kv ..` to use a different backend or start etcd."))?;
+                let store = KeyValueStoreManager::etcd(etcd_client.clone());
+                (Some(etcd_client), store)
             }
+            KeyValueStoreSelect::File(root) => (None, KeyValueStoreManager::file(root)),
+            KeyValueStoreSelect::Memory => (None, KeyValueStoreManager::memory()),
         };
 
         let nats_client = Some(nats_config.clone().connect().await?);
@@ -234,6 +232,7 @@ impl DistributedRuntime {
 
     pub fn shutdown(&self) {
         self.runtime.shutdown();
+        self.store.shutdown();
     }
 
     /// Create a [`Namespace`]
@@ -302,7 +301,7 @@ impl DistributedRuntime {
 
 #[derive(Dissolve)]
 pub struct DistributedConfig {
-    pub etcd_config: etcd::ClientOptions,
+    pub store_backend: KeyValueStoreSelect,
     pub nats_config: nats::ClientOptions,
     pub is_static: bool,
 }
@@ -310,22 +309,22 @@ pub struct DistributedConfig {
 impl DistributedConfig {
     pub fn from_settings(is_static: bool) -> DistributedConfig {
         DistributedConfig {
-            etcd_config: etcd::ClientOptions::default(),
+            store_backend: KeyValueStoreSelect::Etcd(Box::default()),
             nats_config: nats::ClientOptions::default(),
             is_static,
         }
     }
 
     pub fn for_cli() -> DistributedConfig {
-        let mut config = DistributedConfig {
-            etcd_config: etcd::ClientOptions::default(),
+        let etcd_config = etcd::ClientOptions {
+            attach_lease: false,
+            ..Default::default()
+        };
+        DistributedConfig {
+            store_backend: KeyValueStoreSelect::Etcd(Box::new(etcd_config)),
             nats_config: nats::ClientOptions::default(),
             is_static: false,
-        };
-
-        config.etcd_config.attach_lease = false;
-
-        config
+        }
     }
 }
 

--- a/lib/runtime/src/storage/key_value_store/etcd.rs
+++ b/lib/runtime/src/storage/key_value_store/etcd.rs
@@ -54,6 +54,10 @@ impl KeyValueStore for EtcdStore {
     fn connection_id(&self) -> u64 {
         self.client.lease_id()
     }
+
+    fn shutdown(&self) {
+        // Revoke the lease? etcd will do it for us on disconnect.
+    }
 }
 
 pub struct EtcdBucket {
@@ -132,13 +136,13 @@ impl KeyValueBucket for EtcdBucket {
                             continue;
                         }
                     };
-                    let item = KeyValue::new(key, v_bytes.into());
                     match e.event_type() {
                         EventType::Put => {
+                            let item = KeyValue::new(key, v_bytes.into());
                             yield WatchEvent::Put(item);
                         }
                         EventType::Delete => {
-                            yield WatchEvent::Delete(item);
+                            yield WatchEvent::Delete(Key::from_raw(key));
                         }
                     }
                 }

--- a/lib/runtime/src/storage/key_value_store/file.rs
+++ b/lib/runtime/src/storage/key_value_store/file.rs
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::fmt;
+use std::fs;
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use std::{collections::HashMap, pin::Pin};
+
+use anyhow::Context as _;
+use async_trait::async_trait;
+use futures::StreamExt;
+use inotify::{Event, EventMask, EventStream, Inotify, WatchMask};
+use parking_lot::Mutex;
+
+use crate::storage::key_value_store::KeyValue;
+
+use super::{Key, KeyValueBucket, KeyValueStore, StoreError, StoreOutcome, WatchEvent};
+
+/// Treat as a singleton
+#[derive(Clone)]
+pub struct FileStore {
+    root: PathBuf,
+    connection_id: u64,
+    /// Directories we may have created files in, for shutdown cleanup
+    /// Arc so that we only ever have one map here after clone
+    active_dirs: Arc<Mutex<HashMap<PathBuf, Directory>>>,
+}
+
+impl FileStore {
+    pub(super) fn new<P: Into<PathBuf>>(root_dir: P) -> Self {
+        FileStore {
+            root: root_dir.into(),
+            connection_id: rand::random::<u64>(),
+            active_dirs: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl KeyValueStore for FileStore {
+    type Bucket = Directory;
+
+    /// A "bucket" is a directory
+    async fn get_or_create_bucket(
+        &self,
+        bucket_name: &str,
+        _ttl: Option<Duration>, // TODO ttl not used yet
+    ) -> Result<Self::Bucket, StoreError> {
+        let p = self.root.join(bucket_name);
+        if let Some(dir) = self.active_dirs.lock().get(&p) {
+            return Ok(dir.clone());
+        };
+
+        if p.exists() {
+            // Get
+            if !p.is_dir() {
+                return Err(StoreError::FilesystemError(
+                    "Bucket name is not a directory".to_string(),
+                ));
+            }
+        } else {
+            // Create
+            fs::create_dir_all(&p).map_err(to_fs_err)?;
+        }
+        let dir = Directory::new(self.root.clone(), p.clone());
+        self.active_dirs.lock().insert(p, dir.clone());
+        Ok(dir)
+    }
+
+    /// A "bucket" is a directory
+    async fn get_bucket(&self, bucket_name: &str) -> Result<Option<Self::Bucket>, StoreError> {
+        let p = self.root.join(bucket_name);
+        if let Some(dir) = self.active_dirs.lock().get(&p) {
+            return Ok(Some(dir.clone()));
+        };
+
+        if !p.exists() {
+            return Ok(None);
+        }
+        if !p.is_dir() {
+            return Err(StoreError::FilesystemError(
+                "Bucket name is not a directory".to_string(),
+            ));
+        }
+        let dir = Directory::new(self.root.clone(), p.clone());
+        self.active_dirs.lock().insert(p, dir.clone());
+        Ok(Some(dir))
+    }
+
+    fn connection_id(&self) -> u64 {
+        self.connection_id
+    }
+
+    // This cannot be a Drop imp because DistributedRuntime is cloned various places including
+    // Python. Drop doesn't get called.
+    fn shutdown(&self) {
+        for (_, mut dir) in self.active_dirs.lock().drain() {
+            if let Err(err) = dir.delete_owned_files() {
+                tracing::error!(error = %err, %dir, "Failed shutdown delete of owned files");
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Directory {
+    root: PathBuf,
+    p: PathBuf,
+    /// These are the files we created and hence must delete on shutdown
+    owned_files: Arc<Mutex<HashSet<PathBuf>>>,
+}
+
+impl Directory {
+    fn new(root: PathBuf, p: PathBuf) -> Self {
+        Directory {
+            root,
+            p,
+            owned_files: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    fn delete_owned_files(&mut self) -> anyhow::Result<()> {
+        let mut errs = Vec::new();
+        for p in self.owned_files.lock().drain() {
+            if let Err(err) = fs::remove_file(&p) {
+                errs.push(format!("{}: {err}", p.display()));
+            }
+        }
+        if !errs.is_empty() {
+            anyhow::bail!(errs.join(", "));
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Directory {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.p.display())
+    }
+}
+
+#[async_trait]
+impl KeyValueBucket for Directory {
+    /// Write a file to the directory
+    async fn insert(
+        &self,
+        key: &Key,
+        value: bytes::Bytes,
+        _revision: u64, // Not used. Maybe put in file name?
+    ) -> Result<StoreOutcome, StoreError> {
+        let safe_key = Key::new(key.as_ref()); // because of from_raw
+        let full_path = self.p.join(safe_key.as_ref());
+        self.owned_files.lock().insert(full_path.clone());
+        let str_path = full_path.display().to_string();
+        fs::write(&full_path, &value)
+            .context(str_path)
+            .map_err(a_to_fs_err)?;
+        Ok(StoreOutcome::Created(0))
+    }
+
+    /// Read a file from the directory
+    async fn get(&self, key: &Key) -> Result<Option<bytes::Bytes>, StoreError> {
+        let safe_key = Key::new(key.as_ref()); // because of from_raw
+        let full_path = self.p.join(safe_key.as_ref());
+        if !full_path.exists() {
+            return Ok(None);
+        }
+        let str_path = full_path.display().to_string();
+        let data: bytes::Bytes = fs::read(&full_path)
+            .context(str_path)
+            .map_err(a_to_fs_err)?
+            .into();
+        Ok(Some(data))
+    }
+
+    /// Delete a file from the directory
+    async fn delete(&self, key: &Key) -> Result<(), StoreError> {
+        let safe_key = Key::new(key.as_ref()); // because of from_raw
+        let full_path = self.p.join(safe_key.as_ref());
+        let str_path = full_path.display().to_string();
+        if !full_path.exists() {
+            return Err(StoreError::MissingKey(str_path));
+        }
+
+        self.owned_files.lock().remove(&full_path);
+
+        fs::remove_file(&full_path)
+            .context(str_path)
+            .map_err(a_to_fs_err)
+    }
+
+    async fn watch(
+        &self,
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = WatchEvent> + Send + 'life0>>, StoreError> {
+        let inotify = Inotify::init().map_err(to_fs_err)?;
+        inotify
+            .watches()
+            .add(
+                &self.p,
+                WatchMask::MODIFY | WatchMask::CREATE | WatchMask::DELETE,
+            )
+            .map_err(to_fs_err)?;
+
+        let dir = self.p.clone();
+        Ok(Box::pin(async_stream::stream! {
+            let mut buffer = [0; 1024];
+            let mut events = match inotify.into_event_stream(&mut buffer) {
+                Ok(events) => events,
+                Err(err) => {
+                    tracing::error!(error = %err, "Failed getting event stream from inotify");
+                    return;
+                }
+            };
+            while let Some(Ok(event)) = events.next().await {
+                let Some(name) = event.name else {
+                    tracing::warn!("Unexpected event on the directory itself");
+                    continue;
+                };
+                let item_path = dir.join(name);
+                let key = match item_path.strip_prefix(&self.root) {
+                    Ok(stripped) => stripped.display().to_string().replace("_", "/"),
+                    Err(err) => {
+                        // Possibly this should be a panic.
+                        // A key cannot be outside the file store root.
+                        tracing::error!(
+                            error = %err,
+                            item_path = %item_path.display(),
+                            root = %self.root.display(),
+                            "Item in file store is not prefixed with file store root. Should be impossible. Ignoring invalid key.");
+                        continue;
+                    }
+                };
+
+                match event.mask {
+                    EventMask::MODIFY | EventMask::CREATE => {
+                        let data: bytes::Bytes = match fs::read(&item_path) {
+                            Ok(data) => data.into(),
+                            Err(err) => {
+                                tracing::warn!(error = %err, item = %item_path.display(), "Failed reading event item. Skipping.");
+                                continue;
+                            }
+                        };
+                        let item = KeyValue::new(key, data);
+                        yield WatchEvent::Put(item);
+                    }
+                    EventMask::DELETE => {
+                        yield WatchEvent::Delete(Key::from_raw(key));
+                    }
+                    event_type => {
+                        tracing::warn!(?event_type, dir = %dir.display(), "Unexpected event type");
+                        continue;
+                    }
+                }
+            }
+        }))
+    }
+
+    async fn entries(&self) -> Result<HashMap<String, bytes::Bytes>, StoreError> {
+        let contents = fs::read_dir(&self.p)
+            .with_context(|| self.p.display().to_string())
+            .map_err(a_to_fs_err)?;
+        let mut out = HashMap::new();
+        for entry in contents {
+            let entry = entry.map_err(to_fs_err)?;
+            if !entry.path().is_file() {
+                tracing::warn!(
+                    path = %entry.path().display(),
+                    "Unexpected entry, directory should only contain files."
+                );
+                continue;
+            }
+
+            let key = match entry.path().strip_prefix(&self.root) {
+                Ok(p) => p.to_string_lossy().to_string().replace("_", "/"),
+                Err(err) => {
+                    tracing::error!(
+                        error = %err,
+                        path = %entry.path().display(),
+                        root = %self.root.display(),
+                        "FileStore path not in root. Should be impossible. Skipping entry."
+                    );
+                    continue;
+                }
+            };
+            let data: bytes::Bytes = fs::read(entry.path())
+                .with_context(|| self.p.display().to_string())
+                .map_err(a_to_fs_err)?
+                .into();
+            out.insert(key, data);
+        }
+        Ok(out)
+    }
+}
+
+// For anyhow preserve the context
+fn a_to_fs_err(err: anyhow::Error) -> StoreError {
+    StoreError::FilesystemError(format!("{err:#}"))
+}
+
+fn to_fs_err<E: std::error::Error>(err: E) -> StoreError {
+    StoreError::FilesystemError(err.to_string())
+}

--- a/lib/runtime/src/storage/key_value_store/mem.rs
+++ b/lib/runtime/src/storage/key_value_store/mem.rs
@@ -57,7 +57,7 @@ impl MemoryBucket {
 }
 
 impl MemoryStore {
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         MemoryStore {
             inner: Arc::new(MemoryStoreInner {
@@ -107,6 +107,8 @@ impl KeyValueStore for MemoryStore {
     fn connection_id(&self) -> u64 {
         self.connection_id
     }
+
+    fn shutdown(&self) {}
 }
 
 #[async_trait]
@@ -205,8 +207,7 @@ impl KeyValueBucket for MemoryBucketRef {
                         yield WatchEvent::Put(item);
                     },
                     Some(MemoryEvent::Delete { key }) => {
-                        let item = KeyValue::new(key, bytes::Bytes::new());
-                        yield WatchEvent::Delete(item);
+                        yield WatchEvent::Delete(Key::from_raw(key));
                     }
                 }
             }

--- a/lib/runtime/src/storage/key_value_store/nats.rs
+++ b/lib/runtime/src/storage/key_value_store/nats.rs
@@ -52,6 +52,11 @@ impl KeyValueStore for NATSStore {
     fn connection_id(&self) -> u64 {
         self.client.client().server_info().client_id
     }
+
+    fn shutdown(&self) {
+        // TODO: Track and delete any owned keys
+        // The TTL should ensure NATS does it, but best we do it immediately
+    }
 }
 
 impl NATSStore {
@@ -160,12 +165,14 @@ impl KeyValueBucket for NATSBucket {
                 >| async move {
                     match maybe_entry {
                         Ok(entry) => {
-                            let item = KeyValue::new(entry.key, entry.value);
                             Some(match entry.operation {
-                                Operation::Put => WatchEvent::Put(item),
-                                Operation::Delete => WatchEvent::Delete(item),
+                                Operation::Put => {
+                                    let item = KeyValue::new(entry.key, entry.value);
+                                    WatchEvent::Put(item)
+                                }
+                                Operation::Delete => WatchEvent::Delete(Key::from_raw(entry.key)),
                                 // TODO: What is Purge? Not urgent, NATS impl not used
-                                Operation::Purge => WatchEvent::Delete(item),
+                                Operation::Purge => WatchEvent::Delete(Key::from_raw(entry.key)),
                             })
                         }
                         Err(e) => {

--- a/tests/planner/unit/test_virtual_connector.py
+++ b/tests/planner/unit/test_virtual_connector.py
@@ -31,7 +31,7 @@ def get_runtime():
     except Exception:
         # If no existing runtime, create a new one
         loop = asyncio.get_running_loop()
-        _runtime_instance = DistributedRuntime(loop, False)
+        _runtime_instance = DistributedRuntime(loop, "etcd", False)
 
     return _runtime_instance
 

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -226,7 +226,7 @@ def get_runtime():
             # No running loop, create a new one (sync context)
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-        _runtime_instance = DistributedRuntime(loop, False)
+        _runtime_instance = DistributedRuntime(loop, "etcd", False)
 
     return _runtime_instance
 


### PR DESCRIPTION
Running any of the components with `--store-kv file` will use the file system instead of etcd for discovery. If there is a shared folder, or for the single-node case, this allows running frontend + backend without etcd.

The default folder is `/tmp/dynamo_store_kv`, configurable via `DYN_FILE_KV` env var.

This PR touched a lot of things in relatively light ways, including some nice simplifications  where we can now always take a `DistributedRuntime` instead of that or a `Runtime`.

The main file is `lib/runtime/src/storage/key_value_store/file.rs`.

Follow up PRs (this is big enough) will add:
- Cleanup old keys similar to etcd lease revokation.
- Remove the `is_static` stuff in favor of this file based KeyValueStore.

## Example

Worker:

```
python -m dynamo.vllm --connector none --max-model-len 4096 --model Qwen/Qwen3-0.6B --store-kv file
```
and / or
```
python -m dynamo.sglang --model-path nvidia/NVIDIA-Nemotron-Nano-9B-v2 --page-size 16 --trust-remote-code --mem-fraction-static 0.92 --store-kv file
```

Frontend:
```
python -m dynamo.frontend --store-kv file
```

Look in `$TMPDIR/dynamo_store_kv` (typically `/tmp`) for the live keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--store-kv` CLI option to select key-value store backend (etcd, memory, or file).
  * Introduced filesystem-based key-value store with file watching capabilities.
  * Added in-memory key-value store option for deployment flexibility.

* **Chores**
  * Added inotify dependency for file system event monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->