### PR TITLE
test(key_value_store): Assert entries() works correctly

### DIFF
--- a/lib/runtime/src/storage/key_value_store/mem.rs
+++ b/lib/runtime/src/storage/key_value_store/mem.rs
@@ -220,9 +220,36 @@ impl KeyValueBucket for MemoryBucketRef {
             Some(bucket) => Ok(bucket
                 .data
                 .iter()
-                .map(|(k, (_rev, v))| (k.to_string(), v.clone()))
+                .map(|(k, (_rev, v))| ([self.name.clone(), k.to_string()].join("/"), v.clone()))
                 .collect()),
             None => Err(StoreError::MissingBucket(self.name.clone())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use crate::storage::key_value_store::{
+        Key, KeyValueBucket as _, KeyValueStore as _, MemoryStore,
+    };
+
+    #[tokio::test]
+    async fn test_entries_full_path() {
+        let m = MemoryStore::new();
+        let bucket = m.get_or_create_bucket("bucket1", None).await.unwrap();
+        let _ = bucket
+            .insert(&Key::new("key1"), "value1".into(), 0)
+            .await
+            .unwrap();
+        let _ = bucket
+            .insert(&Key::new("key2"), "value2".into(), 0)
+            .await
+            .unwrap();
+        let entries = bucket.entries().await.unwrap();
+        let keys: HashSet<String> = entries.into_keys().collect();
+        assert!(keys.contains("bucket1/key1"));
+        assert!(keys.contains("bucket1/key2"));
     }
 }


### PR DESCRIPTION
And fix it for MemoryStore.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage entries now consistently return full paths including bucket prefixes, improving key retrieval behavior across all storage implementations.
* **Tests**
  * Added unit tests to verify full-path key behavior for both file-based and in-memory storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->