### PR TITLE
docs: fix build, include doc in toctree

### DIFF
--- a/docs/_sections/k8s_deployment.rst
+++ b/docs/_sections/k8s_deployment.rst
@@ -8,3 +8,4 @@ Deployment Guide
    Detailed Installation Guide <../kubernetes/installation_guide>
    Dynamo Operator <../kubernetes/dynamo_operator>
    Minikube Setup <../kubernetes/deployment/minikube>
+   Managing Models with DynamoModel <../kubernetes/deployment/dynamomodel-guide>


### PR DESCRIPTION
#### Overview:

fix
```
#15 5.369 checking consistency... /workspace/dynamo/docs/kubernetes/deployment/dynamomodel-guide.md: WARNING: document isn't included in any toctree [toc.not_included]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide entry for managing models with DynamoModel to the Kubernetes deployment documentation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->