### PR TITLE
fix: remove wideep image ref from recipes

### DIFF
--- a/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
@@ -23,7 +23,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: my-registry/sglang-runtime:my-tag
     decode:
       dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
@@ -47,7 +47,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: my-registry/sglang-runtime:my-tag
           workingDir: /sgl-workspace/dynamo
           command:
             - python3
@@ -99,7 +99,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: my-registry/sglang-runtime:my-tag
           workingDir: /sgl-workspace/dynamo
           command:
             - python3

--- a/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
@@ -23,7 +23,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: my-registry/sglang-runtime:my-tag
     decode:
       dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
@@ -45,7 +45,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: my-registry/sglang-runtime:my-tag
           workingDir: /sgl-workspace/dynamo
           command:
             - python3
@@ -93,7 +93,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: my-registry/sglang-wideep-runtime:my-tag
+          image: my-registry/sglang-runtime:my-tag
           workingDir: /sgl-workspace/dynamo
           command:
             - python3


### PR DESCRIPTION
#### Overview:

sglang container now supports wideep, so should be able to use that across all configs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime container images across deployment configurations to use optimized runtime versions for both 8-GPU and 16-GPU setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->