### PR TITLE
docs: remove frontend image from support matrix

### DIFF
--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -102,9 +102,6 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 - **Dynamo Kubernetes Operator Images**: We distribute multi-arch images (x86 & ARM64 compatible) of the Dynamo Operator on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo):
   - [kubernetes-operator](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/kubernetes-operator) to simplify deployments of Dynamo Graphs.
 
-- **Dynamo Frontend Images**: We distribute multi-arch images (x86 & ARM64 compatible) of the Dynamo Frontend on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo):
-  -  **New as of Dynamo v0.7.0:** [dynamo-frontend](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/dynamo-frontend) as a standalone implementation.
-
 - **Helm Charts**: [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo) hosts the helm charts supporting Kubernetes deployments of Dynamo:
   - [Dynamo CRDs](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-crds)
   - [Dynamo Platform](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/helm-charts/dynamo-platform)


### PR DESCRIPTION
# Remove Frontend Image from Support Matrix

## Summary
Removes the Dynamo Frontend Images section from the support matrix documentation.

## Changes
- Removed **Dynamo Frontend Images** section (lines 105-106)
- This section mentioned the `dynamo-frontend` container as a standalone implementation new in v0.7.0

## Rationale
The frontend image reference was included prematurely and should not be in the main branch support matrix at this time.

## Testing
- [x] Documentation builds without errors
- [x] No linter errors
- [x] Section removed cleanly without affecting surrounding content

---
**Signed-off-by:** Dan Gil <dagil@nvidia.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated support matrix with new Helm Chart support for Dynamo Graph
  * Removed outdated multi-architecture frontend Docker image references from build support section

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->