### PR TITLE
ci: OPS-2135: Push dynamo base image on main merges

### DIFF
--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -132,6 +132,8 @@ jobs:
           - { arch: arm64, runner: cpu-arm-r8g-4xlarge }
     name: vllm (${{ matrix.platform.arch }})
     runs-on: ${{ matrix.platform.runner }}
+    env:
+      DYNAMO_BASE_IMAGE: dynamo-base:latest
     steps:
       - name: Output Node Name
         shell: bash
@@ -157,7 +159,7 @@ jobs:
           aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - name: Docker Tag and Push
+      - name: Push framework runtime image
         uses: ./.github/actions/docker-tag-push
         with:
           local_image: ${{ steps.build-image.outputs.image_tag }}
@@ -165,6 +167,19 @@ jobs:
           # OPS-1145: Switch aws_push to true
           aws_push: 'false'
           azure_push: 'true'
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+      - name: Push dynamo base image
+        uses: ./.github/actions/docker-tag-push
+        # if: ${{ github.ref_name == 'main' }}
+        with:
+          local_image: ${{ env.DYNAMO_BASE_IMAGE }}
+          push_tag: ai-dynamo/dynamo:${{ github.ref_name }}-dynamo-${{ matrix.platform.arch }}
+          aws_push: 'true'
+          azure_push: 'false'
           aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
@@ -224,7 +239,7 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Docker Tag and Push
+      - name: Push framework runtime image
         uses: ./.github/actions/docker-tag-push
         with:
           local_image: ${{ steps.build-image.outputs.image_tag }}
@@ -291,7 +306,7 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Docker Tag and Push
+      - name: Push framework runtime image
         uses: ./.github/actions/docker-tag-push
         with:
           local_image: ${{ steps.build-image.outputs.image_tag }}

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -174,10 +174,10 @@ jobs:
           azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
       - name: Push dynamo base image
         uses: ./.github/actions/docker-tag-push
-        # if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         with:
           local_image: ${{ env.DYNAMO_BASE_IMAGE }}
-          push_tag: ai-dynamo/dynamo:test-dynamo-${{ matrix.platform.arch }}
+          push_tag: ai-dynamo/dynamo:${{ github.ref_name }}-dynamo-${{ matrix.platform.arch }}
           aws_push: 'true'
           azure_push: 'false'
           aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -177,7 +177,7 @@ jobs:
         # if: ${{ github.ref_name == 'main' }}
         with:
           local_image: ${{ env.DYNAMO_BASE_IMAGE }}
-          push_tag: ai-dynamo/dynamo:${{ github.ref_name }}-dynamo-${{ matrix.platform.arch }}
+          push_tag: ai-dynamo/dynamo:test-dynamo-${{ matrix.platform.arch }}
           aws_push: 'true'
           azure_push: 'false'
           aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/container/build.sh
+++ b/container/build.sh
@@ -842,8 +842,8 @@ fi
 if [[ -z "${DEV_IMAGE_INPUT:-}" ]]; then
     # Follow 2-step build process for all frameworks
     if [[ $FRAMEWORK != "NONE" ]]; then
-        # Define base image tag before using it
-        DYNAMO_BASE_IMAGE="dynamo-base:${VERSION}"
+        # Define base image tag before using it, or use predefined image name
+        DYNAMO_BASE_IMAGE=${DYNAMO_BASE_IMAGE:-dynamo-base:$VERSION}
         # Start base image build
         echo "======================================"
         echo "Starting Build 1: Base Image"


### PR DESCRIPTION
#### Overview:

Pushes `dynamo-base` images to ECR on merges to main. We will be able to utilize these for docker caching in a future PR.

Example push: https://github.com/ai-dynamo/dynamo/actions/runs/19547412991/job/55976387455


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container validation workflow with improved image management configuration.
  * Updated build script to support environment variable overrides for base image configuration, enabling greater flexibility in deployment scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->