### PR TITLE
feat: parameterize request plane tests

### DIFF
--- a/lib/bindings/python/tests/conftest.py
+++ b/lib/bindings/python/tests/conftest.py
@@ -402,7 +402,7 @@ def temp_file_store():
         yield tmpdir
 
 
-@pytest.fixture(scope="function", autouse=False)
+@pytest.fixture(scope="function", autouse=False, params=["tcp", "nats"])
 async def runtime(request):
     """
     Create a DistributedRuntime for testing.
@@ -434,7 +434,8 @@ This is required because DistributedRuntime is a process-level singleton.
 """
             )
 
+    request_plane = request.param
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "file", "nats")
+    runtime = DistributedRuntime(loop, "file", request_plane)
     yield runtime
     runtime.shutdown()


### PR DESCRIPTION
#### Overview:

parameterize pytest to run unit tests with both request planes: nats and tcp

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with parameterized runtime fixture to validate multiple transport configurations, improving test coverage and reliability across different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->