### PR TITLE
feat: Do not restart etcd and nats

### DIFF
--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -867,8 +867,6 @@ class ManagedDeployment:
             logging.getLogger("httpx").setLevel(logging.WARNING)
             await self._init_kubernetes()
             await self._delete_deployment()
-            # ETCD and NATS restarts removed - platform is now managed cluster-wide
-            # No need to restart these services as they are managed by the cluster operator
             await self._create_deployment()
             await self._wait_for_ready()
 

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -867,8 +867,8 @@ class ManagedDeployment:
             logging.getLogger("httpx").setLevel(logging.WARNING)
             await self._init_kubernetes()
             await self._delete_deployment()
-            await self._restart_etcd()
-            await self._restart_nats()
+            # ETCD and NATS restarts removed - platform is now managed cluster-wide
+            # No need to restart these services as they are managed by the cluster operator
             await self._create_deployment()
             await self._wait_for_ready()
 


### PR DESCRIPTION
#### Overview:

Remove unnecessary ETCD and NATS restarts from fault tolerance test infrastructure. The Dynamo platform (operator) is now managed cluster-wide in target environments (dynamo-dev, dynamo-ops, and nebius), eliminating the need to restart these services before each test deployment.

#### Details:

**Background:**
The Dynamo platform operator installation is now managed and deployed cluster-wide in the following clusters:
- `dynamo-dev`
- `dynamo-ops`
- `nebius` (nebius-mk8s-dynamo-h200-01)

With the managed instance reconciling Dynamo resources (DGD, DGDR, etc.), individual namespaces no longer need their own dynamo-platform installation

#### Where should the reviewer start?
tests/utils/managed_deployment.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined managed deployment handling by removing per-deployment ETCD and NATS restarts. The platform now manages these components at the cluster level, proceeding directly to deployment creation and readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->