### PR TITLE
fix(operator): add back injection of DYN_SYSTEM_ENABLED env var

### DIFF
--- a/deploy/cloud/operator/docs/footer.md
+++ b/deploy/cloud/operator/docs/footer.md
@@ -137,6 +137,7 @@ The operator automatically injects environment variables based on component type
 
 - **`DYN_SYSTEM_PORT`**: `9090` (automatically enables the system metrics server)
 - **`DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS`**: `["generate"]`
+- **`DYN_SYSTEM_ENABLED`**: `true` (needed for runtime images 0.6.1 and older)
 
 ### Planner Components
 

--- a/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -828,6 +828,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 											{Name: commonconsts.DynamoNamespaceEnvVar, Value: "default"},
 											{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "test-lws-deploy"},
 											{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: "default"},
+											{Name: "DYN_SYSTEM_ENABLED", Value: "true"},
 											{Name: "DYN_SYSTEM_PORT", Value: "9090"},
 											{Name: "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS", Value: "[\"generate\"]"},
 											{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
@@ -952,6 +953,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 											{Name: commonconsts.DynamoNamespaceEnvVar, Value: "default"},
 											{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "test-lws-deploy"},
 											{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: "default"},
+											{Name: "DYN_SYSTEM_ENABLED", Value: "true"},
 											{Name: "DYN_SYSTEM_PORT", Value: "9090"},
 											{Name: "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS", Value: "[\"generate\"]"},
 											{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{

--- a/deploy/cloud/operator/internal/dynamo/component_worker.go
+++ b/deploy/cloud/operator/internal/dynamo/component_worker.go
@@ -75,6 +75,10 @@ func (w *WorkerDefaults) GetBaseContainer(context ComponentContext) (corev1.Cont
 
 	container.Env = append(container.Env, []corev1.EnvVar{
 		{
+			Name:  "DYN_SYSTEM_ENABLED",
+			Value: "true",
+		},
+		{
 			Name:  "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS",
 			Value: "[\"generate\"]",
 		},

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -1931,6 +1931,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: "1",
 													},
 													{
+														Name:  "DYN_SYSTEM_ENABLED",
+														Value: "true",
+													},
+													{
 														Name:  "DYN_SYSTEM_PORT",
 														Value: "9090",
 													},
@@ -2098,6 +2102,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													{
 														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
 														Value: "1",
+													},
+													{
+														Name:  "DYN_SYSTEM_ENABLED",
+														Value: "true",
 													},
 													{
 														Name:  "DYN_SYSTEM_PORT",
@@ -2812,6 +2820,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: "9090",
 													},
 													{
+														Name:  "DYN_SYSTEM_ENABLED",
+														Value: "true",
+													},
+													{
 														Name:  "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS",
 														Value: "[\"generate\"]",
 													},
@@ -2966,6 +2978,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													{
 														Name:  "DYN_SYSTEM_PORT",
 														Value: "9090",
+													},
+													{
+														Name:  "DYN_SYSTEM_ENABLED",
+														Value: "true",
 													},
 													{
 														Name:  "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS",
@@ -4937,6 +4953,7 @@ func TestGenerateBasePodSpec_Worker(t *testing.T) {
 							{Name: commonconsts.DynamoNamespaceEnvVar, Value: ""},
 							{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "test-deployment"},
 							{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: "default"},
+							{Name: "DYN_SYSTEM_ENABLED", Value: "true"},
 							{Name: "DYN_SYSTEM_PORT", Value: "9090"},
 							{Name: "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS", Value: "[\"generate\"]"},
 							{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{

--- a/deploy/helm/chart/templates/deployment.yaml
+++ b/deploy/helm/chart/templates/deployment.yaml
@@ -113,6 +113,8 @@ spec:
         - name: DYN_HTTP_PORT
           value: "{{ $.Values.dynamoPort | default 8000 }}"
         {{- else if $serviceSpec.componentType | eq "worker" }}
+        - name: DYN_SYSTEM_ENABLED
+          value: "true"
         - name: DYN_SYSTEM_PORT
           value: "{{ $.Values.dynamoSystemPort | default 9090 }}"
         - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS

--- a/deploy/helm/chart/templates/grove-podgangset.yaml
+++ b/deploy/helm/chart/templates/grove-podgangset.yaml
@@ -105,6 +105,8 @@ spec:
             - name: DYN_HTTP_PORT
               value: "{{ $.Values.dynamoPort | default 8000 }}"
             {{- else if $serviceSpec.componentType | eq "worker" }}
+            - name: DYN_SYSTEM_ENABLED
+              value: "true"
             - name: DYN_SYSTEM_PORT
               value: "{{ $.Values.dynamoSystemPort | default 9090 }}"
             - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS

--- a/docs/kubernetes/api_reference.md
+++ b/docs/kubernetes/api_reference.md
@@ -732,6 +732,7 @@ The operator automatically injects environment variables based on component type
 
 - **`DYN_SYSTEM_PORT`**: `9090` (automatically enables the system metrics server)
 - **`DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS`**: `["generate"]`
+- **`DYN_SYSTEM_ENABLED`**: `true` (needed for runtime images 0.6.1 and older)
 
 ### Planner Components
 


### PR DESCRIPTION
#### Overview:

PR [4082](https://github.com/ai-dynamo/dynamo/pull/4082) removed the injection of `DYN_SYSTEM_ENABLED` because the runtime now only uses `DYN_SYSTEM_PORT` (already injected by operator) to determine if the http status server is launched on a worker.

However, for old runtime images like 0.6.1, the runtime requires `DYN_SYSTEM_ENABLED` in order to start http status server. Not injecting this results in the `startupProbe` failing on the worker container - Pod never hits Ready and is then recycled.

Example failure:
```
Startup probe failed: Get "http://10.0.162.156:9090/health": dial tcp 10.0.162.156:9090: connect: connection refused
```

#### Details:

This PR adds back the injection of `DYN_SYSTEM_ENABLED` for backwards compatibility of older runtime images with the newest operator version.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker container environment variables in cloud operator deployment manifests, Helm chart templates (deployment and pod gang set), and operator components to include new configuration settings.
  * Modified and aligned test cases across controller and component test suites to ensure consistency with the updated environment variable configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->