### PR TITLE
docs: remove build container instructions from trtllm multimodal example

### DIFF
--- a/docs/backends/trtllm/multinode/multinode-multimodal-example.md
+++ b/docs/backends/trtllm/multinode/multinode-multimodal-example.md
@@ -16,29 +16,8 @@ limitations under the License.
 -->
 
 # Example: Multi-node TRTLLM Workers with Dynamo on Slurm for multimodal models
-
+a
 > **Note:** The scripts referenced in this example (such as `srun_aggregated.sh` and `srun_disaggregated.sh`) can be found in [`examples/basics/multinode/trtllm/`](https://github.com/ai-dynamo/dynamo/tree/main/examples/basics/multinode/trtllm/).
-
-> [!IMPORTANT]
-> There are some known issues in tensorrt_llm==1.1.0rc5 version for multinode multimodal support. It is important to rebuild the dynamo container with a specific version of tensorrt_llm commit to use multimodal feature.
->
-> **Build Container**
-> ```bash
-> ./container/build.sh --framework trtllm --tensorrtllm-commit b4065d8ca64a64eee9fdc64b39cb66d73d4be47c
-> ```
->
-> **Run Container**
-> ```bash
-> ./container/run.sh --framework trtllm -it
-> ```
->
-> **Update Engine Configuration Files**
->
-> Before running the deployment, you must update the engine configuration files to change `backend: DEFAULT` to `backend: default` (lowercase). Run the following command:
-> ```bash
-> sed -i 's/backend: DEFAULT/backend: default/g' /mnt/examples/backends/trtllm/engine_configs/llama4/multimodal/prefill.yaml /mnt/examples/backends/trtllm/engine_configs/llama4/multimodal/decode.yaml
-> ```
-
 
 This guide demonstrates how to deploy large multimodal models that require a multi-node setup. It builds on the general multi-node deployment process described in the main [multinode-examples.md](./multinode-examples.md) guide.
 

--- a/docs/backends/trtllm/multinode/multinode-multimodal-example.md
+++ b/docs/backends/trtllm/multinode/multinode-multimodal-example.md
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 
 # Example: Multi-node TRTLLM Workers with Dynamo on Slurm for multimodal models
-a
+
 > **Note:** The scripts referenced in this example (such as `srun_aggregated.sh` and `srun_disaggregated.sh`) can be found in [`examples/basics/multinode/trtllm/`](https://github.com/ai-dynamo/dynamo/tree/main/examples/basics/multinode/trtllm/).
 
 This guide demonstrates how to deploy large multimodal models that require a multi-node setup. It builds on the general multi-node deployment process described in the main [multinode-examples.md](./multinode-examples.md) guide.


### PR DESCRIPTION
# Remove TensorRT-LLM Custom Build Workaround for Multimodal

## Summary
This PR removes the outdated workaround instructions for building the Dynamo container with a specific TensorRT-LLM commit to support multinode multimodal deployments. The workaround is no longer necessary as the issues in `tensorrt_llm==1.1.0rc5` have been resolved in newer versions.

## Changes
- Removed the `IMPORTANT` callout section containing:
  - Instructions to rebuild the container with `tensorrt_llm` commit `b4065d8ca64a64eee9fdc64b39cb66d73d4be47c`
  - Manual engine configuration file modifications (`backend: DEFAULT` → `backend: default`)
- Documentation now reflects the current, simplified deployment process without requiring custom builds

## Impact
- Users can now follow the standard container build process for multimodal multinode deployments
- Eliminates confusion from outdated workaround instructions
- Improves documentation clarity and maintenance

## Testing
- Documentation change only, no functional code changes
- Verified the standard build process now works for multimodal multinode deployments

## Related Issues
- Fixes [5695589](https://nvbugs/5695589)

## Cherry-pick Required?
**Yes** - This should be cherry-picked to `release/0.7.0` to ensure users on the release branch have accurate documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified multimodal multi-node setup documentation by consolidating procedural steps and replacing detailed configuration instructions with direct links to example scripts for faster user onboarding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->