### PR TITLE
fix: add kv events config in agg_router sglang example

### DIFF
--- a/examples/backends/sglang/deploy/agg_router.yaml
+++ b/examples/backends/sglang/deploy/agg_router.yaml
@@ -44,3 +44,5 @@ spec:
             - "1"
             - --trust-remote-code
             - --skip-tokenizer-init
+            - --kv-events-config
+            - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'


### PR DESCRIPTION
#### Overview:

The example deploying with the router for SGLang lack the argument mentioned in the [launch example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/sglang/launch/agg_router.sh).

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Resolves: https://github.com/ai-dynamo/dynamo/issues/4390


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled KV events publishing capability in deployment configurations for enhanced event streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->