### PR TITLE
feat(planner): rely on DGD for prefill/decode count

### DIFF
--- a/components/src/dynamo/planner/virtual_connector.py
+++ b/components/src/dynamo/planner/virtual_connector.py
@@ -99,6 +99,16 @@ class VirtualConnector(PlannerConnector):
         if blocking:
             await self._wait_for_scaling_completion()
 
+    async def get_number_workers(
+        self,
+        prefill_component_name: Optional[str] = None,
+        decode_component_name: Optional[str] = None,
+    ) -> tuple[int, int]:
+        """Get the number of prefill and decode workers from the connector"""
+        state = self.connector.read_state()
+
+        return state.num_prefill_workers, state.num_decode_workers
+
     async def set_component_replicas(
         self, target_replicas: list[TargetReplica], blocking: bool = True
     ):

--- a/tests/planner/unit/test_virtual_connector.py
+++ b/tests/planner/unit/test_virtual_connector.py
@@ -69,11 +69,16 @@ async def async_internal(distributed_runtime):
     # This is the client
     client = VirtualConnectorClient(distributed_runtime, NAMESPACE)
     event = await client.get()
+
     # Here the client would do the scaling
     assert event.num_prefill_workers == 1
     assert event.num_decode_workers == 2
     assert event.decision_id == 0
     await client.complete(event)
+
+    num_prefill_workers, num_decode_workers = await c.get_number_workers()
+    assert num_prefill_workers == 1
+    assert num_decode_workers == 2
 
     await c._wait_for_scaling_completion()
 
@@ -88,6 +93,10 @@ async def async_internal(distributed_runtime):
     assert event.num_decode_workers == 8
     assert event.decision_id == 1
     await client.complete(event)
+
+    num_prefill_workers, num_decode_workers = await c.get_number_workers()
+    assert num_prefill_workers == 5
+    assert num_decode_workers == 8
 
     await c._wait_for_scaling_completion()
 


### PR DESCRIPTION
#### Overview:

Updates planner to use the DGD state to determine prefill/decode replica count instead of using Dynamo Runtime clients.

Also updates `docs/planner/sla_planner_quickstart.md` to include instructions on how to manually scale prefill/decode replica counts.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured how worker replica counts are retrieved from Kubernetes deployments, centralizing through a single connector method.
  * Removed legacy worker endpoint discovery and client initialization logic.
  * Updated worker count tracking throughout the planning and adjustment workflows.

* **Tests**
  * Updated test suite to reflect new worker count retrieval API.
  * Added comprehensive test scenarios for the new retrieval mechanism.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->