### PR TITLE
feat: add experimental support for checkpoint vLLM Dynamo Workers

### DIFF
--- a/components/backends/vllm/deploy/agg.yaml
+++ b/components/backends/vllm/deploy/agg.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-agg
+spec:
+  pvcs:
+    - name: dynamo-checkpoint-pvc
+      create: false
+  services:
+    Frontend:
+      dynamoNamespace: vllm-agg
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: mmshin613/dynamo:vllm-nov-13-01
+    VllmDecodeWorker:
+      dynamoNamespace: vllm-agg
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      volumeMounts: 
+        - name: dynamo-checkpoint-pvc
+          mountPoint: /workspace/checkpoints
+      envs:
+        - name: ENABLE_CHECKPOINTING
+          value: "true"
+        - name: CHECKPOINT_DIR
+          value: "/workspace/checkpoints"
+      extraPodSpec:
+        nodeSelector:
+          platform.centml.ai/instance-type: large
+        tolerations:
+          - key: "dedicated_compute"
+            operator: "Exists"
+            effect: "NoSchedule"
+        mainContainer:
+          image: mmshin613/dynamo:vllm-nov-13-01
+          workingDir: /workspace/components/backends/vllm
+          command:
+          # - sleep
+          # - infinity
+          - python3
+          args:
+          - -m
+          - dynamo.vllm
+          - --model
+          - Qwen/Qwen3-0.6B
+          - --connector 
+          - "none"
+          - --disable-log-stats
+          securityContext:
+            privileged: true

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -25,6 +25,10 @@ VALID_CONNECTORS = {"nixl", "lmcache", "kvbm", "null", "none"}
 # Global LMCache configuration - initialize once on module import
 ENABLE_LMCACHE = os.getenv("ENABLE_LMCACHE", "0").lower() in ("1", "true", "yes")
 
+# Global checkpoint configuration - initialize once on module import
+ENABLE_CHECKPOINTING = os.getenv("ENABLE_CHECKPOINTING", "0").lower() in ("1", "true", "yes")
+CHECKPOINT_DIR = os.getenv("CHECKPOINT_DIR", None)  # Optional: directory to restore from
+
 
 class Config:
     """Command line parameters or defaults"""

--- a/components/src/dynamo/vllm/checkpoint/__init__.py
+++ b/components/src/dynamo/vllm/checkpoint/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checkpoint/restore functionality for Dynamo."""
+
+from .checkpointable_async_llm import CheckpointableAsyncLLM
+from .metadata import CheckpointMetadata
+
+__all__ = ["CheckpointableAsyncLLM", "CheckpointMetadata"]
+

--- a/components/src/dynamo/vllm/checkpoint/checkpointable_async_llm.py
+++ b/components/src/dynamo/vllm/checkpoint/checkpointable_async_llm.py
@@ -1,0 +1,1166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+import asyncio
+import contextlib
+import errno
+import multiprocessing
+import os
+import pty
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from collections.abc import AsyncGenerator, Mapping
+from typing import Any, Optional, Union
+import logging
+import cloudpickle
+import msgspec
+import zmq
+import zmq.asyncio
+
+from vllm.config import LiteVllmConfig, ModelConfig, VllmConfig
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.inputs import PromptType
+from vllm.inputs.preprocess import InputPreprocessor
+from vllm.lora.request import LoRARequest
+from vllm.outputs import PoolingRequestOutput, RequestOutput
+from vllm.pooling_params import PoolingParams
+from vllm.sampling_params import SamplingParams
+from vllm.tasks import SupportedTask
+from vllm.transformers_utils.tokenizer import AnyTokenizer
+from vllm.usage.usage_lib import UsageContext
+from vllm.utils import Device, get_open_port
+from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.output_processor import RequestOutputCollector
+from vllm.v1.executor.abstract import Executor
+from vllm.v1.metrics.loggers import StatLoggerFactory
+
+from .utils import (
+    find_gpu_worker_pids,
+    collect_process_tree_pids,
+    verify_processes_exited, get_tty_info,
+)
+from .metadata import CheckpointMetadata
+from .zmq_async_llm_server import (
+    RPCMessageType, RPCResponse, PropertyRequest, PropertyResponse,
+    run_async_llm_server,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _create_engine_config_in_subprocess(queue: multiprocessing.Queue, engine_args_pickle: bytes) -> None:
+    """Create engine config in a subprocess with isolated CUDA context.
+
+    This function runs in a separate process to ensure complete CUDA context isolation.
+    The subprocess will have its own CUDA context that won't interfere with the main
+    process or any subsequent subprocesses.
+
+    Args:
+        queue: Multiprocessing queue to send results back to parent process
+        engine_args_pickle: Pickled AsyncEngineArgs object
+    """
+    try:
+        # Unpickle the engine args
+        engine_args = cloudpickle.loads(engine_args_pickle)
+
+        # Create the config (this may initialize CUDA)
+        org_vllm_config = engine_args.create_engine_config()
+        vllm_config = LiteVllmConfig.from_vllm_config(org_vllm_config)
+
+        # Pickle and send back the result
+        config_pickle = cloudpickle.dumps(vllm_config)
+        queue.put(("success", config_pickle))
+    except Exception as e:
+        # Send back the error with traceback for debugging
+        import traceback
+        error_msg = f"{str(e)}\n{traceback.format_exc()}"
+        queue.put(("error", error_msg))
+
+
+def create_engine_config_isolated(engine_args: AsyncEngineArgs) -> VllmConfig:
+    """Create engine config in a short-lived subprocess with separate CUDA context.
+
+    This function spawns a new process to create the VllmConfig, ensuring that any
+    CUDA initialization happens in a completely isolated context. This prevents
+    CUDA context conflicts between the configuration phase and the actual engine
+    execution.
+
+    The subprocess uses the 'spawn' start method to ensure a clean state without
+    inheriting any CUDA context from the parent process.
+
+    Args:
+        engine_args: AsyncEngineArgs object containing engine configuration
+
+    Returns:
+        VllmConfig: The created configuration object
+
+    Raises:
+        RuntimeError: If the subprocess fails to create the config
+        TimeoutError: If the subprocess takes too long
+    """
+    # Use spawn to ensure a clean CUDA context
+    ctx = multiprocessing.get_context('spawn')
+    queue = ctx.Queue()
+
+    # Pickle the engine args
+    engine_args_pickle = cloudpickle.dumps(engine_args)
+
+    # Start the subprocess
+    process = ctx.Process(
+        target=_create_engine_config_in_subprocess,
+        args=(queue, engine_args_pickle),
+        daemon=True
+    )
+    logger.info("Spawning subprocess for isolated config creation...")
+    process.start()
+
+    # Wait for the result
+    try:
+        status, result = queue.get(timeout=60)  # 60 second timeout
+        process.join(timeout=5)  # Wait for process to cleanup
+
+        if status == "error":
+            raise RuntimeError(f"Failed to create engine config in subprocess:\n{result}")
+
+        # Unpickle and return the config
+        return cloudpickle.loads(result)
+    except multiprocessing.TimeoutError:
+        # Handle timeout specifically
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+        raise TimeoutError("Subprocess timed out while creating engine config")
+    except Exception as e:
+        # Make sure to terminate the subprocess if something goes wrong
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+        raise e
+
+
+class CheckpointableAsyncLLM(AsyncLLM):
+    """
+    A wrapper around AsyncLLM that runs it in a subprocess and
+    communicates via ZMQ. Supports CRIU checkpoint/restore functionality.
+
+    This class is designed for checkpointing workflows:
+    1. Start the AsyncLLM subprocess
+    2. Checkpoint the process using CRIU
+    3. Restore from checkpoint later
+
+    Example usage:
+        # Start and checkpoint
+        engine_args = AsyncEngineArgs(model="...")
+        llm = CheckpointableAsyncLLM.from_engine_args(engine_args)
+        await llm.criu_checkpoint("/path/to/checkpoint/dir")
+
+        # Restore from existing checkpoint
+        llm = CheckpointableAsyncLLM.from_engine_args(engine_args,
+                                                       auto_start=False)
+        llm.checkpoint_dir = "/path/to/existing/checkpoint"
+        await llm.criu_resume()
+
+        # Now use normally
+        async for output in llm.generate(...):
+            print(output)
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        executor_class: type[Executor],
+        log_stats: bool,
+        usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
+        log_requests: bool = True,
+        start_engine_loop: bool = True,
+        stat_loggers: Optional[list[StatLoggerFactory]] = None,
+        client_addresses: Optional[dict[str, str]] = None,
+        client_count: int = 1,
+        client_index: int = 0,
+        auto_start: bool = True,
+    ) -> None:
+        if auto_start:
+            # Use TCP socket instead of IPC for better CRIU compatibility
+            # Only set these attributes if not restoring (auto_start=True)
+            self.port = get_open_port()
+            self.socket_url = f"tcp://127.0.0.1:{self.port}"
+
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        # Processor and io_processor are managed by the subprocess AsyncLLM
+        # Set to None as we proxy through ZMQ RPC
+        self.processor = None  # type: ignore
+        self.io_processor = None
+        self.process: Optional[multiprocessing.Process] = None
+        self.ctx = zmq.asyncio.Context()
+        self.socket: Optional[zmq.asyncio.Socket] = None
+        self.checkpoint_dir: Optional[str] = None
+        self._is_running = False
+        self._subprocess_started = False
+        # For CRIU TTY forwarding
+        self._pty_main_fd: Optional[int] = None
+        self._pty_forwarder_thread: Optional[threading.Thread] = None
+
+        # Serialize configuration for subprocess
+        self.vllm_config_pickle = cloudpickle.dumps(vllm_config)
+        self.executor_class_pickle = cloudpickle.dumps(executor_class)
+        kwargs = {
+            'log_stats': log_stats,
+            'usage_context': usage_context,
+            'log_requests': log_requests,
+            'start_engine_loop': start_engine_loop,
+            'stat_loggers': None,  # Set to None - stat_loggers contain unpicklable Component objects
+            'client_addresses': client_addresses,
+            'client_count': client_count,
+            'client_index': client_index,
+        }
+        self.kwargs_pickle = cloudpickle.dumps(kwargs)
+
+        # Only start the subprocess if auto_start is True
+        # This allows creating the instance without starting a subprocess
+        # when we plan to restore from CRIU
+        if auto_start:
+            self._start_subprocess()
+
+    def _start_subprocess(self):
+        """Start the AsyncLLM subprocess."""
+        if self._subprocess_started:
+            logger.warning("Subprocess already started")
+            return
+
+        ctx = multiprocessing.get_context('spawn')
+        # Note: daemon=False is required because AsyncLLM may need to spawn
+        # its own child processes (e.g., DPCoordinator for data parallel)
+        # Create a private PTY for the child so it can become a session leader
+        # with a controlling TTY. We pass the parent's PID and the worker fd
+        # number so the child can open it via /proc and call TIOCSCTTY.
+        pty_main_fd, pty_worker_fd = pty.openpty()
+        os.set_inheritable(pty_worker_fd, True)
+        self.process = ctx.Process(
+            target=run_async_llm_server,
+            args=(self.socket_url, self.vllm_config_pickle,
+                  self.executor_class_pickle, self.kwargs_pickle,
+                  os.getpid(), pty_worker_fd),
+            daemon=False
+        )
+        self.process.start()
+        self._is_running = True
+        self._subprocess_started = True
+
+        # Close the worker fd in parent process (child has it)
+        os.close(pty_worker_fd)
+
+        # Forward child's PTY main to our stdout so logs are visible
+        # Do this BEFORE connecting so we can see any startup errors
+        try:
+            self._start_pty_forwarder(pty_main_fd)
+        except Exception as e:
+            logger.warning("Failed to start startup PTY forwarder: %s", e)
+
+        # Connect to the subprocess
+        self._connect()
+
+    def _connect(self):
+        """Connect to the AsyncLLM subprocess."""
+        # Use a synchronous REQ socket for initial connection
+        sync_ctx = zmq.Context()
+        sync_socket = sync_ctx.socket(zmq.REQ)
+        sync_socket.connect(self.socket_url)
+
+        try:
+            # Send initial hello and wait for acknowledgment
+            sync_socket.send(b"HELLO")
+            logger.debug("Sent HELLO to subprocess")
+            hello_ack = sync_socket.recv()
+            if hello_ack != b"HELLO_ACK":
+                raise RuntimeError(f"Unexpected HELLO response: {hello_ack}")
+
+            # Now check for readiness
+            sync_socket.send(b"READY_CHECK")
+            logger.debug("Sent READY_CHECK to subprocess")
+
+            # Wait for ready signal
+            # Must match or exceed the server's max_wait_time (900s in zmq_async_llm_server.py)
+            timeout = 900  # 15 minutes for initial connection and engine initialization
+            # With REQ socket, we just wait for the response
+            if sync_socket.poll(timeout=timeout * 1000):  # Convert to milliseconds
+                msg = sync_socket.recv()
+                logger.debug("Received message: %s", msg)
+                if msg == b"READY":
+                    logger.info("Connected to AsyncLLM subprocess")
+                    # Now create the async socket for normal operations
+                    # Client side of REQ-REP pattern
+                    self.socket = self.ctx.socket(zmq.REQ)
+                    # REQ sockets automatically wait for connection establishment
+                    self.socket.connect(self.socket_url)
+                    return
+                else:
+                    raise RuntimeError(f"Unexpected READY response: {msg}")
+            else:
+                # Poll timed out - check if process is still alive
+                if self.process and not self.process.is_alive():
+                    exit_code = self.process.exitcode
+                    raise RuntimeError(
+                        f"AsyncLLM subprocess died during startup "
+                        f"(exit code: {exit_code})")
+                raise TimeoutError(
+                    f"Timeout waiting for AsyncLLM subprocess to start "
+                    f"after {timeout} seconds")
+        finally:
+            sync_socket.close()
+            sync_ctx.term()
+
+    async def start(self) -> None:
+        """Explicitly start the AsyncLLM subprocess.
+
+        This is used when auto_start=False was passed to __init__.
+        """
+        if self._subprocess_started:
+            logger.info("Subprocess already started")
+            return
+
+        self._start_subprocess()
+        logger.info("AsyncLLM subprocess started successfully")
+
+    async def wait_until_ready(self, timeout: float = 300.0) -> None:
+        """Wait until the AsyncLLM engine is fully initialized and ready.
+
+        This method ensures the engine has completed all initialization steps:
+        - Model loaded
+        - torch.compile completed (if applicable)
+        - CUDA graphs captured
+        - KV cache allocated
+        - Engine ready to handle requests
+
+        Args:
+            timeout: Maximum time to wait in seconds
+                    (default: 300.0 = 5 minutes). Set higher for large models
+                    or when torch.compile is enabled.
+
+        Raises:
+            TimeoutError: If engine doesn't become ready within timeout
+            RuntimeError: If engine fails during initialization
+        """
+        if not self._subprocess_started:
+            raise RuntimeError(
+                "AsyncLLM subprocess not started. Call start() first.")
+
+        start_time = time.time()
+        last_error = None
+
+        logger.info("Waiting for AsyncLLM engine to be fully initialized...")
+
+        while time.time() - start_time < timeout:
+            try:
+                # Check if the engine is fully ready
+                is_ready = await self._rpc_call("is_engine_ready")
+                if is_ready:
+                    logger.info(
+                        "AsyncLLM engine is fully initialized and ready")
+                    return
+            except Exception as e:
+                last_error = e
+                # Check if process is still alive
+                if self.process and not self.process.is_alive():
+                    raise RuntimeError(
+                        f"AsyncLLM subprocess died during initialization: "
+                        f"{last_error}"
+                    ) from e
+
+            # Engine not ready yet, wait a bit before retrying
+            await asyncio.sleep(0.5)
+
+            # Log progress
+            elapsed = time.time() - start_time
+            if int(elapsed) % 10 == 0 and int(elapsed) > 0:
+                logger.info("Still waiting for engine initialization... "
+                           "(%d seconds elapsed)", int(elapsed))
+
+        raise TimeoutError(
+            f"AsyncLLM engine did not become ready within {timeout} seconds. "
+            f"Last error: {last_error}"
+        )
+
+    async def _rpc_call(self, method: str, *args, **kwargs) -> Any:
+        """Make an RPC call to the AsyncLLM subprocess."""
+        if not self._subprocess_started:
+            raise RuntimeError(
+                "AsyncLLM subprocess not started. "
+                "Call start() first or use auto_start=True")
+        if not self.socket:
+            raise RuntimeError(
+                "Not connected to AsyncLLM subprocess")
+
+        request_id = str(uuid.uuid4())
+        msg = RPCMessageType(
+            request_id=request_id,
+            method=method,
+            args_pickle=cloudpickle.dumps(args),
+            kwargs_pickle=cloudpickle.dumps(kwargs),
+            is_generator=False
+        )
+
+        # Send request as single message
+        await self.socket.send(b"RPC|" + msgspec.msgpack.encode(msg))
+
+        # Wait for response
+        raw_response = await self.socket.recv()
+        # Parse response format: TYPE|PAYLOAD
+        delimiter_idx = raw_response.find(b'|')
+        if delimiter_idx == -1:
+            raise RuntimeError("Invalid response format")
+        response_type = raw_response[:delimiter_idx]
+        if response_type != b"RPC_RESPONSE":
+            raise RuntimeError(f"Unexpected response type: {response_type}")
+
+        response = msgspec.msgpack.decode(raw_response[delimiter_idx+1:], type=RPCResponse)
+        if response.error:
+            raise RuntimeError(f"RPC error: {response.error}")
+
+        return cloudpickle.loads(response.result_pickle)
+
+    async def _rpc_generator(self, method: str, *args,
+                             **kwargs) -> AsyncGenerator:
+        """Make an RPC call that returns an async generator."""
+        if not self._subprocess_started:
+            raise RuntimeError(
+                "AsyncLLM subprocess not started. "
+                "Call start() first or use auto_start=True")
+        if not self.socket:
+            raise RuntimeError(
+                "Not connected to AsyncLLM subprocess")
+
+        request_id = str(uuid.uuid4())
+
+        # Initial call to start the generator
+        msg = RPCMessageType(
+            request_id=request_id,
+            method=method,
+            args_pickle=cloudpickle.dumps(args),
+            kwargs_pickle=cloudpickle.dumps(kwargs),
+            is_generator=True
+        )
+
+        await self.socket.send(b"RPC|" + msgspec.msgpack.encode(msg))
+
+        # Get initial response
+        raw_response = await self.socket.recv()
+        delimiter_idx = raw_response.find(b'|')
+        if delimiter_idx == -1:
+            raise RuntimeError("Invalid response format")
+        response_type = raw_response[:delimiter_idx]
+        if response_type != b"RPC_RESPONSE":
+            raise RuntimeError(f"Unexpected response type: {response_type}")
+
+        response = msgspec.msgpack.decode(raw_response[delimiter_idx+1:], type=RPCResponse)
+        if response.error:
+            raise RuntimeError(f"RPC error: {response.error}")
+
+        # Now iterate through generator items
+        while True:
+            # Request next item
+            next_msg = RPCMessageType(
+                request_id=str(uuid.uuid4()),
+                method="_generator_next",
+                args_pickle=cloudpickle.dumps((request_id,))
+            )
+
+            await self.socket.send(b"RPC|" + msgspec.msgpack.encode(next_msg))
+
+            raw_response = await self.socket.recv()
+            delimiter_idx = raw_response.find(b'|')
+            if delimiter_idx == -1:
+                raise RuntimeError("Invalid response format")
+            response_type = raw_response[:delimiter_idx]
+            if response_type != b"RPC_RESPONSE":
+                raise RuntimeError(f"Unexpected response type: {response_type}")
+
+            response = msgspec.msgpack.decode(raw_response[delimiter_idx+1:], type=RPCResponse)
+            if response.error:
+                raise RuntimeError(f"RPC error: {response.error}")
+
+            if response.generator_done:
+                break
+
+            yield cloudpickle.loads(response.result_pickle)
+
+    async def _get_property(self, property_name: str) -> Any:
+        """Get a property value from the AsyncLLM subprocess."""
+        if not self._subprocess_started:
+            raise RuntimeError(
+                "AsyncLLM subprocess not started. "
+                "Call start() first or use auto_start=True")
+        if not self.socket:
+            raise RuntimeError(
+                "Not connected to AsyncLLM subprocess")
+
+        request_id = str(uuid.uuid4())
+        msg = PropertyRequest(request_id=request_id,
+                              property_name=property_name)
+
+        await self.socket.send(b"PROPERTY|" + msgspec.msgpack.encode(msg))
+
+        raw_response = await self.socket.recv()
+        delimiter_idx = raw_response.find(b'|')
+        if delimiter_idx == -1:
+            raise RuntimeError("Invalid response format")
+        response_type = raw_response[:delimiter_idx]
+        if response_type != b"PROPERTY_RESPONSE":
+            raise RuntimeError(f"Unexpected response type: {response_type}")
+
+        response = msgspec.msgpack.decode(raw_response[delimiter_idx+1:], type=PropertyResponse)
+        if response.error:
+            raise RuntimeError(f"Property error: {response.error}")
+
+        return cloudpickle.loads(response.value_pickle)
+
+    # Implement all AsyncLLM methods
+    async def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
+        return await self._rpc_call("get_supported_tasks")
+
+    async def add_request(
+        self,
+        request_id: str,
+        prompt: PromptType,
+        params: Union[SamplingParams, PoolingParams],
+        arrival_time: Optional[float] = None,
+        lora_request: Optional[LoRARequest] = None,
+        tokenization_kwargs: Optional[dict[str, Any]] = None,
+        trace_headers: Optional[Mapping[str, str]] = None,
+        priority: int = 0,
+        data_parallel_rank: Optional[int] = None,
+    ) -> RequestOutputCollector:
+        return await self._rpc_call(
+            "add_request",
+            request_id,
+            prompt,
+            params,
+            arrival_time,
+            lora_request,
+            tokenization_kwargs,
+            trace_headers,
+            priority,
+            data_parallel_rank
+        )
+
+    async def generate(
+        self,
+        prompt: PromptType,
+        sampling_params: SamplingParams,
+        request_id: str,
+        lora_request: Optional[LoRARequest] = None,
+        trace_headers: Optional[Mapping[str, str]] = None,
+        priority: int = 0,
+        data_parallel_rank: Optional[int] = None,
+    ) -> AsyncGenerator[RequestOutput, None]:
+        async for output in self._rpc_generator(
+            "generate",
+            prompt,
+            sampling_params,
+            request_id,
+            lora_request,
+            trace_headers,
+            priority,
+            data_parallel_rank
+        ):
+            yield output
+
+    async def abort(self, request_id: Union[str, list[str]]) -> None:
+        await self._rpc_call("abort", request_id)
+
+    async def encode(
+        self,
+        prompt: PromptType,
+        pooling_params: PoolingParams,
+        request_id: str,
+        lora_request: Optional[LoRARequest] = None,
+        trace_headers: Optional[Mapping[str, str]] = None,
+        priority: int = 0,
+        truncate_prompt_tokens: Optional[int] = None,
+        tokenization_kwargs: Optional[dict[str, Any]] = None,
+    ) -> AsyncGenerator[PoolingRequestOutput, None]:
+        async for output in self._rpc_generator(
+            "encode",
+            prompt,
+            pooling_params,
+            request_id,
+            lora_request,
+            trace_headers,
+            priority,
+            truncate_prompt_tokens,
+            tokenization_kwargs
+        ):
+            yield output
+
+    async def get_vllm_config(self) -> VllmConfig:
+        return await self._rpc_call("get_vllm_config")
+
+    async def get_model_config(self) -> ModelConfig:
+        return await self._rpc_call("get_model_config")
+
+    async def get_input_preprocessor(self) -> InputPreprocessor:
+        return await self._rpc_call("get_input_preprocessor")
+
+    async def get_tokenizer(self) -> AnyTokenizer:
+        return await self._rpc_call("get_tokenizer")
+
+    async def is_tracing_enabled(self) -> bool:
+        return await self._rpc_call("is_tracing_enabled")
+
+    async def do_log_stats(self) -> None:
+        await self._rpc_call("do_log_stats")
+
+    async def check_health(self) -> None:
+        await self._rpc_call("check_health")
+
+    async def start_profile(self) -> None:
+        await self._rpc_call("start_profile")
+
+    async def stop_profile(self) -> None:
+        await self._rpc_call("stop_profile")
+
+    async def reset_mm_cache(self) -> None:
+        await self._rpc_call("reset_mm_cache")
+
+    async def reset_prefix_cache(self,
+                                 device: Optional[Device] = None) -> None:
+        await self._rpc_call("reset_prefix_cache", device)
+
+    async def sleep(self, level: int = 1) -> None:
+        await self._rpc_call("sleep", level)
+
+    async def wake_up(self, tags: Optional[list[str]] = None) -> None:
+        await self._rpc_call("wake_up", tags)
+
+    async def is_sleeping(self) -> bool:
+        return await self._rpc_call("is_sleeping")
+
+    async def add_lora(self, lora_request: LoRARequest) -> bool:
+        return await self._rpc_call("add_lora", lora_request)
+
+    async def remove_lora(self, lora_id: int) -> bool:
+        return await self._rpc_call("remove_lora", lora_id)
+
+    async def list_loras(self) -> set[int]:
+        return await self._rpc_call("list_loras")
+
+    async def pin_lora(self, lora_id: int) -> bool:
+        return await self._rpc_call("pin_lora", lora_id)
+
+    async def collective_rpc(
+        self,
+        method: str,
+        timeout: Optional[float] = None,
+        args: tuple = (),
+        kwargs: Optional[dict] = None
+    ):
+        return await self._rpc_call(
+            "collective_rpc", method, timeout, args, kwargs)
+
+    async def wait_for_requests_to_drain(self, drain_timeout: int = 300):
+        await self._rpc_call("wait_for_requests_to_drain", drain_timeout)
+
+    async def scale_elastic_ep(self, new_data_parallel_size: int,
+                               drain_timeout: int = 300):
+        await self._rpc_call(
+            "scale_elastic_ep", new_data_parallel_size, drain_timeout)
+
+    # Properties
+    @property
+    def is_running(self) -> bool:
+        return (self._is_running and
+                (self.process is not None and self.process.is_alive()))
+
+    @property
+    def is_stopped(self) -> bool:
+        return not self.is_running
+
+    @property
+    def errored(self) -> bool:
+        # Synchronous property - cannot make async RPC call
+        # Return False as default; actual error handling is via exceptions
+        return False
+
+    @property
+    def dead_error(self) -> BaseException:
+        # Synchronous property - cannot make async RPC call
+        # Return a default exception; actual error handling is via exceptions
+        return RuntimeError("Engine error - check logs for details")
+
+    # CRIU-specific methods
+    async def criu_checkpoint(
+            self, checkpoint_dir: str,
+            cuda_checkpoint_path: str = "cuda-checkpoint") -> None:
+        """Checkpoint the AsyncLLM subprocess using CRIU.
+
+        Args:
+            checkpoint_dir: Directory to save checkpoint files
+            cuda_checkpoint_path: Unused; kept for backward compatibility
+        """
+        if not self._subprocess_started:
+            raise RuntimeError(
+                "AsyncLLM subprocess not started. "
+                "Call start() first")
+        if not self.process or not self.process.is_alive():
+            raise RuntimeError("AsyncLLM subprocess is not running")
+
+        self.checkpoint_dir = checkpoint_dir
+        try:
+            os.makedirs(checkpoint_dir, exist_ok=False)
+        except FileExistsError as err:
+            raise RuntimeError(
+                "Checkpoint directory "
+                f"{checkpoint_dir} already exists. "
+                "Please delete it before checkpointing."
+            ) from err
+
+        # Root of the subprocess tree
+        root_pid = self.process.pid
+
+        # Validate that only leaf processes have CUDA contexts
+        logger.info("Getting CUDA process tree...")
+        cuda_pids = find_gpu_worker_pids(root_pid)
+
+
+        # Sleep the model (level 1) to free GPU memory before checkpointing
+        logger.info("Putting model to sleep (level 1) before checkpoint...")
+        await self.sleep(level=1)
+        logger.info("Model sleep completed")
+
+        
+
+        # Create checkpoint metadata
+        metadata = CheckpointMetadata()
+
+        # Get TTY info from the subprocess
+        rdev, dev = get_tty_info(root_pid)
+        metadata.tty_rdev = rdev
+        metadata.tty_dev = dev
+
+        # Save process tree info
+        metadata.tree_pid = root_pid
+        metadata.zmq_port = self.port
+        metadata.cuda_pids = cuda_pids
+
+        # Take a snapshot of the process tree (for post-dump verification)
+        pre_dump_tree = collect_process_tree_pids(root_pid)
+
+        # Build CRIU dump command
+        cmd = [
+            "criu", "dump",
+            "--shell-job",
+            "--images-dir", checkpoint_dir,
+            "-o", "criu-dump.log",
+            "-v4",
+            "--ext-unix-sk",
+            "--tcp-established",
+            "--external", "mnt[shm]:/dev/shm",
+            "--link-remap",
+            "--manage-cgroups=ignore",
+            "--tree", str(root_pid),
+            "--ghost-limit", "50M",
+            "--timeout", "1800",
+        ]
+
+        if metadata.tty_external:
+            cmd.extend(["--external", metadata.tty_external])
+
+        logger.info("Running CRIU dump: %s", ' '.join(cmd))
+
+        # Run CRIU dump
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            raise RuntimeError(f"CRIU dump failed: {result.stderr}")
+
+        logger.info(
+            "Successfully checkpointed AsyncLLM to %s", checkpoint_dir)
+
+        # Save all metadata to JSON file
+        metadata.save(checkpoint_dir)
+
+        # Reap the child process to avoid a zombie holding the PID.
+        # This ensures /proc/<pid> disappears if the process is already dead.
+        if self.process is not None:
+            try:
+                self.process.join(timeout=5)
+            except Exception as err:
+                raise RuntimeError("Failed to reap child process") from err
+
+        # Verify that all processes in the pre-dump tree are gone.
+        # This helps catch stray children that might linger due to plugins.
+        verify_processes_exited(pre_dump_tree)
+
+        # The process is now frozen, mark it as not running
+        self._is_running = False
+        self.process = None
+
+        # Close the socket connection
+        if self.socket:
+            self.socket.close()
+            self.socket = None
+
+    async def criu_resume(
+            self, cuda_checkpoint_path: str = "cuda-checkpoint") -> None:
+        """Restore from CRIU checkpoint.
+
+        This method:
+        1. Restores the AsyncLLM subprocess from CRIU checkpoint
+        2. Re-establishes the ZMQ connection
+        3. Wakes up the model to restore GPU memory
+
+        Args:
+            cuda_checkpoint_path: Path to cuda-checkpoint utility (not used)
+        """
+        if not self.checkpoint_dir:
+            raise RuntimeError(
+                "No checkpoint directory set. Call criu_checkpoint first.")
+
+        # Load checkpoint metadata
+        metadata = CheckpointMetadata.load(self.checkpoint_dir)
+        if metadata is None:
+            raise RuntimeError(
+                f"Could not load checkpoint metadata from {self.checkpoint_dir}")
+
+        # Use the saved port from checkpoint
+        assert metadata.zmq_port is not None
+        self.port = metadata.zmq_port
+        self.socket_url = f"tcp://127.0.0.1:{self.port}"
+        logger.info("Using saved port %d from checkpoint", self.port)
+
+        # Ensure the original tree PID from dump is fully gone to avoid
+        # PID collisions when restoring into the same PID namespace.
+        if metadata.tree_pid:
+            start = time.time()
+            # Wait up to a short grace period since dump should have killed it
+            while time.time() - start < 5.0:
+                if os.system(f"kill -0 {metadata.tree_pid} >/dev/null 2>&1") != 0:
+                    break
+                await asyncio.sleep(0.05)
+
+            # Verify root PID is not taken now (PID could be reused by others)
+            pid_path = f"/proc/{metadata.tree_pid}"
+            if os.path.exists(pid_path):
+                # Try to read the cmdline of the holder for diagnostics
+                holder = ""
+                try:
+                    cmd_path = os.path.join(pid_path, "cmdline")
+                    with open(cmd_path, "rb") as f:
+                        raw = f.read().replace(b"\x00", b" ")
+                        holder = raw.decode("utf-8", "ignore").strip()
+                except Exception:
+                    holder = ""
+                msg = (
+                    "CRIU restore pre-check failed: root PID "
+                    f"{metadata.tree_pid} is in use in current PID namespace. "
+                    "Restore will fail with EEXIST. Consider restoring in a "
+                    "new PID namespace or wait until the PID is free."
+                )
+                if holder:
+                    logger.error(
+                        "%s Holder cmdline: %s",
+                        msg,
+                        holder,
+                    )
+                else:
+                    logger.error("%s", msg)
+
+        # Build CRIU restore command
+        cmd = [
+            "criu", "restore",
+            "--shell-job",
+            "--restore-detached",
+            "--images-dir", self.checkpoint_dir,
+            "-o", "criu-restore.log",
+            "-v4",
+            "--ext-unix-sk",
+            "--tcp-established",
+            "--external", "mnt[shm]:/dev/shm",
+            "--link-remap",
+            "--manage-cgroups=ignore",
+            "--ghost-limit", "50M",
+        ]
+
+        # Provide a valid TTY to CRIU using a Python-created pty, so we can
+        # mirror logs back to this terminal and support non-TTY parents.
+        # We pass the pty worker fd to CRIU and map it to the saved TTY id.
+        pass_fds = ()
+        pty_main_fd = None
+        pty_worker_fd = None
+        if metadata.tty_external:
+            try:
+                pty_main_fd, pty_worker_fd = pty.openpty()
+                os.set_inheritable(pty_worker_fd, True)
+                # Map the saved tty id to the pty worker fd in CRIU
+                cmd.extend([
+                    "--inherit-fd", f"fd[{pty_worker_fd}]:{metadata.tty_external}",
+                ])
+                pass_fds = (pty_worker_fd,)
+            except Exception as e:
+                logger.warning("Failed to create PTY for CRIU restore: %s", e)
+
+        logger.info("Running CRIU restore: %s", ' '.join(cmd))
+
+        # Run CRIU restore
+        if pass_fds:
+            result = subprocess.run(cmd, capture_output=True, text=True,
+                                    pass_fds=pass_fds)
+        else:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"CRIU restore failed: {result.stderr}")
+
+        logger.info("Successfully restored AsyncLLM from checkpoint")
+
+        # Re-establish connection to the restored process
+        self._is_running = True
+        # Mark subprocess as started after restore
+        self._subprocess_started = True
+
+        # Create new socket and perform reconnection handshake
+        # Re-establish client side of REQ-REP pattern
+        self.socket = self.ctx.socket(zmq.REQ)
+        # REQ sockets automatically wait for connection establishment
+        self.socket.connect(self.socket_url)
+
+        # Send reconnection signal and wait for acknowledgment
+        logger.info("Sending reconnection signal to restored process...")
+
+        # With REQ-REP pattern, the socket will block until connected
+        # This should succeed on the first attempt
+        await self.socket.send(b"RECONNECT")
+        logger.info("Waiting for reconnection acknowledgment...")
+
+        # REQ socket will wait for the response
+        # Use a generous timeout for post-restore initialization
+        if await self.socket.poll(timeout=500000):  # 5 second timeout
+            ack = await self.socket.recv()
+            if ack == b"RECONNECT_ACK":
+                logger.info("Reconnection acknowledged by server")
+            else:
+                raise ValueError(f"Unexpected reconnection response: {ack}")
+        else:
+            raise TimeoutError("No response to reconnection signal after 30 seconds")
+
+        # Wake up the model to restore GPU memory
+        logger.info("Waking up model after restore...")
+        await self.wake_up()
+        logger.info("Model wake up completed")
+
+        # Start forwarding the restored process output to our stdout
+        if pty_main_fd is not None:
+            try:
+                self._start_pty_forwarder(pty_main_fd)
+            except Exception as e:
+                logger.warning("Failed to start PTY forwarder: %s", e)
+        # Close the worker fd in this process; CRIU/restored proc holds it now
+        if pty_worker_fd is not None:
+            with contextlib.suppress(Exception):
+                os.close(pty_worker_fd)
+
+    def shutdown(self):
+        """Shutdown the subprocess and clean up resources."""
+        # Close PTY main if present
+        if getattr(self, "_pty_main_fd", None) is not None:
+            with contextlib.suppress(Exception):
+                os.close(self._pty_main_fd)  # type: ignore[arg-type]
+            self._pty_main_fd = None
+
+        # Try to send shutdown signal if we have a socket connection
+        # This works both for normal operation and after CRIU restore
+        if self.socket and self._is_running:
+            try:
+                # Create a synchronous context for shutdown
+                sync_ctx = zmq.Context()
+                sync_socket = sync_ctx.socket(zmq.REQ)
+                sync_socket.connect(self.socket_url)
+
+                # Send shutdown signal and wait for acknowledgment
+                sync_socket.send(b"SHUTDOWN")
+                logger.info("Sent SHUTDOWN signal to AsyncLLM subprocess")
+                # Wait for acknowledgment with timeout
+                if sync_socket.poll(timeout=5000):  # 5 second timeout
+                    ack = sync_socket.recv()
+                    logger.debug("Received shutdown acknowledgment: %s", ack)
+                else:
+                    logger.warning("No shutdown acknowledgment received")
+
+                # If we have a process reference (normal operation), wait for it
+                if self.process and self.process.is_alive():
+                    # Wait for the process to exit gracefully
+                    # (give it more time)
+                    shutdown_timeout = 30  # 30 seconds for graceful shutdown
+                    self.process.join(timeout=shutdown_timeout)
+
+                    if self.process.is_alive():
+                        logger.warning(
+                            "AsyncLLM subprocess did not exit gracefully "
+                            "after %d seconds, terminating...",
+                            shutdown_timeout)
+                        self.process.terminate()
+                        self.process.join(timeout=5)
+
+                        if self.process.is_alive():
+                            logger.error(
+                                "AsyncLLM subprocess did not terminate, "
+                                "killing...")
+                            self.process.kill()
+                            self.process.join()
+                else:
+                    # After CRIU restore, we don't have process reference
+                    # Give processes time to shutdown gracefully
+                    time.sleep(2)
+
+                sync_socket.close()
+                sync_ctx.term()
+            except Exception as e:
+                logger.error("Error during shutdown: %s", e)
+                # Force kill if graceful shutdown fails and we have process ref
+                if self.process and self.process.is_alive():
+                    self.process.kill()
+
+        # Close async socket
+        if self.socket:
+            self.socket.close()
+
+        if self.ctx:
+            self.ctx.term()
+
+        self._is_running = False
+
+    def __del__(self):
+        self.shutdown()
+
+
+    # ----- Internal helpers for CRIU PTY forwarding -----
+    def _start_pty_forwarder(self, main_fd: int) -> None:
+        """Forward data from PTY main fd to this process' stdout.
+
+        This mirrors the restored process' stdout/stderr back
+        into the controlling terminal running CheckpointableAsyncLLM.
+        """
+        self._pty_main_fd = main_fd
+        logger.debug("Starting PTY forwarder for fd %d", main_fd)
+
+        def _forward_loop(fd: int):
+            try:
+                os.set_blocking(fd, False)  # Non-blocking reads
+                logger.debug("PTY forwarder started for fd %d", fd)
+                while True:
+                    try:
+                        data = os.read(fd, 4096)
+                        if not data:
+                            break
+                        # Write raw bytes to stdout to preserve ANSI
+                        # sequences
+                        sys.stdout.buffer.write(data)
+                        sys.stdout.buffer.flush()
+                    except OSError as e:
+                        if e.errno == errno.EAGAIN:
+                            time.sleep(0.01)
+                            continue
+                        raise
+                    except InterruptedError:
+                        continue
+            except Exception as e:
+                logger.debug("PTY forwarder stopped: %s", e)
+            finally:
+                with contextlib.suppress(Exception):
+                    os.close(fd)
+                if getattr(self, "_pty_main_fd", None) == fd:
+                    self._pty_main_fd = None
+
+        t = threading.Thread(target=_forward_loop,
+                             args=(main_fd,),
+                             name="criu-pty-forwarder",
+                             daemon=True)
+        t.start()
+        self._pty_forwarder_thread = t
+
+    @classmethod
+    def from_vllm_config(
+        cls,
+        vllm_config: VllmConfig,
+        start_engine_loop: bool = True,
+        usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
+        stat_loggers: Optional[list[StatLoggerFactory]] = None,
+        enable_log_requests: bool = False,
+        disable_log_stats: bool = False,
+        client_addresses: Optional[dict[str, str]] = None,
+        client_count: int = 1,
+        client_index: int = 0,
+        auto_start: bool = True,
+    ) -> "CheckpointableAsyncLLM":
+        """Create CheckpointableAsyncLLM from VllmConfig."""
+        # Validate required settings for checkpointing
+        if not vllm_config.model_config.enable_sleep_mode:
+            raise ValueError(
+                "enable_sleep_mode must be True in vllm_config for checkpointing. "
+                "Sleep mode is required to omit KV cache from the checkpoint image."
+            )
+        
+        if hasattr(vllm_config.parallel_config, 'disable_custom_all_reduce'):
+            if not vllm_config.parallel_config.disable_custom_all_reduce:
+                raise ValueError(
+                    "disable_custom_all_reduce must be True in vllm_config for checkpointing. "
+                    "Custom all-reduce uses CUDA IPC which is not compatible with CRIU."
+                )
+        
+        return cls(
+            vllm_config=vllm_config,
+            executor_class=Executor.get_class(vllm_config),
+            start_engine_loop=start_engine_loop,
+            stat_loggers=stat_loggers,
+            log_requests=enable_log_requests,
+            log_stats=not disable_log_stats,
+            usage_context=usage_context,
+            client_addresses=client_addresses,
+            client_count=client_count,
+            client_index=client_index,
+            auto_start=auto_start,
+        )
+
+    @classmethod
+    def from_engine_args(
+        cls,
+        engine_args: AsyncEngineArgs,
+        start_engine_loop: bool = True,
+        usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
+        stat_loggers: Optional[list[StatLoggerFactory]] = None,
+        auto_start: bool = True,
+    ) -> "CheckpointableAsyncLLM":
+        """Create CheckpointableAsyncLLM from EngineArgs.
+
+        Args:
+            engine_args: Engine configuration arguments
+            start_engine_loop: Whether to start the engine loop
+            usage_context: Usage context for the engine
+            stat_loggers: Optional stat logger factories
+            auto_start: Whether to automatically start the subprocess
+            port: Optional port to use for ZMQ connection (for restore)
+
+        Returns:
+            CheckpointableAsyncLLM instance
+        """
+        # Force enable sleep mode and disable custom all reduce for checkpointing
+        if not engine_args.enable_sleep_mode:
+            logger.warning("enable_sleep_mode was False, forcing to True for checkpointing")
+            engine_args.enable_sleep_mode = True
+        
+        if not engine_args.disable_custom_all_reduce:
+            logger.warning("disable_custom_all_reduce was False, forcing to True for checkpointing")
+            engine_args.disable_custom_all_reduce = True
+        
+        vllm_config = create_engine_config_isolated(engine_args)
+
+        return cls(
+            vllm_config=vllm_config,
+            executor_class=Executor.get_class(vllm_config),
+            log_requests=engine_args.enable_log_requests,
+            log_stats=not engine_args.disable_log_stats,
+            start_engine_loop=start_engine_loop,
+            usage_context=usage_context,
+            stat_loggers=stat_loggers,
+            auto_start=auto_start,
+        )

--- a/components/src/dynamo/vllm/checkpoint/metadata.py
+++ b/components/src/dynamo/vllm/checkpoint/metadata.py
@@ -19,6 +19,17 @@ class CheckpointMetadata:
         self.tree_pid: Optional[int] = None
         self.zmq_port: Optional[int] = None
         self.cuda_pids: list[int] = []
+        # List of POSIX shared memory/tmpfs files under /dev/shm that were open
+        # by the process tree at checkpoint time. Each entry is a dict with
+        # keys: name (basename in /dev/shm), size (bytes), mode (int file mode).
+        self.dev_shm_files: list[dict] = []
+        # List of GPU UUIDs in the order they appear to CUDA at checkpoint time
+        self.gpu_uuids: list[str] = []
+        # Primary IP address of the system at checkpoint time
+        self.primary_ip: Optional[str] = None
+        # Cache directory paths at checkpoint time
+        self.vllm_cache_path: Optional[str] = None
+        self.flashinfer_cache_path: Optional[str] = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
@@ -28,6 +39,11 @@ class CheckpointMetadata:
             "tree_pid": self.tree_pid,
             "zmq_port": self.zmq_port,
             "cuda_pids": self.cuda_pids,
+            "dev_shm_files": self.dev_shm_files,
+            "gpu_uuids": self.gpu_uuids,
+            "primary_ip": self.primary_ip,
+            "vllm_cache_path": self.vllm_cache_path,
+            "flashinfer_cache_path": self.flashinfer_cache_path,
         }
 
     @classmethod
@@ -39,6 +55,11 @@ class CheckpointMetadata:
         meta.tree_pid = data.get("tree_pid")
         meta.zmq_port = data.get("zmq_port")
         meta.cuda_pids = data.get("cuda_pids", [])
+        meta.dev_shm_files = data.get("dev_shm_files", [])
+        meta.gpu_uuids = data.get("gpu_uuids", [])
+        meta.primary_ip = data.get("primary_ip")
+        meta.vllm_cache_path = data.get("vllm_cache_path")
+        meta.flashinfer_cache_path = data.get("flashinfer_cache_path")
         return meta
 
     def save(self, checkpoint_dir: str) -> None:

--- a/components/src/dynamo/vllm/checkpoint/metadata.py
+++ b/components/src/dynamo/vllm/checkpoint/metadata.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Checkpoint metadata management for CRIU checkpoint/restore."""
+
+import json
+import os
+from typing import Optional
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class CheckpointMetadata:
+    """Metadata saved alongside CRIU checkpoint for restore."""
+
+    def __init__(self):
+        self.tty_rdev: Optional[str] = None
+        self.tty_dev: Optional[str] = None
+        self.tree_pid: Optional[int] = None
+        self.zmq_port: Optional[int] = None
+        self.cuda_pids: list[int] = []
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "tty_rdev": self.tty_rdev,
+            "tty_dev": self.tty_dev,
+            "tree_pid": self.tree_pid,
+            "zmq_port": self.zmq_port,
+            "cuda_pids": self.cuda_pids,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "CheckpointMetadata":
+        """Create from dictionary loaded from JSON."""
+        meta = cls()
+        meta.tty_rdev = data.get("tty_rdev")
+        meta.tty_dev = data.get("tty_dev")
+        meta.tree_pid = data.get("tree_pid")
+        meta.zmq_port = data.get("zmq_port")
+        meta.cuda_pids = data.get("cuda_pids", [])
+        return meta
+
+    def save(self, checkpoint_dir: str) -> None:
+        """Save metadata to JSON file in checkpoint directory."""
+        try:
+            path = os.path.join(checkpoint_dir, "vllm_checkpoint_metadata.json")
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(self.to_dict(), f, indent=2)
+            logger.info("Saved checkpoint metadata to %s", path)
+        except Exception as e:
+            logger.warning("Failed to save checkpoint metadata: %s", e)
+
+    @classmethod
+    def load(cls, checkpoint_dir: str) -> Optional["CheckpointMetadata"]:
+        """Load metadata from JSON file in checkpoint directory."""
+        try:
+            path = os.path.join(checkpoint_dir, "vllm_checkpoint_metadata.json")
+            if not os.path.exists(path):
+                logger.warning("Checkpoint metadata file not found: %s", path)
+                return None
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            return cls.from_dict(data)
+        except Exception as e:
+            logger.warning("Failed to load checkpoint metadata: %s", e)
+            return None
+
+    @property
+    def tty_external(self) -> Optional[str]:
+        """Format TTY info for CRIU external option."""
+        if self.tty_rdev and self.tty_dev:
+            return f"tty[{self.tty_rdev}:{self.tty_dev}]"
+        return None

--- a/components/src/dynamo/vllm/checkpoint/metadata.py
+++ b/components/src/dynamo/vllm/checkpoint/metadata.py
@@ -1,5 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Checkpoint metadata management for CRIU checkpoint/restore."""
 
 import json

--- a/components/src/dynamo/vllm/checkpoint/test_checkpoint_restore.py
+++ b/components/src/dynamo/vllm/checkpoint/test_checkpoint_restore.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 #!/usr/bin/env python3
 """
 Test checkpoint/restore functionality of CheckpointableAsyncLLM.

--- a/components/src/dynamo/vllm/checkpoint/test_checkpoint_restore.py
+++ b/components/src/dynamo/vllm/checkpoint/test_checkpoint_restore.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+Test checkpoint/restore functionality of CheckpointableAsyncLLM.
+
+This test:
+1. Starts the engine
+2. Waits for readiness
+3. Runs a test generation to verify functionality
+4. Checkpoints the engine (cuda-checkpoint + CRIU)
+5. Restores from checkpoint
+6. Runs another generation to verify functionality after restore
+
+NOTE: This test requires sudo privileges for CRIU operations.
+Run with: sudo -E python3 test_checkpoint_restore.py
+Or use the provided script: ./test_checkpoint_restore_sudo.sh
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import tempfile
+
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.sampling_params import SamplingParams
+from dynamo.vllm.checkpoint import CheckpointableAsyncLLM
+
+# Enable debug logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def get_engine_args():
+    """Get standard engine arguments."""
+    return AsyncEngineArgs(
+        model="Qwen/Qwen3-0.6B",
+        max_model_len=512,
+        disable_custom_all_reduce=True,
+        enable_sleep_mode=True,
+    )
+
+
+async def test_restore_only(checkpoint_dir):
+    """Test restore-only functionality from an existing checkpoint."""
+    print("\n=== Testing Restore-Only Functionality ===\n")
+    print(f"Restoring from checkpoint directory: {checkpoint_dir}")
+
+    if not os.path.exists(checkpoint_dir):
+        raise ValueError(f"Checkpoint directory does not exist: {checkpoint_dir}")
+
+    try:
+        # Phase 1: Create new instance and restore
+        print("\n--- Phase 1: Restoring from checkpoint ---")
+        engine_args = get_engine_args()
+
+        # Create a new instance without auto-starting
+        llm_restored = CheckpointableAsyncLLM.from_engine_args(
+            engine_args,
+            auto_start=False
+        )
+
+        # Set the checkpoint directory
+        llm_restored.checkpoint_dir = checkpoint_dir
+
+        print(f"Restoring from: {checkpoint_dir}")
+        # This internally runs CRIU restore and cuda-checkpoint restore/unlock
+        await llm_restored.criu_resume()
+        print("Restore completed successfully!")
+
+        # Phase 2: Test generation after restore
+        print("\n--- Phase 2: Testing generation after restore ---")
+        test_prompt = "The capital of France is"
+        sampling_params = SamplingParams(
+            temperature=0.0,  # Deterministic
+            max_tokens=10,
+        )
+
+        print(f"Prompt: {test_prompt}")
+        print("Generating...")
+
+        outputs_after = []
+        async for output in llm_restored.generate(
+            test_prompt,
+            sampling_params,
+            request_id="test-after-restore"
+        ):
+            if output.finished:
+                outputs_after.append(output)
+
+        if outputs_after:
+            generated_text_after = outputs_after[-1].outputs[0].text
+            print(f"Generated: {generated_text_after}")
+            assert len(generated_text_after.strip()) > 0, \
+                "No output generated after restore"
+        else:
+            raise RuntimeError("No output received after restore")
+
+        # Cleanup
+        print("\n--- Phase 3: Cleanup ---")
+        llm_restored.shutdown()
+        print("Shutdown complete")
+
+        print("\n=== Test Passed! ===")
+        print("Successfully:")
+        print("- Restored from checkpoint")
+        print("- Generated text after restore")
+        print("- Verified engine remains functional after restore")
+
+    except Exception:
+        raise
+
+
+async def test_checkpoint_restore():
+    """Test full checkpoint/restore cycle."""
+    print("\n=== Testing Checkpoint/Restore Functionality ===\n")
+
+    # Generate a unique checkpoint directory path (but don't create it)
+    checkpoint_dir = tempfile.mktemp(
+        prefix="vllm_test_checkpoint_", dir="/tmp")
+    print(f"Will use checkpoint directory: {checkpoint_dir}")
+
+    try:
+
+        # Phase 1: Start engine and verify it works
+        print("\n--- Phase 1: Starting engine ---")
+        engine_args = get_engine_args()
+
+        llm = CheckpointableAsyncLLM.from_engine_args(engine_args)
+
+        # Wait for engine to be fully ready
+        print("Waiting for engine to be fully initialized...")
+        await llm.wait_until_ready()
+        print("Engine is ready!")
+
+        # Test generation before checkpoint
+        print("\n--- Phase 2: Testing generation before checkpoint ---")
+        test_prompt = "The capital of France is"
+        sampling_params = SamplingParams(
+            temperature=0.0,  # Deterministic
+            max_tokens=10,
+        )
+
+        print(f"Prompt: {test_prompt}")
+        print("Generating...")
+
+        outputs_before = []
+        async for output in llm.generate(
+            test_prompt,
+            sampling_params,
+            request_id="test-before-checkpoint"
+        ):
+            if output.finished:
+                outputs_before.append(output)
+
+        if outputs_before:
+            generated_text = outputs_before[-1].outputs[0].text
+            print(f"Generated: {generated_text}")
+            assert len(generated_text.strip()) > 0, "No output generated"
+        else:
+            raise RuntimeError("No output received before checkpoint")
+
+        # Phase 3: Checkpoint the engine
+        print("\n--- Phase 3: Checkpointing engine ---")
+        print(f"Checkpointing to: {checkpoint_dir}")
+
+        # This internally runs cuda-checkpoint lock/checkpoint and CRIU dump
+        await llm.criu_checkpoint(checkpoint_dir)
+        print("Checkpoint completed successfully!")
+
+        # The engine is now stopped, llm object is no longer usable
+        print("Engine has been checkpointed and stopped")
+
+        # Phase 4: Create new instance and restore
+        print("\n--- Phase 4: Restoring from checkpoint ---")
+
+        # Create a new instance without auto-starting
+        llm_restored = CheckpointableAsyncLLM.from_engine_args(
+            engine_args,
+            auto_start=False
+        )
+
+        # Set the checkpoint directory
+        llm_restored.checkpoint_dir = checkpoint_dir
+
+        print(f"Restoring from: {checkpoint_dir}")
+        # This internally runs CRIU restore and cuda-checkpoint restore/unlock
+        await llm_restored.criu_resume()
+        print("Restore completed successfully!")
+
+        # Phase 5: Test generation after restore
+        print("\n--- Phase 5: Testing generation after restore ---")
+        print(f"Prompt: {test_prompt}")
+        print("Generating...")
+
+        outputs_after = []
+        async for output in llm_restored.generate(
+            test_prompt,
+            sampling_params,
+            request_id="test-after-restore"
+        ):
+            if output.finished:
+                outputs_after.append(output)
+
+        if outputs_after:
+            generated_text_after = outputs_after[-1].outputs[0].text
+            print(f"Generated: {generated_text_after}")
+            assert len(generated_text_after.strip()) > 0, \
+                "No output generated after restore"
+
+            # Check if outputs are consistent
+            # (should be identical with temperature=0)
+            if generated_text == generated_text_after:
+                print("\n✓ Outputs are consistent before and after "
+                      "checkpoint/restore!")
+            else:
+                print("\n⚠ Outputs differ:")
+                print(f"  Before: {generated_text}")
+                print(f"  After:  {generated_text_after}")
+                print("  This may be expected due to engine state differences")
+        else:
+            raise RuntimeError("No output received after restore")
+
+        # Cleanup
+        print("\n--- Phase 6: Cleanup ---")
+        llm_restored.shutdown()
+        print("Shutdown complete")
+
+        print("\n=== Test Passed! ===")
+        print("Successfully:")
+        print("- Started engine and waited for readiness")
+        print("- Generated text before checkpoint")
+        print("- Checkpointed engine (cuda-checkpoint + CRIU)")
+        print("- Restored from checkpoint")
+        print("- Generated text after restore")
+        print("- Verified engine remains functional after restore")
+
+    except Exception:
+        raise
+    finally:
+        # Clean up checkpoint directory if it exists
+        # Comment this out to preserve logs for debugging
+        # if os.path.exists(checkpoint_dir):
+        #     shutil.rmtree(checkpoint_dir)
+        #     print(f"\nCleaned up checkpoint directory: {checkpoint_dir}")
+        print(f"\nCheckpoint directory preserved for debugging: "
+              f"{checkpoint_dir}")
+
+
+async def main():
+    """Run all tests."""
+    parser = argparse.ArgumentParser(
+        description="Test checkpoint/restore functionality of CheckpointableAsyncLLM"
+    )
+    parser.add_argument(
+        "--restore-only",
+        action="store_true",
+        help="Only restore from an existing checkpoint (skip checkpoint creation)"
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
+        type=str,
+        help="Checkpoint directory to restore from (required when --restore-only is used)"
+    )
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if args.restore_only:
+        if not args.checkpoint_dir:
+            parser.error("--checkpoint-dir is required when --restore-only is used")
+
+    try:
+        if args.restore_only:
+            # Restore-only mode
+            await test_restore_only(args.checkpoint_dir)
+        else:
+            # Full checkpoint/restore test
+            await test_checkpoint_restore()
+
+        print("\n🎉 All tests passed!")
+
+    except Exception as e:
+        print(f"\n❌ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        raise
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/components/src/dynamo/vllm/checkpoint/utils.py
+++ b/components/src/dynamo/vllm/checkpoint/utils.py
@@ -1,0 +1,462 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""General utilities for checkpoint/restore operations."""
+
+import os
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Try to import cuda-python
+try:
+    from cuda import cuda
+    cuda_available = True
+except Exception:  # pragma: no cover
+    logger.warning("cuda-python package not found. CUDA checkpointing will not be available. "
+                   "Install with: pip install cuda-python")
+    cuda = None
+    cuda_available = False
+
+
+# General checkpoint utilities
+
+def read_comm(pid: int) -> str:
+    """Best-effort read of the process command name."""
+    try:
+        with open(f"/proc/{pid}/comm", encoding="utf-8") as f:
+            return f.read().strip()
+    except Exception:
+        return "?"
+
+
+def read_cmdline(pid: int) -> str:
+    """Best-effort read of the full command line."""
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as f:
+            raw = f.read()
+        if not raw:
+            return ""
+        parts = [p.decode("utf-8", "ignore") for p in raw.split(b"\x00") if p]
+        return " ".join(parts)
+    except Exception:
+        return ""
+
+
+def collect_process_tree_pids(root_pid: int) -> set[int]:
+    """Recursively collect PIDs in the process tree rooted at root_pid.
+
+    Uses /proc/<pid>/task/<pid>/children to discover descendants.
+    Best-effort: missing /proc entries are ignored.
+    """
+    pending: list[int] = [root_pid]
+    seen: set[int] = set[int]()
+    while pending:
+        pid = pending.pop()
+        if pid in seen:
+            continue
+        seen.add(pid)
+        children_path = f"/proc/{pid}/task/{pid}/children"
+        try:
+            with open(children_path, encoding="utf-8") as f:
+                content = f.read().strip()
+        except FileNotFoundError:
+            continue
+        except Exception:
+            continue
+        if not content:
+            continue
+        for token in content.split():
+            try:
+                child = int(token)
+            except ValueError:
+                continue
+            pending.append(child)
+    return seen
+
+
+def process_is_leaf(pid: int) -> bool:
+    """Check if a process is a leaf (has no children).
+
+    Args:
+        pid: Process ID to check
+
+    Returns:
+        True if the process has no children, False otherwise
+    """
+    children_path = f"/proc/{pid}/task/{pid}/children"
+    try:
+        with open(children_path, encoding="utf-8") as f:
+            content = f.read().strip()
+        return not content  # Empty means no children
+    except Exception:
+        # If we can't read, assume it's a leaf to be safe
+        return True
+
+
+def verify_processes_exited(pre_dump_pids: set[int], timeout_s: float = 5.0) -> list[int]:
+    """Verify that all processes from pre-dump snapshot have exited.
+
+    Args:
+        pre_dump_pids: Set of PIDs that existed before CRIU dump
+        timeout_s: Maximum time to wait for processes to exit
+
+    Returns:
+        List of PIDs that are still running after timeout
+    """
+    deadline = time.time() + timeout_s
+    lingering: set[int] = set()
+
+    while time.time() < deadline:
+        lingering = {
+            pid for pid in pre_dump_pids
+            if os.path.exists(f"/proc/{pid}")
+        }
+        if not lingering:
+            break
+        time.sleep(0.05)
+
+    if lingering:
+        logger.error(
+            "CRIU dump verification: %d lingering PIDs: %s",
+            len(lingering),
+            sorted(lingering)
+        )
+        # Collect info about lingering processes
+        for pid in sorted(lingering):
+            try:
+                comm = read_comm(pid)
+                cmdline = read_cmdline(pid)
+                logger.error("  PID %d (%s): %s", pid, comm, cmdline)
+            except Exception:
+                logger.error("  PID %d (unable to read info)", pid)
+    else:
+        logger.info("CRIU dump verification: all pre-dump PIDs have exited")
+
+    return list(lingering)
+
+
+def get_tty_info(pid: int) -> tuple[str, str]:
+    """Get TTY device info for a process.
+
+    Args:
+        pid: Process ID to get TTY info for
+
+    Returns:
+        Tuple of (rdev, dev) as hex strings for CRIU
+    """
+    try:
+        # Get the TTY device from /proc/PID/fd/0
+        tty_path = f"/proc/{pid}/fd/0"
+        st = os.stat(tty_path)
+
+        # Format as hex values for CRIU
+        rdev = f"{st.st_rdev:x}"
+        dev = f"{st.st_dev:x}"
+
+        return rdev, dev
+    except Exception as e:
+        logger.warning("Could not get TTY info: %s", e)
+        return "", ""
+
+
+# CUDA checkpoint utilities
+
+def get_cuda_error_details(err) -> tuple[str, str]:
+    """Get detailed error information from a CUDA error code.
+    
+    Returns:
+        Tuple of (error_name, error_description)
+    """
+    # Get error name
+    _, name_ptr = cuda.cuGetErrorName(err)
+    error_name = name_ptr.decode() if isinstance(name_ptr, bytes) else str(name_ptr)
+    
+    # Get error description
+    try:
+        _, desc_ptr = cuda.cuGetErrorString(err)
+        error_desc = desc_ptr.decode() if isinstance(desc_ptr, bytes) else str(desc_ptr)
+    except Exception:
+        error_desc = "No description available"
+    
+    return error_name, error_desc
+
+
+def get_process_gpu_devices(pid: int) -> list[int]:
+    """Get list of GPU device indices that a process has open file descriptors to.
+    
+    Args:
+        pid: Process ID to check
+        
+    Returns:
+        List of GPU device indices (e.g., [0, 1, 3])
+    """
+    fd_dir = f"/proc/{pid}/fd"
+    devices = set()
+    
+    if not os.path.exists(fd_dir):
+        return []
+    
+    try:
+        for fd in os.listdir(fd_dir):
+            try:
+                link = os.readlink(os.path.join(fd_dir, fd))
+                # Check for /dev/nvidia0, /dev/nvidia1, etc.
+                if link.startswith("/dev/nvidia") and link[12:].isdigit():
+                    device_idx = int(link[12:])
+                    devices.add(device_idx)
+            except Exception:
+                continue
+    except Exception:
+        pass
+    
+    return sorted(list(devices))
+
+
+def log_gpu_memory_for_devices(devices: list[int], context: str = "") -> None:
+    """Log memory usage for specific GPU devices.
+    
+    Args:
+        devices: List of GPU device indices to log
+        context: Context string to include in log messages
+    """
+    try:
+        import torch
+        if not torch.cuda.is_available():
+            return
+        
+        for device_idx in devices:
+            if device_idx < torch.cuda.device_count():
+                try:
+                    allocated = torch.cuda.memory_allocated(device_idx) / 1024**3
+                    reserved = torch.cuda.memory_reserved(device_idx) / 1024**3
+                    free_bytes, total_bytes = torch.cuda.mem_get_info(device_idx)
+                    free = free_bytes / 1024**3
+                    total = total_bytes / 1024**3
+                    props = torch.cuda.get_device_properties(device_idx)
+                    
+                    logger.info(
+                        "[CUDA CHECKPOINT%s] GPU %d (%s): "
+                        "Allocated=%.2fGB, Reserved=%.2fGB, Free=%.2fGB, Total=%.2fGB",
+                        f" {context}" if context else "",
+                        device_idx,
+                        props.name,
+                        allocated,
+                        reserved,
+                        free,
+                        total
+                    )
+                except Exception as e:
+                    logger.warning("Could not get memory info for GPU %d: %s", device_idx, e)
+    except ImportError:
+        pass
+
+
+def checkpoint_cuda_process(pid: int) -> None:
+    """Lock and checkpoint a CUDA process using the CUDA checkpoint API."""
+    if not cuda_available:
+        raise RuntimeError("cuda-python package not available")
+
+    # Get which GPU devices this process is using
+    gpu_devices = get_process_gpu_devices(pid)
+    if gpu_devices:
+        logger.info("PID %d is using GPU device(s): %s", pid, gpu_devices)
+        log_gpu_memory_for_devices(gpu_devices, f"PID_{pid}_BEFORE")
+    else:
+        logger.warning("PID %d: Could not determine which GPU devices are in use", pid)
+
+    logger.info("Locking CUDA process (PID: %d)...", pid)
+
+    # Lock the CUDA process
+    err, = cuda.cuCheckpointProcessLock(pid, None)
+    if err != cuda.CUresult.CUDA_SUCCESS:
+        error_name, error_desc = get_cuda_error_details(err)
+        if gpu_devices:
+            log_gpu_memory_for_devices(gpu_devices, f"PID_{pid}_LOCK_FAILED")
+        raise RuntimeError(
+            f"Failed to lock CUDA process (PID {pid}, GPUs {gpu_devices}): "
+            f"{error_name} - {error_desc}"
+        )
+    logger.info("CUDA process locked (PID: %d)", pid)
+
+    # Checkpoint the CUDA process
+    logger.info("Checkpointing CUDA process (PID: %d)...", pid)
+    err, = cuda.cuCheckpointProcessCheckpoint(pid, None)
+    if err != cuda.CUresult.CUDA_SUCCESS:
+        error_name, error_desc = get_cuda_error_details(err)
+        if gpu_devices:
+            log_gpu_memory_for_devices(gpu_devices, f"PID_{pid}_CHECKPOINT_FAILED")
+        raise RuntimeError(
+            f"Failed to checkpoint CUDA process (PID {pid}, GPUs {gpu_devices}): "
+            f"{error_name} - {error_desc}"
+        )
+    
+    logger.info("CUDA process checkpointed (PID: %d)", pid)
+    
+    # Log memory after successful checkpoint
+    if gpu_devices:
+        log_gpu_memory_for_devices(gpu_devices, f"PID_{pid}_AFTER")
+
+
+def process_has_nvidia_fd(pid: int) -> bool:
+    """Check if a process has any NVIDIA device file descriptors open.
+
+    Args:
+        pid: Process ID to check
+
+    Returns:
+        True if the process has /dev/nvidia* FDs open, False otherwise
+    """
+    fd_dir = f"/proc/{pid}/fd"
+    if not os.path.exists(fd_dir):
+        return False
+    try:
+        for fd in os.listdir(fd_dir):
+            try:
+                link = os.readlink(os.path.join(fd_dir, fd))
+                if link.startswith("/dev/nvidia"):
+                    return True
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return False
+
+
+def find_gpu_worker_pids(root_pid: int) -> list[int]:
+    """Find all GPU worker processes in the process tree.
+
+    Returns PIDs of leaf processes that use GPU (workers).
+    """
+    all_pids = collect_process_tree_pids(root_pid)
+
+    # Find leaf processes (no children)
+    leaf_pids = []
+    for pid in all_pids:
+        if process_is_leaf(pid):
+            leaf_pids.append(pid)
+
+    # Filter for GPU-using processes
+    gpu_pids = []
+    for pid in leaf_pids:
+        if process_has_nvidia_fd(pid):
+            gpu_pids.append(pid)
+
+    return gpu_pids
+
+
+
+def get_processes_with_nvidia_fds(pids: list[int]) -> list[int]:
+    """Get list of PIDs that still have NVIDIA device file descriptors.
+
+    Args:
+        pids: List of PIDs to check
+
+    Returns:
+        List of PIDs that have /dev/nvidia* FDs open
+    """
+    return [pid for pid in pids if process_has_nvidia_fd(pid)]
+
+
+def assert_no_nvidia_fds_in_tree(root_pid: int) -> None:
+    """Assert that no processes in the tree have NVIDIA FDs after checkpoint.
+
+    Args:
+        root_pid: Root process ID of the tree to check
+
+    Raises:
+        RuntimeError: If any process still has NVIDIA FDs
+    """
+    all_pids = collect_process_tree_pids(root_pid)
+    remaining = get_processes_with_nvidia_fds(list(all_pids))
+
+    if remaining:
+        # Collect detailed info about processes that still have FDs
+        detailed_info = []
+        for pid in remaining:
+            try:
+                comm = read_comm(pid)
+                cmdline = read_cmdline(pid)
+                detailed_info.append(f"PID {pid} ({comm}): {cmdline}")
+            except Exception:
+                detailed_info.append(f"PID {pid}")
+
+        raise RuntimeError(
+            f"CUDA checkpoint failed: {len(remaining)} process(es) still have "
+            f"/dev/nvidia* FDs open.\n"
+            f"Processes with NVIDIA FDs:\n" + "\n".join(detailed_info)
+        )
+
+    logger.info("Verified: No processes in tree have /dev/nvidia* FDs")
+
+
+def format_cuda_checkpoint_results(succeeded: list[int],
+                                  failed: list[tuple[int, str]]) -> str:
+    """Format CUDA checkpoint results for logging.
+
+    Args:
+        succeeded: List of PIDs that were successfully checkpointed
+        failed: List of (pid, error_message) tuples for failed checkpoints
+
+    Returns:
+        Formatted string summarizing the results
+    """
+    msg_parts = []
+
+    if succeeded:
+        msg_parts.append(f"CUDA checkpoint succeeded for {len(succeeded)} PID(s):")
+        for pid in succeeded:
+            devices = get_process_gpu_devices(pid)
+            if devices:
+                msg_parts.append(f"  PID {pid} (GPUs: {devices})")
+            else:
+                msg_parts.append(f"  PID {pid}")
+
+    if failed:
+        msg_parts.append(f"CUDA checkpoint failed for {len(failed)} PID(s):")
+        for pid, error in failed:
+            devices = get_process_gpu_devices(pid)
+            if devices:
+                msg_parts.append(f"  PID {pid} (GPUs: {devices}): {error}")
+            else:
+                msg_parts.append(f"  PID {pid}: {error}")
+
+    return "\n".join(msg_parts)
+
+
+def checkpoint_cuda_processes_from_pids(cuda_pids: list[int]) -> tuple[list[int], list[tuple[int, str]]]:
+    """Checkpoint CUDA processes from a list of PIDs.
+
+    This function attempts to checkpoint each CUDA process and returns
+    success/failure results.
+
+    Args:
+        cuda_pids: List of PIDs to checkpoint
+
+    Returns:
+        Tuple of (succeeded, failed) where:
+        - succeeded: List of PIDs that were successfully checkpointed
+        - failed: List of (pid, error_message) tuples for failed checkpoints
+    """
+    if not cuda_pids:
+        return [], []
+
+    if not cuda_available:
+        raise RuntimeError(
+            "cuda-python is not installed; install 'cuda-python' to "
+            "enable CUDA API checkpointing")
+
+    succeeded: list[int] = []
+    failed: list[tuple[int, str]] = []
+
+    for pid in cuda_pids:
+        try:
+            checkpoint_cuda_process(pid)
+            succeeded.append(pid)
+        except Exception as e:
+            error_msg = str(e)
+            failed.append((pid, error_msg))
+            logger.debug("cuCheckpoint failed for PID %d: %s", pid, error_msg)
+
+    return succeeded, failed
+

--- a/components/src/dynamo/vllm/checkpoint/utils.py
+++ b/components/src/dynamo/vllm/checkpoint/utils.py
@@ -2,22 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """General utilities for checkpoint/restore operations."""
 
-import os
-import time
+import fcntl
 import logging
+import os
+import subprocess
+import time
+import shutil
+import socket
+import struct
+from pathlib import Path
+from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
-
-# Try to import cuda-python
-try:
-    from cuda import cuda
-    cuda_available = True
-except Exception:  # pragma: no cover
-    logger.warning("cuda-python package not found. CUDA checkpointing will not be available. "
-                   "Install with: pip install cuda-python")
-    cuda = None
-    cuda_available = False
-
 
 # General checkpoint utilities
 
@@ -162,142 +158,6 @@ def get_tty_info(pid: int) -> tuple[str, str]:
 
 # CUDA checkpoint utilities
 
-def get_cuda_error_details(err) -> tuple[str, str]:
-    """Get detailed error information from a CUDA error code.
-    
-    Returns:
-        Tuple of (error_name, error_description)
-    """
-    # Get error name
-    _, name_ptr = cuda.cuGetErrorName(err)
-    error_name = name_ptr.decode() if isinstance(name_ptr, bytes) else str(name_ptr)
-    
-    # Get error description
-    try:
-        _, desc_ptr = cuda.cuGetErrorString(err)
-        error_desc = desc_ptr.decode() if isinstance(desc_ptr, bytes) else str(desc_ptr)
-    except Exception:
-        error_desc = "No description available"
-    
-    return error_name, error_desc
-
-
-def get_process_gpu_devices(pid: int) -> list[int]:
-    """Get list of GPU device indices that a process has open file descriptors to.
-    
-    Args:
-        pid: Process ID to check
-        
-    Returns:
-        List of GPU device indices (e.g., [0, 1, 3])
-    """
-    fd_dir = f"/proc/{pid}/fd"
-    devices = set()
-    
-    if not os.path.exists(fd_dir):
-        return []
-    
-    try:
-        for fd in os.listdir(fd_dir):
-            try:
-                link = os.readlink(os.path.join(fd_dir, fd))
-                # Check for /dev/nvidia0, /dev/nvidia1, etc.
-                if link.startswith("/dev/nvidia") and link[12:].isdigit():
-                    device_idx = int(link[12:])
-                    devices.add(device_idx)
-            except Exception:
-                continue
-    except Exception:
-        pass
-    
-    return sorted(list(devices))
-
-
-def log_gpu_memory_for_devices(devices: list[int], context: str = "") -> None:
-    """Log memory usage for specific GPU devices.
-    
-    Args:
-        devices: List of GPU device indices to log
-        context: Context string to include in log messages
-    """
-    try:
-        import torch
-        if not torch.cuda.is_available():
-            return
-        
-        for device_idx in devices:
-            if device_idx < torch.cuda.device_count():
-                try:
-                    allocated = torch.cuda.memory_allocated(device_idx) / 1024**3
-                    reserved = torch.cuda.memory_reserved(device_idx) / 1024**3
-                    free_bytes, total_bytes = torch.cuda.mem_get_info(device_idx)
-                    free = free_bytes / 1024**3
-                    total = total_bytes / 1024**3
-                    props = torch.cuda.get_device_properties(device_idx)
-                    
-                    logger.info(
-                        "[CUDA CHECKPOINT%s] GPU %d (%s): "
-                        "Allocated=%.2fGB, Reserved=%.2fGB, Free=%.2fGB, Total=%.2fGB",
-                        f" {context}" if context else "",
-                        device_idx,
-                        props.name,
-                        allocated,
-                        reserved,
-                        free,
-                        total
-                    )
-                except Exception as e:
-                    logger.warning("Could not get memory info for GPU %d: %s", device_idx, e)
-    except ImportError:
-        pass
-
-
-def checkpoint_cuda_process(pid: int) -> None:
-    """Lock and checkpoint a CUDA process using the CUDA checkpoint API."""
-    if not cuda_available:
-        raise RuntimeError("cuda-python package not available")
-
-    # Get which GPU devices this process is using
-    gpu_devices = get_process_gpu_devices(pid)
-    if gpu_devices:
-        logger.info("PID %d is using GPU device(s): %s", pid, gpu_devices)
-        log_gpu_memory_for_devices(gpu_devices, f"PID_{pid}_BEFORE")
-    else:
-        logger.warning("PID %d: Could not determine which GPU devices are in use", pid)
-
-    logger.info("Locking CUDA process (PID: %d)...", pid)
-
-    # Lock the CUDA process
-    err, = cuda.cuCheckpointProcessLock(pid, None)
-    if err != cuda.CUresult.CUDA_SUCCESS:
-        error_name, error_desc = get_cuda_error_details(err)
-        if gpu_devices:
-            log_gpu_memory_for_devices(gpu_devices, f"PID_{pid}_LOCK_FAILED")
-        raise RuntimeError(
-            f"Failed to lock CUDA process (PID {pid}, GPUs {gpu_devices}): "
-            f"{error_name} - {error_desc}"
-        )
-    logger.info("CUDA process locked (PID: %d)", pid)
-
-    # Checkpoint the CUDA process
-    logger.info("Checkpointing CUDA process (PID: %d)...", pid)
-    err, = cuda.cuCheckpointProcessCheckpoint(pid, None)
-    if err != cuda.CUresult.CUDA_SUCCESS:
-        error_name, error_desc = get_cuda_error_details(err)
-        if gpu_devices:
-            log_gpu_memory_for_devices(gpu_devices, f"PID_{pid}_CHECKPOINT_FAILED")
-        raise RuntimeError(
-            f"Failed to checkpoint CUDA process (PID {pid}, GPUs {gpu_devices}): "
-            f"{error_name} - {error_desc}"
-        )
-    
-    logger.info("CUDA process checkpointed (PID: %d)", pid)
-    
-    # Log memory after successful checkpoint
-    if gpu_devices:
-        log_gpu_memory_for_devices(gpu_devices, f"PID_{pid}_AFTER")
-
-
 def process_has_nvidia_fd(pid: int) -> bool:
     """Check if a process has any NVIDIA device file descriptors open.
 
@@ -323,27 +183,33 @@ def process_has_nvidia_fd(pid: int) -> bool:
     return False
 
 
-def find_gpu_worker_pids(root_pid: int) -> list[int]:
-    """Find all GPU worker processes in the process tree.
+def validate_cuda_process_tree(root_pid: int) -> tuple[list[int], list[int]]:
+    """Validate that all processes with NVIDIA fds are leaf processes.
 
-    Returns PIDs of leaf processes that use GPU (workers).
+    Args:
+        root_pid: Root process ID of the tree to validate
+
+    Returns:
+        Tuple of (valid_cuda_pids, invalid_cuda_pids) where:
+        - valid_cuda_pids: List of PIDs that have nvidia fds and are leaves
+        - invalid_cuda_pids: List of PIDs that have nvidia fds but are NOT leaves
+
+    Raises:
+        RuntimeError: If any non-leaf process has NVIDIA file descriptors
     """
     all_pids = collect_process_tree_pids(root_pid)
 
-    # Find leaf processes (no children)
-    leaf_pids = []
+    valid_cuda_pids = []
+    invalid_cuda_pids = []
+
     for pid in all_pids:
-        if process_is_leaf(pid):
-            leaf_pids.append(pid)
-
-    # Filter for GPU-using processes
-    gpu_pids = []
-    for pid in leaf_pids:
         if process_has_nvidia_fd(pid):
-            gpu_pids.append(pid)
+            if process_is_leaf(pid):
+                valid_cuda_pids.append(pid)
+            else:
+                invalid_cuda_pids.append(pid)
 
-    return gpu_pids
-
+    return valid_cuda_pids, invalid_cuda_pids
 
 
 def get_processes_with_nvidia_fds(pids: list[int]) -> list[int]:
@@ -404,28 +270,18 @@ def format_cuda_checkpoint_results(succeeded: list[int],
     msg_parts = []
 
     if succeeded:
-        msg_parts.append(f"CUDA checkpoint succeeded for {len(succeeded)} PID(s):")
-        for pid in succeeded:
-            devices = get_process_gpu_devices(pid)
-            if devices:
-                msg_parts.append(f"  PID {pid} (GPUs: {devices})")
-            else:
-                msg_parts.append(f"  PID {pid}")
+        msg_parts.append(f"CUDA checkpoint succeeded for {len(succeeded)} PIDs: {succeeded}")
 
     if failed:
-        msg_parts.append(f"CUDA checkpoint failed for {len(failed)} PID(s):")
+        msg_parts.append(f"CUDA checkpoint failed for {len(failed)} PIDs:")
         for pid, error in failed:
-            devices = get_process_gpu_devices(pid)
-            if devices:
-                msg_parts.append(f"  PID {pid} (GPUs: {devices}): {error}")
-            else:
-                msg_parts.append(f"  PID {pid}: {error}")
+            msg_parts.append(f"  PID {pid}: {error}")
 
     return "\n".join(msg_parts)
 
 
 def checkpoint_cuda_processes_from_pids(cuda_pids: list[int]) -> tuple[list[int], list[tuple[int, str]]]:
-    """Checkpoint CUDA processes from a list of PIDs.
+    """Checkpoint CUDA processes from a list of PIDs using cuda-checkpoint CLI.
 
     This function attempts to checkpoint each CUDA process and returns
     success/failure results.
@@ -441,22 +297,611 @@ def checkpoint_cuda_processes_from_pids(cuda_pids: list[int]) -> tuple[list[int]
     if not cuda_pids:
         return [], []
 
-    if not cuda_available:
-        raise RuntimeError(
-            "cuda-python is not installed; install 'cuda-python' to "
-            "enable CUDA API checkpointing")
+    # Two-phase approach for multi-process: lock all, then checkpoint all.
+    # This approximates a cohort-style checkpoint across ranks and avoids
+    # capturing inconsistent cross-process CUDA/NCCL/IPC state.
 
-    succeeded: list[int] = []
-    failed: list[tuple[int, str]] = []
+    locked: list[int] = []
+    lock_failed: list[tuple[int, str]] = []
 
+    # Phase 1: Lock all CUDA processes
     for pid in cuda_pids:
         try:
-            checkpoint_cuda_process(pid)
+            result = subprocess.run(
+                ["cuda-checkpoint", "--action", "lock", "--pid", str(pid)],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"Failed to lock CUDA process: {result.stderr}")
+            locked.append(pid)
+        except Exception as e:
+            error_msg = str(e)
+            lock_failed.append((pid, error_msg))
+            logger.debug("cuda-checkpoint lock failed for PID %d: %s", pid, error_msg)
+
+    # Phase 2: Checkpoint all locked processes
+    succeeded: list[int] = []
+    failed: list[tuple[int, str]] = list(lock_failed)
+
+    for pid in locked:
+        try:
+            result = subprocess.run(
+                ["cuda-checkpoint", "--action", "checkpoint", "--pid", str(pid)],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"Failed to checkpoint CUDA process: {result.stderr}")
             succeeded.append(pid)
         except Exception as e:
             error_msg = str(e)
             failed.append((pid, error_msg))
-            logger.debug("cuCheckpoint failed for PID %d: %s", pid, error_msg)
+            logger.debug("cuda-checkpoint checkpoint failed for PID %d: %s", pid, error_msg)
 
     return succeeded, failed
 
+
+def format_cuda_restore_results(succeeded: list[int],
+                                failed: list[tuple[int, str]]) -> str:
+    """Format CUDA restore/unlock results for logging.
+
+    Args:
+        succeeded: List of PIDs that were successfully restored/unlocked
+        failed: List of (pid, error_message) tuples for failures
+
+    Returns:
+        Formatted string summarizing the results
+    """
+    msg_parts = []
+
+    if succeeded:
+        msg_parts.append(f"CUDA restore/unlock succeeded for {len(succeeded)} PIDs: {succeeded}")
+
+    if failed:
+        msg_parts.append(f"CUDA restore/unlock failed for {len(failed)} PIDs:")
+        for pid, error in failed:
+            msg_parts.append(f"  PID {pid}: {error}")
+
+    return "\n".join(msg_parts)
+
+
+def restore_cuda_processes_from_pids(cuda_pids: list[int], device_map: Optional[str] = None) -> tuple[list[int], list[tuple[int, str]]]:
+    """Restore and unlock CUDA processes from a list of PIDs using cuda-checkpoint CLI.
+
+    Args:
+        cuda_pids: List of PIDs to restore and unlock
+        device_map: Optional device map string for GPU migration
+
+    Returns:
+        Tuple of (succeeded, failed) where:
+        - succeeded: List of PIDs that were successfully restored and unlocked
+        - failed: List of (pid, error_message) tuples for failed operations
+    """
+    if not cuda_pids:
+        return [], []
+
+    # Two-phase approach for multi-process restore: restore all, then unlock all.
+    # This mirrors how we checkpoint (lock all, then checkpoint all) and helps
+    # avoid per-rank inconsistencies during restore/unlock.
+
+    restored: list[int] = []
+    restore_failed: list[tuple[int, str]] = []
+
+    # Phase 1: Restore all CUDA processes
+    for pid in cuda_pids:
+        try:
+            cmd = ["cuda-checkpoint", "--action", "restore", "--pid", str(pid)]
+            if device_map:
+                cmd.extend(["--device-map", device_map])
+            logger.info("Running cuda-checkpoint restore with device map: %s", ' '.join(cmd))
+
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                raise RuntimeError(f"Failed to restore CUDA process: {result.stderr}")
+            restored.append(pid)
+        except Exception as e:
+            error_msg = str(e)
+            restore_failed.append((pid, error_msg))
+            logger.debug("cuda-checkpoint restore failed for PID %d: %s", pid, error_msg)
+
+    # Phase 2: Unlock all successfully restored processes
+    succeeded: list[int] = []
+    failed: list[tuple[int, str]] = list(restore_failed)
+
+    for pid in restored:
+        try:
+            result = subprocess.run(
+                ["cuda-checkpoint", "--action", "unlock", "--pid", str(pid)],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"Failed to unlock CUDA process: {result.stderr}")
+            succeeded.append(pid)
+        except Exception as e:
+            error_msg = str(e)
+            failed.append((pid, error_msg))
+            logger.debug("cuda-checkpoint unlock failed for PID %d: %s", pid, error_msg)
+
+    return succeeded, failed
+
+
+# CRIU helper utilities
+
+def ensure_dummy_criu_libdir(base_dir: str, dir_name: str = "noop-criu-libdir") -> str:
+    """Ensure a dummy libdir exists to prevent CRIU from loading plugins.
+
+    Returns the path to a directory that can be passed via --libdir to CRIU
+    to avoid discovering system-wide plugins such as the CUDA plugin.
+    """
+    path = os.path.join(base_dir, dir_name)
+    try:
+        os.makedirs(path, exist_ok=True)
+    except Exception as e:
+        logger.warning("Failed to create dummy CRIU libdir %s: %s", path, e)
+    return path
+
+
+def snapshot_dev_shm_files_for_tree(root_pid: int) -> list[dict]:
+    """Snapshot open /dev/shm files across a process tree.
+
+    Returns a list of dict entries with keys: name, size, mode.
+    For files opened multiple times with different sizes, the largest size
+    is kept.
+    """
+    dev_shm_files: dict[str, dict] = {}
+    try:
+        tree_pids = collect_process_tree_pids(root_pid)
+        for pid in tree_pids:
+            fd_dir = f"/proc/{pid}/fd"
+            if not os.path.isdir(fd_dir):
+                continue
+            for fd in os.listdir(fd_dir):
+                fd_path = os.path.join(fd_dir, fd)
+                try:
+                    link = os.readlink(fd_path)
+                except Exception:
+                    continue
+                # Normalize deleted marker appended by the kernel
+                if link.endswith(" (deleted)"):
+                    link = link[:-10]
+                if not link.startswith("/dev/shm/"):
+                    continue
+                name = os.path.basename(link)
+                # Stat via fd path to obtain mode/size of the opened file
+                try:
+                    st = os.stat(fd_path)
+                    size = int(getattr(st, "st_size", 0))
+                    mode = int(getattr(st, "st_mode", 0))
+                except Exception:
+                    size = 0
+                    mode = 0o600
+                entry = dev_shm_files.get(name)
+                if entry is None or size > entry.get("size", 0):
+                    dev_shm_files[name] = {"name": name, "size": size, "mode": mode}
+        if dev_shm_files:
+            logger.info("Captured %d /dev/shm files for restore: %s",
+                        len(dev_shm_files), [f["name"] for f in dev_shm_files.values()])
+    except Exception as e:
+        logger.warning("Failed to snapshot /dev/shm files: %s", e)
+    return list(dev_shm_files.values())
+
+
+def precreate_dev_shm_files(files: list[dict]) -> None:
+    """Pre-create /dev/shm files described by snapshot entries.
+
+    Each entry should contain keys: name, size, mode.
+    """
+    try:
+        if files:
+            if not os.path.isdir("/dev/shm"):
+                os.makedirs("/dev/shm", exist_ok=True)
+            for shm in files:
+                name = shm.get("name")
+                if not name:
+                    continue
+                path = os.path.join("/dev/shm", name)
+                # Skip if already exists
+                if os.path.exists(path):
+                    continue
+                mode = int(shm.get("mode", 0o600)) & 0o777
+                size = int(shm.get("size", 0))
+                try:
+                    fd = os.open(path, os.O_CREAT | os.O_RDWR, mode)
+                    if size > 0:
+                        try:
+                            os.ftruncate(fd, size)
+                        except Exception:
+                            pass
+                    os.close(fd)
+                except Exception as e:
+                    logger.warning("Failed to pre-create /dev/shm/%s: %s", name, e)
+    except Exception as e:
+        logger.warning("Error while preparing /dev/shm files: %s", e)
+
+
+# GPU UUID helper functions
+
+# Try to import NVML (prefer nvidia-ml-py over deprecated pynvml)
+nvml_available = False
+nvml = None
+try:
+    import nvidia_ml_py as nvml
+    nvml_available = True
+except ImportError:
+    try:
+        import pynvml as nvml
+        nvml_available = True
+    except ImportError:
+        logger.debug("Neither nvidia-ml-py nor pynvml available for GPU process detection")
+
+
+def get_gpu_uuids() -> list[str]:
+    """Get all GPU UUIDs from the system.
+    
+    Uses NVML to query all visible GPU UUIDs in cuda-checkpoint format.
+    This is required because cuda-checkpoint needs ALL GPUs to be specified
+    in the device map, not just the ones actually used by the process.
+    
+    Returns:
+        List of all GPU UUIDs in cuda-checkpoint format (with 'GPU-' prefix)
+    """
+    if not nvml_available or nvml is None:
+        logger.warning("NVML not available, cannot get GPU UUIDs")
+        return []
+        
+    try:
+        # Initialize NVML
+        nvml.nvmlInit()
+        
+        device_count = nvml.nvmlDeviceGetCount()
+        gpu_uuids = []
+        
+        for i in range(device_count):
+            try:
+                handle = nvml.nvmlDeviceGetHandleByIndex(i)
+                uuid_str = nvml.nvmlDeviceGetUUID(handle)
+                
+                # Ensure UUID has the 'GPU-' prefix required by cuda-checkpoint
+                if uuid_str and not uuid_str.startswith("GPU-"):
+                    uuid_str = f"GPU-{uuid_str}"
+                    
+                gpu_uuids.append(uuid_str)
+            except Exception as e:
+                logger.warning("Error getting UUID for device %d: %s", i, e)
+                continue
+        
+        nvml.nvmlShutdown()
+        
+        logger.info("Found %d GPU(s): %s", len(gpu_uuids), gpu_uuids)
+        return gpu_uuids
+        
+    except Exception as e:
+        logger.error("Error using NVML for GPU detection: %s", e)
+        try:
+            nvml.nvmlShutdown()
+        except:
+            pass
+        return []
+
+
+def create_gpu_device_map(old_uuids: list[str],
+                         new_uuids: list[str]) -> Optional[str]:
+    """Create GPU device map string for cuda-checkpoint restore.
+
+    This function maps old GPU UUIDs to new GPU UUIDs for migration.
+    The mapping preserves the device index order.
+
+    Args:
+        old_uuids: List of GPU UUIDs from checkpoint time (in cuda-checkpoint format)
+        new_uuids: List of current GPU UUIDs (in cuda-checkpoint format)
+
+    Returns:
+        Device map string in format "oldUuid1=newUuid1,oldUuid2=newUuid2,..."
+        suitable for cuda-checkpoint --device-map option, or None if mapping
+        cannot be created.
+    """
+    if len(old_uuids) != len(new_uuids):
+        logger.error("GPU count mismatch: checkpoint had %d GPUs, current has %d",
+                    len(old_uuids), len(new_uuids))
+        return None
+
+    if not old_uuids:
+        logger.warning("No GPUs to migrate")
+        return None
+
+    # Build device map string
+    pairs = []
+    for i, (old_uuid, new_uuid) in enumerate(zip(old_uuids, new_uuids)):
+        pairs.append(f"{old_uuid}={new_uuid}")
+
+        if old_uuid != new_uuid:
+            logger.info("GPU migration: device %d %s -> %s",
+                       i, old_uuid, new_uuid)
+
+    return ",".join(pairs)
+
+
+# Cache directory utilities
+
+def get_cache_directories() -> Tuple[str, str]:
+    """Get vLLM and FlashInfer cache directories.
+    
+    Returns:
+        Tuple of (vllm_cache_dir, flashinfer_cache_dir)
+    """
+    # Check environment variables first
+    vllm_cache = os.environ.get("VLLM_CACHE_ROOT")
+    if not vllm_cache:
+        # Check for XDG_CACHE_HOME
+        xdg_cache = os.environ.get("XDG_CACHE_HOME")
+        if xdg_cache:
+            vllm_cache = os.path.join(xdg_cache, "vllm")
+        else:
+            vllm_cache = os.path.expanduser("~/.cache/vllm")
+    
+    flashinfer_cache = os.environ.get("FLASHINFER_CACHE_DIR")
+    if not flashinfer_cache:
+        # Check for XDG_CACHE_HOME
+        xdg_cache = os.environ.get("XDG_CACHE_HOME")
+        if xdg_cache:
+            flashinfer_cache = os.path.join(xdg_cache, "flashinfer")
+        else:
+            flashinfer_cache = os.path.expanduser("~/.cache/flashinfer")
+    
+    return vllm_cache, flashinfer_cache
+
+
+def save_cache_directories(checkpoint_dir: str, vllm_cache: str, flashinfer_cache: str) -> None:
+    """Copy cache directories to checkpoint directory.
+    
+    Args:
+        checkpoint_dir: Directory where checkpoint is being saved
+        vllm_cache: Path to vLLM cache directory
+        flashinfer_cache: Path to FlashInfer cache directory
+    """
+    cache_backup_dir = os.path.join(checkpoint_dir, "cache_backup")
+    os.makedirs(cache_backup_dir, exist_ok=True)
+    
+    # Copy vLLM cache if it exists
+    if os.path.exists(vllm_cache):
+        vllm_dest = os.path.join(cache_backup_dir, "vllm")
+        try:
+            if os.path.exists(vllm_dest):
+                shutil.rmtree(vllm_dest)
+            shutil.copytree(vllm_cache, vllm_dest)
+            logger.info("Saved vLLM cache from %s to checkpoint", vllm_cache)
+        except Exception as e:
+            logger.warning("Failed to save vLLM cache: %s", e)
+    else:
+        logger.info("vLLM cache directory %s does not exist, skipping", vllm_cache)
+    
+    # Copy FlashInfer cache if it exists  
+    if os.path.exists(flashinfer_cache):
+        flashinfer_dest = os.path.join(cache_backup_dir, "flashinfer")
+        try:
+            if os.path.exists(flashinfer_dest):
+                shutil.rmtree(flashinfer_dest)
+            shutil.copytree(flashinfer_cache, flashinfer_dest)
+            logger.info("Saved FlashInfer cache from %s to checkpoint", flashinfer_cache)
+        except Exception as e:
+            logger.warning("Failed to save FlashInfer cache: %s", e)
+    else:
+        logger.info("FlashInfer cache directory %s does not exist, skipping", flashinfer_cache)
+
+
+def restore_cache_directories(checkpoint_dir: str, vllm_cache: str, flashinfer_cache: str) -> None:
+    """Restore cache directories from checkpoint, overwriting existing caches.
+    
+    Args:
+        checkpoint_dir: Directory where checkpoint was saved
+        vllm_cache: Path to restore vLLM cache to
+        flashinfer_cache: Path to restore FlashInfer cache to
+    """
+    cache_backup_dir = os.path.join(checkpoint_dir, "cache_backup")
+    
+    # Restore vLLM cache
+    vllm_src = os.path.join(cache_backup_dir, "vllm")
+    if os.path.exists(vllm_src):
+        try:
+            # Ensure parent directory exists
+            os.makedirs(os.path.dirname(vllm_cache), exist_ok=True)
+            # Remove existing cache
+            if os.path.exists(vllm_cache):
+                shutil.rmtree(vllm_cache)
+            # Copy from checkpoint
+            shutil.copytree(vllm_src, vllm_cache)
+            logger.info("Restored vLLM cache to %s", vllm_cache)
+        except Exception as e:
+            logger.warning("Failed to restore vLLM cache: %s", e)
+    else:
+        logger.info("No vLLM cache found in checkpoint")
+    
+    # Restore FlashInfer cache
+    flashinfer_src = os.path.join(cache_backup_dir, "flashinfer")
+    if os.path.exists(flashinfer_src):
+        try:
+            # Ensure parent directory exists
+            os.makedirs(os.path.dirname(flashinfer_cache), exist_ok=True)
+            # Remove existing cache
+            if os.path.exists(flashinfer_cache):
+                shutil.rmtree(flashinfer_cache)
+            # Copy from checkpoint
+            shutil.copytree(flashinfer_src, flashinfer_cache)
+            logger.info("Restored FlashInfer cache to %s", flashinfer_cache)
+        except Exception as e:
+            logger.warning("Failed to restore FlashInfer cache: %s", e)
+    else:
+        logger.info("No FlashInfer cache found in checkpoint")
+
+
+# Network utilities
+
+def get_primary_ip_address() -> Optional[str]:
+    """Get the primary IP address from the default network interface.
+    
+    This attempts to find the IP address of the interface used for external
+    connectivity (typically eth0 or similar).
+    
+    Returns:
+        IP address as string, or None if not found
+    """
+    try:
+        # Method 1: Use socket to connect to a public DNS and see which interface is used
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            # Connect to a public DNS server (doesn't actually send data)
+            s.connect(("8.8.8.8", 80))
+            ip = s.getsockname()[0]
+            if ip and ip != "127.0.0.1":
+                logger.info("Found primary IP address: %s", ip)
+                return ip
+    except Exception as e:
+        logger.debug("Socket method failed: %s", e)
+    
+    try:
+        # Method 2: Parse /proc/net/fib_trie to find non-loopback IPs
+        with open("/proc/net/fib_trie", "r") as f:
+            lines = f.readlines()
+        
+        ips = []
+        for i, line in enumerate(lines):
+            if "/32 host LOCAL" in line and i > 0:
+                # Look at previous line for the IP
+                prev_line = lines[i-1].strip()
+                if prev_line.startswith("|--"):
+                    ip = prev_line.split()[-1]
+                    if ip and not ip.startswith("127."):
+                        ips.append(ip)
+        
+        # Return the first non-loopback IP found
+        if ips:
+            ip = ips[0]
+            logger.info("Found primary IP address from fib_trie: %s", ip)
+            return ip
+    except Exception as e:
+        logger.debug("fib_trie method failed: %s", e)
+    
+    try:
+        # Method 3: Use ioctl to enumerate interfaces (more complex but reliable)
+        # This is similar to what ifconfig does
+        import array
+        
+        # Constants for ioctl
+        SIOCGIFCONF = 0x8912
+        SIOCGIFADDR = 0x8915
+        
+        # Create socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        
+        # Query interface list
+        max_possible = 128  # Maximum number of interfaces
+        bytes_needed = max_possible * 32
+        names = array.array('B', b'\0' * bytes_needed)
+        outbytes = struct.unpack('iL', fcntl.ioctl(
+            sock.fileno(),
+            SIOCGIFCONF,
+            struct.pack('iL', bytes_needed, names.buffer_info()[0])
+        ))[0]
+        
+        namestr = names.tobytes()
+        
+        # Parse interface names
+        interfaces = []
+        for i in range(0, outbytes, 40):
+            name = namestr[i:i+16].split(b'\0', 1)[0].decode('utf-8')
+            if name and name != 'lo':
+                interfaces.append(name)
+        
+        # Get IP for each interface
+        for iface in interfaces:
+            try:
+                ip = socket.inet_ntoa(fcntl.ioctl(
+                    sock.fileno(),
+                    SIOCGIFADDR,
+                    struct.pack('256s', iface.encode('utf-8'))
+                )[20:24])
+                if ip and not ip.startswith('127.'):
+                    logger.info("Found IP address %s on interface %s", ip, iface)
+                    sock.close()
+                    return ip
+            except Exception:
+                continue
+        
+        sock.close()
+    except Exception as e:
+        logger.debug("ioctl method failed: %s", e)
+    
+    logger.warning("Could not determine primary IP address")
+    return None
+
+
+def set_ip_nonlocal_bind(enable: bool = True) -> bool:
+    """Set net.ipv4.ip_nonlocal_bind sysctl parameter.
+    
+    Args:
+        enable: True to set to 1, False to set to 0
+        
+    Returns:
+        True if successful, False otherwise
+    """
+    value = "1" if enable else "0"
+    sysctl_path = "/proc/sys/net/ipv4/ip_nonlocal_bind"
+    
+    try:
+        with open(sysctl_path, "w") as f:
+            f.write(value)
+        logger.info("Set net.ipv4.ip_nonlocal_bind = %s", value)
+        return True
+    except Exception as e:
+        logger.error("Failed to set ip_nonlocal_bind: %s", e)
+        # Fall back to sysctl command
+        try:
+            result = subprocess.run(
+                ["sysctl", "-w", f"net.ipv4.ip_nonlocal_bind={value}"],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode == 0:
+                logger.info("Set net.ipv4.ip_nonlocal_bind = %s via sysctl command", value)
+                return True
+        except Exception as e2:
+            logger.error("Failed to set ip_nonlocal_bind via sysctl command: %s", e2)
+    
+    return False
+
+
+def add_ip_to_loopback(ip_address: str) -> bool:
+    """Add an IP address to the loopback interface.
+    
+    Args:
+        ip_address: IP address to add (e.g., "10.244.7.185")
+        
+    Returns:
+        True if successful, False otherwise
+    """
+    if not ip_address:
+        logger.warning("No IP address provided to add to loopback")
+        return False
+    
+    try:
+        # Use ip command to add address
+        # Format: ip addr add <IP>/32 dev lo
+        result = subprocess.run(
+            ["ip", "addr", "add", f"{ip_address}/32", "dev", "lo"],
+            capture_output=True,
+            text=True
+        )
+        if result.returncode == 0:
+            logger.info("Added IP %s to loopback interface", ip_address)
+            return True
+        elif "File exists" in result.stderr:
+            # IP already exists on interface, that's OK
+            logger.info("IP %s already exists on loopback interface", ip_address)
+            return True
+        else:
+            logger.error("Failed to add IP to loopback: %s", result.stderr)
+    except Exception as e:
+        logger.error("Exception adding IP to loopback: %s", e)
+    
+    return False

--- a/components/src/dynamo/vllm/checkpoint/utils.py
+++ b/components/src/dynamo/vllm/checkpoint/utils.py
@@ -1,5 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """General utilities for checkpoint/restore operations."""
 
 import os

--- a/components/src/dynamo/vllm/checkpoint/zmq_async_llm_server.py
+++ b/components/src/dynamo/vllm/checkpoint/zmq_async_llm_server.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ZMQ-based async LLM server for checkpoint/restore operations."""
+
+import asyncio
+import contextlib
+import os
+import sys
+import time
+import traceback
+import logging
+from collections.abc import AsyncGenerator
+from typing import Any, Optional
+
+import cloudpickle
+import msgspec
+import zmq
+import zmq.asyncio
+
+from vllm.config import VllmConfig
+from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.executor.abstract import Executor
+
+logger = logging.getLogger(__name__)
+
+# RPC message types
+class RPCMessageType(msgspec.Struct):
+    request_id: str
+    method: str
+    args_pickle: bytes = b''  # Cloudpickle serialized args
+    kwargs_pickle: bytes = b''  # Cloudpickle serialized kwargs
+    is_generator: bool = False
+
+class RPCResponse(msgspec.Struct):
+    request_id: str
+    result_pickle: bytes = b''  # Cloudpickle serialized result
+    error: Optional[str] = None
+    is_generator_item: bool = False
+    generator_done: bool = False
+
+class PropertyRequest(msgspec.Struct):
+    request_id: str
+    property_name: str
+
+class PropertyResponse(msgspec.Struct):
+    request_id: str
+    value_pickle: bytes = b''  # Cloudpickle serialized value
+    error: Optional[str] = None
+
+
+class ZMQAsyncLLMServer:
+    """Server process that runs AsyncLLM and handles RPC calls via ZMQ."""
+
+    def __init__(self, socket_url: str, vllm_config: VllmConfig,
+                 executor_class: type[Executor], **kwargs):
+        self.socket_url = socket_url
+        self.vllm_config = vllm_config
+        self.executor_class = executor_class
+        self.kwargs = kwargs
+        self.async_llm: Optional[AsyncLLM] = None
+        self.running = True
+        self.engine_ready = False
+
+        # For handling async generators
+        self.active_generators: dict[str, AsyncGenerator] = {}
+
+    async def initialize(self):
+        """Initialize the AsyncLLM instance and wait for engine to be ready."""
+        logger.info("Initializing AsyncLLM...")
+        self.async_llm = AsyncLLM(
+            vllm_config=self.vllm_config,
+            executor_class=self.executor_class,
+            **self.kwargs
+        )
+
+        # The AsyncLLM constructor returns after starting the engine,
+        # but the engine may still be initializing (loading model,
+        # compiling, etc.)
+        # Try to verify the engine is ready by calling a simple method
+        max_wait_time = 900  # 15 minutes
+        start_time = time.time()
+        last_error = None
+
+        while time.time() - start_time < max_wait_time:
+            try:
+                # Try to get model config - this will succeed when
+                # engine is ready
+                await self.async_llm.get_model_config()
+                self.engine_ready = True
+                logger.info("AsyncLLM engine is fully initialized and ready")
+                return
+            except Exception as e:
+                last_error = e
+                # Check if the engine is dead
+                if (hasattr(self.async_llm, 'errored') and
+                        self.async_llm.errored):
+                    raise RuntimeError(
+                        f"AsyncLLM engine failed during initialization: {e}"
+                    ) from e
+                # Engine not ready yet, wait a bit
+                await asyncio.sleep(0.5)
+                elapsed = time.time() - start_time
+                if int(elapsed) % 10 == 0 and int(elapsed) > 0:
+                    logger.info("Waiting for AsyncLLM engine to initialize... "
+                               "(%d seconds elapsed)", int(elapsed))
+
+        raise RuntimeError(
+            f"AsyncLLM engine failed to initialize within {max_wait_time} "
+            f"seconds. Last error: {last_error}")
+
+    async def is_engine_ready(self) -> bool:
+        """Check if the AsyncLLM engine is fully initialized and ready."""
+        return self.engine_ready and self.async_llm is not None
+
+    async def handle_rpc_request(self, msg: RPCMessageType) -> Any:
+        """Handle an RPC request and return the result."""
+        if self.async_llm is None:
+            raise RuntimeError("AsyncLLM not initialized")
+
+        # Handle special server-side methods
+        if msg.method == "is_engine_ready":
+            return await self.is_engine_ready()
+
+        method = getattr(self.async_llm, msg.method)
+
+        # Deserialize args and kwargs
+        args = cloudpickle.loads(msg.args_pickle) if msg.args_pickle else ()
+        kwargs = (cloudpickle.loads(msg.kwargs_pickle)
+                  if msg.kwargs_pickle else {})
+
+        if msg.is_generator:
+            # For generator methods, we store the generator and
+            # return items one by one
+            generator = method(*args, **kwargs)
+            self.active_generators[msg.request_id] = generator
+            return None  # Initial response for generator
+        else:
+            # Regular method call
+            result = method(*args, **kwargs)
+            # Handle both sync and async methods
+            if asyncio.iscoroutine(result):
+                result = await result
+            return result
+
+    async def handle_generator_next(self,
+                                     request_id: str) -> tuple[Any, bool]:
+        """Get the next item from a generator."""
+        if request_id not in self.active_generators:
+            raise RuntimeError(
+                f"No active generator for request {request_id}")
+
+        generator = self.active_generators[request_id]
+        try:
+            item = await generator.__anext__()
+            return item, False  # not done
+        except StopAsyncIteration:
+            del self.active_generators[request_id]
+            return None, True  # done
+
+    async def handle_property_request(self, msg: PropertyRequest) -> Any:
+        """Handle a property access request."""
+        if self.async_llm is None:
+            raise RuntimeError("AsyncLLM not initialized")
+
+        return getattr(self.async_llm, msg.property_name)
+
+    async def run(self):
+        """Main server loop."""
+        ctx = zmq.asyncio.Context()
+        # Using REP socket for reliable request-reply pattern
+        # REP ensures proper message pairing and connection establishment
+        socket = ctx.socket(zmq.REP)
+        socket.bind(self.socket_url)
+        socket.setsockopt(zmq.LINGER, 0)  # Don't wait on socket close
+
+        logger.info("AsyncLLM server listening on %s", self.socket_url)
+
+        # Wait for initial HELLO from client
+        logger.debug("Waiting for HELLO message...")
+        hello_msg = await socket.recv()
+        logger.debug("Received message: %s", hello_msg)
+        if hello_msg != b"HELLO":
+            logger.warning("Expected HELLO, got %s", hello_msg)
+        else:
+            # REP socket must always send a reply
+            await socket.send(b"HELLO_ACK")
+
+        # Initialize AsyncLLM
+        logger.debug("Initializing AsyncLLM...")
+        await self.initialize()
+        logger.debug("AsyncLLM initialized")
+
+        # With REQ-REP, client will need to explicitly ask for readiness
+        # Wait for READY_CHECK from client
+        ready_check = await socket.recv()
+        if ready_check == b"READY_CHECK":
+            logger.debug("Sending READY signal...")
+            await socket.send(b"READY")
+            logger.debug("READY signal sent")
+
+        try:
+            while self.running:
+                # Use poll with timeout to handle CRIU restore properly
+                # After CRIU restore, the socket's epoll registration might be stale
+                # Using poll with timeout ensures we periodically check for messages
+                # REP socket blocks on recv, no need for poll
+                try:
+                    # Receive single message with protocol: TYPE|PAYLOAD
+                    raw_msg = await socket.recv()
+                    # Handle simple text messages first
+                    if raw_msg == b"RECONNECT":
+                        msg_type = "RECONNECT"
+                        frames = None
+                    elif raw_msg == b"SHUTDOWN":
+                        msg_type = "SHUTDOWN"
+                        frames = None
+                    else:
+                        # Parse structured messages
+                        delimiter_idx = raw_msg.find(b'|')
+                        if delimiter_idx == -1:
+                            logger.error("Invalid message format: %s", raw_msg)
+                            await socket.send(b"ERROR: Invalid message format")
+                            continue
+                        msg_type = raw_msg[:delimiter_idx].decode()
+                        frames = [raw_msg[:delimiter_idx], raw_msg[delimiter_idx+1:]]
+                except asyncio.TimeoutError:
+                    # This shouldn't happen with REP socket
+                    continue
+
+                if msg_type == "RPC":
+                    msg = msgspec.msgpack.decode(frames[1], type=RPCMessageType)
+                    try:
+                        if msg.method == "_generator_next":
+                            # Special case for getting next item from generator
+                            # Deserialize the request_id from args_pickle
+                            request_id = cloudpickle.loads(msg.args_pickle)[0]
+                            result, done = await self.handle_generator_next(
+                                request_id)
+                            response = RPCResponse(
+                                request_id=msg.request_id,
+                                result_pickle=(cloudpickle.dumps(result)
+                                              if not done else b''),
+                                is_generator_item=True,
+                                generator_done=done
+                            )
+                        else:
+                            result = await self.handle_rpc_request(msg)
+                            response = RPCResponse(
+                                request_id=msg.request_id,
+                                result_pickle=cloudpickle.dumps(result)
+                            )
+                    except Exception as e:
+                        response = RPCResponse(
+                            request_id=msg.request_id,
+                            error=(f"{type(e).__name__}: {str(e)}\n"
+                                   f"{traceback.format_exc()}")
+                        )
+                    # Send response as single message
+                    await socket.send(b"RPC_RESPONSE|" + msgspec.msgpack.encode(response))
+
+                elif msg_type == "PROPERTY":
+                    msg = msgspec.msgpack.decode(
+                        frames[1], type=PropertyRequest)
+                    try:
+                        value = await self.handle_property_request(msg)
+                        response = PropertyResponse(
+                            request_id=msg.request_id,
+                            value_pickle=cloudpickle.dumps(value)
+                        )
+                    except Exception as e:
+                        response = PropertyResponse(
+                            request_id=msg.request_id,
+                            error=f"{type(e).__name__}: {str(e)}"
+                        )
+                    # Send response as single message
+                    await socket.send(b"PROPERTY_RESPONSE|" + msgspec.msgpack.encode(response))
+
+                elif msg_type == "SHUTDOWN":
+                    logger.info("Received shutdown signal")
+                    # REP socket must send reply before breaking
+                    await socket.send(b"SHUTDOWN_ACK")
+                    break
+
+                elif msg_type == "RECONNECT":
+                    # Handle reconnection after CRIU restore
+                    logger.info("Received reconnect signal after CRIU restore")
+                    await socket.send(b"RECONNECT_ACK")
+                    logger.info("Sent reconnect acknowledgment")
+
+                    # After CRIU restore, log that we're back to normal operation
+                    logger.info("Server successfully handling messages after CRIU restore")
+
+        finally:
+            logger.info("AsyncLLM server shutting down...")
+            if self.async_llm:
+                logger.info("Shutting down AsyncLLM instance...")
+                self.async_llm.shutdown()
+                logger.info("AsyncLLM instance shutdown complete")
+            socket.close()
+            ctx.term()
+            logger.info("AsyncLLM server shutdown complete")
+
+
+def run_async_llm_server(socket_url: str, vllm_config_pickle: bytes,
+                        executor_class_pickle: bytes,
+                        kwargs_pickle: bytes,
+                        parent_pid_for_tty: Optional[int] = None,
+                        parent_tty_worker_fd: Optional[int] = None):
+    """Entry point for the subprocess running AsyncLLM."""
+    # Set up a private PTY for logs without making it a controlling TTY.
+    # We intentionally avoid TIOCSCTTY so no session in the checkpointed
+    # subtree owns a controlling TTY (simplifies CRIU restore).
+    if parent_pid_for_tty is not None and parent_tty_worker_fd is not None:
+        try:
+            # Become a new session leader with no controlling TTY
+            with contextlib.suppress(Exception):
+                os.setsid()
+
+            # Open the PTY worker passed by the parent without acquiring
+            # a controlling TTY.
+            fd_path = f"/proc/{parent_pid_for_tty}/fd/{parent_tty_worker_fd}"
+            tty_fd = os.open(fd_path, os.O_RDWR | os.O_NOCTTY)
+
+            # Mirror logs to this PTY (stdout/stderr; stdin optional)
+            with contextlib.suppress(Exception):
+                os.dup2(tty_fd, 1)
+                os.dup2(tty_fd, 2)
+            with contextlib.suppress(Exception):
+                os.dup2(tty_fd, 0)
+        except Exception as e:
+            # Fall back to default stdio if anything fails; logs still work.
+            print(f"Failed to set PTY for logs: {e}", file=sys.stderr)
+        finally:
+            with contextlib.suppress(Exception):
+                os.close(tty_fd)  # type: ignore[name-defined]
+
+    # Ensure logger is initialized in subprocess AFTER stdio is set
+    import logging
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+
+    try:
+        print(f"AsyncLLM server starting on {socket_url}", file=sys.stderr)
+
+        # Deserialize the configuration
+        vllm_config = cloudpickle.loads(vllm_config_pickle)
+        executor_class = cloudpickle.loads(executor_class_pickle)
+        kwargs = cloudpickle.loads(kwargs_pickle)
+
+        print(f"Model: {vllm_config.model_config.model}", file=sys.stderr)
+
+        # Create and run the server
+        server = ZMQAsyncLLMServer(
+            socket_url,
+            vllm_config,
+            executor_class,
+            **kwargs,
+        )
+
+        # Run the async event loop
+        asyncio.run(server.run())
+    except Exception as e:
+        print(f"AsyncLLM server failed: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(1)
+

--- a/components/src/dynamo/vllm/checkpoint/zmq_async_llm_server.py
+++ b/components/src/dynamo/vllm/checkpoint/zmq_async_llm_server.py
@@ -1,5 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """ZMQ-based async LLM server for checkpoint/restore operations."""
 
 import asyncio

--- a/components/src/dynamo/vllm/checkpoint/zmq_async_llm_server.py
+++ b/components/src/dynamo/vllm/checkpoint/zmq_async_llm_server.py
@@ -365,4 +365,3 @@ def run_async_llm_server(socket_url: str, vllm_config_pickle: bytes,
         print(f"AsyncLLM server failed: {e}", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
         sys.exit(1)
-

--- a/components/src/dynamo/vllm/engine.py
+++ b/components/src/dynamo/vllm/engine.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unified vLLM engine interface that supports both regular AsyncLLM
+and CheckpointableAsyncLLM based on configuration.
+"""
+
+import errno
+import logging
+import os
+import shutil
+import time
+import uuid
+from typing import Optional
+
+from vllm.usage.usage_lib import UsageContext
+from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.metrics.loggers import StatLoggerFactory
+
+from dynamo.vllm.checkpoint import CheckpointableAsyncLLM
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_vllm_engine(
+    vllm_config,
+    usage_context: UsageContext,
+    stat_loggers: Optional[list[StatLoggerFactory]] = None,
+    disable_log_requests: bool = False,
+    disable_log_stats: bool = False,
+    enable_checkpointing: bool = False,
+    checkpoint_dir: Optional[str] = None,
+) -> AsyncLLM:
+    """
+    Factory function to create either AsyncLLM or CheckpointableAsyncLLM
+    based on configuration.
+    
+    When enable_checkpointing=False, returns standard AsyncLLM (no overhead).
+    When enable_checkpointing=True, returns CheckpointableAsyncLLM (subprocess + ZMQ).
+    
+    Args:
+        vllm_config: vLLM configuration
+        usage_context: Usage context for telemetry
+        stat_loggers: Optional stat loggers
+        disable_log_requests: Whether to disable request logging
+        disable_log_stats: Whether to disable stats logging
+        enable_checkpointing: Whether to enable CRIU checkpointing support
+        checkpoint_dir: Optional checkpoint directory for restore
+        
+    Returns:
+        AsyncLLM instance (standard or checkpointable variant)
+    """
+    factory = []
+    if stat_loggers:
+        factory.extend(stat_loggers)
+    
+    if not enable_checkpointing:
+        # Standard path: use AsyncLLM directly (no subprocess, no overhead)
+        logger.info("Creating standard AsyncLLM engine (checkpointing disabled)")
+        return AsyncLLM.from_vllm_config(
+            vllm_config=vllm_config,
+            usage_context=usage_context,
+            stat_loggers=factory,
+            disable_log_requests=disable_log_requests,
+            disable_log_stats=disable_log_stats,
+        )
+    else:
+        # Checkpointing enabled: use CheckpointableAsyncLLM
+        # Use vLLM's built-in config hash for checkpoint directory naming
+        config_hash = vllm_config.compute_hash()[:8]  # Use first 8 chars for brevity
+        
+        if checkpoint_dir:
+            # Create checkpoint path with config hash subfolder
+            checkpoint_dir_with_hash = os.path.join(checkpoint_dir, config_hash)
+            logger.info(f"Checkpoint directory with config hash: {checkpoint_dir_with_hash}")
+        else:
+            checkpoint_dir_with_hash = None
+        
+        # Only auto_start if checkpoint doesn't exist yet
+        checkpoint_exists = checkpoint_dir_with_hash and os.path.exists(checkpoint_dir_with_hash)
+        auto_start = not checkpoint_exists
+        
+        if checkpoint_exists:
+            logger.info(f"Creating CheckpointableAsyncLLM engine for checkpoint restore (auto_start=False, config_hash={config_hash})")
+        else:
+            logger.info(f"Creating CheckpointableAsyncLLM engine (auto_start=True, will create checkpoint, config_hash={config_hash})")
+        
+        vllm_config.model_config.enable_sleep_mode = True
+        vllm_config.parallel_config.disable_custom_all_reduce = True
+
+        engine = CheckpointableAsyncLLM.from_vllm_config(
+            vllm_config=vllm_config,
+            usage_context=usage_context,
+            stat_loggers=factory,
+            enable_log_requests=not disable_log_requests,
+            disable_log_stats=disable_log_stats,
+            auto_start=auto_start,
+        )
+        
+        # Store the full checkpoint path on the engine for later use
+        if checkpoint_dir_with_hash:
+            engine.checkpoint_dir = checkpoint_dir_with_hash
+        
+        return engine
+
+
+async def _sync_vllm_config_from_subprocess(engine: CheckpointableAsyncLLM):
+    """Helper to sync vLLM config from restored subprocess.
+    
+    Args:
+        engine: CheckpointableAsyncLLM instance
+        
+    Returns:
+        The synced VllmConfig
+        
+    Raises:
+        RuntimeError: If get_vllm_config method is not available
+    """
+    if hasattr(engine, 'get_vllm_config'):
+        logger.info("Syncing vLLM config from restored subprocess...")
+        engine.vllm_config = await engine.get_vllm_config()
+        logger.info(f"Synced config - num_gpu_blocks: {engine.vllm_config.cache_config.num_gpu_blocks}")
+        return engine.vllm_config
+    else:
+        raise RuntimeError("get_vllm_config method not found on engine")
+
+
+async def initialize_engine(engine: AsyncLLM, enable_checkpointing: bool, checkpoint_dir: Optional[str] = None):
+    """
+    Initialize the engine after creation.
+    
+    Handles three cases:
+    1. Checkpointing disabled: No-op (engine already ready)
+    2. Checkpointing enabled + checkpoint exists: Restore from checkpoint
+    3. Checkpointing enabled + checkpoint doesn't exist: Wait for ready, checkpoint, 
+       atomic move (race with other workers), then restore
+    
+    Args:
+        engine: Engine instance to initialize
+        enable_checkpointing: Whether checkpointing is enabled
+        checkpoint_dir: Optional checkpoint directory (destination path).
+                       If engine already has checkpoint_dir set (from create_vllm_engine),
+                       that takes precedence.
+    
+    Returns:
+        The vllm_config (synced from subprocess if checkpointing is enabled)
+    """
+    # Case 1: Checkpointing disabled - return the config from the engine
+    if not enable_checkpointing:
+        logger.debug("Standard AsyncLLM is ready (no initialization needed)")
+        return engine.vllm_config if hasattr(engine, 'vllm_config') else None
+    
+    if not isinstance(engine, CheckpointableAsyncLLM):
+        logger.warning("Engine is not CheckpointableAsyncLLM, skipping initialization")
+        return engine.vllm_config if hasattr(engine, 'vllm_config') else None
+    
+    # Use checkpoint_dir from engine if already set (includes config hash)
+    # Otherwise use the provided checkpoint_dir
+    if hasattr(engine, 'checkpoint_dir') and engine.checkpoint_dir:
+        checkpoint_dir = engine.checkpoint_dir
+        logger.debug(f"Using checkpoint_dir from engine: {checkpoint_dir}")
+    
+    if not checkpoint_dir:
+        raise ValueError("checkpoint_dir must be provided when enable_checkpointing=True")
+    
+    # Case 2: Checkpoint already exists - restore from it
+    if os.path.exists(checkpoint_dir):
+        logger.info(f"Checkpoint directory exists: {checkpoint_dir}")
+        logger.info(f"Starting checkpoint restore from: {checkpoint_dir}")
+        start_time = time.perf_counter()
+        
+        engine.checkpoint_dir = checkpoint_dir
+        await engine.criu_resume()
+        
+        elapsed_time = time.perf_counter() - start_time
+        logger.info(f"Checkpoint restore completed successfully in {elapsed_time:.2f} seconds")
+        
+        # Sync config from restored subprocess
+        return await _sync_vllm_config_from_subprocess(engine)
+    
+    # Case 3: No checkpoint exists - create one with atomic move
+    logger.info("No checkpoint found, will create one")
+    logger.info("Waiting for CheckpointableAsyncLLM engine to initialize...")
+    start_time = time.perf_counter()
+    
+    await engine.wait_until_ready()
+    
+    elapsed_time = time.perf_counter() - start_time
+    logger.info(f"CheckpointableAsyncLLM engine is ready (initialization time: {elapsed_time:.2f}s)")
+    
+    # Create checkpoint in temporary directory (same filesystem as checkpoint_dir)
+    temp_dir = f"{checkpoint_dir}.tmp.{uuid.uuid4().hex[:8]}"
+    logger.info(f"Creating checkpoint in temporary directory: {temp_dir}")
+    
+    checkpoint_start = time.perf_counter()
+    await engine.criu_checkpoint(temp_dir)
+    checkpoint_elapsed = time.perf_counter() - checkpoint_start
+    logger.info(f"Checkpoint created in {checkpoint_elapsed:.2f} seconds")
+    
+    # Attempt atomic move to final destination using os.rename()
+    # os.rename() is atomic and will fail with EEXIST if destination already exists
+    logger.info(f"Attempting atomic move to final destination: {checkpoint_dir}")
+    try:
+        os.rename(temp_dir, checkpoint_dir)
+        logger.info(f"Successfully moved checkpoint to {checkpoint_dir} (this worker won the race)")
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            logger.info(f"Another worker already created checkpoint at {checkpoint_dir} (race lost)")
+            # Clean up our temp directory
+            logger.info(f"Cleaning up temporary checkpoint directory: {temp_dir}")
+            shutil.rmtree(temp_dir)
+        else:
+            raise
+    
+    # Now restore from the final checkpoint (whether we created it or another worker did)
+    logger.info(f"Restoring from checkpoint: {checkpoint_dir}")
+    restore_start = time.perf_counter()
+    
+    engine.checkpoint_dir = checkpoint_dir
+    await engine.criu_resume()
+    
+    restore_elapsed = time.perf_counter() - restore_start
+    logger.info(f"Checkpoint restore completed in {restore_elapsed:.2f} seconds")
+    
+    # Sync config from restored subprocess
+    return await _sync_vllm_config_from_subprocess(engine)

--- a/container/Dockerfile.vllm-checkpoint
+++ b/container/Dockerfile.vllm-checkpoint
@@ -203,15 +203,20 @@ RUN apt-get update && \
         # prometheus dependencies
         ca-certificates \
         # DeepGemm uses 'cuobjdump' which does not come with CUDA image
-        cuda-command-line-tools-12-8 \
-        # For CRIU installation
-        software-properties-common \
-        iptables
+        cuda-command-line-tools-12-8
+
     
-# Install CRIU for checkpointing support
-RUN add-apt-repository ppa:criu/ppa && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends criu && \
+# Install CRIU 4.2 from source
+RUN git clone https://github.com/checkpoint-restore/criu && \
+    cd criu && \
+    git checkout 1d08ff8ca7b2a8bee5238e80bddd52a627c637cf && \
+    # Install CRIU build dependencies using official script
+    ./contrib/dependencies/apt-packages.sh && \
+    # Build and install CRIU
+    make install && \
+    cd .. && \
+    rm -rf criu && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy CUDA development tools (nvcc, headers, dependencies, etc.) from base devel image

--- a/container/Dockerfile.vllm-checkpoint
+++ b/container/Dockerfile.vllm-checkpoint
@@ -178,6 +178,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 ARG ARCH_ALT
 ARG PYTHON_VERSION
+ARG ENABLE_KVBM
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl
 ENV NIXL_LIB_DIR=$NIXL_PREFIX/lib/${ARCH_ALT}-linux-gnu
 ENV NIXL_PLUGIN_DIR=$NIXL_LIB_DIR/plugins
@@ -268,6 +269,9 @@ RUN uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
     /opt/dynamo/wheelhouse/nixl/nixl*.whl \
+    && if [ "${ENABLE_KVBM}" = "true" ]; then \
+        uv pip install /opt/dynamo/wheelhouse/kvbm*.whl; \
+       fi \
     && cd /opt/dynamo/benchmarks \
     && UV_GIT_LFS=1 uv pip install --no-cache . \
     && cd - \

--- a/container/Dockerfile.vllm-checkpoint
+++ b/container/Dockerfile.vllm-checkpoint
@@ -1,0 +1,363 @@
+# syntax=docker/dockerfile:1.10.0
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
+# TODO OPS-612: NCCL will hang with 25.03, so use 25.01 for now
+# Please check https://github.com/ai-dynamo/dynamo/pull/1065
+# for details and reproducer to manually test if the image
+# can be updated to later versions.
+ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
+ARG ENABLE_KVBM=false
+ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
+ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
+ARG CUDA_VERSION="12.8"
+
+# Make sure to update the dependency version in pyproject.toml when updating this
+ARG VLLM_REF="e3803db362ea36ff24e21751800027bc0dd082d1"
+# FlashInfer only respected when building vLLM from source, ie when VLLM_REF does not start with 'v' or for arm64 builds
+ARG FLASHINF_REF="v0.3.1"
+ARG TORCH_BACKEND="cu128"
+
+# If left blank, then we will fallback to vLLM defaults
+ARG DEEPGEMM_REF=""
+
+# sccache configuration - inherit from base build
+ARG USE_SCCACHE
+ARG SCCACHE_BUCKET=""
+ARG SCCACHE_REGION=""
+
+# Define general architecture ARGs for supporting both x86 and aarch64 builds.
+#   ARCH: Used for package suffixes (e.g., amd64, arm64)
+#   ARCH_ALT: Used for Rust targets, manylinux suffix (e.g., x86_64, aarch64)
+#
+# Default values are for x86/amd64:
+#   --build-arg ARCH=amd64 --build-arg ARCH_ALT=x86_64
+#
+# For arm64/aarch64, build with:
+#   --build-arg ARCH=arm64 --build-arg ARCH_ALT=aarch64
+#
+# NOTE: There isn't an easy way to define one of these values based on the other value
+# without adding if statements everywhere, so just define both as ARGs for now.
+ARG ARCH=amd64
+ARG ARCH_ALT=x86_64
+# Python configuration
+ARG PYTHON_VERSION=3.12
+
+ARG DYNAMO_BASE_IMAGE="dynamo:latest-none"
+FROM ${DYNAMO_BASE_IMAGE} AS dynamo_base
+
+########################################################
+########## Framework Development Image ################
+########################################################
+#
+# PURPOSE: Framework development and vLLM compilation
+#
+# This stage builds and compiles framework dependencies including:
+# - vLLM inference engine with CUDA support
+# - DeepGEMM and FlashInfer optimizations
+# - All necessary build tools and compilation dependencies
+# - Framework-level Python packages and extensions
+#
+# Use this stage when you need to:
+# - Build vLLM from source with custom modifications
+# - Develop or debug framework-level components
+# - Create custom builds with specific optimization flags
+#
+
+# Use dynamo base image (see /container/Dockerfile for more details)
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS framework
+
+ARG PYTHON_VERSION
+
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        # Python runtime - CRITICAL for virtual environment to work
+        python${PYTHON_VERSION}-dev \
+        build-essential \
+        # vLLM build dependencies
+        cmake \
+        ibverbs-providers \
+        ibverbs-utils \
+        libibumad-dev \
+        libibverbs-dev \
+        libnuma-dev \
+        librdmacm-dev \
+        rdma-core \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# if libmlx5.so not shipped with 24.04 rdma-core packaging, CMAKE will fail when looking for
+# generic dev name .so so we symlink .s0.1 -> .so
+RUN ln -sf /usr/lib/aarch64-linux-gnu/libmlx5.so.1 /usr/lib/aarch64-linux-gnu/libmlx5.so || true
+
+### VIRTUAL ENVIRONMENT SETUP ###
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Create virtual environment
+RUN mkdir -p /opt/dynamo/venv && \
+    uv venv /opt/dynamo/venv --python $PYTHON_VERSION
+
+# Activate virtual environment
+ENV VIRTUAL_ENV=/opt/dynamo/venv \
+    PATH="/opt/dynamo/venv/bin:${PATH}"
+
+ARG ARCH
+# Install vllm - keep this early in Dockerfile to avoid
+# rebuilds from unrelated source code changes
+ARG VLLM_REF
+ARG VLLM_GIT_URL
+ARG DEEPGEMM_REF
+ARG FLASHINF_REF
+ARG TORCH_BACKEND
+ARG CUDA_VERSION
+
+ARG MAX_JOBS=16
+ENV MAX_JOBS=$MAX_JOBS
+ENV CUDA_HOME=/usr/local/cuda
+
+# Install sccache if requested
+COPY container/use-sccache.sh /tmp/use-sccache.sh
+# Install sccache if requested
+ARG USE_SCCACHE
+ARG ARCH_ALT
+ARG SCCACHE_BUCKET
+ARG SCCACHE_REGION
+
+ENV ARCH_ALT=${ARCH_ALT}
+RUN if [ "$USE_SCCACHE" = "true" ]; then \
+        /tmp/use-sccache.sh install; \
+    fi
+
+# Set environment variables - they'll be empty strings if USE_SCCACHE=false
+ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
+    SCCACHE_REGION=${USE_SCCACHE:+${SCCACHE_REGION}} \
+    CMAKE_C_COMPILER_LAUNCHER=${USE_SCCACHE:+sccache} \
+    CMAKE_CXX_COMPILER_LAUNCHER=${USE_SCCACHE:+sccache} \
+    CMAKE_CUDA_COMPILER_LAUNCHER=${USE_SCCACHE:+sccache}
+# Install VLLM and related dependencies
+RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
+    --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+    export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
+        cp /tmp/deps/vllm/install_vllm.sh /tmp/install_vllm.sh && \
+        chmod +x /tmp/install_vllm.sh && \
+        /tmp/install_vllm.sh --editable --vllm-ref $VLLM_REF --max-jobs $MAX_JOBS --arch $ARCH --installation-dir /opt ${DEEPGEMM_REF:+--deepgemm-ref "$DEEPGEMM_REF"} ${FLASHINF_REF:+--flashinf-ref "$FLASHINF_REF"} --torch-backend $TORCH_BACKEND --cuda-version $CUDA_VERSION && \
+        /tmp/use-sccache.sh show-stats "vLLM";
+
+ENV LD_LIBRARY_PATH=\
+/opt/vllm/tools/ep_kernels/ep_kernels_workspace/nvshmem_install/lib:\
+$LD_LIBRARY_PATH
+
+##################################################
+########## Runtime Image ########################
+##################################################
+#
+# PURPOSE: Production runtime environment
+#
+# This stage creates a lightweight production-ready image containing:
+# - Pre-compiled vLLM and framework dependencies
+# - Dynamo runtime libraries and Python packages
+# - Essential runtime dependencies and configurations
+# - Optimized for inference workloads and deployment
+#
+# Use this stage when you need:
+# - Production deployment of Dynamo with vLLM
+# - Minimal runtime footprint without build tools
+# - Ready-to-run inference server environment
+# - Base for custom application containers
+#
+
+FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
+
+WORKDIR /workspace
+ENV DYNAMO_HOME=/opt/dynamo
+ENV VIRTUAL_ENV=/opt/dynamo/venv
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+ARG ARCH_ALT
+ARG PYTHON_VERSION
+ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl
+ENV NIXL_LIB_DIR=$NIXL_PREFIX/lib/${ARCH_ALT}-linux-gnu
+ENV NIXL_PLUGIN_DIR=$NIXL_LIB_DIR/plugins
+
+# Install Python, build-essential and python3-dev as apt dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        # Python runtime - CRITICAL for virtual environment to work
+        python${PYTHON_VERSION}-dev \
+        build-essential \
+        # jq and curl for polling various endpoints and health checks
+        jq \
+        git \
+        git-lfs \
+        curl \
+        # Libraries required by UCX to find RDMA devices
+        libibverbs1 rdma-core ibverbs-utils libibumad3 \
+        libnuma1 librdmacm1 ibverbs-providers \
+        # JIT Kernel Compilation, flashinfer
+        ninja-build \
+        g++ \
+        # prometheus dependencies
+        ca-certificates \
+        # DeepGemm uses 'cuobjdump' which does not come with CUDA image
+        cuda-command-line-tools-12-8 \
+        # For CRIU installation
+        software-properties-common \
+        iptables
+    
+# Install CRIU for checkpointing support
+RUN add-apt-repository ppa:criu/ppa && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends criu && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy CUDA development tools (nvcc, headers, dependencies, etc.) from base devel image
+COPY --from=framework /usr/local/cuda/bin/nvcc /usr/local/cuda/bin/nvcc
+COPY --from=framework /usr/local/cuda/bin/cudafe++ /usr/local/cuda/bin/cudafe++
+COPY --from=framework /usr/local/cuda/bin/ptxas /usr/local/cuda/bin/ptxas
+COPY --from=framework /usr/local/cuda/bin/fatbinary /usr/local/cuda/bin/fatbinary
+COPY --from=framework /usr/local/cuda/include/ /usr/local/cuda/include/
+COPY --from=framework /usr/local/cuda/nvvm /usr/local/cuda/nvvm
+COPY --from=framework /usr/local/cuda/lib64/libcudart.so* /usr/local/cuda/lib64/
+
+# Clone cuda-checkpoint repository
+RUN git clone https://github.com/NVIDIA/cuda-checkpoint.git
+RUN cd cuda-checkpoint && cp bin/x86_64_Linux/cuda-checkpoint /usr/local/bin/cuda-checkpoint
+
+### COPY NATS & ETCD ###
+# Copy nats and etcd from dev image
+COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
+COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
+# Add ETCD and CUDA binaries to PATH so cicc and other CUDA tools are accessible
+ENV PATH=/usr/local/bin/etcd/:/usr/local/cuda/nvvm/bin:$PATH
+
+# Copy UCX from dev image as plugin for NIXL
+# Copy NIXL source from devr image
+# Copy dynamo wheels for gitlab artifacts
+COPY --from=dynamo_base /usr/local/ucx /usr/local/ucx
+COPY --from=dynamo_base $NIXL_PREFIX $NIXL_PREFIX
+ENV PATH=/usr/local/ucx/bin:$PATH
+
+# Copies vllm, DeepEP, DeepGEMM, PPLX repos (all editable installs) and nvshmem binaries
+COPY --from=framework /opt/vllm /opt/vllm
+
+ENV LD_LIBRARY_PATH=\
+/opt/vllm/tools/ep_kernels/ep_kernels_workspace/nvshmem_install/lib:\
+$NIXL_LIB_DIR:\
+$NIXL_PLUGIN_DIR:\
+/usr/local/ucx/lib:\
+/usr/local/ucx/lib/ucx:\
+$LD_LIBRARY_PATH
+
+# DeepGemm runs nvcc for JIT kernel compilation, however the CUDA include path
+# is not properly set for complilation. Set CPATH to help nvcc find the headers.
+ENV CPATH=/usr/local/cuda/include
+
+### VIRTUAL ENVIRONMENT SETUP ###
+
+# Copy uv and entire virtual environment from framework container
+COPY --from=framework /bin/uv /bin/uvx /bin/
+COPY --from=framework ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+
+# Install dynamo, NIXL, and dynamo-specific dependencies
+COPY benchmarks/ /opt/dynamo/benchmarks/
+COPY --from=dynamo_base /opt/dynamo/wheelhouse/ /opt/dynamo/wheelhouse/
+RUN uv pip install \
+    /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
+    /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
+    /opt/dynamo/wheelhouse/nixl/nixl*.whl \
+    && cd /opt/dynamo/benchmarks \
+    && UV_GIT_LFS=1 uv pip install --no-cache . \
+    && cd - \
+    && rm -rf /opt/dynamo/benchmarks
+
+# Install common and test dependencies
+RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
+    --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.test.txt \
+    UV_GIT_LFS=1 uv pip install \
+        --no-cache \
+        --requirement /tmp/requirements.txt \
+        --requirement /tmp/requirements.test.txt
+
+# Copy benchmarks, examples, and tests for CI
+COPY . /workspace/
+
+# Copy attribution files
+COPY ATTRIBUTION* LICENSE /workspace/
+# Copy launch banner
+RUN --mount=type=bind,source=./container/launch_message.txt,target=/workspace/launch_message.txt \
+    sed '/^#\s/d' /workspace/launch_message.txt > ~/.launch_screen && \
+    echo "cat ~/.launch_screen" >> ~/.bashrc && \
+    echo "source $VIRTUAL_ENV/bin/activate" >> ~/.bashrc
+
+ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
+CMD []
+
+###########################################################
+########## Development (run.sh, runs as root user) ########
+###########################################################
+#
+# PURPOSE: Local development environment for use with run.sh (not Dev Container plug-in)
+#
+# This stage runs as root and provides:
+# - Development tools and utilities for local debugging
+# - Support for vscode/cursor development outside the Dev Container plug-in
+#
+# Use this stage if you need a full-featured development environment with extra tools,
+# but do not use it with the Dev Container plug-in.
+
+FROM runtime AS dev
+
+# Don't want ubuntu to be editable, just change uid and gid.
+ARG WORKSPACE_DIR=/workspace
+
+# Install utilities as root
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends  \
+    # Install utilities
+    nvtop \
+    wget \
+    tmux \
+    vim \
+    git \
+    openssh-client \
+    iproute2 \
+    rsync \
+    zip \
+    unzip \
+    htop \
+    # Build Dependencies
+    autoconf \
+    automake \
+    cmake \
+    libtool \
+    meson \
+    net-tools \
+    pybind11-dev \
+    # Rust build dependencies
+    clang \
+    libclang-dev \
+    protobuf-compiler && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set workspace directory variable
+ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
+    DYNAMO_HOME=${WORKSPACE_DIR} \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    CARGO_TARGET_DIR=/workspace/target \
+    VIRTUAL_ENV=/opt/dynamo/venv \
+    PATH=/usr/local/cargo/bin:$PATH
+
+COPY --from=dynamo_base /usr/local/rustup /usr/local/rustup
+COPY --from=dynamo_base /usr/local/cargo /usr/local/cargo
+
+# Install maturin, for maturin develop
+# Editable install of dynamo
+RUN uv pip install maturin[patchelf] && \
+    uv pip install --no-deps -e .
+
+ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
+CMD []

--- a/container/build.sh
+++ b/container/build.sh
@@ -519,7 +519,7 @@ fi
 
 # Update DOCKERFILE if framework is VLLM
 if [[ $FRAMEWORK == "VLLM" ]]; then
-    DOCKERFILE=${SOURCE_DIR}/Dockerfile.vllm
+    DOCKERFILE=${SOURCE_DIR}/Dockerfile.vllm-checkpoint
 elif [[ $FRAMEWORK == "TRTLLM" ]]; then
     DOCKERFILE=${SOURCE_DIR}/Dockerfile.trtllm
 elif [[ $FRAMEWORK == "NONE" ]]; then

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-VLLM_REF="v0.11.0"
+VLLM_REF="e3803db362ea36ff24e21751800027bc0dd082d1"
 
 # Basic Configurations
 ARCH=$(uname -m)
@@ -28,7 +28,7 @@ CUDA_VERSION="12.8" # For DEEPGEMM
 
 # These flags are applicable when installing vLLM from source code
 EDITABLE=true
-VLLM_GIT_URL="https://github.com/vllm-project/vllm.git"
+VLLM_GIT_URL="https://github.com/galletas1712/vllm.git"
 FLASHINF_REF="v0.3.1"
 
 while [[ $# -gt 0 ]]; do
@@ -198,7 +198,7 @@ else
 
         # When updating above VLLM_REF make sure precompiled wheel file URL is correct. Run this command:
         # aws s3 ls s3://vllm-wheels/${VLLM_REF}/ --region us-west-2 --no-sign-request
-        export VLLM_PRECOMPILED_WHEEL_LOCATION="https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-0.10.2-cp38-abi3-manylinux1_x86_64.whl"
+        # export VLLM_PRECOMPILED_WHEEL_LOCATION="https://vllm-wheels.s3.us-west-2.amazonaws.com/${VLLM_REF}/vllm-0.10.2-cp38-abi3-manylinux1_x86_64.whl"
 
         if [ "$EDITABLE" = "true" ]; then
             uv pip install -e . --torch-backend=$TORCH_BACKEND


### PR DESCRIPTION
#### Overview:

Co-written by @galletas1712 

This feature enables fast startup of vLLM inference engines by checkpointing GPU-initialized processes and restoring them on-demand. This dramatically reduces the time to initialize vLLM workers, especially beneficial in autoscaling scenarios.

##### Important Caveats
- Intra-Pod Only: This feature currently only works for checkpoint/restore within the same pod. This is due to a known issue where CRIU cannot restore due to process ID collisions. This is actively being worked on and is crucial to fix the cold start problem.
- Requires upstream vLLM changes: CRIU requires small changes to vLLM to enable this feature and we require a vLLM patch before merging this
- Requires a lot of permissions: The pod must have root, host PIDs exposed, and securityContext
- Requires 580 drivers

#### Details:

The checkpoint/restore functionality uses
1. cuda-checkpoint: Checkpoints GPU memory and CUDA state
2. CRIU (Checkpoint/Restore In Userspace): Captures the complete process state including memory, file descriptors, and process tree


The implementation uses `CheckpointableAsyncLLM`, a wrapper around vLLM's `AsyncLLM` that:
- Runs the vLLM engine in a subprocess
- Communicates via ZMQ (REQ-REP pattern) for client-server communication
- Supports CRIU checkpoint/restore operations
- Handles GPU memory checkpointing via NVIDIA's cuda-checkpoint API


![Mermaid Chart - Create complex, visual diagrams with text -2025-11-07-211945](https://github.com/user-attachments/assets/13628e03-5d8f-48d7-8872-2326e1b52d06)

## Three Initialization Paths
##### 1. Checkpointing Disabled (Standard Path)
- Creates a standard `AsyncLLM` instance directly
- No subprocess, no ZMQ overhead
- Normal vLLM startup time

##### 2. Checkpoint Exists (Fast Restore Path)
- Detects existing checkpoint directory (with matching config hash)
- Creates `CheckpointableAsyncLLM` with `auto_start=False`
- Runs CRIU and cuda checkpoint plugin to restore to resurrect the checkpointed process
- Reconnects ZMQ socket to restored subprocess
- **Result**: Engine ready in seconds instead of minutes

##### 3. Checkpoint Doesn't Exist (Initial Checkpoint Creation)
- Creates `CheckpointableAsyncLLM` with `auto_start=True`
- Starts vLLM engine in subprocess and waits for readiness
- Dumps process state with CRIU and cuda checkpoint plugin
- Atomically moves checkpoint to final directory (handles race conditions)
- Restores from the checkpoint (whether created by this worker or another)
- **Result**: Checkpoint created for future use, engine ready after restore

#### Where should the reviewer start?

##### CheckpointableAsyncLLM
- Found in `components/src/dynamo/vllm/checkpoint/checkpointable_async_llm.py`
- Wraps AsyncLLM in subprocess with ZMQ server, exposes same async API
- Manages CRIU checkpoint/restore lifecycle and PTY/TTY handling

##### vLLM Engine Management
- Found in `components/src/dynamo/vllm/engine.py`
- Added a new function to choose between AsyncLLM and CheckpointableAsyncLLM

##### Dockerfile.vllm-checkpoint
- A new Docker image to add CRIU, cuda-checkpoint and additional dependencies while this is an experimental feature

##### Config Hash-Based Isolation
- Uses `VllmConfig.compute_hash()[:8]` for subdirectories: `checkpoint_dir/{hash}/`
- Prevents mismatches when using same checkpoint_dir with different configs

##### GPU Memory Checkpointing (`checkpoint/utils.py`)
- NVIDIA cuda-checkpoint API: Lock → Checkpoint → Restore/Unlock
- Logs GPU memory usage for debugging

##### ZMQ Communication
- REQ-REP over TCP, cloudpickle serialization
- Subprocess runs `ZMQAsyncLLMServer`, parent sends requests

##### Metadata (`checkpoint/metadata.py`)
- Stores `vllm_checkpoint_metadata.json` with TTY info, PIDs, ZMQ port
- Used for TTY remapping during restore

##### Race Condition Handling
- Atomic `os.rename()` ensures only one checkpoint survives
- First worker wins, others clean up and restore from the shared checkpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model checkpoint and restore capabilities for LLM inference engines, controllable via `ENABLE_CHECKPOINTING` and `CHECKPOINT_DIR` environment variables
  * Supports CUDA-aware checkpointing with automatic metadata persistence and recovery

* **Chores**
  * Added container image for deploying checkpoint-enabled inference environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->