### PR TITLE
fix: set `SGLANG_BLOCK_NONZERO_RANK_CHILDREN` to be no-op 

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -102,8 +102,11 @@ async def init(runtime: DistributedRuntime, config: Config):
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
     # Prevent SGLang from blocking on non-leader nodes
+    # We can switch this to 0 and leverage our own metrics
+    # after https://github.com/sgl-project/sglang/pull/13686
+    # is merged in
     if server_args.node_rank >= 1:
-        os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "0"
+        os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "1"
 
     engine = sgl.Engine(server_args=server_args)
 

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -191,8 +191,11 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
     # Prevent SGLang from blocking on non-leader nodes
+    # We can switch this to 0 and leverage our own metrics
+    # after https://github.com/sgl-project/sglang/pull/13686
+    # is merged in
     if server_args.node_rank >= 1:
-        os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "0"
+        os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "1"
 
     engine = sgl.Engine(server_args=server_args)
 


### PR DESCRIPTION
Until https://github.com/sgl-project/sglang/pull/13686 goes in, we cannot leverage this env var and combine metrics. Its a bit of a funky race condition that was never caught cause most people don't leverage the engine api for multinode