### PR TITLE
fix: Fix Dockerfile.local_vllm

### DIFF
--- a/tests/fault_tolerance/deploy/container/Dockerfile.local_vllm
+++ b/tests/fault_tolerance/deploy/container/Dockerfile.local_vllm
@@ -132,7 +132,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY --from=dynamo_base /opt/dynamo/wheelhouse/ /opt/dynamo/wheelhouse/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install \
-    /opt/dynamo/wheelhouse/ai_dynamo_runtime*cp312*.whl \
+    /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl \
     && rm -rf /opt/dynamo/wheelhouse


### PR DESCRIPTION
#### Overview:

Update the Dockerfile. Otherwise it ends with "0.262 error: The wheel filename "ai_dynamo_runtime*cp312*.whl" is invalid: Must have a version  "
#### Details:

Remove the "cp312" for ai_dynamo_runtime

#### Where should the reviewer start?

Dockerfile.local_vllm
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test Docker configuration to improve wheel installation compatibility across multiple Python versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->