### PR TITLE
chore(container): clean up Dockerfile.{sglang,trtllm,vllm} and build.sh

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -6,16 +6,14 @@
 ########## Build Arguments ########
 ##################################
 
-# Base image configuration
-ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
-# TODO OPS-612: NCCL will hang with 25.03, so use 25.01 for now
-# Please check https://github.com/ai-dynamo/dynamo/pull/1065
-# for details and reproducer to manually test if the image
-# can be updated to later versions.
-ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
+# This section contains build arguments that are common and shared across various
+# Dockerfile.<frameworks>, so they should NOT have a default. The source of truth is from build.sh.
 
-# Build configuration
-ARG ENABLE_KVBM=false
+ARG BASE_IMAGE
+ARG BASE_IMAGE_TAG
+
+ARG PYTHON_VERSION
+ARG ENABLE_KVBM
 ARG CARGO_BUILD_JOBS
 
 # Define general architecture ARGs for supporting both x86 and aarch64 builds.
@@ -40,9 +38,6 @@ ARG SCCACHE_REGION=""
 ARG NIXL_UCX_REF=v1.19.0
 ARG NIXL_REF=0.7.1
 ARG NIXL_GDRCOPY_REF=v2.5.1
-
-# Python configuration
-ARG PYTHON_VERSION=3.12
 
 ##################################
 ########## Base Image ############

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -6,7 +6,8 @@ ARG CUDA_VERSION=12.9.1
 
 # Runtime image and build-time configuration (aligned with other backends)
 # TODO: OPS-<number>: Use the same runtime image as the other backends
-ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
+# See build.sh's SGLANG_BASE_IMAGE and SGLANG_BASE_IMAGE_TAG for the actual values.
+#ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"  # This is not used for now because we use "FROM framework"
 ARG RUNTIME_IMAGE_TAG="12.9.1-cudnn-runtime-ubuntu24.04"
 
 ARG PYTHON_VERSION=3.10

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -2,13 +2,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CUDA_VERSION=12.9.1
+# This section contains build arguments that are common and shared with
+# the plain Dockerfile, so they should NOT have a default. The source of truth is from build.sh.
 
-# Unlike vllm and trtllm, SGLang is using hardcoded runtime image and tag (see the "AS framework" target)
-#ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"  # This is not used for now because we use "FROM framework"
-#ARG RUNTIME_IMAGE_TAG="12.9.1-cudnn-runtime-ubuntu24.04"
+ARG BASE_IMAGE
+ARG BASE_IMAGE_TAG
 
-ARG PYTHON_VERSION=3.10
+ARG FRAMEWORK_IMAGE
+ARG FRAMEWORK_IMAGE_TAG
+ARG PYTHON_VERSION
+ARG CUDA_VERSION
+
 ARG ARCH=amd64
 ARG ARCH_ALT=x86_64
 ARG CARGO_BUILD_JOBS
@@ -38,7 +42,8 @@ FROM ${DYNAMO_BASE_IMAGE} AS dynamo_base
 # - Develop or debug framework-level components
 # - Create custom builds with specific optimization flags
 #
-FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu24.04 AS framework
+#FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu24.04 AS framework
+FROM ${FRAMEWORK_IMAGE}:${FRAMEWORK_IMAGE_TAG} AS framework
 
 # Declare all ARGs
 ARG BUILD_TYPE=all

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -4,11 +4,9 @@
 
 ARG CUDA_VERSION=12.9.1
 
-# Runtime image and build-time configuration (aligned with other backends)
-# TODO: OPS-<number>: Use the same runtime image as the other backends
-# See build.sh's SGLANG_BASE_IMAGE and SGLANG_BASE_IMAGE_TAG for the actual values.
+# Unlike vllm and trtllm, SGLang is using hardcoded runtime image and tag (see the "AS framework" target)
 #ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"  # This is not used for now because we use "FROM framework"
-ARG RUNTIME_IMAGE_TAG="12.9.1-cudnn-runtime-ubuntu24.04"
+#ARG RUNTIME_IMAGE_TAG="12.9.1-cudnn-runtime-ubuntu24.04"
 
 ARG PYTHON_VERSION=3.10
 ARG ARCH=amd64

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -1,14 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# See build.sh's TRTLLM_BASE_IMAGE and TRTLLM_BASE_IMAGE_TAG for the actual values.
+# This section contains build arguments that are common and shared with
+# the plain Dockerfile, so they should NOT have a default. The source of truth is from build.sh.
 ARG BASE_IMAGE
 ARG BASE_IMAGE_TAG
 
+ARG PYTHON_VERSION
+ARG ENABLE_KVBM
+
 ARG PYTORCH_BASE_IMAGE="nvcr.io/nvidia/pytorch"
 ARG PYTORCH_BASE_IMAGE_TAG="25.10-py3"
-# See build.sh's ENABLE_KVBM for the actual value.
-ARG ENABLE_KVBM
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 ARG RUNTIME_IMAGE_TAG="25.10-cuda13.0-runtime-ubuntu24.04"
 
@@ -32,8 +34,6 @@ ARG GITHUB_TRTLLM_COMMIT
 # without adding if statements everywhere, so just define both as ARGs for now.
 ARG ARCH=amd64
 ARG ARCH_ALT=x86_64
-# Python configuration
-ARG PYTHON_VERSION=3.12
 
 ARG DYNAMO_BASE_IMAGE="dynamo:latest-none"
 FROM ${DYNAMO_BASE_IMAGE} AS dynamo_base

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
-ARG BASE_IMAGE_TAG="25.10-cuda13.0-devel-ubuntu24.04"
+# See build.sh's TRTLLM_BASE_IMAGE and TRTLLM_BASE_IMAGE_TAG for the actual values.
+ARG BASE_IMAGE
+ARG BASE_IMAGE_TAG
 
 ARG PYTORCH_BASE_IMAGE="nvcr.io/nvidia/pytorch"
 ARG PYTORCH_BASE_IMAGE_TAG="25.10-py3"
-ARG ENABLE_KVBM=false
+# See build.sh's ENABLE_KVBM for the actual value.
+ARG ENABLE_KVBM
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 ARG RUNTIME_IMAGE_TAG="25.10-cuda13.0-runtime-ubuntu24.04"
 

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -2,13 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
-# TODO OPS-612: NCCL will hang with 25.03, so use 25.01 for now
-# Please check https://github.com/ai-dynamo/dynamo/pull/1065
-# for details and reproducer to manually test if the image
-# can be updated to later versions.
-ARG BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
-ARG ENABLE_KVBM=false
+# See build.sh's VLLM_BASE_IMAGE and VLLM_BASE_IMAGE_TAG for the actual values.
+ARG BASE_IMAGE
+ARG BASE_IMAGE_TAG
+# See build.sh's ENABLE_KVBM for the actual value.
+ARG ENABLE_KVBM
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
 ARG CUDA_VERSION="12.8"

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -2,11 +2,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# See build.sh's VLLM_BASE_IMAGE and VLLM_BASE_IMAGE_TAG for the actual values.
+# This section contains build arguments that are common and shared with
+# the plain Dockerfile, so they should NOT have a default. The source of truth is from build.sh.
 ARG BASE_IMAGE
 ARG BASE_IMAGE_TAG
-# See build.sh's ENABLE_KVBM for the actual value.
+
+ARG PYTHON_VERSION
 ARG ENABLE_KVBM
+
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
 ARG RUNTIME_IMAGE_TAG="12.8.1-runtime-ubuntu24.04"
 ARG CUDA_VERSION="12.8"
@@ -39,8 +42,6 @@ ARG SCCACHE_REGION=""
 # without adding if statements everywhere, so just define both as ARGs for now.
 ARG ARCH=amd64
 ARG ARCH_ALT=x86_64
-# Python configuration
-ARG PYTHON_VERSION=3.12
 
 ARG DYNAMO_BASE_IMAGE="dynamo:latest-none"
 FROM ${DYNAMO_BASE_IMAGE} AS dynamo_base

--- a/container/build.sh
+++ b/container/build.sh
@@ -111,8 +111,9 @@ VLLM_BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 NONE_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 NONE_BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 
-SGLANG_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
-SGLANG_BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
+# For now, SGLang is using hardcoded framework image and tag (see the Dockerfile.sglang)
+#SGLANG_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
+#SGLANG_BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
 
 NIXL_REF=0.7.1
 NIXL_UCX_REF=v1.19.0


### PR DESCRIPTION
#### Overview:

Update container build artifacts for sglang, vLLM, and TRT-LLM; small fixes, consistency, and environment handling across Dockerfiles and build.sh. Add --no-tag-latest for CI and testing environments; latest should not be clobbered all the time.

#### Details:

1) Add a -no-latest-tag to build.sh, so the user will not clobber existing latest tag
2) Remove overridden variables in Dockerfile.*
3) Ensure the dynamo-base images are tagged with frameworks, because every dynamo-base has a different dependency (e.g. python3.10 vs python3.12, etc)

#### Where should the reviewer start?
- container/build.sh (review comments and small flow tweaks)
- container/Dockerfile.vllm
- container/Dockerfile.trtllm
- container/Dockerfile.sglang

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)
Relates to OPS-2191

/coderabbit profile chill