### PR TITLE
feat: Support  a dynamic default max_tokens for VLLM backend

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -339,7 +339,11 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
     ) = setup_vllm_engine(config)
 
     handler = PrefillWorkerHandler(
-        runtime, component, engine_client, default_sampling_params
+        runtime,
+        component,
+        engine_client,
+        default_sampling_params,
+        getattr(getattr(vllm_config, "model_config", None), "max_model_len", None),
     )
     handler.add_temp_dir(prometheus_temp_dir)
 
@@ -450,6 +454,7 @@ async def init(runtime: DistributedRuntime, config: Config):
         component,
         engine_client,
         default_sampling_params,
+        getattr(getattr(vllm_config, "model_config", None), "max_model_len", None),
     )
     handler.add_temp_dir(prometheus_temp_dir)
 


### PR DESCRIPTION
#### Overview:

This PR introduces a dynamic default max_tokens for VLLM backend when the request doesn't specify a value.

The new default is calculated as max(1, model_max_len - input_length), ensuring token generation respects the model's maximum sequence length while accounting for the current input length.

#### Details:

- Added logic to compute max_tokens dynamically using the model's maximum sequence length and the current input length when the request omits max_tokens

- Modified build_sampling_paramsto accept model_max_len and implement the dynamic default logic

- Updated handler constructors to pass the model’s maximum length configuration

#### Where should the reviewer start?

- components/src/dynamo/vllm/handlers.py: Focus on build_sampling_params changes and handler modifications

- components/src/dynamo/vllm/main.py: Check how model_max_len is passed to handler constructors

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #3876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Output token limits are now computed dynamically from model capacity and input length, improving token allocation and adherence to model constraints.
* **Reliability**
  * Sampling parameter computation is more robust—fallback logic prevents failures during default calculation, reducing run-time errors and unexpected truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->