### PR TITLE
feat: Enable multimodal tool calling

### DIFF
--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -321,8 +321,8 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         let has_tools = tools.as_ref().and_then(|v| v.len()).is_some_and(|l| l > 0);
         let add_generation_prompt = req.should_add_generation_prompt();
 
-        tracing::debug!(
-            "Applying template with tools: {}, add_generation_prompt: {}",
+        tracing::trace!(
+            "Rendering prompt with tools: {:?}, add_generation_prompt: {}",
             has_tools,
             add_generation_prompt
         );
@@ -364,7 +364,6 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
                 }
             }
         } else {
-            tracing::debug!("Using 'default' template");
             self.env.get_template("default")?
         };
         Ok(tmpl.render(&ctx)?)

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -110,9 +110,7 @@ fn may_be_fix_msg_content(messages: serde_json::Value) -> Value {
                                 content_string.push(if is_text_only { '\n' } else { ' ' });
                             }
 
-                            let part_type = part.get("type")
-                                .and_then(|t| t.as_str())
-                                .unwrap_or("");
+                            let part_type = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
                             match part_type {
                                 "text" => {
@@ -131,7 +129,10 @@ fn may_be_fix_msg_content(messages: serde_json::Value) -> Value {
                                 }
                                 _ => {
                                     // Unknown type - skip or add placeholder
-                                    tracing::warn!("Unknown content type in message: {}", part_type);
+                                    tracing::warn!(
+                                        "Unknown content type in message: {}",
+                                        part_type
+                                    );
                                 }
                             }
                         }
@@ -357,7 +358,7 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
                 Ok(t) => {
                     tracing::debug!("Using 'tool_use' template");
                     t
-                },
+                }
                 Err(_) => {
                     tracing::debug!("'tool_use' template not found, using 'default'");
                     self.env.get_template("default")?


### PR DESCRIPTION
#### Overview:

Extends multimodal content array handling in the Rust preprocessor to support tool calling with multimodal requests (images, video, audio). 

#### Details:

1. Extended may_be_fix_msg_content() (Lines 76-150)
Previously only handled text-only content arrays (PR #3067)
Now flattens multimodal arrays by replacing image_url, video_url, audio_url with <image>, <video>, <audio> placeholders
Mimics vLLM's preprocessing behavior so chat templates receive strings instead of arrays
Example: [{"type": "text", "text": "Look"}, {"type": "image_url", ...}] → "Look <image>"

#### Where should the reviewer start?

`may_be_fix_msg_content()` function - Core logic for flattening multimodal content arrays

#### Testing

Verified Unit tests for `may_be_fix_tool_schema` and tested multimodal flow with 

`python3 -m dynamo.vllm --model Qwen/Qwen2.5-VL-7B-Instruct --max-model-len 1000 --custom-jinja-template tool_chat_template_hermes.jinja --dyn-tool-call-parser hermes`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multimodal content support in prompts with proper handling of images, videos, and audio via placeholder representation

* **Improvements**
  * Enhanced prompt template selection logic, prioritizing appropriate templates when tools are integrated into prompts
  * Optimized message content preprocessing for better multimodal content handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->