### PR TITLE
fix: TRTLLM build from source was not repsecting the wheel installation directory

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -335,6 +335,9 @@ ARG ARCH_ALT
 ENV DYNAMO_HOME=/opt/dynamo \
     CARGO_TARGET_DIR=/opt/dynamo/target
 
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
+
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
         # required for AIC perf files

--- a/container/Dockerfile.docs
+++ b/container/Dockerfile.docs
@@ -15,6 +15,9 @@
 
 FROM ubuntu:24.04
 
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
+
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 RUN apt-get update && \

--- a/container/Dockerfile.epp
+++ b/container/Dockerfile.epp
@@ -54,6 +54,9 @@ RUN go build \
 ############################
 FROM ${BASE_IMAGE} AS runtime
 
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
+
 # Minimal runtime deps; include libstdc++ runtime for -lstdc++
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \

--- a/container/Dockerfile.local_dev
+++ b/container/Dockerfile.local_dev
@@ -20,6 +20,9 @@ ARG USER_UID
 ARG USER_GID
 ARG WORKSPACE_DIR=/workspace
 
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
+
 ARG ARCH
 
 # Update package lists and install developer utilities. Some of these may exist in the base image,

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -329,6 +329,10 @@ ${NIXL_PLUGIN_DIR}:\
 /usr/local/nvidia/lib64:\
 ${LD_LIBRARY_PATH}
 
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
+
+
 # Copy NATS and ETCD from dynamo_base, and UCX/NIXL
 COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
@@ -399,6 +403,9 @@ FROM runtime AS dev
 
 ARG WORKSPACE_DIR=/sgl-workspace/dynamo
 ARG PYTHON_VERSION
+
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
 
 # NOTE: SGLang uses system Python (not a virtualenv in framework/runtime stages) to align with
 # upstream SGLang Dockerfile: https://github.com/sgl-project/sglang/blob/main/docker/Dockerfile

--- a/container/Dockerfile.sglang-wideep
+++ b/container/Dockerfile.sglang-wideep
@@ -12,6 +12,9 @@ FROM lmsysorg/sglang:${SGLANG_IMAGE_TAG}
 
 WORKDIR /sgl-workspace
 
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
+
 # Install jq for JSON processing
 RUN apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -181,6 +181,7 @@ FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
 
 ARG ARCH_ALT
 ARG PYTHON_VERSION
+ARG DYNAMO_COMMIT_SHA
 
 WORKDIR /workspace
 
@@ -189,6 +190,7 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl
 ENV NIXL_LIB_DIR=$NIXL_PREFIX/lib/${ARCH_ALT}-linux-gnu
 ENV NIXL_PLUGIN_DIR=$NIXL_LIB_DIR/plugins
+ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
 
 # Install Python, build-essential and python3-dev as apt dependencies
 RUN apt-get update && \

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -181,7 +181,6 @@ FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
 
 ARG ARCH_ALT
 ARG PYTHON_VERSION
-ARG DYNAMO_COMMIT_SHA
 
 WORKDIR /workspace
 
@@ -190,6 +189,8 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl
 ENV NIXL_LIB_DIR=$NIXL_PREFIX/lib/${ARCH_ALT}-linux-gnu
 ENV NIXL_PLUGIN_DIR=$NIXL_LIB_DIR/plugins
+
+ARG DYNAMO_COMMIT_SHA
 ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
 
 # Install Python, build-essential and python3-dev as apt dependencies

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -183,6 +183,9 @@ ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl
 ENV NIXL_LIB_DIR=$NIXL_PREFIX/lib/${ARCH_ALT}-linux-gnu
 ENV NIXL_PLUGIN_DIR=$NIXL_LIB_DIR/plugins
 
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
+
 # Install Python, build-essential and python3-dev as apt dependencies
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -322,6 +325,9 @@ FROM runtime AS dev
 
 # Don't want ubuntu to be editable, just change uid and gid.
 ARG WORKSPACE_DIR=/workspace
+
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
 
 USER root
 # Install utilities as root

--- a/container/build.sh
+++ b/container/build.sh
@@ -491,6 +491,10 @@ if [[ "$PLATFORM" == *"linux/arm64"* ]]; then
     BUILD_ARGS+=" --build-arg ARCH=arm64 --build-arg ARCH_ALT=aarch64 "
 fi
 
+# Set the commit sha in the container so we can inspect what build this relates to
+DYNAMO_COMMIT_SHA=$(git rev-parse HEAD)
+BUILD_ARGS+=" --build-arg DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA "
+
 # Special handling for vLLM on ARM64 - set required defaults if not already specified by user
 if [[ $FRAMEWORK == "VLLM" ]] && [[ "$PLATFORM" == *"linux/arm64"* ]]; then
     # Set base image tag to CUDA 12.9 if using the default value (user didn't override)

--- a/container/build.sh
+++ b/container/build.sh
@@ -26,13 +26,13 @@ RUN_PREFIX=
 PLATFORM=linux/amd64
 
 # Get short commit hash
-commit_id=$(git rev-parse --short HEAD)
+commit_id=${commit_id:-$(git rev-parse --short HEAD)}
 
 # if COMMIT_ID matches a TAG use that
-current_tag=$(git describe --tags --exact-match 2>/dev/null | sed 's/^v//') || true
+current_tag=${commit_tag:-$($(git describe --tags --exact-match 2>/dev/null | sed 's/^v//') || true)}
 
 # Get latest TAG and add COMMIT_ID for dev
-latest_tag=$(git describe --tags --abbrev=0 "$(git rev-list --tags --max-count=1)" | sed 's/^v//') || true
+latest_tag=${latest_tag:-$($(git describe --tags --abbrev=0 "$(git rev-list --tags --max-count=1)" | sed 's/^v//') || true)}
 if [[ -z ${latest_tag} ]]; then
     latest_tag="0.0.1"
     echo "No git release tag found, setting to unknown version: ${latest_tag}"

--- a/container/build.sh
+++ b/container/build.sh
@@ -32,7 +32,7 @@ commit_id=${commit_id:-$(git rev-parse --short HEAD)}
 current_tag=${commit_tag:-$($(git describe --tags --exact-match 2>/dev/null | sed 's/^v//') || true)}
 
 # Get latest TAG and add COMMIT_ID for dev
-latest_tag=${latest_tag:-$($(git describe --tags --abbrev=0 "$(git rev-list --tags --max-count=1)" | sed 's/^v//') || true)}
+latest_tag=${latest_tag:-$(git describe --tags --abbrev=0 "$(git rev-list --tags --max-count=1)" | sed 's/^v//' || true)}
 if [[ -z ${latest_tag} ]]; then
     latest_tag="0.0.1"
     echo "No git release tag found, setting to unknown version: ${latest_tag}"

--- a/container/build.sh
+++ b/container/build.sh
@@ -29,7 +29,7 @@ PLATFORM=linux/amd64
 commit_id=${commit_id:-$(git rev-parse --short HEAD)}
 
 # if COMMIT_ID matches a TAG use that
-current_tag=${commit_tag:-$(git describe --tags --exact-match 2>/dev/null | sed 's/^v//' || true)}
+current_tag=${current_tag:-$($(git describe --tags --exact-match 2>/dev/null | sed 's/^v//') || true)}
 
 # Get latest TAG and add COMMIT_ID for dev
 latest_tag=${latest_tag:-$(git describe --tags --abbrev=0 "$(git rev-list --tags --max-count=1)" | sed 's/^v//' || true)}

--- a/container/build.sh
+++ b/container/build.sh
@@ -492,7 +492,7 @@ if [[ "$PLATFORM" == *"linux/arm64"* ]]; then
 fi
 
 # Set the commit sha in the container so we can inspect what build this relates to
-DYNAMO_COMMIT_SHA=$(git rev-parse HEAD)
+DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA:-$(git rev-parse HEAD)}
 BUILD_ARGS+=" --build-arg DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA "
 
 # Special handling for vLLM on ARM64 - set required defaults if not already specified by user

--- a/container/build.sh
+++ b/container/build.sh
@@ -29,7 +29,7 @@ PLATFORM=linux/amd64
 commit_id=${commit_id:-$(git rev-parse --short HEAD)}
 
 # if COMMIT_ID matches a TAG use that
-current_tag=${commit_tag:-$($(git describe --tags --exact-match 2>/dev/null | sed 's/^v//') || true)}
+current_tag=${commit_tag:-$(git describe --tags --exact-match 2>/dev/null | sed 's/^v//' || true)}
 
 # Get latest TAG and add COMMIT_ID for dev
 latest_tag=${latest_tag:-$(git describe --tags --abbrev=0 "$(git rev-list --tags --max-count=1)" | sed 's/^v//' || true)}

--- a/container/build.sh
+++ b/container/build.sh
@@ -637,22 +637,29 @@ check_wheel_file() {
 }
 
 function determine_user_intention_trtllm() {
-    # The following options are grouped to be mutually exclusive.
-    # This function determines if the flags set are can be interpreted
-    # without ambiguity.
+    # The tensorrt llm installation flags are not quite mutually exclusive
+    # since the user should be able to point at a directory of their choosing
+    # for storing a trtllm wheel built from source.
+    #
+    # This function attempts to discern the intention of the user by
+    # applying checks, or rules, for each of the scenarios.
     #
     # /return: Calculated intention. One of "download", "install", "build".
     #
     # The three different methods of installing TRTLLM with build.sh are:
     # 1. Download
-    # --tensorrtllm-index-url
-    # --tensorrtllm-pip-wheel
+    # required: --tensorrtllm-pip-wheel
+    # optional: --tensorrtllm-index-url
+    # optional: --tensorrtllm-commit
     #
     # 2. Install from pre-built
-    # --tensorrtllm-pip-wheel-dir
+    # required: --tensorrtllm-pip-wheel-dir
+    # optional: --tensorrtllm-commit
     #
     # 3. Build from source
-    # --tensorrtllm-git-url
+    # required: --tensorrtllm-git-url
+    # optional: --tensorrtllm-commit
+    # optional: --tensorrtllm-pip-wheel-dir
     local intention_download="false"
     local intention_install="false"
     local intention_build="false"
@@ -660,7 +667,7 @@ function determine_user_intention_trtllm() {
     TRTLLM_INTENTION=${TRTLLM_INTENTION}
 
     # Install from pre-built
-    if [[ -n "$TENSORRTLLM_PIP_WHEEL_DIR" ]]; then
+    if [[ -n "$TENSORRTLLM_PIP_WHEEL_DIR"  && ! -n "$TRTLLM_GIT_URL" ]]; then
         intention_install="true";
         intention_count=$((intention_count+1))
         TRTLLM_INTENTION="install"
@@ -747,6 +754,9 @@ if [[ $FRAMEWORK == "TRTLLM" ]]; then
             if ! env -i ${SOURCE_DIR}/build_trtllm_wheel.sh -o ${TENSORRTLLM_PIP_WHEEL_DIR} -c ${TRTLLM_COMMIT} -a ${ARCH} -n ${NIXL_REF} ${GIT_URL_ARG}; then
                 error "ERROR: Failed to build TensorRT-LLM wheel"
             fi
+            BUILD_ARGS+=" --build-arg HAS_TRTLLM_CONTEXT=1"
+            BUILD_CONTEXT_ARG+=" --build-context trtllm_wheel=${TENSORRTLLM_PIP_WHEEL_DIR}"
+            PRINT_TRTLLM_WHEEL_FILE=$(find $TENSORRTLLM_PIP_WHEEL_DIR -name "*.whl" | head -n 1)
         fi
     else
         echo 'No intention was set. This error should have been detected in "determine_user_intention_trtllm()". Exiting...'

--- a/container/build_trtllm_wheel.sh
+++ b/container/build_trtllm_wheel.sh
@@ -90,15 +90,6 @@ sed -i "s/__version__ = \"\(.*\)\"/__version__ = \"\1+dev${COMMIT_VERSION}\"/" "
 echo "Updated version:"
 grep "__version__" "$VERSION_FILE"
 
-echo "Copying install_nixl.sh from $MAIN_DIR to ${PWD}/docker/common/"
-# Copy install_nixl.sh to docker/common/
-cp $MAIN_DIR/deps/trtllm/install_nixl.sh docker/common/install_nixl.sh
-# Update NIXL_COMMIT in install_nixl.sh to use the parameter passed to this script
-sed -i "s/NIXL_COMMIT=\"[^\"]*\"/NIXL_COMMIT=\"${NIXL_COMMIT}\"/" docker/common/install_nixl.sh
-
-
-
-
 if [ "$ARCH" = "amd64" ]; then
     # Need to build in the Triton Devel Image for NIXL support.
     make -C docker tritondevel_build

--- a/tests/ci/test_build_sh.py
+++ b/tests/ci/test_build_sh.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.unit, pytest.mark.ci, pytest.mark.cpu_only]
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge]
 
 
 @pytest.fixture

--- a/tests/ci/test_build_sh.py
+++ b/tests/ci/test_build_sh.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = [pytest.mark.unit, pytest.mark.ci, pytest.mark.cpu_only]
 
 @pytest.fixture
 def temp_wheel_dir():

--- a/tests/ci/test_build_sh.py
+++ b/tests/ci/test_build_sh.py
@@ -21,6 +21,7 @@ import pytest
 
 pytestmark = [pytest.mark.unit, pytest.mark.ci, pytest.mark.cpu_only]
 
+
 @pytest.fixture
 def temp_wheel_dir():
     """Create a temporary directory for wheel files"""

--- a/tests/ci/test_build_sh.py
+++ b/tests/ci/test_build_sh.py
@@ -38,9 +38,9 @@ def dynamo_repo_dir():
     repo_root = Path(__file__).parent.parent.parent
 
     # Get commit hash from environment variable or git
-    commit_hash = os.environ.get("DYNAMO_GIT_COMMIT")
+    commit_hash = os.environ.get("DYNAMO_COMMIT_SHA")
     if commit_hash:
-        print(f"Using commit from DYNAMO_GIT_COMMIT: {commit_hash}")
+        print(f"Using commit from DYNAMO_COMMIT_SHA: {commit_hash}")
     else:
         try:
             result = subprocess.run(

--- a/tests/ci/test_build_sh.py
+++ b/tests/ci/test_build_sh.py
@@ -145,7 +145,14 @@ def run_build_script(build_script_path, args, expect_failure=False):
         tuple: (exit_code, stdout, stderr)
     """
     cmd = ["bash", build_script_path] + args
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+
+    # Add placeholder environment variables required by build.sh
+    env = os.environ.copy()
+    env["commit_id"] = "commit_id"
+    env["current_tag"] = "current_tag"
+    env["latest_tag"] = "latest_tag"
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, env=env)
 
     if not expect_failure and result.returncode != 0:
         print(f"Command failed: {' '.join(cmd)}")

--- a/tests/ci/test_build_sh.py
+++ b/tests/ci/test_build_sh.py
@@ -1,0 +1,363 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def temp_wheel_dir():
+    """Create a temporary directory for wheel files"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a dummy wheel file so the directory is valid
+        wheel_file = Path(tmpdir) / "tensorrt_llm-1.0.0-py3-none-any.whl"
+        wheel_file.touch()
+        yield tmpdir
+
+
+@pytest.fixture
+def build_script_path():
+    """Get the path to the build.sh script"""
+    script_dir = Path(__file__).parent.parent.parent / "container"
+    build_sh = script_dir / "build.sh"
+    assert build_sh.exists(), f"build.sh not found at {build_sh}"
+    return str(build_sh)
+
+
+def run_build_script(build_script_path, args, expect_failure=False):
+    """
+    Run build.sh with specified arguments and return the result.
+
+    Args:
+        build_script_path: Path to build.sh
+        args: List of arguments to pass to build.sh
+        expect_failure: If True, expect non-zero exit code
+
+    Returns:
+        tuple: (exit_code, stdout, stderr)
+    """
+    cmd = ["bash", build_script_path] + args
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+
+    if not expect_failure and result.returncode != 0:
+        print(f"Command failed: {' '.join(cmd)}")
+        print(f"Exit code: {result.returncode}")
+        print(f"Stdout:\n{result.stdout}")
+        print(f"Stderr:\n{result.stderr}")
+
+    return result.returncode, result.stdout, result.stderr
+
+
+class TestBuildShTRTLLMDownload:
+    """Test download intention scenarios for TRTLLM"""
+
+    def test_default_behavior_downloads(self, build_script_path):
+        """Test that default behavior (no TRTLLM flags) defaults to download"""
+        args = ["--framework", "TRTLLM", "--dry-run"]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        assert exit_code == 0, f"Script failed with exit code {exit_code}"
+        assert "Intent to Download TRTLLM: true" in stdout
+        assert "Intent to Install TRTLLM: false" in stdout
+        assert "Intent to Build TRTLLM: false" in stdout
+        assert (
+            "Inferring download because both TENSORRTLLM_PIP_WHEEL and TENSORRTLLM_INDEX_URL are not set"
+            in stdout
+        )
+
+    def test_download_with_pip_wheel_only(self, build_script_path):
+        """Test download with --tensorrtllm-pip-wheel flag only"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-pip-wheel",
+            "tensorrt-llm==1.2.0",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        assert exit_code == 0, f"Script failed with exit code {exit_code}"
+        assert "Intent to Download TRTLLM: true" in stdout
+        assert "Intent to Install TRTLLM: false" in stdout
+        assert "Intent to Build TRTLLM: false" in stdout
+        assert (
+            "Installing tensorrt-llm==1.2.0 trtllm version from default pip index"
+            in stdout
+        )
+
+    def test_download_with_pip_wheel_and_index_url(self, build_script_path):
+        """Test download with both --tensorrtllm-pip-wheel and --tensorrtllm-index-url"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-pip-wheel",
+            "tensorrt-llm==1.2.0",
+            "--tensorrtllm-index-url",
+            "https://custom.pypi.org/simple",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        assert exit_code == 0, f"Script failed with exit code {exit_code}"
+        assert "Intent to Download TRTLLM: true" in stdout
+        assert "Intent to Install TRTLLM: false" in stdout
+        assert "Intent to Build TRTLLM: false" in stdout
+        assert (
+            "Installing tensorrt-llm==1.2.0 trtllm version from index: https://custom.pypi.org/simple"
+            in stdout
+        )
+
+    def test_download_with_commit(self, build_script_path):
+        """Test download with --tensorrtllm-pip-wheel and --tensorrtllm-commit"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-pip-wheel",
+            "tensorrt-llm==1.2.0",
+            "--tensorrtllm-commit",
+            "abc123def456",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        assert exit_code == 0, f"Script failed with exit code {exit_code}"
+        assert "Intent to Download TRTLLM: true" in stdout
+        assert "Intent to Install TRTLLM: false" in stdout
+        assert "Intent to Build TRTLLM: false" in stdout
+
+
+class TestBuildShTRTLLMInstall:
+    """Test install from pre-built wheel directory scenarios"""
+
+    def test_install_with_wheel_dir_and_commit(self, build_script_path, temp_wheel_dir):
+        """Test install with --tensorrtllm-pip-wheel-dir and --tensorrtllm-commit"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-pip-wheel-dir",
+            temp_wheel_dir,
+            "--tensorrtllm-commit",
+            "abc123def456",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        assert exit_code == 0, f"Script failed with exit code {exit_code}"
+        assert "Intent to Download TRTLLM: false" in stdout
+        assert "Intent to Install TRTLLM: true" in stdout
+        assert "Intent to Build TRTLLM: false" in stdout
+
+
+class TestBuildShTRTLLMBuild:
+    """Test build from source scenarios"""
+
+    def test_build_with_git_url_and_commit(self, build_script_path):
+        """Test build with --tensorrtllm-git-url and --tensorrtllm-commit"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-git-url",
+            "https://github.com/NVIDIA/TensorRT-LLM",
+            "--tensorrtllm-commit",
+            "abc123def456",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        assert exit_code == 0, f"Script failed with exit code {exit_code}"
+        assert "Intent to Download TRTLLM: false" in stdout
+        assert "Intent to Install TRTLLM: false" in stdout
+        assert "Intent to Build TRTLLM: true" in stdout
+
+    def test_build_with_git_url_and_wheel_dir(self, build_script_path, temp_wheel_dir):
+        """Test build with --tensorrtllm-git-url and --tensorrtllm-pip-wheel-dir"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-git-url",
+            "https://github.com/NVIDIA/TensorRT-LLM",
+            "--tensorrtllm-pip-wheel-dir",
+            temp_wheel_dir,
+            "--tensorrtllm-commit",
+            "abc123def456",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        assert exit_code == 0, f"Script failed with exit code {exit_code}"
+        assert "Intent to Download TRTLLM: false" in stdout
+        assert "Intent to Install TRTLLM: false" in stdout
+        assert "Intent to Build TRTLLM: true" in stdout
+
+
+class TestBuildShTRTLLMInvalidCombinations:
+    """Test invalid/conflicting flag combinations"""
+
+    def test_build_with_git_url_requires_commit(self, build_script_path):
+        """Test build with --tensorrtllm-git-url flag requires commit"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-git-url",
+            "https://github.com/NVIDIA/TensorRT-LLM",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(
+            build_script_path, args, expect_failure=True
+        )
+
+        # Git URL alone requires commit to be specified
+        assert exit_code != 0, "Script should fail without commit"
+        combined_output = stdout + stderr
+        assert (
+            "[ERROR] TRTLLM framework was set as a target but the TRTLLM_COMMIT variable was not set"
+            in combined_output
+        )
+
+    def test_install_with_wheel_dir(self, build_script_path, temp_wheel_dir):
+        """Test install with --tensorrtllm-pip-wheel-dir flag"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-pip-wheel-dir",
+            temp_wheel_dir,
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        assert exit_code != 0, f"Script failed with exit code {exit_code}"
+        combined_output = stdout + stderr
+        assert (
+            "[ERROR] TRTLLM framework was set as a target but the TRTLLM_COMMIT variable was not set."
+            in combined_output
+        )
+
+    def test_conflicting_all_three_intentions(self, build_script_path, temp_wheel_dir):
+        """Test that all three intentions together causes an error"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-pip-wheel",
+            "tensorrt-llm==1.2.0",
+            "--tensorrtllm-index-url",
+            "https://custom.pypi.org/simple",
+            "--tensorrtllm-pip-wheel-dir",
+            temp_wheel_dir,
+            "--tensorrtllm-git-url",
+            "https://github.com/NVIDIA/TensorRT-LLM",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(
+            build_script_path, args, expect_failure=True
+        )
+
+        assert exit_code != 0, "Script should have failed with conflicting flags"
+        combined_output = stdout + stderr
+        assert (
+            "[ERROR] Could not figure out the trtllm installation intent"
+            in combined_output
+        )
+
+    def test_wheel_dir_with_git_url_builds(self, build_script_path, temp_wheel_dir):
+        """Test that --tensorrtllm-git-url takes precedence over --tensorrtllm-pip-wheel-dir"""
+        # Note: Based on the code, git-url takes precedence and triggers build intention
+        # The wheel-dir is used as output directory for the build
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-pip-wheel-dir",
+            temp_wheel_dir,
+            "--tensorrtllm-git-url",
+            "https://github.com/NVIDIA/TensorRT-LLM",
+            "--tensorrtllm-commit",
+            "abc123def456",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        # According to the code logic (line 678), git-url sets build=true
+        # And wheel-dir only sets install=true if git-url is NOT set (line 670)
+        # So git-url takes precedence and this should succeed with build intention
+        assert exit_code == 0, f"Script failed with exit code {exit_code}"
+        assert "Intent to Download TRTLLM: false" in stdout
+        assert "Intent to Install TRTLLM: false" in stdout
+        assert "Intent to Build TRTLLM: true" in stdout
+
+    def test_index_url_without_pip_wheel_fails(self, build_script_path):
+        """Test that --tensorrtllm-index-url alone without pip-wheel fails"""
+        # According to the code, index-url alone doesn't trigger download
+        # Only when both index-url AND pip-wheel are set (line 686)
+        # So this should fail with an error about unclear intention
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-index-url",
+            "https://custom.pypi.org/simple",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(
+            build_script_path, args, expect_failure=True
+        )
+
+        # Should fail because no clear intention can be determined
+        assert exit_code != 0, "Script should fail with unclear intention"
+        combined_output = stdout + stderr
+        assert (
+            "[ERROR] Could not figure out the trtllm installation intent"
+            in combined_output
+        )
+
+
+class TestBuildShTRTLLMFlagValidation:
+    """Test individual flag parsing and validation"""
+
+    def test_tensorrtllm_commit_flag_parsed(self, build_script_path):
+        """Test that --tensorrtllm-commit flag is properly parsed"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-git-url",
+            "https://github.com/NVIDIA/TensorRT-LLM",
+            "--tensorrtllm-commit",
+            "test-commit-hash",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        assert exit_code == 0, f"Script failed with exit code {exit_code}"
+        assert "Intent to Download TRTLLM: false" in stdout
+        assert "Intent to Install TRTLLM: false" in stdout
+        assert "Intent to Build TRTLLM: true" in stdout
+
+    def test_tensorrtllm_git_url_flag_parsed(self, build_script_path):
+        """Test that --tensorrtllm-git-url flag is properly parsed"""
+        args = [
+            "--framework",
+            "TRTLLM",
+            "--tensorrtllm-git-url",
+            "https://custom-git-url.example.com/TensorRT-LLM",
+            "--tensorrtllm-commit",
+            "test-commit",
+            "--dry-run",
+        ]
+        exit_code, stdout, stderr = run_build_script(build_script_path, args)
+
+        assert exit_code == 0, f"Script failed with exit code {exit_code}"
+        assert "Intent to Download TRTLLM: false" in stdout
+        assert "Intent to Install TRTLLM: false" in stdout
+        assert "Intent to Build TRTLLM: true" in stdout


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

When invoking `build.sh` for the trtllm framework with the intention of building trtllm from source and then installing that build into the dynamo container, the `--tensorrtllm-pip-wheel-dir` was not being respected. Additionally, users would get the dynamo specified nixl version when building the trtllm wheel, not the nixl version which is specified in the trtllm repository itself. This causes build issues when these versions drift far apart.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes DIS-1036


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced TRTLLM build script with improved handling for download, install from wheel, and build-from-source workflows.
  * Better error messages and validation for flag combinations.

* **Tests**
  * Added comprehensive test suite covering TRTLLM installation and build scenarios including edge cases and invalid combinations.

* **Chores**
  * Removed unused installation script copying logic from build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->