### PR TITLE
feat: `nvext` field to OpenAI APIs and add `worker_id` reporting

### DIFF
--- a/lib/async-openai/src/types/chat.rs
+++ b/lib/async-openai/src/types/chat.rs
@@ -1045,6 +1045,10 @@ pub struct CreateChatCompletionResponse {
     /// The object type, which is always `chat.completion`.
     pub object: String,
     pub usage: Option<CompletionUsage>,
+    
+    /// NVIDIA extension field for response metadata (worker IDs, etc.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<serde_json::Value>,
 }
 
 /// Parsed server side events stream until an \[DONE\] is received from server.
@@ -1136,6 +1140,10 @@ pub struct CreateChatCompletionStreamResponse {
     /// An optional field that will only be present when you set `stream_options: {"include_usage": true}` in your request.
     /// When present, it contains a null value except for the last chunk which contains the token usage statistics for the entire request.
     pub usage: Option<CompletionUsage>,
+    
+    /// NVIDIA extension field for response metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<serde_json::Value>,
 }
 
 #[cfg(test)]

--- a/lib/async-openai/src/types/completion.rs
+++ b/lib/async-openai/src/types/completion.rs
@@ -216,6 +216,10 @@ pub struct CreateCompletionResponse {
     /// The object type, which is always "text_completion"
     pub object: String,
     pub usage: Option<CompletionUsage>,
+    
+    /// NVIDIA extension field for response metadata (worker IDs, etc.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<serde_json::Value>,
 }
 
 /// Parsed server side events stream until an \[DONE\] is received from server.

--- a/lib/llm/src/audit/stream.rs
+++ b/lib/llm/src/audit/stream.rs
@@ -98,6 +98,7 @@ where
                     system_fingerprint: None,
                     choices: vec![],
                     service_tier: None,
+                    nvext: None,
                 }
             })
         }),
@@ -132,6 +133,7 @@ where
                     system_fingerprint: None,
                     choices: vec![],
                     service_tier: None,
+                    nvext: None,
                 };
                 let _ = tx.send(fallback.clone());
                 final_response_to_one_chunk_stream(fallback)
@@ -151,6 +153,7 @@ where
                 system_fingerprint: None,
                 choices: vec![],
                 service_tier: None,
+                nvext: None,
             }
         })
     });
@@ -226,6 +229,7 @@ pub fn final_response_to_one_chunk_stream(
         service_tier: resp.service_tier.clone(),
         choices,
         usage: resp.usage.clone(),
+        nvext: resp.nvext.clone(),
     };
 
     let annotated = Annotated {
@@ -275,6 +279,7 @@ mod tests {
             object: "chat.completion.chunk".to_string(),
             usage: None,
             service_tier: None,
+            nvext: None,
         };
 
         Annotated {
@@ -311,6 +316,7 @@ mod tests {
             object: "chat.completion.chunk".to_string(),
             usage: None,
             service_tier: None,
+            nvext: None,
         };
 
         Annotated {
@@ -430,6 +436,7 @@ mod tests {
                 object: "chat.completion.chunk".to_string(),
                 usage: None,
                 service_tier: None,
+                nvext: None,
             }),
             id: Some("correlation-123".to_string()),
             event: Some("test-event".to_string()),

--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -242,6 +242,7 @@ impl
                     finish_reason: data.finish_reason,
                     //mdcsum: mdcsum.clone(),
                     index: data.index,
+                    disaggregated_params: data.disaggregated_params,
                 })
             })
         });

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -587,9 +587,10 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         // Check if worker_id is requested in extra_fields
         let should_populate_worker_id = backend_input
             .extra_fields
-            .as_ref()
-            .map(|fields| fields.contains(&"worker_id".to_string()))
-            .unwrap_or(false);
+            .as_deref()
+            .unwrap_or(&[])
+            .iter()
+            .any(|s| s == "worker_id");
         
         // Get prefill worker ID if available (stored by PrefillRouter)
         // In aggregated mode, prefill_worker_id is None, so we use decode_worker_id for both

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -228,9 +228,10 @@ impl OpenAIPreprocessor {
         builder.annotations(request.annotations().unwrap_or_default());
         builder.mdc_sum(Some(self.mdcsum.clone()));
         builder.estimated_prefix_hit_num_blocks(None);
-        // Extract backend_instance_id from nvext if present
+        // Extract backend_instance_id and extra_fields from nvext if present
         if let Some(nvext) = request.nvext() {
             builder.backend_instance_id(nvext.backend_instance_id);
+            builder.extra_fields(nvext.extra_fields.clone());
         }
 
         Ok(builder)

--- a/lib/llm/src/protocols/common/llm_backend.rs
+++ b/lib/llm/src/protocols/common/llm_backend.rs
@@ -48,6 +48,10 @@ pub struct BackendOutput {
 
     // Index field for batch requests to match OpenAI format
     pub index: Option<u32>,
+    
+    /// Disaggregated execution parameters (for prefill/decode separation)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disaggregated_params: Option<serde_json::Value>,
 }
 
 /// The LLM engine and backnd with manage it's own state, specifically translating how a

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -83,6 +83,11 @@ pub struct PreprocessedRequest {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra_args: Option<serde_json::Value>,
+    
+    /// Extra fields requested to be included in the response's nvext
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_fields: Option<Vec<String>>,
 }
 
 impl PreprocessedRequest {

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -582,6 +582,7 @@ impl JailedStream {
                     usage: None,
                     service_tier: None,
                     system_fingerprint: None,
+                    nvext: None,
                 };
 
                 let final_metadata = (last_annotated_id, last_annotated_event, last_annotated_comment);

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -291,6 +291,7 @@ impl ResponseFactory {
             choices: vec![choice],
             system_fingerprint: self.system_fingerprint.clone(),
             usage,
+            nvext: None, // Will be populated by router layer if needed
         };
         NvCreateCompletionResponse { inner }
     }

--- a/lib/llm/src/protocols/openai/completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/completions/aggregator.rs
@@ -24,6 +24,7 @@ pub struct DeltaAggregator {
     system_fingerprint: Option<String>,
     choices: HashMap<u32, DeltaChoice>,
     error: Option<String>,
+    nvext: Option<serde_json::Value>,
 }
 
 struct DeltaChoice {
@@ -49,6 +50,7 @@ impl DeltaAggregator {
             system_fingerprint: None,
             choices: HashMap::new(),
             error: None,
+            nvext: None,
         }
     }
 
@@ -83,6 +85,10 @@ impl DeltaAggregator {
                     }
                     if let Some(system_fingerprint) = delta.inner.system_fingerprint {
                         aggregator.system_fingerprint = Some(system_fingerprint);
+                    }
+                    // Preserve nvext from first chunk that has it (typically contains worker_id)
+                    if aggregator.nvext.is_none() && delta.inner.nvext.is_some() {
+                        aggregator.nvext = delta.inner.nvext;
                     }
 
                     // handle the choices
@@ -163,6 +169,7 @@ impl DeltaAggregator {
             object: "text_completion".to_string(),
             system_fingerprint: aggregator.system_fingerprint,
             choices,
+            nvext: aggregator.nvext,
         };
 
         let response = NvCreateCompletionResponse { inner };
@@ -250,6 +257,7 @@ mod tests {
                 logprobs,
             }],
             object: "text_completion".to_string(),
+            nvext: None,
         };
 
         let response = NvCreateCompletionResponse { inner };
@@ -379,6 +387,7 @@ mod tests {
                 },
             ],
             object: "text_completion".to_string(),
+            nvext: None,
         };
 
         let response = NvCreateCompletionResponse { inner };


### PR DESCRIPTION
#### Overview:

This PR introduces an optional `extra_fields` for exposing NVIDIA-specific execution metadata through OpenAI-compatible responses. It adds `nvext` to chat/completion types, wires `disaggregated_params` through the KV router and backend, and exposes structured worker ID information (`prefill_worker_id`, `decode_worker_id`). Existing behavior is unchanged unless callers explicitly request extra fields, so it's backward-compatible and OpenAI API-compatible.

#### Details:

- **Added**:
  - `lib/async-openai/src/types/chat.rs`, `lib/async-openai/src/types/completion.rs`: optional `nvext: Option<serde_json::Value>` fields on chat and completion responses to carry NVIDIA-specific metadata (e.g., worker IDs).
  - `lib/llm/src/protocols/common/preprocessor.rs`: `extra_fields: Option<Vec<String>>` on `PreprocessedRequest` so callers can request extra metadata to be populated into `nvext` (e.g., `"worker_id"`).
  - `lib/llm/src/protocols/openai/nvext.rs`: `WorkerIdInfo` and `NvExtResponse` types for structured worker ID metadata in OpenAI-style responses.

- **Changed**:
  - `lib/llm/src/preprocessor.rs`: preprocessor now extracts both `backend_instance_id` and `extra_fields` from the request `nvext` and passes them into the internal builder so routing can honor requested extra metadata.
  - `lib/llm/src/protocols/common/llm_backend.rs`: extends `BackendOutput` with `disaggregated_params: Option<serde_json::Value>` to hold execution details such as worker IDs.
  - `lib/llm/src/kv_router/prefill_router.rs`: `call_prefill` now returns `(disaggregated_params, prefill_worker_id)` and stores `prefill_worker_id` in the decode context when available.
  - `lib/llm/src/kv_router.rs`: when `extra_fields` contains `"worker_id"`, injects a JSON `worker_id` object (`prefill_worker_id`, `decode_worker_id`) into the first chunk’s `disaggregated_params`, using `prefill_worker_id` from context or falling back to the decode worker.
  - `lib/llm/src/protocols/openai/chat_completions/delta.rs`, `.../aggregator.rs`, `.../jail.rs`, `lib/llm/src/audit/stream.rs`, `lib/llm/src/protocols/openai/completions.rs`: plumb `nvext` through delta generation, aggregation, jailed streams, audit paths, and completion factories, and in the NV-specific delta path extract `worker_id` from `disaggregated_params` to produce a typed `NvExtResponse` on outgoing chunks.

- **Why it matters**:
  - Enables OpenAI-compatible clients to receive structured NVIDIA extensions via `nvext`, including which prefill and decode workers handled a request, improving observability and debugging of multi-worker inference.
  - Keeps the additional metadata strictly opt-in via `extra_fields` so existing traffic is unaffected unless it explicitly requests `worker_id`, minimizing overhead and behavioral risk.
  - Establishes a general path (`disaggregated_params` → `nvext`) for future per-request execution metadata without changing the external OpenAI API surface.

- **Breaking changes / Migrations**:
  - None (all new fields are optional and default to `None`; existing callers do not need to change).

- **Docs**:
  - None.
#### Where should the reviewer start?

1. Begin with the core data-flow:
   - `lib/llm/src/preprocessor.rs` (handles `extra_fields` + nvext setup)
   - `lib/llm/src/kv_router/prefill_router.rs` and `kv_router.rs` (worker ID extraction + injection)
   - `lib/llm/src/protocols/common/llm_backend.rs` (new `disaggregated_params`)
2. Then check the OpenAI protocol surface:
   - `lib/async-openai/.../chat.rs` and `completion.rs` (new `nvext` fields)
   - `lib/llm/src/protocols/openai/chat_completions/...` (delta aggregation + nvext emission)
3. Validate final response construction in:
   - `lib/llm/src/audit/stream.rs`
   - `lib/llm/src/protocols/openai/completions.rs`

This order gives a clean top-to-bottom trace from request → routing → backend → streamed output.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- From NAT team's Dynamo requirements
