### PR TITLE
docs: use default dynamo queue in KAI-Scheduler example

### DIFF
--- a/docs/kubernetes/deployment/multinode-deployment.md
+++ b/docs/kubernetes/deployment/multinode-deployment.md
@@ -51,7 +51,7 @@ These systems provide enhanced scheduling capabilities including topology-aware 
 ##### Prerequisites
 
 - [Grove](https://github.com/NVIDIA/grove/blob/main/docs/installation.md) installed on the cluster
-- (Optional) [KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler) installed on the cluster with default queue name `dynamo` created. You can use a different queue name by setting the `nvidia.com/kai-scheduler-queue` annotation on the DGD resource.
+- (Optional) [KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler) installed on the cluster with the default queue name `dynamo` created. If no queue annotation is specified on the DGD resource, the operator uses the `dynamo` queue by default. Custom queue names can be specified via the `nvidia.com/kai-scheduler-queue` annotation, but the queue must exist in the cluster before deployment.
 
 KAI-Scheduler is optional but recommended for advanced scheduling capabilities.
 
@@ -94,10 +94,12 @@ kind: DynamoGraphDeployment
 metadata:
   name: my-multinode-deployment
   annotations:
-    nvidia.com/kai-scheduler-queue: "gpu-intensive"  # Optional: defaults to "dynamo"
+    nvidia.com/kai-scheduler-queue: "dynamo"
 spec:
   # ... your deployment spec
 ```
+
+> **Note:** The `nvidia.com/kai-scheduler-queue` annotation defaults to `"dynamo"`. If you specify a custom queue name, ensure the queue exists in your cluster before deploying. You can verify available queues with `kubectl get queues`.
 
 **Force LWS usage:**
 ```yaml


### PR DESCRIPTION
## Summary

Updates the KAI-Scheduler queue example in the multinode deployment documentation to use the default `"dynamo"` queue name instead of `"gpu-intensive"`.

## Problem

The previous example showed `nvidia.com/kai-scheduler-queue: "gpu-intensive"` which causes deployment failures with:
```
queue 'gpu-intensive' not found in cluster. Ensure the queue exists before using kai-scheduler
```

Users copying the example directly would hit this error since `gpu-intensive` doesn't exist by default—only the `dynamo` queue is created when KAI-Scheduler is installed.

## Changes

- Updated example to use `"dynamo"` (the default queue)
- Clarified in prerequisites that the operator uses the `dynamo` queue by default when no annotation is specified
- Added note about verifying custom queues exist with `kubectl get queues` before deployment

## Related

- NVBugs 5696395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
  * Clarified KAI-Scheduler queue configuration behavior and default queue application
  * Updated prerequisites with guidance on custom queue annotations and requirements
  * Enhanced deployment documentation with instructions for verifying available queues in the cluster

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->