### PR TITLE
fix: Increase the failure threshold for k8s dsr1 trtllm wideep deploy…

### DIFF
--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
@@ -172,7 +172,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 500
+            failureThreshold: 600
           volumeMounts:
             - name: prefill-config-volume
               mountPath: /config
@@ -230,7 +230,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: 500
+            failureThreshold: 600
           volumeMounts:
             - name: decode-config-volume
               mountPath: /config


### PR DESCRIPTION
# Cherry-pick: Increase failure threshold for k8s dsr1 trtllm wideep deploy.yaml

## Overview
Cherry-pick of PR #4557 to `release/0.7.0`.

**Original PR:** https://github.com/ai-dynamo/dynamo/pull/4557  
**Related Bug:** https://nvbugspro.nvidia.com/bug/5685145

## Changes
- Increased `failureThreshold` from 500 to 600 in startup probes for both prefill and decode containers
- File: `recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml`

## Reason for Cherry-pick
QA testing found that 500 iterations were insufficient for model loading and stability. The additional 100 iterations provide better reliability for startup health checks in the DSR1 TRT-LLM wide-EP deployment configuration.

## Testing
- Original PR was tested and merged to main on Nov 25, 2025
- CI checks passed on main branch

## Checklist
- [x] Cherry-picked from main (commit: d6aa4a0)
- [x] DCO sign-off applied
- [ ] Update Cherry Pick table in release canvas
- [ ] Notify Release PiC in #swdl-dynamo-release
