### PR TITLE
feat: initial kvbm object support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2184,7 +2184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.110",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2416,7 +2416,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2720,6 +2720,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "unicode-segmentation",
  "url",
  "utoipa",
@@ -3055,7 +3056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4836,7 +4837,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4874,15 +4875,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -4908,7 +4900,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6685,9 +6677,8 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d80bd4b5b8363cfd933000a8757a453e58ee10ee6e400c38ae31db512444a31"
+version = "0.8.0"
+source = "git+https://github.com/cheese-head/nixl.git?branch=cheese-head%2Frust-param-bindings#d53bd5f98b68debadb0dbf3c5900f3bbb6b807c1"
 dependencies = [
  "bindgen",
  "cc",
@@ -6784,7 +6775,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9033,7 +9024,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10378,7 +10369,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12084,7 +12075,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -167,7 +167,11 @@ RUN yum groupinstall -y 'Development Tools' &&  \
         libibumad \
         libibumad-devel \
         librdmacm-devel \
-        numactl-devel
+        numactl-devel \
+        libcurl-devel \
+        openssl-devel \
+        libuuid-devel \
+        zlib-devel
 
 # Ensure a modern protoc is available (required for --experimental_allow_proto3_optional)
 RUN set -eux; \
@@ -186,6 +190,27 @@ RUN set -eux; \
 
 # Point build tools explicitly at the modern protoc
 ENV PROTOC=/usr/local/bin/protoc
+
+# Build and install AWS SDK C++ (required for NIXL OBJ backend / S3 support)
+ARG AWS_SDK_CPP_VERSION=1.11.581
+RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+    export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${ARCH}}" && \
+    git clone --recurse-submodules --depth 1 --branch ${AWS_SDK_CPP_VERSION} \
+        https://github.com/aws/aws-sdk-cpp.git /tmp/aws-sdk-cpp && \
+    mkdir -p /tmp/aws-sdk-cpp/build && \
+    cd /tmp/aws-sdk-cpp/build && \
+    cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_ONLY="s3" \
+        -DENABLE_TESTING=OFF \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/aws-sdk-cpp && \
+    ldconfig && \
+    /tmp/use-sccache.sh show-stats "AWS SDK C++"
 
 # Set environment variables first so they can be used in COPY commands
 ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-16} \

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -101,7 +101,7 @@ dialoguer = { version = "0.11", default-features = false, features = [
 
 # block_manager
 aligned-vec = { version = "0.6.4", optional = true }
-nixl-sys = { version = "=0.7.1", optional = true }
+nixl-sys = { git = "https://github.com/cheese-head/nixl.git", branch = "cheese-head/rust-param-bindings", optional = true }
 cudarc = { workspace = true, optional = true }
 nix = { version = "0.26", optional = true }
 
@@ -176,6 +176,7 @@ rstest_reuse = "0.7.0"
 serial_test = "3"
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 tempfile = "3.17.1"
+tracing-subscriber = { workspace = true }
 insta = { version = "1.41", features = [
   "glob",
   "json",

--- a/lib/llm/src/block_manager/block/transfer/nixl.rs
+++ b/lib/llm/src/block_manager/block/transfer/nixl.rs
@@ -31,13 +31,13 @@ where
                 src_desc.as_ptr() as usize,
                 src_desc.size(),
                 src_desc.device_id(),
-            )?;
+            );
 
             dst_dl.add_desc(
                 dst_desc.as_ptr() as usize,
                 dst_desc.size(),
                 dst_desc.device_id(),
-            )?;
+            );
         }
 
         Ok(())
@@ -58,13 +58,13 @@ where
                         src_desc.as_ptr() as usize,
                         src_desc.size(),
                         src_desc.device_id(),
-                    )?;
+                    );
 
                     dst_dl.add_desc(
                         dst_desc.as_ptr() as usize,
                         dst_desc.size(),
                         dst_desc.device_id(),
-                    )?;
+                    );
                 }
             }
         }

--- a/lib/llm/src/block_manager/v2/memory/mod.rs
+++ b/lib/llm/src/block_manager/v2/memory/mod.rs
@@ -13,6 +13,7 @@ pub mod actions;
 
 mod device;
 mod disk;
+mod object;
 mod pinned;
 mod registered;
 mod system;
@@ -23,6 +24,7 @@ mod tests;
 
 pub use device::DeviceStorage;
 pub use disk::DiskStorage;
+pub use object::ObjectStorage;
 pub use pinned::PinnedStorage;
 pub use registered::{
     NixlCompatible, NixlDescriptor, NixlRegistered, RegisteredView, register_with_nixl,
@@ -81,6 +83,9 @@ pub enum StorageKind {
 
     /// Disk-backed memory (mmap)
     Disk(u64),
+
+    /// Object Storage
+    Object(u64),
 }
 
 /// Core trait for memory regions that can be type-erased.

--- a/lib/llm/src/block_manager/v2/memory/object.rs
+++ b/lib/llm/src/block_manager/v2/memory/object.rs
@@ -18,7 +18,10 @@ pub struct ObjectStorage {
     addr: usize,
     /// Size of the object storage region in bytes
     size: usize,
-    /// Object key
+    /// Object key (u64 identifier used by NIXL for object identification)
+    ///
+    /// This is a numeric identifier that uniquely identifies the object within the bucket.
+    /// NIXL's OBJ backend uses this as the device_id for transfer descriptors.
     key: u64,
     /// Object bucket name
     bucket: String,
@@ -29,7 +32,7 @@ impl ObjectStorage {
     ///
     /// # Arguments
     /// * `bucket` - Object Bucket Name
-    /// * `key` - Object Key
+    /// * `key` - Object Key (u64 numeric identifier for the object)
     /// * `size` - Size of the region in bytes
     ///
     /// # Returns
@@ -39,7 +42,7 @@ impl ObjectStorage {
     /// ```ignore
     /// use dynamo_memory::ObjectStorage;
     ///
-    /// let storage = ObjectStorage::new("my-bucket", "1234567890", 4096 * 128)?;
+    /// let storage = ObjectStorage::new("my-bucket", 1234567890u64, 4096 * 128)?;
     /// ```
     pub fn new(bucket: impl Into<String>, key: u64, size: usize) -> Result<Self> {
 

--- a/lib/llm/src/block_manager/v2/memory/object.rs
+++ b/lib/llm/src/block_manager/v2/memory/object.rs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Object storage memory region
+//!
+//! This module provides memory-mapped access to object storage via NIXL's OBJ plugin.
+
+use super::{MemoryRegion, Result, StorageKind};
+use std::any::Any;
+use std::fmt;
+
+/// Object storage backed by NIXL's OBJ plugin
+///
+/// This represents a region of memory that is backed by object storage.
+/// NIXL's OBJ plugin handles the actual transfers to/from Object.
+pub struct ObjectStorage {
+    /// Base address (virtual, managed by NIXL)
+    addr: usize,
+    /// Size of the object storage region in bytes
+    size: usize,
+    /// Object key
+    key: u64,
+    /// Object bucket name
+    bucket: String,
+}
+
+impl ObjectStorage {
+    /// Create a new object storage region
+    ///
+    /// # Arguments
+    /// * `bucket` - Object Bucket Name
+    /// * `key` - Object Key
+    /// * `size` - Size of the region in bytes
+    ///
+    /// # Returns
+    /// A new ObjectStorage instance
+    ///
+    /// # Example
+    /// ```ignore
+    /// use dynamo_memory::ObjectStorage;
+    ///
+    /// let storage = ObjectStorage::new("my-bucket", "1234567890", 4096 * 128)?;
+    /// ```
+    pub fn new(bucket: impl Into<String>, key: u64, size: usize) -> Result<Self> {
+
+        Ok(Self { addr: 0, bucket: bucket.into(), key, size })
+    }
+
+    pub fn key(&self) -> u64 {
+        self.key
+    }
+
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+}
+
+impl MemoryRegion for ObjectStorage {
+    fn addr(&self) -> usize {
+        self.addr
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
+
+    fn storage_kind(&self) -> StorageKind {
+        StorageKind::Object(self.key())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn nixl_descriptor(&self) -> Option<crate::block_manager::v2::memory::NixlDescriptor> {
+        Some(crate::block_manager::v2::memory::NixlDescriptor {
+            addr: self.addr() as u64,
+            size: self.size(),
+            mem_type: nixl_sys::MemType::Object,
+            device_id: self.key(),
+        })
+    }
+}
+
+impl super::registered::NixlCompatible for ObjectStorage {
+    fn nixl_params(&self) -> (*const u8, usize, nixl_sys::MemType, u64) {
+        (
+            std::ptr::null(),
+            self.size,
+            nixl_sys::MemType::Object,
+            self.key(),
+        )
+    }
+}
+
+impl fmt::Debug for ObjectStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("ObjectStorage");
+        debug
+            .field("addr", &format!("0x{:x}", self.addr))
+            .field("size", &self.size)
+            .field("key", &format!("{:x}", self.key))
+            .field("bucket", &self.bucket)
+            .finish()
+    }
+}

--- a/lib/llm/src/block_manager/v2/physical/layout/mod.rs
+++ b/lib/llm/src/block_manager/v2/physical/layout/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod builder;
 mod config;
 mod fully_contiguous;
 mod layer_separate;
+mod object_layout;
 mod physical;
 mod serialize;
 mod validation;
@@ -28,9 +29,11 @@ pub use builder::{LayoutKind, PhysicalLayoutBuilder};
 pub use config::{BlockDimension, LayoutConfig};
 pub use fully_contiguous::FullyContiguousLayout;
 pub use layer_separate::LayerSeparateLayout;
+pub use object_layout::ObjectLayout;
 pub use physical::{NixlMetadata, PhysicalLayout};
 pub use serialize::{
     BlockFormat, FullyContiguousDetails, LayerSeparateDetails, LayoutDescriptor, LayoutTypeDetails,
+    ObjectLayoutDetails,
 };
 pub use validation::{TensorFormat, validate_tensor_shapes, validate_tensor_strides};
 

--- a/lib/llm/src/block_manager/v2/physical/layout/object_layout.rs
+++ b/lib/llm/src/block_manager/v2/physical/layout/object_layout.rs
@@ -1,0 +1,369 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Object storage layout implementation.
+//!
+//! This layout is designed for object storage where each "block" in the layout
+//! corresponds to one complete Object. This enables efficient batch operations
+//! where multiple Objects can be read/written in a single NIXL transfer call.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! Block 0 → object key_0 (complete KV cache with tp_world_size partitions)
+//! Block 1 → object key_1 (complete KV cache with tp_world_size partitions)
+//! Block 2 → object key_2 (complete KV cache with tp_world_size partitions)
+//! ...
+//! ```
+//!
+//! ## Use Cases
+//!
+//! 1. **Batch onboarding**: Read multiple objects in one NIXL call
+//! 2. **Batch offloading**: Write multiple objects in one NIXL call
+//!
+//! ## Example
+//!
+//! ```ignore
+//! // Batch: 10 Objects
+//! let layout = PhysicalLayout::builder(agent)
+//!     .with_config(config)  // num_blocks = 10
+//!     .object_layout()
+//!     .allocate_objects("bucket", vec![key1, key2, ..., key10])?
+//!     .build()?;
+//!
+//! // Single: 1 Object
+//! let layout = PhysicalLayout::builder(agent)
+//!     .with_config(config)  // num_blocks = 1
+//!     .object_layout()
+//!     .allocate_object("bucket", key)
+//!     .build()?;
+//! ```
+
+use anyhow::{Result, anyhow};
+use std::sync::Arc;
+use validator::Validate;
+
+use super::serialize::{LayoutTypeDetails, ObjectLayoutDetails};
+use super::{Layout, LayoutConfig, MemoryDescriptor, MemoryRegion, OwnedMemoryRegion};
+
+/// Object storage layout where each block is a separate Object.
+///
+/// This layout is optimized for object storage operations where:
+/// - Each block_id maps directly to one Object (memory region)
+/// - All regions are independent (different object keys)
+/// - Batch operations read/write multiple objects in parallel via NIXL
+#[derive(Debug)]
+pub struct ObjectLayout {
+    config: LayoutConfig,
+    /// Memory regions, one per block (one per Object)
+    regions: Vec<Arc<dyn MemoryRegion>>,
+    /// Total size of each complete object in bytes
+    object_size: usize,
+}
+
+impl ObjectLayout {
+    /// Create a new object storage layout.
+    ///
+    /// # Arguments
+    /// * `config` - Layout configuration (num_blocks = number of Objects)
+    /// * `regions` - Memory regions, one per Object (must match num_blocks)
+    ///
+    /// # Returns
+    /// A new ObjectLayout instance
+    ///
+    /// # Errors
+    /// Returns error if:
+    /// - Number of regions doesn't match num_blocks
+    /// - Any region is too small for the configured object size
+    pub fn new(config: LayoutConfig, regions: Vec<Arc<dyn MemoryRegion>>) -> Result<Self> {
+        config.validate()?;
+
+        if regions.len() != config.num_blocks {
+            return Err(anyhow!(
+                "Number of memory regions ({}) must match num_blocks ({})",
+                regions.len(),
+                config.num_blocks
+            ));
+        }
+
+        // Calculate required size for each complete Object
+        // Size = num_layers × outer_dim × page_size × inner_dim × dtype_bytes
+        // Note: In object layout, each "block" is a complete Object containing
+        // all layers, so we don't multiply by num_blocks here
+        let object_size = config.num_layers
+            * config.outer_dim
+            * config.page_size
+            * config.inner_dim
+            * config.dtype_width_bytes;
+
+        // Validate each region is large enough
+        for (i, region) in regions.iter().enumerate() {
+            if region.size() < object_size {
+                return Err(anyhow!(
+                    "Memory region {} too small for object. Required: {} bytes, got: {} bytes",
+                    i,
+                    object_size,
+                    region.size()
+                ));
+            }
+        }
+
+        Ok(Self {
+            config,
+            regions,
+            object_size,
+        })
+    }
+
+    /// Get the size of each complete object in bytes.
+    pub fn object_size(&self) -> usize {
+        self.object_size
+    }
+
+    /// Get the number of objects in this layout.
+    pub fn num_objects(&self) -> usize {
+        self.regions.len()
+    }
+}
+
+impl Layout for ObjectLayout {
+    fn config(&self) -> &LayoutConfig {
+        &self.config
+    }
+
+    fn memory_regions(&self) -> &[OwnedMemoryRegion] {
+        &self.regions
+    }
+
+    fn memory_region(
+        &self,
+        block_id: usize,
+        layer_id: usize,
+        outer_id: usize,
+    ) -> Result<MemoryDescriptor> {
+        // In ObjectLayout, block_id directly maps to the Object (memory region)
+        // Within that object, we compute the offset for the specific layer/outer_id
+
+        if block_id >= self.regions.len() {
+            return Err(anyhow!(
+                "Block ID {} out of range (num_objects: {})",
+                block_id,
+                self.regions.len()
+            ));
+        }
+
+        if layer_id >= self.config.num_layers {
+            return Err(anyhow!(
+                "Layer ID {} out of range (num_layers: {})",
+                layer_id,
+                self.config.num_layers
+            ));
+        }
+
+        if outer_id >= self.config.outer_dim {
+            return Err(anyhow!(
+                "Outer ID {} out of range (outer_dim: {})",
+                outer_id,
+                self.config.outer_dim
+            ));
+        }
+
+        let current_region = &self.regions[block_id];
+
+        // For object storage, NIXL uses the addr field as the offset within the Object
+        // for byte-ranged GET requests (see nixl obj_backend.cpp line 245, 268)
+        // The device_id (object key) identifies WHICH object, addr is the offset WITHIN it.
+
+        // ObjectLayout supports two use cases:
+        // 1. Multiple separate Objects: each block → different object key, offset = 0
+        // 2. TP partitions in ONE Object: all blocks → same object key, sequential offsets
+        //
+        // To determine which case: check if this block's key matches earlier blocks.
+        // If we find an earlier block with the same key, compute offset relative to the first.
+
+        // Stride calculations
+        let region_size = self.config.page_size * self.config.inner_dim * self.config.dtype_width_bytes;
+        let outer_stride = region_size;
+        let layer_stride = outer_stride * self.config.outer_dim;
+        let block_stride = self.object_size;  // Full size of one complete block/partition
+
+        // Find the "base block" - the first block that shares this object key
+        let current_key = current_region.storage_kind();
+        let base_block_offset = self.regions.iter()
+            .position(|r| r.storage_kind() == current_key)
+            .unwrap_or(block_id);  // Fallback to block_id if not found
+
+        // Calculate offset within the Object:
+        // - If this is the first block with this key: offset = 0 + layer/outer
+        // - If this is a later partition: offset = (block_id - base) * stride + layer/outer
+        let blocks_from_base = block_id - base_block_offset;
+        let offset = blocks_from_base * block_stride + layer_id * layer_stride + outer_id * outer_stride;
+
+        Ok(MemoryDescriptor {
+            addr: offset,  // Offset within Object (for byte-ranged GET)
+            size: region_size,
+        })
+    }
+
+    fn required_allocations(&self) -> Vec<usize> {
+        // Each object requires object_size bytes
+        vec![self.object_size; self.config.num_blocks]
+    }
+
+    fn is_fully_contiguous(&self) -> bool {
+        // ObjectLayout is NOT fully contiguous - each object is separate
+        false
+    }
+
+    fn num_blocks(&self) -> usize {
+        self.config.num_blocks
+    }
+
+    fn num_layers(&self) -> usize {
+        self.config.num_layers
+    }
+
+    fn outer_dim(&self) -> usize {
+        self.config.outer_dim
+    }
+
+    fn page_size(&self) -> usize {
+        self.config.page_size
+    }
+
+    fn inner_dim(&self) -> usize {
+        self.config.inner_dim
+    }
+
+    fn dtype_width_bytes(&self) -> usize {
+        self.config.dtype_width_bytes
+    }
+
+    fn serialization_details(&self) -> LayoutTypeDetails {
+        LayoutTypeDetails::ObjectLayout(ObjectLayoutDetails {
+            num_objects: self.regions.len(),
+            object_size: self.object_size,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_manager::v2::memory::{MemoryRegion, StorageKind};
+    use std::any::Any;
+
+    #[derive(Debug)]
+    struct TestMemoryRegion {
+        data: Vec<u8>,
+    }
+
+    impl MemoryRegion for TestMemoryRegion {
+        fn addr(&self) -> usize {
+            self.data.as_ptr() as usize
+        }
+
+        fn size(&self) -> usize {
+            self.data.len()
+        }
+
+        fn storage_kind(&self) -> StorageKind {
+            StorageKind::System
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn nixl_descriptor(&self) -> Option<crate::block_manager::v2::memory::NixlDescriptor> {
+            None
+        }
+    }
+
+    #[test]
+    fn test_object_layout_single() {
+        let config = LayoutConfig::builder()
+            .num_blocks(1)
+            .num_layers(32)
+            .outer_dim(2)
+            .page_size(16)
+            .inner_dim(64)
+            .dtype_width_bytes(2)
+            .build()
+            .unwrap();
+
+        let object_size = 32 * 2 * 16 * 64 * 2;
+        let region = Arc::new(TestMemoryRegion {
+            data: vec![0u8; object_size],
+        }) as Arc<dyn MemoryRegion>;
+
+        let layout = ObjectLayout::new(config, vec![region]).unwrap();
+
+        assert_eq!(layout.num_objects(), 1);
+        assert_eq!(layout.object_size(), object_size);
+        assert!(!layout.is_fully_contiguous());
+    }
+
+    #[test]
+    fn test_object_layout_batch() {
+        let config = LayoutConfig::builder()
+            .num_blocks(10)
+            .num_layers(32)
+            .outer_dim(2)
+            .page_size(16)
+            .inner_dim(64)
+            .dtype_width_bytes(2)
+            .build()
+            .unwrap();
+
+        let object_size = 32 * 2 * 16 * 64 * 2;
+        let regions: Vec<Arc<dyn MemoryRegion>> = (0..10)
+            .map(|_| {
+                Arc::new(TestMemoryRegion {
+                    data: vec![0u8; object_size],
+                }) as Arc<dyn MemoryRegion>
+            })
+            .collect();
+
+        let layout = ObjectLayout::new(config, regions).unwrap();
+
+        assert_eq!(layout.num_objects(), 10);
+        assert_eq!(layout.object_size(), object_size);
+        assert_eq!(layout.num_blocks(), 10);
+    }
+
+    #[test]
+    fn test_object_layout_memory_descriptor() {
+        let config = LayoutConfig::builder()
+            .num_blocks(3)
+            .num_layers(2)
+            .outer_dim(2)
+            .page_size(4)
+            .inner_dim(8)
+            .dtype_width_bytes(2)
+            .build()
+            .unwrap();
+
+        let object_size = 2 * 2 * 4 * 8 * 2; // 256 bytes per object
+        let regions: Vec<Arc<dyn MemoryRegion>> = (0..3)
+            .map(|_| {
+                Arc::new(TestMemoryRegion {
+                    data: vec![0u8; object_size],
+                }) as Arc<dyn MemoryRegion>
+            })
+            .collect();
+
+        let layout = ObjectLayout::new(config, regions).unwrap();
+
+        // Test memory_region for block 0, layer 0, outer 0
+        let desc = layout.memory_region(0, 0, 0).unwrap();
+        assert_eq!(desc.size, 4 * 8 * 2); // page_size * inner_dim * dtype_bytes
+
+        // Test memory_region for block 1 (different Object)
+        let desc1 = layout.memory_region(1, 0, 0).unwrap();
+        let desc0 = layout.memory_region(0, 0, 0).unwrap();
+        // Different blocks should have different base addresses (different Objects)
+        assert_ne!(desc1.addr, desc0.addr);
+    }
+}
+

--- a/lib/llm/src/block_manager/v2/physical/layout/physical.rs
+++ b/lib/llm/src/block_manager/v2/physical/layout/physical.rs
@@ -4,7 +4,7 @@
 //! Physical layout types that combine abstract layouts with storage location metadata.
 
 use super::{
-    FullyContiguousLayout, LayerSeparateLayout, Layout, MemoryDescriptor,
+    FullyContiguousLayout, LayerSeparateLayout, Layout, MemoryDescriptor, ObjectLayout,
     builder::{PhysicalLayoutBuilder, PhysicalLayoutBuilderDefault},
     serialize::{LayoutDescriptor, LayoutTypeDetails},
 };
@@ -246,6 +246,20 @@ impl PhysicalLayout {
                     serialized.layout_config.clone(),
                     remote_regions,
                     details.block_dim,
+                )?;
+                Arc::new(layout)
+            }
+            LayoutTypeDetails::ObjectLayout(details) => {
+                if remote_regions.len() != details.num_objects {
+                    return Err(anyhow!(
+                        "ObjectLayout requires {} memory regions (one per object), got {}",
+                        details.num_objects,
+                        remote_regions.len()
+                    ));
+                }
+                let layout = ObjectLayout::new(
+                    serialized.layout_config.clone(),
+                    remote_regions,
                 )?;
                 Arc::new(layout)
             }

--- a/lib/llm/src/block_manager/v2/physical/layout/serialize.rs
+++ b/lib/llm/src/block_manager/v2/physical/layout/serialize.rs
@@ -43,6 +43,15 @@ pub struct LayerSeparateDetails {
     pub block_dim: BlockDimension,
 }
 
+/// Details specific to object storage layouts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObjectLayoutDetails {
+    /// Number of objects in this layout
+    pub num_objects: usize,
+    /// Size of each complete object in bytes
+    pub object_size: usize,
+}
+
 /// Layout-type-specific details.
 ///
 /// This enum captures the information that differs between layout types
@@ -53,6 +62,8 @@ pub enum LayoutTypeDetails {
     FullyContiguous(FullyContiguousDetails),
     /// Layer-separate layout details
     LayerSeparate(LayerSeparateDetails),
+    /// Object storage layout details
+    ObjectLayout(ObjectLayoutDetails),
 }
 
 /// Serializable representation of a physical layout.

--- a/lib/llm/src/block_manager/v2/physical/transfer/checksum.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/checksum.rs
@@ -149,8 +149,13 @@ fn compute_single_block_checksum(
                 }
                 StorageKind::Object(_) => {
                     // Object storage checksums are handled by NIXL's OBJ plugin
-                    // For now, skip checksumming object storage regions
-                    tracing::warn!("Checksum computation for object storage not yet implemented");
+                    // Checksumming object storage requires fetching data from remote storage,
+                    // which is not yet implemented. Return an error rather than computing
+                    // an incorrect checksum.
+                    return Err(anyhow!(
+                        "Checksum computation for object storage is not yet implemented. \
+                         Object storage data must be fetched from remote storage before checksumming."
+                    ));
                 }
             }
         }

--- a/lib/llm/src/block_manager/v2/physical/transfer/checksum.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/checksum.rs
@@ -147,6 +147,11 @@ fn compute_single_block_checksum(
                     file.read_exact(&mut system_region)?;
                     hasher.update(system_region.as_slice());
                 }
+                StorageKind::Object(_) => {
+                    // Object storage checksums are handled by NIXL's OBJ plugin
+                    // For now, skip checksumming object storage regions
+                    tracing::warn!("Checksum computation for object storage not yet implemented");
+                }
             }
         }
     }

--- a/lib/llm/src/block_manager/v2/physical/transfer/executor/contiguous_transfer.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/executor/contiguous_transfer.rs
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Contiguous transfer optimizations for NIXL.
+//!
+//! This module provides batched transfer building for contiguous memory layouts,
+//! dramatically improving performance for large transfers by reducing descriptor count.
+
+use crate::block_manager::v2::physical::layout::PhysicalLayout;
+use anyhow::Result;
+use nixl_sys::XferDescList;
+use std::ops::Range;
+
+/// Build batched contiguous transfer - optimizes contiguous→contiguous transfers.
+///
+/// Intelligently batches contiguous ranges even when overall block list is fragmented.
+/// For example: [0,1,2, 10,11, 50] creates 3 batched descriptors instead of 6 individual ones.
+/// This dramatically improves performance for large transfers (e.g., 877 blocks: 12s → <1s).
+pub(crate) fn build_batched_contiguous_transfer(
+    src: &PhysicalLayout,
+    dst: &PhysicalLayout,
+    src_block_ids: &[usize],
+    dst_block_ids: &[usize],
+    layers: &Range<usize>,
+    src_device_id: u64,
+    dst_device_id: u64,
+    src_dl: &mut XferDescList,
+    dst_dl: &mut XferDescList,
+) -> Result<()> {
+    let src_layout = src.layout();
+
+    if src_block_ids.is_empty() {
+        return Ok(());
+    }
+
+    // Find contiguous ranges in both source and destination
+    // A range is contiguous when both src and dst blocks increment by 1
+    let mut ranges: Vec<(usize, usize)> = Vec::new(); // (start_idx, end_idx)
+    let mut range_start = 0;
+
+    for i in 1..src_block_ids.len() {
+        let src_contiguous = src_block_ids[i] == src_block_ids[i - 1] + 1;
+        let dst_contiguous = dst_block_ids[i] == dst_block_ids[i - 1] + 1;
+
+        if !src_contiguous || !dst_contiguous {
+            // End of contiguous range
+            ranges.push((range_start, i));
+            range_start = i;
+        }
+    }
+    // Add final range
+    ranges.push((range_start, src_block_ids.len()));
+
+    let total_blocks = src_block_ids.len();
+    let mut batched_blocks = 0;
+
+    // Create one descriptor per contiguous range
+    for &(start_idx, end_idx) in &ranges {
+        let range_len = end_idx - start_idx;
+
+        if range_len == 1 {
+            // Single block - use simple descriptor
+            let src_block_id = src_block_ids[start_idx];
+            let dst_block_id = dst_block_ids[start_idx];
+
+            let first_src = src.memory_region(src_block_id, layers.start, 0)?;
+            let first_dst = dst.memory_region(dst_block_id, layers.start, 0)?;
+            let total_size = layers.len() * src_layout.outer_dim() * first_src.size();
+
+            src_dl.add_desc(first_src.addr(), total_size, src_device_id);
+            dst_dl.add_desc(first_dst.addr(), total_size, dst_device_id);
+        } else {
+            // Contiguous range - use batched descriptor
+            let src_block_id = src_block_ids[start_idx];
+            let dst_block_id = dst_block_ids[start_idx];
+
+            let first_src = src.memory_region(src_block_id, layers.start, 0)?;
+            let first_dst = dst.memory_region(dst_block_id, layers.start, 0)?;
+            let total_size = range_len * layers.len() * src_layout.outer_dim() * first_src.size();
+
+            src_dl.add_desc(first_src.addr(), total_size, src_device_id);
+            dst_dl.add_desc(first_dst.addr(), total_size, dst_device_id);
+
+            batched_blocks += range_len;
+        }
+    }
+
+    if ranges.len() == 1 && batched_blocks == total_blocks {
+        // Fully contiguous - single batch
+        tracing::info!(
+            "⚡ FULLY BATCHED: {} blocks in ONE descriptor ({:.2} MB)",
+            total_blocks,
+            (total_blocks
+                * layers.len()
+                * src_layout.outer_dim()
+                * src.memory_region(src_block_ids[0], layers.start, 0)?.size()) as f64
+                / 1_000_000.0
+        );
+    } else if batched_blocks > 0 {
+        // Partially batched - some ranges
+        tracing::info!(
+            "⚡ PARTIALLY BATCHED: {} blocks in {} descriptors ({} batched, {} single)",
+            total_blocks,
+            ranges.len(),
+            batched_blocks,
+            total_blocks - batched_blocks
+        );
+    } else {
+        // All single blocks
+        tracing::debug!(
+            "No batching possible: {} individual descriptors",
+            total_blocks
+        );
+    }
+
+    Ok(())
+}
+
+/// Build single-descriptor transfer for fully contiguous layouts.
+///
+/// Optimizes transfers when both source and destination are fully contiguous
+/// by creating a single descriptor covering all blocks. Falls back to
+/// per-block descriptors if blocks are non-contiguous.
+pub(crate) fn build_single_descriptor_transfer(
+    src: &PhysicalLayout,
+    dst: &PhysicalLayout,
+    src_block_ids: &[usize],
+    dst_block_ids: &[usize],
+    layers: &Range<usize>,
+    src_device_id: u64,
+    dst_device_id: u64,
+    src_dl: &mut XferDescList,
+    dst_dl: &mut XferDescList,
+) -> Result<()> {
+    let src_layout = src.layout();
+
+    // Check if blocks are contiguous for single-descriptor optimization
+    let blocks_are_contiguous = src_block_ids.len() > 1
+        && src_block_ids.windows(2).all(|w| w[1] == w[0] + 1)
+        && dst_block_ids.windows(2).all(|w| w[1] == w[0] + 1);
+
+    if blocks_are_contiguous {
+        // Single descriptor covering all contiguous blocks
+        let first_src = src.memory_region(src_block_ids[0], layers.start, 0)?;
+        let first_dst = dst.memory_region(dst_block_ids[0], layers.start, 0)?;
+
+        let total_size =
+            src_block_ids.len() * layers.len() * src_layout.outer_dim() * first_src.size();
+
+        src_dl.add_desc(first_src.addr(), total_size, src_device_id);
+        dst_dl.add_desc(first_dst.addr(), total_size, dst_device_id);
+
+        tracing::trace!(
+            "Single descriptor: {} contiguous blocks, {} bytes",
+            src_block_ids.len(),
+            total_size
+        );
+    } else {
+        // One descriptor per block (non-contiguous)
+        for (&src_block_id, &dst_block_id) in src_block_ids.iter().zip(dst_block_ids.iter()) {
+            let first_src = src.memory_region(src_block_id, layers.start, 0)?;
+            let first_dst = dst.memory_region(dst_block_id, layers.start, 0)?;
+
+            let total_size = layers.len() * src_layout.outer_dim() * first_src.size();
+
+            src_dl.add_desc(first_src.addr(), total_size, src_device_id);
+            dst_dl.add_desc(first_dst.addr(), total_size, dst_device_id);
+        }
+        tracing::trace!("Single-desc mode: {} descriptors", src_block_ids.len());
+    }
+
+    Ok(())
+}
+
+/// Build multi-descriptor transfer with per-block device_id support.
+///
+/// Standard mode: one descriptor per (block, layer, outer) tuple.
+/// Used for non-contiguous layouts or complex patterns.
+pub(crate) fn build_multi_descriptor_transfer(
+    src: &PhysicalLayout,
+    dst: &PhysicalLayout,
+    src_block_ids: &[usize],
+    dst_block_ids: &[usize],
+    layers: &Range<usize>,
+    get_device_id: &dyn Fn(&PhysicalLayout, usize, u64) -> u64,
+    src_device_id: u64,
+    dst_device_id: u64,
+    src_dl: &mut XferDescList,
+    dst_dl: &mut XferDescList,
+) -> Result<()> {
+    use anyhow::anyhow;
+
+    let src_layout = src.layout();
+
+    for (&src_block_id, &dst_block_id) in src_block_ids.iter().zip(dst_block_ids.iter()) {
+        // Get device_id for this specific block (unique key for ObjectLayout)
+        let src_key = get_device_id(src, src_block_id, src_device_id);
+        let dst_key = get_device_id(dst, dst_block_id, dst_device_id);
+
+        for layer_id in layers.clone() {
+            for outer_id in 0..src_layout.outer_dim() {
+                let src_region = src.memory_region(src_block_id, layer_id, outer_id)?;
+                let dst_region = dst.memory_region(dst_block_id, layer_id, outer_id)?;
+
+                if src_region.size() != dst_region.size() {
+                    return Err(anyhow!(
+                        "Size mismatch at block=({},{}), layer={}, outer={}: src={}, dst={}",
+                        src_block_id,
+                        dst_block_id,
+                        layer_id,
+                        outer_id,
+                        src_region.size(),
+                        dst_region.size()
+                    ));
+                }
+
+                src_dl.add_desc(src_region.addr(), src_region.size(), src_key);
+                dst_dl.add_desc(dst_region.addr(), dst_region.size(), dst_key);
+            }
+        }
+    }
+
+    let total = src_block_ids.len() * layers.len() * src_layout.outer_dim();
+    tracing::trace!("Multi-descriptor mode: {} descriptors", total);
+    Ok(())
+}
+

--- a/lib/llm/src/block_manager/v2/physical/transfer/executor/mod.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/executor/mod.rs
@@ -26,6 +26,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 // Re-export the NIXL transfer builder for public use
 pub use nixl::NixlTransferBuilder;
 
+// Re-export for testing (used by descriptor_tests)
+#[cfg(feature = "testing-nixl")]
+#[allow(unused_imports)]
+pub(crate) use nixl::{DescriptorParams, build_descriptors};
+
 /// Execute a transfer between two physical layouts.
 ///
 /// This is an internal entry point for all transfer operations called by TransportManager.

--- a/lib/llm/src/block_manager/v2/physical/transfer/executor/nixl.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/executor/nixl.rs
@@ -373,7 +373,7 @@ impl<'a> NixlTransferBuilder<'a, Set, Set, Set, Set, Set> {
 /// Build NIXL descriptors based on descriptor hint (or auto-detection).
 ///
 /// Uses explicit hints when provided, otherwise auto-detects from layout characteristics.
-fn build_descriptors(
+pub(crate) fn build_descriptors(
     params: &DescriptorParams,
     src_dl: &mut XferDescList,
     dst_dl: &mut XferDescList,

--- a/lib/llm/src/block_manager/v2/physical/transfer/executor/nixl.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/executor/nixl.rs
@@ -285,16 +285,24 @@ impl<'a> NixlTransferBuilder<'a, Set, Set, Set, Set, Set> {
         );
 
         if !is_flipped {
-            assert!(
-                nixl_agent.name() == src.nixl_metadata().agent_name(),
-                "the source must be local for non-flipped NIXL operations"
-            );
+            if nixl_agent.name() != src.nixl_metadata().agent_name() {
+                return Err(anyhow!(
+                    "Source must be local for non-flipped NIXL operations. \
+                     Expected agent '{}', but source uses agent '{}'",
+                    nixl_agent.name(),
+                    src.nixl_metadata().agent_name()
+                ));
+            }
         } else {
             // For flipped ops, destination is actually the local side (gets swapped)
-            assert!(
-                nixl_agent.name() == dst.nixl_metadata().agent_name(),
-                "the destination must be local for flipped NIXL operations"
-            );
+            if nixl_agent.name() != dst.nixl_metadata().agent_name() {
+                return Err(anyhow!(
+                    "Destination must be local for flipped NIXL operations. \
+                     Expected agent '{}', but destination uses agent '{}'",
+                    nixl_agent.name(),
+                    dst.nixl_metadata().agent_name()
+                ));
+            }
         }
 
         // Capture NIXL metadata for both layouts

--- a/lib/llm/src/block_manager/v2/physical/transfer/executor/object_transfer.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/executor/object_transfer.rs
@@ -1,161 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Object storage transfer optimizations for NIXL.
+//! Object storage utilities for NIXL transfers.
 //!
-//! This module provides optimized transfer building strategies for object storage (Object/MinIO)
-//! backends.
-//!
-//! # Key Constraints
-//!
-//! **READ (Object → Host):** Supports byte-range offsets via Object GET Range header.
-//! Multiple blocks CAN share one Object key with different offsets (TP partitions).
-//!
-//! **WRITE (Host → Object):** One-to-one mapping ONLY. Object PUT does NOT support
-//! partial writes at offsets. Each block MUST map to a unique Object.
+//! This module provides helper functions for object storage backends,
+//! particularly for extracting per-block device IDs (object keys).
 
 use crate::block_manager::v2::physical::layout::PhysicalLayout;
 use crate::block_manager::v2::memory::StorageKind;
-use anyhow::Result;
-use nixl_sys::XferDescList;
-use std::collections::HashSet;
-use std::ops::Range;
 
-/// Build optimized transfer for ObjectLayout ↔ Contiguous layout.
-///
-/// # Read Path (Object → Host): Supports byte-range offsets
-///
-/// Multiple blocks CAN share one Object key with different offsets (TP partitions).
-/// Uses Object GET with Range header for partial reads:
-/// ```text
-/// Object key 99999, offset 0MB       → Block 0 (TP partition 0)
-/// Object key 99999, offset 2.3MB     → Block 1 (TP partition 1)
-/// Object key 99999, offset 4.6MB     → Block 2 (TP partition 2)
-/// Object key 99999, offset 6.9MB     → Block 3 (TP partition 3)
-/// ```
-///
-/// # Write Path (Host → Object): One-to-one mapping ONLY
-///
-/// **IMPORTANT:** Object PUT does NOT support partial writes at offsets.
-/// Each host block MUST map to a separate Object (unique key):
-/// ```text
-/// Block 0 → Object key 123456  (separate object)
-/// Block 1 → Object key 789012  (separate object)
-/// Block 2 → Object key 345678  (separate object)
-/// ```
-///
-/// Returns error if multiple blocks share the same Object key (would require offset writes)
-///
-/// # Arguments
-/// * `is_read` - true for Object→Host reads, false for Host→Object writes
-/// * `get_device_id` - Closure that extracts Object key for each block
-pub(crate) fn build_object_storage_transfer(
-    src: &PhysicalLayout,
-    dst: &PhysicalLayout,
-    src_block_ids: &[usize],
-    dst_block_ids: &[usize],
-    layers: &Range<usize>,
-    src_device_id: u64,
-    dst_device_id: u64,
-    src_dl: &mut XferDescList,
-    dst_dl: &mut XferDescList,
-    get_device_id: &dyn Fn(&PhysicalLayout, usize, u64) -> u64,
-    is_read: bool,
-) -> Result<()> {
-    let region_size = |layout: &PhysicalLayout| -> usize {
-        let l = layout.layout();
-        layers.len() * l.outer_dim() * l.page_size() * l.inner_dim() * l.dtype_width_bytes()
-    };
-
-    match is_read {
-        true => {
-            // READ: Object → Host
-            // Each source block may be:
-            // 1. A separate Object (different keys) - requires unique key per block
-            // 2. A partition within one Object (same key, different offsets) - byte-range GET
-            tracing::debug!("Object storage READ: {} blocks from Object", src_block_ids.len());
-
-            src_block_ids
-                .iter()
-                .zip(dst_block_ids.iter())
-                .try_for_each(|(&src_id, &dst_id)| {
-                    let src_region = src.memory_region(src_id, layers.start, 0)?;
-                    let dst_region = dst.memory_region(dst_id, layers.start, 0)?;
-                    let total_size = region_size(src);
-                    let src_key = get_device_id(src, src_id, src_device_id);
-
-                    src_dl.add_desc(src_region.addr(), total_size, src_key);
-                    dst_dl.add_desc(dst_region.addr(), total_size, dst_device_id);
-
-                    tracing::trace!(
-                        "  Object[{src_id}] (key={src_key}) → Host[{dst_id}]: {total_size} bytes"
-                    );
-                    Ok(())
-                })
-        }
-        false => {
-            // WRITE: Host → Object
-            // IMPORTANT: Object PUT does NOT support partial writes at offsets.
-            // Each block MUST map to a unique Object (one-to-one mapping).
-
-            // Collect all destination Object keys
-            let dst_keys: Vec<u64> = dst_block_ids
-                .iter()
-                .map(|&dst_id| get_device_id(dst, dst_id, dst_device_id))
-                .collect();
-
-            // Validate one-to-one mapping: each block must have a unique Object key
-            let unique_keys: HashSet<u64> = dst_keys.iter().copied().collect();
-            if unique_keys.len() != dst_block_ids.len() {
-                return Err(anyhow::anyhow!(
-                    "Object storage WRITE requires one-to-one mapping: {} blocks but only {} unique Object keys. \
-                     Object PUT does not support partial writes at offsets.",
-                    dst_block_ids.len(),
-                    unique_keys.len()
-                ));
-            }
-
-            tracing::debug!(
-                "Object storage WRITE: {} blocks → {} Objects",
-                src_block_ids.len(),
-                unique_keys.len()
-            );
-
-            // One descriptor per block (one-to-one mapping)
-            src_block_ids
-                .iter()
-                .zip(dst_block_ids.iter())
-                .zip(dst_keys.iter())
-                .try_for_each(|((&src_id, &dst_id), &dst_key)| {
-                    let src_region = src.memory_region(src_id, layers.start, 0)?;
-                    let dst_region = dst.memory_region(dst_id, layers.start, 0)?;
-                    let total_size = region_size(src);
-
-                    // Validate destination offset is 0 (Object PUT doesn't support offsets)
-                    if dst_region.addr() != 0 {
-                        return Err(anyhow::anyhow!(
-                            "Object storage WRITE: block {} has non-zero offset {}. \
-                             Object PUT does not support partial writes at offsets.",
-                            dst_id,
-                            dst_region.addr()
-                        ));
-                    }
-
-                    src_dl.add_desc(src_region.addr(), total_size, src_device_id);
-                    dst_dl.add_desc(0, total_size, dst_key); // Always offset 0 for writes
-
-                    tracing::trace!(
-                        "  Host[{src_id}] → Object key={dst_key}: {total_size} bytes"
-                    );
-                    Ok(())
-                })
-        }
-    }
-}
-
-/// Extract device_id (Object key) for a specific block.
+/// Extract device_id (object key) for a specific block.
 ///
 /// ObjectLayout has unique keys per block; other layouts share one device_id.
+///
+/// # Behavior
+/// - For `ObjectLayout` (non-contiguous): Returns the unique object key for this block
+/// - For `FullyContiguous` with object backing: Returns the shared object key
+/// - For other layouts: Returns the default device_id
 pub(crate) fn get_object_device_id(
     layout: &PhysicalLayout,
     block_id: usize,
@@ -163,7 +24,7 @@ pub(crate) fn get_object_device_id(
 ) -> u64 {
     match (layout.location(), layout.layout().is_fully_contiguous()) {
         (StorageKind::Object(_), false) => {
-            // ObjectLayout: each block has its own Object key
+            // ObjectLayout: each block has its own object key
             layout
                 .layout()
                 .memory_regions()

--- a/lib/llm/src/block_manager/v2/physical/transfer/executor/object_transfer.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/executor/object_transfer.rs
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Object storage transfer optimizations for NIXL.
+//!
+//! This module provides optimized transfer building strategies for object storage (Object/MinIO)
+//! backends.
+//!
+//! # Key Constraints
+//!
+//! **READ (Object → Host):** Supports byte-range offsets via Object GET Range header.
+//! Multiple blocks CAN share one Object key with different offsets (TP partitions).
+//!
+//! **WRITE (Host → Object):** One-to-one mapping ONLY. Object PUT does NOT support
+//! partial writes at offsets. Each block MUST map to a unique Object.
+
+use crate::block_manager::v2::physical::layout::PhysicalLayout;
+use crate::block_manager::v2::memory::StorageKind;
+use anyhow::Result;
+use nixl_sys::XferDescList;
+use std::collections::HashSet;
+use std::ops::Range;
+
+/// Build optimized transfer for ObjectLayout ↔ Contiguous layout.
+///
+/// # Read Path (Object → Host): Supports byte-range offsets
+///
+/// Multiple blocks CAN share one Object key with different offsets (TP partitions).
+/// Uses Object GET with Range header for partial reads:
+/// ```text
+/// Object key 99999, offset 0MB       → Block 0 (TP partition 0)
+/// Object key 99999, offset 2.3MB     → Block 1 (TP partition 1)
+/// Object key 99999, offset 4.6MB     → Block 2 (TP partition 2)
+/// Object key 99999, offset 6.9MB     → Block 3 (TP partition 3)
+/// ```
+///
+/// # Write Path (Host → Object): One-to-one mapping ONLY
+///
+/// **IMPORTANT:** Object PUT does NOT support partial writes at offsets.
+/// Each host block MUST map to a separate Object (unique key):
+/// ```text
+/// Block 0 → Object key 123456  (separate object)
+/// Block 1 → Object key 789012  (separate object)
+/// Block 2 → Object key 345678  (separate object)
+/// ```
+///
+/// Returns error if multiple blocks share the same Object key (would require offset writes)
+///
+/// # Arguments
+/// * `is_read` - true for Object→Host reads, false for Host→Object writes
+/// * `get_device_id` - Closure that extracts Object key for each block
+pub(crate) fn build_object_storage_transfer(
+    src: &PhysicalLayout,
+    dst: &PhysicalLayout,
+    src_block_ids: &[usize],
+    dst_block_ids: &[usize],
+    layers: &Range<usize>,
+    src_device_id: u64,
+    dst_device_id: u64,
+    src_dl: &mut XferDescList,
+    dst_dl: &mut XferDescList,
+    get_device_id: &dyn Fn(&PhysicalLayout, usize, u64) -> u64,
+    is_read: bool,
+) -> Result<()> {
+    let region_size = |layout: &PhysicalLayout| -> usize {
+        let l = layout.layout();
+        layers.len() * l.outer_dim() * l.page_size() * l.inner_dim() * l.dtype_width_bytes()
+    };
+
+    match is_read {
+        true => {
+            // READ: Object → Host
+            // Each source block may be:
+            // 1. A separate Object (different keys) - requires unique key per block
+            // 2. A partition within one Object (same key, different offsets) - byte-range GET
+            tracing::debug!("Object storage READ: {} blocks from Object", src_block_ids.len());
+
+            src_block_ids
+                .iter()
+                .zip(dst_block_ids.iter())
+                .try_for_each(|(&src_id, &dst_id)| {
+                    let src_region = src.memory_region(src_id, layers.start, 0)?;
+                    let dst_region = dst.memory_region(dst_id, layers.start, 0)?;
+                    let total_size = region_size(src);
+                    let src_key = get_device_id(src, src_id, src_device_id);
+
+                    src_dl.add_desc(src_region.addr(), total_size, src_key);
+                    dst_dl.add_desc(dst_region.addr(), total_size, dst_device_id);
+
+                    tracing::trace!(
+                        "  Object[{src_id}] (key={src_key}) → Host[{dst_id}]: {total_size} bytes"
+                    );
+                    Ok(())
+                })
+        }
+        false => {
+            // WRITE: Host → Object
+            // IMPORTANT: Object PUT does NOT support partial writes at offsets.
+            // Each block MUST map to a unique Object (one-to-one mapping).
+
+            // Collect all destination Object keys
+            let dst_keys: Vec<u64> = dst_block_ids
+                .iter()
+                .map(|&dst_id| get_device_id(dst, dst_id, dst_device_id))
+                .collect();
+
+            // Validate one-to-one mapping: each block must have a unique Object key
+            let unique_keys: HashSet<u64> = dst_keys.iter().copied().collect();
+            if unique_keys.len() != dst_block_ids.len() {
+                return Err(anyhow::anyhow!(
+                    "Object storage WRITE requires one-to-one mapping: {} blocks but only {} unique Object keys. \
+                     Object PUT does not support partial writes at offsets.",
+                    dst_block_ids.len(),
+                    unique_keys.len()
+                ));
+            }
+
+            tracing::debug!(
+                "Object storage WRITE: {} blocks → {} Objects",
+                src_block_ids.len(),
+                unique_keys.len()
+            );
+
+            // One descriptor per block (one-to-one mapping)
+            src_block_ids
+                .iter()
+                .zip(dst_block_ids.iter())
+                .zip(dst_keys.iter())
+                .try_for_each(|((&src_id, &dst_id), &dst_key)| {
+                    let src_region = src.memory_region(src_id, layers.start, 0)?;
+                    let dst_region = dst.memory_region(dst_id, layers.start, 0)?;
+                    let total_size = region_size(src);
+
+                    // Validate destination offset is 0 (Object PUT doesn't support offsets)
+                    if dst_region.addr() != 0 {
+                        return Err(anyhow::anyhow!(
+                            "Object storage WRITE: block {} has non-zero offset {}. \
+                             Object PUT does not support partial writes at offsets.",
+                            dst_id,
+                            dst_region.addr()
+                        ));
+                    }
+
+                    src_dl.add_desc(src_region.addr(), total_size, src_device_id);
+                    dst_dl.add_desc(0, total_size, dst_key); // Always offset 0 for writes
+
+                    tracing::trace!(
+                        "  Host[{src_id}] → Object key={dst_key}: {total_size} bytes"
+                    );
+                    Ok(())
+                })
+        }
+    }
+}
+
+/// Extract device_id (Object key) for a specific block.
+///
+/// ObjectLayout has unique keys per block; other layouts share one device_id.
+pub(crate) fn get_object_device_id(
+    layout: &PhysicalLayout,
+    block_id: usize,
+    default_id: u64,
+) -> u64 {
+    match (layout.location(), layout.layout().is_fully_contiguous()) {
+        (StorageKind::Object(_), false) => {
+            // ObjectLayout: each block has its own Object key
+            layout
+                .layout()
+                .memory_regions()
+                .get(block_id)
+                .and_then(|region| match region.storage_kind() {
+                    StorageKind::Object(key) => Some(key),
+                    _ => None,
+                })
+                .unwrap_or(default_id)
+        }
+        _ => default_id,
+    }
+}

--- a/lib/llm/src/block_manager/v2/physical/transfer/fill.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/fill.rs
@@ -111,6 +111,11 @@ pub fn fill_blocks(
                         file.sync_all()?;
                         file.flush()?;
                     }
+                    StorageKind::Object(_) => {
+                        // Object storage fill is handled by NIXL's OBJ plugin
+                        // For testing, we skip filling object storage regions
+                        tracing::warn!("Fill for object storage not yet implemented");
+                    }
                 }
             }
         }

--- a/lib/llm/src/block_manager/v2/physical/transfer/mod.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/mod.rs
@@ -59,7 +59,7 @@ pub use capabilities::TransferCapabilities;
 pub use checksum::{BlockChecksum, compute_block_checksums, compute_layer_checksums};
 pub use fill::{FillPattern, fill_blocks, fill_layers};
 pub use nixl_agent::{NixlAgent, NixlBackendConfig};
-pub use options::{TransferOptions, TransferOptionsBuilder};
+pub use options::{DescriptorHint, TransferOptions, TransferOptionsBuilder};
 pub use preferences::{NativeVsNixlPolicy, TransferPreferences};
 pub use strategy::{TransferPlan, TransferStrategy};
 pub use validation::BlockValidationError;

--- a/lib/llm/src/block_manager/v2/physical/transfer/nixl_agent/mod.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/nixl_agent/mod.rs
@@ -12,7 +12,7 @@ mod config;
 pub use config::NixlBackendConfig;
 
 use anyhow::Result;
-use nixl_sys::Agent as RawNixlAgent;
+use nixl_sys::{Agent as RawNixlAgent, Params};
 use std::collections::HashSet;
 
 /// A NIXL agent wrapper that tracks which backends were successfully initialized.
@@ -34,15 +34,126 @@ pub struct NixlAgent {
 }
 
 impl NixlAgent {
+    /// Generic helper function to create backend parameters from environment variables.
+    ///
+    /// Parses environment variables with the pattern:
+    /// `DYN_KVBM_NIXL_BACKEND_{BACKEND_NAME}_{PARAM}`
+    ///
+    /// For example:
+    /// - `DYN_KVBM_NIXL_BACKEND_POSIX_PATH=/my/path` -> `path` parameter for POSIX backend
+    /// - `DYN_KVBM_NIXL_BACKEND_UCX_DEVICE=mlx5_0`   -> `device` parameter for UCX backend
+    /// - `DYN_KVBM_NIXL_BACKEND_OBJ_ACCESS_KEY=...`  -> `access_key` parameter for OBJ backend
+    ///
+    /// Returns `None` if no custom parameters are found for this backend.
+    ///
+    /// This is public so it can be used when constructing custom configurations before
+    /// calling `new_with_backends_and_params()`.
+    pub fn create_backend_params_from_env(backend_name: &str) -> Result<Option<Params>> {
+        let prefix = format!("DYN_KVBM_NIXL_BACKEND_{}_", backend_name);
+        let mut param_pairs: Vec<(String, String)> = Vec::new();
+
+        // Parse DYN_KVBM_NIXL_BACKEND_{BACKEND_NAME}_* variables
+        for (env_key, env_value) in std::env::vars() {
+            if let Some(param_name) = env_key.strip_prefix(&prefix) {
+                let param_key = param_name.to_lowercase();
+                param_pairs.push((param_key, env_value));
+            }
+        }
+
+        if param_pairs.is_empty() {
+            return Ok(None);
+        }
+
+        tracing::debug!(
+            "{} backend parameters configured from environment: {:?}",
+            backend_name,
+            param_pairs
+        );
+
+        // Create Params object from the collected key-value pairs
+        let params =
+            Params::from(param_pairs.iter().map(|(k, v)| (k.as_str(), v.as_str())))?;
+        Ok(Some(params))
+    }
+
+    /// Create a new NIXL agent with the specified backends and explicit parameters.
+    ///
+    /// This method allows you to provide explicit `Params` for each backend. If a backend fails,
+    /// it logs a warning but continues with remaining backends. At least one backend must
+    /// succeed or this returns an error.
+    ///
+    /// # Arguments
+    /// * `name` - Agent name
+    /// * `backends` - List of (backend_name, params) tuples
+    ///
+    /// # Returns
+    /// A `NixlAgent` that tracks which backends were successfully initialized.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - Agent creation fails
+    /// - All backend initialization attempts fail
+    ///
+    /// # Example
+    /// ```ignore
+    /// let obj_params = Params::try_from_iter([
+    ///     ("bucket", "my-bucket"),
+    ///     ("region", "us-west-2"),
+    /// ])?;
+    ///
+    /// let agent = NixlAgent::new_with_backends_and_params(
+    ///     "my-agent",
+    ///     &[("OBJ", obj_params)]
+    /// )?;
+    /// ```
+    pub fn new_with_backends_and_params(name: &str, backends: &[(&str, Params)]) -> Result<Self> {
+        let agent = RawNixlAgent::new(name)?;
+        let mut available_backends = HashSet::new();
+
+        for (backend, params) in backends {
+            let backend_upper = backend.to_uppercase();
+
+            match agent.create_backend(&backend_upper, params) {
+                Ok(_) => {
+                    available_backends.insert(backend_upper.clone());
+                    tracing::debug!("{} backend created with provided parameters", backend_upper);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Failed to create {} backend with provided params: {}. Operations requiring this backend will fail.",
+                        backend_upper, e
+                    );
+                }
+            }
+        }
+
+        if available_backends.is_empty() {
+            let backend_names: Vec<_> = backends.iter().map(|(name, _)| *name).collect();
+            anyhow::bail!(
+                "Failed to initialize any NIXL backends from {:?}",
+                backend_names
+            );
+        }
+
+        Ok(Self {
+            agent,
+            available_backends,
+        })
+    }
+
     /// Create a new NIXL agent with the specified backends.
     ///
     /// Attempts to initialize all requested backends. If a backend fails, it logs
     /// a warning but continues with remaining backends. At least one backend must
     /// succeed or this returns an error.
     ///
+    /// This method will first check for custom parameters in environment variables
+    /// (DYN_KVBM_NIXL_BACKEND_{BACKEND_NAME}_{PARAM}), and if not found, will use
+    /// the default plugin parameters.
+    ///
     /// # Arguments
     /// * `name` - Agent name
-    /// * `backends` - List of backend names to try (e.g., `&["UCX", "GDS_MT, "POSIX"]`)
+    /// * `backends` - List of backend names to try (e.g., `&["UCX", "GDS_MT", "POSIX"]`)
     ///
     /// # Returns
     /// A `NixlAgent` that tracks which backends were successfully initialized.
@@ -57,22 +168,75 @@ impl NixlAgent {
 
         for backend in backends {
             let backend_upper = backend.to_uppercase();
-            match agent.get_plugin_params(&backend_upper) {
-                Ok((_, params)) => match agent.create_backend(&backend_upper, &params) {
-                    Ok(_) => {
-                        available_backends.insert(backend_upper);
+
+            // Try to get custom parameters from environment first
+            match Self::create_backend_params_from_env(&backend_upper) {
+                Ok(Some(custom_params)) => {
+                    // Custom parameters found - use them
+                    match agent.create_backend(&backend_upper, &custom_params) {
+                        Ok(_) => {
+                            available_backends.insert(backend_upper.clone());
+                            tracing::info!(
+                                "{} backend created with custom configuration from environment",
+                                backend_upper
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to create {} backend with custom params: {}. Check your DYN_KVBM_NIXL_BACKEND_{}_* environment variables.",
+                                backend_upper, e, backend_upper
+                            );
+                            eprintln!(
+                                "Failed to create {} backend with custom params: {}. Check your DYN_KVBM_NIXL_BACKEND_{}_* environment variables.",
+                                backend_upper, e, backend_upper
+                            );
+                        }
                     }
-                    Err(e) => {
-                        eprintln!(
-                            "✗ Failed to create {} backend: {}. Operations requiring this backend will fail.",
-                            backend_upper, e
-                        );
-                    }
-                },
-                Err(_) => {
-                    eprintln!(
-                        "✗ No {} plugin found. Operations requiring this backend will fail.",
+                }
+                Ok(None) => {
+                    // No custom parameters - fall back to default plugin parameters
+                    tracing::debug!(
+                        "Attempting to create {} backend with default params",
                         backend_upper
+                    );
+                    match agent.get_plugin_params(&backend_upper) {
+                        Ok((_, params)) => match agent.create_backend(&backend_upper, &params) {
+                            Ok(_) => {
+                                available_backends.insert(backend_upper.clone());
+                                tracing::info!("Successfully created {} backend", backend_upper);
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to create {} backend: {}. Operations requiring this backend will fail.",
+                                    backend_upper, e
+                                );
+                                eprintln!(
+                                    "Failed to create {} backend: {}. Operations requiring this backend will fail.",
+                                    backend_upper, e
+                                );
+                            }
+                        },
+                        Err(e) => {
+                            tracing::error!(
+                                "No {} plugin found: {:?}. Operations requiring this backend will fail.",
+                                backend_upper, e
+                            );
+                            eprintln!(
+                                "No {} plugin found. Operations requiring this backend will fail.",
+                                backend_upper
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to parse {} backend parameters from environment: {}",
+                        backend_upper,
+                        e
+                    );
+                    eprintln!(
+                        "Failed to parse {} backend parameters from environment: {}",
+                        backend_upper, e
                     );
                 }
             }
@@ -88,11 +252,87 @@ impl NixlAgent {
         })
     }
 
+    /// Create a NIXL agent requiring ALL specified backends with explicit parameters.
+    ///
+    /// Unlike `new_with_backends_and_params()` which continues if some backends fail,
+    /// this method will return an error if ANY backend fails to initialize. Use this
+    /// in production when specific backends with specific configurations are mandatory.
+    ///
+    /// # Arguments
+    /// * `name` - Agent name
+    /// * `backends` - List of (backend_name, params) tuples that MUST be available
+    ///
+    /// # Returns
+    /// A `NixlAgent` with all requested backends initialized.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - Agent creation fails
+    /// - Any backend fails to initialize
+    ///
+    /// # Example
+    /// ```ignore
+    /// let obj_params = Params::try_from_iter([
+    ///     ("bucket", "my-bucket"),
+    /// ])?;
+    ///
+    /// let agent = NixlAgent::require_backends_with_params(
+    ///     "worker-0",
+    ///     &[("OBJ", obj_params)]
+    /// )?;
+    /// ```
+    pub fn require_backends_with_params(name: &str, backends: &[(&str, Params)]) -> Result<Self> {
+        let agent = RawNixlAgent::new(name)?;
+        let mut available_backends = HashSet::new();
+        let mut failed_backends = Vec::new();
+
+        for (backend, params) in backends {
+            let backend_upper = backend.to_uppercase();
+
+            match agent.create_backend(&backend_upper, params) {
+                Ok(_) => {
+                    available_backends.insert(backend_upper.clone());
+                    tracing::debug!("{} backend created with provided parameters", backend_upper);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Failed to create {} backend with provided params: {}",
+                        backend_upper, e
+                    );
+                    failed_backends.push((
+                        backend_upper.clone(),
+                        format!("create with provided params failed: {}", e),
+                    ));
+                }
+            }
+        }
+
+        if !failed_backends.is_empty() {
+            let error_details: Vec<String> = failed_backends
+                .iter()
+                .map(|(name, reason)| format!("{}: {}", name, reason))
+                .collect();
+            anyhow::bail!(
+                "Failed to initialize required backends: [{}]",
+                error_details.join(", ")
+            );
+        }
+
+        Ok(Self {
+            agent,
+            available_backends,
+        })
+    }
+
     /// Create a NIXL agent requiring ALL specified backends to be available.
     ///
     /// Unlike `new_with_backends()` which continues if some backends fail, this method
     /// will return an error if ANY backend fails to initialize. Use this in production
     /// when specific backends are mandatory.
+    ///
+    /// This method will first check for custom parameters in environment variables
+    /// (DYN_KVBM_NIXL_BACKEND_{BACKEND_NAME}_{PARAM}), and if not found, will use
+    /// the default plugin parameters.
     ///
     /// # Arguments
     /// * `name` - Agent name
@@ -109,7 +349,7 @@ impl NixlAgent {
     /// # Example
     /// ```ignore
     /// // In production: require both UCX and GDS, fail if either is missing
-    /// let agent = NixlAgent::require_backends("worker-0", &["UCX", "GDS_MT])?;
+    /// let agent = NixlAgent::require_backends("worker-0", &["UCX", "GDS_MT"])?;
     /// ```
     pub fn require_backends(name: &str, backends: &[&str]) -> Result<Self> {
         let agent = RawNixlAgent::new(name)?;
@@ -118,21 +358,60 @@ impl NixlAgent {
 
         for backend in backends {
             let backend_upper = backend.to_uppercase();
-            match agent.get_plugin_params(&backend_upper) {
-                Ok((_, params)) => match agent.create_backend(&backend_upper, &params) {
-                    Ok(_) => {
-                        available_backends.insert(backend_upper);
+
+            // Try to get custom parameters from environment first
+            match Self::create_backend_params_from_env(&backend_upper) {
+                Ok(Some(custom_params)) => {
+                    // Custom parameters found - use them
+                    match agent.create_backend(&backend_upper, &custom_params) {
+                        Ok(_) => {
+                            available_backends.insert(backend_upper.clone());
+                            tracing::debug!(
+                                "{} backend created with custom configuration from environment",
+                                backend_upper
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "Failed to create {} backend with custom params: {}",
+                                backend_upper, e
+                            );
+                            failed_backends.push((
+                                backend_upper.clone(),
+                                format!("create with custom params failed: {}", e),
+                            ));
+                        }
                     }
-                    Err(e) => {
-                        eprintln!("✗ Failed to create {} backend: {}", backend_upper, e);
-                        failed_backends
-                            .push((backend_upper.clone(), format!("create failed: {}", e)));
+                }
+                Ok(None) => {
+                    // No custom parameters - fall back to default plugin parameters
+                    match agent.get_plugin_params(&backend_upper) {
+                        Ok((_, params)) => match agent.create_backend(&backend_upper, &params) {
+                            Ok(_) => {
+                                available_backends.insert(backend_upper);
+                            }
+                            Err(e) => {
+                                eprintln!("Failed to create {} backend: {}", backend_upper, e);
+                                failed_backends
+                                    .push((backend_upper.clone(), format!("create failed: {}", e)));
+                            }
+                        },
+                        Err(e) => {
+                            eprintln!("No {} plugin found", backend_upper);
+                            failed_backends
+                                .push((backend_upper.clone(), format!("plugin not found: {}", e)));
+                        }
                     }
-                },
+                }
                 Err(e) => {
-                    eprintln!("✗ No {} plugin found", backend_upper);
-                    failed_backends
-                        .push((backend_upper.clone(), format!("plugin not found: {}", e)));
+                    eprintln!(
+                        "Failed to parse {} backend parameters from environment: {}",
+                        backend_upper, e
+                    );
+                    failed_backends.push((
+                        backend_upper.clone(),
+                        format!("params parsing failed: {}", e),
+                    ));
                 }
             }
         }

--- a/lib/llm/src/block_manager/v2/physical/transfer/tests/descriptor_tests.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/tests/descriptor_tests.rs
@@ -1,0 +1,606 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Descriptor building tests for verifying hint behavior.
+//!
+//! These tests verify that each `DescriptorHint` produces the expected
+//! descriptor patterns through the `build_descriptors` entry point.
+
+use super::*;
+use crate::block_manager::v2::physical::layout::PhysicalLayout;
+use crate::block_manager::v2::physical::transfer::executor::{DescriptorParams, build_descriptors};
+use crate::block_manager::v2::physical::transfer::DescriptorHint;
+use anyhow::Result;
+use nixl_sys::XferDescList;
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/// Create a pinned layout for descriptor tests.
+fn create_pinned_layout(agent: NixlAgent, num_blocks: usize) -> Result<PhysicalLayout> {
+    let config = standard_config(num_blocks);
+    Ok(PhysicalLayout::builder(agent)
+        .with_config(config)
+        .fully_contiguous()
+        .allocate_pinned(false)
+        .build()?)
+}
+
+/// Create an object layout with multiple objects (one per block).
+fn create_multi_object_layout(
+    agent: NixlAgent,
+    bucket: &str,
+    base_key: u64,
+    num_blocks: usize,
+) -> Result<PhysicalLayout> {
+    let config = standard_config(num_blocks);
+    let keys: Vec<u64> = (0..num_blocks as u64).map(|i| base_key + i).collect();
+    PhysicalLayout::builder(agent)
+        .with_config(config)
+        .object_layout()
+        .allocate_objects(bucket.to_string(), keys)?
+        .build()
+}
+
+/// Create a single-object layout (TP partition style).
+fn create_single_object_layout(
+    agent: NixlAgent,
+    bucket: &str,
+    key: u64,
+    num_blocks: usize,
+) -> Result<PhysicalLayout> {
+    let config = standard_config(num_blocks);
+    PhysicalLayout::builder(agent)
+        .with_config(config)
+        .fully_contiguous()
+        .allocate_object(bucket.to_string(), key)
+        .build()
+}
+
+/// Calculate block size in bytes from layout.
+fn block_size_bytes(layout: &PhysicalLayout) -> usize {
+    let l = layout.layout();
+    l.num_layers() * l.outer_dim() * l.page_size() * l.inner_dim() * l.dtype_width_bytes()
+}
+
+/// Get descriptor details for verification.
+struct DescriptorInfo {
+    addr: usize,
+    len: usize,
+    device_id: u64,
+}
+
+fn get_descriptors(dl: &XferDescList) -> Vec<DescriptorInfo> {
+    let count = dl.len().unwrap_or(0);
+    (0..count)
+        .filter_map(|i| dl.get(i).ok())
+        .map(|d| DescriptorInfo {
+            addr: d.addr,
+            len: d.len,
+            device_id: d.dev_id,
+        })
+        .collect()
+}
+
+/// Helper to build descriptors with a specific hint.
+fn build_with_hint(
+    src: &PhysicalLayout,
+    dst: &PhysicalLayout,
+    src_blocks: &[usize],
+    dst_blocks: &[usize],
+    hint: DescriptorHint,
+) -> Result<(Vec<DescriptorInfo>, Vec<DescriptorInfo>)> {
+    let layers = 0..src.layout().num_layers();
+
+    let src_mem_type = src.nixl_metadata().mem_type();
+    let dst_mem_type = dst.nixl_metadata().mem_type();
+
+    let mut src_dl = XferDescList::new(src_mem_type)?;
+    let mut dst_dl = XferDescList::new(dst_mem_type)?;
+
+    let params = DescriptorParams {
+        src,
+        dst,
+        src_block_ids: src_blocks,
+        dst_block_ids: dst_blocks,
+        layers: &layers,
+        hint,
+    };
+
+    build_descriptors(&params, &mut src_dl, &mut dst_dl)?;
+
+    Ok((get_descriptors(&src_dl), get_descriptors(&dst_dl)))
+}
+
+// ============================================================================
+// Coalesced Hint Tests
+// ============================================================================
+
+#[test]
+fn test_hint_coalesced_creates_single_descriptor() -> Result<()> {
+    let agent = create_test_agent("test-coalesced");
+    let src = create_pinned_layout(agent.clone(), 4)?;
+    let dst = create_pinned_layout(agent.clone(), 4)?;
+
+    let (src_descs, dst_descs) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1, 2, 3],
+        &[0, 1, 2, 3],
+        DescriptorHint::Coalesced,
+    )?;
+
+    // Should create exactly 1 descriptor covering all 4 blocks
+    assert_eq!(src_descs.len(), 1, "Coalesced should create 1 src descriptor");
+    assert_eq!(dst_descs.len(), 1, "Coalesced should create 1 dst descriptor");
+
+    // Verify size covers all blocks
+    let expected_block_size = block_size_bytes(&src);
+    let expected_total = 4 * expected_block_size;
+    assert_eq!(
+        src_descs[0].len, expected_total,
+        "Size should cover all 4 blocks ({} bytes)",
+        expected_total
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_hint_coalesced_non_contiguous_fallback() -> Result<()> {
+    let agent = create_test_agent("test-coalesced-nc");
+    let src = create_pinned_layout(agent.clone(), 8)?;
+    let dst = create_pinned_layout(agent.clone(), 8)?;
+
+    // Non-contiguous blocks
+    let (src_descs, _) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 2, 4, 6],
+        &[1, 3, 5, 7],
+        DescriptorHint::Coalesced,
+    )?;
+
+    // Non-contiguous should fall back to per-block
+    assert_eq!(
+        src_descs.len(),
+        4,
+        "Non-contiguous should create 4 descriptors"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// PerBlockWithOffset Hint Tests
+// ============================================================================
+
+#[test]
+fn test_hint_per_block_offset_creates_n_descriptors() -> Result<()> {
+    let agent = create_test_agent("test-offset");
+    let src = create_pinned_layout(agent.clone(), 4)?;
+    let dst = create_pinned_layout(agent.clone(), 4)?;
+
+    let (src_descs, dst_descs) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1, 2, 3],
+        &[0, 1, 2, 3],
+        DescriptorHint::PerBlockWithOffset,
+    )?;
+
+    // Should create 4 descriptors (one per block)
+    assert_eq!(src_descs.len(), 4, "Should create 4 src descriptors");
+    assert_eq!(dst_descs.len(), 4, "Should create 4 dst descriptors");
+
+    // Verify offsets are different for each block (addresses are absolute, not relative)
+    let block_size = block_size_bytes(&src);
+    let base_addr = src_descs[0].addr;
+    for (i, desc) in src_descs.iter().enumerate() {
+        let relative_offset = desc.addr - base_addr;
+        let expected_offset = i * block_size;
+        assert_eq!(
+            relative_offset, expected_offset,
+            "Block {} should have relative offset {}",
+            i, expected_offset
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_hint_per_block_offset_object_read() -> Result<()> {
+    let agent = create_test_agent("test-offset-obj");
+
+    // Single object layout (all blocks share same key, different offsets)
+    let src = create_single_object_layout(agent.clone(), "test-bucket", 99999, 4)?;
+    let dst = create_pinned_layout(agent.clone(), 4)?;
+
+    let (src_descs, _) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1, 2, 3],
+        &[0, 1, 2, 3],
+        DescriptorHint::PerBlockWithOffset,
+    )?;
+
+    // All descriptors should share the same object key (99999)
+    for (i, desc) in src_descs.iter().enumerate() {
+        assert_eq!(
+            desc.device_id, 99999,
+            "Block {} should share key 99999, got {}",
+            i, desc.device_id
+        );
+    }
+
+    // Offsets should be different (byte-range reads)
+    let offsets: Vec<usize> = src_descs.iter().map(|d| d.addr).collect();
+    let unique_offsets: std::collections::HashSet<_> = offsets.iter().collect();
+    assert_eq!(
+        unique_offsets.len(),
+        4,
+        "Each block should have unique offset"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// PerBlockUniqueTarget Hint Tests
+// ============================================================================
+
+#[test]
+fn test_hint_per_block_unique_memory_preserves_offsets() -> Result<()> {
+    let agent = create_test_agent("test-unique");
+    let src = create_pinned_layout(agent.clone(), 4)?;
+    let dst = create_pinned_layout(agent.clone(), 4)?;
+
+    let (_, dst_descs) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1, 2, 3],
+        &[0, 1, 2, 3],
+        DescriptorHint::PerBlockUniqueTarget,
+    )?;
+
+    // For memory transfers, relative offsets should be preserved (addresses are absolute)
+    let block_size = block_size_bytes(&dst);
+    let base_addr = dst_descs[0].addr;
+    for (i, desc) in dst_descs.iter().enumerate() {
+        let relative_offset = desc.addr - base_addr;
+        let expected_offset = i * block_size;
+        assert_eq!(
+            relative_offset, expected_offset,
+            "Block {} should have relative offset {}",
+            i, expected_offset
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_hint_per_block_unique_object_write() -> Result<()> {
+    let agent = create_test_agent("test-unique-obj");
+    let src = create_pinned_layout(agent.clone(), 4)?;
+    let dst = create_multi_object_layout(agent.clone(), "test-bucket", 1000, 4)?;
+
+    let (_, dst_descs) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1, 2, 3],
+        &[0, 1, 2, 3],
+        DescriptorHint::PerBlockUniqueTarget,
+    )?;
+
+    // All destination offsets should be 0 (object storage requirement)
+    for (i, desc) in dst_descs.iter().enumerate() {
+        assert_eq!(
+            desc.addr, 0,
+            "Block {} should have offset 0 for object write",
+            i
+        );
+    }
+
+    // Each block should have unique device_id (object key)
+    let keys: Vec<u64> = dst_descs.iter().map(|d| d.device_id).collect();
+    let expected_keys: Vec<u64> = vec![1000, 1001, 1002, 1003];
+    assert_eq!(keys, expected_keys, "Each block should have unique object key");
+
+    Ok(())
+}
+
+// ============================================================================
+// BatchedRanges Hint Tests
+// ============================================================================
+
+#[test]
+fn test_hint_batched_fully_contiguous() -> Result<()> {
+    let agent = create_test_agent("test-batched-full");
+    let src = create_pinned_layout(agent.clone(), 8)?;
+    let dst = create_pinned_layout(agent.clone(), 8)?;
+
+    // Fully contiguous blocks
+    let (src_descs, _) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1, 2, 3, 4, 5, 6, 7],
+        &[0, 1, 2, 3, 4, 5, 6, 7],
+        DescriptorHint::BatchedRanges,
+    )?;
+
+    // Fully contiguous should create 1 descriptor
+    assert_eq!(
+        src_descs.len(),
+        1,
+        "Fully contiguous should batch into 1 descriptor"
+    );
+
+    // Verify size covers all 8 blocks
+    let expected_size = 8 * block_size_bytes(&src);
+    assert_eq!(src_descs[0].len, expected_size, "Should cover all 8 blocks");
+
+    Ok(())
+}
+
+#[test]
+fn test_hint_batched_partial_contiguous() -> Result<()> {
+    let agent = create_test_agent("test-batched-partial");
+    let src = create_pinned_layout(agent.clone(), 16)?;
+    let dst = create_pinned_layout(agent.clone(), 16)?;
+
+    // Source contiguous ranges: [0,1,2] + [10,11] + [15]
+    // But dst is also fragmented, breaking batches
+    let (src_descs, _) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1, 2, 10, 11, 15],
+        &[0, 1, 2, 3, 4, 5], // dst contiguous breaks src batching
+        DescriptorHint::BatchedRanges,
+    )?;
+
+    // Should batch some ranges (fewer than 6 descriptors)
+    assert!(
+        src_descs.len() <= 6,
+        "Should batch at least some ranges, got {} descriptors",
+        src_descs.len()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_hint_batched_no_contiguous() -> Result<()> {
+    let agent = create_test_agent("test-batched-sep");
+    let src = create_pinned_layout(agent.clone(), 16)?;
+    let dst = create_pinned_layout(agent.clone(), 16)?;
+
+    // No contiguous pairs in either src or dst
+    let (src_descs, _) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 2, 4, 6],
+        &[1, 3, 5, 7],
+        DescriptorHint::BatchedRanges,
+    )?;
+
+    // No batching possible, should create 4 descriptors
+    assert_eq!(
+        src_descs.len(),
+        4,
+        "Non-contiguous should create 4 descriptors"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Auto Hint Tests
+// ============================================================================
+
+#[test]
+fn test_hint_auto_memory_to_memory() -> Result<()> {
+    let agent = create_test_agent("test-auto-mem");
+    let src = create_pinned_layout(agent.clone(), 4)?;
+    let dst = create_pinned_layout(agent.clone(), 4)?;
+
+    // Auto should detect contiguous→contiguous and use BatchedRanges
+    let (src_descs, _) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1, 2, 3],
+        &[0, 1, 2, 3],
+        DescriptorHint::Auto,
+    )?;
+
+    // Should batch into 1 descriptor (contiguous)
+    assert_eq!(
+        src_descs.len(),
+        1,
+        "Auto should batch contiguous memory transfer"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_hint_auto_object_read() -> Result<()> {
+    let agent = create_test_agent("test-auto-obj-read");
+    let src = create_single_object_layout(agent.clone(), "bucket", 12345, 4)?;
+    let dst = create_pinned_layout(agent.clone(), 4)?;
+
+    // Auto should detect Object→Memory and use PerBlockWithOffset
+    let (src_descs, _) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1, 2, 3],
+        &[0, 1, 2, 3],
+        DescriptorHint::Auto,
+    )?;
+
+    // Should create 4 descriptors (per-block for object reads)
+    assert_eq!(
+        src_descs.len(),
+        4,
+        "Auto should use per-block for object reads"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_hint_auto_object_write() -> Result<()> {
+    let agent = create_test_agent("test-auto-obj-write");
+    let src = create_pinned_layout(agent.clone(), 4)?;
+    let dst = create_multi_object_layout(agent.clone(), "bucket", 5000, 4)?;
+
+    // Auto should detect Memory→Object and use PerBlockUniqueTarget
+    let (_, dst_descs) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1, 2, 3],
+        &[0, 1, 2, 3],
+        DescriptorHint::Auto,
+    )?;
+
+    // Should create 4 descriptors with unique keys and offset 0
+    assert_eq!(
+        dst_descs.len(),
+        4,
+        "Auto should use per-block for object writes"
+    );
+
+    for desc in &dst_descs {
+        assert_eq!(desc.addr, 0, "Object writes should have offset 0");
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Default Hint Tests (no hint provided)
+// ============================================================================
+
+/// Helper to build descriptors with the default hint (Auto).
+fn build_with_default_hint(
+    src: &PhysicalLayout,
+    dst: &PhysicalLayout,
+    src_blocks: &[usize],
+    dst_blocks: &[usize],
+) -> Result<(Vec<DescriptorInfo>, Vec<DescriptorInfo>)> {
+    // DescriptorHint::default() is Auto
+    build_with_hint(src, dst, src_blocks, dst_blocks, DescriptorHint::default())
+}
+
+#[test]
+fn test_default_hint_is_auto() {
+    // Verify that the default hint is Auto
+    assert_eq!(
+        DescriptorHint::default(),
+        DescriptorHint::Auto,
+        "Default hint should be Auto"
+    );
+}
+
+#[test]
+fn test_default_hint_memory_to_memory() -> Result<()> {
+    let agent = create_test_agent("test-default-mem");
+    let src = create_pinned_layout(agent.clone(), 4)?;
+    let dst = create_pinned_layout(agent.clone(), 4)?;
+
+    // Using default hint (no explicit hint provided)
+    let (src_descs, _) = build_with_default_hint(&src, &dst, &[0, 1, 2, 3], &[0, 1, 2, 3])?;
+
+    // Should auto-detect contiguous and batch
+    assert_eq!(
+        src_descs.len(),
+        1,
+        "Default hint should batch contiguous memory"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_default_hint_object_read() -> Result<()> {
+    let agent = create_test_agent("test-default-read");
+    let src = create_single_object_layout(agent.clone(), "bucket", 55555, 4)?;
+    let dst = create_pinned_layout(agent.clone(), 4)?;
+
+    let (src_descs, _) = build_with_default_hint(&src, &dst, &[0, 1, 2, 3], &[0, 1, 2, 3])?;
+
+    // Should auto-detect object read and use per-block
+    assert_eq!(
+        src_descs.len(),
+        4,
+        "Default hint should use per-block for object reads"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_default_hint_object_write() -> Result<()> {
+    let agent = create_test_agent("test-default-write");
+    let src = create_pinned_layout(agent.clone(), 4)?;
+    let dst = create_multi_object_layout(agent.clone(), "bucket", 7000, 4)?;
+
+    let (_, dst_descs) = build_with_default_hint(&src, &dst, &[0, 1, 2, 3], &[0, 1, 2, 3])?;
+
+    // Should auto-detect object write
+    assert_eq!(dst_descs.len(), 4, "Default hint should use per-block for object writes");
+
+    // All offsets should be 0
+    for desc in &dst_descs {
+        assert_eq!(desc.addr, 0, "Object writes should have offset 0");
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Edge Case Tests
+// ============================================================================
+
+#[test]
+fn test_single_block_transfer() -> Result<()> {
+    let agent = create_test_agent("test-single");
+    let src = create_pinned_layout(agent.clone(), 4)?;
+    let dst = create_pinned_layout(agent.clone(), 4)?;
+
+    let (src_descs, _) = build_with_hint(
+        &src,
+        &dst,
+        &[2],
+        &[3],
+        DescriptorHint::Coalesced,
+    )?;
+
+    assert_eq!(src_descs.len(), 1, "Single block should create 1 descriptor");
+
+    Ok(())
+}
+
+#[test]
+fn test_descriptor_sizes_match() -> Result<()> {
+    let agent = create_test_agent("test-sizes");
+    let src = create_pinned_layout(agent.clone(), 4)?;
+    let dst = create_pinned_layout(agent.clone(), 4)?;
+
+    let (src_descs, dst_descs) = build_with_hint(
+        &src,
+        &dst,
+        &[0, 1],
+        &[2, 3],
+        DescriptorHint::PerBlockWithOffset,
+    )?;
+
+    // Sizes should match between src and dst
+    for (s, d) in src_descs.iter().zip(dst_descs.iter()) {
+        assert_eq!(s.len, d.len, "Src and dst descriptor sizes should match");
+    }
+
+    Ok(())
+}

--- a/lib/llm/src/block_manager/v2/physical/transfer/tests/local_transfers.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/tests/local_transfers.rs
@@ -112,6 +112,7 @@ pub fn create_fc_layout(
         StorageKind::Pinned => builder.allocate_pinned(false).build().unwrap(),
         StorageKind::Device(device_id) => builder.allocate_device(device_id).build().unwrap(),
         StorageKind::Disk(_) => builder.allocate_disk(None).build().unwrap(),
+        StorageKind::Object(_) => panic!("Object storage not supported in local transfer tests"),
     }
 }
 
@@ -131,6 +132,7 @@ pub fn create_lw_layout(
         StorageKind::Pinned => builder.allocate_pinned(false).build().unwrap(),
         StorageKind::Device(device_id) => builder.allocate_device(device_id).build().unwrap(),
         StorageKind::Disk(_) => builder.allocate_disk(None).build().unwrap(),
+        StorageKind::Object(_) => panic!("Object storage not supported in local transfer tests"),
     }
 }
 
@@ -373,6 +375,9 @@ fn build_agent_for_kinds(src_kind: StorageKind, dst_kind: StorageKind) -> Result
             }
             StorageKind::Disk(_) => {
                 backends.insert("POSIX"); // Required for disk I/O
+            }
+            StorageKind::Object(_) => {
+                panic!("Object storage not supported in local transfer tests")
             }
         }
     }

--- a/lib/llm/src/block_manager/v2/physical/transfer/tests/mod.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/tests/mod.rs
@@ -9,6 +9,9 @@ mod local_transfers;
 #[cfg(all(feature = "testing-cuda", feature = "testing-nixl"))]
 mod object_transfers;
 
+#[cfg(feature = "testing-nixl")]
+mod descriptor_tests;
+
 use super::{NixlAgent, PhysicalLayout};
 use crate::block_manager::v2::physical::layout::{
     LayoutConfig,

--- a/lib/llm/src/block_manager/v2/physical/transfer/tests/mod.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/tests/mod.rs
@@ -6,6 +6,9 @@
 #[cfg(all(feature = "testing-cuda", feature = "testing-nixl"))]
 mod local_transfers;
 
+#[cfg(all(feature = "testing-cuda", feature = "testing-nixl"))]
+mod object_transfers;
+
 use super::{NixlAgent, PhysicalLayout};
 use crate::block_manager::v2::physical::layout::{
     LayoutConfig,

--- a/lib/llm/src/block_manager/v2/physical/transfer/tests/object_transfers.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/tests/object_transfers.rs
@@ -1,0 +1,782 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Object storage transfer tests for verifying offload/onboard operations via NIXL OBJ backend.
+//!
+//! These tests require:
+//! - NIXL with OBJ backend support
+//! - Object-compatible object storage
+//! - Environment variables for connection configuration
+//!
+//! # Environment Variables
+//!
+//! ```bash
+//! export DYN_KVBM_NIXL_BACKEND_OBJ_ENDPOINT="http://localhost:9000"
+//! export DYN_KVBM_NIXL_BACKEND_OBJ_BUCKET="test-bucket"
+//! export DYN_KVBM_NIXL_BACKEND_OBJ_ACCESS_KEY=""
+//! export DYN_KVBM_NIXL_BACKEND_OBJ_SECRET_KEY=""
+//! ```
+
+use super::*;
+use crate::block_manager::v2::physical::layout::PhysicalLayout;
+use crate::block_manager::v2::physical::transfer::executor::execute_transfer;
+use crate::block_manager::v2::physical::transfer::{
+    BounceBufferSpec, DescriptorHint, FillPattern, TransferCapabilities, TransferOptions,
+    compute_block_checksums, fill_blocks,
+};
+use anyhow::Result;
+use rstest::rstest;
+use std::collections::HashMap;
+use std::env;
+use std::sync::{Arc, Once};
+
+static INIT_TRACING: Once = Once::new();
+
+/// Initialize tracing subscriber for tests (only once across all tests).
+fn init_tracing() {
+    INIT_TRACING.call_once(|| {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .init();
+    });
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/// Object storage configuration from environment variables.
+#[derive(Debug, Clone)]
+struct ObjectStorageConfig {
+    #[allow(dead_code)]
+    endpoint: String,
+    bucket: String,
+    #[allow(dead_code)]
+    access_key: String,
+    #[allow(dead_code)]
+    secret_key: String,
+}
+
+impl ObjectStorageConfig {
+    /// Load configuration from environment variables.
+    /// Panics if any required variable is missing.
+    fn from_env() -> Self {
+        Self {
+            endpoint: env::var("DYN_KVBM_NIXL_BACKEND_OBJ_ENDPOINT")
+                .expect("DYN_KVBM_NIXL_BACKEND_OBJ_ENDPOINT env var required for object storage tests"),
+            bucket: env::var("DYN_KVBM_NIXL_BACKEND_OBJ_BUCKET")
+                .expect("DYN_KVBM_NIXL_BACKEND_OBJ_BUCKET env var required for object storage tests"),
+            access_key: env::var("DYN_KVBM_NIXL_BACKEND_OBJ_ACCESS_KEY")
+                .expect("DYN_KVBM_NIXL_BACKEND_OBJ_ACCESS_KEY env var required for object storage tests"),
+            secret_key: env::var("DYN_KVBM_NIXL_BACKEND_OBJ_SECRET_KEY")
+                .expect("DYN_KVBM_NIXL_BACKEND_OBJ_SECRET_KEY env var required for object storage tests"),
+        }
+    }
+}
+
+// ============================================================================
+// Test Types (similar to local_transfers.rs)
+// ============================================================================
+
+/// Host storage type for object transfer tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostStorageType {
+    Pinned,
+    Device,
+}
+
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Create an agent with OBJ backend for object storage tests.
+fn create_object_test_agent(name: &str) -> Result<NixlAgent> {
+    NixlAgent::new_with_backends(name, &["OBJ", "POSIX"])
+}
+
+/// Generate a unique object key for testing (based on timestamp).
+fn generate_test_object_key() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let duration = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    duration.as_nanos() as u64
+}
+
+/// Create an ObjectLayout with multiple Objects (one per block).
+/// Used for WRITE operations where each block maps to a unique Object.
+fn create_multi_object_layout(
+    agent: NixlAgent,
+    bucket: &str,
+    base_key: u64,
+    num_blocks: usize,
+) -> Result<PhysicalLayout> {
+    let config = standard_config(num_blocks);
+    let keys: Vec<u64> = (0..num_blocks as u64).map(|i| base_key + i).collect();
+    PhysicalLayout::builder(agent)
+        .with_config(config)
+        .object_layout()
+        .allocate_objects(bucket.to_string(), keys)?
+        .build()
+}
+
+/// Create a FullyContiguous layout backed by a SINGLE Object.
+/// Used for READ operations where blocks read from different byte offsets.
+fn create_single_object_layout(
+    agent: NixlAgent,
+    bucket: &str,
+    key: u64,
+    num_blocks: usize,
+) -> Result<PhysicalLayout> {
+    let config = standard_config(num_blocks);
+    PhysicalLayout::builder(agent)
+        .with_config(config)
+        .fully_contiguous()
+        .allocate_object(bucket.to_string(), key)
+        .build()
+}
+
+/// Create a pinned memory layout for testing.
+fn create_pinned_layout(agent: NixlAgent, num_blocks: usize) -> Result<PhysicalLayout> {
+    let config = standard_config(num_blocks);
+    Ok(PhysicalLayout::builder(agent)
+        .with_config(config)
+        .fully_contiguous()
+        .allocate_pinned(false)
+        .build()?)
+}
+
+/// Create a device memory layout for testing.
+fn create_device_layout(agent: NixlAgent, num_blocks: usize) -> Result<PhysicalLayout> {
+    let config = standard_config(num_blocks);
+    Ok(PhysicalLayout::builder(agent)
+        .with_config(config)
+        .fully_contiguous()
+        .allocate_device(0)
+        .build()?)
+}
+
+/// Create host layout based on storage type.
+fn create_host_layout(
+    agent: NixlAgent,
+    storage: HostStorageType,
+    num_blocks: usize,
+) -> Result<PhysicalLayout> {
+    match storage {
+        HostStorageType::Pinned => create_pinned_layout(agent, num_blocks),
+        HostStorageType::Device => create_device_layout(agent, num_blocks),
+    }
+}
+
+/// Create a transfer context for object storage tests.
+fn create_object_transfer_context(
+    agent: NixlAgent,
+) -> Result<crate::block_manager::v2::physical::manager::TransportManager> {
+    crate::block_manager::v2::physical::manager::TransportManager::builder()
+        .capabilities(TransferCapabilities::default())
+        .worker_id(0)
+        .nixl_agent(agent)
+        .cuda_device_id(0)
+        .build()
+}
+
+/// Fill blocks and compute checksums (for pinned/system storage).
+fn fill_and_checksum(
+    layout: &PhysicalLayout,
+    block_ids: &[usize],
+    pattern: FillPattern,
+) -> Result<HashMap<usize, crate::block_manager::v2::physical::transfer::BlockChecksum>> {
+    fill_blocks(layout, block_ids, pattern)?;
+    compute_block_checksums(layout, block_ids)
+}
+
+/// Verify checksums match by position.
+fn verify_checksums_by_position(
+    src_checksums: &HashMap<usize, crate::block_manager::v2::physical::transfer::BlockChecksum>,
+    src_block_ids: &[usize],
+    dst_layout: &PhysicalLayout,
+    dst_block_ids: &[usize],
+) -> Result<()> {
+    assert_eq!(
+        src_block_ids.len(),
+        dst_block_ids.len(),
+        "Source and destination block arrays must have same length"
+    );
+
+    let dst_checksums = compute_block_checksums(dst_layout, dst_block_ids)?;
+
+    for (src_id, dst_id) in src_block_ids.iter().zip(dst_block_ids.iter()) {
+        let src_checksum = src_checksums
+            .get(src_id)
+            .unwrap_or_else(|| panic!("Missing source checksum for block {}", src_id));
+        let dst_checksum = dst_checksums
+            .get(dst_id)
+            .unwrap_or_else(|| panic!("Missing destination checksum for block {}", dst_id));
+
+        assert_eq!(
+            src_checksum, dst_checksum,
+            "Checksum mismatch: src[{}] != dst[{}]: {} != {}",
+            src_id, dst_id, src_checksum, dst_checksum
+        );
+    }
+
+    Ok(())
+}
+
+// Bounce buffer helper for device transfers
+struct TestBounceBuffer {
+    layout: PhysicalLayout,
+    block_ids: Vec<usize>,
+}
+
+impl BounceBufferSpec for TestBounceBuffer {
+    fn layout(&self) -> &PhysicalLayout {
+        &self.layout
+    }
+    fn block_ids(&self) -> &[usize] {
+        &self.block_ids
+    }
+}
+
+// ============================================================================
+// Offload Tests (Host → Object Storage)
+// ============================================================================
+
+/// Implementation helper for offload tests.
+async fn test_offload_impl(
+    host_storage: HostStorageType,
+    num_blocks: usize,
+    name_suffix: &str,
+) -> Result<()> {
+    init_tracing();
+    let config = ObjectStorageConfig::from_env();
+    let test_name = format!("test-offload-{}-{}", name_suffix, generate_test_object_key());
+    let agent = create_object_test_agent(&test_name)?;
+    let object_key = generate_test_object_key();
+
+    // Create layouts
+    let src = create_host_layout(agent.clone(), host_storage, num_blocks)?;
+    let dst = create_multi_object_layout(agent.clone(), &config.bucket, object_key, num_blocks)?;
+
+    let block_ids: Vec<usize> = (0..num_blocks).collect();
+
+    // For device storage, we need a bounce buffer
+    let bounce_spec: Option<Arc<dyn BounceBufferSpec>> = match host_storage {
+        HostStorageType::Device => {
+            let bounce = create_pinned_layout(agent.clone(), num_blocks)?;
+            Some(Arc::new(TestBounceBuffer {
+                layout: bounce,
+                block_ids: block_ids.clone(),
+            }))
+        }
+        HostStorageType::Pinned => None,
+    };
+
+    // Fill source with test data (via bounce for device)
+    let src_checksums = if host_storage == HostStorageType::Pinned {
+        fill_and_checksum(&src, &block_ids, FillPattern::Sequential)?
+    } else {
+        // For device, we can't directly fill - just transfer and verify structure
+        HashMap::new()
+    };
+
+    let ctx = create_object_transfer_context(agent.clone())?;
+
+    // Build transfer options
+    let mut options_builder = TransferOptions::builder()
+        .descriptor_hint(DescriptorHint::PerBlockUniqueTarget);
+    if let Some(bounce) = bounce_spec.clone() {
+        options_builder = options_builder.bounce_buffer(bounce);
+    }
+    let options = options_builder.build()?;
+
+    // Execute offload
+    let notification = execute_transfer(
+        &src,
+        &dst,
+        &block_ids,
+        &block_ids,
+        options,
+        ctx.context(),
+    )?;
+    notification.await?;
+
+    // Verify by reading back (only for pinned where we have checksums)
+    if host_storage == HostStorageType::Pinned {
+        let verify = create_pinned_layout(agent.clone(), num_blocks)?;
+        let read_options = TransferOptions::builder()
+            .descriptor_hint(DescriptorHint::PerBlockWithOffset)
+            .build()?;
+        let notification = execute_transfer(
+            &dst,
+            &verify,
+            &block_ids,
+            &block_ids,
+            read_options,
+            ctx.context(),
+        )?;
+        notification.await?;
+
+        verify_checksums_by_position(&src_checksums, &block_ids, &verify, &block_ids)?;
+    }
+
+    Ok(())
+}
+
+#[rstest]
+#[case(HostStorageType::Pinned, 4, "pinned_4")]
+#[case(HostStorageType::Pinned, 8, "pinned_8")]
+#[case(HostStorageType::Device, 4, "device_4")]
+#[tokio::test]
+async fn test_offload(
+    #[case] host_storage: HostStorageType,
+    #[case] num_blocks: usize,
+    #[case] name_suffix: &str,
+) -> Result<()> {
+    test_offload_impl(host_storage, num_blocks, name_suffix).await
+}
+
+// ============================================================================
+// Onboard Tests (Object Storage → Host)
+// ============================================================================
+
+/// Implementation helper for onboard tests.
+async fn test_onboard_impl(
+    host_storage: HostStorageType,
+    num_blocks: usize,
+    name_suffix: &str,
+) -> Result<()> {
+    init_tracing();
+    let config = ObjectStorageConfig::from_env();
+    let test_name = format!("test-onboard-{}-{}", name_suffix, generate_test_object_key());
+    let agent = create_object_test_agent(&test_name)?;
+    let object_key = generate_test_object_key();
+
+    // First, create source data and offload to object storage
+    let src = create_pinned_layout(agent.clone(), num_blocks)?;
+    let obj = create_multi_object_layout(agent.clone(), &config.bucket, object_key, num_blocks)?;
+
+    let block_ids: Vec<usize> = (0..num_blocks).collect();
+
+    // Fill and checksum source
+    let original_checksums = fill_and_checksum(&src, &block_ids, FillPattern::Sequential)?;
+
+    let ctx = create_object_transfer_context(agent.clone())?;
+
+    // Offload to object storage
+    let write_options = TransferOptions::builder()
+        .descriptor_hint(DescriptorHint::PerBlockUniqueTarget)
+        .build()?;
+    let notification = execute_transfer(
+        &src,
+        &obj,
+        &block_ids,
+        &block_ids,
+        write_options,
+        ctx.context(),
+    )?;
+    notification.await?;
+
+    // Create destination layout
+    let dst = create_host_layout(agent.clone(), host_storage, num_blocks)?;
+
+    // For device storage, we need a bounce buffer
+    let bounce_spec: Option<Arc<dyn BounceBufferSpec>> = match host_storage {
+        HostStorageType::Device => {
+            let bounce = create_pinned_layout(agent.clone(), num_blocks)?;
+            Some(Arc::new(TestBounceBuffer {
+                layout: bounce,
+                block_ids: block_ids.clone(),
+            }))
+        }
+        HostStorageType::Pinned => None,
+    };
+
+    // Build read options
+    let mut options_builder = TransferOptions::builder()
+        .descriptor_hint(DescriptorHint::PerBlockWithOffset);
+    if let Some(bounce) = bounce_spec {
+        options_builder = options_builder.bounce_buffer(bounce);
+    }
+    let options = options_builder.build()?;
+
+    // Execute onboard
+    let notification = execute_transfer(
+        &obj,
+        &dst,
+        &block_ids,
+        &block_ids,
+        options,
+        ctx.context(),
+    )?;
+    notification.await?;
+
+    // Verify (only for pinned where we can compute checksums)
+    if host_storage == HostStorageType::Pinned {
+        verify_checksums_by_position(&original_checksums, &block_ids, &dst, &block_ids)?;
+    }
+
+    Ok(())
+}
+
+#[rstest]
+#[case(HostStorageType::Pinned, 4, "pinned_4")]
+#[case(HostStorageType::Pinned, 8, "pinned_8")]
+#[case(HostStorageType::Device, 4, "device_4")]
+#[tokio::test]
+async fn test_onboard(
+    #[case] host_storage: HostStorageType,
+    #[case] num_blocks: usize,
+    #[case] name_suffix: &str,
+) -> Result<()> {
+    test_onboard_impl(host_storage, num_blocks, name_suffix).await
+}
+
+// ============================================================================
+// Roundtrip Tests (Host → Object → Host)
+// ============================================================================
+
+/// Implementation helper for roundtrip tests.
+async fn test_roundtrip_impl(num_blocks: usize, name_suffix: &str) -> Result<()> {
+    init_tracing();
+    let config = ObjectStorageConfig::from_env();
+    let test_name = format!("test-roundtrip-{}-{}", name_suffix, generate_test_object_key());
+    let agent = create_object_test_agent(&test_name)?;
+    let object_key = generate_test_object_key();
+
+    let src = create_pinned_layout(agent.clone(), num_blocks)?;
+    let obj = create_multi_object_layout(agent.clone(), &config.bucket, object_key, num_blocks)?;
+    let dst = create_pinned_layout(agent.clone(), num_blocks)?;
+
+    let block_ids: Vec<usize> = (0..num_blocks).collect();
+
+    // Fill source
+    let original_checksums = fill_and_checksum(&src, &block_ids, FillPattern::Sequential)?;
+
+    let ctx = create_object_transfer_context(agent)?;
+
+    // Step 1: Offload
+    let write_options = TransferOptions::builder()
+        .descriptor_hint(DescriptorHint::PerBlockUniqueTarget)
+        .build()?;
+    let notification = execute_transfer(
+        &src,
+        &obj,
+        &block_ids,
+        &block_ids,
+        write_options,
+        ctx.context(),
+    )?;
+    notification.await?;
+
+    // Step 2: Onboard
+    let read_options = TransferOptions::builder()
+        .descriptor_hint(DescriptorHint::PerBlockWithOffset)
+        .build()?;
+    let notification = execute_transfer(
+        &obj,
+        &dst,
+        &block_ids,
+        &block_ids,
+        read_options,
+        ctx.context(),
+    )?;
+    notification.await?;
+
+    // Step 3: Verify
+    verify_checksums_by_position(&original_checksums, &block_ids, &dst, &block_ids)?;
+
+    Ok(())
+}
+
+#[rstest]
+#[case(4, "4_blocks")]
+#[case(8, "8_blocks")]
+#[case(16, "16_blocks")]
+#[tokio::test]
+async fn test_roundtrip(#[case] num_blocks: usize, #[case] name_suffix: &str) -> Result<()> {
+    test_roundtrip_impl(num_blocks, name_suffix).await
+}
+
+// ============================================================================
+// TP Partition Tests (byte-range reads from single Object)
+// ============================================================================
+
+/// Implementation helper for TP partition read tests.
+///
+/// This simulates a TP scenario where:
+/// 1. One Object contains data for all tensor parallel partitions
+/// 2. Each TP rank reads its partition from a different byte offset
+///
+/// ```text
+/// Object:
+/// ┌──────────────┬──────────────┬──────────────┬──────────────┐
+/// │    TP0       │    TP1       │    TP2       │    TP3       │
+/// │  offset 0    │  offset 1N   │  offset 2N   │  offset 3N   │
+/// └──────────────┴──────────────┴──────────────┴──────────────┘
+/// ```
+async fn test_tp_partition_read_impl(
+    num_tp_partitions: usize,
+    read_all_at_once: bool,
+    name_suffix: &str,
+) -> Result<()> {
+    init_tracing();
+    let config = ObjectStorageConfig::from_env();
+    let test_name = format!("test-tp-{}-{}", name_suffix, generate_test_object_key());
+    let agent = create_object_test_agent(&test_name)?;
+    let object_key = generate_test_object_key();
+
+    // Create source data in pinned memory
+    let src_pinned = create_pinned_layout(agent.clone(), num_tp_partitions)?;
+    let block_ids: Vec<usize> = (0..num_tp_partitions).collect();
+
+    // Fill with sequential pattern
+    let original_checksums = fill_and_checksum(&src_pinned, &block_ids, FillPattern::Sequential)?;
+
+    // Write ALL data to ONE Object (TP layout uses fully_contiguous)
+    let obj_tp = create_single_object_layout(
+        agent.clone(),
+        &config.bucket,
+        object_key,
+        num_tp_partitions,
+    )?;
+
+    let ctx = create_object_transfer_context(agent.clone())?;
+
+    // Coalesced write to single Object
+    let write_options = TransferOptions::builder()
+        .descriptor_hint(DescriptorHint::Coalesced)
+        .build()?;
+    let notification = execute_transfer(
+        &src_pinned,
+        &obj_tp,
+        &block_ids,
+        &block_ids,
+        write_options,
+        ctx.context(),
+    )?;
+    notification.await?;
+
+    if read_all_at_once {
+        // Read all partitions in one transfer
+        let dst_pinned = create_pinned_layout(agent.clone(), num_tp_partitions)?;
+        let read_options = TransferOptions::builder()
+            .descriptor_hint(DescriptorHint::PerBlockWithOffset)
+            .build()?;
+        let notification = execute_transfer(
+            &obj_tp,
+            &dst_pinned,
+            &block_ids,
+            &block_ids,
+            read_options,
+            ctx.context(),
+        )?;
+        notification.await?;
+
+        verify_checksums_by_position(&original_checksums, &block_ids, &dst_pinned, &block_ids)?;
+    } else {
+        // Read each TP partition individually (simulates TP ranks reading their data)
+        for tp_rank in 0..num_tp_partitions {
+            let dst_pinned = create_pinned_layout(agent.clone(), 1)?;
+
+            let read_options = TransferOptions::builder()
+                .descriptor_hint(DescriptorHint::PerBlockWithOffset)
+                .build()?;
+            let notification = execute_transfer(
+                &obj_tp,
+                &dst_pinned,
+                &[tp_rank],
+                &[0],
+                read_options,
+                ctx.context(),
+            )?;
+            notification.await?;
+
+            // Verify this partition
+            let dst_checksum = compute_block_checksums(&dst_pinned, &[0])?;
+            let expected = original_checksums.get(&tp_rank).unwrap();
+            let actual = dst_checksum.get(&0).unwrap();
+            assert_eq!(
+                expected, actual,
+                "TP{} data mismatch: expected {}, got {}",
+                tp_rank, expected, actual
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[rstest]
+#[case(4, true, "tp4_batch")]
+#[case(4, false, "tp4_individual")]
+#[case(8, true, "tp8_batch")]
+#[tokio::test]
+async fn test_tp_partition_read(
+    #[case] num_partitions: usize,
+    #[case] read_all_at_once: bool,
+    #[case] name_suffix: &str,
+) -> Result<()> {
+    test_tp_partition_read_impl(num_partitions, read_all_at_once, name_suffix).await
+}
+
+/// Test reading non-contiguous TP partitions (e.g., only TP0 and TP2).
+async fn test_tp_selective_read_impl(
+    num_tp_partitions: usize,
+    selected: &[usize],
+    name_suffix: &str,
+) -> Result<()> {
+    init_tracing();
+    let config = ObjectStorageConfig::from_env();
+    let test_name = format!("test-tp-selective-{}-{}", name_suffix, generate_test_object_key());
+    let agent = create_object_test_agent(&test_name)?;
+    let object_key = generate_test_object_key();
+
+    // Create and populate source data
+    let src_pinned = create_pinned_layout(agent.clone(), num_tp_partitions)?;
+    let all_block_ids: Vec<usize> = (0..num_tp_partitions).collect();
+
+    let original_checksums = fill_and_checksum(&src_pinned, &all_block_ids, FillPattern::Sequential)?;
+
+    // Write all partitions to single Object
+    let obj_tp = create_single_object_layout(
+        agent.clone(),
+        &config.bucket,
+        object_key,
+        num_tp_partitions,
+    )?;
+    let ctx = create_object_transfer_context(agent.clone())?;
+
+    let write_options = TransferOptions::builder()
+        .descriptor_hint(DescriptorHint::Coalesced)
+        .build()?;
+    let notification = execute_transfer(
+        &src_pinned,
+        &obj_tp,
+        &all_block_ids,
+        &all_block_ids,
+        write_options,
+        ctx.context(),
+    )?;
+    notification.await?;
+
+    // Read only selected partitions
+    let dst_pinned = create_pinned_layout(agent.clone(), selected.len())?;
+    let dst_block_ids: Vec<usize> = (0..selected.len()).collect();
+
+    let read_options = TransferOptions::builder()
+        .descriptor_hint(DescriptorHint::PerBlockWithOffset)
+        .build()?;
+    let notification = execute_transfer(
+        &obj_tp,
+        &dst_pinned,
+        selected,
+        &dst_block_ids,
+        read_options,
+        ctx.context(),
+    )?;
+    notification.await?;
+
+    // Verify selected partitions
+    let dst_checksums = compute_block_checksums(&dst_pinned, &dst_block_ids)?;
+    for (dst_idx, &src_tp) in selected.iter().enumerate() {
+        let expected = original_checksums.get(&src_tp).unwrap();
+        let actual = dst_checksums.get(&dst_idx).unwrap();
+        assert_eq!(
+            expected, actual,
+            "TP{} -> dst[{}] mismatch: expected {}, got {}",
+            src_tp, dst_idx, expected, actual
+        );
+    }
+
+    Ok(())
+}
+
+#[rstest]
+#[case(4, vec![0, 2], "tp4_0_2")]
+#[case(4, vec![1, 3], "tp4_1_3")]
+#[case(8, vec![0, 2, 4, 6], "tp8_even")]
+#[case(8, vec![1, 3, 5, 7], "tp8_odd")]
+#[tokio::test]
+async fn test_tp_selective_read(
+    #[case] num_partitions: usize,
+    #[case] selected: Vec<usize>,
+    #[case] name_suffix: &str,
+) -> Result<()> {
+    test_tp_selective_read_impl(num_partitions, &selected, name_suffix).await
+}
+
+// ============================================================================
+// Batch Operation Tests
+// ============================================================================
+
+/// Test batch operations with multiple unique object keys.
+async fn test_batch_impl(num_objects: usize, name_suffix: &str) -> Result<()> {
+    init_tracing();
+    let config = ObjectStorageConfig::from_env();
+    let test_name = format!("test-batch-{}-{}", name_suffix, generate_test_object_key());
+    let agent = create_object_test_agent(&test_name)?;
+
+    // Create multiple object keys
+    let base_key = generate_test_object_key();
+    let keys: Vec<u64> = (0..num_objects as u64).map(|i| base_key + i).collect();
+
+    let layout_config = standard_config(num_objects);
+
+    // Create object layout with multiple keys
+    let obj = PhysicalLayout::builder(agent.clone())
+        .with_config(layout_config)
+        .object_layout()
+        .allocate_objects(config.bucket.clone(), keys)?
+        .build()?;
+
+    let src = create_pinned_layout(agent.clone(), num_objects)?;
+    let block_ids: Vec<usize> = (0..num_objects).collect();
+
+    let original_checksums = fill_and_checksum(&src, &block_ids, FillPattern::Sequential)?;
+
+    let ctx = create_object_transfer_context(agent.clone())?;
+
+    // Batch offload
+    let write_options = TransferOptions::builder()
+        .descriptor_hint(DescriptorHint::PerBlockUniqueTarget)
+        .build()?;
+    let notification = execute_transfer(
+        &src,
+        &obj,
+        &block_ids,
+        &block_ids,
+        write_options,
+        ctx.context(),
+    )?;
+    notification.await?;
+
+    // Batch onboard to new buffer
+    let dst = create_pinned_layout(agent.clone(), num_objects)?;
+    let read_options = TransferOptions::builder()
+        .descriptor_hint(DescriptorHint::PerBlockWithOffset)
+        .build()?;
+    let notification = execute_transfer(
+        &obj,
+        &dst,
+        &block_ids,
+        &block_ids,
+        read_options,
+        ctx.context(),
+    )?;
+    notification.await?;
+
+    // Verify
+    verify_checksums_by_position(&original_checksums, &block_ids, &dst, &block_ids)?;
+
+    Ok(())
+}
+
+#[rstest]
+#[case(4, "4_objects")]
+#[case(8, "8_objects")]
+#[case(16, "16_objects")]
+#[tokio::test]
+async fn test_batch(#[case] num_objects: usize, #[case] name_suffix: &str) -> Result<()> {
+    test_batch_impl(num_objects, name_suffix).await
+}

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -26,7 +26,7 @@ dynamo-config = { workspace = true }
 
 anyhow = { workspace = true }
 cudarc = { workspace = true }
-nixl-sys = { version = "0.7" }
+nixl-sys = { git = "https://github.com/cheese-head/nixl.git", branch = "cheese-head/rust-param-bindings" }
 serde = { workspace = true}
 thiserror = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
#### Overview:

Introduces NIXL object storage backend integration for KVBM. This enables offloading and onboarding KV cache blocks to/from object storage (S3-compatible backends) via NIXL's OBJ plugin, with support for batch operations, byte-range reads for tensor parallelism scenarios.

#### Details:

#### Object Storage Transfer Support:
Added DescriptorHint enum to guide NIXL descriptor building for different transfer patterns:
- PerBlockUniqueTarget - batch writes to multiple objects (one per block)
- PerBlockWithOffset - byte-range reads from single object (TP scenarios)
- Coalesced - single descriptor covering all blocks
- BatchedRanges - batched contiguous ranges
Implemented object-specific transfer logic in object_transfer.rs
Added DescriptorParams struct to simplify descriptor building function signatures
##### Layout Support:
- Added ObjectLayout for multi-object layouts (one S3 key per block)
- Added allocate_object() and allocate_objects() builder methods
###### Test Infrastructure:
Tests cover: offload, onboard, roundtrip, TP partition reads, selective reads, batch operations

#### Where should the reviewer start?
lib/llm/src/block_manager/v2/physical/transfer/options.rs - DescriptorHint enum
lib/llm/src/block_manager/v2/physical/transfer/executor/object_transfer.rs - Object-specific transfer logic
lib/llm/src/block_manager/v2/physical/transfer/executor/nixl.rs - Descriptor building with hints
lib/llm/src/block_manager/v2/physical/transfer/tests/object_transfers.rs - End-to-end tests

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: https://github.com/ai-dynamo/nixl/pull/900

#### Running Object Transfer Tests
```
export DYN_KVBM_NIXL_BACKEND_OBJ_ENDPOINT_OVERRIDE=http://localhost:9000
export DYN_KVBM_NIXL_BACKEND_OBJ_ACCESS_KEY="access-key"
export DYN_KVBM_NIXL_BACKEND_OBJ_SECRET_KEY="super secret key"
export DYN_KVBM_NIXL_BACKEND_OBJ_BUCKET=distributed-demo
export AWS_DEFAULT_BUCKET=distributed-demo

NIXL_LOG_LEVEL=ERROR cargo test -p dynamo-llm --features "block-manager,testing-cuda,testing-nixl" object_transfers -- --nocapture
   Compiling dynamo-llm v0.7.0 (/workspace/lib/llm)
warning: dynamo-llm@0.7.0: Building with CUDA KV off
warning: dynamo-llm@0.7.0: Found FATBIN at default location: ./src/block_manager/block/transfer/kernels/vectorized_copy.fatbin
warning: dynamo-llm@0.7.0: CUDA FATBIN found at: ./src/block_manager/block/transfer/kernels/vectorized_copy.fatbin - copied to OUT_DIR
    Finished `test` profile [unoptimized + debuginfo] target(s) in 49.66s
     Running unittests src/lib.rs (target/debug/deps/dynamo_llm-d48df79881b348d4)

running 19 tests
test block_manager::v2::physical::transfer::tests::object_transfers::test_offload::case_3 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_tp_selective_read::case_4 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_roundtrip::case_1 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_tp_selective_read::case_3 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_tp_partition_read::case_3 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_tp_selective_read::case_2 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_roundtrip::case_3 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_roundtrip::case_2 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_tp_partition_read::case_2 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_offload::case_1 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_batch::case_2 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_onboard::case_1 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_batch::case_1 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_onboard::case_3 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_batch::case_3 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_onboard::case_2 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_offload::case_2 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_tp_partition_read::case_1 ... ok
test block_manager::v2::physical::transfer::tests::object_transfers::test_tp_selective_read::case_1 ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 994 filtered out; finished in 23.32s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added object storage support for block memory management, enabling data storage and retrieval via object backends.
  * Introduced configurable transfer descriptor hints for optimized data movement between memory types.
  * Enhanced Docker container with AWS S3 integration capabilities.
  * Extended memory layout system to support object-backed storage alongside existing contiguous and layered layouts.

* **Tests**
  * Added comprehensive object storage transfer test suite covering offload, onboard, and roundtrip scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->