### PR TITLE
feat: Use try-catch block for import to avoid error

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -10,7 +10,11 @@ from typing import Any, Dict, Optional
 from vllm.config import KVTransferConfig
 from vllm.distributed.kv_events import KVEventsConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.utils import FlexibleArgumentParser
+
+try:
+    from vllm.utils import FlexibleArgumentParser
+except ImportError:
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 from dynamo._core import get_reasoning_parser_names, get_tool_parser_names
 from dynamo.common.config_dump import add_config_dump_args, register_encoder


### PR DESCRIPTION
#### Overview
Add forward compatibility for vLLM 0.11.1 import path changes

#### Details:

In vLLM 0.11.1, `FlexibleArgumentParser` is moving from `vllm.utils` to `vllm.utils.argparse_utils`. This PR implements a try-except import pattern to maintain compatibility with both current vLLM versions and vLLM 0.11.1+.

**Changes:**- Updated import statement in `components/src/dynamo/vllm/args.py` to handle both import paths- Uses try-except pattern: attempts the current import path first, falls back to the new path if ImportError occurs

**Compatibility:**
- ✅ Works with current vLLM versions (`from vllm.utils import FlexibleArgumentParser`)
- ✅ Works with vLLM 0.11.1+ (`from vllm.utils.argparse_utils import FlexibleArgumentParser`)
- No code changes required when upgrading vLLM

#### Where should the reviewer start?

components/src/dynamo/vllm/args.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-1044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved import handling for better compatibility across different dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->