### PR TITLE
fix: cancellation test fix

### DIFF
--- a/examples/custom_backend/cancellation/client.py
+++ b/examples/custom_backend/cancellation/client.py
@@ -50,7 +50,7 @@ async def main():
             return
 
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "mem", True)
+    runtime = DistributedRuntime(loop, "etcd", False)
 
     # Connect to middle server or direct server based on argument
     if use_middle_server:

--- a/examples/custom_backend/cancellation/middle_server.py
+++ b/examples/custom_backend/cancellation/middle_server.py
@@ -50,7 +50,7 @@ class MiddleServer:
 async def main():
     """Start the middle server"""
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "mem", True)
+    runtime = DistributedRuntime(loop, "etcd", False)
 
     # Create middle server handler
     handler = MiddleServer(runtime)

--- a/examples/custom_backend/cancellation/server.py
+++ b/examples/custom_backend/cancellation/server.py
@@ -31,7 +31,7 @@ class DemoServer:
 async def main():
     """Start the demo server"""
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "mem", True)
+    runtime = DistributedRuntime(loop, "etcd", False)
 
     # Create server component
     component = runtime.namespace("demo").component("server")

--- a/lib/bindings/python/tests/conftest.py
+++ b/lib/bindings/python/tests/conftest.py
@@ -436,6 +436,6 @@ This is required because DistributedRuntime is a process-level singleton.
             )
 
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "mem", True)
+    runtime = DistributedRuntime(loop, "etcd", False)
     yield runtime
     runtime.shutdown()


### PR DESCRIPTION
#### Overview:
This PR Fixes test failures in natsless cherry-pick PR 

* lib/bindings/python/tests/conftest.py 
* examples/custom_backend/cancellation/*.py

Fixed test: https://github.com/ai-dynamo/dynamo/actions/runs/19357019425/job/55380169758?pr=4332#step:10:237
```
...
lib/bindings/python/tests/cancellation/test_cancellation.py .......      [ 56%]
lib/bindings/python/tests/cancellation/test_example.py ...               [ 57%]
lib/bindings/python/tests/conftest.py .                                  [ 57%]
...
========== 346 passed, 3 skipped, 311 deselected in 427.87s (0:07:07) ==========
```

## Details
`main` branch uses file based kv store for discovery layer
```
runtime = DistributedRuntime(loop, "file")
```

`release/0.7.0` uses  in-proc memory (not shared) across 2 client / server processes in examples and (forked) tests
```
# before
runtime = DistributedRuntime(loop, "mem", True)

# after 
runtime = DistributedRuntime(loop, "etcd", False)
```

in lib/bindings/python/tests/conftest.py and examples/custom_backend/cancellation/*.py


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
