### PR TITLE
fix: change labels to annotations in reference dgd

### DIFF
--- a/deploy/discovery/dgd.yaml
+++ b/deploy/discovery/dgd.yaml
@@ -6,7 +6,7 @@ apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: dynamo
-  labels:
+  annotations:
     nvidia.com/dynamo-discovery-backend: kubernetes
 spec:
   envs:


### PR DESCRIPTION
#### Overview:

Kube based discovery is turned on via an annotation, not a label


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment configuration to reflect metadata field modifications. No observable changes to user-facing functionality or system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->