### PR TITLE
docs: update TensorRT-LLM commit for NIXL to v1.2.0rc2 (#4582)

### DIFF
--- a/docs/backends/trtllm/kv-cache-transfer.md
+++ b/docs/backends/trtllm/kv-cache-transfer.md
@@ -47,7 +47,7 @@ To enable NIXL for KV cache transfer in disaggregated serving:
    ```bash
    ./container/build.sh --framework trtllm \
      --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git \
-     --tensorrtllm-commit main
+     --tensorrtllm-commit v1.2.0rc2
    ```
 
 2. **Run the containerized environment:**

--- a/docs/backends/trtllm/multimodal_epd.md
+++ b/docs/backends/trtllm/multimodal_epd.md
@@ -8,7 +8,7 @@ This is an experimental feature that requires using a specific TensorRT-LLM comm
 To enable it build the dynamo container with the `--tensorrtllm-commit` flag, followed by the commit hash:
 
 ```bash
-./container/build.sh --framework trtllm --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git --tensorrtllm-commit main
+./container/build.sh --framework trtllm --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git --tensorrtllm-commit v1.2.0rc2
 ```
 
 ## Key Features


### PR DESCRIPTION
# docs: update TensorRT-LLM commit for NIXL to v1.2.0rc2 (cherry-pick to release/0.7.0)

## Summary

Cherry-pick of PR #4582 from main to `release/0.7.0`.

Updates the TensorRT-LLM commit reference from `main` to `v1.2.0rc2` in the documentation for NIXL KV cache transfer and EPD (Encode-Prefill-Decode) flow features.

## Changes

* Updated `docs/backends/trtllm/kv-cache-transfer.md` to use `--tensorrtllm-commit v1.2.0rc2`
* Updated `docs/backends/trtllm/multimodal_epd.md` to use `--tensorrtllm-commit v1.2.0rc2`

## Motivation

These features require a specific TensorRT-LLM version. Using `main` can lead to compatibility issues as the TensorRT-LLM main branch evolves. Pinning to `v1.2.0rc2` ensures users build with the correct tested version for the 0.7.0 release.

## Original PR

* Main PR: https://github.com/ai-dynamo/dynamo/pull/4582
* Merge commit: 93c814208

## Testing

* Documentation builds without warnings
* No linter errors
* Changes are documentation only

## Checklist

* [x] Cherry-picked from main (PR #4582)
* [x] Commit includes DCO sign-off
* [x] Changes are documentation only
* [x] Branch pushed: `dagil/cherrypick-trtllm-docs-v1.2.0rc2`
* [ ] Cherry Pick table updated in #swdl-dynamo-release

---

**Cherry-Pick Info for Release Team:**
- **Type**: docs
- **Scope**: Small (2 files, 2 lines)
- **Risk**: Very low (documentation only)
- **Customer Impact**: Ensures users build with correct TensorRT-LLM version for 0.7.0
