### PR TITLE
fix: Fix cublas and cublasLt symlinks in vLLM runtime container

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -217,6 +217,8 @@ COPY --from=framework /usr/local/cuda/bin/fatbinary /usr/local/cuda/bin/fatbinar
 COPY --from=framework /usr/local/cuda/include/ /usr/local/cuda/include/
 COPY --from=framework /usr/local/cuda/nvvm /usr/local/cuda/nvvm
 COPY --from=framework /usr/local/cuda/lib64/libcudart.so* /usr/local/cuda/lib64/
+COPY --from=framework /usr/local/cuda/lib64/libcublas.so* /usr/local/cuda/lib64/
+COPY --from=framework /usr/local/cuda/lib64/libcublasLt.so* /usr/local/cuda/lib64/
 
 ### COPY NATS & ETCD ###
 # Copy nats and etcd from dev image


### PR DESCRIPTION
When JITing kernels, flashinfer needs `libcublas.so` and `libcublasLt.so`. The vLLM runtime container only has `libcublas.so.12` and `libcublasLt.so.12`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CUDA runtime library support in containerized deployments to improve compatibility and runtime performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->