### PR TITLE
test: Deterministic ETCD client failover tests

### DIFF
--- a/tests/fault_tolerance/etcd_ha/test_sglang.py
+++ b/tests/fault_tolerance/etcd_ha/test_sglang.py
@@ -277,12 +277,8 @@ def test_etcd_ha_failover_sglang_disaggregated(
                         # Step 7: Cycle through each replica to terminate/verify/restart
                         for i in range(num_replicas):
                             # Terminate a replica
-                            logger.info(f"Iteration {i}: Terminating replica")
-                            terminated_idx = etcd_cluster.terminate_replica(i)
-                            if terminated_idx is None:
-                                pytest.fail(
-                                    f"Iteration {i}: Failed to terminate replica"
-                                )
+                            logger.info(f"Iteration {i}: Terminating replica etcd-{i}")
+                            etcd_cluster.terminate_replica(i)
 
                             # Send inference request to verify system still works
                             logger.info(
@@ -296,13 +292,8 @@ def test_etcd_ha_failover_sglang_disaggregated(
                             ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
                             # Restart the terminated replica
-                            logger.info(
-                                f"Iteration {i}: Restarting replica etcd-{terminated_idx}"
-                            )
-                            if not etcd_cluster.restart_replica(terminated_idx):
-                                pytest.fail(
-                                    f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
-                                )
+                            logger.info(f"Iteration {i}: Restarting replica etcd-{i}")
+                            etcd_cluster.restart_replica(i)
 
 
 @pytest.mark.sglang

--- a/tests/fault_tolerance/etcd_ha/test_sglang.py
+++ b/tests/fault_tolerance/etcd_ha/test_sglang.py
@@ -197,10 +197,8 @@ def test_etcd_ha_failover_sglang_aggregated(request, predownload_models):
                     # Step 6: Cycle through each replica to terminate/verify/restart
                     for i in range(num_replicas):
                         # Terminate a replica
-                        logger.info(f"Iteration {i}: Terminating replica")
-                        terminated_idx = etcd_cluster.terminate_replica(i)
-                        if terminated_idx is None:
-                            pytest.fail(f"Iteration {i}: Failed to terminate replica")
+                        logger.info(f"Iteration {i}: Terminating replica etcd-{i}")
+                        etcd_cluster.terminate_replica(i)
 
                         # Send inference request to verify system still works
                         logger.info(
@@ -214,13 +212,8 @@ def test_etcd_ha_failover_sglang_aggregated(request, predownload_models):
                         ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
                         # Restart the terminated replica
-                        logger.info(
-                            f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
-                        )
-                        if not etcd_cluster.restart_replica(terminated_idx):
-                            pytest.fail(
-                                f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
-                            )
+                        logger.info(f"Iteration {i}: Restarting replica etcd-{i}")
+                        etcd_cluster.restart_replica(i)
 
 
 @pytest.mark.sglang
@@ -304,7 +297,7 @@ def test_etcd_ha_failover_sglang_disaggregated(
 
                             # Restart the terminated replica
                             logger.info(
-                                f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
+                                f"Iteration {i}: Restarting replica etcd-{terminated_idx}"
                             )
                             if not etcd_cluster.restart_replica(terminated_idx):
                                 pytest.fail(

--- a/tests/fault_tolerance/etcd_ha/test_sglang.py
+++ b/tests/fault_tolerance/etcd_ha/test_sglang.py
@@ -148,7 +148,6 @@ class DynamoWorkerProcess(ManagedProcess):
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_ha_failover_sglang_aggregated(request, predownload_models):
     """
     Test ETCD High Availability with leader failover using SGLang.
@@ -209,7 +208,6 @@ def test_etcd_ha_failover_sglang_aggregated(request, predownload_models):
 @pytest.mark.gpu_2
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_ha_failover_sglang_disaggregated(
     request, predownload_models, set_ucx_tls_no_mm
 ):
@@ -278,7 +276,6 @@ def test_etcd_ha_failover_sglang_disaggregated(
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_non_ha_shutdown_sglang_aggregated(request, predownload_models):
     """
     Test that frontend and worker shut down when single ETCD node is terminated using SGLang.
@@ -335,7 +332,6 @@ def test_etcd_non_ha_shutdown_sglang_aggregated(request, predownload_models):
 @pytest.mark.gpu_2
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_non_ha_shutdown_sglang_disaggregated(
     request, predownload_models, set_ucx_tls_no_mm
 ):

--- a/tests/fault_tolerance/etcd_ha/test_sglang.py
+++ b/tests/fault_tolerance/etcd_ha/test_sglang.py
@@ -150,21 +150,27 @@ class DynamoWorkerProcess(ManagedProcess):
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
 def test_etcd_ha_failover_sglang_aggregated(request, predownload_models):
     """
-    Test ETCD High Availability with leader failover using SGLang.
+    Test ETCD High Availability with repeated node failures and recoveries using SGLang.
 
     This test:
     1. Starts a 3-node ETCD cluster
     2. Starts NATS, frontend, and an SGLang worker
-    3. Sends an inference request to verify the system works
-    4. Terminates the ETCD leader node
-    5. Sends another inference request to verify the system still works
+    3. Cycles through each of the 3 replicas:
+       - Terminate the replica by index
+       - Send inference request to verify system still works
+       - Restart the terminated node
+
+    This ensures testing of:
+    - ETCD leader termination
+    - Frontend/worker disconnection from their connected ETCD replica
     """
     # Step 1: Start NATS server
     with NatsServer(request):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
-        with EtcdCluster(request) as etcd_cluster:
+        num_replicas = 3
+        with EtcdCluster(request, num_replicas=num_replicas) as etcd_cluster:
             logger.info("3-node ETCD cluster started successfully")
 
             # Get the endpoints for all ETCD nodes
@@ -181,27 +187,40 @@ def test_etcd_ha_failover_sglang_aggregated(request, predownload_models):
                     # Small wait to ensure worker is fully ready
                     time.sleep(2)
 
-                    # Step 5: Send first inference request to verify system is working
-                    logger.info("Sending first inference request (before failover)")
-                    result1 = send_inference_request("What is 2+2? The answer is")
+                    # Step 5: Send initial inference request to verify system is working
+                    logger.info("Sending initial inference request")
+                    result = send_inference_request("What is 2+2? The answer is")
                     assert (
-                        "4" in result1.lower() or "four" in result1.lower()
-                    ), f"Expected '4' or 'four' in response, got: '{result1}'"
+                        "4" in result.lower() or "four" in result.lower()
+                    ), f"Expected '4' or 'four' in response, got: '{result}'"
 
-                    # Step 6: Identify and terminate the ETCD leader
-                    logger.info("Terminating ETCD leader to test failover")
-                    terminated_idx = etcd_cluster.terminate_leader()
-                    if terminated_idx is None:
-                        pytest.fail("Failed to identify and terminate ETCD leader")
+                    # Step 6: Cycle through each replica to terminate/verify/restart
+                    for i in range(num_replicas):
+                        # Terminate a replica
+                        logger.info(f"Iteration {i}: Terminating replica")
+                        terminated_idx = etcd_cluster.terminate_replica(i)
+                        if terminated_idx is None:
+                            pytest.fail(f"Iteration {i}: Failed to terminate replica")
 
-                    logger.info(f"Terminated ETCD node {terminated_idx}")
+                        # Send inference request to verify system still works
+                        logger.info(
+                            f"Iteration {i}: Sending inference request after termination"
+                        )
+                        result = send_inference_request(
+                            "The capital of France is", max_tokens=20
+                        )
+                        assert (
+                            "paris" in result.lower()
+                        ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
-                    # Step 7: Send second inference request to verify system still works
-                    logger.info("Sending second inference request (after failover)")
-                    result2 = send_inference_request("The capital of France is")
-                    assert (
-                        "paris" in result2.lower()
-                    ), f"Expected 'Paris' in response, got: '{result2}'"
+                        # Restart the terminated replica
+                        logger.info(
+                            f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
+                        )
+                        if not etcd_cluster.restart_replica(terminated_idx):
+                            pytest.fail(
+                                f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
+                            )
 
 
 @pytest.mark.sglang
@@ -212,14 +231,19 @@ def test_etcd_ha_failover_sglang_disaggregated(
     request, predownload_models, set_ucx_tls_no_mm
 ):
     """
-    Test ETCD High Availability with leader failover in disaggregated mode using SGLang.
+    Test ETCD High Availability with repeated node failures and recoveries in disaggregated mode using SGLang.
 
     This test:
     1. Starts a 3-node ETCD cluster
     2. Starts NATS, frontend, and both prefill and decode SGLang workers
-    3. Sends an inference request to verify the system works
-    4. Terminates the ETCD leader node
-    5. Sends another inference request to verify the system still works
+    3. Cycles through each of the 3 replicas:
+       - Terminate the replica by index
+       - Send inference request to verify system still works
+       - Restart the terminated node
+
+    This ensures testing of:
+    - ETCD leader termination
+    - Frontend/worker disconnection from their connected ETCD replica
 
     Note: This test requires 2 GPUs to run decode and prefill workers on separate GPUs.
     """
@@ -228,7 +252,8 @@ def test_etcd_ha_failover_sglang_disaggregated(
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
-        with EtcdCluster(request) as etcd_cluster:
+        num_replicas = 3
+        with EtcdCluster(request, num_replicas=num_replicas) as etcd_cluster:
             logger.info("3-node ETCD cluster started successfully")
 
             # Get the endpoints for all ETCD nodes
@@ -249,27 +274,42 @@ def test_etcd_ha_failover_sglang_disaggregated(
                         # Small wait to ensure workers are fully ready
                         time.sleep(2)
 
-                        # Step 6: Send first inference request to verify system is working
-                        logger.info("Sending first inference request (before failover)")
-                        result1 = send_inference_request("What is 2+2? The answer is")
+                        # Step 6: Send initial inference request to verify system is working
+                        logger.info("Sending initial inference request")
+                        result = send_inference_request("What is 2+2? The answer is")
                         assert (
-                            "4" in result1.lower() or "four" in result1.lower()
-                        ), f"Expected '4' or 'four' in response, got: '{result1}'"
+                            "4" in result.lower() or "four" in result.lower()
+                        ), f"Expected '4' or 'four' in response, got: '{result}'"
 
-                        # Step 7: Identify and terminate the ETCD leader
-                        logger.info("Terminating ETCD leader to test failover")
-                        terminated_idx = etcd_cluster.terminate_leader()
-                        if terminated_idx is None:
-                            pytest.fail("Failed to identify and terminate ETCD leader")
+                        # Step 7: Cycle through each replica to terminate/verify/restart
+                        for i in range(num_replicas):
+                            # Terminate a replica
+                            logger.info(f"Iteration {i}: Terminating replica")
+                            terminated_idx = etcd_cluster.terminate_replica(i)
+                            if terminated_idx is None:
+                                pytest.fail(
+                                    f"Iteration {i}: Failed to terminate replica"
+                                )
 
-                        logger.info(f"Terminated ETCD node {terminated_idx}")
+                            # Send inference request to verify system still works
+                            logger.info(
+                                f"Iteration {i}: Sending inference request after termination"
+                            )
+                            result = send_inference_request(
+                                "The capital of France is", max_tokens=20
+                            )
+                            assert (
+                                "paris" in result.lower()
+                            ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
-                        # Step 8: Send second inference request to verify system still works
-                        logger.info("Sending second inference request (after failover)")
-                        result2 = send_inference_request("The capital of France is")
-                        assert (
-                            "paris" in result2.lower()
-                        ), f"Expected 'Paris' in response, got: '{result2}'"
+                            # Restart the terminated replica
+                            logger.info(
+                                f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
+                            )
+                            if not etcd_cluster.restart_replica(terminated_idx):
+                                pytest.fail(
+                                    f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
+                                )
 
 
 @pytest.mark.sglang

--- a/tests/fault_tolerance/etcd_ha/test_trtllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_trtllm.py
@@ -134,7 +134,6 @@ class DynamoWorkerProcess(ManagedProcess):
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_ha_failover_trtllm_aggregated(request, predownload_models):
     """
     Test ETCD High Availability with leader failover for TRT-LLM in aggregated mode.
@@ -195,7 +194,6 @@ def test_etcd_ha_failover_trtllm_aggregated(request, predownload_models):
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_ha_failover_trtllm_disaggregated(
     request, predownload_models, set_ucx_tls_no_mm
 ):
@@ -263,7 +261,6 @@ def test_etcd_ha_failover_trtllm_disaggregated(
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_non_ha_shutdown_trtllm_aggregated(request, predownload_models):
     """
     Test that frontend and worker shut down when single ETCD node is terminated for TRT-LLM in aggregated mode.
@@ -323,7 +320,6 @@ def test_etcd_non_ha_shutdown_trtllm_aggregated(request, predownload_models):
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_non_ha_shutdown_trtllm_disaggregated(
     request, predownload_models, set_ucx_tls_no_mm
 ):

--- a/tests/fault_tolerance/etcd_ha/test_trtllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_trtllm.py
@@ -136,21 +136,27 @@ class DynamoWorkerProcess(ManagedProcess):
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
 def test_etcd_ha_failover_trtllm_aggregated(request, predownload_models):
     """
-    Test ETCD High Availability with leader failover for TRT-LLM in aggregated mode.
+    Test ETCD High Availability with repeated node failures and recoveries for TRT-LLM in aggregated mode.
 
     This test:
     1. Starts a 3-node ETCD cluster
     2. Starts NATS, frontend, and an aggregated TRT-LLM worker
-    3. Sends an inference request to verify the system works
-    4. Terminates the ETCD leader node
-    5. Sends another inference request to verify the system still works
+    3. Cycles through each of the 3 replicas:
+       - Terminate the replica by index
+       - Send inference request to verify system still works
+       - Restart the terminated node
+
+    This ensures testing of:
+    - ETCD leader termination
+    - Frontend/worker disconnection from their connected ETCD replica
     """
     # Step 1: Start NATS server
     with NatsServer(request):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
-        with EtcdCluster(request) as etcd_cluster:
+        num_replicas = 3
+        with EtcdCluster(request, num_replicas=num_replicas) as etcd_cluster:
             logger.info("3-node ETCD cluster started successfully")
 
             # Get the endpoints for all ETCD nodes
@@ -167,27 +173,40 @@ def test_etcd_ha_failover_trtllm_aggregated(request, predownload_models):
                 ):
                     logger.info("Aggregated TRT-LLM worker started successfully")
 
-                    # Step 5: Send first inference request to verify system is working
-                    logger.info("Sending first inference request (before failover)")
-                    result1 = send_inference_request("What is 2+2? The answer is")
+                    # Step 5: Send initial inference request to verify system is working
+                    logger.info("Sending initial inference request")
+                    result = send_inference_request("What is 2+2? The answer is")
                     assert (
-                        "4" in result1.lower() or "four" in result1.lower()
-                    ), f"Expected '4' or 'four' in response, got: '{result1}'"
+                        "4" in result.lower() or "four" in result.lower()
+                    ), f"Expected '4' or 'four' in response, got: '{result}'"
 
-                    # Step 6: Identify and terminate the ETCD leader
-                    logger.info("Terminating ETCD leader to test failover")
-                    terminated_idx = etcd_cluster.terminate_leader()
-                    if terminated_idx is None:
-                        pytest.fail("Failed to identify and terminate ETCD leader")
+                    # Step 6: Cycle through each replica to terminate/verify/restart
+                    for i in range(num_replicas):
+                        # Terminate a replica
+                        logger.info(f"Iteration {i}: Terminating replica")
+                        terminated_idx = etcd_cluster.terminate_replica(i)
+                        if terminated_idx is None:
+                            pytest.fail(f"Iteration {i}: Failed to terminate replica")
 
-                    logger.info(f"Terminated ETCD node {terminated_idx}")
+                        # Send inference request to verify system still works
+                        logger.info(
+                            f"Iteration {i}: Sending inference request after termination"
+                        )
+                        result = send_inference_request(
+                            "The capital of France is", max_tokens=20
+                        )
+                        assert (
+                            "paris" in result.lower()
+                        ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
-                    # Step 7: Send second inference request to verify system still works
-                    logger.info("Sending second inference request (after failover)")
-                    result2 = send_inference_request("The capital of France is")
-                    assert (
-                        "paris" in result2.lower()
-                    ), f"Expected 'Paris' in response, got: '{result2}'"
+                        # Restart the terminated replica
+                        logger.info(
+                            f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
+                        )
+                        if not etcd_cluster.restart_replica(terminated_idx):
+                            pytest.fail(
+                                f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
+                            )
 
 
 @pytest.mark.trtllm_marker
@@ -198,21 +217,27 @@ def test_etcd_ha_failover_trtllm_disaggregated(
     request, predownload_models, set_ucx_tls_no_mm
 ):
     """
-    Test ETCD High Availability with leader failover for TRT-LLM in disaggregated mode.
+    Test ETCD High Availability with repeated node failures and recoveries for TRT-LLM in disaggregated mode.
 
     This test:
     1. Starts a 3-node ETCD cluster
     2. Starts NATS, frontend, and both prefill and decode TRT-LLM workers
-    3. Sends an inference request to verify the system works
-    4. Terminates the ETCD leader node
-    5. Sends another inference request to verify the system still works
+    3. Cycles through each of the 3 replicas:
+       - Terminate the replica by index
+       - Send inference request to verify system still works
+       - Restart the terminated node
+
+    This ensures testing of:
+    - ETCD leader termination
+    - Frontend/worker disconnection from their connected ETCD replica
     """
     # Step 1: Start NATS server
     with NatsServer(request):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
-        with EtcdCluster(request) as etcd_cluster:
+        num_replicas = 3
+        with EtcdCluster(request, num_replicas=num_replicas) as etcd_cluster:
             logger.info("3-node ETCD cluster started successfully")
 
             # Get the endpoints for all ETCD nodes
@@ -234,27 +259,42 @@ def test_etcd_ha_failover_trtllm_disaggregated(
                         # TODO: Fix disagg health checks
                         time.sleep(2)
 
-                        # Step 6: Send first inference request to verify system is working
-                        logger.info("Sending first inference request (before failover)")
-                        result1 = send_inference_request("What is 2+2? The answer is")
+                        # Step 6: Send initial inference request to verify system is working
+                        logger.info("Sending initial inference request")
+                        result = send_inference_request("What is 2+2? The answer is")
                         assert (
-                            "4" in result1.lower() or "four" in result1.lower()
-                        ), f"Expected '4' or 'four' in response, got: '{result1}'"
+                            "4" in result.lower() or "four" in result.lower()
+                        ), f"Expected '4' or 'four' in response, got: '{result}'"
 
-                        # Step 7: Identify and terminate the ETCD leader
-                        logger.info("Terminating ETCD leader to test failover")
-                        terminated_idx = etcd_cluster.terminate_leader()
-                        if terminated_idx is None:
-                            pytest.fail("Failed to identify and terminate ETCD leader")
+                        # Step 7: Cycle through each replica to terminate/verify/restart
+                        for i in range(num_replicas):
+                            # Terminate a replica
+                            logger.info(f"Iteration {i}: Terminating replica")
+                            terminated_idx = etcd_cluster.terminate_replica(i)
+                            if terminated_idx is None:
+                                pytest.fail(
+                                    f"Iteration {i}: Failed to terminate replica"
+                                )
 
-                        logger.info(f"Terminated ETCD node {terminated_idx}")
+                            # Send inference request to verify system still works
+                            logger.info(
+                                f"Iteration {i}: Sending inference request after termination"
+                            )
+                            result = send_inference_request(
+                                "The capital of France is", max_tokens=20
+                            )
+                            assert (
+                                "paris" in result.lower()
+                            ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
-                        # Step 8: Send second inference request to verify system still works
-                        logger.info("Sending second inference request (after failover)")
-                        result2 = send_inference_request("The capital of France is")
-                        assert (
-                            "paris" in result2.lower()
-                        ), f"Expected 'Paris' in response, got: '{result2}'"
+                            # Restart the terminated replica
+                            logger.info(
+                                f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
+                            )
+                            if not etcd_cluster.restart_replica(terminated_idx):
+                                pytest.fail(
+                                    f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
+                                )
 
 
 @pytest.mark.trtllm_marker

--- a/tests/fault_tolerance/etcd_ha/test_trtllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_trtllm.py
@@ -183,10 +183,8 @@ def test_etcd_ha_failover_trtllm_aggregated(request, predownload_models):
                     # Step 6: Cycle through each replica to terminate/verify/restart
                     for i in range(num_replicas):
                         # Terminate a replica
-                        logger.info(f"Iteration {i}: Terminating replica")
-                        terminated_idx = etcd_cluster.terminate_replica(i)
-                        if terminated_idx is None:
-                            pytest.fail(f"Iteration {i}: Failed to terminate replica")
+                        logger.info(f"Iteration {i}: Terminating replica etcd-{i}")
+                        etcd_cluster.terminate_replica(i)
 
                         # Send inference request to verify system still works
                         logger.info(
@@ -200,13 +198,8 @@ def test_etcd_ha_failover_trtllm_aggregated(request, predownload_models):
                         ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
                         # Restart the terminated replica
-                        logger.info(
-                            f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
-                        )
-                        if not etcd_cluster.restart_replica(terminated_idx):
-                            pytest.fail(
-                                f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
-                            )
+                        logger.info(f"Iteration {i}: Restarting replica etcd-{i}")
+                        etcd_cluster.restart_replica(i)
 
 
 @pytest.mark.trtllm_marker
@@ -269,12 +262,8 @@ def test_etcd_ha_failover_trtllm_disaggregated(
                         # Step 7: Cycle through each replica to terminate/verify/restart
                         for i in range(num_replicas):
                             # Terminate a replica
-                            logger.info(f"Iteration {i}: Terminating replica")
-                            terminated_idx = etcd_cluster.terminate_replica(i)
-                            if terminated_idx is None:
-                                pytest.fail(
-                                    f"Iteration {i}: Failed to terminate replica"
-                                )
+                            logger.info(f"Iteration {i}: Terminating replica etcd-{i}")
+                            etcd_cluster.terminate_replica(i)
 
                             # Send inference request to verify system still works
                             logger.info(
@@ -288,13 +277,8 @@ def test_etcd_ha_failover_trtllm_disaggregated(
                             ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
                             # Restart the terminated replica
-                            logger.info(
-                                f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
-                            )
-                            if not etcd_cluster.restart_replica(terminated_idx):
-                                pytest.fail(
-                                    f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
-                                )
+                            logger.info(f"Iteration {i}: Restarting replica etcd-{i}")
+                            etcd_cluster.restart_replica(i)
 
 
 @pytest.mark.trtllm_marker

--- a/tests/fault_tolerance/etcd_ha/test_vllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_vllm.py
@@ -163,10 +163,8 @@ def test_etcd_ha_failover_vllm_aggregated(request, predownload_models):
                     # Step 6: Cycle through each replica to terminate/verify/restart
                     for i in range(num_replicas):
                         # Terminate a replica
-                        logger.info(f"Iteration {i}: Terminating replica")
-                        terminated_idx = etcd_cluster.terminate_replica(i)
-                        if terminated_idx is None:
-                            pytest.fail(f"Iteration {i}: Failed to terminate replica")
+                        logger.info(f"Iteration {i}: Terminating replica etcd-{i}")
+                        etcd_cluster.terminate_replica(i)
 
                         # Send inference request to verify system still works
                         logger.info(
@@ -180,13 +178,8 @@ def test_etcd_ha_failover_vllm_aggregated(request, predownload_models):
                         ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
                         # Restart the terminated replica
-                        logger.info(
-                            f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
-                        )
-                        if not etcd_cluster.restart_replica(terminated_idx):
-                            pytest.fail(
-                                f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
-                            )
+                        logger.info(f"Iteration {i}: Restarting replica etcd-{i}")
+                        etcd_cluster.restart_replica(i)
 
 
 @pytest.mark.vllm
@@ -246,12 +239,8 @@ def test_etcd_ha_failover_vllm_disaggregated(
                         # Step 7: Cycle through each replica to terminate/verify/restart
                         for i in range(num_replicas):
                             # Terminate a replica
-                            logger.info(f"Iteration {i}: Terminating replica")
-                            terminated_idx = etcd_cluster.terminate_replica(i)
-                            if terminated_idx is None:
-                                pytest.fail(
-                                    f"Iteration {i}: Failed to terminate replica"
-                                )
+                            logger.info(f"Iteration {i}: Terminating replica etcd-{i}")
+                            etcd_cluster.terminate_replica(i)
 
                             # Send inference request to verify system still works
                             logger.info(
@@ -265,13 +254,8 @@ def test_etcd_ha_failover_vllm_disaggregated(
                             ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
                             # Restart the terminated replica
-                            logger.info(
-                                f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
-                            )
-                            if not etcd_cluster.restart_replica(terminated_idx):
-                                pytest.fail(
-                                    f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
-                                )
+                            logger.info(f"Iteration {i}: Restarting replica etcd-{i}")
+                            etcd_cluster.restart_replica(i)
 
 
 @pytest.mark.vllm

--- a/tests/fault_tolerance/etcd_ha/test_vllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_vllm.py
@@ -116,7 +116,6 @@ class DynamoWorkerProcess(ManagedProcess):
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_ha_failover_vllm_aggregated(request, predownload_models):
     """
     Test ETCD High Availability with leader failover.
@@ -175,7 +174,6 @@ def test_etcd_ha_failover_vllm_aggregated(request, predownload_models):
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_ha_failover_vllm_disaggregated(
     request, predownload_models, set_ucx_tls_no_mm
 ):
@@ -240,7 +238,6 @@ def test_etcd_ha_failover_vllm_disaggregated(
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_non_ha_shutdown_vllm_aggregated(request, predownload_models):
     """
     Test that frontend and worker shut down when single ETCD node is terminated.
@@ -295,7 +292,6 @@ def test_etcd_non_ha_shutdown_vllm_aggregated(request, predownload_models):
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.skip(reason="Broken, temporarily disabled")
 def test_etcd_non_ha_shutdown_vllm_disaggregated(
     request, predownload_models, set_ucx_tls_no_mm
 ):

--- a/tests/fault_tolerance/etcd_ha/test_vllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_vllm.py
@@ -118,21 +118,27 @@ class DynamoWorkerProcess(ManagedProcess):
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
 def test_etcd_ha_failover_vllm_aggregated(request, predownload_models):
     """
-    Test ETCD High Availability with leader failover.
+    Test ETCD High Availability with repeated node failures and recoveries.
 
     This test:
     1. Starts a 3-node ETCD cluster
     2. Starts NATS, frontend, and a vLLM worker
-    3. Sends an inference request to verify the system works
-    4. Terminates the ETCD leader node
-    5. Sends another inference request to verify the system still works
+    3. Cycles through each of the 3 replicas:
+       - Terminate the replica by index
+       - Send inference request to verify system still works
+       - Restart the terminated node
+
+    This ensures testing of:
+    - ETCD leader termination
+    - Frontend/worker disconnection from their connected ETCD replica
     """
     # Step 1: Start NATS server
     with NatsServer(request):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
-        with EtcdCluster(request) as etcd_cluster:
+        num_replicas = 3
+        with EtcdCluster(request, num_replicas=num_replicas) as etcd_cluster:
             logger.info("3-node ETCD cluster started successfully")
 
             # Get the endpoints for all ETCD nodes
@@ -147,27 +153,40 @@ def test_etcd_ha_failover_vllm_aggregated(request, predownload_models):
                 with DynamoWorkerProcess(request, etcd_endpoints):
                     logger.info("Worker started successfully")
 
-                    # Step 5: Send first inference request to verify system is working
-                    logger.info("Sending first inference request (before failover)")
-                    result1 = send_inference_request("What is 2+2? The answer is")
+                    # Step 5: Send initial inference request to verify system is working
+                    logger.info("Sending initial inference request")
+                    result = send_inference_request("What is 2+2? The answer is")
                     assert (
-                        "4" in result1.lower() or "four" in result1.lower()
-                    ), f"Expected '4' or 'four' in response, got: '{result1}'"
+                        "4" in result.lower() or "four" in result.lower()
+                    ), f"Expected '4' or 'four' in response, got: '{result}'"
 
-                    # Step 6: Identify and terminate the ETCD leader
-                    logger.info("Terminating ETCD leader to test failover")
-                    terminated_idx = etcd_cluster.terminate_leader()
-                    if terminated_idx is None:
-                        pytest.fail("Failed to identify and terminate ETCD leader")
+                    # Step 6: Cycle through each replica to terminate/verify/restart
+                    for i in range(num_replicas):
+                        # Terminate a replica
+                        logger.info(f"Iteration {i}: Terminating replica")
+                        terminated_idx = etcd_cluster.terminate_replica(i)
+                        if terminated_idx is None:
+                            pytest.fail(f"Iteration {i}: Failed to terminate replica")
 
-                    logger.info(f"Terminated ETCD node {terminated_idx}")
+                        # Send inference request to verify system still works
+                        logger.info(
+                            f"Iteration {i}: Sending inference request after termination"
+                        )
+                        result = send_inference_request(
+                            "The capital of France is", max_tokens=20
+                        )
+                        assert (
+                            "paris" in result.lower()
+                        ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
-                    # Step 7: Send second inference request to verify system still works
-                    logger.info("Sending second inference request (after failover)")
-                    result2 = send_inference_request("The capital of France is")
-                    assert (
-                        "paris" in result2.lower()
-                    ), f"Expected 'Paris' in response, got: '{result2}'"
+                        # Restart the terminated replica
+                        logger.info(
+                            f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
+                        )
+                        if not etcd_cluster.restart_replica(terminated_idx):
+                            pytest.fail(
+                                f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
+                            )
 
 
 @pytest.mark.vllm
@@ -178,21 +197,27 @@ def test_etcd_ha_failover_vllm_disaggregated(
     request, predownload_models, set_ucx_tls_no_mm
 ):
     """
-    Test ETCD High Availability with leader failover in disaggregated mode.
+    Test ETCD High Availability with repeated node failures and recoveries in disaggregated mode.
 
     This test:
     1. Starts a 3-node ETCD cluster
     2. Starts NATS, frontend, and both prefill and decode vLLM workers
-    3. Sends an inference request to verify the system works
-    4. Terminates the ETCD leader node
-    5. Sends another inference request to verify the system still works
+    3. Cycles through each of the 3 replicas:
+       - Terminate the replica by index
+       - Send inference request to verify system still works
+       - Restart the terminated node
+
+    This ensures testing of:
+    - ETCD leader termination
+    - Frontend/worker disconnection from their connected ETCD replica
     """
     # Step 1: Start NATS server
     with NatsServer(request):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
-        with EtcdCluster(request) as etcd_cluster:
+        num_replicas = 3
+        with EtcdCluster(request, num_replicas=num_replicas) as etcd_cluster:
             logger.info("3-node ETCD cluster started successfully")
 
             # Get the endpoints for all ETCD nodes
@@ -211,27 +236,42 @@ def test_etcd_ha_failover_vllm_disaggregated(
                     with DynamoWorkerProcess(request, etcd_endpoints, is_prefill=False):
                         logger.info("Decode worker started successfully")
 
-                        # Step 6: Send first inference request to verify system is working
-                        logger.info("Sending first inference request (before failover)")
-                        result1 = send_inference_request("What is 2+2? The answer is")
+                        # Step 6: Send initial inference request to verify system is working
+                        logger.info("Sending initial inference request")
+                        result = send_inference_request("What is 2+2? The answer is")
                         assert (
-                            "4" in result1.lower() or "four" in result1.lower()
-                        ), f"Expected '4' or 'four' in response, got: '{result1}'"
+                            "4" in result.lower() or "four" in result.lower()
+                        ), f"Expected '4' or 'four' in response, got: '{result}'"
 
-                        # Step 7: Identify and terminate the ETCD leader
-                        logger.info("Terminating ETCD leader to test failover")
-                        terminated_idx = etcd_cluster.terminate_leader()
-                        if terminated_idx is None:
-                            pytest.fail("Failed to identify and terminate ETCD leader")
+                        # Step 7: Cycle through each replica to terminate/verify/restart
+                        for i in range(num_replicas):
+                            # Terminate a replica
+                            logger.info(f"Iteration {i}: Terminating replica")
+                            terminated_idx = etcd_cluster.terminate_replica(i)
+                            if terminated_idx is None:
+                                pytest.fail(
+                                    f"Iteration {i}: Failed to terminate replica"
+                                )
 
-                        logger.info(f"Terminated ETCD node {terminated_idx}")
+                            # Send inference request to verify system still works
+                            logger.info(
+                                f"Iteration {i}: Sending inference request after termination"
+                            )
+                            result = send_inference_request(
+                                "The capital of France is", max_tokens=20
+                            )
+                            assert (
+                                "paris" in result.lower()
+                            ), f"Iteration {i}: Expected 'Paris' in response, got: '{result}'"
 
-                        # Step 8: Send second inference request to verify system still works
-                        logger.info("Sending second inference request (after failover)")
-                        result2 = send_inference_request("The capital of France is")
-                        assert (
-                            "paris" in result2.lower()
-                        ), f"Expected 'Paris' in response, got: '{result2}'"
+                            # Restart the terminated replica
+                            logger.info(
+                                f"Iteration {i}: Restarting terminated replica etcd-{terminated_idx}"
+                            )
+                            if not etcd_cluster.restart_replica(terminated_idx):
+                                pytest.fail(
+                                    f"Iteration {i}: Failed to restart replica etcd-{terminated_idx}"
+                                )
 
 
 @pytest.mark.vllm

--- a/tests/fault_tolerance/etcd_ha/utils.py
+++ b/tests/fault_tolerance/etcd_ha/utils.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import os
 import shutil
+import subprocess
 import tempfile
 import time
 from typing import List, Optional
@@ -62,6 +64,7 @@ class EtcdReplicaServer(ManagedProcess):
         data_dir: str,
         log_dir: str,
         timeout: int = 30,
+        cluster_state: str = "new",
     ):
         self.name = name
         self.client_port = client_port
@@ -81,15 +84,15 @@ class EtcdReplicaServer(ManagedProcess):
             "--listen-client-urls",
             f"http://0.0.0.0:{client_port}",
             "--advertise-client-urls",
-            f"http://localhost:{client_port}",
+            f"http://127.0.0.1:{client_port}",
             "--listen-peer-urls",
             f"http://0.0.0.0:{peer_port}",
             "--initial-advertise-peer-urls",
-            f"http://localhost:{peer_port}",
+            f"http://127.0.0.1:{peer_port}",
             "--initial-cluster",
             initial_cluster,
             "--initial-cluster-state",
-            "new",
+            cluster_state,
             "--initial-cluster-token",
             "etcd-cluster",
         ]
@@ -108,7 +111,7 @@ class EtcdReplicaServer(ManagedProcess):
         """Get the status of this ETCD node"""
         try:
             response = requests.post(
-                f"http://localhost:{self.client_port}/v3/maintenance/status",
+                f"http://127.0.0.1:{self.client_port}/v3/maintenance/status",
                 json={},
                 timeout=2,
             )
@@ -118,16 +121,6 @@ class EtcdReplicaServer(ManagedProcess):
             logger.warning(f"Failed to get status for {self.name}: {e}")
         return {}
 
-    def is_leader(self) -> bool:
-        """Check if this node is the current leader"""
-        status = self.get_status()
-        # In etcd v3 API, we check if this member ID matches the leader ID
-        if status:
-            member_id = status.get("header", {}).get("member_id", "")
-            leader_id = status.get("leader", "")
-            return member_id == leader_id
-        return False
-
 
 class EtcdCluster:
     """Manager for an ETCD cluster with configurable number of replicas"""
@@ -136,13 +129,11 @@ class EtcdCluster:
         self,
         request,
         num_replicas: int = 3,
-        base_client_port: int = 2379,
-        base_peer_port: int = 12380,
+        base_port: int = 2379,
     ):
         self.request = request
         self.num_replicas = num_replicas
-        self.base_client_port = base_client_port
-        self.base_peer_port = base_peer_port
+        self.base_port = base_port
         self.replicas: List[Optional[EtcdReplicaServer]] = []
         self.data_dirs: List[str] = []
         self.log_base_dir = f"{request.node.name}_etcd_cluster"
@@ -156,78 +147,156 @@ class EtcdCluster:
 
         os.makedirs(self.log_base_dir, exist_ok=True)
 
+    def _get_initial_cluster(self) -> str:
+        """Build the initial cluster configuration string"""
+        initial_cluster_parts = []
+        for i in range(self.num_replicas):
+            name = f"etcd-{i}"
+            peer_port = self.base_port + (2 * i) + 1
+            initial_cluster_parts.append(f"{name}=http://127.0.0.1:{peer_port}")
+        return ",".join(initial_cluster_parts)
+
+    def _start_replica(self, idx: int, cluster_state: str = "new") -> EtcdReplicaServer:
+        """Start a single ETCD replica"""
+        name = f"etcd-{idx}"
+        # e.g. base_port = 2379 -> client_port = 2379, 2381, 2383
+        # e.g. base_port = 2379 -> peer_port = 2380, 2382, 2384
+        client_port = self.base_port + (2 * idx)
+        peer_port = self.base_port + (2 * idx) + 1
+
+        # Create data dir for the node
+        data_dir = tempfile.mkdtemp(prefix=f"etcd_{idx}_")
+        if idx < len(self.data_dirs):
+            self.data_dirs[idx] = data_dir
+        else:
+            self.data_dirs.append(data_dir)
+
+        log_dir = os.path.join(self.log_base_dir, name)
+        os.makedirs(log_dir, exist_ok=True)
+
+        logger.info(
+            f"Starting {name} on client port {client_port}, peer port {peer_port}"
+        )
+
+        replica = EtcdReplicaServer(
+            request=self.request,
+            name=name,
+            client_port=client_port,
+            peer_port=peer_port,
+            initial_cluster=self._get_initial_cluster(),
+            data_dir=data_dir,
+            log_dir=log_dir,
+            cluster_state=cluster_state,
+        )
+
+        replica.__enter__()
+        return replica
+
+    def _replace_member(self, idx: int) -> bool:
+        """Remove old member and add new member to the cluster using etcdctl"""
+        # Find a healthy replica to perform member operations
+        healthy_replica = None
+        for i, r in enumerate(self.replicas):
+            if r and i != idx:
+                healthy_replica = r
+                break
+
+        if not healthy_replica:
+            logger.error("No healthy replica found to perform member operations")
+            return False
+
+        name = f"etcd-{idx}"
+        peer_port = self.base_port + (2 * idx) + 1
+        peer_url = f"http://127.0.0.1:{peer_port}"
+
+        # Set ETCDCTL_ENDPOINTS for etcdctl commands
+        etcdctl_env = os.environ.copy()
+        etcdctl_env[
+            "ETCDCTL_ENDPOINTS"
+        ] = f"http://127.0.0.1:{healthy_replica.client_port}"
+        etcdctl_env["ETCDCTL_API"] = "3"
+
+        # First, get member list to find the old member's ID
+        logger.info(f"Getting member list to find {name}")
+        try:
+            result = subprocess.run(
+                ["etcdctl", "member", "list", "--write-out=json"],
+                env=etcdctl_env,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                members = json.loads(result.stdout).get("members", [])
+                old_member_id = None
+                for member in members:
+                    if member.get("name") == name:
+                        old_member_id = member.get("ID")
+                        break
+
+                if old_member_id:
+                    # Convert member ID to hex format (etcdctl expects hex)
+                    hex_member_id = format(int(old_member_id), "x")
+                    logger.info(
+                        f"Removing member with ID {old_member_id} (hex: {hex_member_id})"
+                    )
+                    remove_result = subprocess.run(
+                        ["etcdctl", "member", "remove", hex_member_id],
+                        env=etcdctl_env,
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
+                    if remove_result.returncode != 0:
+                        logger.error(
+                            f"Failed to remove old member: {remove_result.stderr}"
+                        )
+                        return False
+                    logger.info(f"Successfully removed old member {name}")
+        except Exception as e:
+            logger.error(f"Error during member removal: {e}")
+            # Continue anyway - member might already be removed
+
+        # Add the new member to the cluster
+        logger.info(f"Adding new member {name} to cluster with peer URL {peer_url}")
+        try:
+            add_result = subprocess.run(
+                ["etcdctl", "member", "add", name, f"--peer-urls={peer_url}"],
+                env=etcdctl_env,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if add_result.returncode != 0:
+                logger.error(f"Failed to add new member: {add_result.stderr}")
+                return False
+            logger.info(f"Successfully added new member {name}")
+        except Exception as e:
+            logger.error(f"Error adding new member: {e}")
+            return False
+
+        return True
+
     def start(self):
         """Start ETCD cluster with configured number of replicas"""
         logger.info(f"Starting {self.num_replicas}-node ETCD cluster")
 
-        # Build initial cluster configuration
-        initial_cluster_parts = []
-        for i in range(self.num_replicas):
-            name = f"etcd-{i}"
-            peer_port = self.base_peer_port + i
-            initial_cluster_parts.append(f"{name}=http://localhost:{peer_port}")
-
-        initial_cluster = ",".join(initial_cluster_parts)
-
         # Start each replica
         for i in range(self.num_replicas):
-            name = f"etcd-{i}"
-            client_port = self.base_client_port + i
-            peer_port = self.base_peer_port + i
-            data_dir = tempfile.mkdtemp(prefix=f"etcd_{i}_")
-            log_dir = os.path.join(self.log_base_dir, name)
-
-            self.data_dirs.append(data_dir)
-            os.makedirs(log_dir, exist_ok=True)
-
-            logger.info(
-                f"Starting {name} on client port {client_port}, peer port {peer_port}"
-            )
-
-            replica = EtcdReplicaServer(
-                request=self.request,
-                name=name,
-                client_port=client_port,
-                peer_port=peer_port,
-                initial_cluster=initial_cluster,
-                data_dir=data_dir,
-                log_dir=log_dir,
-            )
-
-            replica.__enter__()
+            replica = self._start_replica(i, cluster_state="new")
             self.replicas.append(replica)
 
         logger.info(f"All {self.num_replicas} ETCD replicas started successfully")
 
-        # Wait for cluster to stabilize and elect a leader
-        self._wait_for_healthy_cluster(timeout=30)
-
-        leader_idx = self.find_leader()
-        if leader_idx is not None:
-            logger.info(f"Initial leader elected: etcd-{leader_idx}")
-        else:
-            logger.warning("No leader elected yet")
-
-    def _wait_for_healthy_cluster(self, timeout: int = 30):
-        """Wait for all replicas to be healthy and responsive.
-
-        Args:
-            timeout: Maximum time to wait in seconds
-
-        Raises:
-            RuntimeError: If cluster doesn't become healthy within timeout
-        """
+        # Wait for cluster to stabilize
         logger.info("Waiting for all replicas to be healthy...")
+
         start_time = time.time()
-
-        while time.time() - start_time < timeout:
-            time.sleep(1)
-
-            # Check if all replicas are responding
+        while time.time() - start_time < 30:  # 30s timeout
             all_healthy = True
-            for i, replica in enumerate(self.replicas):
-                if replica:
-                    status = replica.get_status()
+            for i, r in enumerate(self.replicas):
+                if r:
+                    status = r.get_status()
                     if not status:
                         logger.debug(f"etcd-{i} not yet responsive")
                         all_healthy = False
@@ -237,40 +306,71 @@ class EtcdCluster:
                 logger.info("All replicas are healthy")
                 return
 
-        raise RuntimeError(f"ETCD cluster failed to become healthy within {timeout}s")
+            time.sleep(1)
 
-    def find_leader(self) -> Optional[int]:
-        """Find which replica is currently the leader"""
-        for i, replica in enumerate(self.replicas):
-            if replica and replica.is_leader():
-                return i
-        return None
+        raise RuntimeError("ETCD cluster failed to become healthy within 30s")
 
-    def terminate_leader(self) -> Optional[int]:
-        """Terminate the current leader and return its index"""
-        leader_idx = self.find_leader()
+    def terminate_replica(self, idx: int) -> Optional[int]:
+        """Terminate a specific replica by index.
 
-        if leader_idx is None:
-            logger.warning("No leader found to terminate")
+        Args:
+            idx: Index of replica to terminate.
+
+        Returns:
+            Index of terminated replica, or None if termination failed
+        """
+        # Use modulo to wrap around
+        actual_idx = idx % self.num_replicas
+        logger.info(f"Terminating replica: etcd-{actual_idx}")
+
+        replica = self.replicas[actual_idx]
+        if not replica:
+            logger.error(f"Replica etcd-{actual_idx} is already terminated")
             return None
 
-        logger.info(f"Terminating current leader: etcd-{leader_idx}")
-        replica = self.replicas[leader_idx]
+        replica.__exit__(None, None, None)
+        self.replicas[actual_idx] = None
+        logger.info(f"Replica etcd-{actual_idx} has been terminated")
+        return actual_idx
 
-        if replica:
-            replica.__exit__(None, None, None)
-            self.replicas[leader_idx] = None
-            logger.info(f"Leader etcd-{leader_idx} has been terminated")
+    def restart_replica(self, idx: int) -> bool:
+        """Restart a terminated replica"""
+        if idx < 0 or idx >= self.num_replicas:
+            logger.error(f"Invalid replica index: {idx}")
+            return False
 
-        return leader_idx
+        if self.replicas[idx] is not None:
+            logger.error(f"Replica etcd-{idx} is already running")
+            return False
+
+        # Remove old member and add new member
+        if not self._replace_member(idx):
+            logger.error(f"Failed to replace member etcd-{idx}")
+            return False
+
+        # Start the replica with existing cluster state
+        replica = self._start_replica(idx, cluster_state="existing")
+        self.replicas[idx] = replica
+
+        # Wait for the replica to become healthy
+        name = f"etcd-{idx}"
+        logger.info(f"Waiting for {name} to become healthy...")
+        for _ in range(30):
+            time.sleep(1)
+            if replica.get_status():
+                logger.info(f"{name} is now healthy")
+                return True
+
+        logger.error(f"{name} failed to become healthy")
+        return False
 
     def get_client_endpoints(self) -> List[str]:
         """Get list of active client endpoints"""
         endpoints = []
         for i, replica in enumerate(self.replicas):
             if replica:  # Only include active replicas
-                client_port = self.base_client_port + i
-                endpoints.append(f"http://localhost:{client_port}")
+                client_port = self.base_port + (2 * i)
+                endpoints.append(f"http://127.0.0.1:{client_port}")
         return endpoints
 
     def stop(self):


### PR DESCRIPTION
#### Overview:

Revised the ETCD replica shutdown failover tests such that the ETCD replica connected to by the frontend/worker is always shutdown during testing.

#### Details:

(1) Revised `test_etcd_ha_failover_*` testing steps:
1. Starts a 3-node ETCD cluster.
2. Starts NATS, frontend and worker(s).
3. For each ETCD replica, (a) terminate the replica, (b) send a request verifying health, and (c) restart the replica.

This steps ensures testing of ETCD leader termination and frontend/worker disconnect from connected ETCD replica.

(2) Fixed a race condition determining when the next ETCD lease keep-alive renewal should be sent:
* Previously, the next renewal message is sent at 1/2 TTL from the last renewal response received.
* The renewal may not went through at 1/2 TTL, e.g. stream disconnected.
* If the new stream is established ms before the 1/2 TTL, the next renewal will be another 1/2 TTL later, passing the expiration time and failing the keep-alive.

Solution: Tracking the lease expiration time instead of a TTL value, and the next renewal is always due at 1/2 between the current time and the expiration time, e.g.
* If the next expiration time is at time 10, the renewal is at time 5.
* If the renewal at time 5 failed, the next renewal will be at time 7.5... never passing the expiration time.

(3) Test reliability
* vLLM test ran 22 times and all passed ✅
* TRT-LLM test ran 14 times and all passed ✅
* SGLang test ran 10 times and all passed ✅

#### Where should the reviewer start?

Start from all the `test_etcd_ha_failover_*` tests, and then look into the updated `utils.py`. Finally, the updated lease renewal logic.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Resolves https://github.com/ai-dynamo/dynamo/pull/4198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ETCD lease keep-alive mechanism with stream-based handling, automatic reconnection, and enhanced cancellation support for greater reliability.

* **Tests**
  * Enhanced ETCD High Availability failover testing to cycle through and validate all replicas instead of single-leader scenarios, providing more comprehensive resilience verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->