### PR TITLE
fix: Remove constant gpt-2 token_id upper bound check

### DIFF
--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -85,8 +85,6 @@ pub const MAX_TOOLS: usize = 128;
 // Metadata validation constants removed - we are no longer restricting the metadata field char limits
 /// Maximum allowed length for function names
 pub const MAX_FUNCTION_NAME_LENGTH: usize = 64;
-/// Maximum allowed value for Prompt IntegerArray elements
-pub const MAX_PROMPT_TOKEN_ID: u32 = 50256;
 /// Minimum allowed value for `repetition_penalty`
 pub const MIN_REPETITION_PENALTY: f32 = 0.0;
 /// Maximum allowed value for `repetition_penalty`
@@ -405,16 +403,6 @@ pub fn validate_prompt(prompt: &dynamo_async_openai::types::Prompt) -> Result<()
             if arr.is_empty() {
                 anyhow::bail!("Prompt integer array cannot be empty");
             }
-            for (i, &token_id) in arr.iter().enumerate() {
-                if token_id > MAX_PROMPT_TOKEN_ID {
-                    anyhow::bail!(
-                        "Token ID at index {} must be between 0 and {}, got {}",
-                        i,
-                        MAX_PROMPT_TOKEN_ID,
-                        token_id
-                    );
-                }
-            }
         }
         dynamo_async_openai::types::Prompt::ArrayOfIntegerArray(arr) => {
             if arr.is_empty() {
@@ -423,17 +411,6 @@ pub fn validate_prompt(prompt: &dynamo_async_openai::types::Prompt) -> Result<()
             for (i, inner_arr) in arr.iter().enumerate() {
                 if inner_arr.is_empty() {
                     anyhow::bail!("Prompt integer array at index {} cannot be empty", i);
-                }
-                for (j, &token_id) in inner_arr.iter().enumerate() {
-                    if token_id > MAX_PROMPT_TOKEN_ID {
-                        anyhow::bail!(
-                            "Token ID at index [{}][{}] must be between 0 and {}, got {}",
-                            i,
-                            j,
-                            MAX_PROMPT_TOKEN_ID,
-                            token_id
-                        );
-                    }
                 }
             }
         }


### PR DESCRIPTION
# Cherry-pick: fix: Remove constant gpt-2 token_id upper bound check

## Summary
Cherry-pick of PR #3760 into release/0.6.1.

This fix removes the hard-coded `MAX_PROMPT_TOKEN_ID = 50256` constant that was specific to GPT-2/3 vocabulary size. This constant was blocking requests with token IDs above 50256, which prevented proper support for models with larger vocabularies (LLaMA, Qwen, Mistral, etc. that use SentencePiece or SPTokenizer with 32000-120000 vocab sizes).

## Original PR
- **Main PR:** https://github.com/ai-dynamo/dynamo/pull/3760
- **Merged to main:** Nov 6, 2025
- **Merge commit:** 6336eea
- **Original author:** @nathan-barry
- **Closes issue:** #3727

## Changes
- Removed the `MAX_PROMPT_TOKEN_ID` constant from `lib/llm/src/protocols/openai/validate.rs`
- Removed upper bound validation checks that enforced token IDs within `0..=MAX_PROMPT_TOKEN_ID` range
- This enables support for models with arbitrary vocabulary sizes while maintaining lower bound validation (token_id >= 0)

## Why Cherry-pick to release/0.6.1?
This is a **bug fix** that unblocks usage of non-GPT models with Dynamo. Without this fix, users cannot send requests with token IDs above 50256, which limits model compatibility significantly.

**Type:** `fix:`
**Reason:** Unblocks non-GPT model usage (LLaMA, Qwen, Mistral, etc.) by removing vocabulary size constraint
**Severity:** Blocks customers using models with large vocabularies
**Risk:** Low - removes validation constraint, code change is small and localized

## Testing
- Original PR passed all CI/CD checks on main
- Cherry-pick applied cleanly with no conflicts

## Cherry Pick Table Entry
Add to the release/0.6.1 Cherry Pick table in #swdl-dynamo-release:

| Type | Reason | PiC | PR to main | PR to release | Status |
|------|--------|-----|------------|---------------|--------|
| fix: | Remove GPT-2 token_id upper bound check - blocks non-GPT models (LLaMA, Qwen, Mistral) - NVBug TBD | dagil | [#3760](https://github.com/ai-dynamo/dynamo/pull/3760) | [TBD] | :pr-opened: |

---

## Related Issues
- Closes #3727: [BUG]: MAX_PROMPT_TOKEN_ID (50256) validation blocks non-OpenAI tokenizers

