### PR TITLE
fix: Use /proc/driver/nvidia/gpus to get PCI addresses 

### DIFF
--- a/tests/fault_tolerance/hardware/fault_injection_service/agents/gpu_fault_injector/gpu_xid_injector.py
+++ b/tests/fault_tolerance/hardware/fault_injection_service/agents/gpu_fault_injector/gpu_xid_injector.py
@@ -185,7 +185,10 @@ class GPUXIDInjectorKernel:
             )
 
         # Iterate through all GPU directories
-        gpu_dirs = os.listdir(proc_path)
+        try:
+            gpu_dirs = os.listdir(proc_path)
+        except (PermissionError, OSError) as e:
+            raise FileNotFoundError(f"Cannot access {proc_path}: {e}")
         logger.debug(
             f"Found {len(gpu_dirs)} GPU directories in {proc_path}: {gpu_dirs}"
         )

--- a/tests/fault_tolerance/hardware/fault_injection_service/agents/gpu_fault_injector/gpu_xid_injector.py
+++ b/tests/fault_tolerance/hardware/fault_injection_service/agents/gpu_fault_injector/gpu_xid_injector.py
@@ -153,6 +153,67 @@ class GPUXIDInjectorKernel:
         """Check if we have privileged access (required for nsenter)"""
         return os.geteuid() == 0
 
+    def _get_pci_address_from_proc(self, gpu_id: int) -> str:
+        """
+        Get PCI address for GPU by reading /host/proc/driver/nvidia/gpus/.
+        
+        This method works without nvidia-smi by reading NVIDIA kernel driver's procfs.
+        Maps GPU ID (Device Minor) to PCI address by scanning all GPU directories.
+        
+        Directory structure:
+            /host/proc/driver/nvidia/gpus/
+            ├── 0001:00:00.0/information  (Device Minor: 0 → GPU 0)
+            ├── 0002:00:00.0/information  (Device Minor: 1 → GPU 1)
+            └── ...
+        
+        Args:
+            gpu_id: GPU device ID (0, 1, 2, ...)
+        
+        Returns:
+            PCI address (e.g., "0001:00:00.0")
+        
+        Raises:
+            FileNotFoundError: If /host/proc is not mounted
+            ValueError: If GPU ID not found
+        """
+        proc_path = "/host/proc/driver/nvidia/gpus"
+        
+        # Check if proc path exists
+        if not os.path.exists(proc_path):
+            raise FileNotFoundError(
+                f"{proc_path} not found. Ensure /host/proc is mounted in pod spec."
+            )
+        
+        # Iterate through all GPU directories
+        gpu_dirs = os.listdir(proc_path)
+        logger.debug(f"Found {len(gpu_dirs)} GPU directories in {proc_path}: {gpu_dirs}")
+        
+        for pci_addr in gpu_dirs:
+            info_file = f"{proc_path}/{pci_addr}/information"
+            
+            try:
+                with open(info_file, 'r') as f:
+                    for line in f:
+                        if line.startswith("Device Minor:"):
+                            # Parse: "Device Minor:    0" → 0
+                            device_minor = int(line.split(':')[1].strip())
+                            
+                            if device_minor == gpu_id:
+                                logger.info(
+                                    f"GPU {gpu_id} mapped to PCI {pci_addr} "
+                                    f"via /proc (Device Minor: {device_minor})"
+                                )
+                                return pci_addr
+            except Exception as e:
+                logger.warning(f"Could not read {info_file}: {e}")
+                continue
+        
+        # GPU ID not found
+        raise ValueError(
+            f"GPU {gpu_id} not found in {proc_path}. "
+            f"Available Device Minors: {gpu_dirs}"
+        )
+    
     def _normalize_pci_address(self, pci_addr: str) -> str:
         """
         Normalize PCI address from nvidia-smi format to kernel sysfs format.
@@ -247,28 +308,8 @@ class GPUXIDInjectorKernel:
         message template for each XID type.
         """
         try:
-            # Get PCI address for the GPU
-            pci_result = subprocess.run(
-                [
-                    "nvidia-smi",
-                    "--query-gpu=pci.bus_id",
-                    "--format=csv,noheader",
-                    "-i",
-                    str(gpu_id),
-                ],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-
-            if pci_result.returncode != 0:
-                return (
-                    False,
-                    f"Failed to get PCI address for GPU {gpu_id}: {pci_result.stderr}",
-                )
-
-            pci_addr_full = pci_result.stdout.strip()
-            pci_addr = self._normalize_pci_address(pci_addr_full)
+            # Get PCI address using /proc method (works without nvidia-smi)
+            pci_addr = self._get_pci_address_from_proc(gpu_id)
 
             # Get appropriate error message for this XID type
             # If XID is known, use specific message; otherwise use generic format


### PR DESCRIPTION
#### Overview:

Fix GPU fault injector to use `/proc/driver/nvidia/gpus` for PCI address discovery instead of `nvidia-smi`, enabling cloud-agnostic XID error injection without requiring GPU resource allocation.

#### Details:

**Problem:**
The GPU fault injector previously relied on `nvidia-smi` to map GPU IDs to PCI addresses, which created a circular dependency:
- Without requesting `nvidia.com/gpu` resources, `nvidia-smi` is unavailable in the container
- With GPU resources requested, `CUDA_VISIBLE_DEVICES` limits visibility to only the allocated GPU
- Example: Injector allocated GPU 0, but needs to inject XID on GPU 1 used by target workload → fails with "No devices were found"

**Solution:**
Read GPU-to-PCI mapping directly from NVIDIA kernel driver's procfs interface at `/host/proc/driver/nvidia/gpus/`:
- Each directory (e.g., `0001:00:00.0/`) represents a GPU's PCI address
- The `information` file contains `Device Minor: N` where N is the GPU ID
- Scan all directories to build complete GPU ID → PCI address mapping
- No `nvidia-smi` dependency, no GPU resource request needed

**Benefits:**
- ✅ Works on any cloud provider (tested on AKS and Nebius)
- ✅ Sees all GPUs on the node without resource allocation
- ✅ No CUDA_VISIBLE_DEVICES restrictions
- ✅ Matches the working `dynamoci.azurecr.io/gpu-fault-injector:latest` implementation

**Changes:**
- Added `_get_pci_address_from_proc()` method to read PCI addresses from `/host/proc/driver/nvidia/gpus/`
- Replaced `nvidia-smi` subprocess call with direct procfs parsing
- Requires `/host/proc` volume mount (already present in deployment YAML)

#### Where should the reviewer start?

- `tests/fault_tolerance/hardware/fault_injection_service/agents/gpu_fault_injector/gpu_xid_injector.py`:
  - Lines 156-217: New `_get_pci_address_from_proc()` method implementation
  - Line 314: Replacement of nvidia-smi call with `/proc` method
  
**Testing:**
Verified on AKS that `/proc/driver/nvidia/gpus/` contains all GPU information and successfully maps Device Minor to PCI addresses without nvidia-smi access.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-1129


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved GPU fault injection testing by implementing procfs-based PCI address discovery, removing dependency on external utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->