### PR TITLE
fix: Include special tokens in Completions API Requests

### DIFF
--- a/lib/llm/benches/tokenizer.rs
+++ b/lib/llm/benches/tokenizer.rs
@@ -33,7 +33,7 @@ pub fn encode(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(test_str.len() as u64));
     group.bench_function("tokenizer_encode", |b| {
         b.iter(|| {
-            let _ = encoder.encode(black_box(test_str)).unwrap();
+            let _ = encoder.encode(black_box(test_str), false).unwrap();
         })
     });
     group.finish();

--- a/lib/llm/src/tokenizers.rs
+++ b/lib/llm/src/tokenizers.rs
@@ -53,8 +53,8 @@ pub mod traits {
     use super::*;
 
     pub trait Encoder: Send + Sync {
-        fn encode(&self, input: &str) -> Result<Encoding>;
-        fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>>;
+        fn encode(&self, input: &str, add_special_tokens: bool) -> Result<Encoding>;
+        fn encode_batch(&self, inputs: &[&str], add_special_tokens: bool) -> Result<Vec<Encoding>>;
     }
 
     pub trait Decoder: Send + Sync {
@@ -293,7 +293,7 @@ impl Sequence {
         //     Error::msg(format!("Failed to acquire read lock on tokenizer: {}", err))
         // })?;
 
-        let encoding = self.tokenizer.encode(input)?;
+        let encoding = self.tokenizer.encode(input, false)?;
         self.token_ids.extend(encoding.token_ids());
         Ok(())
     }

--- a/lib/llm/src/tokenizers/hf.rs
+++ b/lib/llm/src/tokenizers/hf.rs
@@ -26,20 +26,20 @@ impl HuggingFaceTokenizer {
 }
 
 impl Encoder for HuggingFaceTokenizer {
-    fn encode(&self, input: &str) -> Result<Encoding> {
+    fn encode(&self, input: &str, add_special_tokens: bool) -> Result<Encoding> {
         // This self.tokenizer is the library
         let encoding = self
             .tokenizer
-            .encode(input, false)
+            .encode(input, add_special_tokens)
             .map_err(|err| Error::msg(format!("Error tokenizing input: {err}")))?;
 
         Ok(Encoding::Hf(Box::new(encoding)))
     }
 
-    fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
+    fn encode_batch(&self, inputs: &[&str], add_special_tokens: bool) -> Result<Vec<Encoding>> {
         let hf_encodings = self
             .tokenizer
-            .encode_batch(inputs.to_vec(), false)
+            .encode_batch(inputs.to_vec(), add_special_tokens)
             .map_err(|err| Error::msg(format!("Error batch tokenizing input: {err}")))?;
 
         let encodings = hf_encodings

--- a/lib/llm/tests/tokenizers.rs
+++ b/lib/llm/tests/tokenizers.rs
@@ -187,7 +187,9 @@ fn test_decode_with_skip_special_tokens() {
     // Create a sequence with special tokens:
     // <s> (token_id: 1) + "Hello world" + </s> (token_id: 2)
     let text = "Hello world";
-    let encoding = tokenizer.encode(text, false).expect("Failed to encode text");
+    let encoding = tokenizer
+        .encode(text, false)
+        .expect("Failed to encode text");
     let mut token_ids = vec![1]; // <s>
     token_ids.extend(encoding.token_ids());
     token_ids.push(2); // </s>

--- a/lib/llm/tests/tokenizers.rs
+++ b/lib/llm/tests/tokenizers.rs
@@ -60,7 +60,7 @@ fn compute_hashes_for_tokenizer<E: Encoder>(tokenizer: &E, prompts: &[&str]) -> 
         .iter()
         .map(|&prompt| {
             tokenizer
-                .encode(prompt)
+                .encode(prompt, false)
                 .expect("Failed to encode prompt")
                 .get_hash()
             // Assuming `get_hash` returns a `u64`
@@ -93,7 +93,7 @@ fn test_hf_lifecycle() {
         .expect("Failed to load remote HuggingFace tokenizer");
 
     let encoding = tokenizer
-        .encode(TEST_PROMPTS[0])
+        .encode(TEST_PROMPTS[0], false)
         .expect("Failed to encode prompt");
 
     let decoded = tokenizer
@@ -113,7 +113,7 @@ fn test_sequence() {
     // let tokenizer = shared_tokenizer.read().unwrap();
 
     let encoding = shared_tokenizer
-        .encode(TEST_PROMPTS[0])
+        .encode(TEST_PROMPTS[0], false)
         .expect("Failed to encode prompt");
 
     let mut sequence = Sequence::new(shared_tokenizer.clone().into());
@@ -157,11 +157,11 @@ fn test_long_sequence_incremental_decode_with_prefill() {
 
     for (input_text, output_text) in LONG_TEST_PROMPTS.iter() {
         let input_encoding = shared_tokenizer
-            .encode(input_text)
+            .encode(input_text, false)
             .expect("Failed to encode prompt");
 
         let output_encoding = shared_tokenizer
-            .encode(output_text)
+            .encode(output_text, false)
             .expect("Failed to encode prompt");
 
         let mut decoder =
@@ -187,7 +187,7 @@ fn test_decode_with_skip_special_tokens() {
     // Create a sequence with special tokens:
     // <s> (token_id: 1) + "Hello world" + </s> (token_id: 2)
     let text = "Hello world";
-    let encoding = tokenizer.encode(text).expect("Failed to encode text");
+    let encoding = tokenizer.encode(text, false).expect("Failed to encode text");
     let mut token_ids = vec![1]; // <s>
     token_ids.extend(encoding.token_ids());
     token_ids.push(2); // </s>


### PR DESCRIPTION
Our tokenizers have `add_special_tokens` hardcoded to false. This works fine for chat completions requests, since the chat template generally includes things like the BOS token. However, completions requests are just directly tokenized. With `add_special_tokens=False` we don't include things like the BOS token that would otherwise be included by the framework. This MR sets `add_special_tokens=True` for completions requests, and `False` for chat completions requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tokenization handling to provide more consistent and controlled special token processing across different request types and contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->