### PR TITLE
feat: Request Cancellation when transitioning from Prefill to Decode at KV Prefill Router

### DIFF
--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -243,9 +243,9 @@ def test_request_cancellation_sglang_decode_cancel(
     request, runtime_services, predownload_models
 ):
     """
-    End-to-end test for request cancellation during remote decode phase.
+    End-to-end test for request cancellation during decode phase.
 
-    This test verifies that when a request is cancelled by the client during the remote decode phase,
+    This test verifies that when a request is cancelled by the client during the decode phase,
     the system properly handles the cancellation and cleans up resources
     on both the prefill and decode workers in a disaggregated setup.
 
@@ -267,9 +267,9 @@ def test_request_cancellation_sglang_decode_cancel(
                 # TODO: Why wait after worker ready fixes frontend 404 / 500 flakiness?
                 time.sleep(2)
 
-                # Step 4: Test request cancellation during remote decode phase
+                # Step 4: Test request cancellation during decode phase
                 logger.info(
-                    "Testing chat completion stream request cancellation during remote decode phase..."
+                    "Testing chat completion stream request cancellation during decode phase..."
                 )
 
                 # Send streaming request (non-blocking)

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -274,13 +274,13 @@ def test_request_cancellation_vllm_decode_cancel(
 @pytest.mark.gpu_1
 @pytest.mark.e2e
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-def test_request_cancellation_vllm_remote_prefill_cancel(
+def test_request_cancellation_vllm_prefill_cancel(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):
     """
-    End-to-end test for request cancellation during remote prefill phase.
+    End-to-end test for request cancellation during prefill phase.
 
-    This test verifies that when a request is cancelled by the client during the remote prefill phase,
+    This test verifies that when a request is cancelled by the client during the prefill phase,
     the system properly handles the cancellation and cleans up resources
     on both the decode and prefill workers in a disaggregated setup.
     """
@@ -334,6 +334,23 @@ def test_request_cancellation_vllm_remote_prefill_cancel(
                     pattern="issued control message Kill to sender",
                 )
 
+                # Verify decode worker never received the request
+                pattern = "Request ID: "
+                try:
+                    _, decode_log_offset = poll_for_pattern(
+                        process=decode_worker,
+                        pattern=pattern,
+                        max_wait_ms=10,
+                        match_type="contains",
+                    )
+                    pytest.fail(
+                        "Decode worker received request cancelled during prefill phase"
+                    )
+                except AssertionError as e:
+                    assert str(e).startswith(
+                        f"Failed to find '{pattern}' pattern after 2 iterations "
+                    ), f"Unexpected error: {e}"
+
                 logger.info(
-                    "Completion request cancellation during remote prefill phase detected successfully"
+                    "Completion request cancellation during prefill phase detected successfully"
                 )

--- a/tests/fault_tolerance/cancellation/utils.py
+++ b/tests/fault_tolerance/cancellation/utils.py
@@ -388,6 +388,6 @@ def poll_for_pattern(
         time.sleep(poll_interval_ms / 1000.0)
         iteration += 1
 
-    pytest.fail(
+    raise AssertionError(
         f"Failed to find '{pattern}' pattern after {max_iterations} iterations ({max_wait_ms}ms)"
     )


### PR DESCRIPTION
#### Overview:

Cancel the request when transitioning from Prefill to Decode at KV Prefill Router, if the request is cancelled. Avoids the decode worker from being called if the request is cancelled during Prefill.

#### Details:

* Request Cancellation when transitioning from Prefill to Decode at KV Prefill Router, if the request is cancelled.
* Test if the Decode worker does not receive the request, after the request is cancelled at the Prefill worker.

#### Where should the reviewer start?

Start with the KV Prefill Router change, and then look into the updated test cases.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved request cancellation handling with enhanced context management and early termination checks.
  * Added robust error handling for prefill failures with graceful fallback options.
  * Enhanced verification that decode operations properly respect cancellation signals during prefill phase.

* **Tests**
  * Refined cancellation test coverage and assertions for clearer behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->