### PR TITLE
ci: Use dockerhub credential for helm install

### DIFF
--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -375,7 +375,7 @@ jobs:
           # Install dynamo env secrets
           kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=${{ secrets.HF_TOKEN }} -n $KUBE_NS || true
           # Create docker pull secret for operator image
-          kubectl create secret docker-registry docker-imagepullsecret --docker-server=${{ secrets.AZURE_ACR_HOSTNAME }} --docker-username=${{ secrets.AZURE_ACR_USER }} --docker-password=${{ secrets.AZURE_ACR_PASSWORD }} --namespace=${NAMESPACE}
+          kubectl create secret docker-registry docker-imagepullsecret --docker-server="https://index.docker.io/v1/" --docker-username=${{ secrets.DOCKERHUB_USERNAME }} --docker-password=${{ secrets.DOCKERHUB_PASSWORD }} --namespace=${NAMESPACE}
           # Install helm dependencies
           helm repo add bitnami https://charts.bitnami.com/bitnami
           cd deploy/cloud/helm/platform/

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -554,7 +554,7 @@ jobs:
         # Install dynamo env secrets
         kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=${{ secrets.HF_TOKEN }} -n $KUBE_NS || true
         # Create docker pull secret for operator image
-        kubectl create secret docker-registry docker-imagepullsecret --docker-server=${{ secrets.AZURE_ACR_HOSTNAME }} --docker-username=${{ secrets.AZURE_ACR_USER }} --docker-password=${{ secrets.AZURE_ACR_PASSWORD }} --namespace=${NAMESPACE}
+          kubectl create secret docker-registry docker-imagepullsecret --docker-server="https://index.docker.io/v1/" --docker-username=${{ secrets.DOCKERHUB_USERNAME }} --docker-password=${{ secrets.DOCKERHUB_PASSWORD }} --namespace=${NAMESPACE}
         # Install helm dependencies
         helm repo add bitnami https://charts.bitnami.com/bitnami
         cd deploy/cloud/helm/platform/


### PR DESCRIPTION
#### Overview:

Uses a dockerhub secret to pull from docker.io to remove reliance on ACR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container validation infrastructure configuration to use an alternative registry service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->