### PR TITLE
fix: docs surrounding `uv pip install` with --prerelease=allow and quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ source venv/bin/activate
 uv pip install pip
 
 # Choose one
-uv pip install "ai-dynamo[sglang]"  #replace with [vllm], [trtllm], etc.
+uv pip install --prerelease=allow "ai-dynamo[sglang]"  #replace with [vllm], [trtllm], etc.
 ```
 
 ## 3. Run Dynamo
@@ -211,7 +211,7 @@ To specify which GPUs to use set environment variable `CUDA_VISIBLE_DEVICES`.
 # Install libnuma
 apt install -y libnuma-dev
 
-uv pip install "ai-dynamo[sglang]"
+uv pip install --prerelease=allow "ai-dynamo[sglang]"
 ```
 
 Run the backend/worker like this:

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Dynamo is designed to be inference engine agnostic. To use any engine with Dynam
 ## vLLM
 
 ```
-uv pip install ai-dynamo[vllm]
+uv pip install "ai-dynamo[vllm]"
 ```
 
 Run the backend/worker like this:
@@ -211,7 +211,7 @@ To specify which GPUs to use set environment variable `CUDA_VISIBLE_DEVICES`.
 # Install libnuma
 apt install -y libnuma-dev
 
-uv pip install ai-dynamo[sglang]
+uv pip install "ai-dynamo[sglang]"
 ```
 
 Run the backend/worker like this:
@@ -252,7 +252,7 @@ sudo apt-get -y install libopenmpi-dev
 ### After installing the pre-requisites above, install Dynamo
 
 ```
-uv pip install ai-dynamo[trtllm]
+uv pip install "ai-dynamo[trtllm]"
 ```
 
 Run the backend/worker like this:

--- a/docs/_includes/install.rst
+++ b/docs/_includes/install.rst
@@ -10,7 +10,7 @@ Install a pre-built wheel from PyPI.
    source venv/bin/activate
 
    # Install Dynamo from PyPI (choose one backend extra)
-   uv pip install "ai-dynamo[sglang]==my-tag"  # or [vllm], [trtllm]
+   uv pip install --prerelease=allow "ai-dynamo[sglang]==my-tag"  # or [vllm], [trtllm]
 
 
 Pip from source

--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -97,7 +97,7 @@ We suggest using uv to install the latest release of ai-dynamo[sglang]. You can 
 # create a virtual env
 uv venv --python 3.12 --seed
 # install the latest release (which comes bundled with a stable sglang version)
-uv pip install "ai-dynamo[sglang]"
+uv pip install --prerelease=allow "ai-dynamo[sglang]"
 ```
 
 </details>


### PR DESCRIPTION
#### Overview:

The documentation for installing sglang wheels omits the `--prerelease=allow` flag which results in installing an older version. This updates the documentation to reflect that need.

Additionally when trying to install a backend-specific wheel, e.g. `ai-dynamo[vllm]` quotes are required around the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions for ai-dynamo and optional backends (sglang, vllm, trtllm).
  * Installation commands now properly quote package specifiers and include the `--prerelease=allow` flag to enable prerelease version access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->