### PR TITLE
feat: Update test_vllm_health_check_active to make it stable

### DIFF
--- a/tests/fault_tolerance/test_vllm_health_check.py
+++ b/tests/fault_tolerance/test_vllm_health_check.py
@@ -206,20 +206,26 @@ def test_vllm_health_check_active(request, runtime_services):
             if vllm_child:
                 try:
                     vllm_child.wait(timeout=30)
-                    logger.info(f"vLLM engine process {vllm_child.pid} has been terminated")
+                    logger.info(
+                        f"vLLM engine process {vllm_child.pid} has been terminated"
+                    )
                 except Exception as e:
                     logger.error(f"Failed to wait for vLLM engine process to die: {e}")
                     pytest.fail(f"vLLM engine process did not terminate: {e}")
 
             # Step 5: Send a request that should fail due to the dead engine.
             try:
-                test_response = send_completion_request("How old are you?", 100, timeout=60)
+                test_response = send_completion_request(
+                    "How old are you?", 100, timeout=60
+                )
                 # Verify the response indicates an error (non-2xx status code)
                 if test_response.status_code < 400:
                     pytest.fail(
                         f"Expected error response after killing vLLM engine, but got status {test_response.status_code}"
                     )
-                logger.info(f"Request correctly failed with status {test_response.status_code}: {test_response.text}")
+                logger.info(
+                    f"Request correctly failed with status {test_response.status_code}: {test_response.text}"
+                )
             except requests.exceptions.RequestException as e:
                 # It's also acceptable for the request to raise an exception
                 logger.info(f"Request correctly failed with exception: {e}")


### PR DESCRIPTION
#### Overview:

This PR fixes the flaky `test_vllm_health_check_active` test by adding proper synchronization and error handling, allowing it to be re-enabled.

#### Details:

The `test_vllm_health_check_active` test was previously disabled due to flakiness. This PR addresses the root causes of the flakiness:

1. **Removed the skip marker**: Removed `@pytest.mark.skip(reason="Flaky, temporarily disabled")` to re-enable the test.

2. **Added proper process termination wait**: After killing the vLLM engine process, the test now explicitly waits for the process to fully terminate (up to 30 seconds) before proceeding, eliminating race conditions.

3. **Improved error handling for the test request**: Added proper exception handling and status code validation when sending the completion request after the engine is killed. The test now correctly handles both HTTP error responses and connection exceptions.

4. **Added polling for worker shutdown**: Replaced the single check with a polling loop (60 seconds max, 0.5s intervals) to wait for the worker process to stop after the EngineDeadError condition. This eliminates timing-related failures where the worker hadn't stopped yet when checked.

These changes ensure the test reliably validates the worker fault tolerance behavior without race conditions or timing issues.

#### Where should the reviewer start?

`tests/fault_tolerance/test_vllm_health_check.py` 

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-993


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Re-enabled a previously skipped fault tolerance test
  * Enhanced engine process tracking and termination verification
  * Improved error validation to confirm proper failure handling after engine termination
  * Added robust wait logic with timeout and polling for process cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->