### PR TITLE
docs: use default dynamo queue in KAI-Scheduler example (#4625)

### DIFF
--- a/docs/kubernetes/deployment/multinode-deployment.md
+++ b/docs/kubernetes/deployment/multinode-deployment.md
@@ -51,7 +51,7 @@ These systems provide enhanced scheduling capabilities including topology-aware 
 ##### Prerequisites
 
 - [Grove](https://github.com/NVIDIA/grove/blob/main/docs/installation.md) installed on the cluster
-- (Optional) [KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler) installed on the cluster with default queue name `dynamo` created. You can use a different queue name by setting the `nvidia.com/kai-scheduler-queue` annotation on the DGD resource.
+- (Optional) [KAI-Scheduler](https://github.com/NVIDIA/KAI-Scheduler) installed on the cluster with the default queue name `dynamo` created. If no queue annotation is specified on the DGD resource, the operator uses the `dynamo` queue by default. Custom queue names can be specified via the `nvidia.com/kai-scheduler-queue` annotation, but the queue must exist in the cluster before deployment.
 
 KAI-Scheduler is optional but recommended for advanced scheduling capabilities.
 
@@ -94,10 +94,12 @@ kind: DynamoGraphDeployment
 metadata:
   name: my-multinode-deployment
   annotations:
-    nvidia.com/kai-scheduler-queue: "gpu-intensive"  # Optional: defaults to "dynamo"
+    nvidia.com/kai-scheduler-queue: "dynamo"
 spec:
   # ... your deployment spec
 ```
+
+> **Note:** The `nvidia.com/kai-scheduler-queue` annotation defaults to `"dynamo"`. If you specify a custom queue name, ensure the queue exists in your cluster before deploying. You can verify available queues with `kubectl get queues`.
 
 **Force LWS usage:**
 ```yaml


### PR DESCRIPTION
# Cherry-pick: docs: use default dynamo queue in KAI-Scheduler example

## Summary

Cherry-pick of PR #4625 from main to release/0.7.0.

Updates the KAI-Scheduler queue example in the multinode deployment documentation to use the default `"dynamo"` queue name instead of `"gpu-intensive"`.

## Problem

The previous example showed `nvidia.com/kai-scheduler-queue: "gpu-intensive"` which causes deployment failures with:

```
queue 'gpu-intensive' not found in cluster. Ensure the queue exists before using kai-scheduler
```

Users copying the example directly would hit this error since `gpu-intensive` doesn't exist by default—only the `dynamo` queue is created when KAI-Scheduler is installed.

## Changes

* Updated example to use `"dynamo"` (the default queue)
* Clarified in prerequisites that the operator uses the `dynamo` queue by default when no annotation is specified
* Added note about verifying custom queues exist with `kubectl get queues` before deployment

## Related

* Original PR: #4625
* NVBugs 5696395

## Cherry-pick Justification

This is a documentation fix (size/XS) that prevents users from hitting a deployment error when following the multinode deployment guide. The fix is minimal and only affects documentation, making it low-risk for the release branch.

