### PR TITLE
docs: remove build container instructions from trtllm multimodal exam…

### DIFF
--- a/docs/backends/trtllm/multinode/multinode-multimodal-example.md
+++ b/docs/backends/trtllm/multinode/multinode-multimodal-example.md
@@ -19,27 +19,6 @@ limitations under the License.
 
 > **Note:** The scripts referenced in this example (such as `srun_aggregated.sh` and `srun_disaggregated.sh`) can be found in [`examples/basics/multinode/trtllm/`](https://github.com/ai-dynamo/dynamo/tree/main/examples/basics/multinode/trtllm/).
 
-> [!IMPORTANT]
-> There are some known issues in tensorrt_llm==1.1.0rc5 version for multinode multimodal support. It is important to rebuild the dynamo container with a specific version of tensorrt_llm commit to use multimodal feature.
->
-> **Build Container**
-> ```bash
-> ./container/build.sh --framework trtllm --tensorrtllm-commit b4065d8ca64a64eee9fdc64b39cb66d73d4be47c
-> ```
->
-> **Run Container**
-> ```bash
-> ./container/run.sh --framework trtllm -it
-> ```
->
-> **Update Engine Configuration Files**
->
-> Before running the deployment, you must update the engine configuration files to change `backend: DEFAULT` to `backend: default` (lowercase). Run the following command:
-> ```bash
-> sed -i 's/backend: DEFAULT/backend: default/g' /mnt/examples/backends/trtllm/engine_configs/llama4/multimodal/prefill.yaml /mnt/examples/backends/trtllm/engine_configs/llama4/multimodal/decode.yaml
-> ```
-
-
 This guide demonstrates how to deploy large multimodal models that require a multi-node setup. It builds on the general multi-node deployment process described in the main [multinode-examples.md](./multinode-examples.md) guide.
 
 Before you begin, ensure you have completed the initial environment configuration by following the **Setup** section in that guide.


### PR DESCRIPTION
# Cherry-pick: docs: remove build container instructions from trtllm multimodal example

## Summary

Cherry-pick of PR #4624 to `release/0.7.0` to remove outdated workaround instructions for building the Dynamo container with a specific TensorRT-LLM commit for multinode multimodal deployments.

## Original PR

- **Original PR**: #4624 (merged to main)
- **Original Merge Commit**: 2e5e68b

## Changes

* Removed the `IMPORTANT` callout section containing:
  * Instructions to rebuild the container with `tensorrt_llm` commit `b4065d8ca64a64eee9fdc64b39cb66d73d4be47c`
  * Manual engine configuration file modifications (`backend: DEFAULT` → `backend: default`)
* Documentation now reflects the current, simplified deployment process without requiring custom builds

## Why Cherry-pick to Release?

The workaround instructions are outdated and no longer necessary in newer TensorRT-LLM versions. Users on `release/0.7.0` should have accurate documentation without confusing, obsolete build instructions.

## Impact

* Users on release/0.7.0 can now follow the standard container build process for multimodal multinode deployments
* Eliminates confusion from outdated workaround instructions
* Improves documentation clarity and maintenance

## Testing

* Documentation change only, no functional code changes
* Standard documentation build verification applies

## Related Issues

* Original PR: #4624
* Fixes 5695589

---

**Type**: docs  
**Reason**: Remove outdated TensorRT-LLM multimodal workaround instructions for release/0.7.0  
**PiC**: Dan Gil  
**PR to main**: #4624  
**Cherry-pick commit**: 23e91e7a3
