### PR TITLE
feat: cached prompt tokens reporting in vLLM

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -242,10 +242,10 @@ class BaseWorkerHandler(ABC):
                     out = {"token_ids": output.token_ids[num_output_tokens_so_far:]}
                     if output.finish_reason:
                         out["finish_reason"] = output.finish_reason
-                        out["completion_usage"] = (
-                            BaseWorkerHandler._build_completion_usage(
-                                request_output=res
-                            )
+                        out[
+                            "completion_usage"
+                        ] = BaseWorkerHandler._build_completion_usage(
+                            request_output=res
                         )
                     if output.stop_reason:
                         out["stop_reason"] = output.stop_reason
@@ -398,9 +398,9 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                     # Build disaggregated_params with KV transfer params and router overlap
                     disaggregated_params = {}
                     if res.kv_transfer_params:
-                        disaggregated_params["kv_transfer_params"] = (
-                            res.kv_transfer_params
-                        )
+                        disaggregated_params[
+                            "kv_transfer_params"
+                        ] = res.kv_transfer_params
                     # Include router's overlap calculation for PrefillRouter
                     disaggregated_params["overlap_blocks"] = overlap_blocks
 

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -267,8 +267,9 @@ where
     };
 
     // Use the provided prefill chooser, or create a disabled one if not provided
-    let prefill_chooser =
-        prefill_chooser.unwrap_or_else(|| PrefillRouter::disabled(router_mode, enforce_disagg));
+    let block_size = card.kv_cache_block_size;
+    let prefill_chooser = prefill_chooser
+        .unwrap_or_else(|| PrefillRouter::disabled(router_mode, enforce_disagg, block_size));
     let prefill_op = prefill_chooser.into_operator();
 
     // Link with prefill chooser including backward edge for response flow

--- a/lib/llm/src/kv_router/prefill_router.rs
+++ b/lib/llm/src/kv_router/prefill_router.rs
@@ -258,7 +258,8 @@ impl PrefillRouter {
             .as_ref()
             .and_then(|params| params.get("overlap_blocks"))
             .and_then(|v| v.as_u64())
-            .unwrap_or(0) as u32;
+            .and_then(|v| u32::try_from(v).ok())
+            .unwrap_or(0);
 
         Ok((
             PrefillResult {
@@ -335,7 +336,7 @@ impl
                 let final_cached_tokens = if let Some(vllm_value) = vllm_cached_tokens {
                     vllm_value
                 } else {
-                    overlap_blocks * self.block_size
+                    overlap_blocks.saturating_mul(self.block_size)
                 };
 
                 prefill_result.prompt_tokens_details =


### PR DESCRIPTION
#### Overview:

This PR wires up accurate “cached_tokens” reporting from vLLM into Dynamo’s responses (`usage.prompt_tokens_details` fields). It's OpenAI compatible because it's also an option in OpenAI API spec.

#### Details:
**Added**:
- Expose router-estimated overlap blocks in vLLM response metadata via `disaggregated_params["overlap_blocks"]` in `components/src/dynamo/vllm/handlers.py`.
- Combine router overlap and vLLM-reported cached token stats into a unified `PromptTokensDetails.cached_tokens` in `lib/llm/src/kv_router/prefill_router.rs`.

**Changed**:
- `_build_completion_usage` now always emits `prompt_tokens_details.cached_tokens` when `num_cached_tokens` is non-negative (including `0`), instead of treating `0` as falsy and omitting the field. (`components/src/dynamo/vllm/handlers.py`)
- `generate` handler now constructs a single `disaggregated_params` dict carrying both `kv_transfer_params` and `overlap_blocks`, ensuring downstream consumers see both router overlap and KV transfer metadata. (`components/src/dynamo/vllm/handlers.py`)
- `PrefillRouter::disabled` now requires and stores `block_size`, wiring it from `card.kv_cache_block_size` in the engine input path so disabled routers still know the KV block size. (`lib/llm/src/entrypoint/input/common.rs`, `lib/llm/src/kv_router/prefill_router.rs`)
- `PrefillRouter::call_prefill` signature extended to accept `block_size` and return `overlap_blocks` alongside the existing result and worker id, allowing it to compute cached token counts consistently. (`lib/llm/src/kv_router/prefill_router.rs`)
- Prefill success path now prefers vLLM’s `prompt_tokens_details.cached_tokens` when available and falls back to `overlap_blocks * block_size`, then rewrites `PromptTokensDetails` to include a definitive `cached_tokens` while preserving any `audio_tokens`. (`lib/llm/src/kv_router/prefill_router.rs`)

**Breaking changes / Migrations**:
- Internal-only signature change for `PrefillRouter::disabled` and `PrefillRouter::call_prefill` (now requires `block_size` and returns `overlap_blocks`); all in-tree call sites are updated. External APIs and JSON schema remain backward compatible.

#### Where should the reviewer start?

1. lib/llm/src/kv_router/prefill_router.rs
This is where cached_tokens is computed, where overlap_blocks is introduced, and where the rewrite of PromptTokensDetails happens. Understanding this file explains why the handler changes are needed.

2. components/src/dynamo/vllm/handlers.py
Once the router logic is clear, the handler updates (surfacing overlap_blocks, merging disaggregated_params, and always emitting cached_tokens) make immediate sense.

3. lib/llm/src/entrypoint/input/common.rs
Very small but essential: this wires block_size into PrefillRouter::disabled, enabling the router to compute fallback cached-token counts.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to Dynamo Requirements doc from NAT team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token detail construction to properly handle zero and false-like values in usage reporting.
  * Improved accuracy of cached token calculations in usage metrics.

* **Improvements**
  * Enhanced KV cache block overlap tracking and propagation through request processing.
  * Updated token usage reporting to include computed cache overlap information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->