### PR TITLE
fix: use release build for ucx

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -248,20 +248,21 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
      git clone https://github.com/openucx/ucx.git && \
      cd ucx && 			     \
      git checkout $NIXL_UCX_REF &&	 \
-     ./autogen.sh && ./configure     \
-         --prefix=/usr/local/ucx     \
-         --enable-shared             \
-         --disable-static            \
-         --disable-doxygen-doc       \
-         --enable-optimizations      \
-         --enable-cma                \
-         --enable-devel-headers      \
-         --with-cuda=/usr/local/cuda \
-         --with-verbs                \
-         --with-dm                   \
-         --with-gdrcopy=/usr/local   \
-         --with-efa                  \
-         --enable-mt &&              \
+     ./autogen.sh &&      \
+     ./contrib/configure-release    \
+        --prefix=/usr/local/ucx     \
+        --enable-shared             \
+        --disable-static            \
+        --disable-doxygen-doc       \
+        --enable-optimizations      \
+        --enable-cma                \
+        --enable-devel-headers      \
+        --with-cuda=/usr/local/cuda \
+        --with-verbs                \
+        --with-dm                   \
+        --with-gdrcopy=/usr/local   \
+        --with-efa                  \
+        --enable-mt &&              \
      make -j &&                      \
      make -j install-strip &&        \
      /tmp/use-sccache.sh show-stats "UCX" && \


### PR DESCRIPTION
#### Overview:

Use configure-release for ucx build, as recommended in docs - https://github.com/openucx/ucx?tab=readme-ov-file#release-builds

It adds some extra flags like disable-debug/assertions.... in the configure command

```
/usr/local/ucx/bin/ucx_info -v
# Library version: 1.19.0
# Library path: /usr/local/ucx/lib/libucs.so.0
# API headers version: 1.19.0
# Git branch '', revision e463614
# Configured with: --disable-logging --disable-debug --disable-assertions --disable-params-check --prefix=/usr/local/ucx --enable-shared --disable-static --disable-doxygen-doc --disable-debug --enable-optimizations --enable-cma --enable-devel-headers --with-cuda=/usr/local/cuda --with-verbs --with-dm --with-gdrcopy=/usr/local --with-efa --enable-mt
```

closes: OPS-1746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration process to use an alternative release configuration script while maintaining equivalent feature flags and installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->