### PR TITLE
fix: helm default for etcd PodDisruptionBudget

### DIFF
--- a/deploy/cloud/helm/platform/values.yaml
+++ b/deploy/cloud/helm/platform/values.yaml
@@ -200,6 +200,16 @@ etcd:
   # Node tolerations for etcd pods (allows scheduling on specific nodes)
   tolerations: []
 
+  # Pod Disruption Budget configuration
+  # If replicas is 1, then need minAvailable to be 0 to enable node draining
+  pdb:
+    # Enable/disable a Pod Disruption Budget creation
+    create: true
+    # Minimum number/percentage of pods that should remain scheduled
+    minAvailable: 0
+    # Maximum number/percentage of pods that may be made unavailable
+    maxUnavailable: ""
+
 # NATS configuration - messaging system for operator communication
 nats:
   # -- Whether to enable NATS deployment, disable if you want to use an external NATS instance. For complete configuration options, see: https://github.com/nats-io/k8s/tree/main/helm/charts/nats , all nats settings should be prefixed with "nats."


### PR DESCRIPTION
#### Overview:

Our default `values.yaml` for the the dynamo platform installation has 1 etcd replica. The etcd helm chart creates a `PodDisruptionBudget` with `minAvailable` 51%. Node draining fails because it can't evict the etcd pod given the `PDB`. This sets the default `minAvailable` on the etcd `PDB` to 0

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced platform infrastructure resilience through configuration that improves pod availability management during system maintenance and cluster upgrades, enabling better control over rolling updates and reducing potential service disruptions during maintenance windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->