### PR TITLE
fix: k8s native discovery

### DIFF
--- a/deploy/cloud/operator/internal/consts/consts.go
+++ b/deploy/cloud/operator/internal/consts/consts.go
@@ -43,6 +43,7 @@ const (
 	KubeLabelDynamoBaseModelHash        = "nvidia.com/dynamo-base-model-hash"
 	KubeAnnotationDynamoBaseModel       = "nvidia.com/dynamo-base-model"
 	KubeLabelDynamoDiscoveryBackend     = "nvidia.com/dynamo-discovery-backend"
+	KubeLabelDynamoDiscoveryEnabled     = "nvidia.com/dynamo-discovery-enabled"
 
 	KubeLabelValueFalse = "false"
 	KubeLabelValueTrue  = "true"

--- a/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -1298,6 +1298,10 @@ func (r *DynamoComponentDeploymentReconciler) generateService(opt generateResour
 	if isK8sDiscovery {
 		labels[commonconsts.KubeLabelDynamoDiscoveryBackend] = "kubernetes"
 	}
+	// Discovery is enabled for non frontend components
+	if isK8sDiscovery && !opt.dynamoComponentDeployment.IsFrontendComponent() {
+		labels[commonconsts.KubeLabelDynamoDiscoveryEnabled] = commonconsts.KubeLabelValueTrue
+	}
 
 	var servicePort corev1.ServicePort
 	if opt.dynamoComponentDeployment.IsFrontendComponent() {

--- a/deploy/cloud/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/cloud/operator/internal/controller/dynamographdeployment_controller.go
@@ -368,8 +368,9 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGroveResources(ctx context.Co
 
 		// if k8s discovery is enabled, create a service for each component
 		// else, only create for the frontend component
-		if r.Config.IsK8sDiscoveryEnabled(dynamoDeployment.Annotations) || component.ComponentType == consts.ComponentTypeFrontend {
-			mainComponentService, err := dynamo.GenerateComponentService(ctx, dynamoDeployment, component, componentName)
+		isK8sDiscoveryEnabled := r.Config.IsK8sDiscoveryEnabled(dynamoDeployment.Annotations)
+		if isK8sDiscoveryEnabled || component.ComponentType == consts.ComponentTypeFrontend {
+			mainComponentService, err := dynamo.GenerateComponentService(ctx, dynamoDeployment, component, componentName, isK8sDiscoveryEnabled)
 			if err != nil {
 				logger.Error(err, "failed to generate the main component service")
 				return "", "", "", fmt.Errorf("failed to generate the main component service: %w", err)

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -435,6 +435,10 @@ func GenerateComponentService(ctx context.Context, dynamoDeployment *v1alpha1.Dy
 		service.Labels = map[string]string{
 			commonconsts.KubeLabelDynamoDiscoveryBackend: "kubernetes",
 		}
+		// Discovery is enabled for non frontend components
+		if component.ComponentType != commonconsts.ComponentTypeFrontend {
+			service.Labels[commonconsts.KubeLabelDynamoDiscoveryEnabled] = commonconsts.KubeLabelValueTrue
+		}
 	}
 	return service, nil
 }

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -396,7 +396,7 @@ func getCliqueStartupDependencies(
 	return nil
 }
 
-func GenerateComponentService(ctx context.Context, dynamoDeployment *v1alpha1.DynamoGraphDeployment, component *v1alpha1.DynamoComponentDeploymentSharedSpec, componentName string) (*corev1.Service, error) {
+func GenerateComponentService(ctx context.Context, dynamoDeployment *v1alpha1.DynamoGraphDeployment, component *v1alpha1.DynamoComponentDeploymentSharedSpec, componentName string, isK8sDiscoveryEnabled bool) (*corev1.Service, error) {
 	if component.DynamoNamespace == nil {
 		return nil, fmt.Errorf("expected DynamoComponentDeployment %s to have a dynamoNamespace", componentName)
 	}
@@ -430,6 +430,11 @@ func GenerateComponentService(ctx context.Context, dynamoDeployment *v1alpha1.Dy
 			},
 			Ports: []corev1.ServicePort{servicePort},
 		},
+	}
+	if isK8sDiscoveryEnabled {
+		service.Labels = map[string]string{
+			commonconsts.KubeLabelDynamoDiscoveryBackend: "kubernetes",
+		}
 	}
 	return service, nil
 }

--- a/deploy/discovery/README.md
+++ b/deploy/discovery/README.md
@@ -16,7 +16,7 @@ When deploying with the Dynamo operator, simply add the annotation to your DGD m
 ```yaml
 metadata:
   annotations:
-    nvidia.com/dynamo-discover-backend: kubernetes
+    nvidia.com/dynamo-discovery-backend: kubernetes
 ```
 
 The operator will automatically configure the required EndpointSlices, labels, and pod environment variables. See [`dgd.yaml`](./dgd.yaml) for a complete example.

--- a/deploy/discovery/dgd.yaml
+++ b/deploy/discovery/dgd.yaml
@@ -17,9 +17,6 @@ spec:
       dynamoNamespace: dynamo
       componentType: frontend
       replicas: 1
-      envs:
-        - name: DYN_SYSTEM_PORT
-          value: "9090"
       extraPodSpec:
         mainContainer:
           image: ${IMAGE}
@@ -30,29 +27,6 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: DYN_SYSTEM_PORT
-          value: "9090"
-        - name: DYN_SYSTEM_STARTING_HEALTH_STATUS
-          value: "notready"
-        - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
-          value: "[\"generate\", \"clear_kv_blocks\"]"
-      readinessProbe:
-        httpGet:
-          path: /health
-          port: 9090
-        initialDelaySeconds: 60
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        httpGet:
-          path: /live
-          port: 9090
-        initialDelaySeconds: 60
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 60
       extraPodSpec:
         terminationGracePeriodSeconds: 120
         mainContainer:
@@ -72,29 +46,6 @@ spec:
       resources:
         limits:
           gpu: "1"
-      envs:
-        - name: DYN_SYSTEM_PORT
-          value: "9090"
-        - name: DYN_SYSTEM_STARTING_HEALTH_STATUS
-          value: "notready"
-        - name: DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS
-          value: "[\"generate\", \"clear_kv_blocks\"]"
-      readinessProbe:
-        httpGet:
-          path: /health
-          port: 9090
-        initialDelaySeconds: 60
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 60
-      livenessProbe:
-        httpGet:
-          path: /live
-          port: 9090
-        initialDelaySeconds: 60
-        periodSeconds: 10
-        timeoutSeconds: 5
-        failureThreshold: 60
       extraPodSpec:
         terminationGracePeriodSeconds: 120
         mainContainer:

--- a/lib/runtime/src/discovery/kube/daemon.rs
+++ b/lib/runtime/src/discovery/kube/daemon.rs
@@ -68,11 +68,12 @@ impl DiscoveryDaemon {
         let (reader, writer) = reflector::store();
 
         // Apply label selector to only watch discovery-enabled EndpointSlices
-        let watch_config =
-            Config::default().labels("nvidia.com/dynamo-discovery-backend=kubernetes");
+        let watch_config = Config::default()
+            .labels("nvidia.com/dynamo-discovery-backend=kubernetes")
+            .labels("nvidia.com/dynamo-discovery-enabled=true");
 
         tracing::info!(
-            "Daemon watching EndpointSlices with label: nvidia.com/dynamo-discovery-backend=kubernetes"
+            "Daemon watching EndpointSlices with labels: nvidia.com/dynamo-discovery-backend=kubernetes, nvidia.com/dynamo-discovery-enabled=true"
         );
 
         // Spawn reflector task (runs independently)

--- a/lib/runtime/src/discovery/kube/utils.rs
+++ b/lib/runtime/src/discovery/kube/utils.rs
@@ -26,15 +26,16 @@ fn extract_system_port(slice: &EndpointSlice) -> Option<u16> {
 
 /// Extract endpoint information from an EndpointSlice
 /// Returns (instance_id, pod_name, pod_ip, system_port) tuples for ready endpoints
-pub(super) fn extract_endpoint_info(
-    slice: &EndpointSlice,
-) -> Vec<(u64, String, String, u16)> {
+pub(super) fn extract_endpoint_info(slice: &EndpointSlice) -> Vec<(u64, String, String, u16)> {
     // Extract system port from EndpointSlice ports
     let system_port = match extract_system_port(slice) {
         Some(port) => port,
         None => {
             let slice_name = slice.metadata.name.as_deref().unwrap_or("unknown");
-            tracing::warn!("EndpointSlice '{}' did not have a system port defined", slice_name);
+            tracing::warn!(
+                "EndpointSlice '{}' did not have a system port defined",
+                slice_name
+            );
             return Vec::new();
         }
     };

--- a/lib/runtime/src/discovery/kube/utils.rs
+++ b/lib/runtime/src/discovery/kube/utils.rs
@@ -23,17 +23,15 @@ fn extract_system_port(slice: &EndpointSlice) -> Option<u16> {
             .find(|p| p.name.as_deref() == Some("system"))
             .and_then(|p| p.port.map(|port| port as u16))
             // Fall back to first port if "system" not found
-            .or_else(|| {
-                ports
-                    .first()
-                    .and_then(|p| p.port.map(|port| port as u16))
-            })
+            .or_else(|| ports.first().and_then(|p| p.port.map(|port| port as u16)))
     })
 }
 
 /// Extract endpoint information from an EndpointSlice
 /// Returns (instance_id, pod_name, pod_ip, system_port) tuples for ready endpoints
-pub(super) fn extract_endpoint_info(slice: &EndpointSlice) -> Vec<(u64, String, String, Option<u16>)> {
+pub(super) fn extract_endpoint_info(
+    slice: &EndpointSlice,
+) -> Vec<(u64, String, String, Option<u16>)> {
     let mut result = Vec::new();
 
     // Extract system port from EndpointSlice ports


### PR DESCRIPTION
#### Overview:

Some fixes to the etcd-less implementation (experimental and opt-in) in the Operator and runtime introduced in [4136](https://github.com/ai-dynamo/dynamo/pull/4136) and [4214](https://github.com/ai-dynamo/dynamo/pull/4214).

#### Details:

- `deploy/cloud/operator/internal/dynamo/graph.go`: ensure we are injecting the proper annotations in the Service (creates resulting EndpointSlice) that the kube discovery client is filtering on.
- `*.rs`: Extract system port from the EndpointSlice of the discoverable component. Previously this was determined by the current components system port which differs from the component it's attempting to retrieve metadata from (frontend is random and worker is 9090).

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Kubernetes service discovery now supports configurable system ports for improved endpoint detection and compatibility.
  * Services include automatic discovery backend labeling when Kubernetes discovery is enabled.

* **Chores**
  * Enhanced internal service generation and discovery daemon infrastructure for better configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->