### PR TITLE
fix: add explicit sniffio dependency to fix kr8s port forwarding

### DIFF
--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -43,6 +43,12 @@ PyYAML==6.0.3
 scikit-learn==1.7.2
 scipy<1.14.0  # Upper bound for pmdarima compatibility
 sentencepiece==0.2.1
+# sniffio: Required by kr8s for port forwarding. Previously provided transitively via
+# kubernetes→kr8s (requires anyio>=3.7.0)→anyio 4.11.0→sniffio, but anyio 4.12.0 removed
+# sniffio from its dependencies. kr8s 0.20.13 imports sniffio directly without declaring it
+# and doesn't pin anyio to <4.12.0, so we must explicitly include sniffio here to prevent
+# ModuleNotFoundError during kr8s port forwarding.
+sniffio==1.3.1
 tensorboard==2.19.0
 tensorboardX==2.6.2.2
 # Transformers version constraint for container builds


### PR DESCRIPTION
#### Overview:

Fixes `ModuleNotFoundError: No module named 'sniffio'` when using kr8s port forwarding. The issue occurs because kr8s imports sniffio directly but doesn't declare it as a dependency, and anyio 4.12.0 removed sniffio from its transitive dependencies.

#### Details:

- Added explicit `sniffio==1.3.1` dependency to `container/deps/requirements.txt`
- Previously provided transitively: `kubernetes→kr8s→anyio 4.11.0→sniffio`
- `anyio` 4.12.0 removed `sniffio` from dependencies, breaking kr8s port forwarding
- `kr8s 0.20.13` imports `sniffio` directly without declaring it or pinning anyio

#### Where should the reviewer start?

`container/deps/requirements.txt` - Added sniffio dependency with detailed comment explaining the transitive dependency chain issue

#### Related Issues:

/coderabbit profile chill