### PR TITLE
fix: Add UCX override in TRTLLM backend

### DIFF
--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -209,7 +209,7 @@ async def init(runtime: DistributedRuntime, config: Config):
             sys.exit(1)
 
     # NIXL version shipped with dynamo is not supported by tensorrt-llm<=1.2.0rc2.
-    # so we override the cache_transceiver_config to use NIXL backend.
+    # so we override the cache_transceiver_config to use UCX backend.
     # This is a temporary workaround until we upgrade to tensorrt-llm>=1.2.0rc3.
     # You can disable this override by setting DYN_TRTLLM_UCX_OVERRIDE_DISABLE=1.
     # TODO: Remove this override once we upgrade to tensorrt-llm>=1.2.0rc3.


### PR DESCRIPTION
#### Overview:

There might be some issues in propagating TRTLLM_USE_UCX_BACKEND in different ranks for multi-node.
Explicitly overriding the config would ensure that UCX is used instead of NIXL in all cases.

If a user is building with TRTLLM >= 1.2.0rc3 on their own, then they can define DYN_TRTLLM_UCX_OVERRIDE_DISABLE=1 to ensure NIXL backend is used. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache transceiver backend initialization logic with conditional UCX backend configuration to ensure proper runtime setup during engine preparation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->