### PR TITLE
ci: Pin transformers version to <= 4.57.1

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pydantic>=2",
     "tabulate",
     "types-tabulate",
-    "transformers==4.57.1",
+    "transformers<=4.57.1",
     "pytest-mypy",
 ]
 

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pydantic>=2",
     "tabulate",
     "types-tabulate",
-    "transformers",
+    "transformers==4.57.1",
     "pytest-mypy",
 ]
 

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -36,7 +36,7 @@ scipy<1.14.0  # Pin scipy version for pmdarima compatibility
 sentencepiece
 tensorboard==2.19.0
 tensorboardX==2.6.2.2
-transformers==4.57.1
+transformers<=4.57.1
 types-aiofiles
 types-PyYAML
 uvicorn

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -36,7 +36,7 @@ scipy<1.14.0  # Pin scipy version for pmdarima compatibility
 sentencepiece
 tensorboard==2.19.0
 tensorboardX==2.6.2.2
-transformers
+transformers==4.57.1
 types-aiofiles
 types-PyYAML
 uvicorn


### PR DESCRIPTION
#### Overview:

Pin the version of transformer's lib to `transformers<=4.57.1`. 

With `transformers==4.57.2`, we were observing the following failures [[Job Link](https://github.com/ai-dynamo/dynamo/actions/runs/19645820152/job/56268386355?pr=3988)]:
```bash
[BASH] Traceback (most recent call last):
[BASH]   File "<frozen runpy>", line 198, in _run_module_as_main
[BASH]   File "<frozen runpy>", line 88, in _run_code
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/dynamo/vllm/__main__.py", line 7, in <module>
[BASH]     main()
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/dynamo/vllm/main.py", line 736, in main
[BASH]     uvloop.run(worker())
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/uvloop/__init__.py", line 109, in run
[BASH]     return __asyncio.run(
[BASH]            ^^^^^^^^^^^^^^
[BASH]   File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
[BASH]     return runner.run(main)
[BASH]            ^^^^^^^^^^^^^^^^
[BASH]   File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
[BASH]     return self._loop.run_until_complete(task)
[BASH]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[BASH]   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/uvloop/__init__.py", line 61, in wrapper
[BASH]     return await main
[BASH]            ^^^^^^^^^^
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/dynamo/vllm/main.py", line 102, in worker
[BASH]     await init(runtime, config)
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/dynamo/vllm/main.py", line 438, in init
[BASH]     ) = setup_vllm_engine(config, factory)
[BASH]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/dynamo/vllm/main.py", line 231, in setup_vllm_engine
[BASH]     engine_client = AsyncLLM.from_vllm_config(
[BASH]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/utils/__init__.py", line 1572, in inner
[BASH]     return fn(*args, **kwargs)
[BASH]            ^^^^^^^^^^^^^^^^^^^
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 207, in from_vllm_config
[BASH]     return cls(
[BASH]            ^^^^
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 114, in __init__
[BASH]     self.tokenizer = init_tokenizer_from_configs(
[BASH]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/transformers_utils/tokenizer.py", line 286, in init_tokenizer_from_configs
[BASH]     return get_tokenizer(
[BASH]            ^^^^^^^^^^^^^^
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/transformers_utils/tokenizer.py", line 217, in get_tokenizer
[BASH]     tokenizer = AutoTokenizer.from_pretrained(
[BASH]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/transformers/models/auto/tokenization_auto.py", line 1156, in from_pretrained
[BASH]     return tokenizer_class.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
[BASH]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/transformers/tokenization_utils_base.py", line 2112, in from_pretrained
[BASH]     return cls._from_pretrained(
[BASH]            ^^^^^^^^^^^^^^^^^^^^^
[BASH]   File "/opt/dynamo/venv/lib/python3.12/site-packages/transformers/tokenization_utils_base.py", line 2419, in _from_pretrained
[BASH]     if _is_local and _config.model_type not in [
[BASH]                      ^^^^^^^^^^^^^^^^^^
[BASH] AttributeError: 'dict' object has no attribute 'model_type'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned transformers dependency to version 4.57.1 to ensure consistent builds and deployments across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->