### PR TITLE
fix: multi-turn bug in should_add_generation_prompt

### DIFF
--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -163,14 +163,17 @@ impl OAIChatLikeRequest for NvCreateChatCompletionRequest {
     }
 
     fn should_add_generation_prompt(&self) -> bool {
-        if let Some(last) = self.inner.messages.last() {
-            matches!(
-                last,
-                dynamo_async_openai::types::ChatCompletionRequestMessage::User(_)
-            )
-        } else {
-            true
-        }
+        // Only add generation prompt if the last message was not assistant (default to true when no last message)
+        self.inner
+            .messages
+            .last()
+            .map(|last| {
+                !matches!(
+                    last,
+                    dynamo_async_openai::types::ChatCompletionRequestMessage::Assistant(_)
+                )
+            })
+            .unwrap_or(true)
     }
 
     fn extract_text(&self) -> Option<TextInput> {
@@ -294,6 +297,7 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_async_openai::types::ChatCompletionRequestMessage as Msg;
 
     #[test]
     fn test_may_be_fix_tool_schema_missing_type_and_properties() {
@@ -699,5 +703,47 @@ NORMAL MODE
         // Unknown types mixed with text should preserve array
         assert!(messages[0]["content"].is_array());
         assert_eq!(messages[0]["content"].as_array().unwrap().len(), 3);
+    }
+
+    fn user() -> Msg {
+        Msg::User(Default::default())
+    }
+    fn asst() -> Msg {
+        Msg::Assistant(Default::default())
+    }
+    fn tool() -> Msg {
+        Msg::Tool(Default::default())
+    }
+
+    fn dummy_state(messages: Vec<Msg>) -> NvCreateChatCompletionRequest {
+        let json = serde_json::json!({
+            "model": "test-model",
+            "messages": messages
+        });
+        serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn add_after_user() {
+        let s = dummy_state(vec![user()]);
+        assert!(s.should_add_generation_prompt());
+    }
+
+    #[test]
+    fn add_after_tool() {
+        let s = dummy_state(vec![tool()]);
+        assert!(s.should_add_generation_prompt());
+    }
+
+    #[test]
+    fn no_after_assistant() {
+        let s = dummy_state(vec![asst()]);
+        assert!(!s.should_add_generation_prompt());
+    }
+
+    #[test]
+    fn add_when_empty() {
+        let s = dummy_state(vec![]);
+        assert!(s.should_add_generation_prompt());
     }
 }


### PR DESCRIPTION
#### Overview:
Add generation prompt unless the last message was `Assistant(_)`  
(defaults to `true` when no messages exist).

Added unit tests and local test results here after change applied:

```
(venv) ubuntu@workstation:/workspace$ python test_tool_call_simple.py
ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=[ChatCompletionMessageFunctionToolCall(id='call-72ec0ccd-828a-4bb8-88de-12b123684ee4', function=Function(arguments='{"location":"San Francisco, CA","format":"celsius"}', name='get_current_weather'), type='function')], reasoning_content=None)
ChatCompletionMessage(content='The current weather in San Francisco, CA is88 degrees Celsius.', refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=None, reasoning_content=None)
```

#### Details:

Change the behavior of `should_add_generation_prompt` to not simply check if the last message was `User(_)` but to check if the last message was not `Assistant(_)` and then return true in that case. This fixes issues such as those found in bug #4013 where the last message being `Tool(_) `caused the model to leak header ids into the return content.

#### Where should the reviewer start?

`lib/llm/src/preprocessor/prompt/template/oai.rs`

`#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes GitHub issue: [#4013](https://github.com/ai-dynamo/dynamo/issues/4013)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt generation logic in chat completions to better handle different conversation message types, including improved handling of assistant-generated messages.

* **Tests**
  * Expanded test coverage for prompt generation across various message type scenarios to ensure proper handling in different conversation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->