### PR TITLE
ci: Remove the gitlab pipeline runs on pre-merge and post-merge workflows

### DIFF
--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -40,85 +40,20 @@ jobs:
 
   trigger-ci:
     name: Trigger CI Pipeline
+    if: startsWith(github.ref_name, 'release/') && contains(github.ref_name, '.')
     environment: GITLAB
     needs: mirror_repo
     runs-on:
       group: gitlab_ci_runners
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Detect source code changes
-      id: src_changes
-      uses: dorny/paths-filter@v3
-      with:
-        filters: .github/filters.yaml
-    - name: Check if Validation Workflow has run
-      id: check_workflow
-      uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const eventName = context.eventName;
-          let commit_sha = context.sha;
-          const workflow_id = 'build-and-test.yml';
-          if (eventName === 'pull_request') {
-            commit_sha = context.payload.pull_request.head.sha;
-          }
-          const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: workflow_id,
-              head_sha: commit_sha,
-              event: eventName
-            });
-          const inProgressCount = runs.data.workflow_runs.filter(run => run.status === 'in_progress').length;
-          const queuedCount = runs.data.workflow_runs.filter(run => run.status === 'queued').length;
-          const skip_ci = inProgressCount > 0 || queuedCount > 0;
-          console.log(`Validation Workflow is running: ${skip_ci}`);
-          core.setOutput('skip_ci', skip_ci.toString());
     - name: Trigger Pipeline
       run: |
         #!/bin/bash -e
         declare -A ci_variables
 
-        ci_variables["ENABLE_BUILD"]="true"
-        ci_variables["ENABLE_PREMERGE"]="true"
-        ci_variables["ENABLE_E2E_TEST"]="true"
-
-        # Override to false if validation workflow is running
-        if [[ "${{ vars.ALLOW_GITLAB_TEST_SKIP }}" == "1" && "${{ steps.check_workflow.outputs.skip_ci }}" == "true" ]]; then
-          echo "Github Workflow has run and ENABLE_PREMERGE variable value is False"
-          ci_variables["ENABLE_PREMERGE"]="false"
-        fi
-
-        # Build space-separated FRAMEWORKS variable
-        frameworks=""
-        if [ "${{ steps.src_changes.outputs.vllm }}" == "true" ]; then
-          frameworks+="vllm "
-        fi
-
-        if [ "${{ steps.src_changes.outputs.trtllm }}" == "true" ]; then
-          frameworks+="trtllm "
-        fi
-
-        if [ "${{ steps.src_changes.outputs.sglang }}" == "true" ]; then
-          frameworks+="sglang "
-        fi
-
-        # Trim trailing space and set FRAMEWORKS variable if any frameworks detected
-        frameworks=$(echo "$frameworks" | xargs)
-        if [ -n "$frameworks" ]; then
-          ci_variables["FRAMEWORKS"]="$frameworks"
-        fi
-
-        # Set BUILD_ARCHS to empty string to build both amd64 and arm64
-        ci_variables["BUILD_ARCHS"]=""
-
-        # Set additional pipeline variables
-        ci_variables["ENABLE_PUBLISH_WHEELS"]="false"
-        ci_variables["ENABLE_JET_BENCHMARKS"]="false"
-        ci_variables["ENABLE_SECURITY_SCAN"]="false"
-        ci_variables["RELEASE_BUILD"]="false"
+        # Only set required variables for release builds
+        ci_variables["NIGHTLY_RUN"]="true"
+        ci_variables["RELEASE_BUILD"]="true"
 
         ci_args=()
         for key in "${!ci_variables[@]}"; do


### PR DESCRIPTION

#### Overview:

Remove the GitLab pipeline runs from the pre-merge and post-merge developer workflows. This update will also automate RC pipeline execution whenever changes are pushed to the release branch or when a new release branch is created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal CI/CD release workflow configuration to improve process efficiency and ensure releases are properly gated to designated release branches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->