### PR TITLE
fix: no build in post-create.sh and document Docker 29.0.x issue

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,23 +1,25 @@
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 -->
 
 # NVIDIA Dynamo Development Environment
 
 > Warning: Dev Containers (aka `devcontainers`) is an evolving feature and we are not testing in CI. Please submit any problem/feedback using the issues on GitHub.
+
+## Known Issues
+
+### Docker Version Compatibility
+
+**Docker 29.x has compatibility issues with Dev Containers (by Anysphere):**
+- It is known that Docker Engine version **29.0.1** (released November 14, 2025) may cause Dev Containers to hang all the time, rendering it unusable
+- The Dev Containers extension (v1.0.26) and devcontainer CLI (v0.75.0) were not tested against Docker 29.x
+- Symptoms: Container builds successfully but connection hangs, requiring a manual reload to connect
+- This may be fixed in a later version of the Anysphere Dev Containers extension and/or Docker Engine patch
+
+**Recommended Docker Version:**
+- Use Docker Engine **28.5.2** or earlier for stable Dev Container operation
+- Docker 27.x and 28.x series are confirmed working with current Dev Containers tooling
 
 ## Framework-Specific Devcontainers
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -65,19 +65,13 @@ mkdir -p $CARGO_TARGET_DIR
 uv pip uninstall --yes ai-dynamo ai-dynamo-runtime 2>/dev/null || true
 
 # Build project, with `dev` profile it will be saved at $CARGO_TARGET_DIR/debug
-cargo build --locked --profile dev --features dynamo-llm/block-manager
-
-# install the python bindings
-
-# Install maturin if not already installed.
-# TODO: Uncomment for SGLANG. Right now, the CI team is making a refactor
-#       to the Dockerfile, so this is a temporary fix.
-# if ! command -v maturin &> /dev/null; then
-#     echo "Installing maturin..."
-#     retry uv pip install maturin[patchelf]
-# else
-#     echo "maturin is already installed"
-# fi
+if ! cargo build --locked --profile dev --features dynamo-llm/block-manager 2>/dev/null; then
+    echo "⚠️  WARNING: Cargo.lock needs updating. Running 'cargo update' to sync dependencies..."
+    echo "    This is expected when switching branches or after dependency changes."
+    cargo update
+    echo "✅ Cargo.lock updated. Proceeding with build..."
+    cargo build --locked --profile dev --features dynamo-llm/block-manager
+fi
 
 # install ai-dynamo-runtime
 (cd $WORKSPACE_DIR/lib/bindings/python && retry maturin develop)

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -48,7 +48,9 @@ show_and_run() {
     # Run commands with debug output shown
     set -x
     "$@"
+    local exit_code=$?
     { set +x; } 2>/dev/null
+    return $exit_code
 }
 
 set -x
@@ -62,22 +64,7 @@ pre-commit run --all-files || true # don't fail the build if pre-commit hooks fa
 export CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-$WORKSPACE_DIR/target}
 mkdir -p $CARGO_TARGET_DIR
 
-uv pip uninstall --yes ai-dynamo ai-dynamo-runtime 2>/dev/null || true
-
-# Build project, with `dev` profile it will be saved at $CARGO_TARGET_DIR/debug
-if ! cargo build --locked --profile dev --features dynamo-llm/block-manager 2>/dev/null; then
-    echo "⚠️  WARNING: Cargo.lock needs updating. Running 'cargo update' to sync dependencies..."
-    echo "    This is expected when switching branches or after dependency changes."
-    cargo update
-    echo "✅ Cargo.lock updated. Proceeding with build..."
-    cargo build --locked --profile dev --features dynamo-llm/block-manager
-fi
-
-# install ai-dynamo-runtime
-(cd $WORKSPACE_DIR/lib/bindings/python && retry maturin develop)
-
-# install ai-dynamo
-cd $WORKSPACE_DIR && retry env DYNAMO_BIN_PATH=$CARGO_TARGET_DIR/debug uv pip install -e .
+# Note: Build steps moved to after sanity check - see instructions at the end
 
 { set +x; } 2>/dev/null
 
@@ -108,16 +95,26 @@ else
     echo "⚠️ SSH agent forwarding not configured - SSH_AUTH_SOCK is not set"
 fi
 
-show_and_run $WORKSPACE_DIR/deploy/sanity_check.py
+echo -e "\n🔍 Running sanity check..."
+if show_and_run $WORKSPACE_DIR/deploy/sanity_check.py; then
+    SANITY_STATUS="✅ Sanity check passed"
+else
+    SANITY_STATUS="⚠️ Sanity check failed - review output above"
+fi
 
 cat <<EOF
 
-✅ SUCCESS: Built cargo project, installed Python bindings, configured pre-commit hooks
+========================================
+$SANITY_STATUS
+✅ Pre-commit hooks configured
 
-Example commands:
-  cargo build --locked --profile dev              # Build Rust project in $CARGO_TARGET_DIR
-  cd lib/bindings/python && maturin develop --uv  # Update Python bindings (if you changed them)
-  cargo fmt && cargo clippy                       # Format and lint code before committing
-  cargo doc --no-deps                             # Generate documentation
-  uv pip install -e .                             # Install various Python packages Dynamo depends on
+Now build the project:
+  cargo build --locked --profile dev --features dynamo-llm/block-manager
+  cd lib/bindings/python && maturin develop --uv
+  DYNAMO_BIN_PATH=$CARGO_TARGET_DIR/debug uv pip install -e .
+
+Optional: cd lib/bindings/kvbm && maturin develop --uv  # For KVBM support
+
+If cargo build fails with a Cargo.lock error, try to update it with 'cargo update'
+========================================
 EOF


### PR DESCRIPTION
#### Overview:

Improves dev container setup reliability by auto-recovering when Cargo.lock is out of sync, and documents Docker 29.x compatibility issues.

#### Details:

- Add fallback logic in post-create.sh to run `cargo update` if `--locked` build fails
- Prevents container setup failures when switching branches with different dependencies
- Document known Docker Engine 29.0.1 hanging issues in devcontainer README
- Recommend Docker Engine 28.5.2 or earlier for stable operation

#### Where should the reviewer start?

- .devcontainer/post-create.sh lines 68-74 (new fallback logic)
- .devcontainer/README.md (new Known Issues section)

#### Related Issues:

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated devcontainer setup guide with Docker version compatibility information and known issues
  * Added framework-specific devcontainer configuration options
  * Enhanced troubleshooting and configuration guidance

* **Chores**
  * Improved build process reliability with automatic retry mechanism for failed builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->