### PR TITLE
docs: update TensorRT-LLM commit for multimodal EPD to v1.2.0rc3 (#4713)

### DIFF
--- a/docs/backends/trtllm/multimodal_epd.md
+++ b/docs/backends/trtllm/multimodal_epd.md
@@ -8,7 +8,7 @@ This is an experimental feature that requires using a specific TensorRT-LLM comm
 To enable it build the dynamo container with the `--tensorrtllm-commit` flag, followed by the commit hash:
 
 ```bash
-./container/build.sh --framework trtllm --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git --tensorrtllm-commit v1.2.0rc2
+./container/build.sh --framework trtllm --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git --tensorrtllm-commit v1.2.0rc3
 ```
 
 ## Key Features


### PR DESCRIPTION
# docs: update TensorRT-LLM commit for multimodal EPD to v1.2.0rc3

## Summary

Cherry-pick of #4713 to `release/0.7.0.post1`

Updates the TensorRT-LLM commit reference from `v1.2.0rc2` to `v1.2.0rc3` in the multimodal EPD documentation.

## Changes

* Updated `docs/backends/trtllm/multimodal_epd.md` to use `--tensorrtllm-commit v1.2.0rc3`

## Original PR

- Main PR: https://github.com/ai-dynamo/dynamo/pull/4713
- Merged to main: d5a75dd8c

## Motivation

The EPD (Encode-Prefill-Decode) feature requires a specific TensorRT-LLM version. This update pins to the latest release candidate `v1.2.0rc3` to ensure users build with the correct tested version.

## Testing

* Documentation only change
* No code changes

## Checklist

- [x] Commit message follows conventional commit format (`docs:` prefix)
- [x] DCO sign-off included (`--signoff`)
- [x] Original PR merged to main first
- [ ] Cherry Pick table updated in release canvas

