### PR TITLE
fix: use --num-dataset-entries instead of --conversation-num

### DIFF
--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/perf.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/perf.yaml
@@ -74,7 +74,7 @@ spec:
                 --concurrency $concurrency \
                 --request-count $((10*concurrency)) \
                 --warmup-request-count $concurrency \
-                --conversation-num 12800 \
+                --num-dataset-entries 12800 \
                 --random-seed 100 \
                 --workers-max 252 \
                 -H 'Authorization: Bearer NOT USED' \

--- a/recipes/gpt-oss-120b/trtllm/agg/perf.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/perf.yaml
@@ -74,7 +74,7 @@ spec:
                 --concurrency $concurrency \
                 --request-count $((10*concurrency)) \
                 --warmup-request-count $concurrency \
-                --conversation-num 12800 \
+                --num-dataset-entries 12800 \
                 --random-seed 100 \
                 --workers-max 252 \
                 -H 'Authorization: Bearer NOT USED' \

--- a/recipes/llama-3-70b/vllm/agg/perf.yaml
+++ b/recipes/llama-3-70b/vllm/agg/perf.yaml
@@ -66,7 +66,7 @@ spec:
                 --concurrency $concurrency \
                 --request-count $((10*concurrency)) \
                 --warmup-request-count $concurrency \
-                --conversation-num 12800 \
+                --num-dataset-entries 12800 \
                 --random-seed 100 \
                 --workers-max $max_threads \
                 -H 'Authorization: Bearer NOT USED' \

--- a/recipes/llama-3-70b/vllm/disagg-multi-node/perf.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-multi-node/perf.yaml
@@ -66,7 +66,7 @@ spec:
                 --concurrency $concurrency \
                 --request-count $((10*concurrency)) \
                 --warmup-request-count $concurrency \
-                --conversation-num 12800 \
+                --num-dataset-entries 12800 \
                 --random-seed 100 \
                 --workers-max $max_threads \
                 -H 'Authorization: Bearer NOT USED' \

--- a/recipes/llama-3-70b/vllm/disagg-single-node/perf.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-single-node/perf.yaml
@@ -66,7 +66,7 @@ spec:
                 --concurrency $concurrency \
                 --request-count $((10*concurrency)) \
                 --warmup-request-count $concurrency \
-                --conversation-num 12800 \
+                --num-dataset-entries 12800 \
                 --random-seed 100 \
                 --workers-max $max_threads \
                 -H 'Authorization: Bearer NOT USED' \

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/perf.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/perf.yaml
@@ -74,7 +74,7 @@ spec:
                 --concurrency $concurrency \
                 --request-count $((10*concurrency)) \
                 --warmup-request-count $concurrency \
-                --conversation-num 12800 \
+                --num-dataset-entries 12800 \
                 --random-seed 100 \
                 --workers-max 252 \
                 -H 'Authorization: Bearer NOT USED' \

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/perf.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/perf.yaml
@@ -74,7 +74,7 @@ spec:
                 --concurrency $concurrency \
                 --request-count $((10*concurrency)) \
                 --warmup-request-count $concurrency \
-                --conversation-num 12800 \
+                --num-dataset-entries 12800 \
                 --random-seed 100 \
                 --workers-max 252 \
                 -H 'Authorization: Bearer NOT USED' \

--- a/recipes/qwen3-32b-fp8/trtllm/agg/perf.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/agg/perf.yaml
@@ -74,7 +74,7 @@ spec:
                 --concurrency $concurrency \
                 --request-count $((10*concurrency)) \
                 --warmup-request-count $concurrency \
-                --conversation-num 12800 \
+                --num-dataset-entries 12800 \
                 --random-seed 100 \
                 --workers-max 252 \
                 -H 'Authorization: Bearer NOT USED' \

--- a/recipes/qwen3-32b-fp8/trtllm/disagg/perf.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/disagg/perf.yaml
@@ -74,7 +74,7 @@ spec:
                 --concurrency $concurrency \
                 --request-count $((10*concurrency)) \
                 --warmup-request-count $concurrency \
-                --conversation-num 12800 \
+                --num-dataset-entries 12800 \
                 --random-seed 100 \
                 --workers-max 252 \
                 -H 'Authorization: Bearer NOT USED' \


### PR DESCRIPTION
--conversation-num was an invalid alias for --num-dataset-entries, which has since been removed in AIPerf v0.3.0. --num-dataset-entries is the correct alias for ALL versions of AIPerf, so this is both backwards compatible and forwards compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized performance testing configuration parameters across multiple recipe templates. Dataset entry parameters have been updated to use consistent naming conventions throughout all performance test configurations. All numeric test values and execution behaviors remain identical, improving configuration consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->