### PR TITLE
fix: Allow users to set `--kv-transfer-config` for vLLM

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import json
 import logging
 import os
 import socket
@@ -393,13 +392,7 @@ def create_kv_transfer_config(config: Config) -> Optional[KVTransferConfig]:
 
     if has_user_kv_config:
         logger.info("Using user-provided kv_transfer_config from --kv-transfer-config")
-        try:
-            # The default AsyncEngineArgs.kv_transfer_config is a string, we need to parse it into a dict.
-            parsed_config = json.loads(config.engine_args.kv_transfer_config)
-            return KVTransferConfig(**parsed_config)
-        except Exception as e:
-            logger.error(f"Failed to parse kv_transfer_config: {e}")
-            raise ValueError(f"Failed to parse kv_transfer_config: {e}")
+        return None  # Let vLLM use the user's config
 
     # No connector list or empty list means no config
     if not config.connector_list:

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -282,7 +282,6 @@ def parse_args() -> Config:
                 f"Please ensure the file exists and the path is correct."
             )
 
-    # args.connector can never be None or an empty list, since it's defaulted to ["nixl"]
     normalized = [c.lower() for c in args.connector]
 
     invalid = [c for c in normalized if c not in VALID_CONNECTORS]
@@ -297,7 +296,7 @@ def parse_args() -> Config:
         and engine_args.kv_transfer_config is not None
     )
 
-    if "none" in normalized or "null" in normalized:
+    if not normalized or "none" in normalized or "null" in normalized:
         if len(normalized) > 1:
             raise ValueError(
                 "'none' and 'null' cannot be combined with other connectors"

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -282,35 +282,35 @@ def parse_args() -> Config:
                 f"Please ensure the file exists and the path is correct."
             )
 
-    # Check for conflicting flags
+    # args.connector can never be None or an empty list, since it's defaulted to ["nixl"]
+    normalized = [c.lower() for c in args.connector]
+
+    invalid = [c for c in normalized if c not in VALID_CONNECTORS]
+    if invalid:
+        raise ValueError(
+            f"Invalid connector(s): {', '.join(invalid)}. Valid options are: {', '.join(sorted(VALID_CONNECTORS))}"
+        )
+
+    # Check for custom kv_transfer_config
     has_kv_transfer_config = (
         hasattr(engine_args, "kv_transfer_config")
         and engine_args.kv_transfer_config is not None
     )
-    has_connector_flag = args.connector is not None
 
-    if has_kv_transfer_config and has_connector_flag:
-        raise ValueError(
-            "Cannot specify both --kv-transfer-config and --connector flags"
-        )
-
-    if has_connector_flag:
-        normalized = [c.lower() for c in args.connector]
-
-        invalid = [c for c in normalized if c not in VALID_CONNECTORS]
-        if invalid:
+    if "none" in normalized or "null" in normalized:
+        if len(normalized) > 1:
             raise ValueError(
-                f"Invalid connector(s): {', '.join(invalid)}. Valid options are: {', '.join(sorted(VALID_CONNECTORS))}"
+                "'none' and 'null' cannot be combined with other connectors"
+            )
+        config.connector_list = []
+    else:
+        # Check for conflicting flags
+        if has_kv_transfer_config:
+            raise ValueError(
+                "Cannot specify both --kv-transfer-config and --connector flags"
             )
 
-        if "none" in normalized or "null" in normalized:
-            if len(normalized) > 1:
-                raise ValueError(
-                    "'none' and 'null' cannot be combined with other connectors"
-                )
-            config.connector_list = []
-        else:
-            config.connector_list = normalized
+        config.connector_list = normalized
 
     if config.engine_args.block_size is None:
         config.engine_args.block_size = 16
@@ -433,7 +433,12 @@ def create_kv_transfer_config(config: Config) -> Optional[KVTransferConfig]:
 def overwrite_args(config):
     """Set vLLM defaults for Dynamo."""
 
-    if config.has_connector("nixl"):
+    if config.has_connector("nixl") or (
+        # Check if the user provided their own kv_transfer_config
+        config.engine_args.kv_transfer_config is not None
+        # and the connector is NixlConnector
+        and config.engine_args.kv_transfer_config.kv_connector == "NixlConnector"
+    ):
         ensure_side_channel_host()
 
     defaults = {

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import json
 import logging
 import os
 import socket
@@ -392,7 +393,13 @@ def create_kv_transfer_config(config: Config) -> Optional[KVTransferConfig]:
 
     if has_user_kv_config:
         logger.info("Using user-provided kv_transfer_config from --kv-transfer-config")
-        return None  # Let vLLM use the user's config
+        try:
+            # The default AsyncEngineArgs.kv_transfer_config is a string, we need to parse it into a dict.
+            parsed_config = json.loads(config.engine_args.kv_transfer_config)
+            return KVTransferConfig(**parsed_config)
+        except Exception as e:
+            logger.error(f"Failed to parse kv_transfer_config: {e}")
+            raise ValueError(f"Failed to parse kv_transfer_config: {e}")
 
     # No connector list or empty list means no config
     if not config.connector_list:


### PR DESCRIPTION
#### Overview:

The default `--connector nixl` CLI argument was preventing users from being able to set their own custom `--kv-transfer-config`. This PR fixes this while ensuring guarantees by providing a connector argument instead. Namely, this maintains the behavior that `VLLM_NIXL_SIDE_CHANNEL_HOST` is set when `--kv-transfer-config "{\"kv_connector\": \"NixlConnector\"}"` or `--connector nixl`

#### Details:

Rearranges the logic checking whether a `--connector` is set or the user has specified a custom kv transfer config. If the connector is set to `--connector none` or `--connector null`, then a user can specify `--kv-transfer-config`. Otherwise, if `--connector` is set to the default or set to any other connector (e.g. `nixl`, `lmcache`, etc.) and the user attempts to set `--kv-transfer-config`, the CLI will throw a `ValueError` as before.

#### Where should the reviewer start?

The only changes are in `components/src/dynamo/vllm/args.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes #4186 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connector configuration validation with clearer error messages for invalid options.
  * Enhanced detection of conflicting configuration settings between connectors and transfer configs.

* **Improvements**
  * Added support for "none" or "null" connector values to clear connector settings.
  * Refined configuration flow for better handling of transfer configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->