### PR TITLE
feat: SGLang FP8 improvements and vLLM benchmark enhancements

### DIFF
--- a/examples/backends/sglang/slurm_jobs/scripts/gb200-fp8/disagg/1p_4d.sh
+++ b/examples/backends/sglang/slurm_jobs/scripts/gb200-fp8/disagg/1p_4d.sh
@@ -83,6 +83,7 @@ if [ "$mode" = "prefill" ]; then
     if [[ "${USE_INIT_LOCATIONS,,}" == "true" ]]; then command_suffix="--init-expert-location /configs/prefill_dsr1-0528_in1000out1000_num40000.json"; fi
     if [[ -n "${DUMP_CONFIG_PATH}" ]]; then command_suffix="${command_suffix} --dump-config-to ${DUMP_CONFIG_PATH}"; fi
 
+    SGLANG_ENABLE_JIT_DEEPGEMM=false \
     DYN_SKIP_SGLANG_LOG_FORMATTING=1 \
     MC_TE_METRIC=true \
     SGLANG_ENABLE_FLASHINFER_GEMM=1 \
@@ -140,6 +141,7 @@ elif [ "$mode" = "decode" ]; then
     if [[ "${USE_INIT_LOCATIONS,,}" == "true" ]]; then command_suffix="--init-expert-location /configs/decode_dsr1-0528_loadgen_in1024out1024_num2000_2p12d.json"; fi
     if [[ -n "${DUMP_CONFIG_PATH}" ]]; then command_suffix="${command_suffix} --dump-config-to ${DUMP_CONFIG_PATH}"; fi
 
+    SGLANG_ENABLE_JIT_DEEPGEMM=false \
     DYN_SKIP_SGLANG_LOG_FORMATTING=1 \
     MC_TE_METRIC=true \
     SGLANG_ENABLE_FLASHINFER_GEMM=1 \

--- a/examples/backends/sglang/slurm_jobs/scripts/vllm/bench.sh
+++ b/examples/backends/sglang/slurm_jobs/scripts/vllm/bench.sh
@@ -27,7 +27,7 @@ chosen_req_rate=$8
 
 echo "Config ${chosen_isl}; ${chosen_osl}; ${chosen_concurrencies[@]}; ${chosen_req_rate}"
 
-wait_for_model_timeout=1500
+wait_for_model_timeout=3000
 wait_for_model_check_interval=5
 wait_for_model_report_interval=60
 

--- a/examples/backends/sglang/slurm_jobs/scripts/vllm/bench.sh
+++ b/examples/backends/sglang/slurm_jobs/scripts/vllm/bench.sh
@@ -96,7 +96,7 @@ for concurrency in "${chosen_concurrencies[@]}"
 do
     num_prompts=$((concurrency * 5))
     echo "Running benchmark with concurrency: $concurrency and num-prompts: $num_prompts, writing to file ${result_dir}"
-    result_filename="isl_${chosen_isl}_osl_${chosen_osl}_concurrency_${concurrency}_req_rate_${chosen_req_rate}_ctx${prefill_gpus}_gen${decode_gpus}.json"
+    result_filename="isl_${chosen_isl}_osl_${chosen_osl}_concurrency_${concurrency}_req_rate_${chosen_req_rate}_ctx_${prefill_gpus}_gen_${decode_gpus}_gpus_${total_gpus}.json"
 
     set -x
     echo "$(date '+%Y-%m-%d %H:%M:%S')"

--- a/examples/backends/sglang/slurm_jobs/scripts/vllm/bench.sh
+++ b/examples/backends/sglang/slurm_jobs/scripts/vllm/bench.sh
@@ -40,7 +40,7 @@ set -e
 warmup_isl=$chosen_isl
 warmup_osl=$chosen_osl
 warmup_req_rate=250
-warmup_concurrency_list=(1 4 8 32 64 128 256 512 1024)
+warmup_concurrency_list=(1 4 8 32 64 128 256 512)
 
 # Ensure all chosen concurrencies are in warmup list
 for c in "${chosen_concurrencies[@]}"; do


### PR DESCRIPTION
## Summary

- Disable JIT DeepGEMM for FP8 disaggregated inference to improve stability
- Extend model warmup timeout from 25 to 50 minutes for better reliability
- Enhance warmup process to dynamically include all target concurrencies
- Update benchmark result filename format for better clarity and metadata

## Changes

### SGLang FP8 Disaggregated Inference (`1p_4d.sh`)
- Set `SGLANG_ENABLE_JIT_DEEPGEMM=false` for both prefill and decode modes
- Prevents JIT compilation issues with FP8 inference

### vLLM Benchmark Script (`bench.sh`)
- **Warmup improvements:**
  - Increased `wait_for_model_timeout` from 1500s (25 min) to 3000s (50 min)
  - Warmup now dynamically includes all chosen concurrency values, not just predefined list
  - Warmup list is sorted numerically for consistent behavior
- **Filename format:**
  - Changed from `ctx${prefill_gpus}_gen${decode_gpus}` to `ctx_${prefill_gpus}_gen_${decode_gpus}_gpus_${total_gpus}`
  - Improves parsing and adds total GPU count to metadata
- Removed trailing `set +e` for cleaner script termination

## Test Plan

- [ ] Verify FP8 disaggregated inference runs without JIT DeepGEMM errors
- [ ] Confirm warmup completes successfully with extended timeout
- [ ] Validate warmup includes all target concurrencies
- [ ] Check benchmark result files use new naming format
- [ ] Test with various concurrency configurations

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmarking scripts with improved timeout handling (increased from 1500ms to 3000ms).
  * Enhanced warmup orchestration with dynamic concurrency list computation.
  * Improved result file naming convention for clearer GPU configuration tracking.
  * Added performance tuning configuration for deepgemm optimization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->