### PR TITLE
[BUG] Fix perf.sh to create per-concurrency subdirectories (Fixes #4233)

### DIFF
--- a/benchmarks/llm/perf.sh
+++ b/benchmarks/llm/perf.sh
@@ -212,6 +212,11 @@ echo "Concurrency levels: ${concurrency_array[@]}"
 for concurrency in "${concurrency_array[@]}"; do
   echo "Run concurrency: $concurrency"
 
+  # Create a subdirectory for this concurrency level
+  # The plot script expects subdirectories named -concurrency<number>
+  concurrency_dir="${artifact_dir}/-concurrency${concurrency}"
+  mkdir -p "${concurrency_dir}"
+
   # NOTE: For Dynamo HTTP OpenAI frontend, use `nvext` for fields like
   # `ignore_eos` since they are not in the official OpenAI spec.
   aiperf profile \
@@ -234,7 +239,7 @@ for concurrency in "${concurrency_array[@]}"; do
     --warmup-request-count $(($concurrency*2)) \
     --num-dataset-entries $(($concurrency*12)) \
     --random-seed 100 \
-    --artifact-dir ${artifact_dir} \
+    --artifact-dir ${concurrency_dir} \
     --ui simple \
     -v \
     -H 'Authorization: Bearer NOT USED' \


### PR DESCRIPTION
## Summary

This PR fixes a bug in `benchmarks/llm/perf.sh` where the script was overwriting benchmark results instead of creating separate subdirectories for each concurrency level, preventing `plot_pareto.py` from generating Pareto plots.

## Problem

When running `perf.sh` with multiple concurrency levels (e.g., `--concurrency 1,2,4,8`), the script used the same `artifact_dir` for all concurrency levels, causing AIPerf to overwrite results. The `plot_pareto.py` script expects subdirectories named `-concurrency<number>/` to parse concurrency levels from file paths.

## Solution

Modified the script to:
1. Create a unique subdirectory for each concurrency level: `-concurrency1/`, `-concurrency2/`, etc.
2. Pass this subdirectory to AIPerf's `--artifact-dir` flag instead of the base `artifact_dir`

## Changes

- Added code to create `concurrency_dir="${artifact_dir}/-concurrency${concurrency}"` for each iteration
- Changed `--artifact-dir ${artifact_dir}` to `--artifact-dir ${concurrency_dir}`

## Testing

The fix ensures:
- Each concurrency level gets its own subdirectory
- `plot_pareto.py` can correctly find and parse results from all concurrency levels
- The documented workflow in `benchmarks/llm/README.md` works end-to-end

## Directory Structure

**Before (broken):**
```
artifacts_0/
  └── profile_export_aiperf.json  (overwritten for each concurrency)
```

**After (fixed):**
```
artifacts_0/
  ├── -concurrency1/
  │   └── profile_export_aiperf.json
  ├── -concurrency2/
  │   └── profile_export_aiperf.json
  ├── -concurrency4/
  │   └── profile_export_aiperf.json
  └── -concurrency8/
      └── profile_export_aiperf.json
```

Fixes #4233

@hhzhang16 @athreesh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced organization of benchmark artifacts by implementing concurrency-specific subdirectories, enabling improved management and isolation of performance test outputs across different concurrency configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->