### PR TITLE
fix: remove [all] extra from sglang wheel install to fix warning (#4294)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ vllm = [
 sglang = [
     "uvloop",
     "nixl<=0.7.0",
-    "sglang[all]==0.5.4.post3",
+    "sglang==0.5.4.post3",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
#### Overview:

Cherry-pick PR #4294 

Relates to OPS-2067