### PR TITLE
fix: fix trtllm multinode deployment with LWS

### DIFF
--- a/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -952,7 +952,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 										Name:    commonconsts.MainContainerName,
 										Image:   "test-image:latest",
 										Command: []string{"/bin/sh", "-c"},
-										Args:    []string{"ray start --address=$(LWS_LEADER_ADDRESS):6379 --block"},
+										Args:    []string{"ray start --address=$LWS_LEADER_ADDRESS:6379 --block"},
 										Env: []corev1.EnvVar{
 											{Name: commonconsts.DynamoComponentEnvVar, Value: commonconsts.ComponentTypeWorker},
 											{Name: commonconsts.DynamoNamespaceEnvVar, Value: "default"},

--- a/deploy/cloud/operator/internal/dynamo/backend_sglang_test.go
+++ b/deploy/cloud/operator/internal/dynamo/backend_sglang_test.go
@@ -28,6 +28,10 @@ func (m *MockSimpleDeployer) GetNodeRank() (string, bool) {
 	return "1", false // simple rank, no shell interpretation needed
 }
 
+func (m *MockSimpleDeployer) NeedsDNSWait() bool {
+	return false
+}
+
 // Mock MultinodeDeployer for testing with shell interpretation needed
 type MockShellDeployer struct{}
 
@@ -46,6 +50,10 @@ func (m *MockShellDeployer) GetHostNames(serviceName string, numberOfNodes int32
 
 func (m *MockShellDeployer) GetNodeRank() (string, bool) {
 	return "$(WORKER_INDEX)", true // needs shell interpretation
+}
+
+func (m *MockShellDeployer) NeedsDNSWait() bool {
+	return true
 }
 
 func TestSGLangBackend_PythonCommandInjection(t *testing.T) {
@@ -265,7 +273,7 @@ func TestSGLangBackend_ShellCommandInjection(t *testing.T) {
 			multinodeDeployer: &LWSMultinodeDeployer{},
 			initialCommand:    []string{"sh", "-c"},
 			initialArgs:       []string{"python -m dynamo.sglang"},
-			expectedArgs:      []string{"python -m dynamo.sglang --dist-init-addr $(LWS_LEADER_ADDRESS):29500 --nnodes 2 --node-rank 0"},
+			expectedArgs:      []string{"python -m dynamo.sglang --dist-init-addr $LWS_LEADER_ADDRESS:29500 --nnodes 2 --node-rank 0"},
 			description:       "LWS shell commands should use LWS variables",
 		},
 		{

--- a/deploy/cloud/operator/internal/dynamo/backend_trtllm.go
+++ b/deploy/cloud/operator/internal/dynamo/backend_trtllm.go
@@ -154,8 +154,16 @@ func (b *TRTLLMBackend) setupLeaderContainer(container *corev1.Container, number
 		envVarsStr,
 		wrappedCommand)
 
-	// Combine SSH setup and mpirun command
-	fullCommand := strings.Join(append(sshSetupCommands, mpirunCmd), " && ")
+	// Combine SSH setup and mpirun command, optionally adding DNS wait for deployers that need it
+	var allCommands []string
+	if multinodeDeployer.NeedsDNSWait() {
+		// Wait for DNS resolution of all worker nodes (needed for LWS)
+		dnsWaitCmd := fmt.Sprintf(`TIMEOUT=300; START_TIME=$(date +%%s); for worker in $(echo "%s" | tr ',' ' '); do echo "Waiting for DNS: $worker"; until getent hosts $worker >/dev/null 2>&1; do CURRENT_TIME=$(date +%%s); if [ $((CURRENT_TIME - START_TIME)) -gt $TIMEOUT ]; then echo "ERROR: Timeout waiting for DNS: $worker"; exit 1; fi; echo "DNS not ready for $worker, retrying..."; sleep 2; done; echo "✓ DNS resolved: $worker"; done; echo "All workers DNS ready"`, workerHosts)
+		allCommands = append(sshSetupCommands, dnsWaitCmd, mpirunCmd)
+	} else {
+		allCommands = append(sshSetupCommands, mpirunCmd)
+	}
+	fullCommand := strings.Join(allCommands, " && ")
 
 	// Update container to use bash with the full command
 	container.Command = []string{"/bin/sh", "-c"}

--- a/deploy/cloud/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/cloud/operator/internal/dynamo/backend_vllm_test.go
@@ -66,7 +66,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			multinodeDeployer:   &LWSMultinodeDeployer{},
 			initialContainer:    &corev1.Container{Args: []string{"python3", "-m", "dynamo.vllm", tensorParallelSizeFlag, "8"}},
 			gpuCount:            4,
-			expectedArgs:        []string{"ray start --address=$(LWS_LEADER_ADDRESS):6379 --block"},
+			expectedArgs:        []string{"ray start --address=$LWS_LEADER_ADDRESS:6379 --block"},
 			expectProbesRemoved: true,
 		},
 		{
@@ -175,8 +175,7 @@ func TestVLLMBackend_ShellCommandInjection(t *testing.T) {
 			role:              RoleLeader,
 			multinodeDeployer: &LWSMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"sh", "-c"}, Args: []string{fmt.Sprintf("python3 -m dynamo.vllm %s 8", dataParallelSizeFlag)}},
-			gpuCount:          4,
-			expectedArgs:      []string{"python3 -m dynamo.vllm --data-parallel-address $(LWS_LEADER_ADDRESS) --data-parallel-size-local 4 --data-parallel-rpc-port 13445 --data-parallel-start-rank 0 --data-parallel-size 8"},
+			expectedArgs:      []string{"python3 -m dynamo.vllm --data-parallel-address $LWS_LEADER_ADDRESS --data-parallel-size-local 4 --data-parallel-rpc-port 13445 --data-parallel-start-rank 0 --data-parallel-size 8"},
 			description:       "LWS shell commands should use LWS variables",
 		},
 		{
@@ -385,8 +384,7 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			role:              RoleWorker,
 			multinodeDeployer: &LWSMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Args: []string{"python3", "-m", "dynamo.vllm", tensorParallelSizeFlag, "16"}},
-			gpuCount:          8,
-			expectedArgs:      []string{"ray start --address=$(LWS_LEADER_ADDRESS):6379 --block"},
+			expectedArgs:      []string{"ray start --address=$LWS_LEADER_ADDRESS:6379 --block"},
 		},
 		{
 			name:              "main role does not modify args",

--- a/deploy/cloud/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/cloud/operator/internal/dynamo/backend_vllm_test.go
@@ -175,6 +175,7 @@ func TestVLLMBackend_ShellCommandInjection(t *testing.T) {
 			role:              RoleLeader,
 			multinodeDeployer: &LWSMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"sh", "-c"}, Args: []string{fmt.Sprintf("python3 -m dynamo.vllm %s 8", dataParallelSizeFlag)}},
+			gpuCount:          4,
 			expectedArgs:      []string{"python3 -m dynamo.vllm --data-parallel-address $LWS_LEADER_ADDRESS --data-parallel-size-local 4 --data-parallel-rpc-port 13445 --data-parallel-start-rank 0 --data-parallel-size 8"},
 			description:       "LWS shell commands should use LWS variables",
 		},
@@ -384,6 +385,7 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			role:              RoleWorker,
 			multinodeDeployer: &LWSMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Args: []string{"python3", "-m", "dynamo.vllm", tensorParallelSizeFlag, "16"}},
+			gpuCount:          8,
 			expectedArgs:      []string{"ray start --address=$LWS_LEADER_ADDRESS:6379 --block"},
 		},
 		{

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -625,6 +625,7 @@ type MultinodeDeployer interface {
 	GetLeaderHostname(serviceName string) string
 	GetHostNames(serviceName string, numberOfNodes int32) []string
 	GetNodeRank() (string, bool) // returns (rank, needsShellInterpretation)
+	NeedsDNSWait() bool          // returns true if DNS wait is needed to launch multinode components
 }
 
 // BackendFactory creates backend instances based on the framework type

--- a/deploy/cloud/operator/internal/dynamo/grove.go
+++ b/deploy/cloud/operator/internal/dynamo/grove.go
@@ -33,6 +33,11 @@ func (d *GroveMultinodeDeployer) GetNodeRank() (string, bool) {
 	return "$((GROVE_PCLQ_POD_INDEX + 1))", true
 }
 
+func (d *GroveMultinodeDeployer) NeedsDNSWait() bool {
+	// Grove doesn't need DNS wait - it handles startup coordination differently
+	return false
+}
+
 func (d *GroveMultinodeDeployer) GetHostNames(serviceName string, numberOfNodes int32) []string {
 	hostnames := make([]string, 0, numberOfNodes)
 	leaderHostname := d.GetLeaderHostname(serviceName)

--- a/deploy/cloud/operator/internal/dynamo/lws.go
+++ b/deploy/cloud/operator/internal/dynamo/lws.go
@@ -7,7 +7,7 @@ type LWSMultinodeDeployer struct {
 }
 
 func (d *LWSMultinodeDeployer) GetLeaderHostname(serviceName string) string {
-	return "$(LWS_LEADER_ADDRESS)"
+	return "$LWS_LEADER_ADDRESS"
 }
 
 func (d *LWSMultinodeDeployer) GetNodeRank() (string, bool) {
@@ -15,11 +15,23 @@ func (d *LWSMultinodeDeployer) GetNodeRank() (string, bool) {
 	return "$(LWS_WORKER_INDEX)", true
 }
 
+func (d *LWSMultinodeDeployer) NeedsDNSWait() bool {
+	// LWS needs DNS wait because pods start simultaneously and DNS may not be ready
+	return true
+}
+
 func (d *LWSMultinodeDeployer) GetHostNames(serviceName string, numberOfNodes int32) []string {
 	hostnames := make([]string, numberOfNodes)
 	hostnames[0] = d.GetLeaderHostname(serviceName)
+
+	// LWS only provides LWS_LEADER_ADDRESS, LWS_GROUP_SIZE, and LWS_WORKER_INDEX
+	// LWS_LEADER_ADDRESS format: <lws-name>-<group-index>-<leader-pod-index>.<service-name>.<namespace>
+	// Example: trtllm-disagg-tp8-decode-0-0.trtllm-disagg-tp8-decode-0.jsm
+	// Worker pods append their index: trtllm-disagg-tp8-decode-0-0-1, trtllm-disagg-tp8-decode-0-0-2, etc.
+	// We derive worker addresses by inserting -{i} before the first dot
 	for i := int32(1); i < numberOfNodes; i++ {
-		hostnames[i] = fmt.Sprintf("$(LWS_WORKER_%d_ADDRESS)", i)
+		// Use sed to replace first "." with "-{i}." to append worker index
+		hostnames[i] = fmt.Sprintf("$(echo \"$LWS_LEADER_ADDRESS\" | sed 's/\\./-%d\\./')", i)
 	}
 	return hostnames
 }


### PR DESCRIPTION
#### Overview:

fix trtllm multinode deployment with LWS

Apparently LWS_WORKER_X_ADDRESS env variables are not injected by LWS anymore ....
This is the fix to not rely on them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added DNS wait readiness mechanism for multinode deployments to ensure DNS resolution is available before launch.
  * Standardized environment variable handling in container arguments across deployment backends.
  * Implemented conditional DNS wait logic: LWS deployments now perform DNS verification; Grove deployments bypass this step.

* **Tests**
  * Updated test expectations to reflect DNS readiness logic in multinode deployment commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->