### PR TITLE
fix: use latest tag across all branches for version detection

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -32,7 +32,7 @@ commit_id=$(git rev-parse --short HEAD)
 current_tag=$(git describe --tags --exact-match 2>/dev/null | sed 's/^v//') || true
 
 # Get latest TAG and add COMMIT_ID for dev
-latest_tag=$(git describe --tags --abbrev=0 "$(git rev-list --tags --max-count=1 main)" | sed 's/^v//') || true
+latest_tag=$(git describe --tags --abbrev=0 "$(git rev-list --tags --max-count=1)" | sed 's/^v//') || true
 if [[ -z ${latest_tag} ]]; then
     latest_tag="0.0.1"
     echo "No git release tag found, setting to unknown version: ${latest_tag}"


### PR DESCRIPTION
#### Overview:

build.sh was only looking for tags on main, which breaks when main isn't tagged. Now it finds the latest tag from any branch.

#### Details:

- Picks up the latest tag wherever it lives
- Fixes version detection when main doesn't have the latest tag
- **Example:** Previously found `v0.1.0` (latest on main), now correctly finds `v0.6.1` (actual latest tag).

#### Where should the reviewer start?

container/build.sh (line 35)

#### Related Issues:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version tag detection during build process to consider all repository tags, rather than a limited scope, ensuring more accurate version identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->