### PR TITLE
fix: append namespace to planner pod names in tests

### DIFF
--- a/tests/planner/scaling/run_scaling_test.sh
+++ b/tests/planner/scaling/run_scaling_test.sh
@@ -87,7 +87,8 @@ check_existing_deployment() {
         status=$(kubectl get dynamographdeployment "$DEPLOYMENT_NAME" -n "$NAMESPACE" -o jsonpath='{.status.state}')
         if [ "$status" = "successful" ]; then
             # Check if frontend pod is running
-            if kubectl get pods -n "$NAMESPACE" -l "nvidia.com/dynamo-component-type=frontend,nvidia.com/dynamo-namespace=vllm-disagg-planner" --field-selector=status.phase=Running | grep -q .; then
+            # Note: operator automatically prefixes k8s namespace to dynamo-namespace
+            if kubectl get pods -n "$NAMESPACE" -l "nvidia.com/dynamo-component-type=frontend,nvidia.com/dynamo-namespace=${NAMESPACE}-vllm-disagg-planner" --field-selector=status.phase=Running | grep -q .; then
                 log_success "Existing deployment is ready"
                 return 0
             else
@@ -132,7 +133,8 @@ deploy_planner() {
     log_info "Waiting for pods to be running (this may take several minutes for image pulls)..."
 
     log_info "Waiting for frontend pod..."
-    if kubectl wait --for=condition=Ready pod -l "nvidia.com/dynamo-component-type=frontend,nvidia.com/dynamo-namespace=vllm-disagg-planner" -n "$NAMESPACE" --timeout=900s; then
+    # Note: operator automatically prefixes k8s namespace to dynamo-namespace
+    if kubectl wait --for=condition=Ready pod -l "nvidia.com/dynamo-component-type=frontend,nvidia.com/dynamo-namespace=${NAMESPACE}-vllm-disagg-planner" -n "$NAMESPACE" --timeout=900s; then
         log_success "Frontend pod is ready"
     else
         log_error "Frontend pod failed to become ready within timeout"

--- a/tests/planner/test_scaling_e2e.py
+++ b/tests/planner/test_scaling_e2e.py
@@ -78,7 +78,7 @@ class KubernetesMonitor:
             "-n",
             self.namespace,
             "--selector",
-            f"nvidia.com/dynamo-namespace={self.deployment_name}",
+            f"nvidia.com/dynamo-namespace={self.namespace}-{self.deployment_name}",
             "-o",
             "json",
         ]


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated scaling test infrastructure to use dynamic namespace selectors for improved portability across deployment environments.
  * Enhanced pod detection logic to more precisely identify target pods in multi-namespace scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->