### PR TITLE
docs: document uv install workaround for TRT-LLM 1.2.0rc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,27 +22,14 @@ limitations under the License.
 [![Discord](https://dcbadge.limes.pink/api/server/D92uqZRjCZ?style=flat)](https://discord.gg/D92uqZRjCZ)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ai-dynamo/dynamo)
 
-| **[Roadmap](https://github.com/ai-dynamo/dynamo/issues/2486)** | **[Support matrix](https://github.com/ai-dynamo/dynamo/blob/main/docs/reference/support-matrix.md)** | **[Docs](https://docs.nvidia.com/dynamo/latest/index.html)** | **[Recipes](https://github.com/ai-dynamo/dynamo/tree/main/recipes)** | **[Examples](https://github.com/ai-dynamo/dynamo/tree/main/examples)** | **[Prebuilt containers](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)** | **[Design Proposals](https://github.com/ai-dynamo/enhancements)** | **[Blogs](https://developer.nvidia.com/blog/tag/nvidia-dynamo)**
+| **[Roadmap](https://github.com/ai-dynamo/dynamo/issues/2486)** | **[Support matrix](https://github.com/ai-dynamo/dynamo/blob/main/docs/reference/support-matrix.md)** | **[Documentation](https://docs.nvidia.com/dynamo/latest/index.html)** | **[Examples](https://github.com/ai-dynamo/dynamo/tree/main/examples)** | **[Prebuilt containers](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)** | **[Design Proposals](https://github.com/ai-dynamo/enhancements)** | **[Blogs](https://developer.nvidia.com/blog/tag/nvidia-dynamo)**
 
 # NVIDIA Dynamo
 
 High-throughput, low-latency inference framework designed for serving generative AI and reasoning models in multi-node distributed environments.
 
-## Framework Support Matrix
-
-| Feature                                                                                           | [vLLM](docs/backends/vllm/README.md) | [SGLang](docs/backends/sglang/README.md) | [TensorRT-LLM](docs/backends/trtllm/README.md) |
-| ------------------------------------------------------------------------------------------------- | ---- | ------ | ------------ |
-| [**Disaggregated Serving**](/docs/design_docs/disagg_serving.md)                                 | ✅   | ✅     | ✅           |
-| [**KV-Aware Routing**](/docs/router/kv_cache_routing.md)                                    | ✅   | ✅     | ✅           |
-| [**SLA-Based Planner**](docs/planner/sla_planner.md)                                        | ✅   | ✅     | ✅           |
-| [**KVBM**](docs/kvbm/kvbm_architecture.md)                                               | ✅   | 🚧     | ✅           |
-
 ## Latest News
 
-- [11/13] [Dynamo Office Hours Playlist](https://www.youtube.com/playlist?list=PL5B692fm6--tgryKu94h2Zb7jTFM3Go4X)
-- [10/16] [How Baseten achieved 2x faster inference with NVIDIA Dynamo](https://www.baseten.co/blog/how-baseten-achieved-2x-faster-inference-with-nvidia-dynamo/#qwen3-coder-benchmarks-with-kv-routing)
-- [10/13] [NVIDIA Blackwell Leads on New SemiAnalysis InferenceMax Benchmarks](https://developer.nvidia.com/blog/nvidia-blackwell-leads-on-new-semianalysis-inferencemax-benchmarks/)
-- [09/09] [Dynamo + NVIDIA Blackwell Ultra Sets New MLPerf Inference Benchmark Record](https://blogs.nvidia.com/blog/mlperf-inference-blackwell-ultra/)
 - [08/05] Deploy `openai/gpt-oss-120b` with disaggregated serving on NVIDIA Blackwell GPUs using Dynamo [➡️ link](./docs/backends/trtllm/gpt-oss.md)
 
 ## The Era of Multi-GPU, Multi-Node
@@ -64,6 +51,23 @@ Dynamo is designed to be inference engine agnostic (supports TRT-LLM, vLLM, SGLa
 <p align="center">
   <img src="./docs/images/frontpage-architecture.png" alt="Dynamo architecture" width="600" />
 </p>
+
+## Framework Support Matrix
+
+| Feature                                                                                           | vLLM | SGLang | TensorRT-LLM |
+| ------------------------------------------------------------------------------------------------- | ---- | ------ | ------------ |
+| [**Disaggregated Serving**](/docs/design_docs/disagg_serving.md)                                 | ✅   | ✅     | ✅           |
+| [**Conditional Disaggregation**](/docs/design_docs/disagg_serving.md#conditional-disaggregation) | 🚧   | 🚧     | 🚧           |
+| [**KV-Aware Routing**](/docs/router/kv_cache_routing.md)                                    | ✅   | ✅     | ✅           |
+| [**Load Based Planner**](docs/planner/load_planner.md)                                      | 🚧   | 🚧     | 🚧           |
+| [**SLA-Based Planner**](docs/planner/sla_planner.md)                                        | ✅   | ✅     | ✅           |
+| [**KVBM**](docs/kvbm/kvbm_architecture.md)                                               | ✅   | 🚧     | ✅           |
+
+To learn more about each framework and their capabilities, check out each framework's README!
+
+- **[vLLM](docs/backends/vllm/README.md)**
+- **[SGLang](docs/backends/sglang/README.md)**
+- **[TensorRT-LLM](docs/backends/trtllm/README.md)**
 
 Built in Rust for performance and in Python for extensibility, Dynamo is fully open-source and driven by a transparent, OSS (Open Source Software) first development approach.
 
@@ -88,9 +92,9 @@ Backend engines require Python development headers for JIT compilation. Install 
 sudo apt install python3-dev
 ```
 
-### Install etcd (optional) and NATS (required)
+### Install etcd and NATS (required)
 
-To coordinate across a data center, Dynamo relies on etcd and NATS. These will be used in production. To run Dynamo locally etcd is optional.
+To coordinate across a data center, Dynamo relies on etcd and NATS. To run Dynamo locally, these need to be available.
 
 - [etcd](https://etcd.io/) can be run directly as `./etcd`.
 - [nats](https://nats.io/) needs jetstream enabled: `nats-server -js`.
@@ -101,9 +105,6 @@ To quickly setup etcd & NATS, you can also run:
 # At the root of the repository:
 docker compose -f deploy/docker-compose.yml up -d
 ```
-
-To run locally without etcd, pass `--store-kv file` to both the frontend and workers. The directory used for key-value data can be configured via the `DYN_FILE_KV` environment variable (example: `export DYN_FILE_KV=/data/kv/dynamo`). Defaults to `$TMPDIR/dynamo_store_kv`.
-
 
 ## 2. Select an engine
 
@@ -141,13 +142,11 @@ Dynamo provides a simple way to spin up a local set of inference components incl
 ```
 # Start an OpenAI compatible HTTP server, a pre-processor (prompt templating and tokenization) and a router.
 # Pass the TLS certificate and key paths to use HTTPS instead of HTTP.
-# Pass --store-kv to use the filesystem instead of etcd. The workers and frontend must share a disk.
-python -m dynamo.frontend --http-port 8000 [--tls-cert-path cert.pem] [--tls-key-path key.pem] [--store-kv file]
+python -m dynamo.frontend --http-port 8000 [--tls-cert-path cert.pem] [--tls-key-path key.pem]
 
 # Start the SGLang engine, connecting to NATS and etcd to receive requests. You can run several of these,
 # both for the same model and for multiple models. The frontend node will discover them.
-# Pass --store-kv to use the filesystem instead of etcd. The workers and frontend must share a disk.
-python -m dynamo.sglang --model deepseek-ai/DeepSeek-R1-Distill-Llama-8B [--store-kv file]
+python -m dynamo.sglang --model deepseek-ai/DeepSeek-R1-Distill-Llama-8B
 ```
 
 #### Send a Request
@@ -246,7 +245,7 @@ sudo apt-get -y install libopenmpi-dev
 ### Install TensorRT-LLM wheels with `uv`
 
 > [!Warning]
-> `uv pip install ai-dynamo[trtllm]` fails for `tensorrt-llm==1.2.0rc2` because the placeholder wheel cannot download the actual artifact from `https://pypi.nvidia.com/`, and `uv` requires URL-based dependencies (e.g., `etcd3`) to be declared explicitly. Use the same direct-wheel workflow we ship in [`container/Dockerfile.trtllm`](container/Dockerfile.trtllm#L140).
+> `uv pip install ai-dynamo[trtllm]` fails for `tensorrt-llm==1.2.0rc2` because the placeholder wheel cannot download the actual artifact from `https://pypi.nvidia.com/`. Use the direct-wheel workflow we ship in [`container/Dockerfile.trtllm`](container/Dockerfile.trtllm#L156).
 
 ```bash
 export ARCH_ALT=$(uname -m)
@@ -256,7 +255,6 @@ export TENSORRTLLM_PIP_WHEEL="https://pypi.nvidia.com/tensorrt-llm/tensorrt_llm-
 uv pip install --no-cache --index-strategy=unsafe-best-match \
   --extra-index-url "${TENSORRTLLM_INDEX_URL}" \
   "${TENSORRTLLM_PIP_WHEEL}" \
-  "etcd3 @ git+https://github.com/kragniz/python-etcd3.git@e58a899579ba416449c4e225b61f039457c8072a" \
   triton==3.5.0 \
   ai-dynamo[trtllm]
 ```
@@ -350,7 +348,7 @@ uv pip install -e .
 
 You should now be able to run `python -m dynamo.frontend`.
 
-Remember that nats and etcd must typically be running (see earlier).
+Remember that nats and etcd must be running (see earlier).
 
 Set the environment variable `DYN_LOG` to adjust the logging level; for example, `export DYN_LOG=debug`. It has the same syntax as `RUST_LOG`.
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,27 @@ limitations under the License.
 [![Discord](https://dcbadge.limes.pink/api/server/D92uqZRjCZ?style=flat)](https://discord.gg/D92uqZRjCZ)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ai-dynamo/dynamo)
 
-| **[Roadmap](https://github.com/ai-dynamo/dynamo/issues/2486)** | **[Support matrix](https://github.com/ai-dynamo/dynamo/blob/main/docs/reference/support-matrix.md)** | **[Documentation](https://docs.nvidia.com/dynamo/latest/index.html)** | **[Examples](https://github.com/ai-dynamo/dynamo/tree/main/examples)** | **[Prebuilt containers](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)** | **[Design Proposals](https://github.com/ai-dynamo/enhancements)** | **[Blogs](https://developer.nvidia.com/blog/tag/nvidia-dynamo)**
+| **[Roadmap](https://github.com/ai-dynamo/dynamo/issues/2486)** | **[Support matrix](https://github.com/ai-dynamo/dynamo/blob/main/docs/reference/support-matrix.md)** | **[Docs](https://docs.nvidia.com/dynamo/latest/index.html)** | **[Recipes](https://github.com/ai-dynamo/dynamo/tree/main/recipes)** | **[Examples](https://github.com/ai-dynamo/dynamo/tree/main/examples)** | **[Prebuilt containers](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)** | **[Design Proposals](https://github.com/ai-dynamo/enhancements)** | **[Blogs](https://developer.nvidia.com/blog/tag/nvidia-dynamo)**
 
 # NVIDIA Dynamo
 
 High-throughput, low-latency inference framework designed for serving generative AI and reasoning models in multi-node distributed environments.
 
+## Framework Support Matrix
+
+| Feature                                                                                           | [vLLM](docs/backends/vllm/README.md) | [SGLang](docs/backends/sglang/README.md) | [TensorRT-LLM](docs/backends/trtllm/README.md) |
+| ------------------------------------------------------------------------------------------------- | ---- | ------ | ------------ |
+| [**Disaggregated Serving**](/docs/design_docs/disagg_serving.md)                                 | ✅   | ✅     | ✅           |
+| [**KV-Aware Routing**](/docs/router/kv_cache_routing.md)                                    | ✅   | ✅     | ✅           |
+| [**SLA-Based Planner**](docs/planner/sla_planner.md)                                        | ✅   | ✅     | ✅           |
+| [**KVBM**](docs/kvbm/kvbm_architecture.md)                                               | ✅   | 🚧     | ✅           |
+
 ## Latest News
 
+- [11/13] [Dynamo Office Hours Playlist](https://www.youtube.com/playlist?list=PL5B692fm6--tgryKu94h2Zb7jTFM3Go4X)
+- [10/16] [How Baseten achieved 2x faster inference with NVIDIA Dynamo](https://www.baseten.co/blog/how-baseten-achieved-2x-faster-inference-with-nvidia-dynamo/#qwen3-coder-benchmarks-with-kv-routing)
+- [10/13] [NVIDIA Blackwell Leads on New SemiAnalysis InferenceMax Benchmarks](https://developer.nvidia.com/blog/nvidia-blackwell-leads-on-new-semianalysis-inferencemax-benchmarks/)
+- [09/09] [Dynamo + NVIDIA Blackwell Ultra Sets New MLPerf Inference Benchmark Record](https://blogs.nvidia.com/blog/mlperf-inference-blackwell-ultra/)
 - [08/05] Deploy `openai/gpt-oss-120b` with disaggregated serving on NVIDIA Blackwell GPUs using Dynamo [➡️ link](./docs/backends/trtllm/gpt-oss.md)
 
 ## The Era of Multi-GPU, Multi-Node
@@ -51,23 +64,6 @@ Dynamo is designed to be inference engine agnostic (supports TRT-LLM, vLLM, SGLa
 <p align="center">
   <img src="./docs/images/frontpage-architecture.png" alt="Dynamo architecture" width="600" />
 </p>
-
-## Framework Support Matrix
-
-| Feature                                                                                           | vLLM | SGLang | TensorRT-LLM |
-| ------------------------------------------------------------------------------------------------- | ---- | ------ | ------------ |
-| [**Disaggregated Serving**](/docs/design_docs/disagg_serving.md)                                 | ✅   | ✅     | ✅           |
-| [**Conditional Disaggregation**](/docs/design_docs/disagg_serving.md#conditional-disaggregation) | 🚧   | 🚧     | 🚧           |
-| [**KV-Aware Routing**](/docs/router/kv_cache_routing.md)                                    | ✅   | ✅     | ✅           |
-| [**Load Based Planner**](docs/planner/load_planner.md)                                      | 🚧   | 🚧     | 🚧           |
-| [**SLA-Based Planner**](docs/planner/sla_planner.md)                                        | ✅   | ✅     | ✅           |
-| [**KVBM**](docs/kvbm/kvbm_architecture.md)                                               | ✅   | 🚧     | ✅           |
-
-To learn more about each framework and their capabilities, check out each framework's README!
-
-- **[vLLM](docs/backends/vllm/README.md)**
-- **[SGLang](docs/backends/sglang/README.md)**
-- **[TensorRT-LLM](docs/backends/trtllm/README.md)**
 
 Built in Rust for performance and in Python for extensibility, Dynamo is fully open-source and driven by a transparent, OSS (Open Source Software) first development approach.
 
@@ -92,9 +88,9 @@ Backend engines require Python development headers for JIT compilation. Install 
 sudo apt install python3-dev
 ```
 
-### Install etcd and NATS (required)
+### Install etcd (optional) and NATS (required)
 
-To coordinate across a data center, Dynamo relies on etcd and NATS. To run Dynamo locally, these need to be available.
+To coordinate across a data center, Dynamo relies on etcd and NATS. These will be used in production. To run Dynamo locally etcd is optional.
 
 - [etcd](https://etcd.io/) can be run directly as `./etcd`.
 - [nats](https://nats.io/) needs jetstream enabled: `nats-server -js`.
@@ -105,6 +101,9 @@ To quickly setup etcd & NATS, you can also run:
 # At the root of the repository:
 docker compose -f deploy/docker-compose.yml up -d
 ```
+
+To run locally without etcd, pass `--store-kv file` to both the frontend and workers. The directory used for key-value data can be configured via the `DYN_FILE_KV` environment variable (example: `export DYN_FILE_KV=/data/kv/dynamo`). Defaults to `$TMPDIR/dynamo_store_kv`.
+
 
 ## 2. Select an engine
 
@@ -142,11 +141,13 @@ Dynamo provides a simple way to spin up a local set of inference components incl
 ```
 # Start an OpenAI compatible HTTP server, a pre-processor (prompt templating and tokenization) and a router.
 # Pass the TLS certificate and key paths to use HTTPS instead of HTTP.
-python -m dynamo.frontend --http-port 8000 [--tls-cert-path cert.pem] [--tls-key-path key.pem]
+# Pass --store-kv to use the filesystem instead of etcd. The workers and frontend must share a disk.
+python -m dynamo.frontend --http-port 8000 [--tls-cert-path cert.pem] [--tls-key-path key.pem] [--store-kv file]
 
 # Start the SGLang engine, connecting to NATS and etcd to receive requests. You can run several of these,
 # both for the same model and for multiple models. The frontend node will discover them.
-python -m dynamo.sglang --model deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+# Pass --store-kv to use the filesystem instead of etcd. The workers and frontend must share a disk.
+python -m dynamo.sglang --model deepseek-ai/DeepSeek-R1-Distill-Llama-8B [--store-kv file]
 ```
 
 #### Send a Request
@@ -222,9 +223,7 @@ You can pass any sglang flags directly to this worker, see https://docs.sglang.a
 It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch) for running the TensorRT-LLM engine.
 
 > [!Note]
-> Ensure that you select a PyTorch container image version that matches the version of TensorRT-LLM you are using.
-> For example, if you are using `tensorrt-llm==1.1.0rc5`, use the PyTorch container image version `25.06`.
-> To find the correct PyTorch container version for your desired `tensorrt-llm` release, visit the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) on GitHub. Switch to the branch that matches your `tensorrt-llm` version, and look for the `BASE_TAG` line to identify the recommended PyTorch container tag.
+> Always match the PyTorch container tag with the TensorRT-LLM version you plan to use. For Dynamo `0.7.0` RC8 we validate against `tensorrt-llm==1.2.0rc2` inside `nvcr.io/nvidia/pytorch:25.10-py3`. For other releases, inspect [`container/Dockerfile.trtllm`](container/Dockerfile.trtllm) or the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) to find the recommended `BASE_TAG`.
 
 > [!Important]
 > Launch container with the following additional settings `--shm-size=1g --ulimit memlock=-1`
@@ -244,11 +243,26 @@ sudo apt-get -y install libopenmpi-dev
 > [!Tip]
 > You can learn more about these prequisites and known issues with TensorRT-LLM pip based installation [here](https://nvidia.github.io/TensorRT-LLM/installation/linux.html).
 
-### After installing the pre-requisites above, install Dynamo
+### Install TensorRT-LLM wheels with `uv`
 
+> [!Warning]
+> `uv pip install ai-dynamo[trtllm]` fails for `tensorrt-llm==1.2.0rc2` because the placeholder wheel cannot download the actual artifact from `https://pypi.nvidia.com/`, and `uv` requires URL-based dependencies (e.g., `etcd3`) to be declared explicitly. Use the same direct-wheel workflow we ship in [`container/Dockerfile.trtllm`](container/Dockerfile.trtllm#L140).
+
+```bash
+export ARCH_ALT=$(uname -m)
+export TENSORRTLLM_INDEX_URL="https://pypi.nvidia.com/"
+export TENSORRTLLM_PIP_WHEEL="https://pypi.nvidia.com/tensorrt-llm/tensorrt_llm-1.2.0rc2-cp312-cp312-linux_${ARCH_ALT}.whl"
+
+uv pip install --no-cache --index-strategy=unsafe-best-match \
+  --extra-index-url "${TENSORRTLLM_INDEX_URL}" \
+  "${TENSORRTLLM_PIP_WHEEL}" \
+  "etcd3 @ git+https://github.com/kragniz/python-etcd3.git@e58a899579ba416449c4e225b61f039457c8072a" \
+  triton==3.5.0 \
+  ai-dynamo[trtllm]
 ```
-uv pip install ai-dynamo[trtllm]
-```
+
+> [!Tip]
+> If `uv` is not available, `pip install --extra-index-url https://pypi.nvidia.com/ tensorrt-llm==1.2.0rc2` also works, although it downloads more data and is noticeably slower.
 
 Run the backend/worker like this:
 
@@ -336,7 +350,7 @@ uv pip install -e .
 
 You should now be able to run `python -m dynamo.frontend`.
 
-Remember that nats and etcd must be running (see earlier).
+Remember that nats and etcd must typically be running (see earlier).
 
 Set the environment variable `DYN_LOG` to adjust the logging level; for example, `export DYN_LOG=debug`. It has the same syntax as `RUST_LOG`.
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ uv pip install --no-cache --index-strategy=unsafe-best-match \
   --extra-index-url "${TENSORRTLLM_INDEX_URL}" \
   "${TENSORRTLLM_PIP_WHEEL}" \
   triton==3.5.0 \
-  ai-dynamo[trtllm]
+  "ai-dynamo[trtllm]==0.7.0"
 ```
 
 > [!Tip]

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ export ARCH_ALT=$(uname -m)
 export TENSORRTLLM_INDEX_URL="https://pypi.nvidia.com/"
 export TENSORRTLLM_PIP_WHEEL="https://pypi.nvidia.com/tensorrt-llm/tensorrt_llm-1.2.0rc2-cp312-cp312-linux_${ARCH_ALT}.whl"
 
-uv pip install --no-cache --index-strategy=unsafe-best-match \
+uv pip install --index-strategy=unsafe-best-match \
   --extra-index-url "${TENSORRTLLM_INDEX_URL}" \
   "${TENSORRTLLM_PIP_WHEEL}" \
   triton==3.5.0 \

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ You can pass any sglang flags directly to this worker, see https://docs.sglang.a
 It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch) for running the TensorRT-LLM engine.
 
 > [!Note]
-> Always match the PyTorch container tag with the TensorRT-LLM version you plan to use. For Dynamo `0.7.0` RC8 we validate against `tensorrt-llm==1.2.0rc2` inside `nvcr.io/nvidia/pytorch:25.10-py3`. For other releases, inspect [`container/Dockerfile.trtllm`](container/Dockerfile.trtllm) or the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) to find the recommended `BASE_TAG`.
+> Always match the PyTorch container tag with the TensorRT-LLM version you plan to use. For Dynamo `0.7.0` we validate against `tensorrt-llm==1.2.0rc2` inside `nvcr.io/nvidia/pytorch:25.10-py3`. For other releases, inspect [`container/Dockerfile.trtllm`](container/Dockerfile.trtllm) or the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) to find the recommended `BASE_TAG`.
 
 > [!Important]
 > Launch container with the following additional settings `--shm-size=1g --ulimit memlock=-1`


### PR DESCRIPTION
# docs: document uv install workaround for TRT-LLM 1.2.0rc2

## Overview
Documents the validated TensorRT-LLM installation workflow for Dynamo 0.7.0 RC8 and captures the uv-specific workaround needed for `tensorrt-llm==1.2.0rc2`. This addresses installation failures reported in [NVBug 5685805](https://nvbugs/5685805) where `uv pip install ai-dynamo[trtllm]` fails due to the placeholder wheel's inability to download from `https://pypi.nvidia.com/` and uv's strict handling of URL dependencies.

### Problem
- Users attempting `uv pip install ai-dynamo[trtllm]` encounter:
  1. Primary failure: `tensorrt-llm==1.2.0rc2` placeholder wheel cannot reach `https://pypi.nvidia.com/`
  2. Follow-up error: uv requires URL-based dependencies like `etcd3` to be declared explicitly
- The README still referenced outdated versions (`tensorrt-llm==1.1.0rc5` + PyTorch `25.06`) instead of the RC8-validated stack

### Solution
This PR updates the TensorRT-LLM installation section to:
1. **Update version guidance**: Document that RC8 validates `tensorrt-llm==1.2.0rc2` inside `nvcr.io/nvidia/pytorch:25.10-py3` and point users to `container/Dockerfile.trtllm` for future version mappings
2. **Document the direct-wheel workaround**: Add a dedicated subsection with the same installation steps used in `container/Dockerfile.trtllm` (lines 156-157):
   - Export architecture-aware wheel URL
   - Use `--index-strategy=unsafe-best-match` with `--extra-index-url`
   - Explicitly include `etcd3 @ git+https://github.com/kragniz/python-etcd3.git@e58a899579ba416449c4e225b61f039457c8072a`
   - Pin `triton==3.5.0`
3. **Provide fallback**: Document the slower but simpler `pip install --extra-index-url` method for environments without uv

### Changes Included
- Updated PyTorch container version reference from 25.06 to 25.10
- Updated TensorRT-LLM example version from 1.1.0rc5 to 1.2.0rc2
- Added "Install TensorRT-LLM wheels with `uv`" subsection with:
  - Warning callout explaining why the simple install fails
  - Complete working command with all required dependencies
  - Link to the container Dockerfile for reference
  - Tip about the pip fallback option

### Files Changed
- `README.md` (TensorRT-LLM section, lines 221-265)

### Related Issues
- Addresses [NVBug 5685805](https://nvbugs/5685805): `[Dynamo][release/0.7.0][trtllm] pip install failure caused by tensorrt-llm 1.2.0rc2`
- Captures workaround developed by @dtokarev and validated by QA (@qchi)

### Testing
- Not run (docs-only change)
- Workaround validated by QA team in [NVBug 5685805 comment #3](https://nvbugs/5685805)

---

**Note**: This is a documentation-only change. No code or behavior is modified.
