### PR TITLE
fix: KeyValueStore etcd impl should use internal etcd client

### DIFF
--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -112,7 +112,7 @@ impl Client {
 
     /// Get a clone of the underlying [`etcd_client::Client`] instance.
     /// This returns a clone since the client is behind an RwLock.
-    pub fn etcd_client(&self) -> etcd_client::Client {
+    fn etcd_client(&self) -> etcd_client::Client {
         self.connector.get_client()
     }
 

--- a/lib/runtime/src/transports/etcd.rs
+++ b/lib/runtime/src/transports/etcd.rs
@@ -121,28 +121,48 @@ impl Client {
         self.primary_lease
     }
 
-    pub async fn kv_create(&self, key: &str, value: Vec<u8>, lease_id: Option<u64>) -> Result<()> {
+    /// Returns Ok(None) if value was created, Ok(Some(revision)) if the value already exists.
+    pub async fn kv_create(
+        &self,
+        key: &str,
+        value: Vec<u8>,
+        lease_id: Option<u64>,
+    ) -> Result<Option<u64>> {
         let id = lease_id.unwrap_or(self.lease_id());
         let put_options = PutOptions::new().with_lease(id as i64);
 
-        // Build the transaction
+        // Build transaction that creates key only if it doesn't exist
         let txn = Txn::new()
             .when(vec![Compare::version(key, CompareOp::Equal, 0)]) // Ensure the lock does not exist
             .and_then(vec![
                 TxnOp::put(key, value, Some(put_options)), // Create the object
+            ])
+            .or_else(vec![
+                TxnOp::get(key, None), // Key exists, get its info
             ]);
 
         // Execute the transaction
         let result = self.connector.get_client().kv_client().txn(txn).await?;
 
+        // Created
         if result.succeeded() {
-            Ok(())
-        } else {
-            for resp in result.op_responses() {
-                tracing::warn!(response = ?resp, "kv_create etcd op response");
-            }
-            anyhow::bail!("Unable to create key. Check etcd server status")
+            return Ok(None);
         }
+
+        // Already exists
+        if let Some(etcd_client::TxnOpResponse::Get(get_resp)) =
+            result.op_responses().into_iter().next()
+            && let Some(kv) = get_resp.kvs().first()
+        {
+            let version = kv.version() as u64;
+            return Ok(Some(version));
+        }
+
+        // Error
+        for resp in result.op_responses() {
+            tracing::warn!(response = ?resp, "kv_create etcd op response");
+        }
+        anyhow::bail!("Unable to create key. Check etcd server status")
     }
 
     /// Atomically create a key if it does not exist, or validate the values are identical if the key exists.


### PR DESCRIPTION
So that it benefits from failover.

Follow up to https://github.com/ai-dynamo/dynamo/pull/4199


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused dependencies from test modules.

* **Refactor**
  * Improved internal storage operation handling and error recovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->