### PR TITLE
feat: unregister discovery instance

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -335,10 +335,7 @@ fn register_llm<'p>(
 /// Unregister a model from the endpoint.
 #[pyfunction]
 #[pyo3(signature = (endpoint))]
-fn unregister_llm<'p>(
-    py: Python<'p>,
-    endpoint: Endpoint,
-) -> PyResult<Bound<'p, PyAny>> {
+fn unregister_llm<'p>(py: Python<'p>, endpoint: Endpoint) -> PyResult<Bound<'p, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         LocalModel::detach_model_from_endpoint(&endpoint.inner)
             .await

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -141,6 +141,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lora_name_to_id, m)?)?;
     m.add_function(wrap_pyfunction!(log_message, m)?)?;
     m.add_function(wrap_pyfunction!(register_llm, m)?)?;
+    m.add_function(wrap_pyfunction!(unregister_llm, m)?)?;
     m.add_function(wrap_pyfunction!(fetch_llm, m)?)?;
     m.add_function(wrap_pyfunction!(llm::entrypoint::make_engine, m)?)?;
     m.add_function(wrap_pyfunction!(llm::entrypoint::run_input, m)?)?;
@@ -327,6 +328,21 @@ fn register_llm<'p>(
             .await
             .map_err(to_pyerr)?;
 
+        Ok(())
+    })
+}
+
+/// Unregister a model from the endpoint.
+#[pyfunction]
+#[pyo3(signature = (endpoint))]
+fn unregister_llm<'p>(
+    py: Python<'p>,
+    endpoint: Endpoint,
+) -> PyResult<Bound<'p, PyAny>> {
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        LocalModel::detach_model_from_endpoint(&endpoint.inner)
+            .await
+            .map_err(to_pyerr)?;
         Ok(())
     })
 }

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -40,5 +40,6 @@ from dynamo._core import lora_name_to_id as lora_name_to_id
 from dynamo._core import make_engine
 from dynamo._core import register_llm as register_llm
 from dynamo._core import run_input
+from dynamo._core import unregister_llm as unregister_llm
 
 from .exceptions import HttpError

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -5,11 +5,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use dynamo_runtime::component::Endpoint;
+use dynamo_runtime::discovery::DiscoveryInstance;
 use dynamo_runtime::discovery::DiscoverySpec;
 use dynamo_runtime::protocols::EndpointId;
 use dynamo_runtime::slug::Slug;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
-use dynamo_runtime::discovery::DiscoveryInstance;
 
 use crate::entrypoint::RouterConfig;
 use crate::mocker::protocols::MockEngineArgs;

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -455,14 +455,6 @@ impl LocalModel {
 
         let endpoint_id = endpoint.id();
 
-        tracing::info!(
-            "Unregistering model from discovery: namespace={}, component={}, endpoint={}, instance_id={:x}",
-            endpoint_id.namespace,
-            endpoint_id.component,
-            endpoint_id.name,
-            instance_id
-        );
-
         let instance = DiscoveryInstance::Model {
             namespace: endpoint_id.namespace,
             component: endpoint_id.component,

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -9,6 +9,7 @@ use dynamo_runtime::discovery::DiscoverySpec;
 use dynamo_runtime::protocols::EndpointId;
 use dynamo_runtime::slug::Slug;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
+use dynamo_runtime::discovery::DiscoveryInstance;
 
 use crate::entrypoint::RouterConfig;
 use crate::mocker::protocols::MockEngineArgs;
@@ -447,29 +448,25 @@ impl LocalModel {
         Ok(())
     }
 
-    /// Helper associated function for bindings to detach a model
-    /// without having a LocalModel instance.
+    /// Helper associated function to detach a model from an endpoint
     pub async fn detach_model_from_endpoint(endpoint: &Endpoint) -> anyhow::Result<()> {
         let drt = endpoint.drt();
         let instance_id = drt.connection_id();
 
-        let namespace = endpoint.component().namespace().name().to_string();
-        let component = endpoint.component().name().to_string();
-        let endpoint_name = endpoint.name().to_string();
+        let endpoint_id = endpoint.id();
 
         tracing::info!(
             "Unregistering model from discovery: namespace={}, component={}, endpoint={}, instance_id={:x}",
-            namespace,
-            component,
-            endpoint_name,
+            endpoint_id.namespace,
+            endpoint_id.component,
+            endpoint_id.name,
             instance_id
         );
 
-        use dynamo_runtime::discovery::DiscoveryInstance;
         let instance = DiscoveryInstance::Model {
-            namespace,
-            component,
-            endpoint: endpoint_name,
+            namespace: endpoint_id.namespace,
+            component: endpoint_id.component,
+            endpoint: endpoint_id.name,
             instance_id,
             card_json: serde_json::Value::Null,
         };

--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -124,6 +124,24 @@ impl Discovery for KubeDiscoveryClient {
         Ok(instance)
     }
 
+    async fn unregister(&self, instance: DiscoveryInstance) -> Result<()> {
+        let mut metadata = self.metadata.write().await;
+        match &instance {
+            DiscoveryInstance::Endpoint(_inst) => {
+                tracing::info!("Unregistering endpoint instance={:?}", instance);
+                metadata.unregister_endpoint(&instance)?;
+            }
+            DiscoveryInstance::Model {
+                ..
+            } => {
+                tracing::info!("Unregistering model card instance={:?}", instance);
+                metadata.unregister_model_card(&instance)?;
+            }
+        }
+
+        Ok(())
+    }
+
     async fn list(&self, query: DiscoveryQuery) -> Result<Vec<DiscoveryInstance>> {
         tracing::debug!("KubeDiscoveryClient::list called with query={:?}", query);
 

--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -131,9 +131,7 @@ impl Discovery for KubeDiscoveryClient {
                 tracing::info!("Unregistering endpoint instance={:?}", instance);
                 metadata.unregister_endpoint(&instance)?;
             }
-            DiscoveryInstance::Model {
-                ..
-            } => {
+            DiscoveryInstance::Model { .. } => {
                 tracing::info!("Unregistering model card instance={:?}", instance);
                 metadata.unregister_model_card(&instance)?;
             }

--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -131,11 +131,9 @@ impl Discovery for KubeDiscoveryClient {
         let mut metadata = self.metadata.write().await;
         match &instance {
             DiscoveryInstance::Endpoint(_inst) => {
-                tracing::info!("Unregistering endpoint instance={:?}", instance);
                 metadata.unregister_endpoint(&instance)?;
             }
             DiscoveryInstance::Model { .. } => {
-                tracing::info!("Unregistering model card instance={:?}", instance);
                 metadata.unregister_model_card(&instance)?;
             }
         }

--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -125,6 +125,9 @@ impl Discovery for KubeDiscoveryClient {
     }
 
     async fn unregister(&self, instance: DiscoveryInstance) -> Result<()> {
+        // TODO: need to handle meta data change propagation to other pods
+        // Current implementation delete the entry from local metadata but
+        // it doesn't invalidate the cached service metadata on other pods
         let mut metadata = self.metadata.write().await;
         match &instance {
             DiscoveryInstance::Endpoint(_inst) => {

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -203,6 +203,68 @@ impl Discovery for KVStoreDiscovery {
         Ok(instance)
     }
 
+    async fn unregister(&self, instance: DiscoveryInstance) -> Result<()> {
+        let (bucket_name, key_path) = match &instance {
+            DiscoveryInstance::Endpoint(inst) => {
+                let key = Self::endpoint_key(
+                    &inst.namespace,
+                    &inst.component,
+                    &inst.endpoint,
+                    inst.instance_id,
+                );
+                tracing::debug!(
+                    "Unregistering endpoint instance_id={}, namespace={}, component={}, endpoint={}, key={}",
+                    inst.instance_id,
+                    inst.namespace,
+                    inst.component,
+                    inst.endpoint,
+                    key
+                );
+                (INSTANCES_BUCKET, key)
+            }
+            DiscoveryInstance::Model {
+                namespace,
+                component,
+                endpoint,
+                instance_id,
+                ..
+            } => {
+                let key = Self::model_key(namespace, component, endpoint, *instance_id);
+                tracing::debug!(
+                    "Unregistering model instance_id={}, namespace={}, component={}, endpoint={}, key={}",
+                    instance_id,
+                    namespace,
+                    component,
+                    endpoint,
+                    key
+                );
+                (MODELS_BUCKET, key)
+            }
+        };
+
+        // Get the bucket - if it doesn't exist, the instance is already removed from the KV store
+        let Some(bucket) = self.store.get_bucket(bucket_name).await? else {
+            tracing::warn!(
+                "Bucket {} does not exist, instance already removed",
+                bucket_name
+            );
+            return Ok(());
+        };
+
+        let key = crate::storage::key_value_store::Key::from_raw(key_path.clone());
+
+        // Delete the entry from the bucket
+        bucket.delete(&key).await?;
+
+        tracing::debug!(
+            "KVStoreDiscovery::unregister: Successfully unregistered instance_id={}, key={}",
+            instance.instance_id(),
+            key_path
+        );
+
+        Ok(())
+    }
+
     async fn list(&self, query: DiscoveryQuery) -> Result<Vec<DiscoveryInstance>> {
         let prefix = Self::query_prefix(&query);
         let bucket_name = if prefix.starts_with(INSTANCES_BUCKET) {

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -256,12 +256,6 @@ impl Discovery for KVStoreDiscovery {
         // Delete the entry from the bucket
         bucket.delete(&key).await?;
 
-        tracing::debug!(
-            "KVStoreDiscovery::unregister: Successfully unregistered instance_id={}, key={}",
-            instance.instance_id(),
-            key_path
-        );
-
         Ok(())
     }
 

--- a/lib/runtime/src/discovery/metadata.rs
+++ b/lib/runtime/src/discovery/metadata.rs
@@ -60,6 +60,34 @@ impl DiscoveryMetadata {
         }
     }
 
+    /// Unregister an endpoint instance
+    pub fn unregister_endpoint(&mut self, instance: &DiscoveryInstance) -> Result<()> {
+        if let DiscoveryInstance::Endpoint(inst) = instance {
+            let key = make_endpoint_key(&inst.namespace, &inst.component, &inst.endpoint);
+            self.endpoints.remove(&key);
+            Ok(())
+        } else {
+            anyhow::bail!("Cannot unregister non-endpoint instance as endpoint")
+        }
+    }
+
+    /// Unregister a model card instance
+    pub fn unregister_model_card(&mut self, instance: &DiscoveryInstance) -> Result<()> {
+        if let DiscoveryInstance::Model {
+            namespace,
+            component,
+            endpoint,
+            ..
+        } = instance
+        {
+            let key = make_endpoint_key(namespace, component, endpoint);
+            self.model_cards.remove(&key);
+            Ok(())
+        } else {
+            anyhow::bail!("Cannot unregister non-model-card instance as model card")
+        }
+    }
+
     /// Get all registered endpoints
     pub fn get_all_endpoints(&self) -> Vec<DiscoveryInstance> {
         self.endpoints.values().cloned().collect()

--- a/lib/runtime/src/discovery/mock.rs
+++ b/lib/runtime/src/discovery/mock.rs
@@ -140,6 +140,18 @@ impl Discovery for MockDiscovery {
         Ok(instance)
     }
 
+    async fn unregister(&self, instance: DiscoveryInstance) -> Result<()> {
+        let instance_id = instance.instance_id();
+
+        self.registry
+            .instances
+            .lock()
+            .unwrap()
+            .retain(|i| i.instance_id() != instance_id);
+
+        Ok(())
+    }
+
     async fn list(&self, query: DiscoveryQuery) -> Result<Vec<DiscoveryInstance>> {
         let instances = self.registry.instances.lock().unwrap();
         Ok(instances

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -198,6 +198,9 @@ pub trait Discovery: Send + Sync {
     /// Registers an object in the discovery plane with the instance id
     async fn register(&self, spec: DiscoverySpec) -> Result<DiscoveryInstance>;
 
+    /// Unregisters an instance from the discovery plane
+    async fn unregister(&self, instance: DiscoveryInstance) -> Result<()>;
+
     /// Returns a list of currently registered instances for the given discovery query
     /// This is a one-time snapshot without watching for changes
     async fn list(&self, query: DiscoveryQuery) -> Result<Vec<DiscoveryInstance>>;


### PR DESCRIPTION
#### Overview:

This PR adds support for unregistering LLM models from the discovery service, enabling proper cleanup when models are removed from endpoints.  Implementation follows the same architectural patterns as  model registration, with thin Python bindings and core business logic in Rust Land.

-  Consistent with register_llm
```python
await register_llm(model_input, model_type, endpoint, model_path, ...)

# Unregister a model  
await unregister_llm(endpoint)
```

 - Rust API 
```
  LocalModel::detach_model_from_endpoint(&endpoint).await?
```

- todo in another PR: need to handle meta data change propagation to other pods

- closes: DEP-623

## Summary by CodeRabbit

* **New Features**
  * Added ability to unregister discovery instances, enabling removal of previously registered endpoints and model cards from the discovery system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->