### PR TITLE
refactor: New config types for tool calls

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -895,14 +895,14 @@ impl JailedStreamBuilder {
             if let Some(config) = parser_map.get(parser_name.as_str()) {
                 // Auto-populate start sequences if none configured
                 if self.jail_start_sequences.is_empty() {
-                    self.jail_start_sequences = config.json.tool_call_start_tokens.clone();
+                    self.jail_start_sequences = config.parser_config.tool_call_start_tokens();
                 }
 
                 // Auto-populate end sequences if none configured
                 if self.jail_end_sequences.is_empty() {
                     self.jail_end_sequences = config
-                        .json
-                        .tool_call_end_tokens
+                        .parser_config
+                        .tool_call_end_tokens()
                         .iter()
                         .filter(|&s| !s.is_empty())
                         .cloned()
@@ -922,7 +922,7 @@ impl JailedStreamBuilder {
             let parser_map = get_tool_parser_map();
             if let Some(config) = parser_map.get(parser_name.as_str()) {
                 // Add start tokens from the parser config
-                all_patterns.extend(config.json.tool_call_start_tokens.clone());
+                all_patterns.extend(config.parser_config.tool_call_start_tokens());
             }
         }
 

--- a/lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
@@ -271,7 +271,10 @@ mod tests {
     #[test]
     fn test_parse_tool_calls_deepseek_v3_1_basic() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Paris"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
         assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 2);
@@ -286,7 +289,10 @@ mod tests {
     #[test]
     fn test_parse_tool_calls_deepseek_v3_1_with_normal_text() {
         let text = r#"The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "New York"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
         assert_eq!(
             content,
@@ -301,7 +307,10 @@ mod tests {
     #[test]
     fn test_parse_tool_calls_deepseek_v3_1_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>get_current_weather宽带}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
         assert_eq!(content, Some(text.to_string()));
         assert_eq!(result.len(), 0);
@@ -310,7 +319,10 @@ mod tests {
     #[test]
     fn test_parse_tool_calls_deepseek_v3_1_with_multi_tool_calls_with_multiple_args() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Berlin", "units": "metric"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather_forecast<｜tool▁sep｜>{"location": "Berlin", "days": 7, "units": "imperial"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_air_quality<｜tool▁sep｜>{"location": "Berlin", "radius": 50}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
         assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 3);
@@ -333,7 +345,10 @@ mod tests {
     fn test_parse_tool_calls_deepseek_v3_1_with_invalid_json() {
         // Everything is normal text in case of invalid json
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
         assert_eq!(content, Some(text.trim().to_string()));
         assert_eq!(result.len(), 0);
@@ -343,7 +358,10 @@ mod tests {
     fn test_parse_tool_calls_deepseek_v3_1_with_multi_tool_calls_with_normal_text() {
         // Everything is normal text in case of invalid json
         let text = r#"The following tool calls retrieve weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather宽带}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather_forecast宽带}{location": "Berlin", "days": 7, "units": "imperial"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_air_quality宽带}{location": "Berlin", "radius": 50}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
         assert_eq!(content, Some(text.trim().to_string()));
         assert_eq!(result.len(), 0);
@@ -364,7 +382,10 @@ mod tests {
   "Summarize the codebase purpose and functionality", "status": "pending", "activeForm":
   "Summarizing the codebase purpose and
   functionality"}]}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
 
         let (tool_call_results, normal_content) =
             parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
@@ -414,7 +435,10 @@ mod detect_parser_tests {
     #[test]
     fn test_detect_tool_call_start_deepseek_v3_1_chunk_with_tool_call_start_token() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather宽带}"#;
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let result = detect_tool_call_start_deepseek_v3_1(text, &config);
         assert!(result);
     }
@@ -422,7 +446,10 @@ mod detect_parser_tests {
     #[test]
     fn test_detect_tool_call_start_deepseek_v3_1_chunk_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>get_current_weather宽带}"#;
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let result = detect_tool_call_start_deepseek_v3_1(text, &config);
         assert!(!result);
     }
@@ -430,7 +457,10 @@ mod detect_parser_tests {
     #[test]
     fn test_detect_tool_call_start_deepseek_v3_1_chunk_with_tool_call_start_token_in_middle() {
         let text = r#"The following tool calls retrieve weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather宽带}"#;
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let result = detect_tool_call_start_deepseek_v3_1(text, &config);
         assert!(result);
     }
@@ -438,7 +468,10 @@ mod detect_parser_tests {
     #[test]
     fn test_detect_tool_call_start_deepseek_v3_1_partial_tokens() {
         // Test partial token detection for streaming scenarios with unicode characters
-        let config = ToolCallConfig::deepseek_v3_1().json;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
 
         // Test various partial prefixes
         assert!(

--- a/lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs
@@ -281,7 +281,10 @@ mod tests {
 ```json
 {"location": "Paris"}
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
         assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 2);
@@ -299,7 +302,10 @@ mod tests {
 ```json
 {"location": "New York"}
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
         assert_eq!(
             content,
@@ -317,7 +323,10 @@ mod tests {
 ```json
 }
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
         assert_eq!(content, Some(text.to_string()));
         assert_eq!(result.len(), 0);
@@ -335,7 +344,10 @@ mod tests {
 ```json
 {"location": "Shanghai", "radius": 50}
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
         assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 3);
@@ -361,7 +373,10 @@ mod tests {
 ```json
 }
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
         assert_eq!(content, Some(text.trim().to_string()));
         assert_eq!(result.len(), 0);
@@ -380,7 +395,10 @@ mod tests {
 ```json
 }
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
         assert_eq!(content, Some(text.trim().to_string()));
         assert_eq!(result.len(), 0);
@@ -404,7 +422,10 @@ mod tests {
   "Summarizing the codebase purpose and
   functionality"}]}
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
 
         let (tool_call_results, normal_content) =
             parse_tool_calls_deepseek_v3(text, &config).unwrap();
@@ -454,7 +475,10 @@ mod detect_parser_tests {
     #[test]
     fn test_detect_tool_call_start_deepseek_v3_chunk_with_tool_call_start_token() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function宽带}"#;
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let result = detect_tool_call_start_deepseek_v3(text, &config);
         assert!(result);
     }
@@ -462,7 +486,10 @@ mod detect_parser_tests {
     #[test]
     fn test_detect_tool_call_start_deepseek_v3_chunk_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>function宽带}"#;
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let result = detect_tool_call_start_deepseek_v3(text, &config);
         assert!(!result);
     }
@@ -470,7 +497,10 @@ mod detect_parser_tests {
     #[test]
     fn test_detect_tool_call_start_deepseek_v3_chunk_with_tool_call_start_token_in_middle() {
         let text = r#"The following tool calls retrieve weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function宽带}"#;
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
         let result = detect_tool_call_start_deepseek_v3(text, &config);
         assert!(result);
     }
@@ -478,7 +508,10 @@ mod detect_parser_tests {
     #[test]
     fn test_detect_tool_call_start_deepseek_v3_partial_tokens() {
         // Test partial token detection for streaming scenarios with unicode characters
-        let config = ToolCallConfig::deepseek_v3().json;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
 
         // Test various partial prefixes
         assert!(

--- a/lib/parsers/src/tool_calling/mod.rs
+++ b/lib/parsers/src/tool_calling/mod.rs
@@ -13,7 +13,7 @@ pub mod tools;
 pub mod xml;
 
 // Re-export main types and functions for convenience
-pub use config::{JsonParserConfig, ToolCallConfig, ToolCallParserType};
+pub use config::{JsonParserConfig, ParserConfig, ToolCallConfig, XmlParserConfig};
 pub use harmony::parse_tool_calls_harmony_complete;
 pub use json::try_tool_call_parse_json;
 pub use parsers::{


### PR DESCRIPTION
#### Overview:

This PR proposes a tool parser config refactor.

#### Details:

* Why?

We would like the ability to configure different parser types. Prior to this commit, only the JSON parser could be configured.

* What?

This commit refactors the tool parser config in the following ways:
- the `format` and `json` fields of `ToolParserConfig` are merged into a single `config` field that is a "discriminated union" type. Each parser type can declare its own configuration options.
- a `XmlParserConfig` is defined with a default factory method that corresponds to the Qwen3 coder configuration.
- affected calls and tests are adjusted.

#### Where should the reviewer start?

* The changes to `lib/parsers/src/tool_calling/config.rs`
* The modified and new unit tests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added extensive test coverage for tool-call parsing across multiple parser formats, including edge cases and recovery scenarios

* **Improvements**
  * Enhanced XML tool-call parsing with improved configuration flexibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->