### PR TITLE
fix: merge main 4197 (remaining deprecated DYN_SYSTEM_ENABLED var) to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -2178,14 +2178,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-engine-mistralrs"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cudarc 0.17.3",
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-run"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bytemuck",
  "dashmap 6.1.0",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-py3"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4391,7 +4391,7 @@ checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libdynamo_llm"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 description = "Dynamo Inference Framework"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -44,15 +44,15 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 
 [workspace.dependencies]
 # Local crates
-dynamo-runtime = { path = "lib/runtime", version = "0.6.1" }
-dynamo-llm = { path = "lib/llm", version = "0.6.1" }
-dynamo-config = { path = "lib/config", version = "0.6.1" }
-dynamo-tokens = { path = "lib/tokens", version = "0.6.1" }
-dynamo-async-openai = { path = "lib/async-openai", version = "0.6.1", features = [
+dynamo-runtime = { path = "lib/runtime", version = "0.7.0" }
+dynamo-llm = { path = "lib/llm", version = "0.7.0" }
+dynamo-config = { path = "lib/config", version = "0.7.0" }
+dynamo-tokens = { path = "lib/tokens", version = "0.7.0" }
+dynamo-async-openai = { path = "lib/async-openai", version = "0.7.0", features = [
     "byot",
     "rustls",
 ] }
-dynamo-parsers = { path = "lib/parsers", version = "0.6.1" }
+dynamo-parsers = { path = "lib/parsers", version = "0.7.0" }
 
 # External dependencies
 anyhow = { version = "1" }

--- a/Earthfile
+++ b/Earthfile
@@ -134,7 +134,7 @@ dynamo-build:
 
 dynamo-base-docker:
     ARG IMAGE=dynamo-base-docker
-    ARG DOCKER_SERVER=my-registry
+    ARG DOCKER_SERVER=nvcr.io/nvidia/ai-dynamo
     ARG IMAGE_TAG=latest
 
     FROM ubuntu:24.04
@@ -175,7 +175,7 @@ all-test:
     BUILD ./deploy/cloud/operator+test
 
 all-docker:
-    ARG DOCKER_SERVER=my-registry
+    ARG DOCKER_SERVER=nvcr.io/nvidia/ai-dynamo
     ARG IMAGE_TAG=latest
     BUILD ./deploy/cloud/operator+docker --DOCKER_SERVER=$DOCKER_SERVER --IMAGE_TAG=$IMAGE_TAG
 
@@ -189,6 +189,6 @@ all:
 
 # For testing
 custom:
-    ARG DOCKER_SERVER=my-registry
+    ARG DOCKER_SERVER=nvcr.io/nvidia/ai-dynamo
     ARG IMAGE_TAG=latest
     BUILD +all-test

--- a/benchmarks/incluster/benchmark_job.yaml
+++ b/benchmarks/incluster/benchmark_job.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: benchmark-runner
         # TODO: update to latest public image in next release
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/benchmarks/profiler/utils/config.py
+++ b/benchmarks/profiler/utils/config.py
@@ -98,7 +98,7 @@ class DgdPlannerServiceConfig(BaseModel):
     replicas: int = 1
     extraPodSpec: PodSpec = PodSpec(
         mainContainer=Container(
-            image="my-registry/dynamo-runtime:my-tag",  # placeholder
+            image="nvcr.io/nvidia/ai-dynamo/dynamo-runtime:0.7.0",  # placeholder
             workingDir=f"{get_workspace_dir()}/components/src/dynamo/planner",
             command=["python3", "-m", "planner_sla"],
             args=[],

--- a/deploy/cloud/helm/crds/Chart.yaml
+++ b/deploy/cloud/helm/crds/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v2
 name: dynamo-crds
 description: A Helm chart for dynamo CRDs
 type: application
-version: 0.6.1
+version: 0.7.0
 dependencies: []

--- a/deploy/cloud/helm/platform/Chart.yaml
+++ b/deploy/cloud/helm/platform/Chart.yaml
@@ -19,7 +19,7 @@ maintainers:
     url: https://www.nvidia.com
 description: A Helm chart for NVIDIA Dynamo Platform.
 type: application
-version: 0.6.1
+version: 0.7.0
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator

--- a/deploy/cloud/helm/platform/Chart.yaml
+++ b/deploy/cloud/helm/platform/Chart.yaml
@@ -23,7 +23,7 @@ version: 0.7.0
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator
-    version: 0.6.1
+    version: 0.7.0
     repository: file://components/operator
     condition: dynamo-operator.enabled
   - name: nats

--- a/deploy/cloud/helm/platform/components/operator/Chart.yaml
+++ b/deploy/cloud/helm/platform/components/operator/Chart.yaml
@@ -27,9 +27,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.7.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.1"
+appVersion: "0.7.0"

--- a/deploy/cloud/operator/Earthfile
+++ b/deploy/cloud/operator/Earthfile
@@ -45,7 +45,7 @@ test:
     SAVE ARTIFACT cover.out
 
 docker:
-    ARG DOCKER_SERVER=my-registry
+    ARG DOCKER_SERVER=nvcr.io/nvidia/ai-dynamo
     ARG IMAGE_TAG=latest
     ARG IMAGE_SUFFIX=dynamo-operator
     FROM nvcr.io/nvidia/distroless/go:v3.1.13

--- a/deploy/cloud/operator/internal/secrets/docker_test.go
+++ b/deploy/cloud/operator/internal/secrets/docker_test.go
@@ -21,7 +21,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 			},
 			Type: corev1.SecretTypeDockerConfigJson,
 			Data: map[string][]byte{
-				".dockerconfigjson": []byte(`{"auths":{"docker.io":{}, "my-registry.com:5005/registry1":{}}}`),
+				".dockerconfigjson": []byte(`{"auths":{"docker.io":{}, "nvcr.io/nvidia/ai-dynamo.com:5005/registry1":{}}}`),
 			},
 		},
 		{
@@ -31,7 +31,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 			},
 			Type: corev1.SecretTypeDockerConfigJson,
 			Data: map[string][]byte{
-				".dockerconfigjson": []byte(`{"auths":{"my-registry.com:5005/registry2":{}}}`),
+				".dockerconfigjson": []byte(`{"auths":{"nvcr.io/nvidia/ai-dynamo.com:5005/registry2":{}}}`),
 			},
 		},
 		{
@@ -41,7 +41,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 			},
 			Type: corev1.SecretTypeDockerConfigJson,
 			Data: map[string][]byte{
-				".dockerconfigjson": []byte(`{"auths":{"my-registry.com:5005/registry2":{}}}`),
+				".dockerconfigjson": []byte(`{"auths":{"nvcr.io/nvidia/ai-dynamo.com:5005/registry2":{}}}`),
 			},
 		},
 	}
@@ -68,7 +68,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 		t.Errorf("DockerSecretIndexer.GetSecrets() = %v, want %v", secrets[0], "secret1")
 	}
 
-	secrets, err = i.GetSecrets("default", "my-registry.com:5005")
+	secrets, err = i.GetSecrets("default", "nvcr.io/nvidia/ai-dynamo.com:5005")
 	if err != nil {
 		t.Errorf("DockerSecretIndexer.GetSecrets() error = %v, wantErr %v", err, nil)
 	}
@@ -82,7 +82,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 		t.Errorf("DockerSecretIndexer.GetSecrets() = %v, want %v", secrets[1], "secret2")
 	}
 
-	secrets, err = i.GetSecrets("another-namespace", "my-registry.com:5005")
+	secrets, err = i.GetSecrets("another-namespace", "nvcr.io/nvidia/ai-dynamo.com:5005")
 	if err != nil {
 		t.Errorf("DockerSecretIndexer.GetSecrets() error = %v, wantErr %v", err, nil)
 	}

--- a/deploy/cloud/pre-deployment/nixl/README.md
+++ b/deploy/cloud/pre-deployment/nixl/README.md
@@ -286,7 +286,7 @@ Interactive script that provides flexible build and deployment workflow:
 
 ### nixlbench-deployment.yaml
 Base Kubernetes deployment template that gets customized by the script:
-- **Template image**: `my-registry/nixlbench:version-arch`
+- **Template image**: `nvcr.io/nvidia/ai-dynamo/nixlbench:version-arch`
 - **Resource allocation**: 10 CPU, 5Gi memory, 1 GPU per pod
 - **ETCD integration**: Pre-configured environment variables
 - **Benchmark command**: Runs with VRAM segment configuration

--- a/deploy/cloud/pre-deployment/nixl/build_and_deploy.sh
+++ b/deploy/cloud/pre-deployment/nixl/build_and_deploy.sh
@@ -160,7 +160,7 @@ validate_architecture() {
 # Function to prompt for registry
 prompt_for_registry() {
     echo
-    printf "Enter your Docker registry (e.g., my-registry, docker.io/username): "
+    printf "Enter your Docker registry (e.g., nvcr.io/nvidia/ai-dynamo, docker.io/username): "
     read REGISTRY
     if [ -z "$REGISTRY" ]; then
         echo "Error: Registry cannot be empty"
@@ -205,7 +205,7 @@ update_deployment() {
     cp "${SCRIPT_DIR}/nixlbench-deployment.yaml" "$deployment_file"
 
     # Update the image field using sed
-    sed -i "s|my-registry/nixlbench:version-arch|${registry}/nixlbench:${NIXL_VERSION}-${arch}|g" "$deployment_file"
+    sed -i "s|nvcr.io/nvidia/ai-dynamo/nixlbench:version-arch|${registry}/nixlbench:${NIXL_VERSION}-${arch}|g" "$deployment_file"
 
     echo "Deployment file updated with image: ${registry}/nixlbench:${NIXL_VERSION}-${arch}"
 }

--- a/deploy/cloud/pre-deployment/nixl/nixlbench-deployment.yaml
+++ b/deploy/cloud/pre-deployment/nixl/nixlbench-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: nixl-benchmark
-        image: "my-registry/nixlbench:version-arch"
+        image: "nvcr.io/nvidia/ai-dynamo/nixlbench:version-arch"
         command: ["sh", "-c"]
         env:
           - name: ETCD_ENDPOINTS

--- a/deploy/helm/chart/Chart.yaml
+++ b/deploy/helm/chart/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: dynamo-graph
 description: A Helm chart to deploy a Dynamo graph on Kubernetes
 type: application
-version: 0.6.1
-appVersion: 0.6.1
+version: 0.7.0
+appVersion: 0.7.0

--- a/docs/_includes/install.rst
+++ b/docs/_includes/install.rst
@@ -10,7 +10,7 @@ Install a pre-built wheel from PyPI.
    source venv/bin/activate
 
    # Install Dynamo from PyPI (choose one backend extra)
-   uv pip install "ai-dynamo[sglang]==my-tag"  # or [vllm], [trtllm]
+   uv pip install "ai-dynamo[sglang]==0.7.0"  # or [vllm], [trtllm]
 
 
 Pip from source
@@ -41,4 +41,4 @@ Pull and run prebuilt images from NVIDIA NGC (`nvcr.io`).
    docker run --rm -it \
      --gpus all \
      --network host \
-     nvcr.io/nvidia/ai-dynamo/sglang-runtime:my-tag  # or vllm, tensorrtllm
+     nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0  # or vllm, tensorrtllm

--- a/docs/backends/trtllm/gpt-oss.md
+++ b/docs/backends/trtllm/gpt-oss.md
@@ -49,7 +49,7 @@ huggingface-cli download openai/gpt-oss-120b --exclude "original/*" --exclude "m
 
 Set the container image:
 ```bash
-export DYNAMO_CONTAINER_IMAGE=nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+export DYNAMO_CONTAINER_IMAGE=nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
 ```
 
 Launch the Dynamo TensorRT-LLM container with the necessary configurations:

--- a/docs/benchmarks/benchmarking.md
+++ b/docs/benchmarks/benchmarking.md
@@ -413,7 +413,7 @@ The benchmark job is configured directly in the YAML file.
 - **Model**: `Qwen/Qwen3-0.6B`
 - **Benchmark Name**: `qwen3-0p6b-vllm-agg`
 - **Service**: `vllm-agg-frontend:8000`
-- **Docker Image**: `nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag`
+- **Docker Image**: `nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0`
 
 ### Customizing the Job
 

--- a/docs/kubernetes/deployment/create_deployment.md
+++ b/docs/kubernetes/deployment/create_deployment.md
@@ -212,7 +212,7 @@ When disabled, you can manually specify secrets as you would for a normal pod sp
         nvidia.com/disable-image-pull-secret-discovery: "true"
       extraPodSpec:
         imagePullSecrets:
-          - name: my-registry-secret
+          - name: nvcr.io/nvidia/ai-dynamo-secret
           - name: another-secret
         mainContainer:
           image: your-image

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -56,8 +56,8 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 
 | **Python Package** | **Version** | glibc version                         | CUDA Version |
 | :----------------- | :---------- | :------------------------------------ | :----------- |
-| ai-dynamo          | 0.6.1       | >=2.28                                |              |
-| ai-dynamo-runtime  | 0.6.1       | >=2.28 (Python 3.12 has known issues) |              |
+| ai-dynamo          | 0.7.0       | >=2.28                                |              |
+| ai-dynamo-runtime  | 0.7.0       | >=2.28 (Python 3.12 has known issues) |              |
 | NIXL               | 0.7.0       | >=2.27                                | >=11.8       |
 
 ### Build Dependency

--- a/examples/backends/sglang/deploy/README.md
+++ b/examples/backends/sglang/deploy/README.md
@@ -61,7 +61,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/sglang-runtime:my-tag
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
     workingDir: /workspace/examples/backends/sglang
     args:
       - "python3"
@@ -92,7 +92,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: my-registry/sglang-runtime:my-tag
+image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
 
 # Configure your model
 args:

--- a/examples/backends/sglang/deploy/agg.yaml
+++ b/examples/backends/sglang/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/agg_logging.yaml
+++ b/examples/backends/sglang/deploy/agg_logging.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/agg_router.yaml
+++ b/examples/backends/sglang/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg-multinode.yaml
+++ b/examples/backends/sglang/deploy/disagg-multinode.yaml
@@ -22,7 +22,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
     decode:
       multinode:
         nodeCount: 2
@@ -35,7 +35,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3
@@ -72,7 +72,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg.yaml
+++ b/examples/backends/sglang/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3
@@ -61,7 +61,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/disagg_planner.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
     Planner:
       dynamoNamespace: dynamo
       envFromSecret: hf-token-secret
@@ -21,7 +21,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/components/src/dynamo/planner
           command:
           - python3
@@ -53,7 +53,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
             - python3
@@ -89,7 +89,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
             - python3

--- a/examples/backends/trtllm/deploy/README.md
+++ b/examples/backends/trtllm/deploy/README.md
@@ -89,7 +89,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/trtllm-runtime:my-tag
+    image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
     workingDir: /workspace/examples/backends/trtllm
     args:
       - "python3"
@@ -109,7 +109,7 @@ Before using these templates, ensure you have:
 
 ### Container Images
 
-The deployment files currently require access to `my-registry/trtllm-runtime`. If you don't have access, build and push your own image:
+The deployment files currently require access to `nvcr.io/nvidia/ai-dynamo/trtllm-runtime`. If you don't have access, build and push your own image:
 
 ```bash
 ./container/build.sh --framework tensorrtllm
@@ -141,7 +141,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: my-registry/trtllm-runtime:my-tag
+image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
 
 # Configure your model and deployment settings
 args:

--- a/examples/backends/trtllm/deploy/agg-with-config.yaml
+++ b/examples/backends/trtllm/deploy/agg-with-config.yaml
@@ -34,7 +34,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: trtllm-agg
@@ -50,7 +50,7 @@ spec:
           configMap:
             name: nvidia-config
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/trtllm
           # mount the configmap as a volume
           volumeMounts:

--- a/examples/backends/trtllm/deploy/agg.yaml
+++ b/examples/backends/trtllm/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: trtllm-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/agg_router.yaml
+++ b/examples/backends/trtllm/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/trtllm/deploy/disagg-multinode.yaml
@@ -95,7 +95,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/trtllm
           command:
           - python3
@@ -127,7 +127,7 @@ spec:
             - name: nvidia-config
               mountPath: /workspace/
               readOnly: true
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/
           command:
           - python3
@@ -165,7 +165,7 @@ spec:
             - name: nvidia-config
               mountPath: /workspace/
               readOnly: true
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg.yaml
+++ b/examples/backends/trtllm/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
     TRTLLMPrefillWorker:
       dynamoNamespace: trtllm-disagg
       envFromSecret: hf-token-secret
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/
           command:
           - python3
@@ -51,7 +51,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/disagg_planner.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/trtllm
           command:
             - python3
@@ -38,7 +38,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/components/src/dynamo/planner
           ports:
             - name: metrics
@@ -89,7 +89,7 @@ spec:
       extraPodSpec:
         terminationGracePeriodSeconds: 600
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/
           command:
             - python3
@@ -116,7 +116,7 @@ spec:
       extraPodSpec:
         terminationGracePeriodSeconds: 600
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/
           command:
             - python3

--- a/examples/backends/trtllm/deploy/disagg_router.yaml
+++ b/examples/backends/trtllm/deploy/disagg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/
           command:
           - python3
@@ -53,7 +53,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/vllm/deploy/README.md
+++ b/examples/backends/vllm/deploy/README.md
@@ -69,7 +69,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: my-registry/vllm-runtime:my-tag
+    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     workingDir: /workspace/examples/backends/vllm
     args:
       - "python3"
@@ -116,7 +116,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: my-registry/vllm-runtime:my-tag
+image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
 
 # Configure your model
 args:

--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-agg-kvbm
@@ -31,7 +31,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/agg_router.yaml
+++ b/examples/backends/vllm/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/disagg-multinode.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -34,7 +34,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -57,7 +57,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg.yaml
+++ b/examples/backends/vllm/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -46,7 +46,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg-kvbm
       envFromSecret: hf-token-secret
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -56,7 +56,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg-kvbm-2p2d
       envFromSecret: hf-token-secret
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -56,7 +56,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg-kvbm-tp2
       envFromSecret: hf-token-secret
@@ -26,7 +26,7 @@ spec:
           gpu: "2"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -60,7 +60,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/disagg_planner.yaml
@@ -13,14 +13,14 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     Planner:
       dynamoNamespace: vllm-disagg-planner
       componentType: planner
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/components/src/dynamo/planner
           command:
           - python3
@@ -52,7 +52,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -72,7 +72,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -47,7 +47,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/basics/kubernetes/Distributed_Inference/README.md
+++ b/examples/basics/kubernetes/Distributed_Inference/README.md
@@ -69,7 +69,7 @@ aiconfigurator cli --model LLAMA3.1_70B --total_gpus 16 --system h200_sxm
 ```
 and from the output, you can see the Pareto curve with suggest P/D settings
 ![text](images/pareto.png)
-3. Start the serving with 1 prefill worker with tensor parallelism 4 and 1 decoding worker with tensor parallelism 8 as AI Configurator suggested. Update the `my-tag` in `disagg_router.yaml` with the latest Dynamo version and your local cache folder path and run following command.
+3. Start the serving with 1 prefill worker with tensor parallelism 4 and 1 decoding worker with tensor parallelism 8 as AI Configurator suggested. Update the `0.7.0` in `disagg_router.yaml` with the latest Dynamo version and your local cache folder path and run following command.
 ![text](images/settings.png)
 ```sh
 kubectl apply -f disagg_router.yaml --namespace ${NAMESPACE}

--- a/examples/basics/kubernetes/Distributed_Inference/agg_router.yaml
+++ b/examples/basics/kubernetes/Distributed_Inference/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -35,7 +35,7 @@ spec:
             path: /YOUR/LOCAL/CACHE/FOLDER
             type: DirectoryOrCreate
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           volumeMounts:
           - name: local-model-cache
             mountPath: /root/.cache

--- a/examples/basics/kubernetes/Distributed_Inference/disagg_router.yaml
+++ b/examples/basics/kubernetes/Distributed_Inference/disagg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -35,7 +35,7 @@ spec:
             path: /YOUR/LOCAL/CACHE/FOLDER
             type: DirectoryOrCreate
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           volumeMounts:
           - name: local-model-cache
@@ -63,7 +63,7 @@ spec:
             path: /YOUR/LOCAL/CACHE/FOLDER
             type: DirectoryOrCreate
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           volumeMounts:
           - name: local-model-cache

--- a/examples/custom_backend/hello_world/deploy/hello_world.yaml
+++ b/examples/custom_backend/hello_world/deploy/hello_world.yaml
@@ -41,7 +41,7 @@ spec:
           memory: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/dynamo:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:0.7.0
           workingDir: /workspace/examples/custom_backend/hello_world/
           command:
             - /bin/sh
@@ -80,7 +80,7 @@ spec:
           memory: "4Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/dynamo:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/dynamo:0.7.0
           workingDir: /workspace/examples/custom_backend/hello_world/
           command:
             - /bin/sh

--- a/examples/deployments/ECS/task_definition_frontend.json
+++ b/examples/deployments/ECS/task_definition_frontend.json
@@ -3,7 +3,7 @@
     "containerDefinitions": [
         {
             "name": "dynamo-vllm-frontend",
-            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag",
+            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:AWS_REGION:AWS_ID:secret:ngc_nvcr_access"
             },

--- a/examples/deployments/ECS/task_definition_prefillworker.json
+++ b/examples/deployments/ECS/task_definition_prefillworker.json
@@ -3,7 +3,7 @@
     "containerDefinitions": [
         {
             "name": "dynamo-prefill",
-            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag",
+            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:AWS_REGION:AWS_ID:secret:ngc_access"
             },

--- a/examples/deployments/GKE/sglang/disagg.yaml
+++ b/examples/deployments/GKE/sglang/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
             - /bin/sh
@@ -47,7 +47,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
           workingDir: /workspace/examples/backends/sglang
           command:
             - /bin/sh

--- a/examples/deployments/GKE/vllm/disagg.yaml
+++ b/examples/deployments/GKE/vllm/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -27,7 +27,7 @@ spec:
         mainContainer:
           startupProbe:
             initialDelaySeconds: 180
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -49,7 +49,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/examples/multimodal/deploy/agg_llava.yaml
+++ b/examples/multimodal/deploy/agg_llava.yaml
@@ -14,7 +14,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     EncodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: agg-llava
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -42,7 +42,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -59,7 +59,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh

--- a/examples/multimodal/deploy/agg_qwen.yaml
+++ b/examples/multimodal/deploy/agg_qwen.yaml
@@ -14,7 +14,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     EncodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: agg-qwen
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -42,7 +42,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -59,7 +59,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-py3"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "dynamo-py3"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "ai-dynamo-runtime"
-version = "0.6.1"
+version = "0.7.0"
 description = "Dynamo Inference Framework Runtime"
 readme = "README.md"
 authors = [

--- a/lib/kvbm/Cargo.toml
+++ b/lib/kvbm/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kvbm-py3"
-version = "0.1.0"
+version = "0.7.0"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/kvbm/pyproject.toml
+++ b/lib/kvbm/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "kvbm"
-version = "0.6.1"
+version = "0.7.0"
 description = "Dynamo KVBM"
 readme = "README.md"
 authors = [

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1038,7 +1038,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello_world"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "service_metrics"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "system_metrics"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dynamo-runtime",

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -407,7 +407,7 @@ mod tests {
     #[tokio::test]
     async fn test_drt_uptime_after_delay_system_disabled() {
         // Test uptime with system status server disabled
-        temp_env::async_with_vars([("DYN_SYSTEM_ENABLED", Some("false"))], async {
+        temp_env::async_with_vars([("DYN_SYSTEM_PORT", None::<&str>)], async {
             // Start a DRT
             let drt = create_test_drt_async().await;
 

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -258,7 +258,7 @@ mod integration_tests {
     #[tokio::test]
     async fn test_uptime_from_system_health() {
         // Test that uptime is available from SystemHealth
-        temp_env::async_with_vars([("DYN_SYSTEM_ENABLED", Some("false"))], async {
+        temp_env::async_with_vars([("DYN_SYSTEM_PORT", None::<&str>)], async {
             let drt = create_test_drt_async().await;
 
             // Get uptime from SystemHealth
@@ -277,9 +277,9 @@ mod integration_tests {
     #[tokio::test]
     async fn test_runtime_metrics_initialization_and_namespace() {
         // Test that metrics have correct namespace
-        temp_env::async_with_vars([("DYN_SYSTEM_ENABLED", Some("false"))], async {
+        temp_env::async_with_vars([("DYN_SYSTEM_PORT", None::<&str>)], async {
             let drt = create_test_drt_async().await;
-            // SystemStatusState is already created in distributed.rs when DYN_SYSTEM_ENABLED=false
+            // SystemStatusState is already created in distributed.rs
             // so we don't need to create it again here
 
             // The uptime_seconds metric should already be registered and available
@@ -315,7 +315,7 @@ mod integration_tests {
     #[tokio::test]
     async fn test_uptime_gauge_updates() {
         // Test that the uptime gauge is properly updated and increases over time
-        temp_env::async_with_vars([("DYN_SYSTEM_ENABLED", Some("false"))], async {
+        temp_env::async_with_vars([("DYN_SYSTEM_PORT", None::<&str>)], async {
             let drt = create_test_drt_async().await;
 
             // Get initial uptime
@@ -347,17 +347,17 @@ mod integration_tests {
     #[tokio::test]
     async fn test_http_requests_fail_when_system_disabled() {
         // Test that system status server is not running when disabled
-        temp_env::async_with_vars([("DYN_SYSTEM_ENABLED", Some("false"))], async {
+        temp_env::async_with_vars([("DYN_SYSTEM_PORT", None::<&str>)], async {
             let drt = create_test_drt_async().await;
 
             // Verify that system status server info is None when disabled
             let system_info = drt.system_status_server_info();
             assert!(
                 system_info.is_none(),
-                "System status server should not be running when DYN_SYSTEM_ENABLED=false"
+                "System status server should not be running when disabled"
             );
 
-            println!("✓ System status server correctly disabled when DYN_SYSTEM_ENABLED=false");
+            println!("✓ System status server correctly disabled when not enabled");
         })
         .await;
     }
@@ -401,7 +401,6 @@ mod integration_tests {
         #[allow(clippy::redundant_closure_call)]
         temp_env::async_with_vars(
             [
-                ("DYN_SYSTEM_ENABLED", Some("true")),
                 ("DYN_SYSTEM_PORT", Some("0")),
                 (
                     "DYN_SYSTEM_STARTING_HEALTH_STATUS",
@@ -484,7 +483,6 @@ mod integration_tests {
         #[allow(clippy::redundant_closure_call)]
         let _ = temp_env::async_with_vars(
             [
-                ("DYN_SYSTEM_ENABLED", Some("true")),
                 ("DYN_SYSTEM_PORT", Some("0")),
                 ("DYN_SYSTEM_STARTING_HEALTH_STATUS", Some("ready")),
                 ("DYN_LOGGING_JSONL", Some("1")),
@@ -539,7 +537,6 @@ mod integration_tests {
         const ENDPOINT_HEALTH_CONFIG: &str = "[\"generate\"]";
         temp_env::async_with_vars(
             [
-                ("DYN_SYSTEM_ENABLED", Some("true")),
                 ("DYN_SYSTEM_PORT", Some("0")),
                 ("DYN_SYSTEM_STARTING_HEALTH_STATUS", Some("notready")),
                 ("DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS", Some(ENDPOINT_HEALTH_CONFIG)),
@@ -648,7 +645,6 @@ mod integration_tests {
         // use reqwest for HTTP requests
         temp_env::async_with_vars(
             [
-                ("DYN_SYSTEM_ENABLED", Some("true")),
                 ("DYN_SYSTEM_PORT", Some("0")),
                 ("DYN_SYSTEM_STARTING_HEALTH_STATUS", Some("ready")),
             ],
@@ -701,7 +697,6 @@ mod integration_tests {
 
         temp_env::async_with_vars(
             [
-                ("DYN_SYSTEM_ENABLED", Some("true")),
                 ("DYN_SYSTEM_PORT", Some("0")),
                 ("DYN_SYSTEM_STARTING_HEALTH_STATUS", Some("notready")),
                 (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "ai-dynamo"
-version = "0.6.1"
+version = "0.7.0"
 description = "Distributed Inference Framework"
 readme = "README.md"
 authors = [
@@ -13,7 +13,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "ai-dynamo-runtime==0.6.1",
+    "ai-dynamo-runtime==0.7.0",
     "pytest>=8.3.4",
     "types-psutil>=7.0.0.20250218",
     "kubernetes>=32.0.1,<33.0.0",

--- a/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
@@ -23,7 +23,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.7.0
     decode:
       dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
@@ -47,7 +47,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.7.0
           workingDir: /sgl-workspace/dynamo
           command:
             - python3
@@ -99,7 +99,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.7.0
           workingDir: /sgl-workspace/dynamo
           command:
             - python3

--- a/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
@@ -23,7 +23,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.7.0
     decode:
       dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
@@ -45,7 +45,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.7.0
           workingDir: /sgl-workspace/dynamo
           command:
             - python3
@@ -93,7 +93,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-wideep-runtime:0.7.0
           workingDir: /sgl-workspace/dynamo
           command:
             - python3

--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
@@ -129,7 +129,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
           args:
           - |
             python3 -m dynamo.frontend --http-port 8000
@@ -161,7 +161,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
           workingDir: /workspace/components/backends/trtllm
           # NOTE: If your PVCs (Persistent Volume Claims) are really slow,
           #       you might need to increase 'failureThreshold' below to allow more time for startup
@@ -219,7 +219,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
           workingDir: /workspace/components/backends/trtllm
           # NOTE: If your PVCs (Persistent Volume Claims) are really slow,
           #       you might need to increase 'failureThreshold' below to allow more time for startup

--- a/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
@@ -46,7 +46,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
       replicas: 1
     TrtllmWorker:
       componentType: main
@@ -81,7 +81,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: my-registry/trtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/trtllm-runtime:0.7.0
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"

--- a/recipes/llama-3-70b/vllm/agg/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/agg/deploy.yaml
@@ -18,7 +18,7 @@ spec:
           mountPoint: /root/.cache/huggingface
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
     VllmPrefillWorker:
@@ -42,7 +42,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml
@@ -18,7 +18,7 @@ spec:
           mountPoint: /root/.cache/huggingface
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
     VllmPrefillWorker:
@@ -42,7 +42,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:
@@ -71,7 +71,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml
@@ -18,7 +18,7 @@ spec:
           mountPoint: /root/.cache/huggingface
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
     VllmPrefillWorker:
@@ -54,7 +54,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
       replicas: 2
       resources:
@@ -95,7 +95,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml
@@ -62,7 +62,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
       replicas: 1
     TrtllmWorker:
       componentType: main
@@ -96,7 +96,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"

--- a/recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml
@@ -219,7 +219,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
       replicas: 1
     TrtllmPrefillWorker:
       componentType: worker
@@ -255,7 +255,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"
@@ -314,7 +314,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"

--- a/tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-moe-agg
@@ -48,7 +48,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/tests/fault_tolerance/deploy/templates/vllm/moe_disagg.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_disagg.yaml
@@ -15,7 +15,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
     VllmDecodeWorker:
       dynamoNamespace: vllm-moe-disagg
       envFromSecret: hf-token-secret
@@ -51,7 +51,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -116,7 +116,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/tests/planner/perf_test_configs/agg_8b.yaml
+++ b/tests/planner/perf_test_configs/agg_8b.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -86,7 +86,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_2p2d.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_2p2d.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -86,7 +86,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -134,7 +134,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_3p1d.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_3p1d.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -86,7 +86,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -134,7 +134,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_planner.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_planner.yaml
@@ -41,7 +41,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -74,7 +74,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/components/src/dynamo/planner
           ports:
             - name: metrics
@@ -136,7 +136,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -191,7 +191,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/tests/planner/perf_test_configs/disagg_8b_tp2.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_tp2.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -86,7 +86,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -134,7 +134,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/image_cache_daemonset.yaml
+++ b/tests/planner/perf_test_configs/image_cache_daemonset.yaml
@@ -20,7 +20,7 @@ spec:
       - name: nvcr-imagepullsecret
       containers:
       - name: image-cache
-        image: my-registry/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
#### Overview:

Cherry-pick of PR #4197 to release/0.7.0. Removes remaining references to the deprecated `DYN_SYSTEM_ENABLED` environment variable from tests, scripts, and documentation.

#### Details:

* Remove `DYN_SYSTEM_ENABLED` from Python test files and launch scripts
* Update Rust test code to explicitly unset `DYN_SYSTEM_PORT` instead of using `DYN_SYSTEM_ENABLED=false`
* Remove references from documentation (README.md, docstrings)
* Preserve deprecation warning in `config.rs` to inform users of the change

#### Where should the reviewer start?

Review the cherry-picked changes to ensure they apply cleanly to the 0.7.0 release branch.

#### Related Issues:

DIS-971
Closes #4197 (cherry-pick to release/0.7.0)

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped project version to 0.7.0 across all components, including Rust crates, Python packages, and Helm charts.
  * Standardized container registry to NVIDIA's official nvcr.io/nvidia/ai-dynamo for all runtime images, replacing placeholder registry references.
  * Updated all deployment manifests, examples, and configuration files to reference the new registry and version.

* **Documentation**
  * Updated installation guides and reference documentation to reflect version 0.7.0.

* **Tests**
  * Modified system status server test configuration to use port-based control mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->