### PR TITLE
feat: `--config` file support in sglang

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -272,7 +272,7 @@ def _extract_config_section(
         raise
 
     config_index = args.index("--config")
-    args = list(args)  
+    args = list(args)
     args[config_index + 1] = temp_path
 
     return args, temp_path

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -240,7 +240,6 @@ def _extract_config_section(
     with open(config_path, "r") as f:
         config_data = yaml.safe_load(f)
 
-    # Check if config has the requested key
     if not isinstance(config_data, dict):
         raise ValueError(
             f"Config file must contain a dictionary, got {type(config_data).__name__}"
@@ -262,7 +261,6 @@ def _extract_config_section(
             f"Config section '{config_key}' must be a dictionary, got {type(section_data).__name__}"
         )
 
-    # Create temporary flat YAML file
     temp_fd, temp_path = tempfile.mkstemp(suffix=".yaml", prefix="dynamo_config_")
 
     try:
@@ -273,9 +271,8 @@ def _extract_config_section(
         os.unlink(temp_path)
         raise
 
-    # Replace config path in args
     config_index = args.index("--config")
-    args = list(args)  # Make a copy to avoid modifying original
+    args = list(args)  
     args[config_index + 1] = temp_path
 
     return args, temp_path


### PR DESCRIPTION
SGL natively support a flag called `--config` that lets you pass in a YAML with CLI flags. Supporting this will make our K8s flow easier and will allow me to write my own config sweeping tools. 

This allows the following:

1. You can now have a yaml file that is passed in with `--config file.yaml` that is read in by sglang
2. For disagg you can also have a single yaml with nested keys that will be applied to either prefill or decode via `--config-key`

---

Test file: https://justpaste.it/dg8s4

Results
```bash
========================================
Test Summary
========================================
Passed: 5
Failed: 0

🎉 All tests passed!
```