### PR TITLE
fix: Increase the failure threshold for k8s dsr1 trtllm wideep deploy.yaml

### DIFF
--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
@@ -172,7 +172,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 500
+            failureThreshold: 600
           volumeMounts:
             - name: prefill-config-volume
               mountPath: /config
@@ -230,7 +230,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 500
+            failureThreshold: 600
           volumeMounts:
             - name: decode-config-volume
               mountPath: /config


### PR DESCRIPTION
#### Overview:

QA found that 500 might not be sufficient iterations. They suggest adding 100 more iterations for better stability and model loading. 

Check https://nvbugspro.nvidia.com/bug/5685145 for more details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration parameters to optimize system startup and reliability handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->