### PR TITLE
fix: update ai-dynamo[vllm] version and pin transformers

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "tabulate",
     "types-tabulate",
     # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.2.0rc2/rc3 (==4.56.0), SGLang 0.5.3 (==4.57.0)
-    "transformers>=4.56.0",
+    "transformers>=4.56.0,<=4.57.1",
     "pytest-mypy",
 ]
 

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
     "pydantic>=2",
     "tabulate",
     "types-tabulate",
-    "transformers<=4.57.1",
+    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.2.0rc2/rc3 (==4.56.0), SGLang 0.5.3 (==4.57.0)
+    "transformers>=4.56.0",
     "pytest-mypy",
 ]
 

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pydantic>=2",
     "tabulate",
     "types-tabulate",
-    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.2.0rc2/rc3 (==4.56.0), SGLang 0.5.3 (==4.57.0)
+    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.2.0rc2/rc3 (==4.56.0), SGLang 0.5.4.post3 (==4.57.1)
     "transformers>=4.56.0,<=4.57.1",
     "pytest-mypy",
 ]

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -39,7 +39,7 @@ tensorboardX==2.6.2.2
 # Transformers version constraint for container builds
 # - vLLM 0.11.0: >=4.55.2, vLLM 0.11.2: >=4.56.0,<5
 # - TensorRT-LLM 1.2.0rc2/rc3: ==4.56.0
-# - SGLang 0.5.3: ==4.57.0
+# - SGLang 0.5.4.post3: ==4.57.1
 # Using >=4.56.0 to satisfy all frameworks
 transformers>=4.56.0,<=4.57.1
 types-aiofiles

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -41,7 +41,7 @@ tensorboardX==2.6.2.2
 # - TensorRT-LLM 1.2.0rc2/rc3: ==4.56.0
 # - SGLang 0.5.3: ==4.57.0
 # Using >=4.56.0 to satisfy all frameworks
-transformers>=4.56.0
+transformers>=4.56.0,<=4.57.1
 types-aiofiles
 types-PyYAML
 uvicorn

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -36,7 +36,12 @@ scipy<1.14.0  # Pin scipy version for pmdarima compatibility
 sentencepiece
 tensorboard==2.19.0
 tensorboardX==2.6.2.2
-transformers<=4.57.1
+# Transformers version constraint for container builds
+# - vLLM 0.11.0: >=4.55.2, vLLM 0.11.2: >=4.56.0,<5
+# - TensorRT-LLM 1.2.0rc2/rc3: ==4.56.0
+# - SGLang 0.5.3: ==4.57.0
+# Using >=4.56.0 to satisfy all frameworks
+transformers>=4.56.0
 types-aiofiles
 types-PyYAML
 uvicorn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ vllm = [
     "nixl[cu12]<=0.7.1",
     "vllm[flashinfer]==0.11.0",
     # Satisfies vLLM 0.11.0 (>=4.55.2) and vLLM 0.11.2 (>=4.56.0, <5)
-    "transformers>=4.56.0",
+    "transformers>=4.56.0,<=4.57.1",
 ]
 
 sglang = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "ai-dynamo-runtime==0.7.0",
+    "transformers>=4.56.0,<=4.57.1",
     "pytest>=8.3.4",
     "types-psutil>=7.0.0.20250218",
     "kubernetes>=32.0.1,<33.0.0",
@@ -50,24 +51,18 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 trtllm =[
     "uvloop",
     "tensorrt-llm==1.2.0rc2",
-    # Satisfies TensorRT-LLM 1.2.0rc2 and 1.2.0rc3
-    "transformers==4.56.0",
 ]
 
 vllm = [
     "uvloop",
     "nixl[cu12]<=0.7.1",
     "vllm[flashinfer]==0.11.0",
-    # Satisfies vLLM 0.11.0 (>=4.55.2) and vLLM 0.11.2 (>=4.56.0, <5)
-    "transformers>=4.56.0,<=4.57.1",
 ]
 
 sglang = [
     "uvloop",
     "nixl[cu12]<=0.7.1",
     "sglang==0.5.4.post3",
-    # Satisfies SGLang 0.5.3
-    "transformers==4.57.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,18 +50,24 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 trtllm =[
     "uvloop",
     "tensorrt-llm==1.2.0rc2",
+    # Satisfies TensorRT-LLM 1.2.0rc2 and 1.2.0rc3
+    "transformers==4.56.0",
 ]
 
 vllm = [
     "uvloop",
     "nixl[cu12]<=0.7.1",
-    "vllm[flashinfer]==0.10.2",
+    "vllm[flashinfer]==0.11.0",
+    # Satisfies vLLM 0.11.0 (>=4.55.2) and vLLM 0.11.2 (>=4.56.0, <5)
+    "transformers>=4.56.0",
 ]
 
 sglang = [
     "uvloop",
     "nixl[cu12]<=0.7.1",
     "sglang==0.5.4.post3",
+    # Satisfies SGLang 0.5.3
+    "transformers==4.57.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
# fix: update ai-dynamo[vllm] version and pin transformers

## Summary
Fixes [NVBUG 5690140](https://nvbugspro.nvidia.com/bug/5690140) by aligning the `ai-dynamo[vllm]` optional dependency with the vLLM version already used in containers (0.11.0) and pinning transformers to prevent future breakage from upstream releases.

## Root Cause
When we bumped vLLM to `0.11.0` for containers and dev images, we never updated `project.optional-dependencies.vllm` before cutting the `0.7.0rc9` wheels. As a result, every downstream `ai-dynamo[vllm]` install still pulls `vllm[flashinfer]==0.10.2`. Because the release pipeline has no gate that performs a pip install and runs `python -m dynamo.vllm`, the mismatch between container images (`0.11.0`) and pip artifacts (`0.10.2`) went unnoticed until `transformers==4.57.2` exposed it with an `AttributeError: 'dict' object has no attribute 'model_type'` during tokenizer initialization.

## Changes
- **`pyproject.toml`**: Update `vllm[flashinfer]` from `0.10.2` → `0.11.0` and add `transformers~=4.57.2` to the `vllm` optional dependencies
- **`container/deps/requirements.txt`**: Replace `transformers<=4.57.1` with `transformers~=4.57.2` to stay in sync
- **`benchmarks/pyproject.toml`**: Update transformers pin to `~=4.57.2` for consistency

## Relates To
- Closes [NVBUG 5690140](https://nvbugspro.nvidia.com/bug/5690140)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated transformers dependency version specifications across build configurations to allow patch-level updates within the 4.57.x series
  * Upgraded vllm[flashinfer] dependency to version 0.11.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->