### PR TITLE
fix: [k8s service discovery] only replace service account when one isn't set

### DIFF
--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -896,7 +896,9 @@ func GenerateBasePodSpec(
 	}
 
 	if controllerConfig.IsK8sDiscoveryEnabled(component.Annotations) {
-		podSpec.ServiceAccountName = discovery.GetK8sDiscoveryServiceAccountName(parentGraphDeploymentName)
+		if podSpec.ServiceAccountName == "" {
+			podSpec.ServiceAccountName = discovery.GetK8sDiscoveryServiceAccountName(parentGraphDeploymentName)
+		}
 	}
 
 	podSpec.Containers = append(podSpec.Containers, container)


### PR DESCRIPTION
#### Overview:

Fix for namespace-scoped operators using k8s service discovery and DGDRs: only use k8s-service-discovery service account if no specific service account is already set

#### Details:

This prevents component-specific service accounts (like planner-serviceaccount), which have their own RBAC with specific permissions, from being overridden

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Kubernetes service account configuration was unintentionally overwritten during deployment. The system now respects existing service account settings while enabling discovery functionality when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->