### PR TITLE
fix: update ai-dynamo[vllm] version and pin transformers (#4592)

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
     "pydantic>=2",
     "tabulate",
     "types-tabulate",
-    "transformers<=4.57.1",
+    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.2.0rc2/rc3 (==4.56.0), SGLang 0.5.4.post3 (==4.57.1)
+    "transformers>=4.56.0,<=4.57.1",
     "pytest-mypy",
 ]
 

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -35,7 +35,12 @@ scipy<1.14.0  # Pin scipy version for pmdarima compatibility
 sentencepiece
 tensorboard==2.19.0
 tensorboardX==2.6.2.2
-transformers<=4.57.1
+# Transformers version constraint for container builds
+# - vLLM 0.11.0: >=4.55.2, vLLM 0.11.2: >=4.56.0,<5
+# - TensorRT-LLM 1.2.0rc2/rc3: ==4.56.0
+# - SGLang 0.5.4.post3: ==4.57.1
+# Using >=4.56.0 to satisfy all frameworks
+transformers>=4.56.0,<=4.57.1
 types-aiofiles
 types-PyYAML
 uvicorn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "ai-dynamo-runtime==0.7.0",
+    "transformers>=4.56.0,<=4.57.1",
     "pytest>=8.3.4",
     "types-psutil>=7.0.0.20250218",
     "kubernetes>=32.0.1,<33.0.0",
@@ -55,7 +56,7 @@ trtllm =[
 vllm = [
     "uvloop",
     "nixl[cu12]<=0.7.1",
-    "vllm[flashinfer]==0.10.2",
+    "vllm[flashinfer]==0.11.0",
 ]
 
 sglang = [


### PR DESCRIPTION
# fix: update ai-dynamo[vllm] version and pin transformers (cherry-pick for 0.7.0)

## Summary

Cherry-pick of PR #4592 to `release/0.7.0` branch.

Fixes NVBUG 5690140 by aligning the `ai-dynamo[vllm]` optional dependency with the vLLM version already used in containers (0.11.0) and pinning transformers to prevent future breakage from upstream releases.

## Changes

### pyproject.toml
* **vLLM version bump**: Updated `vllm[flashinfer]` from `0.10.2` → `0.11.0` in optional dependencies
* **Transformers constraint**: Added `transformers>=4.56.0,<=4.57.1` to top-level dependencies to ensure compatibility across all backends

### container/deps/requirements.txt
* **Transformers constraint**: Changed from `transformers<=4.57.1` to `transformers>=4.56.0,<=4.57.1`

### benchmarks/pyproject.toml
* **Transformers constraint**: Changed from `transformers<=4.57.1` to `transformers>=4.56.0,<=4.57.1`
* **Added inline comment** explaining multi-backend compatibility requirements

## Cherry-pick Details

- **Original PR**: https://github.com/ai-dynamo/dynamo/pull/4592
- **Merge commit**: ef0a472
- **Target branch**: `release/0.7.0`
- **Cherry-pick branch**: `dagil/cherrypick-vllm-transformers-pins`

## Relates To

* Closes NVBUG 5690140
* Cherry-pick for 0.7.0 release

