### PR TITLE
feat: support MQA + MoE (Qwen3 MoE) TEP/DEP in Planner Profiler

### DIFF
--- a/benchmarks/profiler/profile_sla.py
+++ b/benchmarks/profiler/profile_sla.py
@@ -135,19 +135,6 @@ async def run_profile(args):
         args.aic_backend = args.backend
 
     try:
-        # Log MoE model support
-        if args.model_info.is_moe:
-            logger.info(
-                "MoE (Mixture of Experts) model profiling, sweeping TEP/DEP size for prefill and decode"
-            )
-            assert args.backend in [
-                "sglang"
-            ], "MoE model support is only available for SGLang"
-        else:
-            logger.info(
-                "Dense model profiling, sweeping TP size for prefill and decode"
-            )
-
         config_modifier = CONFIG_MODIFIERS[args.backend]
 
         with open(args.config, "r") as f:
@@ -162,11 +149,7 @@ async def run_profile(args):
             for i in range(int(math.log2(args.max_num_gpus_per_engine)) + 1)
             if args.min_num_gpus_per_engine <= 2**i <= args.max_num_gpus_per_engine
         ]
-        if args.model_info.is_moe:
-            logger.info(f"Profiling MoE GPU counts (TEP/DEP): {profile_num_gpus}")
-        else:
-            logger.info(f"Profiling dense model GPU counts (TP): {profile_num_gpus}")
-
+        logger.info(f"Profiling GPU counts: {profile_num_gpus}")
         os.makedirs(args.output_dir, exist_ok=True)
 
         model_name = config_modifier.get_model_name(config)
@@ -722,11 +705,10 @@ async def run_profile(args):
         config = generate_dgd_config_with_planner(
             config_path=args.config,
             config_modifier=config_modifier,
-            best_prefill_gpus=best_prefill_gpus,
-            best_decode_gpus=best_decode_gpus,
             output_dir=args.output_dir,
             args=args,
-            is_moe_model=args.model_info.is_moe,
+            best_prefill_mapping=best_prefill_mapping,
+            best_decode_mapping=best_decode_mapping,
             num_gpus_per_node=args.num_gpus_per_node,
         )
         logger.debug(f"Final DGD config with planner: {config}")

--- a/benchmarks/profiler/utils/config_modifiers/sglang.py
+++ b/benchmarks/profiler/utils/config_modifiers/sglang.py
@@ -208,10 +208,15 @@ class SGLangConfigModifier:
         args = remove_valued_arguments(args, "--tp-size")
         args = remove_valued_arguments(args, "--tensor-parallel-size")
 
-        # Remove --ep-size / --ep if present
+        # Remove --ep if present
         args = remove_valued_arguments(args, "--ep")
         args = remove_valued_arguments(args, "--ep-size")
         args = remove_valued_arguments(args, "--expert-parallel-size")
+
+        # remove --dp if present
+        args = remove_valued_arguments(args, "--dp")
+        args = remove_valued_arguments(args, "--dp-size")
+        args = remove_valued_arguments(args, "--data-parallel-size")
 
         worker_service.extraPodSpec.mainContainer.args = args
         return cfg.model_dump()

--- a/benchmarks/profiler/utils/config_modifiers/sglang.py
+++ b/benchmarks/profiler/utils/config_modifiers/sglang.py
@@ -205,6 +205,13 @@ class SGLangConfigModifier:
 
         # Set --tp argument
         args = set_argument_value(args, "--tp", str(tp_size))
+        args = remove_valued_arguments(args, "--tp-size")
+        args = remove_valued_arguments(args, "--tensor-parallel-size")
+
+        # Remove --ep-size / --ep if present
+        args = remove_valued_arguments(args, "--ep")
+        args = remove_valued_arguments(args, "--ep-size")
+        args = remove_valued_arguments(args, "--expert-parallel-size")
 
         worker_service.extraPodSpec.mainContainer.args = args
         return cfg.model_dump()
@@ -230,12 +237,18 @@ class SGLangConfigModifier:
 
         # 1. Set --tp=tep_size, if not present add it
         args = set_argument_value(args, "--tp", str(tep_size))
+        args = remove_valued_arguments(args, "--tp-size")
+        args = remove_valued_arguments(args, "--tensor-parallel-size")
 
-        # 2. Set --ep-size=tep_size, if not present add it
-        args = set_argument_value(args, "--ep-size", str(tep_size))
+        # 2. Set --ep=tep_size, if not present add it
+        args = set_argument_value(args, "--ep", str(tep_size))
+        args = remove_valued_arguments(args, "--ep-size")
+        args = remove_valued_arguments(args, "--expert-parallel-size")
 
         # 3. Remove --dp if present
         args = remove_valued_arguments(args, "--dp")
+        args = remove_valued_arguments(args, "--dp-size")
+        args = remove_valued_arguments(args, "--data-parallel-size")
 
         # 4. Remove --enable-dp-attention if present
         if "--enable-dp-attention" in args:
@@ -265,16 +278,21 @@ class SGLangConfigModifier:
 
         # 1. Set --tp=dep_size
         args = set_argument_value(args, "--tp", str(dep_size))
+        args = remove_valued_arguments(args, "--tp-size")
+        args = remove_valued_arguments(args, "--tensor-parallel-size")
 
         # 2. Set --dp=dep_size (data parallelism across experts)
         args = set_argument_value(args, "--dp", str(dep_size))
+        args = remove_valued_arguments(args, "--dp-size")
+        args = remove_valued_arguments(args, "--data-parallel-size")
 
         # 3. Enable --enable-dp-attention
-        if "--enable-dp-attention" not in args:
-            args = append_argument(args, "--enable-dp-attention")
+        args = append_argument(args, "--enable-dp-attention")
 
-        # 4. Set --ep-size=dep_size (expert parallelism size)
-        args = set_argument_value(args, "--ep-size", str(dep_size))
+        # 4. Set --ep=dep_size (expert parallelism size)
+        args = set_argument_value(args, "--ep", str(dep_size))
+        args = remove_valued_arguments(args, "--ep-size")
+        args = remove_valued_arguments(args, "--expert-parallel-size")
 
         worker_service.extraPodSpec.mainContainer.args = args
         return cfg.model_dump()

--- a/benchmarks/profiler/utils/model_info.py
+++ b/benchmarks/profiler/utils/model_info.py
@@ -28,8 +28,16 @@ CONTEXT_LENGTH_ATTRS = [
     "sliding_window",  # Mistral with sliding window attention
 ]
 
-# only for MLA + MoE models, treat other MoE models as dense models
-MOE_ARCHITECTURES = {"DeepseekV3ForCausalLM", "DeepseekV32ForCausalLM"}
+# supported MoE architectures
+MOE_ARCHITECTURES = {
+    "DeepseekV3ForCausalLM",
+    "DeepseekV32ForCausalLM",  # MLA + MoE
+    "Qwen3MoeForCausalLM",  # GQA + MoE
+}
+# MoE architectures that sweeps TP additionally to TEP/DEP
+MOE_ADDITIONAL_TP_ARCHITECTURES = {
+    "Qwen3MoeForCausalLM",  # GQA + MoE
+}
 
 
 def get_local_model_weight_size(

--- a/docs/benchmarks/sla_driven_profiling.md
+++ b/docs/benchmarks/sla_driven_profiling.md
@@ -21,15 +21,20 @@ This document covers:
 
 ## Support Matrix
 
-| Backend | Dense Models (P:TP, D:TP) | MoE Models (P:TEP, D:DEP) |
+| Backend | Dense Models | MoE Models |
 |---------|-------------|------------|
 | vLLM | ✅ | 🚧 |
 | SGLang | ✅ | ✅ |
 | TensorRT-LLM | ✅ | 🚧 |
 
+Specifically, the profiler sweeps over the following parallelization mapping for prefill and decode:
+| Model Architecture | Prefill Parallelization Mapping | Decode Parallelization Mapping |
+|---------|-------------|------------|
+| MLA+MoE (DeepseekV3ForCausalLM, DeepseekV32ForCausalLM) | TEP, DEP | TEP, DEP |
+| GQA+MoE (Qwen3MoeForCausalLM) | TP, TEP, DEP | TP, TEP, DEP |
+| Other Models | TP | TP |
+
 > [!NOTE]
-> - We only support multi-node engines for MoE models.
-> - For MoE models, we currently only support deepseek-style MLA+MoE models. For other MoE models like GQA+MoE, please use the dense mode (sweep over TP sizes) instead.
 > - Exact model x parallelization mapping support is dependent on the backend. The profiler does not guarantee that the recommended P/D engine configuration is supported and bug-free by the backend.
 
 ## Using DGDR for Profiling (Recommended)
@@ -269,7 +274,7 @@ profilingConfig:
 **When to use:**
 - **min_num_gpus_per_engine**: Skip small TP sizes if your model is large
 - **max_num_gpus_per_engine**: Limit search space or work around constraints (e.g., [AIC attention heads](#ai-configurator-attention-head-constraint-error))
-- **num_gpus_per_node**: Required for MoE models with TEP/DEP sizing
+- **num_gpus_per_node**: Determine the upper bound of number of GPUs per node for dense models and configure Grove for multi-node MoE engines.
 - **gpu_type**: Informational, auto-detected by controller
 
 > [!TIP]


### PR DESCRIPTION
- now sweep over TP/TEP/DEP for both P/D for Qwen3 Moe
- fix a bug that generated planner config always use TEP P and DEP D regardless of sweeping result
- now support additional `rdma/ib` resource needed for nebius H200

finally can close [DYN-855: SLA-planner scaling MoE #replicas sglang](https://linear.app/nvidia/issue/DYN-855/sla-planner-scaling-moe-replicas-sglang)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for profiling Qwen3MoeForCausalLM architecture.

* **Documentation**
  * Updated profiling documentation with detailed parallelization mapping guidance for dense and MoE models.
  * Clarified hardware configuration descriptions for multi-node engine setups.

* **Refactor**
  * Streamlined benchmark profiling system to use mapping-based configuration parameters, improving code consistency and reducing conditional branching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->