### PR TITLE
fix: add missed dependency for sglang tracing

### DIFF
--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -29,6 +29,7 @@ msgspec==0.19.0
 mypy==1.18.2
 nvidia-ml-py<=13.580.65  # NVIDIA/CUDA related, may vary by driver version
 opentelemetry-api<=1.38.0  # May need to stay in sync with other components
+opentelemetry-exporter-otlp<=1.38.0  # May need to stay in sync with other components
 opentelemetry-sdk<=1.38.0  # May need to stay in sync with other components
 pip<=25.0.1  # System pip, varies by platform
 pmdarima==2.1.1


### PR DESCRIPTION
#### Overview:

It seems that now native sglang tracing does not work in dynamo containers due to the lack of dependency:
```
{"time":"2025-11-26T10:11:48.258076Z","level":"INFO","target":"log","message":"opentelemetry package is not installed, tracing disabled","log.file":"/sgl-workspace/sglang/python/sglang/srt/tracing/trace.py","log.line":52,"log.target":"trace"}
```

The container already has dependencies for opentelemetry-api and opentelemetry-sdk, but there is not enough dependency for the exporter, which is why the error is flying on this line: 
https://github.com/sgl-project/sglang/blob/21b0582d4bb0cc082854410533dbc7489b3c8b18/python/sglang/srt/tracing/trace.py#L44


#### Details:

* add missed opentelemetry-exporter-otlp dependency in containers requirements
 
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- relates to https://github.com/ai-dynamo/dynamo/issues/3668


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added OpenTelemetry OTLP exporter dependency to support enhanced observability capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->