### PR TITLE
fix: duplicate dictionary key 31 in XID_MESSAGES

### DIFF
--- a/tests/fault_tolerance/hardware/fault-injection-service/agents/gpu-fault-injector/gpu_xid_injector.py
+++ b/tests/fault_tolerance/hardware/fault-injection-service/agents/gpu-fault-injector/gpu_xid_injector.py
@@ -110,7 +110,6 @@ XID_MESSAGES: Dict[int, str] = {
     57: "Clocks Event: Power limit exceeded",
     # Common Graphics XIDs (often seen in test environments)
     13: "Graphics Engine Exception",
-    31: "GPU stopped responding",  # Can be both MMU or timeout context
     45: "Preemptive Cleanup, due to previous errors",
     69: "Graphics Exception: Class Error",
 }


### PR DESCRIPTION
#### Overview:
Remove duplicate key causing ruff to fail.
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
Remove duplicate key 31 from XID_MESSAGES dictionary in gpu_xid_injector.py. Key 31 was defined twice:
- Line 92: "MMU Error" (Memory Subsystem section)
- Line 113: "GPU stopped responding" (Graphics section)

Removed the duplicate from Graphics section as the MMU Error definition is the primary meaning and the comment indicated it can be both contexts.

Fixes ruff pre-commit error: F601 Dictionary key literal `31` repeated

#### Where should the reviewer start?
- Line 92 of gpu_xid_injector.py (XID_MESSAGES dictionary)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to #4043


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GPU fault injection test infrastructure to simplify error handling for certain failure scenarios.

---

**Note:** This is an internal technical change with no direct impact on user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->