### PR TITLE
test: parallel mocker tests in CI

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -54,22 +54,12 @@ runs:
         # Run pytest with detailed output and JUnit XML
         set +e  # Don't exit on test failures
 
-        # Only use parallel execution (-n 4) for tests marked with 'parallel'
-        # Other tests run sequentially to avoid pytest-xdist overhead
-        PYTEST_XDIST_FLAG=""
-        if echo "${{ inputs.pytest_marks }}" | grep -q "parallel"; then
-          PYTEST_XDIST_FLAG="-n 4"
-          echo "🔀 Using parallel execution (4 workers) for parallel-marked tests"
-        else
-          echo "▶️  Running tests sequentially"
-        fi
-
         docker run --runtime=nvidia --gpus all -w /workspace \
           --cpus=${NUM_CPUS} \
           --network host \
           --name ${{ env.CONTAINER_ID }}_pytest \
           ${{ inputs.image_tag }} \
-          bash -c "mkdir -p /workspace/test-results && pytest -v --tb=short --basetemp=/tmp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --durations=10 ${PYTEST_XDIST_FLAG} -m \"${{ inputs.pytest_marks }}\""
+          bash -c "mkdir -p /workspace/test-results && pytest -v --tb=short --basetemp=/tmp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --durations=10 -m \"${{ inputs.pytest_marks }}\""
 
         TEST_EXIT_CODE=$?
         echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -54,12 +54,22 @@ runs:
         # Run pytest with detailed output and JUnit XML
         set +e  # Don't exit on test failures
 
+        # Only use parallel execution (-n 4) for tests marked with 'parallel'
+        # Other tests run sequentially to avoid pytest-xdist overhead
+        PYTEST_XDIST_FLAG=""
+        if echo "${{ inputs.pytest_marks }}" | grep -q "parallel"; then
+          PYTEST_XDIST_FLAG="-n 4"
+          echo "🔀 Using parallel execution (4 workers) for parallel-marked tests"
+        else
+          echo "▶️  Running tests sequentially"
+        fi
+
         docker run --runtime=nvidia --gpus all -w /workspace \
           --cpus=${NUM_CPUS} \
           --network host \
           --name ${{ env.CONTAINER_ID }}_pytest \
           ${{ inputs.image_tag }} \
-          bash -c "mkdir -p /workspace/test-results && pytest -v --tb=short --basetemp=/tmp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --durations=10 -m \"${{ inputs.pytest_marks }}\""
+          bash -c "mkdir -p /workspace/test-results && pytest -v --tb=short --basetemp=/tmp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --durations=10 ${PYTEST_XDIST_FLAG} -m \"${{ inputs.pytest_marks }}\""
 
         TEST_EXIT_CODE=$?
         echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -64,14 +64,13 @@ jobs:
         run: |
           docker compose down
       - name: Run pytest (parallel tests with xdist)
-        continue-on-error: true
         env:
           PYTEST_MARKS: "pre_merge and parallel"
         run: |
           docker run -w /workspace \
             --name ${{ env.CONTAINER_ID }}_pytest_parallel \
             ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_PARALLEL_XML_FILE }} -n 4 -m \"${{ env.PYTEST_MARKS }}\""
+            bash -c "pytest --basetemp=/tmp/pytest-parallel --junitxml=${{ env.PYTEST_PARALLEL_XML_FILE }} -n 4 -m \"${{ env.PYTEST_MARKS }}\""
       - name: Copy parallel test report from Container
         if: always()
         run: |

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -83,7 +83,7 @@ jobs:
           docker run -w /workspace \
             --name ${{ env.CONTAINER_ID }}_pytest \
             ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m \"${{ env.PYTEST_MARKS }}\"
+            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m \"${{ env.PYTEST_MARKS }}\" "
       - name: Copy test report from test Container
         if: always()
         run: |

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -62,24 +62,18 @@ jobs:
         working-directory: ./deploy
         run: |
           docker compose down
-      - name: Run pytest
-        env:
-          PYTEST_MARKS: "(pre_merge and parallel) or mypy"
+      - name: Run pytest (parallel tests with xdist)
         run: |
-          # Only use parallel execution (-n 4) for tests marked with 'parallel'
-          # Other tests run sequentially to avoid pytest-xdist overhead
-          PYTEST_XDIST_FLAG=""
-          if echo "${{ env.PYTEST_MARKS }}" | grep -q "parallel"; then
-            PYTEST_XDIST_FLAG="-n 4"
-            echo "🔀 Using parallel execution (4 workers) for parallel-marked tests"
-          else
-            echo "▶️  Running tests sequentially"
-          fi
-
+          docker run -w /workspace \
+            --name ${{ env.CONTAINER_ID }}_pytest_parallel \
+            ${{ steps.define_image_tag.outputs.image_tag }} \
+            bash -c "pytest --basetemp=/tmp -n 4 -m 'pre_merge and parallel' || true"
+      - name: Run pytest (sequential tests)
+        run: |
           docker run -w /workspace \
             --name ${{ env.CONTAINER_ID }}_pytest \
             ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} ${PYTEST_XDIST_FLAG} -m \"${{ env.PYTEST_MARKS }}\" "
+            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m '(pre_merge and not parallel) or mypy' "
       - name: Copy test report from test Container
         if: always()
         run: |

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}_dynamo
       PYTEST_XML_FILE: pytest_test_report.xml
+      PYTEST_PARALLEL_XML_FILE: pytest_parallel.xml
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,13 +64,18 @@ jobs:
         run: |
           docker compose down
       - name: Run pytest (parallel tests with xdist)
+        continue-on-error: true
         env:
           PYTEST_MARKS: "pre_merge and parallel"
         run: |
           docker run -w /workspace \
             --name ${{ env.CONTAINER_ID }}_pytest_parallel \
             ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c "pytest --basetemp=/tmp -n 4 -m \"${{ env.PYTEST_MARKS }}\" || true"
+            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_PARALLEL_XML_FILE }} -n 4 -m \"${{ env.PYTEST_MARKS }}\""
+      - name: Copy parallel test report from Container
+        if: always()
+        run: |
+          docker cp ${{ env.CONTAINER_ID }}_pytest_parallel:/workspace/${{ env.PYTEST_PARALLEL_XML_FILE }} . || echo "No parallel test report found"
       - name: Run pytest (sequential tests)
         env:
           PYTEST_MARKS: "(pre_merge and not parallel) or mypy"
@@ -77,7 +83,7 @@ jobs:
           docker run -w /workspace \
             --name ${{ env.CONTAINER_ID }}_pytest \
             ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m \"${{ env.PYTEST_MARKS }}\" "
+            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m \"${{ env.PYTEST_MARKS }}\"
       - name: Copy test report from test Container
         if: always()
         run: |
@@ -90,6 +96,7 @@ jobs:
           if-no-files-found: error
           path: |
             ${{ env.PYTEST_XML_FILE }}
+            ${{ env.PYTEST_PARALLEL_XML_FILE }}
 
   event_file:
     name: "Event File"

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -63,17 +63,21 @@ jobs:
         run: |
           docker compose down
       - name: Run pytest (parallel tests with xdist)
+        env:
+          PYTEST_MARKS: "pre_merge and parallel"
         run: |
           docker run -w /workspace \
             --name ${{ env.CONTAINER_ID }}_pytest_parallel \
             ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c "pytest --basetemp=/tmp -n 4 -m 'pre_merge and parallel' || true"
+            bash -c "pytest --basetemp=/tmp -n 4 -m \"${{ env.PYTEST_MARKS }}\" || true"
       - name: Run pytest (sequential tests)
+        env:
+          PYTEST_MARKS: "(pre_merge and not parallel) or mypy"
         run: |
           docker run -w /workspace \
             --name ${{ env.CONTAINER_ID }}_pytest \
             ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m '(pre_merge and not parallel) or mypy' "
+            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m \"${{ env.PYTEST_MARKS }}\" "
       - name: Copy test report from test Container
         if: always()
         run: |

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -64,12 +64,22 @@ jobs:
           docker compose down
       - name: Run pytest
         env:
-          PYTEST_MARKS: "pre_merge or mypy"
+          PYTEST_MARKS: "(pre_merge and parallel) or mypy"
         run: |
+          # Only use parallel execution (-n 4) for tests marked with 'parallel'
+          # Other tests run sequentially to avoid pytest-xdist overhead
+          PYTEST_XDIST_FLAG=""
+          if echo "${{ env.PYTEST_MARKS }}" | grep -q "parallel"; then
+            PYTEST_XDIST_FLAG="-n 4"
+            echo "🔀 Using parallel execution (4 workers) for parallel-marked tests"
+          else
+            echo "▶️  Running tests sequentially"
+          fi
+
           docker run -w /workspace \
             --name ${{ env.CONTAINER_ID }}_pytest \
             ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} -m \"${{ env.PYTEST_MARKS }}\" "
+            bash -c "pytest --basetemp=/tmp --junitxml=${{ env.PYTEST_XML_FILE }} ${PYTEST_XDIST_FLAG} -m \"${{ env.PYTEST_MARKS }}\" "
       - name: Copy test report from test Container
         if: always()
         run: |

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -28,6 +28,7 @@ pytest-forked
 pytest-md-report
 pytest-mypy
 pytest-timeout
+pytest-xdist
 # Triton client to Dynamo gRPC server
 tritonclient[grpc]
 # add types library stub for PyYAML

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ requires-python = ">=3.10"
 dependencies = [
     "ai-dynamo-runtime==0.7.0",
     "pytest>=8.3.4",
-    "pytest-xdist",
     "types-psutil>=7.0.0.20250218",
     "kubernetes>=32.0.1,<33.0.0",
     "fastapi>=0.115.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires-python = ">=3.10"
 dependencies = [
     "ai-dynamo-runtime==0.7.0",
     "pytest>=8.3.4",
+    "pytest-xdist",
     "types-psutil>=7.0.0.20250218",
     "kubernetes>=32.0.1,<33.0.0",
     "fastapi>=0.115.0",
@@ -175,6 +176,8 @@ filterwarnings = [
     "ignore:Support for class-based `config`.*:pydantic.warnings.PydanticDeprecatedSince20",
     "ignore:Using extra keyword arguments on `Field`.*:pydantic.warnings.PydanticDeprecatedSince20",
     "ignore:The `schema` method is deprecated.*:pydantic.warnings.PydanticDeprecatedSince20",
+    # pytest-benchmark automatically disables when xdist is active, ignore the warning
+    "ignore:.*Benchmarks are automatically disabled.*:pytest_benchmark.logger.PytestBenchmarkWarning",
 ]
 
 
@@ -182,6 +185,7 @@ filterwarnings = [
 asyncio_mode = "auto"
 markers = [
     "pre_merge: marks tests to run before merging",
+    "parallel: marks tests that can run in parallel with pytest-xdist",
     "nightly: marks tests to run nightly",
     "weekly: marks tests to run weekly",
     "gpu_1: marks tests to run on GPU",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,10 @@ import logging
 import os
 import shutil
 import tempfile
+from pathlib import Path
 
 import pytest
+from filelock import FileLock
 
 from tests.utils.constants import TEST_MODELS
 from tests.utils.managed_process import ManagedProcess
@@ -229,11 +231,161 @@ class NatsServer(ManagedProcess):
         )
 
 
+class SharedManagedProcess:
+    """Base class for ManagedProcess with file-based reference counting for multi-process sharing."""
+
+    def __init__(
+        self,
+        request,
+        tmp_path_factory,
+        resource_name: str,
+        port: int,
+        timeout: int = 300,
+    ):
+        self.request = request
+        self.port = port
+        self.timeout = timeout
+        self.resource_name = resource_name
+        self._server = None
+        self._owns_process = False
+
+        # Use a fixed shared directory across all pytest-xdist workers
+        # Try to use pytest's basetemp parent, but fall back to /tmp if not available
+        try:
+            basetemp = tmp_path_factory.getbasetemp()
+            if basetemp and str(basetemp):
+                root_tmp = basetemp.parent
+            else:
+                root_tmp = Path("/tmp")
+        except (AttributeError, ValueError):
+            root_tmp = Path("/tmp")
+
+        # Ensure directory exists
+        root_tmp.mkdir(parents=True, exist_ok=True)
+
+        self.ref_file = root_tmp / f"pytest_{resource_name}_{port}_ref_count"
+        self.lock_file = str(self.ref_file) + ".lock"
+
+    def _create_server(self) -> ManagedProcess:
+        """Create the underlying server instance. Must be implemented by subclasses."""
+        raise NotImplementedError
+
+    def _read_ref_count(self) -> int:
+        """Read current reference count."""
+        if self.ref_file.exists():
+            try:
+                return int(self.ref_file.read_text().strip())
+            except (ValueError, IOError):
+                return 0
+        return 0
+
+    def _write_ref_count(self, count: int):
+        """Write reference count atomically."""
+        self.ref_file.write_text(str(count))
+
+    def _increment_ref_count(self) -> int:
+        """Increment reference count and return new count."""
+        count = self._read_ref_count()
+        count += 1
+        self._write_ref_count(count)
+        return count
+
+    def _decrement_ref_count(self) -> int:
+        """Decrement reference count and return new count."""
+        count = self._read_ref_count()
+        count = max(0, count - 1)
+        self._write_ref_count(count)
+        return count
+
+    def __enter__(self):
+        with FileLock(self.lock_file):
+            ref_count = self._increment_ref_count()
+            if ref_count == 1:
+                # First reference - start the process
+                self._server = self._create_server()
+                self._server.__enter__()
+                self._owns_process = True
+                logging.info(f"[{self.resource_name}] Started process (ref_count=1)")
+            else:
+                # Process already running, just track reference
+                self._owns_process = False
+                logging.info(
+                    f"[{self.resource_name}] Reusing existing process (ref_count={ref_count})"
+                )
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        with FileLock(self.lock_file):
+            ref_count = self._decrement_ref_count()
+            if ref_count == 0 and self._owns_process:
+                # Last reference - stop the process
+                if self._server:
+                    self._server.__exit__(exc_type, exc_val, exc_tb)
+                logging.info(f"[{self.resource_name}] Stopped process (ref_count=0)")
+            elif ref_count == 0:
+                # Last reference but we don't own it - shouldn't happen, but clean up ref file
+                if self.ref_file.exists():
+                    self.ref_file.unlink()
+                logging.warning(
+                    f"[{self.resource_name}] Ref count reached 0 but we don't own process"
+                )
+            else:
+                logging.info(
+                    f"[{self.resource_name}] Released reference (ref_count={ref_count})"
+                )
+
+
+class SharedEtcdServer(SharedManagedProcess):
+    """EtcdServer with file-based reference counting for multi-process sharing."""
+
+    def __init__(self, request, tmp_path_factory, port=2379, timeout=300):
+        super().__init__(request, tmp_path_factory, "etcd", port, timeout)
+        # Create a log directory for session-scoped servers
+        self._log_dir = tempfile.mkdtemp(prefix=f"pytest_{self.resource_name}_logs_")
+
+    def _create_server(self) -> ManagedProcess:
+        """Create EtcdServer instance."""
+        server = EtcdServer(self.request, port=self.port, timeout=self.timeout)
+        # Override log_dir since request.node.name is empty in session scope
+        server.log_dir = self._log_dir
+        return server
+
+
+class SharedNatsServer(SharedManagedProcess):
+    """NatsServer with file-based reference counting for multi-process sharing."""
+
+    def __init__(self, request, tmp_path_factory, port=4222, timeout=300):
+        super().__init__(request, tmp_path_factory, "nats", port, timeout)
+        # Create a log directory for session-scoped servers
+        self._log_dir = tempfile.mkdtemp(prefix=f"pytest_{self.resource_name}_logs_")
+
+    def _create_server(self) -> ManagedProcess:
+        """Create NatsServer instance."""
+        server = NatsServer(self.request, port=self.port, timeout=self.timeout)
+        # Override log_dir since request.node.name is empty in session scope
+        server.log_dir = self._log_dir
+        return server
+
+
 @pytest.fixture()
 def runtime_services(request):
     with NatsServer(request) as nats_process:
         with EtcdServer(request) as etcd_process:
             yield nats_process, etcd_process
+
+
+@pytest.fixture(scope="session")
+def runtime_services_session(request, tmp_path_factory):
+    """Session-scoped fixture that provides shared NATS and etcd instances for all tests.
+
+    Uses file-based reference counting to coordinate between pytest-xdist worker processes.
+    Only the first worker starts services, and only the last worker tears them down.
+
+    Test isolation is achieved through unique namespaces (test-namespace-{random-suffix}).
+    """
+    with SharedNatsServer(request, tmp_path_factory) as nats:
+        with SharedEtcdServer(request, tmp_path_factory) as etcd:
+            yield nats, etcd
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -378,20 +378,38 @@ def runtime_services_session(request, tmp_path_factory):
             yield nats, etcd
 
 
-@pytest.fixture
-def file_storage_backend():
-    """Fixture that sets up and tears down file storage backend.
+@pytest.fixture(scope="session")
+def file_storage_backend_root():
+    """Session-scoped fixture that creates a persistent root directory for file storage.
 
-    Creates a temporary directory for file-based KV storage and sets
-    the DYN_FILE_KV environment variable. Cleans up after the test.
+    This directory persists across all tests to avoid race conditions with background
+    threads trying to access deleted directories.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        old_env = os.environ.get("DYN_FILE_KV")
-        os.environ["DYN_FILE_KV"] = tmpdir
-        logging.info(f"Set up file storage backend in: {tmpdir}")
         yield tmpdir
-        # Cleanup
-        if old_env is not None:
-            os.environ["DYN_FILE_KV"] = old_env
-        else:
-            os.environ.pop("DYN_FILE_KV", None)
+
+
+@pytest.fixture
+def file_storage_backend(request, file_storage_backend_root):
+    """Fixture that sets up and tears down file storage backend.
+
+    Creates a subdirectory within the session-scoped root for this specific test.
+    This prevents background threads from erroring when test cleanup happens.
+    """
+    # Create a unique subdirectory for this test
+    import uuid
+
+    test_subdir = Path(file_storage_backend_root) / f"test_{uuid.uuid4().hex[:8]}"
+    test_subdir.mkdir(parents=True, exist_ok=True)
+
+    old_env = os.environ.get("DYN_FILE_KV")
+    os.environ["DYN_FILE_KV"] = str(test_subdir)
+    logging.info(f"Set up file storage backend in: {test_subdir}")
+
+    yield str(test_subdir)
+
+    # Cleanup - just restore env, leave directory for background threads
+    if old_env is not None:
+        os.environ["DYN_FILE_KV"] = old_env
+    else:
+        os.environ.pop("DYN_FILE_KV", None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Optional
 
 import pytest
 from filelock import FileLock
@@ -246,19 +247,24 @@ class SharedManagedProcess:
         self.port = port
         self.timeout = timeout
         self.resource_name = resource_name
-        self._server = None
+        self._server: Optional[ManagedProcess] = None
         self._owns_process = False
 
         # Use a fixed shared directory across all pytest-xdist workers
-        # Try to use pytest's basetemp parent, but fall back to /tmp if not available
+        # Try to use pytest's basetemp parent, but fall back to a subdirectory of /tmp if not available
+        # Never use /tmp directly as pytest will try to clean it up and fail on system files
         try:
             basetemp = tmp_path_factory.getbasetemp()
             if basetemp and str(basetemp):
-                root_tmp = basetemp.parent
+                # If basetemp is /tmp, use a subdirectory to avoid permission issues
+                if str(basetemp) == "/tmp":
+                    root_tmp = Path("/tmp/pytest_ref_counting")
+                else:
+                    root_tmp = basetemp.parent
             else:
-                root_tmp = Path("/tmp")
+                root_tmp = Path("/tmp/pytest_ref_counting")
         except (AttributeError, ValueError):
-            root_tmp = Path("/tmp")
+            root_tmp = Path("/tmp/pytest_ref_counting")
 
         # Ensure directory exists
         root_tmp.mkdir(parents=True, exist_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,23 +250,7 @@ class SharedManagedProcess:
         self._server: Optional[ManagedProcess] = None
         self._owns_process = False
 
-        # Use a fixed shared directory across all pytest-xdist workers
-        # Try to use pytest's basetemp parent, but fall back to a subdirectory of /tmp if not available
-        # Never use /tmp directly as pytest will try to clean it up and fail on system files
-        try:
-            basetemp = tmp_path_factory.getbasetemp()
-            if basetemp and str(basetemp):
-                # If basetemp is /tmp, use a subdirectory to avoid permission issues
-                if str(basetemp) == "/tmp":
-                    root_tmp = Path("/tmp/pytest_ref_counting")
-                else:
-                    root_tmp = basetemp.parent
-            else:
-                root_tmp = Path("/tmp/pytest_ref_counting")
-        except (AttributeError, ValueError):
-            root_tmp = Path("/tmp/pytest_ref_counting")
-
-        # Ensure directory exists
+        root_tmp = Path(tempfile.gettempdir()) / "pytest_ref_counting"
         root_tmp.mkdir(parents=True, exist_ok=True)
 
         self.ref_file = root_tmp / f"pytest_{resource_name}_{port}_ref_count"

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 MODEL_NAME = ROUTER_MODEL_NAME
 NUM_MOCKERS = 2
 SPEEDUP_RATIO = 10.0
-BASE_PORT = 8011  # Base port for all tests
+BASE_PORT = 9100  # Base port for all tests (high port to avoid conflicts)
 NUM_REQUESTS = 100
 BLOCK_SIZE = 16
 
@@ -210,7 +210,7 @@ def test_mocker_kv_router(request, runtime_services_session, predownload_tokeniz
         # Get unique port for this test
         frontend_port = get_unique_ports(request, num_ports=1)[0]
 
-        # Run basic router test (starts router internally, mocker workers don't need frontend readiness check)
+        # Run basic router test (starts router internally and waits for workers to be ready)
         _test_router_basic(
             engine_workers=mockers,
             block_size=BLOCK_SIZE,
@@ -218,7 +218,6 @@ def test_mocker_kv_router(request, runtime_services_session, predownload_tokeniz
             frontend_port=frontend_port,
             test_payload=TEST_PAYLOAD,
             num_requests=NUM_REQUESTS,
-            wait_for_frontend=False,  # Mocker workers are fast, no need to wait
         )
 
     finally:

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -29,12 +29,48 @@ logger = logging.getLogger(__name__)
 MODEL_NAME = ROUTER_MODEL_NAME
 NUM_MOCKERS = 2
 SPEEDUP_RATIO = 10.0
-PORTS = [
-    8011,
-    8022,
-]  # Frontend ports: use PORTS[0] for single router, PORTS for multi-router
+BASE_PORT = 8011  # Base port for all tests
 NUM_REQUESTS = 100
 BLOCK_SIZE = 16
+
+
+def get_unique_ports(
+    request, num_ports: int = 1, store_backend: str = "etcd"
+) -> list[int]:
+    """Generate unique ports for parallel test execution.
+
+    Ports are unique based on:
+    - Test function name (each test gets a base offset)
+    - Parametrization value (etcd=0, file=50)
+    - Port index (for multi-port tests)
+
+    Args:
+        request: Pytest request fixture
+        num_ports: Number of ports needed (1 for single router, 2 for two routers)
+        store_backend: Storage backend parameter ("etcd" or "file")
+
+    Returns:
+        List of unique port numbers
+    """
+    # Get test name without parametrization suffix
+    test_name = request.node.name.split("[")[0]
+
+    # Base offsets per test function (ensures each test gets unique range)
+    test_offsets = {
+        "test_mocker_kv_router": 0,
+        "test_mocker_two_kv_router": 100,
+        "test_mocker_kv_router_overload_503": 200,
+        "test_query_instance_id_returns_worker_and_tokens": 300,
+    }
+
+    base_offset = test_offsets.get(test_name, 0)
+
+    # Parametrization offset (etcd=0, file=50)
+    param_offset = 0 if store_backend == "etcd" else 50
+
+    # Generate ports
+    ports = [BASE_PORT + base_offset + param_offset + i for i in range(num_ports)]
+    return ports
 
 
 # Shared test payload for all tests
@@ -148,8 +184,9 @@ class MockerProcess:
 
 
 @pytest.mark.pre_merge
+@pytest.mark.parallel
 @pytest.mark.model(MODEL_NAME)
-def test_mocker_kv_router(request, runtime_services, predownload_tokenizers):
+def test_mocker_kv_router(request, runtime_services_session, predownload_tokenizers):
     """
     Test KV router with multiple mocker engine instances.
     This test doesn't require GPUs and runs quickly for pre-merge validation.
@@ -170,12 +207,15 @@ def test_mocker_kv_router(request, runtime_services, predownload_tokenizers):
         logger.info(f"All mockers using endpoint: {mockers.endpoint}")
         mockers.__enter__()
 
+        # Get unique port for this test
+        frontend_port = get_unique_ports(request, num_ports=1)[0]
+
         # Run basic router test (starts router internally, mocker workers don't need frontend readiness check)
         _test_router_basic(
             engine_workers=mockers,
             block_size=BLOCK_SIZE,
             request=request,
-            frontend_port=PORTS[0],
+            frontend_port=frontend_port,
             test_payload=TEST_PAYLOAD,
             num_requests=NUM_REQUESTS,
             wait_for_frontend=False,  # Mocker workers are fast, no need to wait
@@ -187,11 +227,12 @@ def test_mocker_kv_router(request, runtime_services, predownload_tokenizers):
 
 
 @pytest.mark.pre_merge
+@pytest.mark.parallel
 @pytest.mark.model(MODEL_NAME)
 @pytest.mark.parametrize("store_backend", ["etcd", "file"])
 def test_mocker_two_kv_router(
     request,
-    runtime_services,
+    runtime_services_session,
     predownload_tokenizers,
     file_storage_backend,
     store_backend,
@@ -222,12 +263,17 @@ def test_mocker_two_kv_router(
         logger.info(f"All mockers using endpoint: {mockers.endpoint}")
         mockers.__enter__()
 
+        # Get unique ports for this test (2 ports for two routers)
+        router_ports = get_unique_ports(
+            request, num_ports=2, store_backend=store_backend
+        )
+
         # Run two-router test (starts KV routers internally and manages their lifecycle)
         _test_router_two_routers(
             engine_workers=mockers,
             block_size=BLOCK_SIZE,
             request=request,
-            router_ports=PORTS,
+            router_ports=router_ports,
             test_payload=TEST_PAYLOAD,
             num_requests=NUM_REQUESTS,
             store_backend=store_backend,
@@ -239,10 +285,11 @@ def test_mocker_two_kv_router(
 
 
 @pytest.mark.pre_merge
+@pytest.mark.parallel
 @pytest.mark.model(MODEL_NAME)
 @pytest.mark.skip(reason="Flaky, temporarily disabled")
 def test_mocker_kv_router_overload_503(
-    request, runtime_services, predownload_tokenizers
+    request, runtime_services_session, predownload_tokenizers
 ):
     """Test that KV router returns 503 when mocker workers are overloaded."""
     logger.info("Starting mocker KV router overload test for 503 status")
@@ -260,8 +307,10 @@ def test_mocker_kv_router_overload_503(
         logger.info(f"Mocker using endpoint: {mockers.endpoint}")
         mockers.__enter__()
 
+        # Get unique port for this test
+        frontend_port = get_unique_ports(request, num_ports=1)[0]
+
         # Run overload 503 test
-        frontend_port = PORTS[0] + 10  # Use different port to avoid conflicts
         _test_router_overload_503(
             engine_workers=mockers,
             block_size=4,  # Match the mocker's block size
@@ -277,8 +326,11 @@ def test_mocker_kv_router_overload_503(
 
 
 @pytest.mark.pre_merge
+@pytest.mark.parallel
 @pytest.mark.model(MODEL_NAME)
-def test_kv_push_router_bindings(request, runtime_services, predownload_tokenizers):
+def test_kv_push_router_bindings(
+    request, runtime_services_session, predownload_tokenizers
+):
     """Test KvPushRouter Python bindings with mocker engines."""
     logger.info("Starting KvPushRouter bindings test")
     mocker_args = {"speedup_ratio": SPEEDUP_RATIO, "block_size": BLOCK_SIZE}
@@ -313,11 +365,12 @@ def test_kv_push_router_bindings(request, runtime_services, predownload_tokenize
 
 
 @pytest.mark.pre_merge
+@pytest.mark.parallel
 @pytest.mark.model(MODEL_NAME)
 @pytest.mark.parametrize("store_backend", ["etcd", "file"])
 def test_indexers_sync(
     request,
-    runtime_services,
+    runtime_services_session,
     predownload_tokenizers,
     file_storage_backend,
     store_backend,
@@ -364,9 +417,10 @@ def test_indexers_sync(
 
 
 @pytest.mark.pre_merge
+@pytest.mark.parallel
 @pytest.mark.model(MODEL_NAME)
 def test_query_instance_id_returns_worker_and_tokens(
-    request, runtime_services, predownload_tokenizers
+    request, runtime_services_session, predownload_tokenizers
 ):
     """Test query_instance_id annotation with mocker engines."""
     logger.info("Starting KV router query_instance_id annotation test")
@@ -382,8 +436,10 @@ def test_query_instance_id_returns_worker_and_tokens(
         logger.info(f"All mockers using endpoint: {mockers.endpoint}")
         mockers.__enter__()
 
+        # Get unique port for this test
+        frontend_port = get_unique_ports(request, num_ports=1)[0]
+
         # Run query_instance_id annotation test
-        frontend_port = PORTS[0] + 30  # Use unique port to avoid conflicts
         _test_router_query_instance_id(
             engine_workers=mockers,
             block_size=BLOCK_SIZE,
@@ -398,8 +454,9 @@ def test_query_instance_id_returns_worker_and_tokens(
 
 
 @pytest.mark.pre_merge
+@pytest.mark.parallel
 @pytest.mark.model(MODEL_NAME)
-def test_router_decisions(request, runtime_services, predownload_tokenizers):
+def test_router_decisions(request, runtime_services_session, predownload_tokenizers):
     """Validate KV cache prefix reuse and dp_rank routing by sending progressive requests with overlapping prefixes."""
 
     # runtime_services starts etcd and nats

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -302,7 +302,7 @@ def test_vllm_kv_router_basic(request, runtime_services, predownload_tokenizers)
         logger.info(f"All vLLM workers using namespace: {vllm_workers.namespace}")
         vllm_workers.__enter__()
 
-        # Run basic router test (starts router internally, vLLM workers need frontend readiness check)
+        # Run basic router test (starts router internally and waits for workers to be ready)
         _test_router_basic(
             engine_workers=vllm_workers,
             block_size=BLOCK_SIZE,
@@ -310,7 +310,6 @@ def test_vllm_kv_router_basic(request, runtime_services, predownload_tokenizers)
             frontend_port=PORTS[0],
             test_payload=TEST_PAYLOAD,
             num_requests=NUM_REQUESTS,
-            wait_for_frontend=True,  # vLLM workers need time to load models
             frontend_timeout=180,  # 3 minutes should be plenty for TinyLlama
             store_backend="etcd",  # Explicit for clarity
         )


### PR DESCRIPTION
#### Overview:

.. with `pytest-xdist`

1. Enable nats and etcd servers to be multiproc-scoped for the parallel tests, via a filelock ref counter
2. Ensured ports and namespaces do not conflict
3. Updated CI to run the mocker tests (and only the mocker tests for now) in parallel with `-n 4`

If CI passes, it should be good


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled parallel test execution to accelerate test suite performance.

* **Chores**
  * Added pytest-xdist dependency for parallel test support.
  * Implemented shared test service management to support concurrent test workers.
  * Introduced dynamic test port allocation to prevent port conflicts during parallel execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->