### PR TITLE
fix: cherrypick 4654 to 0.7.0.post1 - LMCache fix

### DIFF
--- a/components/src/dynamo/common/utils/prometheus.py
+++ b/components/src/dynamo/common/utils/prometheus.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 def register_engine_metrics_callback(
     endpoint: Endpoint,
     registry: "CollectorRegistry",
-    metric_prefix_filter: Optional[str] = None,
+    metric_prefix_filters: Optional[list[str]] = None,
     exclude_prefixes: Optional[list[str]] = None,
     add_prefix: Optional[str] = None,
 ) -> None:
@@ -43,21 +43,26 @@ def register_engine_metrics_callback(
     Args:
         endpoint: Dynamo endpoint object with metrics.register_prometheus_expfmt_callback()
         registry: Prometheus registry to collect from (e.g., REGISTRY or CollectorRegistry)
-        metric_prefix_filter: Prefix to filter metrics (e.g., "vllm:" or "sglang:", None for no filtering)
+        metric_prefix_filters: List of prefixes to filter metrics (e.g., ["vllm:"], ["vllm:", "lmcache:"], or None for no filtering)
         exclude_prefixes: List of metric name prefixes to exclude (e.g., ["python_", "process_"])
-        add_prefix: Prefix to add to remaining metrics (e.g., "trtllm:")
+        add_prefix: Prefix to add to remaining metrics (e.g., "trtllm_")
 
     Example:
         from prometheus_client import REGISTRY
         register_engine_metrics_callback(
-            generate_endpoint, REGISTRY, metric_prefix_filter="vllm:"
+            generate_endpoint, REGISTRY, metric_prefix_filters=["vllm:"]
+        )
+
+        # Include multiple metric prefixes
+        register_engine_metrics_callback(
+            generate_endpoint, REGISTRY, metric_prefix_filters=["vllm:", "lmcache:"]
         )
 
         # With filtering and prefixing for TensorRT-LLM
         register_engine_metrics_callback(
             generate_endpoint, REGISTRY,
             exclude_prefixes=["python_", "process_"],
-            add_prefix="trtllm:"
+            add_prefix="trtllm_"
         )
     """
 
@@ -65,7 +70,7 @@ def register_engine_metrics_callback(
         """Callback to return engine Prometheus metrics in exposition format"""
         return get_prometheus_expfmt(
             registry,
-            metric_prefix_filter=metric_prefix_filter,
+            metric_prefix_filters=metric_prefix_filters,
             exclude_prefixes=exclude_prefixes,
             add_prefix=add_prefix,
         )
@@ -85,10 +90,15 @@ def _compile_exclude_pattern(exclude_prefixes: tuple[str, ...]) -> Pattern:
 
 
 @lru_cache(maxsize=64)
-def _compile_include_pattern(metric_prefix: str) -> Pattern:
-    """Compile and cache regex for including metrics by prefix."""
-    escaped_prefix = re.escape(metric_prefix)
-    return re.compile(rf"^(# (HELP|TYPE) )?{escaped_prefix}")
+def _compile_include_pattern(metric_prefixes: tuple[str, ...]) -> Pattern:
+    """Compile and cache regex for including metrics by prefix.
+
+    Args take tuple not list - lru_cache requires hashable args (tuples are hashable, lists are not).
+    Supports multiple prefixes with OR logic (e.g., ("vllm:", "lmcache:")).
+    """
+    escaped_prefixes = [re.escape(prefix) for prefix in metric_prefixes]
+    prefixes_regex = "|".join(escaped_prefixes)
+    return re.compile(rf"^(# (HELP|TYPE) )?({prefixes_regex})")
 
 
 @lru_cache(maxsize=128)
@@ -99,7 +109,7 @@ def _compile_help_type_pattern() -> Pattern:
 
 def get_prometheus_expfmt(
     registry,
-    metric_prefix_filter: Optional[str] = None,
+    metric_prefix_filters: Optional[list[str]] = None,
     exclude_prefixes: Optional[list[str]] = None,
     add_prefix: Optional[str] = None,
 ) -> str:
@@ -113,23 +123,26 @@ def get_prometheus_expfmt(
         registry: Prometheus registry to collect from.
                  Pass CollectorRegistry with MultiProcessCollector for SGLang.
                  Pass REGISTRY for vLLM single-process mode.
-        metric_prefix_filter: Optional prefix to filter displayed metrics (e.g., "vllm:").
-                             If None, returns all metrics. (default: None)
+        metric_prefix_filters: Optional list of prefixes to filter displayed metrics (e.g., ["vllm:"] or ["vllm:", "lmcache:"]).
+                             If None, returns all metrics. Supports single string or list of strings. (default: None)
         exclude_prefixes: List of metric name prefixes to exclude (e.g., ["python_", "process_"])
-        add_prefix: Prefix to add to remaining metrics (e.g., "trtllm:")
+        add_prefix: Prefix to add to remaining metrics (e.g., "trtllm_")
 
     Returns:
         Formatted metrics text in Prometheus exposition format. Returns empty string on error.
 
     Example:
-        # Filter out python_/process_ metrics and add trtllm: prefix
-        get_prometheus_expfmt(registry, exclude_prefixes=["python_", "process_"], add_prefix="trtllm:")
+        # Filter to include only vllm and lmcache metrics
+        get_prometheus_expfmt(registry, metric_prefix_filters=["vllm:", "lmcache:"])
+
+        # Filter out python_/process_ metrics and add trtllm_ prefix
+        get_prometheus_expfmt(registry, exclude_prefixes=["python_", "process_"], add_prefix="trtllm_")
     """
     try:
         # Generate metrics in Prometheus text format
         metrics_text = generate_latest(registry).decode("utf-8")
 
-        if metric_prefix_filter or exclude_prefixes or add_prefix:
+        if metric_prefix_filters or exclude_prefixes or add_prefix:
             lines = []
 
             # Get cached compiled patterns
@@ -139,8 +152,8 @@ def get_prometheus_expfmt(
 
             # Build include pattern if needed
             include_pattern = None
-            if metric_prefix_filter:
-                include_pattern = _compile_include_pattern(metric_prefix_filter)
+            if metric_prefix_filters:
+                include_pattern = _compile_include_pattern(tuple(metric_prefix_filters))
 
             # Get cached HELP/TYPE pattern
             help_type_pattern = _compile_help_type_pattern()
@@ -164,20 +177,22 @@ def get_prometheus_expfmt(
                         match = help_type_pattern.match(line)
                         if match:
                             comment_type, metric_name, rest = match.groups()
-                            # Remove existing prefix if present
-                            if metric_prefix_filter and metric_name.startswith(
-                                metric_prefix_filter
-                            ):
-                                metric_name = metric_name[len(metric_prefix_filter) :]
+                            # Remove existing prefix if present from any of the filter prefixes
+                            if metric_prefix_filters:
+                                for prefix in metric_prefix_filters:
+                                    if metric_name.startswith(prefix):
+                                        metric_name = metric_name[len(prefix) :]
+                                        break
                             new_metric_name = add_prefix + metric_name
                             line = f"# {comment_type} {new_metric_name}{rest}"
                     # Handle metric lines
                     elif line and not line.startswith("#"):
-                        # Remove existing prefix if present
-                        if metric_prefix_filter and line.startswith(
-                            metric_prefix_filter
-                        ):
-                            line = line[len(metric_prefix_filter) :]
+                        # Remove existing prefix if present from any of the filter prefixes
+                        if metric_prefix_filters:
+                            for prefix in metric_prefix_filters:
+                                if line.startswith(prefix):
+                                    line = line[len(prefix) :]
+                                    break
                         line = add_prefix + line
 
                 lines.append(line)

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -218,7 +218,7 @@ def setup_prometheus_registry(
     register_engine_metrics_callback(
         endpoint=generate_endpoint,
         registry=registry,
-        metric_prefix_filter="sglang:",
+        metric_prefix_filters=["sglang:"],
     )
     return registry
 

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -156,6 +156,21 @@ def setup_metrics_collection(config: Config, generate_endpoint, logger):
                 logger.debug(
                     f"Could not add MultiProcessCollector to REGISTRY ({e}), using separate registry"
                 )
+
+                # Verify PROMETHEUS_MULTIPROC_DIR still exists as a directory
+                multiproc_dir = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+                if not multiproc_dir or not os.path.isdir(multiproc_dir):
+                    logger.warning(
+                        "PROMETHEUS_MULTIPROC_DIR is not set or not a directory, skipping multiprocess collector"
+                    )
+                    # Fall back to single registry mode
+                    register_engine_metrics_callback(
+                        endpoint=generate_endpoint,
+                        registry=REGISTRY,
+                        metric_prefix_filters=["vllm:", "lmcache:"],
+                    )
+                    return
+
                 multiproc_registry = CollectorRegistry()
                 multiprocess.MultiProcessCollector(multiproc_registry)
 

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -5,10 +5,11 @@ import asyncio
 import logging
 import os
 import signal
+import tempfile
 from typing import Optional
 
 import uvloop
-from prometheus_client import REGISTRY
+from prometheus_client import REGISTRY, CollectorRegistry, multiprocess
 from vllm.distributed.kv_events import ZmqEventPublisher
 from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.async_llm import AsyncLLM
@@ -122,6 +123,64 @@ async def worker():
     logger.debug("Worker function completed, exiting...")
 
 
+def setup_metrics_collection(config: Config, generate_endpoint, logger):
+    """Set up metrics collection for vLLM and LMCache metrics.
+
+    In multiprocess mode (PROMETHEUS_MULTIPROC_DIR set), metrics are stored:
+      1. In-memory: Metric objects in global REGISTRY
+      2. On-disk: Metric values in .db files (PROMETHEUS_MULTIPROC_DIR)
+
+    MultiProcessCollector reads from .db files but adding it to REGISTRY can fail
+    with "Duplicated timeseries" if PROMETHEUS_MULTIPROC_DIR was set before process
+    started (K8s deployments) because metrics are already in REGISTRY.
+
+    Solution: Try adding MultiProcessCollector to REGISTRY. If that fails, use
+    separate registry for multiprocess collection and register callbacks to both
+    registries to ensure all metrics (vllm, lmcache, dynamo_component) are collected.
+    """
+    if config.engine_args.disable_log_stats is False:
+        if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+            try:
+                # MultiProcessCollector reads metrics from .db files in PROMETHEUS_MULTIPROC_DIR
+                # Adding it to REGISTRY allows collecting both in-memory and .db file metrics
+                multiprocess.MultiProcessCollector(REGISTRY)
+                logger.debug("Added MultiProcessCollector to global REGISTRY")
+                register_engine_metrics_callback(
+                    endpoint=generate_endpoint,
+                    registry=REGISTRY,
+                    metric_prefix_filters=["vllm:", "lmcache:"],
+                )
+            except ValueError as e:
+                # Conflict: metrics already in REGISTRY, MultiProcessCollector tries to add same metrics from .db files
+                # Solution: Use separate registry that ONLY reads from .db files (no in-memory conflicts)
+                logger.debug(
+                    f"Could not add MultiProcessCollector to REGISTRY ({e}), using separate registry"
+                )
+                multiproc_registry = CollectorRegistry()
+                multiprocess.MultiProcessCollector(multiproc_registry)
+
+                # Register both registries to collect all metrics
+                # Global REGISTRY has in-memory metrics (vllm, dynamo_component)
+                register_engine_metrics_callback(
+                    endpoint=generate_endpoint,
+                    registry=REGISTRY,
+                    metric_prefix_filters=["vllm:", "dynamo_component:"],
+                )
+                # Multiproc registry has .db file metrics (lmcache, possibly vllm duplicates)
+                register_engine_metrics_callback(
+                    endpoint=generate_endpoint,
+                    registry=multiproc_registry,
+                    metric_prefix_filters=["vllm:", "lmcache:"],
+                )
+        else:
+            # No multiprocess mode
+            register_engine_metrics_callback(
+                endpoint=generate_endpoint,
+                registry=REGISTRY,
+                metric_prefix_filters=["vllm:", "lmcache:"],
+            )
+
+
 def setup_kv_event_publisher(
     config: Config,
     component,
@@ -192,7 +251,18 @@ def setup_kv_event_publisher(
 
 
 def setup_vllm_engine(config, stat_logger=None):
-    setup_multiprocess_prometheus()
+    # vLLM v0.11.0 bug: vllm/v1.metrics/prometheus.py:79 passes TemporaryDirectory object
+    # instead of .name string, causing false error on exit. Set PROMETHEUS_MULTIPROC_DIR
+    # ourselves to avoid this and handle cleanup properly.
+    prometheus_temp_dir = None
+    if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
+        prometheus_temp_dir = tempfile.TemporaryDirectory(prefix="vllm_prometheus_")
+        os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_temp_dir.name
+        logger.debug(
+            f"Created PROMETHEUS_MULTIPROC_DIR at: {os.environ['PROMETHEUS_MULTIPROC_DIR']}"
+        )
+
+    setup_multiprocess_prometheus()  # call vLLM's library's function to setup multiprocess prometheus
     logger.debug(
         f"Prometheus multiproc dir set to: {os.environ.get('PROMETHEUS_MULTIPROC_DIR')}"
     )
@@ -357,10 +427,7 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
     if kv_publishers:
         handler.kv_publishers = kv_publishers
 
-    if config.engine_args.disable_log_stats is False:
-        register_engine_metrics_callback(
-            endpoint=generate_endpoint, registry=REGISTRY, metric_prefix_filter="vllm:"
-        )
+    setup_metrics_collection(config, generate_endpoint, logger)
 
     # Register prefill model with ModelType.Prefill
     if not config.engine_args.data_parallel_rank:  # if rank is 0 or None then register
@@ -464,10 +531,7 @@ async def init(runtime: DistributedRuntime, config: Config):
     if kv_publishers:
         handler.kv_publishers = kv_publishers
 
-    if config.engine_args.disable_log_stats is False:
-        register_engine_metrics_callback(
-            endpoint=generate_endpoint, registry=REGISTRY, metric_prefix_filter="vllm:"
-        )
+    setup_metrics_collection(config, generate_endpoint, logger)
 
     if not config.engine_args.data_parallel_rank:  # if rank is 0 or None then register
         await register_vllm_model(

--- a/docs/backends/vllm/LMCache_Integration.md
+++ b/docs/backends/vllm/LMCache_Integration.md
@@ -167,6 +167,17 @@ lmcache_config = {
    - Shared context across sessions
    - Long-running services with warm caches
 
+## Metrics and Monitoring
+
+When LMCache is enabled with `--connector lmcache` and `DYN_SYSTEM_PORT` is set, LMCache metrics are automatically exposed via Dynamo's `/metrics` endpoint alongside vLLM and Dynamo metrics.
+
+**Requirements to access LMCache metrics:**
+- `--connector lmcache` - Enables LMCache
+- `DYN_SYSTEM_PORT=8081` - Enables metrics HTTP endpoint
+- `PROMETHEUS_MULTIPROC_DIR` (optional) - If not set, Dynamo manages it internally. Only set explicitly if you need control over the metrics directory.
+
+For detailed information on LMCache metrics, including the complete list of available metrics and how to access them, see the **[LMCache Metrics section](prometheus.md#lmcache-metrics)** in the vLLM Prometheus Metrics Guide.
+
 ## References and Additional Resources
 
 - [LMCache Documentation](https://docs.lmcache.ai/index.html) - Comprehensive guide and API reference

--- a/docs/backends/vllm/prometheus.md
+++ b/docs/backends/vllm/prometheus.md
@@ -81,9 +81,10 @@ vllm:time_to_first_token_seconds_sum{model_name="meta-llama/Llama-3.1-8B"} 89.38
 ## Implementation Details
 
 - vLLM v1 uses multiprocess metrics collection via `prometheus_client.multiprocess`
-- `PROMETHEUS_MULTIPROC_DIR`: vLLM sets this environment variable to a temporary directory where multiprocess metrics are stored as memory-mapped files. Each worker process writes its metrics to separate files in this directory, which are aggregated when `/metrics` is scraped.
-- Metrics are filtered by the `vllm:` prefix before being exposed
-- The integration uses Dynamo's `register_engine_metrics_callback()` function
+- `PROMETHEUS_MULTIPROC_DIR`: (optional). By default, Dynamo automatically manages this environment variable, setting it to a temporary directory where multiprocess metrics are stored as memory-mapped files. Each worker process writes its metrics to separate files in this directory, which are aggregated when `/metrics` is scraped. Users only need to set this explicitly where complete control over the metrics directory is required.
+- Dynamo uses `MultiProcessCollector` to aggregate metrics from all worker processes
+- Metrics are filtered by the `vllm:` and `lmcache:` prefixes before being exposed (when LMCache is enabled)
+- The integration uses Dynamo's `register_engine_metrics_callback()` function with the global `REGISTRY`
 - Metrics appear after vLLM engine initialization completes
 - vLLM v1 metrics are different from v0 - see the [official documentation](https://docs.vllm.ai/en/latest/design/metrics.html) for migration details
 

--- a/examples/backends/vllm/launch/agg_lmcache.sh
+++ b/examples/backends/vllm/launch/agg_lmcache.sh
@@ -4,12 +4,12 @@
 set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
+# Explicitly unset PROMETHEUS_MULTIPROC_DIR to let LMCache or Dynamo manage it internally
+unset PROMETHEUS_MULTIPROC_DIR
+
 # run ingress
 python -m dynamo.frontend --http-port=8000 &
 
-# run worker with LMCache enabled
-ENABLE_LMCACHE=1 \
-LMCACHE_CHUNK_SIZE=256 \
-LMCACHE_LOCAL_CPU=True \
-LMCACHE_MAX_LOCAL_CPU_SIZE=20 \
+# run worker with LMCache enabled (without PROMETHEUS_MULTIPROC_DIR set externally)
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
   python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector lmcache

--- a/examples/backends/vllm/launch/agg_lmcache_multiproc.sh
+++ b/examples/backends/vllm/launch/agg_lmcache_multiproc.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+# Explicitly set PROMETHEUS_MULTIPROC_DIR (K8s-style deployment)
+# Use unique directory per test run to avoid conflicts
+export PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR:-/tmp/prometheus_multiproc_$$_$RANDOM}
+rm -rf "$PROMETHEUS_MULTIPROC_DIR"
+mkdir -p "$PROMETHEUS_MULTIPROC_DIR"
+
+# Cleanup function to remove the directory on exit
+cleanup() {
+    echo "Cleaning up..."
+    rm -rf "$PROMETHEUS_MULTIPROC_DIR"
+    kill 0
+}
+trap cleanup EXIT
+
+# run ingress
+# dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
+python -m dynamo.frontend &
+
+# run worker with LMCache enabled and PROMETHEUS_MULTIPROC_DIR explicitly set
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+  PROMETHEUS_MULTIPROC_DIR="$PROMETHEUS_MULTIPROC_DIR" \
+  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector lmcache
+

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -53,7 +53,7 @@ vllm_configs = {
         name="aggregated_lmcache",
         directory=vllm_dir,
         script_name="agg_lmcache.sh",
-        marks=[pytest.mark.gpu_1, pytest.mark.pre_merge],
+        marks=[pytest.mark.gpu_1],
         model="Qwen/Qwen3-0.6B",
         request_payloads=[
             chat_payload_default(),

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import random
 from dataclasses import dataclass, field
 
 import pytest
@@ -46,6 +47,35 @@ vllm_configs = {
             chat_payload_default(),
             completion_payload_default(),
             metric_payload_default(min_num_requests=6, backend="vllm"),
+        ],
+    ),
+    "aggregated_lmcache": VLLMConfig(
+        name="aggregated_lmcache",
+        directory=vllm_dir,
+        script_name="agg_lmcache.sh",
+        marks=[pytest.mark.gpu_1, pytest.mark.pre_merge],
+        model="Qwen/Qwen3-0.6B",
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+            metric_payload_default(min_num_requests=6, backend="vllm"),
+            metric_payload_default(min_num_requests=6, backend="lmcache"),
+        ],
+    ),
+    "aggregated_lmcache_multiproc": VLLMConfig(
+        name="aggregated_lmcache_multiproc",
+        directory=vllm_dir,
+        script_name="agg_lmcache_multiproc.sh",
+        marks=[pytest.mark.gpu_1],
+        model="Qwen/Qwen3-0.6B",
+        env={
+            "PROMETHEUS_MULTIPROC_DIR": f"/tmp/prometheus_multiproc_test_{os.getpid()}_{random.randint(0, 10000)}"
+        },
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+            metric_payload_default(min_num_requests=6, backend="vllm"),
+            metric_payload_default(min_num_requests=6, backend="lmcache"),
         ],
     ),
     "agg-request-plane-tcp": VLLMConfig(


### PR DESCRIPTION
#### Overview:

Cherry-pick PR #4654 to fix LMCache metrics visibility by properly managing PROMETHEUS_MULTIPROC_DIR.

#### Details:

- Added `setup_metrics_collection()` to handle multiprocess registry conflicts
- Implemented fallback to separate registry when MultiProcessCollector conflicts occur
- Added automatic PROMETHEUS_MULTIPROC_DIR temp directory management
- Added `aggregated_lmcache_multiproc` test config and launch script
- Updated docs to clarify PROMETHEUS_MULTIPROC_DIR is optional

#### Where should the reviewer start?

- `components/src/dynamo/vllm/main.py` - `setup_metrics_collection()` dual-registry approach

#### Related Issues:

Relates to #4654

/coderabbit profile chill