### PR TITLE
fix: respect router env vars in frontend configuration

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -78,7 +78,10 @@ def parse_args():
         "-i", "--interactive", action="store_true", help="Interactive text chat"
     )
     parser.add_argument(
-        "--kv-cache-block-size", type=int, help="KV cache block size (u32)."
+        "--kv-cache-block-size",
+        type=int,
+        default=os.environ.get("DYN_KV_CACHE_BLOCK_SIZE"),
+        help="KV cache block size (u32). Can be set via DYN_KV_CACHE_BLOCK_SIZE env var.",
     )
     parser.add_argument(
         "--http-host",
@@ -114,20 +117,20 @@ def parse_args():
     parser.add_argument(
         "--kv-overlap-score-weight",
         type=float,
-        default=1.0,
+        default=float(os.environ.get("DYN_KV_OVERLAP_SCORE_WEIGHT", "1.0")),
         help="KV Router: Weight for overlap score in worker selection. Higher values prioritize KV cache reuse.",
     )
     parser.add_argument(
         "--router-temperature",
         type=float,
-        default=0.0,
+        default=float(os.environ.get("DYN_ROUTER_TEMPERATURE", "0.0")),
         help="KV Router: Temperature for worker sampling via softmax. Higher values promote more randomness, and 0 fallbacks to deterministic.",
     )
     parser.add_argument(
         "--no-kv-events",
         action="store_false",
         dest="use_kv_events",
-        default=True,
+        default=os.environ.get("DYN_KV_EVENTS", "true").lower() != "false",
         help="KV Router: Disable KV events. When set, uses ApproxKvRouter for predicting block creation/deletion based only on incoming requests at a timer. By default, KV events are enabled.",
     )
     parser.add_argument(


### PR DESCRIPTION
#### Overview:

wired up `DYN_ROUTER_TEMPERATURE, DYN_KV_OVERLAP_SCORE_WEIGHT, DYN_KV_CACHE_BLOCK_SIZE, DYN_KV_EVENTS` as defaults for the corresponding CLI flags so router behavior can be controlled via env vars as documented here: https://github.com/ai-dynamo/dynamo/blob/main/docs/router/kv_cache_routing.md

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Resolves: https://github.com/ai-dynamo/dynamo/issues/4430


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI configuration now reads from environment variables (`DYN_KV_CACHE_BLOCK_SIZE`, `DYN_KV_OVERLAP_SCORE_WEIGHT`, `DYN_ROUTER_TEMPERATURE`, `DYN_KV_EVENTS`) with fallback defaults for improved deployment flexibility and environment-driven customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->