### PR TITLE
fix: change pytest result artifact upload name to include job id and workf…

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -77,23 +77,31 @@ runs:
           fi
         fi
 
-        # Run without --rm so we can copy results even if container crashes (example SIGSEGV exit 139)
-        docker run ${GPU_FLAGS} -w /workspace \
+        # Get absolute path for test-results directory and ensure it has proper permissions
+        TEST_RESULTS_DIR="$(pwd)/test-results"
+        chmod 777 "${TEST_RESULTS_DIR}"
+        echo "📁 Test results will be saved to: ${TEST_RESULTS_DIR}"
+
+        docker run ${GPU_FLAGS} --rm -w /workspace \
           --cpus=${NUM_CPUS} \
           --network host \
           --name ${{ env.CONTAINER_ID }}_pytest \
+          -v "${TEST_RESULTS_DIR}:/workspace/test-results" \
           ${{ inputs.image_tag }} \
-          bash -c "mkdir -p /workspace/test-results && ${PYTEST_CMD}"
+          bash -c "${PYTEST_CMD}"
 
         TEST_EXIT_CODE=$?
         echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
         echo "🧪 Tests completed with exit code: ${TEST_EXIT_CODE}"
 
-        # Copy test results from container to host
-        docker cp ${{ env.CONTAINER_ID }}_pytest:/workspace/test-results . || echo "Failed to copy test results"
-
-        # Clean up container
-        docker rm -f ${{ env.CONTAINER_ID }}_pytest || echo "Failed to clean up container"
+        # Verify test results were written (only in normal mode)
+        if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+          if [[ -f "${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}" ]]; then
+            echo "✅ Test results file found: ${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}"
+          else
+            echo "⚠️  Test results file not found: ${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }}"
+          fi
+        fi
 
         # Always continue to results processing
         exit 0
@@ -107,13 +115,6 @@ runs:
         STR_TEST_TYPE=$(echo "${{ inputs.test_type }}" | tr ', ' '_')
         echo "STR_TEST_TYPE=${STR_TEST_TYPE}" >> $GITHUB_ENV
 
-        # Skip XML processing if in dry-run mode
-        if [[ "${{ inputs.dry_run }}" == "true" ]]; then
-          echo "✅ Dry-run mode: Test collection completed"
-          echo "⏭️  No JUnit XML generated (dry-run mode)"
-          exit 0
-        fi
-
         # Check for JUnit XML file and determine test status
         JUNIT_FILE="test-results/pytest_test_report.xml"
 
@@ -125,23 +126,9 @@ runs:
           ERROR_TESTS=$(grep -o 'errors="[0-9]*"' "$JUNIT_FILE" | grep -o '[0-9]*' | head -1 || echo "0")
           echo "📊 ${TOTAL_TESTS} tests completed (${FAILED_TESTS} failed, ${ERROR_TESTS} errors)"
 
-          # Create uniquely named metadata file with step context information
-          # Use framework-testtype-arch-runid-jobid to make it unique per test run
-          METADATA_FILE="test-results/test_metadata_${{ inputs.framework }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.json"
-          JUNIT_NAME="pytest_test_report_${{ inputs.framework }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml"
-
           # Rename XML file to unique name
+          JUNIT_NAME="pytest_test_report_${{ inputs.framework }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml"
           mv "$JUNIT_FILE" "test-results/$JUNIT_NAME"
-
-          echo '{' > "$METADATA_FILE"
-          echo '  "job_name": "${{ github.job }}",' >> "$METADATA_FILE"
-          echo '  "framework": "${{ inputs.framework }}",' >> "$METADATA_FILE"
-          echo '  "test_type": "${{ inputs.test_type }}",' >> "$METADATA_FILE"
-          echo '  "platform_arch": "${{ inputs.platform_arch }}",' >> "$METADATA_FILE"
-          echo '  "junit_xml_file": "'"$JUNIT_NAME"'",' >> "$METADATA_FILE"
-          echo '  "step_name": "Run ${{ inputs.test_type }} tests"' >> "$METADATA_FILE"
-          echo '}' >> "$METADATA_FILE"
-          echo "📝 Created test metadata file: $METADATA_FILE"
           echo "📝 Renamed XML file to: $JUNIT_NAME"
         else
           echo "⚠️  JUnit XML file not found - test results may not be available for upload"
@@ -155,10 +142,8 @@ runs:
 
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
-      if: always() && inputs.dry_run != 'true'  # Skip upload in dry-run mode
+      if: always()  # Always upload test results, even if tests failed
       with:
         name: test-results-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
-        path: |
-          test-results/pytest_test_report_${{ inputs.framework }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
-          test-results/test_metadata_${{ inputs.framework }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.json
+        path: test-results/pytest_test_report_${{ inputs.framework }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
         retention-days: 7

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -126,9 +126,9 @@ runs:
           echo "📊 ${TOTAL_TESTS} tests completed (${FAILED_TESTS} failed, ${ERROR_TESTS} errors)"
 
           # Create uniquely named metadata file with step context information
-          # Use framework-testtype-arch to make it unique per test run
-          METADATA_FILE="test-results/test_metadata_${{ inputs.framework }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}.json"
-          JUNIT_NAME="pytest_test_report_${{ inputs.framework }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}.xml"
+          # Use framework-testtype-arch-runid-jobid to make it unique per test run
+          METADATA_FILE="test-results/test_metadata_${{ inputs.framework }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.json"
+          JUNIT_NAME="pytest_test_report_${{ inputs.framework }}_${STR_TEST_TYPE}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml"
 
           # Rename XML file to unique name
           mv "$JUNIT_FILE" "test-results/$JUNIT_NAME"
@@ -157,8 +157,8 @@ runs:
       uses: actions/upload-artifact@v4
       if: always() && inputs.dry_run != 'true'  # Skip upload in dry-run mode
       with:
-        name: test-results-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}
+        name: test-results-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
         path: |
-          test-results/pytest_test_report_${{ inputs.framework }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}.xml
-          test-results/test_metadata_${{ inputs.framework }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}.json
+          test-results/pytest_test_report_${{ inputs.framework }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
+          test-results/test_metadata_${{ inputs.framework }}_${{ env.STR_TEST_TYPE }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.json
         retention-days: 7

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -455,11 +455,11 @@ jobs:
             --client-type legacy \
             --junitxml=test-results/pytest_ft_report.xml \
             --tb=short
-          
+
           TEST_EXIT_CODE=$?
           echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
           echo "🧪 Fault tolerance tests completed with exit code: ${TEST_EXIT_CODE}"
-          
+
           exit ${TEST_EXIT_CODE}
         continue-on-error: true
 
@@ -467,7 +467,7 @@ jobs:
         if: always()
         run: |
           set -x
-          
+
           # Rename JUnit XML with unique naming if it exists
           if [ -f "test-results/pytest_ft_report.xml" ]; then
             mv "test-results/pytest_ft_report.xml" "test-results/pytest_ft_report_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.xml"
@@ -785,10 +785,10 @@ jobs:
       if: always()
       run: |
         set -x
-        
+
         # Create test-results directory
         mkdir -p test-results
-        
+
         # Copy and rename the test output log with unique naming
         if [ -f "test-output.log" ]; then
           cp test-output.log "test-results/deploy_test_output_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.log"

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -468,39 +468,6 @@ jobs:
         run: |
           set -x
           
-          # Determine test outcome
-          if [ "${{ steps.run-ft-tests.outcome }}" == "success" ]; then
-            TEST_STATUS="passed"
-            TEST_CONCLUSION="success"
-          else
-            TEST_STATUS="failed"
-            TEST_CONCLUSION="failure"
-          fi
-          
-          echo "📊 Test Status: ${TEST_STATUS}"
-          
-          # Create structured test metadata file with unique naming
-          METADATA_FILE="test-results/ft_test_metadata_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.json"
-          
-          cat > "${METADATA_FILE}" << EOF
-          {
-            "job_name": "${{ github.job }}",
-            "framework": "${{ matrix.framework.name }}",
-            "test_scenario": "${{ matrix.framework.test_scenario }}",
-            "platform_arch": "amd64",
-            "test_type": "fault_tolerance",
-            "namespace": "${{ env.NAMESPACE }}",
-            "test_status": "${TEST_STATUS}",
-            "test_conclusion": "${TEST_CONCLUSION}",
-            "run_id": "${{ github.run_id }}",
-            "job_id": "${{ job.check_run_id }}",
-            "junit_xml_file": "pytest_ft_report_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.xml"
-          }
-          EOF
-          
-          echo "📝 Created test metadata file: ${METADATA_FILE}"
-          cat "${METADATA_FILE}"
-          
           # Rename JUnit XML with unique naming if it exists
           if [ -f "test-results/pytest_ft_report.xml" ]; then
             mv "test-results/pytest_ft_report.xml" "test-results/pytest_ft_report_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.xml"
@@ -514,9 +481,7 @@ jobs:
         if: always()
         with:
           name: test-results-${{ matrix.framework.name }}-fault_tolerance-amd64-${{ github.run_id }}-${{ job.check_run_id }}
-          path: |
-            test-results/ft_test_metadata_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.json
-            test-results/pytest_ft_report_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.xml
+          path: test-results/pytest_ft_report_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.xml
           retention-days: 7
 
       - name: Cleanup
@@ -824,41 +789,6 @@ jobs:
         # Create test-results directory
         mkdir -p test-results
         
-        # Determine test outcome
-        if [ "${{ steps.run-tests.outcome }}" == "success" ]; then
-          TEST_STATUS="passed"
-          TEST_CONCLUSION="success"
-        else
-          TEST_STATUS="failed"
-          TEST_CONCLUSION="failure"
-        fi
-        
-        echo "📊 Test Status: ${TEST_STATUS}"
-        
-        # Create structured test metadata file with unique naming
-        METADATA_FILE="test-results/deploy_test_metadata_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.json"
-        
-        cat > "${METADATA_FILE}" << EOF
-        {
-          "job_name": "${{ github.job }}",
-          "framework": "${{ env.FRAMEWORK }}",
-          "profile": "${{ matrix.profile }}",
-          "platform_arch": "amd64",
-          "test_type": "deployment",
-          "model_name": "${{ env.MODEL_NAME }}",
-          "namespace": "${{ needs.deploy-operator.outputs.NAMESPACE }}",
-          "graph_name": "${{ env.GRAPH_NAME }}",
-          "test_status": "${TEST_STATUS}",
-          "test_conclusion": "${TEST_CONCLUSION}",
-          "run_id": "${{ github.run_id }}",
-          "job_id": "${{ job.check_run_id }}",
-          "log_file": "deploy_test_output_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.log"
-        }
-        EOF
-        
-        echo "📝 Created test metadata file: ${METADATA_FILE}"
-        cat "${METADATA_FILE}"
-        
         # Copy and rename the test output log with unique naming
         if [ -f "test-output.log" ]; then
           cp test-output.log "test-results/deploy_test_output_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.log"
@@ -872,9 +802,7 @@ jobs:
       if: always()
       with:
         name: test-results-${{ env.FRAMEWORK }}-deploy-${{ matrix.profile }}-amd64-${{ github.run_id }}-${{ job.check_run_id }}
-        path: |
-          test-results/deploy_test_metadata_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.json
-          test-results/deploy_test_output_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.log
+        path: test-results/deploy_test_output_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.log
         retention-days: 7
 
     - name: Cleanup

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -419,6 +419,7 @@ jobs:
           export KUBECONFIG=$(pwd)/.kubeconfig
           kubectl config set-context --current --namespace=$NAMESPACE
       - name: Run Fault Tolerance Tests
+        id: run-ft-tests
         run: |
           set -x
           export KUBECONFIG=$(pwd)/.kubeconfig
@@ -440,14 +441,84 @@ jobs:
           pip install -r container/deps/requirements.test.txt
           pip install kubernetes==32.0.1 kubernetes_asyncio kr8s pyyaml requests tabulate pydantic
 
-          # Run the pytest command (tests orchestrate K8s, don't need dynamo package)
+          # Create test-results directory
+          mkdir -p test-results
+
+          # Run the pytest command with JUnit XML output
+          set +e  # Don't exit on test failures
           pytest tests/fault_tolerance/deploy/test_deployment.py \
             -m 'k8s and fault_tolerance' \
             -k '${{ matrix.framework.test_scenario }}' \
             -s -v \
             --namespace ${NAMESPACE} \
             --image ${IMAGE} \
-            --client-type legacy
+            --client-type legacy \
+            --junitxml=test-results/pytest_ft_report.xml \
+            --tb=short
+          
+          TEST_EXIT_CODE=$?
+          echo "TEST_EXIT_CODE=${TEST_EXIT_CODE}" >> $GITHUB_ENV
+          echo "🧪 Fault tolerance tests completed with exit code: ${TEST_EXIT_CODE}"
+          
+          exit ${TEST_EXIT_CODE}
+        continue-on-error: true
+
+      - name: Process Fault Tolerance Test Results
+        if: always()
+        run: |
+          set -x
+          
+          # Determine test outcome
+          if [ "${{ steps.run-ft-tests.outcome }}" == "success" ]; then
+            TEST_STATUS="passed"
+            TEST_CONCLUSION="success"
+          else
+            TEST_STATUS="failed"
+            TEST_CONCLUSION="failure"
+          fi
+          
+          echo "📊 Test Status: ${TEST_STATUS}"
+          
+          # Create structured test metadata file with unique naming
+          METADATA_FILE="test-results/ft_test_metadata_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.json"
+          
+          cat > "${METADATA_FILE}" << EOF
+          {
+            "job_name": "${{ github.job }}",
+            "framework": "${{ matrix.framework.name }}",
+            "test_scenario": "${{ matrix.framework.test_scenario }}",
+            "platform_arch": "amd64",
+            "test_type": "fault_tolerance",
+            "namespace": "${{ env.NAMESPACE }}",
+            "test_status": "${TEST_STATUS}",
+            "test_conclusion": "${TEST_CONCLUSION}",
+            "run_id": "${{ github.run_id }}",
+            "job_id": "${{ job.check_run_id }}",
+            "junit_xml_file": "pytest_ft_report_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.xml"
+          }
+          EOF
+          
+          echo "📝 Created test metadata file: ${METADATA_FILE}"
+          cat "${METADATA_FILE}"
+          
+          # Rename JUnit XML with unique naming if it exists
+          if [ -f "test-results/pytest_ft_report.xml" ]; then
+            mv "test-results/pytest_ft_report.xml" "test-results/pytest_ft_report_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.xml"
+            echo "✅ JUnit XML report renamed with unique identifier"
+          else
+            echo "⚠️  JUnit XML report not found"
+          fi
+
+      - name: Upload Fault Tolerance Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-${{ matrix.framework.name }}-fault_tolerance-amd64-${{ github.run_id }}-${{ job.check_run_id }}
+          path: |
+            test-results/ft_test_metadata_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.json
+            test-results/pytest_ft_report_${{ matrix.framework.name }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.xml
+          retention-days: 7
+
       - name: Cleanup
         if: always()
         timeout-minutes: 5
@@ -640,12 +711,16 @@ jobs:
         kubectl config set-context --current --namespace=$NAMESPACE --kubeconfig "${KUBECONFIG}"
         kubectl config get-contexts
     - name: Run Tests
+      id: run-tests
       env:
         NAMESPACE: ${{ needs.deploy-operator.outputs.NAMESPACE }}
       run: |
         set -x
         export KUBECONFIG=$(pwd)/.kubeconfig
         kubectl config set-context --current --namespace=$NAMESPACE
+
+        # Redirect all output to a log file while still showing it
+        exec > >(tee -a test-output.log) 2>&1
 
         cd examples/backends/$FRAMEWORK
         export FRAMEWORK_RUNTIME_IMAGE="${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-${FRAMEWORK}-amd64"
@@ -739,6 +814,69 @@ jobs:
           echo "Test passed: Response matches expected format and content"
         fi
         exit $TEST_RESULT
+      continue-on-error: true
+
+    - name: Process Deployment Test Results
+      if: always()
+      run: |
+        set -x
+        
+        # Create test-results directory
+        mkdir -p test-results
+        
+        # Determine test outcome
+        if [ "${{ steps.run-tests.outcome }}" == "success" ]; then
+          TEST_STATUS="passed"
+          TEST_CONCLUSION="success"
+        else
+          TEST_STATUS="failed"
+          TEST_CONCLUSION="failure"
+        fi
+        
+        echo "📊 Test Status: ${TEST_STATUS}"
+        
+        # Create structured test metadata file with unique naming
+        METADATA_FILE="test-results/deploy_test_metadata_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.json"
+        
+        cat > "${METADATA_FILE}" << EOF
+        {
+          "job_name": "${{ github.job }}",
+          "framework": "${{ env.FRAMEWORK }}",
+          "profile": "${{ matrix.profile }}",
+          "platform_arch": "amd64",
+          "test_type": "deployment",
+          "model_name": "${{ env.MODEL_NAME }}",
+          "namespace": "${{ needs.deploy-operator.outputs.NAMESPACE }}",
+          "graph_name": "${{ env.GRAPH_NAME }}",
+          "test_status": "${TEST_STATUS}",
+          "test_conclusion": "${TEST_CONCLUSION}",
+          "run_id": "${{ github.run_id }}",
+          "job_id": "${{ job.check_run_id }}",
+          "log_file": "deploy_test_output_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.log"
+        }
+        EOF
+        
+        echo "📝 Created test metadata file: ${METADATA_FILE}"
+        cat "${METADATA_FILE}"
+        
+        # Copy and rename the test output log with unique naming
+        if [ -f "test-output.log" ]; then
+          cp test-output.log "test-results/deploy_test_output_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.log"
+          echo "✅ Test output log copied to test-results/"
+        else
+          echo "⚠️  test-output.log not found"
+        fi
+
+    - name: Upload Deployment Test Results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results-${{ env.FRAMEWORK }}-deploy-${{ matrix.profile }}-amd64-${{ github.run_id }}-${{ job.check_run_id }}
+        path: |
+          test-results/deploy_test_metadata_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.json
+          test-results/deploy_test_output_${{ env.FRAMEWORK }}_${{ matrix.profile }}_amd64_${{ github.run_id }}_${{ job.check_run_id }}.log
+        retention-days: 7
+
     - name: Cleanup
       if: always()
       timeout-minutes: 5


### PR DESCRIPTION
# Test Results Artifact Upload with Unique Naming

## Overview:

This PR implements consistent artifact upload for all test types (pytest, deployment, and fault tolerance tests) with a unique naming convention that matches the existing build metrics pattern. All test results are now exported as artifacts with identifiers that prevent collisions and enable easy correlation between builds and tests.

## Details:

### 1. **Pytest Action** (`.github/actions/pytest/action.yml`)
- **Added volume mount** for test results: `-v "${TEST_RESULTS_DIR}:/workspace/test-results"`
  - Ensures test results are written directly to host filesystem
  - Avoids issues with container cleanup preventing file access
- **Added permission fix**: `chmod 777` on test-results directory to handle Docker user permissions
- **Updated artifact naming** to include unique identifiers:
  - Pattern: `test-results-<framework>-<test_type>-<arch>-<run_id>-<job_id>`
  - Example: `test-results-vllm-pre_merge-amd64-19912777957-57085021055`
- **File naming** includes same unique identifiers in the actual file names
- **Merged with dry_run feature** from main branch while maintaining volume mount approach
- **Removed metadata files** - only JUnit XML files are uploaded now

### 2. **Fault Tolerance Tests** (`container-validation-backends.yml`)
- **Added JUnit XML output**: `--junitxml=test-results/pytest_ft_report.xml`
- **Added continue-on-error**: Ensures artifacts are uploaded even if tests fail
- **Added artifact upload step** with unique naming:
  - Pattern: `test-results-<framework>-fault_tolerance-amd64-<run_id>-<job_id>`
  - Example: `test-results-vllm-fault_tolerance-amd64-19912777957-57085021055`
- **Removed metadata files** - only JUnit XML files are uploaded

### 3. **Deployment Tests** (`container-validation-backends.yml`)
- **Added log capture**: `exec > >(tee -a test-output.log) 2>&1` to capture all test output
- **Added continue-on-error**: Ensures artifacts are uploaded even if tests fail
- **Added artifact upload step** with unique naming:
  - Pattern: `test-results-<framework>-deploy-<profile>-amd64-<run_id>-<job_id>`
  - Example: `test-results-vllm-deploy-agg-amd64-19912777957-57085021055`
- **Removed metadata files** - only log files are uploaded

### Naming Convention Consistency:
All artifacts now follow the same pattern as build metrics:
```
test-results-<framework>-<test_type>-<arch>-<run_id>-<job_id>
build-metrics-<framework>-<arch>-<run_id>-<job_id>
```

This ensures:
- ✅ Unique identifiers prevent artifact name collisions
- ✅ Easy correlation between builds and their tests
- ✅ Consistent structure for metric aggregation pipelines
- ✅ 7-day retention for all artifacts

## Where should the reviewer start?

1. **Start with `.github/actions/pytest/action.yml`** - Review the volume mount approach and how it integrates with the dry_run feature from main
2. **Check the fault tolerance tests** in `container-validation-backends.yml` (lines ~425-490) - Verify JUnit XML generation and artifact upload
3. **Review deployment tests** in `container-validation-backends.yml` (lines ~690-860) - Verify log capture and artifact upload
4. **Verify naming consistency** - Ensure all three test types use the same `<framework>-<test_type>-<arch>-<run_id>-<job_id>` pattern
5. **Run pre-commit checks** - Already passed (trailing whitespace was auto-fixed)
```

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test result artifact naming to include dynamic run identifiers, improving traceability and organization of test execution results across pipeline runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->