### PR TITLE
fix(tests): failing etcd ha test due to vllm port conflict

### DIFF
--- a/tests/fault_tolerance/etcd_ha/test_vllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_vllm.py
@@ -64,6 +64,10 @@ class DynamoWorkerProcess(ManagedProcess):
         env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
         env["DYN_SYSTEM_PORT"] = port
 
+        if is_prefill:
+            env["DYN_VLLM_KV_EVENT_PORT"] = "20082"
+            env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = "5601"
+
         # Set log directory based on worker type
         worker_type = "prefill_worker" if is_prefill else "worker"
         log_dir = f"{request.node.name}_{worker_type}"


### PR DESCRIPTION
#### Overview:

Need to override ports properly otherwise there are conflicts and one engine will fail. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test environment configuration for prefilling scenario validation in fault tolerance testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->