### PR TITLE
fix: Install jq in trtllm runtime container

### DIFF
--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -206,6 +206,8 @@ RUN apt-get update && \
         # Python runtime - CRITICAL for virtual environment to work
         python${PYTHON_VERSION}-dev \
         python3-pip \
+        # jq for polling various endpoints and health checks
+        jq \
         # CUDA/ML libraries
         libcudnn9-cuda-12 \
         # Network and communication libraries


### PR DESCRIPTION
#### Overview:

Resolves [5667306](https://nvbugs/5667306)

#### Details:

- Install jq in TRT-LLM runtime container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added jq utility to container system dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->