### PR TITLE
fix: typo from mountPoint to mountPath (#4252)

### DIFF
--- a/benchmarks/profiler/utils/dgd_generation.py
+++ b/benchmarks/profiler/utils/dgd_generation.py
@@ -206,7 +206,7 @@ def generate_dgd_config_with_planner(
         mc_mounts.append(
             {
                 "name": "planner-profile-data",
-                "mountPoint": cm_mount_path,
+                "mountPath": cm_mount_path,
                 "readOnly": True,
             }
         )


### PR DESCRIPTION
# fix: typo from mountPoint to mountPath (cherry-pick to 0.7.0)

## Overview
Cherry-pick of PR #4252 to release/0.7.0. This fixes a typo in the volume mount configuration field name from `mountPoint` to `mountPath` in the planner profiler utilities.

## Details
- Cherry-picked commit: a207b4be8 from main
- Original PR: https://github.com/ai-dynamo/dynamo/pull/4252
- Changed file: `benchmarks/profiler/utils/dgd_generation.py`
- The fix corrects the field name in the Planner ConfigMap volume mount configuration to use the correct `mountPath` instead of the typo `mountPoint`

## Where should the reviewer start?
Review the single line change in `benchmarks/profiler/utils/dgd_generation.py` to verify the cherry-pick is clean.

## Related Issues
- Closes GitHub issue: #5655674 (based on original branch name)
- Cherry-pick of PR: #4252

## Cherry-Pick Information
This cherry-pick is needed for the 0.7.0 release to ensure the profiler utilities use the correct volume mount field name.
