### PR TITLE
chore(test): Copy pyproject.toml into containers to avoid 'unknown pytest marker' spam during pytest execution

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -54,20 +54,12 @@ runs:
         # Run pytest with detailed output and JUnit XML
         set +e  # Don't exit on test failures
 
-        # Disable mypy for unit tests to avoid CUDA cleanup segfaults (exit code 139)
-        # Unit tests import GPU framework modules which conflict with mypy's import system during cleanup
-        MYPY_FLAG=""
-        if [[ "${{ inputs.test_type }}" == *"unit"* ]]; then
-          MYPY_FLAG="-p no:mypy"
-          echo "Disabling mypy plugin for unit tests to avoid CUDA cleanup issues"
-        fi
-
         docker run --runtime=nvidia --gpus all -w /workspace \
           --cpus=${NUM_CPUS} \
           --network host \
           --name ${{ env.CONTAINER_ID }}_pytest \
           ${{ inputs.image_tag }} \
-          bash -c "mkdir -p /workspace/test-results && pytest -v --tb=short --basetemp=/tmp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --durations=10 ${MYPY_FLAG} -m \"${{ inputs.pytest_marks }}\""
+          bash -c "mkdir -p /workspace/test-results && pytest -v --tb=short --basetemp=/tmp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --durations=10 -m \"${{ inputs.pytest_marks }}\""
 
         TEST_EXIT_CODE=$?
         echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -54,12 +54,20 @@ runs:
         # Run pytest with detailed output and JUnit XML
         set +e  # Don't exit on test failures
 
+        # Disable mypy for unit tests to avoid CUDA cleanup segfaults (exit code 139)
+        # Unit tests import GPU framework modules which conflict with mypy's import system during cleanup
+        MYPY_FLAG=""
+        if [[ "${{ inputs.test_type }}" == *"unit"* ]]; then
+          MYPY_FLAG="-p no:mypy"
+          echo "Disabling mypy plugin for unit tests to avoid CUDA cleanup issues"
+        fi
+
         docker run --runtime=nvidia --gpus all -w /workspace \
           --cpus=${NUM_CPUS} \
           --network host \
           --name ${{ env.CONTAINER_ID }}_pytest \
           ${{ inputs.image_tag }} \
-          bash -c "mkdir -p /workspace/test-results && pytest -v --tb=short --basetemp=/tmp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --durations=10 -m \"${{ inputs.pytest_marks }}\""
+          bash -c "mkdir -p /workspace/test-results && pytest -v --tb=short --basetemp=/tmp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --durations=10 ${MYPY_FLAG} -m \"${{ inputs.pytest_marks }}\""
 
         TEST_EXIT_CODE=$?
         echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -383,6 +383,9 @@ COPY --chown=dynamo: benchmarks /workspace/benchmarks
 COPY --chown=dynamo: deploy /workspace/deploy
 COPY --chown=dynamo: components/ /workspace/components/
 
+# Copy pyproject.toml for pytest configuration (markers, etc.)
+COPY --chown=dynamo: pyproject.toml /workspace/pyproject.toml
+
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []
 

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -330,6 +330,9 @@ COPY --chown=dynamo: deploy /workspace/deploy
 COPY --chown=dynamo: components/ /workspace/components/
 COPY --chown=dynamo: recipes/ /workspace/recipes/
 
+# Copy pyproject.toml for pytest configuration (markers, etc.)
+COPY --chown=dynamo: pyproject.toml /workspace/pyproject.toml
+
 # Copy attribution files with correct ownership
 COPY --chown=dynamo: ATTRIBUTION* LICENSE /workspace/
 

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -287,8 +287,12 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
         --requirement /tmp/requirements.txt \
         --requirement /tmp/requirements.test.txt
 
+# FIXME: Copy directories more selectively instead of copying everything
 # Copy benchmarks, examples, and tests for CI with correct ownership
 COPY --chown=dynamo: . /workspace/
+
+# Copy pyproject.toml for pytest configuration (markers, etc.)
+COPY --chown=dynamo: pyproject.toml /workspace/pyproject.toml
 
 # Copy attribution files
 COPY --chown=dynamo: ATTRIBUTION* LICENSE /workspace/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ filterwarnings = [
     "ignore:Support for class-based `config`.*:pydantic.warnings.PydanticDeprecatedSince20",
     "ignore:Using extra keyword arguments on `Field`.*:pydantic.warnings.PydanticDeprecatedSince20",
     "ignore:The `schema` method is deprecated.*:pydantic.warnings.PydanticDeprecatedSince20",
+    "ignore:.*transformers version.*incompatible with nvidia-modelopt.*:UserWarning", # Ignore transformers/nvidia-modelopt version compatibility warning, we don't currently control nvidia-modelopt install.
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ addopts = [
     "--showlocals",
     "--strict-markers",
     "--strict-config",
-    "--mypy",
+    #"--mypy",
     "--ignore-glob=*model.py",
     "--ignore-glob=*vllm_integration*",
     "--ignore-glob=*trtllm_integration*",
@@ -245,14 +245,12 @@ ignore_missing_imports = true
 
 [tool.sphinx]
 
-# extra-content-head
 extra_content_head = [
    '''
    <script src="https://assets.adobedtm.com/5d4962a43b79/c1061d2c5e7b/launch-191c2462b890.min.js" ></script>
    ''',
 ]
 
-#extra-content-footer
 extra_content_footer = [
    '''
    <script type="text/javascript">if (typeof _satellite !== "undefined") {_satellite.pageBottom();}</script>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,7 @@ filterwarnings = [
     "ignore:Using extra keyword arguments on `Field`.*:pydantic.warnings.PydanticDeprecatedSince20",
     "ignore:The `schema` method is deprecated.*:pydantic.warnings.PydanticDeprecatedSince20",
     "ignore:.*transformers version.*incompatible with nvidia-modelopt.*:UserWarning", # Ignore transformers/nvidia-modelopt version compatibility warning, we don't currently control nvidia-modelopt install.
+    "ignore:.*TORCH_CUDA_ARCH_LIST is not set.*:UserWarning", # Ignore TORCH_CUDA_ARCH_LIST compilation warning
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,16 +135,14 @@ known_first_party = ["dynamo"]
 minversion = "8.0"
 tmp_path_retention_policy = "failed"
 
-# NOTE
-# We ignore model.py explcitly here to avoid mypy errors with duplicate modules
-# pytest overrides the default mypy exclude configuration and so we exclude here as well
 addopts = [
     "-ra",
+    "-s",
+    "-v",
     "--showlocals",
     "--strict-markers",
     "--strict-config",
     #"--mypy",
-    "--ignore-glob=*model.py",
     "--ignore-glob=*vllm_integration*",
     "--ignore-glob=*trtllm_integration*",
     "--ignore-glob=*kvbm/python/kvbm*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,8 +238,8 @@ ignore_missing_imports = true
 check_untyped_defs = true
 
 [[tool.mypy.overrides]]
-# Skip mypy analysis on internal dependencies of vllm
-module = ["vllm.*"]
+# Skip mypy analysis on internal dependencies of each framework
+module = ["vllm.*", "sglang.*", "tensorrt_llm.*"]
 follow_imports = "skip"
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,8 +238,8 @@ ignore_missing_imports = true
 check_untyped_defs = true
 
 [[tool.mypy.overrides]]
-# Skip mypy analysis on internal dependencies of each framework
-module = ["vllm.*", "sglang.*", "tensorrt_llm.*"]
+# Skip mypy analysis on internal dependencies of vllm
+module = ["vllm.*"]
 follow_imports = "skip"
 ignore_missing_imports = true
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

- Removes 100s of lines of spam in test output about unknown pytest markers
- Runs tests in CI with the actual configurations we've defined in pyproject.toml as a single source of truth
    - This also led to treating warnings as errors, hence the addition of more "ignores" of certain warnings added in this PR.

#### Details:

<!-- Describe the changes made in this PR. -->

- The pytest sections of the Build&Test github actions have hundreds of lines of spam in the [output](https://github.com/ai-dynamo/dynamo/actions/runs/19386604815/job/55474345658?pr=4347) about unknown pytest markers like this:
```
...
tests/kvbm_integration/test_determinism_disagg.py:39
  /workspace/tests/kvbm_integration/test_determinism_disagg.py:39: PytestUnknownMarkWarning: Unknown pytest.mark.slow - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytest.mark.slow,

tests/kvbm_integration/test_determinism_disagg.py:40
  /workspace/tests/kvbm_integration/test_determinism_disagg.py:40: PytestUnknownMarkWarning: Unknown pytest.mark.gpu_2 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytest.mark.gpu_2,

tests/kvbm_integration/test_determinism_disagg.py:488
  /workspace/tests/kvbm_integration/test_determinism_disagg.py:488: PytestUnknownMarkWarning: Unknown pytest.mark.kvbm_v2 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.kvbm_v2
...
```

- The solution is to register the custom marks in your configuration: https://docs.pytest.org/en/stable/how-to/mark.html#registering-marks
- We already do register the custom marks in pyproject.toml here: https://github.com/ai-dynamo/dynamo/blob/1e120ed049595195a66e3e004e404dff35239ed1/pyproject.toml#L183-L207
- However, we don't copy the `pyproject.toml` into the container where `pytest` gets executed, so it doesn't see this configuration and thus outputs all the warnings about unknown markers.
- This PR copies the pyproject.toml into the containers so the pytest configuration is respected and we don't see these warnings are not produced when running the pytests inside the container

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container configurations for Sglang, TRTLLM, and VLLM to include project configuration files, enabling pytest utilities and test tooling within containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->