### PR TITLE
fix(dynamo-run): Run without etcd/nats, HTTP port to 8000

### DIFF
--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -31,7 +31,7 @@ pub struct Flags {
 
     /// HTTP port. `in=http` only
     /// If tls_cert_path and tls_key_path are provided, this will be TLS/HTTPS.
-    #[arg(long, default_value = "8080")]
+    #[arg(long, default_value = "8000")]
     pub http_port: u16,
 
     /// TLS certificate file

--- a/launch/dynamo-run/src/main.rs
+++ b/launch/dynamo-run/src/main.rs
@@ -127,17 +127,9 @@ async fn wrapper(runtime: dynamo_runtime::Runtime) -> anyhow::Result<()> {
             .chain(env::args().skip(non_flag_params)),
     )?;
 
-    if is_in_dynamic(&in_opt) && is_out_dynamic(&out_opt) {
+    if dynamo_run::is_in_dynamic(&in_opt) && dynamo_run::is_out_dynamic(&out_opt) {
         anyhow::bail!("Cannot use endpoint for both in and out");
     }
 
     dynamo_run::run(runtime, in_opt, out_opt, flags).await
-}
-
-fn is_in_dynamic(in_opt: &Input) -> bool {
-    matches!(in_opt, Input::Endpoint(_))
-}
-
-fn is_out_dynamic(out_opt: &Option<Output>) -> bool {
-    matches!(out_opt, Some(Output::Auto))
 }

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -447,6 +447,18 @@ impl DistributedConfig {
             request_plane,
         }
     }
+
+    /// A DistributedConfig that isn't distributed, for when the frontend and backend are in the
+    /// same process.
+    pub fn process_local() -> DistributedConfig {
+        DistributedConfig {
+            store_backend: KeyValueStoreSelect::Memory,
+            nats_config: None,
+            // This won't be used in process local, so we likely need a "none" option to
+            // communicate that and avoid opening the ports.
+            request_plane: RequestPlaneMode::Tcp,
+        }
+    }
 }
 
 /// Request plane transport mode configuration


### PR DESCRIPTION
`dynamo-run` in all-in-one-mode now works without etcd and nats again, as it did before the etcd/nats removal project.

all-in-one means not being a distributed system, the frontend and backend run in the same process:
```
dynamo-run in=http out=mistralrs ...
```

Also change the HTTP port to 8000 to match Python frontend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `dynamo-run` default HTTP port from 8080 to 8000.
  * Refactored internal helper functions and configuration handling for improved code organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->