### PR TITLE
fix: Remove the hard-coded version from installation path (#4564)

### DIFF
--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -144,7 +144,7 @@ RUN if [ "$HAS_TRTLLM_CONTEXT" = "1" ]; then \
         fi; \
     else \
         # Download and run install_tensorrt.sh from TensorRT-LLM GitHub before installing the wheel
-        TRTLLM_VERSION=$(echo "${TENSORRTLLM_PIP_WHEEL}" | sed -n 's/.*==\([0-9a-zA-Z\.\-]*\).*/\1/p') && \
+        TRTLLM_VERSION=$(echo "${TENSORRTLLM_PIP_WHEEL}" | sed -E 's/.*==([0-9a-zA-Z.+-]+).*/\1/') && \
         (curl -fsSL --retry 5 --retry-delay 10 --max-time 1800 -o /tmp/install_tensorrt.sh "https://github.com/NVIDIA/TensorRT-LLM/raw/v${TRTLLM_VERSION}/docker/common/install_tensorrt.sh" || \
          curl -fsSL --retry 5 --retry-delay 10 --max-time 1800 -o /tmp/install_tensorrt.sh "https://github.com/NVIDIA/TensorRT-LLM/raw/${GITHUB_TRTLLM_COMMIT}/docker/common/install_tensorrt.sh") && \
         # Modify the script to use virtual environment pip instead of system pip3
@@ -153,8 +153,14 @@ RUN if [ "$HAS_TRTLLM_CONTEXT" = "1" ]; then \
         # Install TensorRT-LLM wheel from the provided index URL, allow dependencies from PyPI
         # TRTLLM 1.2.0rc2 has issues installing from pypi with uv, installing from direct wheel link works best
         # explicitly installing triton 3.5.0 as trtllm only lists triton as dependency on x64_64 for some reason
-        export TENSORRTLLM_PIP_WHEEL="https://pypi.nvidia.com/tensorrt-llm/tensorrt_llm-1.2.0rc2-cp312-cp312-linux_${ARCH_ALT}.whl"; \
-        uv pip install --no-cache --index-strategy=unsafe-best-match --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" triton==3.5.0; \
+        if echo "${TENSORRTLLM_PIP_WHEEL}" | grep -q '^tensorrt-llm=='; then \
+            TRTLLM_VERSION=$(echo "${TENSORRTLLM_PIP_WHEEL}" | sed -E 's/tensorrt-llm==([0-9a-zA-Z.+-]+).*/\1/'); \
+            PYTHON_TAG="cp$(echo ${PYTHON_VERSION} | tr -d '.')"; \
+            DIRECT_URL="https://pypi.nvidia.com/tensorrt-llm/tensorrt_llm-${TRTLLM_VERSION}-${PYTHON_TAG}-${PYTHON_TAG}-linux_${ARCH_ALT}.whl"; \
+            uv pip install --no-cache --index-strategy=unsafe-best-match --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${DIRECT_URL}" triton==3.5.0; \
+        else \
+            uv pip install --no-cache --index-strategy=unsafe-best-match --extra-index-url "${TENSORRTLLM_INDEX_URL}" "${TENSORRTLLM_PIP_WHEEL}" triton==3.5.0; \
+        fi; \
     fi
 
 ##################################################


### PR DESCRIPTION
# Cherry-pick: fix: Remove the hard-coded version from installation path

## Summary

Cherry-pick of PR #4564 from main to release/0.7.0.

Fixes the TensorRT-LLM wheel installation logic in the container build to support flexible version specifications instead of hard-coded versions.

## Problem

Before this fix, the TensorRT-LLM wheel installation path was hard-coded to `tensorrt_llm-1.2.0rc2`, ignoring the version specified by the script arguments. This prevented users from building containers with different TensorRT-LLM versions (e.g., 1.2.0rc3).

## Changes

* Modified `container/Dockerfile.trtllm` to extract version from pip spec format (`tensorrt-llm==X.Y.Z`)
* Added conditional logic to construct the correct wheel URL with the extracted version
* Maintains backward compatibility with existing wheel specification formats

## Technical Details

When `TENSORRTLLM_PIP_WHEEL` begins with `tensorrt-llm==`, the version is extracted and used to construct a direct URL to the wheel. Otherwise, the original behavior is preserved.

## Related

* Original PR: #4564
* Merged to main: Nov 26, 2025 (commit: 953f5a1)

## Cherry-pick Justification

This is a build system fix (size/XS) that enables flexible TensorRT-LLM version specifications in container builds. This is important for the 0.7.0 release as it allows users to build containers with the correct TensorRT-LLM version without modifying the Dockerfile directly.

The change is minimal (9 additions, 3 deletions), only affects the container build logic, and has been tested in CI. Low risk for the release branch.

## Testing

* Verified container builds with `tensorrt-llm==1.2.0rc2` and `tensorrt-llm==1.2.0rc3`
* CI checks passed on main branch

