### PR TITLE
docs: update KVBM runbooks on metrics due to dynamo metrics change

### DIFF
--- a/docs/kvbm/trtllm-setup.md
+++ b/docs/kvbm/trtllm-setup.md
@@ -135,11 +135,12 @@ export DYN_KVBM_DISK_ZEROFILL_FALLBACK=true
 Follow below steps to enable metrics collection and view via Grafana dashboard:
 ```bash
 # Start the basic services (etcd & natsd), along with Prometheus and Grafana
-docker compose -f deploy/docker-compose.yml --profile metrics up -d
+docker compose -f deploy/docker-observability.yml up -d
 
 # Set env var DYN_KVBM_METRICS to true, when launch via dynamo
 # Optionally set DYN_KVBM_METRICS_PORT to choose the /metrics port (default: 6880).
 DYN_KVBM_METRICS=true \
+DYN_KVBM_CPU_CACHE_GB=20 \
 python3 -m dynamo.trtllm \
   --model-path Qwen/Qwen3-0.6B \
   --served-model-name Qwen/Qwen3-0.6B \
@@ -149,7 +150,7 @@ python3 -m dynamo.trtllm \
 sudo ufw allow 6880/tcp
 ```
 
-View grafana metrics via http://localhost:3001 (default login: dynamo/dynamo) and look for KVBM Dashboard
+View grafana metrics via http://localhost:3000 (default login: dynamo/dynamo) and look for KVBM Dashboard
 
 ## Benchmark KVBM
 

--- a/docs/kvbm/vllm-setup.md
+++ b/docs/kvbm/vllm-setup.md
@@ -127,12 +127,13 @@ export DYN_KVBM_DISK_ZEROFILL_FALLBACK=true
 Follow below steps to enable metrics collection and view via Grafana dashboard:
 ```bash
 # Start the basic services (etcd & natsd), along with Prometheus and Grafana
-docker compose -f deploy/docker-compose.yml --profile metrics up -d
+docker compose -f deploy/docker-observability.yml up -d
 
 # Set env var DYN_KVBM_METRICS to true, when launch via dynamo
 # Optionally set DYN_KVBM_METRICS_PORT to choose the /metrics port (default: 6880).
 # NOTE: update launch/disagg_kvbm.sh or launch/disagg_kvbm_2p2d.sh as needed
 DYN_KVBM_METRICS=true \
+DYN_KVBM_CPU_CACHE_GB=20 \
 python -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \
     --enforce-eager \
@@ -142,7 +143,7 @@ python -m dynamo.vllm \
 sudo ufw allow 6880/tcp
 ```
 
-View grafana metrics via http://localhost:3001 (default login: dynamo/dynamo) and look for KVBM Dashboard
+View grafana metrics via http://localhost:3000 (default login: dynamo/dynamo) and look for KVBM Dashboard
 
 ## Benchmark KVBM
 


### PR DESCRIPTION
#### Overview:

Verified on linux box

<img width="1164" height="622" alt="Screenshot 2025-11-12 at 11 16 42 AM" src="https://github.com/user-attachments/assets/8e24fbc0-b797-48ba-8253-141555366108" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated observability service setup instructions to use the latest Docker compose configuration, improving metrics collection reliability
  * Added new environment variable parameter for CPU cache configuration, enabling more granular system performance tuning
  * Corrected Grafana metrics dashboard URL to reflect the updated monitoring service endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->