### PR TITLE
refactor: Make the Runtime and DistributedRuntime fields private

### DIFF
--- a/lib/bindings/python/rust/http.rs
+++ b/lib/bindings/python/rust/http.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use anyhow::{Error, Result, anyhow as error};
 use pyo3::prelude::*;
 
 use crate::{CancellationToken, engine::*, to_pyerr};
@@ -10,7 +11,6 @@ use crate::{CancellationToken, engine::*, to_pyerr};
 pub use dynamo_llm::endpoint_type::EndpointType;
 pub use dynamo_llm::http::service::{error as http_error, service_v2};
 pub use dynamo_runtime::{
-    Error, Result, error,
     pipeline::{AsyncEngine, Data, ManyOut, SingleIn, async_trait},
     protocols::annotated::Annotated,
 };

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -441,20 +441,20 @@ impl DistributedRuntime {
         // Try to get existing runtime first, create new Worker only if needed
         // This allows multiple DistributedRuntime instances to share the same tokio runtime
         let runtime = rs::Worker::runtime_from_existing()
-            .or_else(|_| {
+            .or_else(|_| -> anyhow::Result<rs::Runtime> {
                 // No existing Worker, create new one
                 let worker = rs::Worker::from_settings()?;
 
                 // Initialize pyo3 bridge (only happens once per process)
-                INIT.get_or_try_init(|| {
+                INIT.get_or_try_init(|| -> anyhow::Result<()> {
                     let primary = worker.tokio_runtime()?;
                     pyo3_async_runtimes::tokio::init_with_runtime(primary).map_err(|e| {
-                        rs::error!("failed to initialize pyo3 static runtime: {:?}", e)
+                        anyhow::anyhow!("failed to initialize pyo3 static runtime: {:?}", e)
                     })?;
-                    rs::OK(())
+                    Ok(())
                 })?;
 
-                rs::OK(worker.runtime().clone())
+                Ok(worker.runtime().clone())
             })
             .map_err(to_pyerr)?;
 

--- a/lib/llm/src/block_manager/pool.rs
+++ b/lib/llm/src/block_manager/pool.rs
@@ -4,6 +4,7 @@
 pub mod managed;
 pub use managed::ManagedBlockPool;
 
+use anyhow::Result;
 use derive_builder::Builder;
 use derive_getters::Dissolve;
 use serde::{Deserialize, Serialize};
@@ -30,8 +31,6 @@ use std::{
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
-
-use dynamo_runtime::Result;
 
 // Type aliases to reduce complexity across the module
 type BlockPoolResult<T> = Result<T, BlockPoolError>;

--- a/lib/llm/src/mocker/engine.rs
+++ b/lib/llm/src/mocker/engine.rs
@@ -6,31 +6,33 @@
 //! This module provides an AsyncEngine implementation that wraps the Scheduler
 //! to provide streaming token generation with realistic timing simulation.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use futures::StreamExt;
+use rand::Rng;
+use tokio::sync::{Mutex, OnceCell, mpsc};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use dynamo_runtime::DistributedRuntime;
+use dynamo_runtime::protocols::annotated::Annotated;
+use dynamo_runtime::{
+    component::Component,
+    engine::AsyncEngineContextProvider,
+    pipeline::{AsyncEngine, Error, ManyOut, ResponseStream, SingleIn, async_trait},
+    traits::DistributedRuntimeProvider,
+};
+
 use crate::kv_router::publisher::WorkerMetricsPublisher;
 use crate::mocker::protocols::DirectRequest;
 use crate::mocker::protocols::{MockEngineArgs, OutputSignal, WorkerType};
 use crate::mocker::scheduler::Scheduler;
 use crate::protocols::TokenIdType;
 use crate::protocols::common::llm_backend::{LLMEngineOutput, PreprocessedRequest};
-use dynamo_runtime::DistributedRuntime;
-use dynamo_runtime::protocols::annotated::Annotated;
-use tokio_util::sync::CancellationToken;
-
-use dynamo_runtime::{
-    Result,
-    component::Component,
-    engine::AsyncEngineContextProvider,
-    pipeline::{AsyncEngine, Error, ManyOut, ResponseStream, SingleIn, async_trait},
-    traits::DistributedRuntimeProvider,
-};
-use futures::StreamExt;
-use rand::Rng;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::sync::{Mutex, OnceCell, mpsc};
-use tokio_stream::wrappers::UnboundedReceiverStream;
-use uuid::Uuid;
 
 pub const MOCKER_COMPONENT: &str = "mocker";
 

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -300,7 +300,6 @@ mod integration_tests {
     use dynamo_runtime::DistributedRuntime;
     use dynamo_runtime::discovery::DiscoveryQuery;
     use dynamo_runtime::pipeline::RouterMode;
-    use dynamo_runtime::traits::DistributedRuntimeProvider;
     use std::sync::Arc;
 
     #[tokio::test]

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -1040,6 +1040,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "hello_world"
 version = "0.6.1"
 dependencies = [
+ "anyhow",
  "dynamo-runtime",
 ]
 
@@ -2633,6 +2634,7 @@ dependencies = [
 name = "service_metrics"
 version = "0.6.1"
 dependencies = [
+ "anyhow",
  "dynamo-runtime",
  "futures",
  "serde",

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -20,5 +20,6 @@ repository = "https://github.com/ai-dynamo/dynamo.git"
 
 [workspace.dependencies]
 # local or crates.io
+anyhow = "1"
 dynamo-runtime = { path = "../" }
 prometheus = { version = "0.14" }

--- a/lib/runtime/examples/hello_world/Cargo.toml
+++ b/lib/runtime/examples/hello_world/Cargo.toml
@@ -13,3 +13,4 @@ homepage.workspace = true
 dynamo-runtime = { workspace = true }
 
 # third-party
+anyhow = { workspace = true }

--- a/lib/runtime/examples/hello_world/src/bin/client.rs
+++ b/lib/runtime/examples/hello_world/src/bin/client.rs
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_runtime::{
-    DistributedRuntime, Result, Runtime, Worker, logging, pipeline::PushRouter,
+    DistributedRuntime, Runtime, Worker, logging, pipeline::PushRouter,
     protocols::annotated::Annotated, stream::StreamExt,
 };
 use hello_world::DEFAULT_NAMESPACE;
 
-fn main() -> Result<()> {
+fn main() -> anyhow::Result<()> {
     logging::init();
     let worker = Worker::from_settings()?;
     worker.execute(app)
 }
 
-async fn app(runtime: Runtime) -> Result<()> {
+async fn app(runtime: Runtime) -> anyhow::Result<()> {
     let distributed = DistributedRuntime::from_settings(runtime.clone()).await?;
 
     let client = distributed

--- a/lib/runtime/examples/hello_world/src/bin/server.rs
+++ b/lib/runtime/examples/hello_world/src/bin/server.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_runtime::{
-    DistributedRuntime, Result, Runtime, Worker, logging,
+    DistributedRuntime, Runtime, Worker, logging,
     pipeline::{
         AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, ResponseStream, SingleIn,
         async_trait, network::Ingress,
@@ -13,13 +13,13 @@ use dynamo_runtime::{
 use hello_world::DEFAULT_NAMESPACE;
 use std::sync::Arc;
 
-fn main() -> Result<()> {
+fn main() -> anyhow::Result<()> {
     logging::init();
     let worker = Worker::from_settings()?;
     worker.execute(app)
 }
 
-async fn app(runtime: Runtime) -> Result<()> {
+async fn app(runtime: Runtime) -> anyhow::Result<()> {
     let distributed = DistributedRuntime::from_settings(runtime.clone()).await?;
     backend(distributed).await
 }
@@ -34,7 +34,10 @@ impl RequestHandler {
 
 #[async_trait]
 impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, Error> for RequestHandler {
-    async fn generate(&self, input: SingleIn<String>) -> Result<ManyOut<Annotated<String>>> {
+    async fn generate(
+        &self,
+        input: SingleIn<String>,
+    ) -> anyhow::Result<ManyOut<Annotated<String>>> {
         let (data, ctx) = input.into_parts();
 
         let chars = data
@@ -48,7 +51,7 @@ impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, Error> for Reques
     }
 }
 
-async fn backend(runtime: DistributedRuntime) -> Result<()> {
+async fn backend(runtime: DistributedRuntime) -> anyhow::Result<()> {
     // attach an ingress to an engine
     let ingress = Ingress::for_engine(RequestHandler::new())?;
 

--- a/lib/runtime/examples/service_metrics/Cargo.toml
+++ b/lib/runtime/examples/service_metrics/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 dynamo-runtime = { workspace = true }
 
 # third-party
+anyhow = { workspace = true }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }

--- a/lib/runtime/examples/service_metrics/src/bin/service_client.rs
+++ b/lib/runtime/examples/service_metrics/src/bin/service_client.rs
@@ -5,17 +5,17 @@ use futures::StreamExt;
 use service_metrics::DEFAULT_NAMESPACE;
 
 use dynamo_runtime::{
-    DistributedRuntime, Result, Runtime, Worker, logging, pipeline::PushRouter,
+    DistributedRuntime, Runtime, Worker, logging, pipeline::PushRouter,
     protocols::annotated::Annotated, utils::Duration,
 };
 
-fn main() -> Result<()> {
+fn main() -> anyhow::Result<()> {
     logging::init();
     let worker = Worker::from_settings()?;
     worker.execute(app)
 }
 
-async fn app(runtime: Runtime) -> Result<()> {
+async fn app(runtime: Runtime) -> anyhow::Result<()> {
     let distributed = DistributedRuntime::from_settings(runtime.clone()).await?;
 
     let namespace = distributed.namespace(DEFAULT_NAMESPACE)?;

--- a/lib/runtime/examples/service_metrics/src/bin/service_server.rs
+++ b/lib/runtime/examples/service_metrics/src/bin/service_server.rs
@@ -4,7 +4,7 @@
 use service_metrics::{DEFAULT_NAMESPACE, MyStats};
 
 use dynamo_runtime::{
-    DistributedRuntime, Result, Runtime, Worker, logging,
+    DistributedRuntime, Runtime, Worker, logging,
     pipeline::{
         AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, ResponseStream, SingleIn,
         async_trait, network::Ingress,
@@ -14,13 +14,13 @@ use dynamo_runtime::{
 };
 use std::sync::Arc;
 
-fn main() -> Result<()> {
+fn main() -> anyhow::Result<()> {
     logging::init();
     let worker = Worker::from_settings()?;
     worker.execute(app)
 }
 
-async fn app(runtime: Runtime) -> Result<()> {
+async fn app(runtime: Runtime) -> anyhow::Result<()> {
     let distributed = DistributedRuntime::from_settings(runtime.clone()).await?;
     backend(distributed).await
 }
@@ -35,7 +35,10 @@ impl RequestHandler {
 
 #[async_trait]
 impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, Error> for RequestHandler {
-    async fn generate(&self, input: SingleIn<String>) -> Result<ManyOut<Annotated<String>>> {
+    async fn generate(
+        &self,
+        input: SingleIn<String>,
+    ) -> anyhow::Result<ManyOut<Annotated<String>>> {
         let (data, ctx) = input.into_parts();
 
         let chars = data
@@ -49,7 +52,7 @@ impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, Error> for Reques
     }
 }
 
-async fn backend(runtime: DistributedRuntime) -> Result<()> {
+async fn backend(runtime: DistributedRuntime) -> anyhow::Result<()> {
     // attach an ingress to an engine
     let ingress = Ingress::for_engine(RequestHandler::new())?;
 

--- a/lib/runtime/examples/system_metrics/src/bin/system_client.rs
+++ b/lib/runtime/examples/system_metrics/src/bin/system_client.rs
@@ -5,17 +5,17 @@ use futures::StreamExt;
 use system_metrics::{DEFAULT_COMPONENT, DEFAULT_ENDPOINT, DEFAULT_NAMESPACE};
 
 use dynamo_runtime::{
-    DistributedRuntime, Result, Runtime, Worker, logging, pipeline::PushRouter,
+    DistributedRuntime, Runtime, Worker, logging, pipeline::PushRouter,
     protocols::annotated::Annotated, utils::Duration,
 };
 
-fn main() -> Result<()> {
+fn main() -> anyhow::Result<()> {
     logging::init();
     let worker = Worker::from_settings()?;
     worker.execute(app)
 }
 
-async fn app(runtime: Runtime) -> Result<()> {
+async fn app(runtime: Runtime) -> anyhow::Result<()> {
     let distributed = DistributedRuntime::from_settings(runtime.clone()).await?;
 
     let namespace = distributed.namespace(DEFAULT_NAMESPACE)?;

--- a/lib/runtime/examples/system_metrics/src/bin/system_server.rs
+++ b/lib/runtime/examples/system_metrics/src/bin/system_server.rs
@@ -1,16 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_runtime::{DistributedRuntime, Result, Runtime, Worker, logging};
+use dynamo_runtime::{DistributedRuntime, Runtime, Worker, logging};
 use system_metrics::backend;
 
-fn main() -> Result<()> {
+fn main() -> anyhow::Result<()> {
     logging::init();
     let worker = Worker::from_settings()?;
     worker.execute(app)
 }
 
-async fn app(runtime: Runtime) -> Result<()> {
+async fn app(runtime: Runtime) -> anyhow::Result<()> {
     let distributed = DistributedRuntime::from_settings(runtime.clone()).await?;
     backend(distributed, None).await
 }

--- a/lib/runtime/examples/system_metrics/src/lib.rs
+++ b/lib/runtime/examples/system_metrics/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_runtime::{
-    DistributedRuntime, Result,
+    DistributedRuntime,
     metrics::MetricsHierarchy,
     pipeline::{
         AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, ResponseStream, SingleIn,
@@ -64,7 +64,10 @@ impl RequestHandler {
 
 #[async_trait]
 impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, Error> for RequestHandler {
-    async fn generate(&self, input: SingleIn<String>) -> Result<ManyOut<Annotated<String>>> {
+    async fn generate(
+        &self,
+        input: SingleIn<String>,
+    ) -> anyhow::Result<ManyOut<Annotated<String>>> {
         let (data, ctx) = input.into_parts();
 
         // Track data bytes processed if metrics are available
@@ -85,7 +88,7 @@ impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, Error> for Reques
 
 /// Backend function that sets up the system status server with metrics and ingress handler
 /// This function can be reused by integration tests to ensure they use the exact same setup
-pub async fn backend(drt: DistributedRuntime, endpoint_name: Option<&str>) -> Result<()> {
+pub async fn backend(drt: DistributedRuntime, endpoint_name: Option<&str>) -> anyhow::Result<()> {
     let endpoint_name = endpoint_name.unwrap_or(DEFAULT_ENDPOINT);
 
     let mut component = drt

--- a/lib/runtime/src/component/component.rs
+++ b/lib/runtime/src/component/component.rs
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Context;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use futures::stream::StreamExt;
 use futures::{Stream, TryStreamExt};
+use serde::{Deserialize, Serialize};
 
-use super::*;
-
+use crate::component::Component;
+use crate::traits::DistributedRuntimeProvider;
 use crate::traits::events::{EventPublisher, EventSubscriber};
 
 #[async_trait]
@@ -71,6 +72,8 @@ impl EventSubscriber for Component {
 #[cfg(feature = "integration")]
 #[cfg(test)]
 mod tests {
+    use crate::{DistributedRuntime, Runtime};
+
     use super::*;
 
     // todo - make a distributed runtime fixture

--- a/lib/runtime/src/component/namespace.rs
+++ b/lib/runtime/src/component/namespace.rs
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;
+use anyhow::Result;
 use async_trait::async_trait;
 use futures::stream::StreamExt;
 use futures::{Stream, TryStreamExt};
+use serde::Deserialize;
+use serde::Serialize;
 
-use super::*;
+use crate::component::Namespace;
 use crate::metrics::{MetricsHierarchy, MetricsRegistry};
+use crate::traits::DistributedRuntimeProvider;
 use crate::traits::events::{EventPublisher, EventSubscriber};
 
 #[async_trait]
@@ -99,6 +103,8 @@ impl MetricsHierarchy for Namespace {
 #[cfg(feature = "integration")]
 #[cfg(test)]
 mod tests {
+    use crate::{DistributedRuntime, Runtime};
+
     use super::*;
 
     // todo - make a distributed runtime fixture

--- a/lib/runtime/src/component/registry.rs
+++ b/lib/runtime/src/component/registry.rs
@@ -1,13 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Component, Registry, RegistryInner, Result};
+use anyhow::Result;
 use async_once_cell::OnceCell;
 use std::{
     collections::HashMap,
     sync::{Arc, Weak},
 };
 use tokio::sync::Mutex;
+
+use crate::component::{Registry, RegistryInner};
 
 impl Default for Registry {
     fn default() -> Self {
@@ -22,66 +24,3 @@ impl Registry {
         }
     }
 }
-
-// impl ComponentRegistry {
-//     pub fn new() -> Self {
-//         Self {
-//             clients: Arc::new(Mutex::new(HashMap::new())),
-//         }
-//     }
-
-//     pub async fn get_or_create(&mut self, component: Component) -> Result<Arc<Client>> {
-//         // Lock the clients HashMap for thread-safe access
-//         let mut guard = self.clients.lock().await;
-
-//         // Check if the component already exists in the registry
-//         if let Some(weak) = guard.get(&component.slug()) {
-//             // Attempt to upgrade the Weak pointer
-//             if let Some(client) = weak.upgrade() {
-//                 return Ok(client);
-//             }
-//         }
-
-//         // Fallback: Create a new Client
-//         let client = component.client().await?;
-
-//         // Insert a Weak reference to the new client into the map
-//         guard.insert(component.slug(), Arc::downgrade(&client));
-
-//         Ok(client)
-//     }
-// }
-
-// #[derive(Clone)]
-// pub struct ServiceRegistry {
-//     clients: Arc<Mutex<HashMap<String, Arc<Service>>>>,
-// }
-
-// impl ServiceRegistry {
-//     pub fn new() -> Self {
-//         Self {
-//             clients: Arc::new(Mutex::new(HashMap::new())),
-//         }
-//     }
-
-//     pub async fn get_or_create(&mut self, component: Component) -> Result<Arc<Client>> {
-//         // Lock the clients HashMap for thread-safe access
-//         let mut guard = self.clients.lock().await;
-
-//         // Check if the component already exists in the registry
-//         if let Some(weak) = guard.get(&component.slug()) {
-//             // Attempt to upgrade the Weak pointer
-//             if let Some(client) = weak.upgrade() {
-//                 return Ok(client);
-//             }
-//         }
-
-//         // Fallback: Create a new Client
-//         let client = component.client().await?;
-
-//         // Insert a Weak reference to the new client into the map
-//         guard.insert(component.slug(), Arc::downgrade(&client));
-
-//         Ok(client)
-//     }
-// }

--- a/lib/runtime/src/config.rs
+++ b/lib/runtime/src/config.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::Result;
+use anyhow::Result;
 use derive_builder::Builder;
 use figment::{
     Figment,

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -1,16 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::storage::key_value_store::{KeyValueStoreManager, WatchEvent};
-use crate::{CancellationToken, Result};
-use async_trait::async_trait;
-use futures::{Stream, StreamExt};
 use std::pin::Pin;
 use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use tokio_util::sync::CancellationToken;
 
 use super::{
     Discovery, DiscoveryEvent, DiscoveryInstance, DiscoveryQuery, DiscoverySpec, DiscoveryStream,
 };
+use crate::storage::key_value_store::{KeyValueStoreManager, WatchEvent};
 
 const INSTANCES_BUCKET: &str = "v1/instances";
 const MODELS_BUCKET: &str = "v1/mdc";

--- a/lib/runtime/src/discovery/mock.rs
+++ b/lib/runtime/src/discovery/mock.rs
@@ -4,9 +4,10 @@
 use super::{
     Discovery, DiscoveryEvent, DiscoveryInstance, DiscoveryQuery, DiscoverySpec, DiscoveryStream,
 };
-use crate::{CancellationToken, Result};
+use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::{Arc, Mutex};
+use tokio_util::sync::CancellationToken;
 
 /// Shared in-memory registry for mock discovery
 #[derive(Clone, Default)]

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -1,21 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::CancellationToken;
-use crate::Result;
-use crate::component::TransportType;
+use anyhow::Result;
 use async_trait::async_trait;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
+use tokio_util::sync::CancellationToken;
 
 mod mock;
 pub use mock::{MockDiscovery, SharedMockRegistry};
-
 mod kv_store;
 pub use kv_store::KVStoreDiscovery;
-
 pub mod utils;
+use crate::component::TransportType;
 pub use utils::watch_and_extract_field;
 
 /// Query key for prefix-based discovery queries
@@ -85,7 +83,7 @@ impl DiscoverySpec {
         component: String,
         endpoint: String,
         card: &T,
-    ) -> crate::Result<Self>
+    ) -> Result<Self>
     where
         T: Serialize,
     {
@@ -158,14 +156,14 @@ impl DiscoveryInstance {
 
     /// Deserializes the model JSON into the specified type T
     /// Returns an error if this is not a Model instance or if deserialization fails
-    pub fn deserialize_model<T>(&self) -> crate::Result<T>
+    pub fn deserialize_model<T>(&self) -> Result<T>
     where
         T: for<'de> Deserialize<'de>,
     {
         match self {
             Self::Model { card_json, .. } => Ok(serde_json::from_value(card_json.clone())?),
             Self::Endpoint(_) => {
-                crate::raise!("Cannot deserialize model from Endpoint instance")
+                anyhow::bail!("Cannot deserialize model from Endpoint instance")
             }
         }
     }

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-pub use crate::component::Component;
+use crate::component::Component;
+use crate::pipeline::PipelineError;
 use crate::storage::key_value_store::{
     EtcdStore, KeyValueStore, KeyValueStoreEnum, KeyValueStoreManager, KeyValueStoreSelect,
     MemoryStore,
 };
 use crate::transports::nats::DRTNatsClientPrometheusMetrics;
 use crate::{
-    ErrorContext,
     component::{self, ComponentBuilder, Endpoint, InstanceSource, Namespace},
     discovery::Discovery,
     metrics::PrometheusUpdateCallback,
@@ -16,16 +16,58 @@ use crate::{
     service::ServiceClient,
     transports::{etcd, nats, tcp},
 };
+use crate::{discovery, system_status_server, transports};
 
 use super::utils::GracefulShutdownTracker;
-use super::{Arc, DistributedRuntime, OK, OnceCell, Result, Runtime, SystemHealth, Weak, error};
-use std::sync::OnceLock;
+use crate::SystemHealth;
+use crate::runtime::Runtime;
 
+use async_once_cell::OnceCell;
+use std::sync::{Arc, OnceLock, Weak};
+
+use anyhow::Result;
 use derive_getters::Dissolve;
 use figment::error;
 use std::collections::HashMap;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
+
+/// Distributed [Runtime] which provides access to shared resources across the cluster, this includes
+/// communication protocols and transports.
+#[derive(Clone)]
+pub struct DistributedRuntime {
+    // local runtime
+    runtime: Runtime,
+
+    // we might consider a unifed transport manager here
+    etcd_client: Option<transports::etcd::Client>,
+    nats_client: Option<transports::nats::Client>,
+    store: KeyValueStoreManager,
+    tcp_server: Arc<OnceCell<Arc<transports::tcp::server::TcpStreamServer>>>,
+    system_status_server: Arc<OnceLock<Arc<system_status_server::SystemStatusServerInfo>>>,
+
+    // Service discovery client
+    discovery_client: Arc<dyn discovery::Discovery>,
+
+    // local registry for components
+    // the registry allows us to use share runtime resources across instances of the same component object.
+    // take for example two instances of a client to the same remote component. The registry allows us to use
+    // a single endpoint watcher for both clients, this keeps the number background tasking watching specific
+    // paths in etcd to a minimum.
+    component_registry: component::Registry,
+
+    // Will only have static components that are not discoverable via etcd, they must be know at
+    // startup. Will not start etcd.
+    is_static: bool,
+
+    instance_sources: Arc<tokio::sync::Mutex<HashMap<Endpoint, Weak<InstanceSource>>>>,
+
+    // Health Status
+    system_health: Arc<parking_lot::Mutex<SystemHealth>>,
+
+    // This hierarchy's own metrics registry
+    metrics_registry: MetricsRegistry,
+}
 
 impl MetricsHierarchy for DistributedRuntime {
     fn basename(&self) -> String {
@@ -229,6 +271,17 @@ impl DistributedRuntime {
         self.runtime.primary_token()
     }
 
+    // TODO: Don't hand out pointers, instead have methods to use the registry in friendly ways
+    // (without being aware of async locks and so on)
+    pub fn component_registry(&self) -> &component::Registry {
+        &self.component_registry
+    }
+
+    // TODO: Don't hand out pointers, instead provide system health related services.
+    pub fn system_health(&self) -> Arc<parking_lot::Mutex<SystemHealth>> {
+        self.system_health.clone()
+    }
+
     pub fn connection_id(&self) -> u64 {
         self.store.connection_id()
     }
@@ -258,7 +311,7 @@ impl DistributedRuntime {
             .get_or_try_init(async move {
                 let options = tcp::server::ServerOptions::default();
                 let server = tcp::server::TcpStreamServer::new(options).await?;
-                OK(server)
+                Ok::<_, PipelineError>(server)
             })
             .await?
             .clone())

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -6,17 +6,6 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, OnceLock, Weak},
-};
-
-pub use anyhow::{
-    Context as ErrorContext, Error, Ok as OK, Result, anyhow as error, bail as raise,
-};
-
-use async_once_cell::OnceCell;
-
 pub mod config;
 pub use config::RuntimeConfig;
 
@@ -27,6 +16,7 @@ pub mod engine;
 pub mod health_check;
 pub mod system_status_server;
 pub use system_status_server::SystemStatusServerInfo;
+pub mod distributed;
 pub mod instances;
 pub mod logging;
 pub mod metrics;
@@ -44,77 +34,10 @@ pub mod transports;
 pub mod utils;
 pub mod worker;
 
-pub mod distributed;
-pub use distributed::distributed_test_utils;
+pub use distributed::{DistributedRuntime, distributed_test_utils};
 pub use futures::stream;
 pub use metrics::MetricsRegistry;
+pub use runtime::Runtime;
 pub use system_health::{HealthCheckTarget, SystemHealth};
 pub use tokio_util::sync::CancellationToken;
 pub use worker::Worker;
-
-use crate::{
-    metrics::prometheus_names::distributed_runtime,
-    storage::key_value_store::{KeyValueStore, KeyValueStoreManager},
-};
-
-use component::{Endpoint, InstanceSource};
-use utils::GracefulShutdownTracker;
-
-use config::HealthStatus;
-
-/// Types of Tokio runtimes that can be used to construct a Dynamo [Runtime].
-#[derive(Clone)]
-enum RuntimeType {
-    Shared(Arc<tokio::runtime::Runtime>),
-    External(tokio::runtime::Handle),
-}
-
-/// Local [Runtime] which provides access to shared resources local to the physical node/machine.
-#[derive(Debug, Clone)]
-pub struct Runtime {
-    id: Arc<String>,
-    primary: RuntimeType,
-    secondary: RuntimeType,
-    cancellation_token: CancellationToken,
-    endpoint_shutdown_token: CancellationToken,
-    graceful_shutdown_tracker: Arc<GracefulShutdownTracker>,
-    compute_pool: Option<Arc<compute::ComputePool>>,
-    block_in_place_permits: Option<Arc<tokio::sync::Semaphore>>,
-}
-
-/// Distributed [Runtime] which provides access to shared resources across the cluster, this includes
-/// communication protocols and transports.
-#[derive(Clone)]
-pub struct DistributedRuntime {
-    // local runtime
-    runtime: Runtime,
-
-    // we might consider a unifed transport manager here
-    etcd_client: Option<transports::etcd::Client>,
-    nats_client: Option<transports::nats::Client>,
-    store: KeyValueStoreManager,
-    tcp_server: Arc<OnceCell<Arc<transports::tcp::server::TcpStreamServer>>>,
-    system_status_server: Arc<OnceLock<Arc<system_status_server::SystemStatusServerInfo>>>,
-
-    // Service discovery interface
-    discovery_client: Arc<dyn discovery::Discovery>,
-
-    // local registry for components
-    // the registry allows us to use share runtime resources across instances of the same component object.
-    // take for example two instances of a client to the same remote component. The registry allows us to use
-    // a single endpoint watcher for both clients, this keeps the number background tasking watching specific
-    // paths in etcd to a minimum.
-    component_registry: component::Registry,
-
-    // Will only have static components that are not discoverable via etcd, they must be know at
-    // startup. Will not start etcd.
-    is_static: bool,
-
-    instance_sources: Arc<tokio::sync::Mutex<HashMap<Endpoint, Weak<InstanceSource>>>>,
-
-    // Health Status
-    system_health: Arc<parking_lot::Mutex<SystemHealth>>,
-
-    // This hierarchy's own metrics registry
-    metrics_registry: MetricsRegistry,
-}

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -19,7 +19,7 @@ use crate::pipeline::network::{
     codec::{TwoPartCodec, TwoPartMessage},
     tcp::StreamType,
 };
-use crate::{ErrorContext, Result, error}; // Import SinkExt to use the `send` method
+use anyhow::{Context, Result, anyhow as error}; // Import SinkExt to use the `send` method
 
 #[allow(dead_code)]
 pub struct TcpClient {

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -16,25 +16,6 @@ use derive_builder::Builder;
 use futures::{SinkExt, StreamExt};
 use local_ip_address::{Error, list_afinet_netifas, local_ip, local_ipv6};
 
-// Trait for IP address resolution - allows dependency injection for testing
-pub trait IpResolver {
-    fn local_ip(&self) -> Result<std::net::IpAddr, Error>;
-    fn local_ipv6(&self) -> Result<std::net::IpAddr, Error>;
-}
-
-// Default implementation using the real local_ip_address crate
-pub struct DefaultIpResolver;
-
-impl IpResolver for DefaultIpResolver {
-    fn local_ip(&self) -> Result<std::net::IpAddr, Error> {
-        local_ip()
-    }
-
-    fn local_ipv6(&self) -> Result<std::net::IpAddr, Error> {
-        local_ipv6()
-    }
-}
-
 use serde::{Deserialize, Serialize};
 use tokio::{
     io::AsyncWriteExt,
@@ -56,7 +37,26 @@ use crate::pipeline::{
         tcp::StreamType,
     },
 };
-use crate::{ErrorContext, Result, error};
+use anyhow::{Context, Result, anyhow as error};
+
+// Trait for IP address resolution - allows dependency injection for testing
+pub trait IpResolver {
+    fn local_ip(&self) -> Result<std::net::IpAddr, Error>;
+    fn local_ipv6(&self) -> Result<std::net::IpAddr, Error>;
+}
+
+// Default implementation using the real local_ip_address crate
+pub struct DefaultIpResolver;
+
+impl IpResolver for DefaultIpResolver {
+    fn local_ip(&self) -> Result<std::net::IpAddr, Error> {
+        local_ip()
+    }
+
+    fn local_ipv6(&self) -> Result<std::net::IpAddr, Error> {
+        local_ipv6()
+    }
+}
 
 #[allow(dead_code)]
 type ResponseType = TwoPartMessage;

--- a/lib/runtime/src/pipeline/nodes/sinks/base.rs
+++ b/lib/runtime/src/pipeline/nodes/sinks/base.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::Error;
+use anyhow::Error;
 
 impl<Resp: PipelineIO> Default for SinkEdge<Resp> {
     fn default() -> Self {

--- a/lib/runtime/src/pipeline/nodes/sinks/pipeline.rs
+++ b/lib/runtime/src/pipeline/nodes/sinks/pipeline.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::Error;
+use anyhow::Error;
 
 impl<Req: PipelineIO, Resp: PipelineIO> ServiceBackend<Req, Resp> {
     pub fn from_engine(engine: ServiceEngine<Req, Resp>) -> Arc<Self> {

--- a/lib/runtime/src/pipeline/nodes/sinks/segment.rs
+++ b/lib/runtime/src/pipeline/nodes/sinks/segment.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::Error;
+use anyhow::Error;
 
 impl<Req: PipelineIO, Resp: PipelineIO> SegmentSink<Req, Resp> {
     pub fn new() -> Arc<Self> {

--- a/lib/runtime/src/protocols/annotated.rs
+++ b/lib/runtime/src/protocols/annotated.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::*;
-use crate::{Result, error};
-use maybe_error::MaybeError;
+use super::maybe_error::MaybeError;
+use anyhow::{Result, anyhow as error};
+use serde::{Deserialize, Serialize};
 
 pub trait AnnotationsProvider {
     fn annotations(&self) -> Option<Vec<String>>;

--- a/lib/runtime/src/runnable.rs
+++ b/lib/runtime/src/runnable.rs
@@ -11,7 +11,7 @@ use std::{
     task::{Context, Poll},
 };
 
-pub use crate::{Error, Result};
+pub use anyhow::{Error, Result};
 pub use async_trait::async_trait;
 pub use tokio::task::JoinHandle;
 pub use tokio_util::sync::CancellationToken;

--- a/lib/runtime/src/service.rs
+++ b/lib/runtime/src/service.rs
@@ -8,15 +8,16 @@
 // component's "service state"
 
 use crate::{
-    DistributedRuntime, Result,
+    DistributedRuntime,
     component::Component,
-    error,
     metrics::{MetricsHierarchy, prometheus_names, prometheus_names::nats_service},
     traits::*,
     transports::nats,
     utils::stream,
 };
 
+use anyhow::Result;
+use anyhow::anyhow as error;
 use async_nats::Message;
 use async_stream::try_stream;
 use bytes::Bytes;

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -81,13 +81,13 @@ pub async fn spawn_system_status_server(
     let server_state = Arc::new(SystemStatusState::new(drt)?);
     let health_path = server_state
         .drt()
-        .system_health
+        .system_health()
         .lock()
         .health_path()
         .to_string();
     let live_path = server_state
         .drt()
-        .system_health
+        .system_health()
         .lock()
         .live_path()
         .to_string();
@@ -158,9 +158,11 @@ pub async fn spawn_system_status_server(
 #[tracing::instrument(skip_all, level = "trace")]
 async fn health_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
     // Get basic health status
-    let system_health = state.drt().system_health.lock();
-    let (healthy, endpoints) = system_health.get_health_status();
-    let uptime = Some(system_health.uptime());
+    let system_health = state.drt().system_health();
+    let system_health_lock = system_health.lock();
+    let (healthy, endpoints) = system_health_lock.get_health_status();
+    let uptime = Some(system_health_lock.uptime());
+    drop(system_health_lock);
 
     let healthy_string = if healthy { "ready" } else { "notready" };
     let status_code = if healthy {
@@ -184,7 +186,7 @@ async fn health_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
 #[tracing::instrument(skip_all, level = "trace")]
 async fn metrics_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
     // Update the uptime gauge with current value
-    state.drt().system_health.lock().update_uptime_gauge();
+    state.drt().system_health().lock().update_uptime_gauge();
 
     // Get all metrics from DistributedRuntime
     // Note: In the new hierarchy-based architecture, metrics are automatically registered
@@ -260,13 +262,13 @@ mod integration_tests {
             let drt = create_test_drt_async().await;
 
             // Get uptime from SystemHealth
-            let uptime = drt.system_health.lock().uptime();
+            let uptime = drt.system_health().lock().uptime();
             // Uptime should exist (even if close to zero)
             assert!(uptime.as_nanos() > 0 || uptime.is_zero());
 
             // Sleep briefly and check uptime increases
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            let uptime_after = drt.system_health.lock().uptime();
+            let uptime_after = drt.system_health().lock().uptime();
             assert!(uptime_after > uptime);
         })
         .await;
@@ -317,19 +319,19 @@ mod integration_tests {
             let drt = create_test_drt_async().await;
 
             // Get initial uptime
-            let initial_uptime = drt.system_health.lock().uptime();
+            let initial_uptime = drt.system_health().lock().uptime();
 
             // Update the gauge with initial value
-            drt.system_health.lock().update_uptime_gauge();
+            drt.system_health().lock().update_uptime_gauge();
 
             // Sleep for 100ms
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
             // Get uptime after sleep
-            let uptime_after_sleep = drt.system_health.lock().uptime();
+            let uptime_after_sleep = drt.system_health().lock().uptime();
 
             // Update the gauge again
-            drt.system_health.lock().update_uptime_gauge();
+            drt.system_health().lock().update_uptime_gauge();
 
             // Verify uptime increased by at least 100ms
             let elapsed = uptime_after_sleep - initial_uptime;
@@ -582,8 +584,8 @@ mod integration_tests {
                 struct TestHandler;
 
                 #[async_trait]
-                impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, Error> for TestHandler {
-                    async fn generate(&self, input: SingleIn<String>) -> crate::Result<ManyOut<Annotated<String>>> {
+                impl AsyncEngine<SingleIn<String>, ManyOut<Annotated<String>>, anyhow::Error> for TestHandler {
+                    async fn generate(&self, input: SingleIn<String>) -> anyhow::Result<ManyOut<Annotated<String>>> {
                         let (data, ctx) = input.into_parts();
                         let response = Annotated::from_data(format!("You responded: {}", data));
                         Ok(crate::pipeline::ResponseStream::new(
@@ -733,8 +735,9 @@ mod integration_tests {
 
                 // Register the endpoint and its health check payload
                 {
-                    let system_health = drt.system_health.lock();
-                    system_health.register_health_check_target(
+                    let system_health = drt.system_health();
+                    let system_health_lock = system_health.lock();
+                    system_health_lock.register_health_check_target(
                         endpoint,
                         crate::component::Instance {
                             component: "test_component".to_string(),
@@ -760,7 +763,7 @@ mod integration_tests {
                 );
 
                 // Set endpoint to healthy state
-                drt.system_health
+                drt.system_health()
                     .lock()
                     .set_endpoint_health_status(endpoint, HealthStatus::Ready);
 
@@ -777,7 +780,7 @@ mod integration_tests {
 
                 // Verify the endpoint status in SystemHealth directly
                 let endpoint_status = drt
-                    .system_health
+                    .system_health()
                     .lock()
                     .get_endpoint_health_status(endpoint);
                 assert_eq!(

--- a/lib/runtime/src/traits.rs
+++ b/lib/runtime/src/traits.rs
@@ -16,7 +16,7 @@ pub trait DistributedRuntimeProvider {
 
 impl RuntimeProvider for DistributedRuntime {
     fn rt(&self) -> &Runtime {
-        &self.runtime
+        self.runtime()
     }
 }
 

--- a/lib/runtime/src/traits/events.rs
+++ b/lib/runtime/src/traits/events.rs
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
-use crate::Result;
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 // #[async_trait]
 // pub trait Publisher: Debug + Clone + Send + Sync {

--- a/lib/runtime/src/transports/etcd/connector.rs
+++ b/lib/runtime/src/transports/etcd/connector.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ErrorContext, Result, error};
+use anyhow::{Context, Result};
 use etcd_client::ConnectOptions;
 use parking_lot::RwLock;
 use std::{sync::Arc, time::Duration};
@@ -76,9 +76,7 @@ impl Connector {
         loop {
             backoff_state.apply_backoff(deadline).await;
             if std::time::Instant::now() >= deadline {
-                return Err(error!(
-                    "Unable to reconnect to ETCD cluster: deadline exceeded"
-                ));
+                anyhow::bail!("Unable to reconnect to ETCD cluster: deadline exceeded");
             }
 
             match Self::connect(&self.etcd_urls, &self.connect_options).await {

--- a/lib/runtime/src/transports/etcd/lock.rs
+++ b/lib/runtime/src/transports/etcd/lock.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use etcd_client::{Compare, CompareOp, PutOptions, Txn, TxnOp};
 
-use crate::Result;
+use anyhow::Result;
 
 use super::Client;
 

--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -16,9 +16,10 @@
 //! - `NATS_AUTH_CREDENTIALS_FILE`: the path to the credentials file
 //!
 //! Note: `NATS_AUTH_USERNAME` and `NATS_AUTH_PASSWORD` must be used together.
+use crate::metrics::MetricsHierarchy;
 use crate::traits::events::EventPublisher;
-use crate::{Result, metrics::MetricsHierarchy};
 
+use anyhow::Result;
 use async_nats::connection::State;
 use async_nats::{Subscriber, client, jetstream};
 use async_trait::async_trait;

--- a/lib/runtime/src/transports/zmq.rs
+++ b/lib/runtime/src/transports/zmq.rs
@@ -217,7 +217,7 @@ impl Server {
                         mpsc::error::TrySendError::Full(data) => {
                             tracing::warn!(
                                 request_id,
-                                "response stream is full; backpressue alert"
+                                "response stream is full; backpressure alert"
                             );
                             // todo - add timeout - we are blocking all other streams
                             if (tx.send(data).await).is_err() {

--- a/lib/runtime/src/transports/zmq.rs
+++ b/lib/runtime/src/transports/zmq.rs
@@ -28,7 +28,6 @@ use tokio::{
     task::{JoinError, JoinHandle},
 };
 use tokio_util::sync::CancellationToken;
-use tracing as log;
 
 // Core message types
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -116,11 +115,11 @@ impl Server {
         // but we also propagate the error to the caller's cancellation token
         let watch_task = tokio::spawn(async move {
             let result = primary_task.await.inspect_err(|e| {
-                log::error!("zmq server/router task failed: {}", e);
+                tracing::error!("zmq server/router task failed: {}", e);
                 cancel_token.cancel();
             })?;
             result.inspect_err(|e| {
-                log::error!("zmq server/router task failed: {}", e);
+                tracing::error!("zmq server/router task failed: {}", e);
                 cancel_token.cancel();
             })
         });
@@ -156,7 +155,7 @@ impl Server {
         // let port = addr.as_socket().map(|s| s.port());
 
         // if let Some(port) = port {
-        //     log::info!("Server listening on port {}", port);
+        //     tracing::info!("Server listening on port {}", port);
         // }
 
         loop {
@@ -169,7 +168,7 @@ impl Server {
                             frames
                         },
                         Some(Err(e)) => {
-                            log::warn!("Error receiving message: {}", e);
+                            tracing::warn!("Error receiving message: {}", e);
                             continue;
                         }
                         None => break,
@@ -177,7 +176,7 @@ impl Server {
                 }
 
                 _ = token.cancelled() => {
-                    log::info!("Server shutting down");
+                    tracing::info!("Server shutting down");
                     break;
                 }
             };
@@ -203,7 +202,7 @@ impl Server {
                 // first we try to send the data eagerly without blocking
                 let action = match tx.try_send(message.into()) {
                     Ok(_) => {
-                        log::trace!(
+                        tracing::trace!(
                             request_id,
                             "response data sent eagerly to stream: {} bytes",
                             message_size
@@ -212,11 +211,14 @@ impl Server {
                     }
                     Err(e) => match e {
                         mpsc::error::TrySendError::Closed(_) => {
-                            log::info!(request_id, "response stream was closed");
+                            tracing::info!(request_id, "response stream was closed");
                             StreamAction::Close
                         }
                         mpsc::error::TrySendError::Full(data) => {
-                            log::warn!(request_id, "response stream is full; backpressue alert");
+                            tracing::warn!(
+                                request_id,
+                                "response stream is full; backpressue alert"
+                            );
                             // todo - add timeout - we are blocking all other streams
                             if (tx.send(data).await).is_err() {
                                 StreamAction::Close
@@ -245,7 +247,7 @@ impl Server {
             } else {
                 // increment bytes_dropped
                 // increment messages_dropped
-                log::trace!(request_id, "no active stream for request_id");
+                tracing::trace!(request_id, "no active stream for request_id");
             }
         }
 

--- a/lib/runtime/src/utils/typed_prefix_watcher.rs
+++ b/lib/runtime/src/utils/typed_prefix_watcher.rs
@@ -6,8 +6,8 @@
 //! This module provides reusable patterns for watching etcd prefixes and maintaining
 //! HashMap-based state that automatically updates based on etcd events.
 
-use crate::Result;
 use crate::transports::etcd::{Client as EtcdClient, WatchEvent};
+use anyhow::Result;
 use etcd_client::KeyValue;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;

--- a/lib/runtime/tests/lifecycle.rs
+++ b/lib/runtime/tests/lifecycle.rs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_runtime::{Result, Runtime, worker::Worker};
+use anyhow::Result;
+
+use dynamo_runtime::{Runtime, worker::Worker};
 
 async fn hello_world(_runtime: Runtime) -> Result<()> {
     Ok(())
@@ -12,50 +14,3 @@ fn test_lifecycle() {
     let worker = Worker::from_settings().unwrap();
     worker.execute(hello_world).unwrap();
 }
-
-// async fn discoverable(runtime: Runtime) -> Result<()> {
-//     let config = DiscoveryConfig {
-//         etcd_url: vec!["http://localhost:2379".to_string()],
-//         etcd_connect_options: None,
-//     };
-
-//     let client = DiscoveryClient::new(config, runtime.clone()).await?;
-//     println!("Primary lease id: {:x}", client.lease_id());
-
-//     let lease = client.create_lease(60).await?;
-
-//     // Keys and values
-//     let lock_key = "lock_key"; // Key for the lock
-//     let object_key = "object_key"; // Key for the object
-//     let object_value = "This is the object value"; // Value for the object
-//     let lock_value = "locked"; // Value indicating a lock
-
-//     let put_options = Some(PutOptions::new().with_lease(lease.id()));
-
-//     // Build the transaction
-//     let txn = Txn::new()
-//         .when(vec![Compare::version(lock_key, CompareOp::Equal, 0)]) // Ensure the lock does not exist
-//         .and_then(vec![
-//             TxnOp::put(object_key, object_value, put_options.clone()), // Create the object
-//             TxnOp::put(lock_key, lock_value, put_options),             // Set the lock
-//         ]);
-
-//     // Execute the transaction
-//     let txn_response = client.etc_client().kv_client().txn(txn).await?;
-
-//     tokio::spawn(async move {
-//         println!("custom lease id: {:x}", lease.id());
-//         lease.cancel_token().cancelled().await;
-//         println!("custom lease revoked");
-//     });
-
-//     runtime.child_token().cancelled().await;
-
-//     Ok(())
-// }
-
-// #[test]
-// fn test_discovery_client() {
-//     let runtime = Runtime::new(RuntimeConfig::default()).unwrap();
-//     runtime.execute(discoverable).unwrap();
-// }

--- a/lib/runtime/tests/pipeline.rs
+++ b/lib/runtime/tests/pipeline.rs
@@ -3,17 +3,23 @@
 
 #![allow(dead_code)]
 
+use anyhow::Error;
 use futures::{StreamExt, stream};
 use serde::{Deserialize, Serialize};
 use std::{sync::Arc, time::Duration};
 
 use dynamo_runtime::engine::ResponseStream;
-use dynamo_runtime::{
-    Error,
-    pipeline::{
-        AsyncEngine, Data, Event, ManyOut, Operator, ServiceBackend, ServiceEngine,
-        ServiceFrontend, SingleIn, async_trait, *,
-    },
+use dynamo_runtime::pipeline::{
+    AsyncEngine,
+    Data,
+    Event,
+    ManyOut,
+    Operator,
+    ServiceBackend,
+    ServiceEngine,
+    ServiceFrontend,
+    SingleIn,
+    *, // TODO remove the star
 };
 
 mod common;
@@ -46,7 +52,7 @@ pub enum Annotated<T: Data> {
 /// to the output stream
 struct PreprocesOperator {}
 
-#[async_trait]
+#[async_trait::async_trait]
 impl
     Operator<
         SingleIn<String>,

--- a/lib/runtime/tests/soak.rs
+++ b/lib/runtime/tests/soak.rs
@@ -18,7 +18,7 @@ mod integration {
     pub const DEFAULT_NAMESPACE: &str = "dynamo";
 
     use dynamo_runtime::{
-        DistributedRuntime, ErrorContext, Result, Runtime, Worker, logging,
+        DistributedRuntime, Runtime, Worker, logging,
         pipeline::{
             AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, PushRouter, ResponseStream,
             SingleIn, async_trait, network::Ingress,
@@ -26,6 +26,8 @@ mod integration {
         protocols::annotated::Annotated,
         stream,
     };
+
+    use anyhow::{Context, Result};
     use futures::StreamExt;
     use std::{
         sync::Arc,


### PR DESCRIPTION
They were public seemingly by accident, because they were declared in `lib.rs` which allowed anything in the crate to read/write them directly. Lots of places did.

Now access to private fields is via the accessor methods. Later we should hide more of the implementation details of
DistributedRuntime.

Also tidy up some weird imports, for example re-exporting `anyhow` types as our own in runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mock LLM engine with streaming token generation and distributed scheduling capabilities, enabling enhanced testing and development workflows.
  * Introduced system health monitoring and tracking for runtime components with centralized status reporting.
  * Added key-value event publishing system for distributed event handling.

* **Bug Fixes & Improvements**
  * Enhanced error handling and reporting across the runtime for better diagnostics.
  * Improved logging with more detailed observability for debugging and monitoring.
  * Refined endpoint configuration and discovery mechanisms for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->