### PR TITLE
feat: Add DYN_SYSTEM_ENABLED=True

### DIFF
--- a/tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml
@@ -27,6 +27,8 @@ spec:
           memory: "100Gi"
           gpu: "2"
       envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
         # MoE-specific environment variables
         - name: VLLM_ALL2ALL_BACKEND
           value: "pplx"

--- a/tests/fault_tolerance/deploy/templates/vllm/moe_disagg.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_disagg.yaml
@@ -30,6 +30,8 @@ spec:
           memory: "100Gi"
           gpu: "2"
       envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
         # MoE-specific environment variables
         - name: VLLM_ALL2ALL_BACKEND
           value: "pplx"
@@ -95,6 +97,8 @@ spec:
           memory: "100Gi"
           gpu: "2"
       envs:
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
         # MoE-specific environment variables
         - name: VLLM_ALL2ALL_BACKEND
           value: "pplx"


### PR DESCRIPTION
#### Overview:

Add `DYN_SYSTEM_ENABLED` environment variable to MoE deployment templates to fix pod readiness issues. Without this setting, decoder pods fail to start properly and never become ready.

#### Details:

**Problem:**
The MoE (Mixture of Experts) deployment templates for vLLM were missing the `DYN_SYSTEM_ENABLED` environment variable. This caused decoder pods to fail their startup probes and never reach a ready state, resulting in deployment failures.

**Error observed without the fix:**
```
Warning Unhealthy 3s (x19 over 3m3s) kubelet Startup probe failed: Get "http://10.7.21.115:9090/live": dial tcp 10.7.21.115:9090: connect: connection refused
```
The health check endpoint on port 9090 was not accessible because the system-level components weren't initialized without `DYN_SYSTEM_ENABLED` being set.

#### Where should the reviewer start?

tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled dynamic system toggle in test deployment configurations for VllmDecodeWorker and VllmPrefillWorker containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->