### PR TITLE
feat: Clean up lora endpoints

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -123,6 +123,23 @@ async def init(runtime: DistributedRuntime, config: Config):
         await _handle_non_leader_node(engine, generate_endpoint)
         return
 
+    # Register engine routes for profiling
+    async def start_profile_handler(body: dict) -> dict:
+        """Handle /engine/start_profile requests"""
+        await engine.tokenizer_manager.start_profile(**body)
+        return {"status": "ok", "message": "Profiling started"}
+
+    async def stop_profile_handler(body: dict) -> dict:
+        """Handle /engine/stop_profile requests"""
+        await engine.tokenizer_manager.stop_profile()
+        return {"status": "ok", "message": "Profiling stopped"}
+
+    runtime.register_engine_route("start_profile", start_profile_handler)
+    runtime.register_engine_route("stop_profile", stop_profile_handler)
+    logging.info(
+        "Registered engine routes: /engine/start_profile, /engine/stop_profile"
+    )
+
     prefill_client = None
     prefill_router_client = None
     if config.serving_mode == DisaggregationMode.DECODE:
@@ -224,6 +241,23 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
     if server_args.node_rank >= 1:
         await _handle_non_leader_node(engine, generate_endpoint)
         return
+
+    # Register engine routes for profiling
+    async def start_profile_handler(body: dict) -> dict:
+        """Handle /engine/start_profile requests"""
+        await engine.tokenizer_manager.start_profile(**body)
+        return {"status": "ok", "message": "Profiling started"}
+
+    async def stop_profile_handler(body: dict) -> dict:
+        """Handle /engine/stop_profile requests"""
+        await engine.tokenizer_manager.stop_profile()
+        return {"status": "ok", "message": "Profiling stopped"}
+
+    runtime.register_engine_route("start_profile", start_profile_handler)
+    runtime.register_engine_route("stop_profile", stop_profile_handler)
+    logging.info(
+        "Registered engine routes: /engine/start_profile, /engine/stop_profile"
+    )
 
     # Perform dummy warmup for prefill worker to avoid initial TTFT hit
     # Only needed on leader node that handles requests

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -526,30 +526,30 @@ async def init(runtime: DistributedRuntime, config: Config):
 
     setup_metrics_collection(config, generate_endpoint, logger)
 
-    # Register engine routes for LoRA management (accessible via /engine/*)
+    # Register engine routes for LoRA management (accessible via /engine/v1/*)
     async def load_lora_handler(body: dict) -> dict:
-        """Handle /engine/load_lora requests"""
+        """Handle /engine/v1/load_lora requests"""
         async for result in handler.load_lora(body):
             return result
         return {"status": "error", "message": "No response from load_lora handler"}
 
     async def unload_lora_handler(body: dict) -> dict:
-        """Handle /engine/unload_lora requests"""
+        """Handle /engine/v1/unload_lora requests"""
         async for result in handler.unload_lora(body):
             return result
         return {"status": "error", "message": "No response from unload_lora handler"}
 
     async def list_loras_handler(body: dict) -> dict:
-        """Handle /engine/list_loras requests"""
+        """Handle /engine/v1/list_loras requests"""
         async for result in handler.list_loras(body):
             return result
         return {"status": "error", "message": "No response from list_loras handler"}
 
-    runtime.register_engine_route("load_lora", load_lora_handler)
-    runtime.register_engine_route("unload_lora", unload_lora_handler)
-    runtime.register_engine_route("list_loras", list_loras_handler)
+    runtime.register_engine_route("v1/load_lora", load_lora_handler)
+    runtime.register_engine_route("v1/unload_lora", unload_lora_handler)
+    runtime.register_engine_route("v1/list_loras", list_loras_handler)
     logger.info(
-        "Registered engine routes: /engine/load_lora, /engine/unload_lora, /engine/list_loras"
+        "Registered engine routes: /engine/v1/load_lora, /engine/v1/unload_lora, /engine/v1/list_loras"
     )
 
     if not config.engine_args.data_parallel_rank:  # if rank is 0 or None then register

--- a/deploy/cloud/operator/internal/modelendpoint/client_test.go
+++ b/deploy/cloud/operator/internal/modelendpoint/client_test.go
@@ -39,7 +39,7 @@ func TestLoadLoRA(t *testing.T) {
 			return
 		}
 		// Verify Content-Type header
-		if r.Header.Get("Content-Type") != "application/json" {
+		if r.Header.Get("Content-Type") != contentTypeJSON {
 			t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
 		}
 		w.WriteHeader(http.StatusOK)

--- a/deploy/cloud/operator/internal/modelendpoint/lora.go
+++ b/deploy/cloud/operator/internal/modelendpoint/lora.go
@@ -17,8 +17,6 @@
 
 package modelendpoint
 
-const contentTypeJSON = "application/json"
-
 import (
 	"bytes"
 	"context"
@@ -30,6 +28,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+const contentTypeJSON = "application/json"
 
 // loadLoRA loads a LoRA model on a single endpoint
 func (c *Client) loadLoRA(ctx context.Context, address, modelName, sourceURI string) error {

--- a/deploy/cloud/operator/internal/modelendpoint/lora.go
+++ b/deploy/cloud/operator/internal/modelendpoint/lora.go
@@ -17,6 +17,8 @@
 
 package modelendpoint
 
+const contentTypeJSON = "application/json"
+
 import (
 	"bytes"
 	"context"
@@ -57,7 +59,7 @@ func (c *Client) loadLoRA(ctx context.Context, address, modelName, sourceURI str
 	if err != nil {
 		return fmt.Errorf("failed to create load LoRA request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentTypeJSON)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -105,7 +107,7 @@ func (c *Client) unloadLoRA(ctx context.Context, address, modelName string) erro
 		logs.V(1).Info("Failed to create unload LoRA request", "error", err)
 		return fmt.Errorf("failed to create unload LoRA request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentTypeJSON)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/deploy/cloud/operator/internal/modelendpoint/lora_test.go
+++ b/deploy/cloud/operator/internal/modelendpoint/lora_test.go
@@ -105,7 +105,7 @@ func TestLoadLoRA_RequestBody(t *testing.T) {
 				body, _ := io.ReadAll(r.Body)
 				_ = json.Unmarshal(body, &capturedBody)
 
-				if r.Header.Get("Content-Type") != "application/json" {
+				if r.Header.Get("Content-Type") != contentTypeJSON {
 					t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
 				}
 
@@ -245,7 +245,7 @@ func TestUnloadLoRA_RequestBody(t *testing.T) {
 				body, _ := io.ReadAll(r.Body)
 				_ = json.Unmarshal(body, &capturedBody)
 
-				if r.Header.Get("Content-Type") != "application/json" {
+				if r.Header.Get("Content-Type") != contentTypeJSON {
 					t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
 				}
 

--- a/docs/backends/sglang/profiling.md
+++ b/docs/backends/sglang/profiling.md
@@ -1,0 +1,39 @@
+# Profiling SGLang Workers in Dynamo
+
+Dynamo exposes profiling endpoints for SGLang workers via the system server's `/engine/*` routes. This allows you to start and stop PyTorch profiling on running inference workers without restarting them.
+
+These endpoints wrap SGLang's internal `TokenizerManager.start_profile()` and `stop_profile()` methods. See SGLang's documentation for the full list of supported parameters.
+
+## Quick Start
+
+1. **Start profiling:**
+
+```bash
+curl -X POST http://localhost:9090/engine/start_profile \
+  -H "Content-Type: application/json" \
+  -d '{"output_dir": "/tmp/profiler_output"}'
+```
+
+2. **Run some inference requests to generate profiling data**
+
+3. **Stop profiling:**
+
+```bash
+curl -X POST http://localhost:9090/engine/stop_profile
+```
+
+4. **View the traces:**
+
+The profiler outputs Chrome trace files in the specified `output_dir`. You can view them using:
+- Chrome's `chrome://tracing`
+- [Perfetto UI](https://ui.perfetto.dev/)
+- TensorBoard with the PyTorch Profiler plugin
+
+## Test Script
+
+A test script is provided at [`examples/backends/sglang/test_sglang_profile.py`](../../../examples/backends/sglang/test_sglang_profile.py) that demonstrates the full profiling workflow:
+
+```bash
+python examples/backends/sglang/test_sglang_profile.py
+```
+

--- a/docs/backends/sglang/profiling.md
+++ b/docs/backends/sglang/profiling.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Profiling SGLang Workers in Dynamo
 
 Dynamo exposes profiling endpoints for SGLang workers via the system server's `/engine/*` routes. This allows you to start and stop PyTorch profiling on running inference workers without restarting them.

--- a/docs/hidden_toctree.rst
+++ b/docs/hidden_toctree.rst
@@ -61,6 +61,7 @@
    backends/sglang/expert-distribution-eplb.md
    backends/sglang/gpt-oss.md
    backends/sglang/multimodal_epd.md
+   backends/sglang/profiling.md
    backends/sglang/sgl-hicache-example.md
    backends/sglang/sglang-disaggregation.md
    backends/sglang/prometheus.md

--- a/examples/backends/sglang/test_sglang_profile.py
+++ b/examples/backends/sglang/test_sglang_profile.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Test script for /engine/start_profile and /engine/stop_profile routes.
 

--- a/examples/backends/sglang/test_sglang_profile.py
+++ b/examples/backends/sglang/test_sglang_profile.py
@@ -153,13 +153,12 @@ def test_profiling_endpoints():
     print("Testing /engine/start_profile and /engine/stop_profile")
     print("=" * 60)
 
-    # Test 1: Start profiling with parameters
+    # Test 1: Start profiling with parameters (no num_steps so we control stop manually)
     print("\n1. Starting profiling with parameters...")
     response = requests.post(
         f"{base_url}/engine/start_profile",
         json={
             "output_dir": PROFILER_OUTPUT_DIR,
-            "num_steps": 5,
             "activities": ["CPU", "GPU"],
             "with_stack": True,
             "record_shapes": True,

--- a/examples/backends/sglang/test_sglang_profile.py
+++ b/examples/backends/sglang/test_sglang_profile.py
@@ -1,0 +1,294 @@
+"""
+Test script for /engine/start_profile and /engine/stop_profile routes.
+
+This script demonstrates the new custom engine route registration feature.
+It starts a simple sglang server with dynamo and tests the profiling endpoints.
+
+Usage:
+    python test_sglang_profile.py
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+# Configuration
+MODEL = "Qwen/Qwen3-0.6B"  # Small model for quick testing
+HOST = "127.0.0.1"
+PORT = 30000
+SYSTEM_PORT = 9090
+PROFILER_OUTPUT_DIR = "/tmp/dynamo_profiler_test"
+
+
+def cleanup_output_dir():
+    """Clean up the profiler output directory"""
+    import shutil
+
+    if os.path.exists(PROFILER_OUTPUT_DIR):
+        shutil.rmtree(PROFILER_OUTPUT_DIR)
+    os.makedirs(PROFILER_OUTPUT_DIR, exist_ok=True)
+
+
+def start_frontend():
+    """Start the Dynamo frontend (HTTP server)"""
+    print("\nStarting Dynamo frontend...")
+    print(f"  - Frontend HTTP: http://{HOST}:{PORT}")
+
+    cmd = [
+        "python",
+        "-m",
+        "dynamo.frontend",
+        "--http-port",
+        str(PORT),
+    ]
+
+    print(f"Command: {' '.join(cmd)}")
+    print("(Output will appear below)\n")
+
+    process = subprocess.Popen(cmd)
+
+    # Wait for frontend to be ready
+    max_wait = 30
+    start_time = time.time()
+    frontend_ready = False
+
+    while time.time() - start_time < max_wait:
+        try:
+            # Check /health endpoint first
+            response = requests.get(f"http://{HOST}:{PORT}/health", timeout=1)
+            if response.status_code == 200:
+                print("✓ Frontend is ready!")
+                frontend_ready = True
+                break
+        except requests.exceptions.RequestException:
+            pass
+
+        if process.poll() is not None:
+            print("✗ Frontend process died!")
+            sys.exit(1)
+
+        time.sleep(1)
+
+    if not frontend_ready:
+        print("✗ Frontend failed to start in time!")
+        process.kill()
+        sys.exit(1)
+
+    return process
+
+
+def start_sglang_backend():
+    """Start the sglang backend (inference engine)"""
+    print("\nStarting SGLang backend...")
+    print(f"  - Model: {MODEL}")
+    print(f"  - System server: http://{HOST}:{SYSTEM_PORT}")
+
+    # Set environment variables
+    env = os.environ.copy()
+    env["SGLANG_TORCH_PROFILER_DIR"] = PROFILER_OUTPUT_DIR
+    env["DYN_SYSTEM_PORT"] = str(SYSTEM_PORT)
+
+    cmd = [
+        "python",
+        "-m",
+        "dynamo.sglang",
+        "--model-path",
+        MODEL,
+        "--tp",
+        "1",
+        "--mem-fraction-static",
+        "0.8",
+    ]
+
+    print(f"Command: {' '.join(cmd)}")
+    print("(Output will appear below)")
+    print("\nWaiting for backend to start...\n")
+
+    process = subprocess.Popen(cmd, env=env)
+
+    # Wait for backend to be ready (check system server health)
+    max_wait = 120  # 2 minutes
+    start_time = time.time()
+    backend_ready = False
+
+    while time.time() - start_time < max_wait:
+        try:
+            # Check system server health endpoint
+            response = requests.get(f"http://{HOST}:{SYSTEM_PORT}/health", timeout=1)
+            if response.status_code == 200:
+                print("✓ Backend is ready!")
+                backend_ready = True
+                break
+        except requests.exceptions.RequestException:
+            pass
+
+        # Check if process has died
+        if process.poll() is not None:
+            print("✗ Backend process died!")
+            sys.exit(1)
+
+        time.sleep(2)
+
+    if not backend_ready:
+        print("✗ Backend failed to start in time!")
+        process.kill()
+        sys.exit(1)
+
+    return process
+
+
+def test_profiling_endpoints():
+    """Test the /engine/start_profile and /engine/stop_profile endpoints"""
+    base_url = f"http://{HOST}:{SYSTEM_PORT}"
+
+    print("\n" + "=" * 60)
+    print("Testing /engine/start_profile and /engine/stop_profile")
+    print("=" * 60)
+
+    # Test 1: Start profiling with parameters
+    print("\n1. Starting profiling with parameters...")
+    response = requests.post(
+        f"{base_url}/engine/start_profile",
+        json={
+            "output_dir": PROFILER_OUTPUT_DIR,
+            "num_steps": 5,
+            "activities": ["CPU", "GPU"],
+            "with_stack": True,
+            "record_shapes": True,
+        },
+    )
+    print(f"   Status: {response.status_code}")
+    print(f"   Response: {response.json()}")
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+    assert response.json()["status"] == "ok", "Expected status 'ok'"
+
+    # Check available models
+    print("\n2. Checking available models...")
+    response = requests.get(f"http://{HOST}:{PORT}/v1/models")
+    if response.status_code == 200:
+        models = response.json()
+        print(f"   Available models: {models}")
+
+    # Make a few inference requests to generate profiling data
+    print("\n3. Making inference requests...")
+    inference_url = f"http://{HOST}:{PORT}/v1/completions"
+    for i in range(3):
+        response = requests.post(
+            inference_url,
+            json={
+                "model": MODEL,
+                "prompt": f"Hello, this is test request {i+1}. ",
+                "max_tokens": 10,
+                "temperature": 0.8,
+            },
+        )
+        print(f"   Request {i+1}: {response.status_code}")
+        if response.status_code != 200:
+            print(f"   Response: {response.text[:200]}")
+        time.sleep(0.5)
+
+    # Test 2: Stop profiling
+    print("\n4. Stopping profiling...")
+    response = requests.post(f"{base_url}/engine/stop_profile")
+    print(f"   Status: {response.status_code}")
+    print(f"   Response: {response.json()}")
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+    assert response.json()["status"] == "ok", "Expected status 'ok'"
+
+    # Test 3: Test with empty body (GET-like POST)
+    print("\n5. Starting profiling with empty body...")
+    response = requests.post(f"{base_url}/engine/start_profile")
+    print(f"   Status: {response.status_code}")
+    print(f"   Response: {response.json()}")
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+
+    # Test 4: Test invalid route
+    print("\n6. Testing invalid route...")
+    response = requests.post(f"{base_url}/engine/nonexistent_route")
+    print(f"   Status: {response.status_code}")
+    print(f"   Response: {response.json()}")
+    assert response.status_code == 404, f"Expected 404, got {response.status_code}"
+
+    # Stop profiling again
+    response = requests.post(f"{base_url}/engine/stop_profile")
+
+    print("\n" + "=" * 60)
+    print("✓ All tests passed!")
+    print("=" * 60)
+
+    # Check if profiling files were created
+    print(f"\nChecking profiler output directory: {PROFILER_OUTPUT_DIR}")
+    if os.path.exists(PROFILER_OUTPUT_DIR):
+        files = list(Path(PROFILER_OUTPUT_DIR).rglob("*"))
+        if files:
+            print(f"✓ Found {len(files)} files in output directory")
+            for f in files[:5]:  # Show first 5 files
+                print(f"  - {f}")
+        else:
+            print("⚠ No files found (profiling may not have run long enough)")
+    else:
+        print("⚠ Output directory not created")
+
+
+def main():
+    """Main test function"""
+    frontend_process = None
+    backend_process = None
+    try:
+        # Clean up output directory
+        cleanup_output_dir()
+
+        # Start frontend first
+        frontend_process = start_frontend()
+
+        # Start backend
+        backend_process = start_sglang_backend()
+
+        # Run tests
+        print("\n" + "=" * 60)
+        print("Both frontend and backend are ready!")
+        print("=" * 60)
+        time.sleep(2)  # Give everything a moment to fully settle
+        test_profiling_endpoints()
+
+        print("\n✓ Test completed successfully!")
+
+    except KeyboardInterrupt:
+        print("\n⚠ Interrupted by user")
+    except Exception as e:
+        print(f"\n✗ Test failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+    finally:
+        # Cleanup
+        print("\nShutting down servers...")
+        if backend_process:
+            print("  Stopping backend...")
+            backend_process.send_signal(signal.SIGTERM)
+            try:
+                backend_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                print("  Force killing backend...")
+                backend_process.kill()
+
+        if frontend_process:
+            print("  Stopping frontend...")
+            frontend_process.send_signal(signal.SIGTERM)
+            try:
+                frontend_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                print("  Force killing frontend...")
+                frontend_process.kill()
+
+        print("✓ Servers stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/backends/vllm/launch/lora/agg_lora_s3.sh
+++ b/examples/backends/vllm/launch/lora/agg_lora_s3.sh
@@ -42,8 +42,8 @@ DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=8081 \
 # Check available models
 curl http://localhost:8000/v1/models | jq .
 
-# Load LoRA using s3 uri
-curl -X POST http://localhost:8081/v1/loras \
+# Load LoRA using s3 uri (via /engine/v1/* route)
+curl -X POST http://localhost:8081/engine/v1/load_lora \
   -H "Content-Type: application/json" \
   -d '{
     "lora_name": "Neural-Hacker/Qwen3-Math-Reasoning-LoRA",
@@ -51,6 +51,11 @@ curl -X POST http://localhost:8081/v1/loras \
       "uri": "s3://my-loras/Neural-Hacker/Qwen3-Math-Reasoning-LoRA"
     }
   }'
+
+# List loaded LoRAs
+curl -X POST http://localhost:8081/engine/v1/list_loras \
+  -H "Content-Type: application/json" \
+  -d '{}'
 
 # Test LoRA inference
 curl -X POST http://localhost:8000/v1/chat/completions \
@@ -73,5 +78,7 @@ curl -X POST http://localhost:8000/v1/chat/completions \
     "temperature": 0.0
   }'
 
-# Unload LoRA
-curl -X DELETE http://localhost:8081/v1/loras/Neural-Hacker/Qwen3-Math-Reasoning-LoRA
+# Unload LoRA (via /engine/v1/* route)
+curl -X POST http://localhost:8081/engine/v1/unload_lora \
+  -H "Content-Type: application/json" \
+  -d '{"lora_name": "Neural-Hacker/Qwen3-Math-Reasoning-LoRA"}'

--- a/examples/backends/vllm/launch/lora/setup_minio.sh
+++ b/examples/backends/vllm/launch/lora/setup_minio.sh
@@ -294,7 +294,7 @@ full_setup() {
     echo "     ./agg_lora_s3.sh"
     echo ""
     echo "  2. Load the LoRA adapter:"
-    echo "     curl -X POST http://localhost:8081/v1/loras \\"
+    echo "     curl -X POST http://localhost:8081/engine/v1/load_lora \\"
     echo "       -H \"Content-Type: application/json\" \\"
     echo "       -d '{\"lora_name\": \"${LORA_NAME}\", \"source\": {\"uri\": \"s3://${BUCKET_NAME}/${LORA_NAME}\"}}'"
     echo ""

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -603,11 +603,13 @@ impl DistributedRuntime {
     ///     callback: Async function with signature: async def(body: dict) -> dict
     ///
     /// Example:
-    ///     async def start_profile(body: dict) -> dict:
-    ///         await engine.start_profile(**body)
-    ///         return {"status": "ok"}
+    /// ```python
+    /// async def start_profile(body: dict) -> dict:
+    ///     await engine.start_profile(**body)
+    ///     return {"status": "ok"}
     ///
-    ///     runtime.register_engine_route("start_profile", start_profile)
+    /// runtime.register_engine_route("start_profile", start_profile)
+    /// ```
     #[pyo3(signature = (route_name, callback))]
     fn register_engine_route(&self, route_name: String, callback: PyObject) -> PyResult<()> {
         // Wrap PyObjects in Arc so we can clone the Arc (not the PyObject) outside the GIL

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -5,6 +5,7 @@ from typing import (
     Any,
     AsyncGenerator,
     AsyncIterator,
+    Awaitable,
     Callable,
     Dict,
     List,
@@ -54,6 +55,32 @@ class DistributedRuntime:
     def child_token(self) -> CancellationToken:
         """
         Get a child cancellation token that can be passed to async tasks
+        """
+        ...
+
+    def register_engine_route(
+        self,
+        route_name: str,
+        callback: Callable[[dict], Awaitable[dict]],
+    ) -> None:
+        """
+        Register an async callback for /engine/{route_name} on the system status server.
+
+        Args:
+            route_name: The route path (e.g., "start_profile" creates /engine/start_profile)
+            callback: Async function with signature: async def(body: dict) -> dict
+
+        Example:
+            async def start_profile(body: dict) -> dict:
+                await engine.start_profile(**body)
+                return {"status": "ok", "message": "Profiling started"}
+
+            runtime.register_engine_route("start_profile", start_profile)
+
+        The callback receives the JSON request body as a dict and should return
+        a dict that will be serialized as the JSON response.
+
+        For GET requests or empty bodies, an empty dict {} is passed.
         """
         ...
 

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -75,6 +75,9 @@ pub struct DistributedRuntime {
 
     // This hierarchy's own metrics registry
     metrics_registry: MetricsRegistry,
+
+    // Registry for /engine/* route callbacks
+    engine_routes: crate::engine_routes::EngineRouteRegistry,
 }
 
 impl MetricsHierarchy for DistributedRuntime {
@@ -199,6 +202,7 @@ impl DistributedRuntime {
             system_health,
             request_plane,
             local_endpoint_registry: crate::local_endpoint_registry::LocalEndpointRegistry::new(),
+            engine_routes: crate::engine_routes::EngineRouteRegistry::new(),
         };
 
         if let Some(nats_client_for_metrics) = nats_client_for_metrics {
@@ -325,6 +329,11 @@ impl DistributedRuntime {
         &self,
     ) -> &crate::local_endpoint_registry::LocalEndpointRegistry {
         &self.local_endpoint_registry
+    }
+
+    /// Get the engine route registry for registering custom /engine/* routes
+    pub fn engine_routes(&self) -> &crate::engine_routes::EngineRouteRegistry {
+        &self.engine_routes
     }
 
     pub fn connection_id(&self) -> u64 {

--- a/lib/runtime/src/engine_routes.rs
+++ b/lib/runtime/src/engine_routes.rs
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+
+/// Callback type for engine routes (async)
+/// Takes JSON body, returns JSON response (or error) wrapped in a Future
+pub type EngineRouteCallback = Arc<
+    dyn Fn(serde_json::Value) -> Pin<Box<dyn Future<Output = anyhow::Result<serde_json::Value>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Registry for engine route callbacks
+///
+/// This registry stores callbacks that handle requests to `/engine/*` routes.
+/// Routes are registered from Python via `runtime.register_engine_route()`.
+#[derive(Clone, Default)]
+pub struct EngineRouteRegistry {
+    routes: Arc<RwLock<HashMap<String, EngineRouteCallback>>>,
+}
+
+impl EngineRouteRegistry {
+    /// Create a new empty registry
+    pub fn new() -> Self {
+        Self {
+            routes: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Register a callback for a route (e.g., "start_profile" for /engine/start_profile)
+    pub fn register(&self, route: &str, callback: EngineRouteCallback) {
+        let mut routes = self.routes.write().unwrap();
+        routes.insert(route.to_string(), callback);
+        tracing::debug!("Registered engine route: /engine/{}", route);
+    }
+
+    /// Get callback for a route
+    pub fn get(&self, route: &str) -> Option<EngineRouteCallback> {
+        let routes = self.routes.read().unwrap();
+        routes.get(route).cloned()
+    }
+
+    /// List all registered routes
+    pub fn routes(&self) -> Vec<String> {
+        let routes = self.routes.read().unwrap();
+        routes.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_registry_basic() {
+        let registry = EngineRouteRegistry::new();
+
+        // Register a simple callback
+        let callback: EngineRouteCallback = Arc::new(|body| {
+            Box::pin(async move { Ok(serde_json::json!({"echo": body})) })
+        });
+
+        registry.register("test", callback);
+
+        // Verify it's registered
+        assert!(registry.get("test").is_some());
+        assert!(registry.get("nonexistent").is_none());
+
+        // Verify routes list
+        let routes = registry.routes();
+        assert_eq!(routes.len(), 1);
+        assert!(routes.contains(&"test".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_callback_execution() {
+        let registry = EngineRouteRegistry::new();
+
+        let callback: EngineRouteCallback = Arc::new(|body| {
+            Box::pin(async move {
+                let input = body.get("input").and_then(|v| v.as_str()).unwrap_or("");
+                Ok(serde_json::json!({
+                    "output": format!("processed: {}", input)
+                }))
+            })
+        });
+
+        registry.register("process", callback);
+
+        // Get and execute callback
+        let cb = registry.get("process").unwrap();
+        let result = cb(serde_json::json!({"input": "test"})).await.unwrap();
+
+        assert_eq!(result["output"], "processed: test");
+    }
+
+    #[tokio::test]
+    async fn test_clone_shares_routes() {
+        let registry = EngineRouteRegistry::new();
+
+        let callback: EngineRouteCallback = Arc::new(|_| {
+            Box::pin(async { Ok(serde_json::json!({"ok": true})) })
+        });
+        registry.register("test", callback);
+
+        // Clone the registry
+        let cloned = registry.clone();
+
+        // Both should see the same route
+        assert!(registry.get("test").is_some());
+        assert!(cloned.get("test").is_some());
+
+        // Register on clone
+        let callback2: EngineRouteCallback = Arc::new(|_| {
+            Box::pin(async { Ok(serde_json::json!({"ok": false})) })
+        });
+        cloned.register("test2", callback2);
+
+        // Original should also see it (they share the Arc)
+        assert!(registry.get("test2").is_some());
+    }
+}
+

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -24,6 +24,7 @@ pub mod component;
 pub mod compute;
 pub mod discovery;
 pub mod engine;
+pub mod engine_routes;
 pub mod health_check;
 pub mod local_endpoint_registry;
 pub mod system_status_server;

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO: (DEP-635) this file should be renamed to system_http_server.rs
-//  it is being used not just for status, health, but others like loras management.
-
 use crate::config::HealthStatus;
 use crate::config::environment_names::logging as env_logging;
 use crate::config::environment_names::runtime::canary as env_canary;
@@ -15,13 +12,11 @@ use crate::traits::DistributedRuntimeProvider;
 use axum::{
     Router,
     body::Bytes,
-    extract::{Json, Path, State},
+    extract::Path,
     http::StatusCode,
     response::IntoResponse,
-    routing::{any, delete, get, post},
+    routing::{any, get},
 };
-use futures::StreamExt;
-use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
@@ -100,35 +95,6 @@ impl SystemStatusState {
     }
 }
 
-/// Request body for POST /v1/loras
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct LoadLoraRequest {
-    pub lora_name: String,
-    pub source: LoraSource,
-}
-
-/// Source information for loading a LoRA
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct LoraSource {
-    pub uri: String,
-}
-
-/// Response body for LoRA operations
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct LoraResponse {
-    pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub lora_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub lora_id: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub loras: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub count: Option<usize>,
-}
-
 /// Start system status server with metrics support
 pub async fn spawn_system_status_server(
     host: &str,
@@ -152,12 +118,7 @@ pub async fn spawn_system_status_server(
         .live_path()
         .to_string();
 
-    // Check if LoRA feature is enabled
-    let lora_enabled = std::env::var(crate::config::environment_names::llm::DYN_LORA_ENABLED)
-        .map(|v| v.to_lowercase() == "true")
-        .unwrap_or(false);
-
-    let mut app = Router::new()
+    let app = Router::new()
         .route(
             &health_path,
             get({
@@ -192,32 +153,7 @@ pub async fn spawn_system_status_server(
                 let state = Arc::clone(&server_state);
                 move |path, body| engine_route_handler(state, path, body)
             }),
-        );
-
-    // Add LoRA routes only if DYN_LORA_ENABLED is set to true
-    if lora_enabled {
-        app = app
-            .route(
-                "/v1/loras",
-                get({
-                    let state = Arc::clone(&server_state);
-                    move || list_loras_handler(State(state))
-                })
-                .post({
-                    let state = Arc::clone(&server_state);
-                    move |body| load_lora_handler(State(state), body)
-                }),
-            )
-            .route(
-                "/v1/loras/{*lora_name}",
-                delete({
-                    let state = Arc::clone(&server_state);
-                    move |path| unload_lora_handler(State(state), path)
-                }),
-            );
-    }
-
-    let app = app
+        )
         .fallback(|| async {
             tracing::info!("[fallback handler] called");
             (StatusCode::NOT_FOUND, "Route not found").into_response()
@@ -344,192 +280,6 @@ async fn metadata_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
             )
                 .into_response()
         }
-    }
-}
-
-/// Handler for POST /v1/loras - Load a LoRA adapter
-#[tracing::instrument(skip_all, level = "debug")]
-async fn load_lora_handler(
-    State(state): State<Arc<SystemStatusState>>,
-    Json(request): Json<LoadLoraRequest>,
-) -> impl IntoResponse {
-    tracing::info!("Loading LoRA: {}", request.lora_name);
-
-    // Call the load_lora endpoint for each available backend
-    match call_lora_endpoint(
-        state.drt(),
-        "load_lora",
-        json!({
-            "lora_name": request.lora_name,
-            "source": {
-                "uri": request.source.uri
-            },
-        }),
-    )
-    .await
-    {
-        Ok(response) => {
-            tracing::info!("LoRA loaded successfully: {}", request.lora_name);
-            (StatusCode::OK, Json(response))
-        }
-        Err(e) => {
-            tracing::error!("Failed to load LoRA {}: {}", request.lora_name, e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(LoraResponse {
-                    status: "error".to_string(),
-                    message: Some(e.to_string()),
-                    lora_name: Some(request.lora_name),
-                    lora_id: None,
-                    loras: None,
-                    count: None,
-                }),
-            )
-        }
-    }
-}
-
-/// Handler for DELETE /v1/loras/*lora_name - Unload a LoRA adapter
-#[tracing::instrument(skip_all, level = "debug")]
-async fn unload_lora_handler(
-    State(state): State<Arc<SystemStatusState>>,
-    Path(lora_name): Path<String>,
-) -> impl IntoResponse {
-    // Strip the leading slash from the wildcard capture
-    let lora_name = lora_name
-        .strip_prefix('/')
-        .unwrap_or(&lora_name)
-        .to_string();
-    tracing::info!("Unloading LoRA: {}", lora_name);
-
-    // Call the unload_lora endpoint for each available backend
-    match call_lora_endpoint(
-        state.drt(),
-        "unload_lora",
-        json!({
-            "lora_name": lora_name.clone(),
-        }),
-    )
-    .await
-    {
-        Ok(response) => {
-            tracing::info!("LoRA unloaded successfully: {}", lora_name);
-            (StatusCode::OK, Json(response))
-        }
-        Err(e) => {
-            tracing::error!("Failed to unload LoRA {}: {}", lora_name, e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(LoraResponse {
-                    status: "error".to_string(),
-                    message: Some(e.to_string()),
-                    lora_name: Some(lora_name),
-                    lora_id: None,
-                    loras: None,
-                    count: None,
-                }),
-            )
-        }
-    }
-}
-
-/// Handler for GET /v1/loras - List all LoRA adapters
-#[tracing::instrument(skip_all, level = "debug")]
-async fn list_loras_handler(State(state): State<Arc<SystemStatusState>>) -> impl IntoResponse {
-    tracing::info!("Listing all LoRAs");
-
-    // Call the list_loras endpoint for each available backend
-    match call_lora_endpoint(state.drt(), "list_loras", json!({})).await {
-        Ok(response) => {
-            tracing::info!("Successfully retrieved LoRA list");
-            (StatusCode::OK, Json(response))
-        }
-        Err(e) => {
-            tracing::error!("Failed to list LoRAs: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(LoraResponse {
-                    status: "error".to_string(),
-                    message: Some(e.to_string()),
-                    lora_name: None,
-                    lora_id: None,
-                    loras: None,
-                    count: None,
-                }),
-            )
-        }
-    }
-}
-
-/// Helper function to call a LoRA management endpoint locally via in-process registry
-///
-/// This function ONLY uses the local endpoint registry for direct in-process calls.
-/// It does NOT fall back to network discovery if the endpoint is not found.
-async fn call_lora_endpoint(
-    drt: &crate::DistributedRuntime,
-    endpoint_name: &str,
-    request_body: serde_json::Value,
-) -> anyhow::Result<LoraResponse> {
-    use crate::engine::AsyncEngine;
-
-    tracing::debug!("Calling local endpoint: '{}'", endpoint_name);
-
-    // Get the endpoint from the local registry (in-process call only)
-    let local_registry = drt.local_endpoint_registry();
-    let engine = local_registry
-        .get(endpoint_name)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "Endpoint '{}' not found in local registry. Make sure it's registered with .register_local_engine()",
-                endpoint_name
-            )
-        })?;
-
-    tracing::debug!(
-        "Found endpoint '{}' in local registry, calling directly",
-        endpoint_name
-    );
-
-    // Call the engine directly without going through the network stack
-    let request = crate::pipeline::SingleIn::new(request_body);
-    let mut stream = engine.generate(request).await?;
-
-    // Get the first response
-    if let Some(response) = stream.next().await {
-        let response_data = response.data.unwrap_or_default();
-
-        // Try structured deserialization first, fall back to manual field extraction
-        let lora_response = serde_json::from_value::<LoraResponse>(response_data.clone())
-            .unwrap_or_else(|_| parse_lora_response(&response_data));
-
-        return Ok(lora_response);
-    }
-
-    anyhow::bail!("No response received from endpoint '{}'", endpoint_name)
-}
-
-/// Helper to parse response data into LoraResponse
-fn parse_lora_response(response_data: &serde_json::Value) -> LoraResponse {
-    LoraResponse {
-        status: response_data
-            .get("status")
-            .and_then(|s| s.as_str())
-            .unwrap_or("success")
-            .to_string(),
-        message: response_data
-            .get("message")
-            .and_then(|m| m.as_str())
-            .map(|s| s.to_string()),
-        lora_name: response_data
-            .get("lora_name")
-            .and_then(|n| n.as_str())
-            .map(|s| s.to_string()),
-        lora_id: response_data.get("lora_id").and_then(|id| id.as_u64()),
-        loras: response_data.get("loras").cloned(),
-        count: response_data
-            .get("count")
-            .and_then(|c| c.as_u64())
-            .map(|c| c as usize),
     }
 }
 

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -14,10 +14,11 @@ use crate::metrics::prometheus_names::{nats_client, nats_service};
 use crate::traits::DistributedRuntimeProvider;
 use axum::{
     Router,
+    body::Bytes,
     extract::{Json, Path, State},
     http::StatusCode,
     response::IntoResponse,
-    routing::{delete, get, post},
+    routing::{any, delete, get, post},
 };
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -183,6 +184,13 @@ pub async fn spawn_system_status_server(
             get({
                 let state = Arc::clone(&server_state);
                 move || metadata_handler(state)
+            }),
+        )
+        .route(
+            "/engine/{*path}",
+            any({
+                let state = Arc::clone(&server_state);
+                move |path, body| engine_route_handler(state, path, body)
             }),
         );
 
@@ -522,6 +530,77 @@ fn parse_lora_response(response_data: &serde_json::Value) -> LoraResponse {
             .get("count")
             .and_then(|c| c.as_u64())
             .map(|c| c as usize),
+    }
+}
+
+/// Engine route handler for /engine/* routes
+///
+/// This handler looks up registered callbacks in the engine routes registry
+/// and invokes them with the request body, returning the response as JSON.
+#[tracing::instrument(skip_all, level = "trace", fields(path = %path))]
+async fn engine_route_handler(
+    state: Arc<SystemStatusState>,
+    Path(path): Path<String>,
+    body: Bytes,
+) -> impl IntoResponse {
+    tracing::trace!("Engine route request to /engine/{}", path);
+
+    // Parse body as JSON (empty object for GET/empty body)
+    let body_json: serde_json::Value = if body.is_empty() {
+        serde_json::json!({})
+    } else {
+        match serde_json::from_slice(&body) {
+            Ok(json) => json,
+            Err(e) => {
+                tracing::warn!("Invalid JSON in request body: {}", e);
+                return (
+                    StatusCode::BAD_REQUEST,
+                    json!({
+                        "error": "Invalid JSON",
+                        "message": format!("{}", e)
+                    })
+                    .to_string(),
+                )
+                    .into_response();
+            }
+        }
+    };
+
+    // Look up callback
+    let callback = match state.drt().engine_routes().get(&path) {
+        Some(cb) => cb,
+        None => {
+            tracing::debug!("Route /engine/{} not found", path);
+            return (
+                StatusCode::NOT_FOUND,
+                json!({
+                    "error": "Route not found",
+                    "message": format!("Route /engine/{} not found", path)
+                })
+                .to_string(),
+            )
+                .into_response();
+        }
+    };
+
+    // Call callback (it's async, so await it)
+    match callback(body_json).await {
+        Ok(response) => {
+            tracing::trace!("Engine route handler succeeded for /engine/{}", path);
+            (StatusCode::OK, response.to_string()).into_response()
+        }
+        Err(e) => {
+            tracing::error!("Engine route handler error for /engine/{}: {}", path, e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                json!({
+                    "error": "Handler error",
+                    "message": format!("{}", e)
+                })
+                .to_string(),
+            )
+                .into_response()
+        }
     }
 }
 


### PR DESCRIPTION
#### Overview:

Adds onto #4617, cleaning up some logic that was put in for doing custom vllm lora routes. It's substantially cleaner with the engine-wildcard routes. @biswapanda 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured LoRA (Low-Rank Adaptation) management to use internal engine routes exclusively, removing previous public API endpoint exposure.
  * Streamlined system status server by eliminating LoRA management features, including public endpoint declarations, request/response data structures, and associated route handlers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->