### PR TITLE
chore: split frontend + runtime launch message to accurately represent container purpose

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -421,7 +421,7 @@ RUN uv pip install \
     && UV_GIT_LFS=1 uv pip install --no-cache .
 
 # Setup launch banner in common directory accessible to all users
-RUN --mount=type=bind,source=./container/launch_message.txt,target=/opt/dynamo/launch_message.txt \
+RUN --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
     sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen
 
 # Setup environment for all users

--- a/container/Dockerfile.frontend
+++ b/container/Dockerfile.frontend
@@ -40,7 +40,7 @@ ENV DYNAMO_HOME=/opt/dynamo
 WORKDIR /
 COPY --chown=dynamo: --from=epp /epp /epp
 
-COPY --chown=dynamo: container/launch_message.txt /opt/dynamo/.launch_screen
+COPY --chown=dynamo: container/launch_message/frontend.txt /opt/dynamo/.launch_screen
 # Copy tests, benchmarks, deploy and components with correct ownership
 COPY --chown=dynamo: tests /workspace/tests
 COPY --chown=dynamo: examples /workspace/examples

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -362,10 +362,9 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
 
 ## Copy attribution files and launch banner with correct ownership
 COPY --chown=dynamo: ATTRIBUTION* LICENSE /workspace/
-COPY --chown=dynamo: container/launch_message.txt /workspace/launch_message.txt
 
 # Setup launch banner in common directory accessible to all users
-RUN --mount=type=bind,source=./container/launch_message.txt,target=/opt/dynamo/launch_message.txt \
+RUN --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
     sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen
 
 # Setup environment for all users

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -336,8 +336,8 @@ COPY --chown=dynamo: recipes/ /workspace/recipes/
 COPY --chown=dynamo: ATTRIBUTION* LICENSE /workspace/
 
 # Setup launch banner in common directory accessible to all users
-RUN --mount=type=bind,source=./container/launch_message.txt,target=/opt/dynamo/launch_message.txt \
-    sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen
+RUN --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
+    sed '/^#\s/d' /opt/dynamo/launch_message .txt > /opt/dynamo/.launch_screen
 
 # Setup environment for all users
 USER root

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -337,7 +337,7 @@ COPY --chown=dynamo: ATTRIBUTION* LICENSE /workspace/
 
 # Setup launch banner in common directory accessible to all users
 RUN --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
-    sed '/^#\s/d' /opt/dynamo/launch_message .txt > /opt/dynamo/.launch_screen
+    sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen
 
 # Setup environment for all users
 USER root

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -296,7 +296,7 @@ COPY --chown=dynamo: . /workspace/
 COPY --chown=dynamo: ATTRIBUTION* LICENSE /workspace/
 
 # Setup launch banner in common directory accessible to all users
-RUN --mount=type=bind,source=./container/launch_message.txt,target=/opt/dynamo/launch_message.txt \
+RUN --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
     sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen
 
 # Setup environment for all users

--- a/container/launch_message/frontend.txt
+++ b/container/launch_message/frontend.txt
@@ -50,7 +50,7 @@ The frontend container includes:
 - HTTP API service
 - Preprocessor
 - Router
-- Endpont Picker (EPP) for Gateway API Inference Extension
+- Endpoint Picker (EPP) for Gateway API Inference Extension
 
 Benefits:
 - Minimal dependencies for purely CPU-based processes

--- a/container/launch_message/frontend.txt
+++ b/container/launch_message/frontend.txt
@@ -1,14 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
                          @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
                          @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
                          @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/container/launch_message/frontend.txt
+++ b/container/launch_message/frontend.txt
@@ -51,7 +51,7 @@ Benefits:
 Quick Start:
 
 Start mocker with custom configuration:
-python -m dynamo.mocker \
+> python -m dynamo.mocker \
   --model-path TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
   --num-gpu-blocks-override 8192 \
   --block-size 16 \

--- a/container/launch_message/frontend.txt
+++ b/container/launch_message/frontend.txt
@@ -64,4 +64,3 @@ Start frontend server:
 > python -m dynamo.frontend --http-port 8000
 
 
-

--- a/container/launch_message/frontend.txt
+++ b/container/launch_message/frontend.txt
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+                         @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+                         @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+                         @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+                    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+               @@@@@@@@@@@@@@@     @@@@@@@@@@@@@@@@@@@@@@@@@
+            @@@@@@@@@@   @@@@@@@@@@    @@@@@@@@@@@@@@@@@@@@@
+         @@@@@@@@     @@@@@@@@@@@@@@@@   @@@@@@@@@@@@@@@@@@@
+       @@@@@@@    @@@@@@@@      @@@@@@@    @@@@@@@@@@@@@@@@@
+     @@@@@@@@   @@@@@@@  @@@@      @@@@@@    @@@@@@@@@@@@@@@
+     @@@@@@@   @@@@@@    @@@@@@   @@@@@@@   @@@@@@@@@@@@@@@@
+      @@@@@@@  @@@@@@    @@@@@@@@@@@@@@    @@@@@@@@@@@@@@@@@
+       @@@@@@   @@@@@@   @@@@@@@@@@@@    @@@@@@@@@@@@@@@@@@@
+        @@@@@@@  @@@@@@@ @@@@@@@@@@   @@@@@@@@@      @@@@@@@
+          @@@@@@   @@@@@@@@@@@@@    @@@@@@@@         @@@@@@@
+            @@@@@@    @@@@     @@@@@@@@@@          @@@@@@@@@
+              @@@@@@@    @@@@@@@@@@@@@        @@@@@@@@@@@@@@
+                @@@@@@@@@@@@@@@@@        @@@@@@@@@@@@@@@@@@@
+                    @@@@@@       @@@@@@@@@@@@@@@@@@@@@@@@@@@
+                         @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+                         @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+                         @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+ @@@@@@@@@     @@@@      @@@@ @@@@  @@@@@@@@       @@@@       @@@@@
+@@@@@@@@@@@@@  @@@@@    @@@@@ @@@@@ @@@@@@@@@@@@@  @@@@@     @@@@@@@
+@@@@@@@@@@@@@@ @@@@@@  @@@@@  @@@@@ @@@@@@@@@@@@@@ @@@@@    @@@@@@@@@
+@@@@@    @@@@@@@@@@@@  @@@@@  @@@@@ @@@@@    @@@@@ @@@@@   @@@@@ @@@@@
+@@@@@     @@@@@ @@@@@@@@@@@   @@@@@ @@@@@    @@@@@ @@@@@  @@@@@  @@@@@@
+@@@@@     @@@@@  @@@@@@@@@@   @@@@@ @@@@@   @@@@@@ @@@@@  @@@@@@@@@@@@@
+@@@@@     @@@@@  @@@@@@@@@    @@@@@ @@@@@@@@@@@@@@ @@@@@ @@@@@@@@@@@@@@@
+@@@@@     @@@@@   @@@@@@@     @@@@@ @@@@@@@@@@@@@  @@@@@@@@@@@     @@@@@@
+ @@@       @@@      @@@@       @@@   @@@@@@@        @@   @@@         @@@  ®
+
+Dynamo: A Datacenter Scale Distributed Inference Serving Framework
+
+This is a framework-less image designed to deploy and run CPU-bound Frontend
+components without requiring CUDA or backend engine dependencies (vllm/sglang).
+
+The frontend container includes:
+- HTTP API service
+- Preprocessor
+- Router
+- Endpont Picker (EPP) for Gateway API Inference Extension
+
+Benefits:
+- Minimal dependencies for purely CPU-based processes
+- Fast deployment for integration testing on GPU-constrained clusters
+- Can spin up frontend with mock workers for rapid testing
+
+Quick Start:
+
+Start mocker with custom configuration:
+python -m dynamo.mocker \
+  --model-path TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
+  --num-gpu-blocks-override 8192 \
+  --block-size 16 \
+  --speedup-ratio 10.0 \
+  --max-num-seqs 512 \
+  --num-workers 4 \
+  --enable-prefix-caching
+
+Start frontend server:
+> python -m dynamo.frontend --http-port 8000
+
+
+

--- a/container/launch_message/runtime.txt
+++ b/container/launch_message/runtime.txt
@@ -1,14 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
                           @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
                           @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
                           @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/container/launch_message/runtime.txt
+++ b/container/launch_message/runtime.txt
@@ -47,9 +47,8 @@ This is a minimum runtime container for interacting with Dynamo via our CLI
 tools.
 
 Try the following to begin interacting with a model:
-> dynamo --help
 > python -m dynamo.frontend [--http-port 8000]
-> python -m dynamo.vllm --model Qwen/Qwen2.5-3B-Instruct
+> python -m dynamo.{vllm,sglang,trtllm} --model Qwen/Qwen2.5-3B-Instruct
 
 To run more complete deployment examples, instances of etcd and nats need to be
 accessible within the container. This is generally done by connecting to


### PR DESCRIPTION
#### Overview:

Resolves (5680875)

Given that we are shipping a new frontend-only container, we need a new launch message to reflect the purpose/usage of the container when accessing via bash. This PR creates a new container/launch_message directory which contains different messages for the various containers that we support. For now, we've created 2 seperate launch messages, one named frontend.txt and one named runtime.txt. We can revisit this later and maintain one launch_message and override accordingly based on container purpose but that's a change for later.

#### Details:

- Add frontend.txt to reflect frontend container image purpose when accessed via bash
- Move launch_message.txt to runtime.txt to accurately reflect when it's used.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized container startup messages with type-specific configurations for frontend and runtime containers
  * Updated runtime backend documentation to support launching multiple backend options with a single command

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->