### PR TITLE
docs: update TensorRT-LLM commit for NIXL to v1.2.0rc2

### DIFF
--- a/docs/backends/trtllm/kv-cache-transfer.md
+++ b/docs/backends/trtllm/kv-cache-transfer.md
@@ -47,7 +47,7 @@ To enable NIXL for KV cache transfer in disaggregated serving:
    ```bash
    ./container/build.sh --framework trtllm \
      --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git \
-     --tensorrtllm-commit main
+     --tensorrtllm-commit v1.2.0rc2
    ```
 
 2. **Run the containerized environment:**

--- a/docs/backends/trtllm/multimodal_epd.md
+++ b/docs/backends/trtllm/multimodal_epd.md
@@ -8,7 +8,7 @@ This is an experimental feature that requires using a specific TensorRT-LLM comm
 To enable it build the dynamo container with the `--tensorrtllm-commit` flag, followed by the commit hash:
 
 ```bash
-./container/build.sh --framework trtllm --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git --tensorrtllm-commit main
+./container/build.sh --framework trtllm --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git --tensorrtllm-commit v1.2.0rc2
 ```
 
 ## Key Features


### PR DESCRIPTION
# docs: update TensorRT-LLM commit to v1.2.0rc2

## Summary
Updates the TensorRT-LLM commit reference from `main` to `v1.2.0rc2` in the documentation for NIXL KV cache transfer and EPD (Encode-Prefill-Decode) flow features.

## Changes
- Updated `docs/backends/trtllm/kv-cache-transfer.md` to use `--tensorrtllm-commit v1.2.0rc2`
- Updated `docs/backends/trtllm/multimodal_epd.md` to use `--tensorrtllm-commit v1.2.0rc2`

## Motivation
These features require a specific TensorRT-LLM version. Using `main` can lead to compatibility issues as the TensorRT-LLM main branch evolves. Pinning to `v1.2.0rc2` ensures users build with the correct tested version.

## Testing
- [x] Documentation builds without warnings
- [x] No linter errors

## Checklist
- [x] Commit message follows conventional commit format (`docs:` prefix)
- [x] DCO sign-off included (`-s`)
- [x] Changes are documentation only
- [ ] GPG signing (note: GPG was not available during commit, can be amended if needed for automated tests)

## PR Link
Create PR from `dagil/fix-trtllm-commit-docs` → `main`
Branch pushed to: https://github.com/ai-dynamo/dynamo/pull/new/dagil/fix-trtllm-commit-docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TensorRT-LLM backend build instructions to reference a specific version (v1.2.0rc2) instead of the main branch for improved consistency and reproducibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->