### PR TITLE
chore: update model cache pvc name to match recipes (#4506)

### DIFF
--- a/recipes/deepseek-r1/model-cache/model-cache.yaml
+++ b/recipes/deepseek-r1/model-cache/model-cache.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: model-cache-pvc
+  name: model-cache
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
# Cherry-pick: chore: update model cache pvc name to match recipes

## Overview
Cherry-pick of PR #4506 to `release/0.7.0`. Updates the model cache PVC name in the DeepSeek-R1 recipe to be consistent with other recipes.

## Details
This change updates the PersistentVolumeClaim resource name from "model-cache-pvc" to "model-cache" in the DeepSeek-R1 model cache configuration to maintain consistency across all recipes.

**Original PR**: https://github.com/ai-dynamo/dynamo/pull/4506  
**Merge commit**: febdc998d

### Changes
- Updated `recipes/deepseek-r1/model-cache/model-cache.yaml` metadata.name field

## Where to start
- Review `recipes/deepseek-r1/model-cache/model-cache.yaml`

## Related Issues
Part of 0.7.0 release stabilization.

## Testing
- Configuration change only, no functional changes
- Follows established naming convention used in other recipes
