### PR TITLE
feat: Reject unsupported parameters with 400 Bad Request (`/v1/completions`)

### DIFF
--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1457,6 +1457,7 @@ dependencies = [
  "async_zmq",
  "axum",
  "axum-server",
+ "base64 0.22.1",
  "bincode 2.0.1",
  "bitflags 2.9.3",
  "blake3",
@@ -1480,12 +1481,14 @@ dependencies = [
  "galil-seiferas",
  "hf-hub",
  "humantime",
+ "image",
  "itertools 0.14.0",
  "json-five",
  "minijinja",
  "minijinja-contrib",
  "modelexpress-client",
  "modelexpress-common",
+ "ndarray",
  "offset-allocator",
  "oneshot",
  "parking_lot",
@@ -1494,6 +1497,7 @@ dependencies = [
  "rand 0.9.2",
  "rayon",
  "regex",
+ "reqwest",
  "rmp-serde",
  "rustls",
  "serde",
@@ -1504,6 +1508,7 @@ dependencies = [
  "tmq",
  "tokenizers",
  "tokio",
+ "tokio-rayon",
  "tokio-stream",
  "tokio-util",
  "toktrie",
@@ -3301,6 +3306,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3508,6 +3523,21 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
 
 [[package]]
 name = "neli"
@@ -4767,6 +4797,12 @@ checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
  "bitflags 2.9.3",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"

--- a/lib/llm/src/grpc/service/openai.rs
+++ b/lib/llm/src/grpc/service/openai.rs
@@ -315,6 +315,7 @@ impl TryFrom<inference::ModelInferRequest> for NvCreateCompletionRequest {
             common: Default::default(),
             nvext: None,
             metadata: None,
+            unsupported_fields: Default::default(),
         })
     }
 }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1469,6 +1469,7 @@ mod tests {
             common: Default::default(),
             nvext: None,
             metadata: None,
+            unsupported_fields: Default::default(),
         };
 
         let result = validate_completion_fields_generic(&request);
@@ -1492,6 +1493,7 @@ mod tests {
             common: Default::default(),
             nvext: None,
             metadata: None,
+            unsupported_fields: Default::default(),
         };
         let result = validate_completion_fields_generic(&request);
         assert!(result.is_err());
@@ -1514,6 +1516,7 @@ mod tests {
             common: Default::default(),
             nvext: None,
             metadata: None,
+            unsupported_fields: Default::default(),
         };
         let result = validate_completion_fields_generic(&request);
         assert!(result.is_err());
@@ -1536,6 +1539,7 @@ mod tests {
             common: Default::default(),
             nvext: None,
             metadata: None,
+            unsupported_fields: Default::default(),
         };
         let result = validate_completion_fields_generic(&request);
         assert!(result.is_err());
@@ -1560,6 +1564,7 @@ mod tests {
                 .unwrap(),
             nvext: None,
             metadata: None,
+            unsupported_fields: Default::default(),
         };
         let result = validate_completion_fields_generic(&request);
         assert!(result.is_err());
@@ -1582,6 +1587,7 @@ mod tests {
             common: Default::default(),
             nvext: None,
             metadata: None,
+            unsupported_fields: Default::default(),
         };
         let result = validate_completion_fields_generic(&request);
         assert!(result.is_err());
@@ -1612,6 +1618,7 @@ mod tests {
                 "session": {"id": "session-1", "timestamp": 1640995200}
             })
             .into(),
+            unsupported_fields: Default::default(),
         };
 
         let result = validate_completion_fields_generic(&request);
@@ -1835,6 +1842,36 @@ mod tests {
             assert!(msg.contains("documents"));
             assert!(msg.contains("chat_template"));
             assert!(msg.contains("chat_template_kwargs"));
+        }
+    }
+
+    #[test]
+    fn test_completions_unsupported_fields_rejected() {
+        // Test that unsupported fields from bug report are rejected in completions API.
+        // Mirrors test_unknown_fields_rejected for chat completions.
+        // Note: response_format type validation is handled by serde's tagged enum.
+        let json = r#"{
+            "model": "test-model",
+            "prompt": "Hello",
+            "add_special_tokens": true,
+            "response_format": {"type": "json_object"}
+        }"#;
+
+        let request: NvCreateCompletionRequest = serde_json::from_str(json).unwrap();
+
+        // Verify both unsupported fields were captured
+        assert!(request.unsupported_fields.contains_key("add_special_tokens"));
+        assert!(request.unsupported_fields.contains_key("response_format"));
+
+        let result = validate_completion_fields_generic(&request);
+        assert!(result.is_err());
+        if let Err(error_response) = result {
+            assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
+            let msg = &error_response.1.message;
+            assert!(msg.contains("Unsupported parameter"));
+            // Verify both fields appear in error message
+            assert!(msg.contains("add_special_tokens"));
+            assert!(msg.contains("response_format"));
         }
     }
 }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1858,7 +1858,11 @@ mod tests {
         let request: NvCreateCompletionRequest = serde_json::from_str(json).unwrap();
 
         // Verify both unsupported fields were captured
-        assert!(request.unsupported_fields.contains_key("add_special_tokens"));
+        assert!(
+            request
+                .unsupported_fields
+                .contains_key("add_special_tokens")
+        );
         assert!(request.unsupported_fields.contains_key("response_format"));
 
         let result = validate_completion_fields_generic(&request);

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1804,8 +1804,8 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_fields_rejected() {
-        // Test that all known unsupported fields are rejected and all shown in error message
+    fn test_chat_completions_unknown_fields_rejected() {
+        // Test that known unsupported fields are rejected and all shown in error message
         let json = r#"{
             "messages": [{"role": "user", "content": "Hello"}],
             "model": "test-model",
@@ -1847,9 +1847,7 @@ mod tests {
 
     #[test]
     fn test_completions_unsupported_fields_rejected() {
-        // Test that unsupported fields from bug report are rejected in completions API.
-        // Mirrors test_unknown_fields_rejected for chat completions.
-        // Note: response_format type validation is handled by serde's tagged enum.
+        // Test that known unsupported fields are rejected and all shown in error message
         let json = r#"{
             "model": "test-model",
             "prompt": "Hello",

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -37,6 +37,10 @@ pub struct NvCreateCompletionRequest {
     // metadata - passthrough parameter without restrictions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
+
+    /// Catch-all for unsupported fields - checked during validation
+    #[serde(flatten, default, skip_serializing)]
+    pub unsupported_fields: std::collections::HashMap<String, serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Validate, Debug, Clone)]
@@ -372,6 +376,7 @@ impl OpenAIOutputOptionsProvider for NvCreateCompletionRequest {
 /// allowing us to validate the data.
 impl ValidateRequest for NvCreateCompletionRequest {
     fn validate(&self) -> Result<(), anyhow::Error> {
+        validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
         validate::validate_model(&self.inner.model)?;
         validate::validate_prompt(&self.inner.prompt)?;
         validate::validate_suffix(self.inner.suffix.as_deref())?;

--- a/lib/llm/tests/openai_completions.rs
+++ b/lib/llm/tests/openai_completions.rs
@@ -29,6 +29,7 @@ impl CompletionSample {
             common: Default::default(),
             nvext: None,
             metadata: None,
+            unsupported_fields: Default::default(),
         };
 
         Ok(Self {


### PR DESCRIPTION
#### Overview:

This PR is to address dynamo receiving unsupported parameters with `/v1/completions` inference requests (for example add_special_tokens, documents, chat_template). These parameters were previously being ignored, but this PR adds validation to explicitly reject these and any other unknown parameters with a clear 400 Bad Request error, by failing fast with helpful feedback. 

Mirror PR for `/v1/chat/completions`:  #4021

#### Details:

Added `unsupported_fields` to `NvCreateCompletionRequest`.

#### Where should the reviewer start?

In `lib/llm/src/protocols/openai/completions.rs`, look at the changes to struct `NvCreateCompletionRequest`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unsupported request parameters are now captured and properly rejected with detailed error messages during validation.

* **Tests**
  * Added test coverage to verify unsupported parameters are correctly identified and rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->