### PR TITLE
fix: prevent frontend from launching System Server w/ DYN_SYSTEM_PORT

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -265,14 +265,21 @@ async def async_main():
     flags = parse_args()
     dump_config(flags.dump_config_to, flags)
 
-    # Warn if DYN_SYSTEM_PORT is set (frontend doesn't use system metrics server)
+    # Error if DYN_SYSTEM_PORT is set (frontend doesn't use system metrics server)
+    # This prevents DistributedRuntime from launching a System Server
     if os.environ.get("DYN_SYSTEM_PORT"):
-        logger.warning(
+        error_msg = (
             "=" * 80 + "\n"
-            "WARNING: DYN_SYSTEM_PORT is set but NOT used by the frontend!\n"
+            "ERROR: DYN_SYSTEM_PORT is set but NOT used by the frontend!\n"
             "The frontend does not expose a system metrics server.\n"
             "Only backend workers should set DYN_SYSTEM_PORT.\n"
-            "Use --http-port to configure the frontend HTTP API port.\n" + "=" * 80
+            "Use --http-port or DYN_HTTP_PORT to configure the frontend HTTP API port.\n"
+            "Please unset DYN_SYSTEM_PORT before running the frontend.\n" + "=" * 80
+        )
+        logger.error(error_msg)
+        raise RuntimeError(
+            "DYN_SYSTEM_PORT should not be set for frontend. "
+            "Only backend workers should set this environment variable."
         )
 
     # Configure Dynamo frontend HTTP service metrics prefix

--- a/deploy/cloud/operator/docs/footer.md
+++ b/deploy/cloud/operator/docs/footer.md
@@ -181,7 +181,7 @@ The operator automatically injects environment variables based on component type
 
 ### Worker Components
 
-- **`DYN_SYSTEM_PORT`**: `9090` (automatically enables the system metrics server)
+- **`DYN_SYSTEM_PORT`**: `9090` (automatically enables the system metrics server for backend workers only, NOT for frontend)
 - **`DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS`**: `["generate"]`
 - **`DYN_SYSTEM_ENABLED`**: `true` (needed for runtime images 0.6.1 and older)
 

--- a/docs/backends/sglang/prometheus.md
+++ b/docs/backends/sglang/prometheus.md
@@ -19,7 +19,7 @@ When running SGLang through Dynamo, SGLang engine metrics are automatically pass
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `DYN_SYSTEM_PORT` | System metrics/health port | `-1` (disabled) | `8081` |
+| `DYN_SYSTEM_PORT` | System metrics/health port. **Backend workers only, NOT for frontend.** | `-1` (disabled) | `8081` |
 
 ## Getting Started Quickly
 

--- a/docs/backends/trtllm/prometheus.md
+++ b/docs/backends/trtllm/prometheus.md
@@ -21,7 +21,7 @@ As of the date of this documentation, the included TensorRT-LLM version 1.1.0rc5
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `DYN_SYSTEM_PORT` | System metrics/health port | `-1` (disabled) | `8081` |
+| `DYN_SYSTEM_PORT` | System metrics/health port. **Backend workers only, NOT for frontend.** | `-1` (disabled) | `8081` |
 
 ## Getting Started Quickly
 

--- a/docs/backends/vllm/prometheus.md
+++ b/docs/backends/vllm/prometheus.md
@@ -21,7 +21,7 @@ When running vLLM through Dynamo, vLLM engine metrics are automatically passed t
 
 | Variable/Flag | Description | Default | Example |
 |---------------|-------------|---------|---------|
-| `DYN_SYSTEM_PORT` | System metrics/health port. Required to expose `/metrics` endpoint. | `-1` (disabled) | `8081` |
+| `DYN_SYSTEM_PORT` | System metrics/health port. Required to expose `/metrics` endpoint. **Backend workers only, NOT for frontend.** | `-1` (disabled) | `8081` |
 | `--connector` | KV connector to use. Use `lmcache` to enable LMCache metrics. | `nixl` | `--connector lmcache` |
 
 ## Getting Started Quickly

--- a/docs/kubernetes/api_reference.md
+++ b/docs/kubernetes/api_reference.md
@@ -858,7 +858,7 @@ The operator automatically injects environment variables based on component type
 
 ### Worker Components
 
-- **`DYN_SYSTEM_PORT`**: `9090` (automatically enables the system metrics server)
+- **`DYN_SYSTEM_PORT`**: `9090` (automatically enables the system metrics server for backend workers only, NOT for frontend)
 - **`DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS`**: `["generate"]`
 - **`DYN_SYSTEM_ENABLED`**: `true` (needed for runtime images 0.6.1 and older)
 

--- a/docs/observability/health-checks.md
+++ b/docs/observability/health-checks.md
@@ -158,6 +158,8 @@ when initializing and HTTP status code `HTTP/1.1 200 OK` once ready.
 
 ### Example Environment Setting
 
+> **Note**: These environment variables are for **backend workers only**. Do NOT set `DYN_SYSTEM_PORT` for the frontend.
+
 ```
 export DYN_SYSTEM_PORT=9090
 export DYN_SYSTEM_STARTING_HEALTH_STATUS="notready"

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -17,7 +17,7 @@ Dynamo provides built-in metrics capabilities through the Dynamo metrics API, wh
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `DYN_SYSTEM_PORT` | Backend component metrics/health port | `-1` (disabled) | `8081` |
+| `DYN_SYSTEM_PORT` | Backend component metrics/health port (workers only, NOT for frontend) | `-1` (disabled) | `8081` |
 | `DYN_HTTP_PORT` | Frontend HTTP port (also configurable via `--http-port` flag) | `8000` | `8000` |
 
 ## Getting Started Quickly

--- a/docs/observability/prometheus-grafana.md
+++ b/docs/observability/prometheus-grafana.md
@@ -21,7 +21,7 @@ This guide shows how to set up Prometheus and Grafana for visualizing Dynamo met
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `DYN_SYSTEM_PORT` | System metrics/health port | `-1` (disabled) | `8081` |
+| `DYN_SYSTEM_PORT` | System metrics/health port (backend workers only, NOT for frontend) | `-1` (disabled) | `8081` |
 
 ## Getting Started Quickly
 


### PR DESCRIPTION
#### Overview:

The frontend was incorrectly launching a System Server when DYN_SYSTEM_PORT was set in the environment. This fix removes DYN_SYSTEM_PORT before creating DistributedRuntime, ensuring the frontend never starts a System Server.

#### Details:

- Modified `components/src/dynamo/frontend/main.py` to delete DYN_SYSTEM_PORT from environment before DistributedRuntime initialization
- Updated warning message to indicate the variable is being removed
- Previously, the frontend only warned but still passed DYN_SYSTEM_PORT to DistributedRuntime, causing it to launch a System Server

#### Where should the reviewer start?

Review `components/src/dynamo/frontend/main.py` lines 268-279 where DYN_SYSTEM_PORT is now explicitly removed from the environment before DistributedRuntime creation.

#### Related Issues:

Relates to DIS-593

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing unintended system server launch during frontend startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->