### PR TITLE
fix(sglang): fix IPv6 support for ZMQ endpoint

### DIFF
--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -10,7 +10,7 @@ import sglang as sgl
 import zmq
 import zmq.asyncio
 from prometheus_client import CollectorRegistry, multiprocess
-from sglang.srt.utils import get_local_ip_auto, get_zmq_socket
+from sglang.srt.utils import get_local_ip_auto, get_zmq_socket, maybe_wrap_ipv6_address
 
 from dynamo.common.utils.prometheus import register_engine_metrics_callback
 from dynamo.llm import (
@@ -24,6 +24,30 @@ from dynamo.llm import (
 )
 from dynamo.runtime import Component, Endpoint
 from dynamo.sglang.args import Config
+
+
+def format_zmq_endpoint(endpoint_template: str, ip_address: str) -> str:
+    """Format ZMQ endpoint by replacing wildcard with IP address.
+
+    Properly handles IPv6 addresses by wrapping them in square brackets.
+    Uses SGLang's maybe_wrap_ipv6_address for consistent formatting.
+
+    Args:
+        endpoint_template: ZMQ endpoint template with wildcard (e.g., "tcp://*:5557")
+        ip_address: IP address to use (can be IPv4 or IPv6)
+
+    Returns:
+        Formatted ZMQ endpoint string
+
+    Example:
+        >>> format_zmq_endpoint("tcp://*:5557", "192.168.1.1")
+        'tcp://192.168.1.1:5557'
+        >>> format_zmq_endpoint("tcp://*:5557", "2a02:6b8:c46:2b4:0:74c1:75b0:0")
+        'tcp://[2a02:6b8:c46:2b4:0:74c1:75b0:0]:5557'
+    """
+    # Use SGLang's utility to wrap IPv6 addresses in brackets
+    formatted_ip = maybe_wrap_ipv6_address(ip_address)
+    return endpoint_template.replace("*", formatted_ip)
 
 
 class DynamoSglangPublisher:
@@ -121,7 +145,7 @@ class DynamoSglangPublisher:
         if self.server_args.kv_events_config:
             kv_events = json.loads(self.server_args.kv_events_config)
             ep = kv_events.get("endpoint")
-            zmq_ep = ep.replace("*", get_local_ip_auto()) if ep else None
+            zmq_ep = format_zmq_endpoint(ep, get_local_ip_auto()) if ep else None
 
             zmq_config = ZmqKvEventPublisherConfig(
                 worker_id=self.generate_endpoint.connection_id(),


### PR DESCRIPTION
#### Overview:

This pull request addresses an issue where the ZMQ endpoint formatting did not properly handle IPv6 addresses. Specifically, it introduces a utility function to wrap IPv6 addresses in square brackets and ensures that wildcard-based endpoint templates get replaced correctly for both IPv4 and IPv6. This fix ensures that the Dynamo SGLang publisher can correctly bind or connect using IPv6 endpoints.

#### Details:

- Added a new function `format_zmq_endpoint(endpoint_template: str, ip_address: str) → str` in `components/src/dynamo/sglang/publisher.py`. The function replaces wildcard `*` in endpoint templates (e.g., `"tcp://*:5557"`) with the given IP address, and uses maybe_wrap_ipv6_address to wrap IPv6 addresses in square brackets (e.g., `"[2a02:...]"`). 

- Modified import list to include `maybe_wrap_ipv6_address` from `sglang.srt.utils` alongside `get_local_ip_auto` and `get_zmq_socket`. 

- Changed the code path in `init_kv_event_publish(self)` method: instead of doing `ep.replace("*", get_local_ip_auto())`, it now uses `format_zmq_endpoint(ep, get_local_ip_auto())` when `ep` is non-null. 

- Added documentation (docstring) to `format_zmq_endpoint`, explaining its purpose, handling of IPv6, and usage examples.

#### Where should the reviewer start?

`components/src/dynamo/sglang/publisher.py`: inspect the newly added format_zmq_endpoint function, its docstring, and how it’s used in place of the previous wildcard replace logic.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved ZMQ endpoint handling with better support for IPv6 addresses and automatic IP address substitution for network publishing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->