### PR TITLE
fix: skip HuggingFace download for non-llms

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -328,8 +328,7 @@ fn register_llm<'p>(
         // For TensorBased models, skip HuggingFace downloads and register directly
         if is_tensor_based {
             let model_name = model_name.unwrap_or_else(|| source_path.clone());
-            let mut card =
-                llm_rs::model_card::ModelDeploymentCard::with_name_only(&model_name);
+            let mut card = llm_rs::model_card::ModelDeploymentCard::with_name_only(&model_name);
             card.model_type = model_type_obj;
             card.model_input = model_input;
             card.user_data = user_data_json;

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -327,7 +327,7 @@ fn register_llm<'p>(
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         // For TensorBased models, skip HuggingFace downloads and register directly
         if is_tensor_based {
-            let model_name = model_name.unwrap_or_else(|| inner_path.clone());
+            let model_name = model_name.unwrap_or_else(|| source_path.clone());
             let mut card =
                 llm_rs::model_card::ModelDeploymentCard::with_name_only(&model_name);
             card.model_type = model_type_obj;

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1095,6 +1095,33 @@ def lora_name_to_id(lora_name: str) -> int:
     """Generate a deterministic integer ID from a LoRA name using blake3 hash."""
     ...
 
+async def register_model(
+    endpoint: Endpoint,
+    model_name: str,
+    model_type: Optional[ModelType] = None,
+    model_input: Optional[ModelInput] = None,
+    user_data: Optional[Dict[str, Any]] = None,
+    runtime_config: Optional[ModelRuntimeConfig] = None,
+) -> None:
+    """
+    Register a model endpoint without requiring local files or HuggingFace downloads.
+
+    This is designed for TensorBased models where the backend handles all preprocessing.
+    Unlike `register_llm`, this function does not download any files from HuggingFace.
+
+    Args:
+        endpoint: The endpoint to register the model on
+        model_name: The display name for the model
+        model_type: The model type (defaults to ModelType.TensorBased)
+        model_input: The input type (defaults to ModelInput.Tensor)
+        user_data: Optional user data to attach to the model card
+        runtime_config: Optional runtime configuration
+
+    Example:
+        await register_model(endpoint, "my-custom-model")
+    """
+    ...
+
 async def fetch_llm(remote_name: str) -> str:
     """
     Download a model from Hugging Face, returning it's local path.

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1096,29 +1096,32 @@ def lora_name_to_id(lora_name: str) -> int:
     ...
 
 async def register_model(
+    model_input: ModelInput,
+    model_type: ModelType,
     endpoint: Endpoint,
     model_name: str,
-    model_type: Optional[ModelType] = None,
-    model_input: Optional[ModelInput] = None,
     user_data: Optional[Dict[str, Any]] = None,
     runtime_config: Optional[ModelRuntimeConfig] = None,
 ) -> None:
     """
-    Register a model endpoint without requiring local files or HuggingFace downloads.
+    Register a tensor-based model endpoint without requiring local files or HuggingFace downloads.
 
-    This is designed for TensorBased models where the backend handles all preprocessing.
+    This is designed for custom backends that handle all preprocessing themselves.
     Unlike `register_llm`, this function does not download any files from HuggingFace.
 
+    This function only supports Tensor input (not Text or Tokens). For LLM models
+    that require tokenizers and config files, use `register_llm` instead.
+
     Args:
+        model_input: The input type (must be ModelInput.Tensor)
+        model_type: The model type (e.g., ModelType.TensorBased)
         endpoint: The endpoint to register the model on
         model_name: The display name for the model
-        model_type: The model type (defaults to ModelType.TensorBased)
-        model_input: The input type (defaults to ModelInput.Tensor)
         user_data: Optional user data to attach to the model card
         runtime_config: Optional runtime configuration
 
     Example:
-        await register_model(endpoint, "my-custom-model")
+        await register_model(ModelInput.Tensor, ModelType.TensorBased, endpoint, "my-custom-model")
     """
     ...
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1077,6 +1077,10 @@ async def register_llm(
         Providing only one of these parameters will raise a ValueError.
         - `lora_name`: The served model name for the LoRA model
         - `base_model_path`: Path to the base model that the LoRA extends
+
+    For TensorBased models (using ModelInput.Tensor), HuggingFace downloads are skipped
+    and a minimal model card is registered directly. Use model_path as the display name
+    for these models.
     """
     ...
 
@@ -1093,23 +1097,6 @@ async def unregister_llm(
 
 def lora_name_to_id(lora_name: str) -> int:
     """Generate a deterministic integer ID from a LoRA name using blake3 hash."""
-    ...
-
-async def register_model(
-    model_input: ModelInput,
-    model_type: ModelType,
-    endpoint: Endpoint,
-    model_name: str,
-    user_data: Optional[Dict[str, Any]] = None,
-    runtime_config: Optional[ModelRuntimeConfig] = None,
-) -> None:
-    """
-    Attach the model at path to the given endpoint, and advertise it as model_type.
-
-    For TensorBased models (using ModelInput.Tensor), HuggingFace downloads are skipped
-    and a minimal model card is registered directly. Use model_path as the display name
-    for these models.
-    """
     ...
 
 async def fetch_llm(remote_name: str) -> str:

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1104,24 +1104,11 @@ async def register_model(
     runtime_config: Optional[ModelRuntimeConfig] = None,
 ) -> None:
     """
-    Register a tensor-based model endpoint without requiring local files or HuggingFace downloads.
+    Attach the model at path to the given endpoint, and advertise it as model_type.
 
-    This is designed for custom backends that handle all preprocessing themselves.
-    Unlike `register_llm`, this function does not download any files from HuggingFace.
-
-    This function only supports Tensor input (not Text or Tokens). For LLM models
-    that require tokenizers and config files, use `register_llm` instead.
-
-    Args:
-        model_input: The input type (must be ModelInput.Tensor)
-        model_type: The model type (e.g., ModelType.TensorBased)
-        endpoint: The endpoint to register the model on
-        model_name: The display name for the model
-        user_data: Optional user data to attach to the model card
-        runtime_config: Optional runtime configuration
-
-    Example:
-        await register_model(ModelInput.Tensor, ModelType.TensorBased, endpoint, "my-custom-model")
+    For TensorBased models (using ModelInput.Tensor), HuggingFace downloads are skipped
+    and a minimal model card is registered directly. Use model_path as the display name
+    for these models.
     """
     ...
 

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -40,6 +40,7 @@ from dynamo._core import fetch_llm as fetch_llm
 from dynamo._core import lora_name_to_id as lora_name_to_id
 from dynamo._core import make_engine
 from dynamo._core import register_llm as register_llm
+from dynamo._core import register_model as register_model
 from dynamo._core import run_input
 from dynamo._core import unregister_llm as unregister_llm
 

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -40,7 +40,6 @@ from dynamo._core import fetch_llm as fetch_llm
 from dynamo._core import lora_name_to_id as lora_name_to_id
 from dynamo._core import make_engine
 from dynamo._core import register_llm as register_llm
-from dynamo._core import register_model as register_model
 from dynamo._core import run_input
 from dynamo._core import unregister_llm as unregister_llm
 

--- a/lib/bindings/python/tests/test_tensor.py
+++ b/lib/bindings/python/tests/test_tensor.py
@@ -8,7 +8,7 @@ import os
 import pytest
 import uvloop
 
-from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_model
+from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_llm
 from dynamo.runtime import DistributedRuntime
 
 TEST_END_TO_END = os.environ.get("TEST_END_TO_END", 0)
@@ -34,12 +34,12 @@ async def test_register(runtime: DistributedRuntime):
 
     assert model_config == runtime_config.get_tensor_model_config()
 
-    # Use register_model for tensor-based backends
-    await register_model(
+    # Use register_llm for tensor-based backends (skips HuggingFace downloads)
+    await register_llm(
         ModelInput.Tensor,
         ModelType.TensorBased,
         endpoint,
-        "tensor",
+        "tensor",  # model_path (used as display name for tensor-based models)
         runtime_config=runtime_config,
     )
 

--- a/lib/bindings/python/tests/test_tensor.py
+++ b/lib/bindings/python/tests/test_tensor.py
@@ -8,7 +8,7 @@ import os
 import pytest
 import uvloop
 
-from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_model
 from dynamo.runtime import DistributedRuntime
 
 TEST_END_TO_END = os.environ.get("TEST_END_TO_END", 0)
@@ -34,14 +34,11 @@ async def test_register(runtime: DistributedRuntime):
 
     assert model_config == runtime_config.get_tensor_model_config()
 
-    # [gluo FIXME] register_llm will attempt to load a LLM model,
-    # which is not well-defined for Tensor yet. Currently provide
-    # a valid model name to pass the registration.
-    await register_llm(
+    # Use register_model for tensor-based backends
+    await register_model(
         ModelInput.Tensor,
         ModelType.TensorBased,
         endpoint,
-        "Qwen/Qwen3-0.6B",
         "tensor",
         runtime_config=runtime_config,
     )

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -385,6 +385,15 @@ impl ModelDeploymentCard {
             return Ok(());
         }
 
+        // For TensorBased models, config files are not used - they handle everything in the backend
+        if self.model_type.supports_tensor() {
+            tracing::debug!(
+                display_name = %self.display_name,
+                "Skipping config download for TensorBased model"
+            );
+            return Ok(());
+        }
+
         let ignore_weights = true;
         let local_path = crate::hub::from_hf(&self.display_name, ignore_weights).await?;
 

--- a/tests/frontend/grpc/echo_tensor_worker.py
+++ b/tests/frontend/grpc/echo_tensor_worker.py
@@ -9,7 +9,7 @@
 import tritonclient.grpc.model_config_pb2 as mc
 import uvloop
 
-from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 
@@ -53,14 +53,11 @@ async def echo_tensor_worker(runtime: DistributedRuntime):
     )
     assert model_config == retrieved_model_config
 
-    # [gluo FIXME] register_llm will attempt to load a LLM model,
-    # which is not well-defined for Tensor yet. Currently provide
-    # a valid model name to pass the registration.
-    await register_llm(
+    # Use register_model for tensor-based backends
+    await register_model(
         ModelInput.Tensor,
         ModelType.TensorBased,
         endpoint,
-        "Qwen/Qwen3-0.6B",
         "echo",
         runtime_config=runtime_config,
     )

--- a/tests/frontend/grpc/echo_tensor_worker.py
+++ b/tests/frontend/grpc/echo_tensor_worker.py
@@ -9,7 +9,7 @@
 import tritonclient.grpc.model_config_pb2 as mc
 import uvloop
 
-from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_model
+from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_llm
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 
@@ -53,12 +53,12 @@ async def echo_tensor_worker(runtime: DistributedRuntime):
     )
     assert model_config == retrieved_model_config
 
-    # Use register_model for tensor-based backends
-    await register_model(
+    # Use register_llm for tensor-based backends (skips HuggingFace downloads)
+    await register_llm(
         ModelInput.Tensor,
         ModelType.TensorBased,
         endpoint,
-        "echo",
+        "echo",  # model_path (used as display name for tensor-based models)
         runtime_config=runtime_config,
     )
 


### PR DESCRIPTION

#### Overview:

This commit modifies the `register_llm` function, allowing users to register non-llm model endpoints without requiring local files or downloads from HuggingFace. This change is designed specifically for TensorBased models, where the frontend doesn't do any pre-processing.

#### Details:

- Modifies the `register_llm` function so that TensorBased models don't download anything
- Modifies the `download_config` MDC function so that TensorBased models don't download anything

#### Where should the reviewer start?

- `lib/bindings/python/rust/lib.rs`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to https://github.com/ai-dynamo/dynamo/pull/2746
