### PR TITLE
fix: enable LMCache metrics visibility with PROMETHEUS_MULTIPROC_DIR

### DIFF
--- a/docs/backends/vllm/LMCache_Integration.md
+++ b/docs/backends/vllm/LMCache_Integration.md
@@ -156,6 +156,7 @@ When LMCache is enabled with `--connector lmcache` and `DYN_SYSTEM_PORT` is set,
 **Requirements to access LMCache metrics:**
 - `--connector lmcache` - Enables LMCache
 - `DYN_SYSTEM_PORT=8081` - Enables metrics HTTP endpoint
+- `PROMETHEUS_MULTIPROC_DIR` (optional) - If not set, Dynamo manages it internally. Only set explicitly if you need control over the metrics directory.
 
 For detailed information on LMCache metrics, including the complete list of available metrics and how to access them, see the **[LMCache Metrics section](prometheus.md#lmcache-metrics)** in the vLLM Prometheus Metrics Guide.
 

--- a/docs/backends/vllm/prometheus.md
+++ b/docs/backends/vllm/prometheus.md
@@ -136,7 +136,7 @@ curl -s localhost:8081/metrics | grep "^lmcache:"
 ## Implementation Details
 
 - vLLM v1 uses multiprocess metrics collection via `prometheus_client.multiprocess`
-- `PROMETHEUS_MULTIPROC_DIR`: vLLM sets this environment variable to a temporary directory where multiprocess metrics are stored as memory-mapped files. Each worker process writes its metrics to separate files in this directory, which are aggregated when `/metrics` is scraped.
+- `PROMETHEUS_MULTIPROC_DIR`: (optional). By default, Dynamo automatically manages this environment variable, setting it to a temporary directory where multiprocess metrics are stored as memory-mapped files. Each worker process writes its metrics to separate files in this directory, which are aggregated when `/metrics` is scraped. Users only need to set this explicitly where complete control over the metrics directory is required.
 - Dynamo uses `MultiProcessCollector` to aggregate metrics from all worker processes
 - Metrics are filtered by the `vllm:` and `lmcache:` prefixes before being exposed (when LMCache is enabled)
 - The integration uses Dynamo's `register_engine_metrics_callback()` function with the global `REGISTRY`

--- a/examples/backends/vllm/launch/agg_lmcache.sh
+++ b/examples/backends/vllm/launch/agg_lmcache.sh
@@ -4,10 +4,13 @@
 set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
+# Explicitly unset PROMETHEUS_MULTIPROC_DIR to let LMCache or Dynamo manage it internally
+unset PROMETHEUS_MULTIPROC_DIR
+
 # run ingress
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
 python -m dynamo.frontend &
 
-# run worker with LMCache enabled
+# run worker with LMCache enabled (without PROMETHEUS_MULTIPROC_DIR set externally)
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
   python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector lmcache

--- a/examples/backends/vllm/launch/agg_lmcache_multiproc.sh
+++ b/examples/backends/vllm/launch/agg_lmcache_multiproc.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+# Explicitly set PROMETHEUS_MULTIPROC_DIR (K8s-style deployment)
+# Use unique directory per test run to avoid conflicts
+export PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR:-/tmp/prometheus_multiproc_$$_$RANDOM}
+rm -rf "$PROMETHEUS_MULTIPROC_DIR"
+mkdir -p "$PROMETHEUS_MULTIPROC_DIR"
+
+# Cleanup function to remove the directory on exit
+cleanup() {
+    echo "Cleaning up..."
+    rm -rf "$PROMETHEUS_MULTIPROC_DIR"
+    kill 0
+}
+trap cleanup EXIT
+
+# run ingress
+# dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
+python -m dynamo.frontend &
+
+# run worker with LMCache enabled and PROMETHEUS_MULTIPROC_DIR explicitly set
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+  PROMETHEUS_MULTIPROC_DIR="$PROMETHEUS_MULTIPROC_DIR" \
+  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector lmcache
+

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -4,6 +4,7 @@
 import base64
 import logging
 import os
+import random
 from dataclasses import dataclass, field
 
 import pytest
@@ -57,6 +58,22 @@ vllm_configs = {
         script_name="agg_lmcache.sh",
         marks=[pytest.mark.gpu_1],
         model="Qwen/Qwen3-0.6B",
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+            metric_payload_default(min_num_requests=6, backend="vllm"),
+            metric_payload_default(min_num_requests=6, backend="lmcache"),
+        ],
+    ),
+    "aggregated_lmcache_multiproc": VLLMConfig(
+        name="aggregated_lmcache_multiproc",
+        directory=vllm_dir,
+        script_name="agg_lmcache_multiproc.sh",
+        marks=[pytest.mark.gpu_1],
+        model="Qwen/Qwen3-0.6B",
+        env={
+            "PROMETHEUS_MULTIPROC_DIR": f"/tmp/prometheus_multiproc_test_{os.getpid()}_{random.randint(0, 10000)}"
+        },
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),


### PR DESCRIPTION
#### Overview:

Fixes LMCache metrics visibility when PROMETHEUS_MULTIPROC_DIR is explicitly set by users (K8s deployments). Previously, lmcache:* metrics were not exposed due to Prometheus registry conflicts when the environment variable was set before process initialization.

#### Details:

- Implemented dual-registry approach in vLLM main.py to handle both deployment scenarios
- Added setup_metrics_collection() helper function that tries MultiProcessCollector(REGISTRY) first, falls back to separate registry on conflict
- Moved prometheus_client imports to top of file for proper multiprocess mode initialization
- Added aggregated_lmcache_multiproc test scenario with explicit PROMETHEUS_MULTIPROC_DIR
- Updated aggregated_lmcache.sh to explicitly unset the variable for local dev testing
- Both test scenarios produce identical metrics (492 lines: 338 vllm, 101 lmcache) with no duplicates

#### Where should the reviewer start?

components/src/dynamo/vllm/main.py - Review the setup_metrics_collection() function (lines 110-190) which implements the dual-registry logic with detailed comments explaining the approach.

#### Related Issues:

Relates to DIS-1071

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-process Prometheus monitoring setup for enhanced metrics collection in distributed scenarios.

* **Refactor**
  * Centralized metrics initialization for improved reliability and consistency across different deployment modes.
  * Enhanced multiprocess metrics handling with better conflict resolution.

* **Tests**
  * Added test configuration for multi-process Prometheus monitoring verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->