### PR TITLE
fix: fix kubectl image

### DIFF
--- a/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
@@ -67,7 +67,7 @@ spec:
           echo "SSH keys generated and saved to shared volume"
       containers:
       - name: kubectl-create-secret
-        image: registry.k8s.io/kubectl:v1.31.7
+        image: alpine/k8s:1.31.2
         volumeMounts:
         - name: shared
           mountPath: /shared

--- a/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
@@ -67,7 +67,7 @@ spec:
           echo "SSH keys generated and saved to shared volume"
       containers:
       - name: kubectl-create-secret
-        image: bitnamisecure/kubectl:latest
+        image: registry.k8s.io/kubectl:v1.31.7
         volumeMounts:
         - name: shared
           mountPath: /shared

--- a/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/mpi-run-ssh-keygen-job.yaml
@@ -67,7 +67,7 @@ spec:
           echo "SSH keys generated and saved to shared volume"
       containers:
       - name: kubectl-create-secret
-        image: alpine/k8s:1.31.2
+        image: alpine/k8s:1.34.1
         volumeMounts:
         - name: shared
           mountPath: /shared


### PR DESCRIPTION
#### Overview:

fix kubectl image

bitnami only publish `latest` tag, and it was updated recently with a breaking change ....

the ssh keygen job would fail with :
```
kubectl-create-secret error: failed to create secret Post "[https://10.40.0.1:443/api/v1/namespaces/dynamo-system/secrets?fieldManager=kubectl-create&fieldValidation=Strict](https://10.40.0.1/api/v1/namespaces/dynamo-system/secrets?fieldManager=kubectl-create&fieldValidation=Strict)": crypto/ecdh: use of X25519 is not allowed in FIPS 140-only mode
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image for deployment infrastructure to an officially-maintained version for improved stability and security alignment with Kubernetes standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->