### PR TITLE
fix: TENSORRTLLM_PIP_WHEEL_DIR has reasonable default set when building and installing TRTLLM from source

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -750,7 +750,7 @@ if [[ $FRAMEWORK == "TRTLLM" ]]; then
         BUILD_CONTEXT_ARG+=" --build-context trtllm_wheel=${TENSORRTLLM_PIP_WHEEL_DIR}"
         PRINT_TRTLLM_WHEEL_FILE=$(find $TENSORRTLLM_PIP_WHEEL_DIR -name "*.whl" | head -n 1)
     elif [[ "$TRTLLM_INTENTION" == "build" ]]; then
-        TENSORRTLLM_PIP_WHEEL_DIR=${TENSORRTLLM_PIP_WHEEL_DIR:=DEFAULT_TENSORRTLLM_PIP_WHEEL_DIR}
+        TENSORRTLLM_PIP_WHEEL_DIR=${TENSORRTLLM_PIP_WHEEL_DIR:=$DEFAULT_TENSORRTLLM_PIP_WHEEL_DIR}
         echo "TRTLLM pip wheel output directory is: ${TENSORRTLLM_PIP_WHEEL_DIR}"
         if [ "$DRY_RUN" != "true" ]; then
             GIT_URL_ARG=""

--- a/container/build.sh
+++ b/container/build.sh
@@ -84,7 +84,7 @@ TRTLLM_BASE_IMAGE_TAG=25.06-py3
 # By default, we will use option 1. If you want to use option 2, you can set
 # TENSORRTLLM_PIP_WHEEL to the TensorRT-LLM wheel on artifactory.
 #
-# DEFAULT_TENSORRTLLM_PIP_WHEEL_DIR="/tmp/trtllm_wheel/"
+DEFAULT_TENSORRTLLM_PIP_WHEEL_DIR="/tmp/trtllm_wheel/"
 
 # TensorRT-LLM commit to use for building the trtllm wheel if not provided.
 # Important Note: This commit is not used in our CI pipeline. See the CI
@@ -750,6 +750,8 @@ if [[ $FRAMEWORK == "TRTLLM" ]]; then
         BUILD_CONTEXT_ARG+=" --build-context trtllm_wheel=${TENSORRTLLM_PIP_WHEEL_DIR}"
         PRINT_TRTLLM_WHEEL_FILE=$(find $TENSORRTLLM_PIP_WHEEL_DIR -name "*.whl" | head -n 1)
     elif [[ "$TRTLLM_INTENTION" == "build" ]]; then
+        TENSORRTLLM_PIP_WHEEL_DIR=${TENSORRTLLM_PIP_WHEEL_DIR:=DEFAULT_TENSORRTLLM_PIP_WHEEL_DIR}
+        echo "TRTLLM pip wheel output directory is: ${TENSORRTLLM_PIP_WHEEL_DIR}"
         if [ "$DRY_RUN" != "true" ]; then
             GIT_URL_ARG=""
             if [ -n "${TRTLLM_GIT_URL}" ]; then

--- a/tests/ci/test_build_sh.py
+++ b/tests/ci/test_build_sh.py
@@ -283,6 +283,7 @@ class TestBuildShTRTLLMBuild:
         assert "Intent to Download TRTLLM: false" in stdout
         assert "Intent to Install TRTLLM: false" in stdout
         assert "Intent to Build TRTLLM: true" in stdout
+        assert "TRTLLM pip wheel output directory is: /tmp/trtllm_wheel/" in stdout
 
     def test_build_with_git_url_and_wheel_dir(self, build_script_path, temp_wheel_dir):
         """Test build with --tensorrtllm-git-url and --tensorrtllm-pip-wheel-dir"""


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This fixes a bug in `build.sh` where, when building TRTLLM from source for installation in the container, the `TENSORRTLLM_PIP_WHEEL_DIR` was not set to a default when omitted as a flag on the command line. This caused a build failure after the trtllm wheel is built when a null directory was trying to be constructed. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes DIS-1053
