### PR TITLE
chore: bump versions for 0.7.0.post1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -2226,14 +2226,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-engine-mistralrs"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2251,7 +2251,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
  "cudarc 0.17.8",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-run"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "bytemuck",
  "dashmap 6.1.0",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-py3"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4627,7 +4627,7 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libdynamo_llm"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,7 +2188,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -2226,14 +2226,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-engine-mistralrs"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2251,7 +2251,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
  "cudarc 0.17.8",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-run"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "bytemuck",
  "dashmap 6.1.0",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-py3"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4627,7 +4627,7 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libdynamo_llm"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 edition = "2024"
 description = "Dynamo Inference Framework"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -44,15 +44,15 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 
 [workspace.dependencies]
 # Local crates
-dynamo-runtime = { path = "lib/runtime", version = "0.7.0+post1" }
-dynamo-llm = { path = "lib/llm", version = "0.7.0+post1" }
-dynamo-config = { path = "lib/config", version = "0.7.0+post1" }
-dynamo-tokens = { path = "lib/tokens", version = "0.7.0+post1" }
-dynamo-async-openai = { path = "lib/async-openai", version = "0.7.0+post1", features = [
+dynamo-runtime = { path = "lib/runtime", version = "0.7.0-post1" }
+dynamo-llm = { path = "lib/llm", version = "0.7.0-post1" }
+dynamo-config = { path = "lib/config", version = "0.7.0-post1" }
+dynamo-tokens = { path = "lib/tokens", version = "0.7.0-post1" }
+dynamo-async-openai = { path = "lib/async-openai", version = "0.7.0-post1", features = [
     "byot",
     "rustls",
 ] }
-dynamo-parsers = { path = "lib/parsers", version = "0.7.0+post1" }
+dynamo-parsers = { path = "lib/parsers", version = "0.7.0-post1" }
 
 # External dependencies
 anyhow = { version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.0+post1"
 edition = "2024"
 description = "Dynamo Inference Framework"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -44,15 +44,15 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 
 [workspace.dependencies]
 # Local crates
-dynamo-runtime = { path = "lib/runtime", version = "0.7.0" }
-dynamo-llm = { path = "lib/llm", version = "0.7.0" }
-dynamo-config = { path = "lib/config", version = "0.7.0" }
-dynamo-tokens = { path = "lib/tokens", version = "0.7.0" }
-dynamo-async-openai = { path = "lib/async-openai", version = "0.7.0", features = [
+dynamo-runtime = { path = "lib/runtime", version = "0.7.0+post1" }
+dynamo-llm = { path = "lib/llm", version = "0.7.0+post1" }
+dynamo-config = { path = "lib/config", version = "0.7.0+post1" }
+dynamo-tokens = { path = "lib/tokens", version = "0.7.0+post1" }
+dynamo-async-openai = { path = "lib/async-openai", version = "0.7.0+post1", features = [
     "byot",
     "rustls",
 ] }
-dynamo-parsers = { path = "lib/parsers", version = "0.7.0" }
+dynamo-parsers = { path = "lib/parsers", version = "0.7.0+post1" }
 
 # External dependencies
 anyhow = { version = "1" }

--- a/benchmarks/incluster/benchmark_job.yaml
+++ b/benchmarks/incluster/benchmark_job.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: benchmark-runner
         # TODO: update to latest public image in next release
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/benchmarks/profiler/deploy/profile_sla_aic_dgdr.yaml
+++ b/benchmarks/profiler/deploy/profile_sla_aic_dgdr.yaml
@@ -12,7 +12,7 @@ spec:
 
   # ProfilingConfig maps directly to the profile_sla.py config format
   profilingConfig:
-    profilerImage: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0"
+    profilerImage: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1"
     config:
       # Sweep/profiling configuration
       sweep:
@@ -31,7 +31,7 @@ spec:
 
   # Deployment overrides for the auto-created DGD
   deploymentOverrides:
-    workersImage: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0"
+    workersImage: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1"
 
   # Automatically create DynamoGraphDeployment after profiling
   autoApply: true

--- a/benchmarks/profiler/deploy/profile_sla_dgdr.yaml
+++ b/benchmarks/profiler/deploy/profile_sla_dgdr.yaml
@@ -12,7 +12,7 @@ spec:
 
   # ProfilingConfig maps directly to the profile_sla.py config format
   profilingConfig:
-    profilerImage: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0"
+    profilerImage: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1"
     config:
       # Sweep/profiling configuration
       sweep:
@@ -28,7 +28,7 @@ spec:
 
   # Deployment overrides for the auto-created DGD
   deploymentOverrides:
-    workersImage: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0"
+    workersImage: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1"
 
   # Automatically create DynamoGraphDeployment after profiling
   autoApply: true

--- a/deploy/cloud/helm/crds/Chart.yaml
+++ b/deploy/cloud/helm/crds/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v2
 name: dynamo-crds
 description: A Helm chart for dynamo CRDs
 type: application
-version: 0.7.0
+version: 0.7.0+post1
 dependencies: []

--- a/deploy/cloud/helm/crds/Chart.yaml
+++ b/deploy/cloud/helm/crds/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v2
 name: dynamo-crds
 description: A Helm chart for dynamo CRDs
 type: application
-version: 0.7.0+post1
+version: 0.7.0-post1
 dependencies: []

--- a/deploy/cloud/helm/platform/Chart.yaml
+++ b/deploy/cloud/helm/platform/Chart.yaml
@@ -19,11 +19,11 @@ maintainers:
     url: https://www.nvidia.com
 description: A Helm chart for NVIDIA Dynamo Platform.
 type: application
-version: 0.7.0
+version: 0.7.0+post1
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator
-    version: 0.7.0
+    version: 0.7.0+post1
     repository: file://components/operator
     condition: dynamo-operator.enabled
   - name: nats

--- a/deploy/cloud/helm/platform/Chart.yaml
+++ b/deploy/cloud/helm/platform/Chart.yaml
@@ -19,11 +19,11 @@ maintainers:
     url: https://www.nvidia.com
 description: A Helm chart for NVIDIA Dynamo Platform.
 type: application
-version: 0.7.0+post1
+version: 0.7.0-post1
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator
-    version: 0.7.0+post1
+    version: 0.7.0-post1
     repository: file://components/operator
     condition: dynamo-operator.enabled
   - name: nats

--- a/deploy/cloud/helm/platform/components/operator/Chart.yaml
+++ b/deploy/cloud/helm/platform/components/operator/Chart.yaml
@@ -27,9 +27,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.0-post1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.0"
+appVersion: "0.7.0-post1"

--- a/deploy/helm/chart/Chart.yaml
+++ b/deploy/helm/chart/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: dynamo-graph
 description: A Helm chart to deploy a Dynamo graph on Kubernetes
 type: application
-version: 0.7.0.post1
-appVersion: 0.7.0.post1
+version: 0.7.0+post1
+appVersion: 0.7.0+post1

--- a/deploy/helm/chart/Chart.yaml
+++ b/deploy/helm/chart/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: dynamo-graph
 description: A Helm chart to deploy a Dynamo graph on Kubernetes
 type: application
-version: 0.7.0+post1
-appVersion: 0.7.0+post1
+version: 0.7.0-post1
+appVersion: 0.7.0-post1

--- a/deploy/helm/chart/Chart.yaml
+++ b/deploy/helm/chart/Chart.yaml
@@ -17,5 +17,5 @@ apiVersion: v2
 name: dynamo-graph
 description: A Helm chart to deploy a Dynamo graph on Kubernetes
 type: application
-version: 0.7.0
-appVersion: 0.7.0
+version: 0.7.0.post1
+appVersion: 0.7.0.post1

--- a/docs/_includes/install.rst
+++ b/docs/_includes/install.rst
@@ -10,7 +10,7 @@ Install a pre-built wheel from PyPI.
    source venv/bin/activate
 
    # Install Dynamo from PyPI (choose one backend extra)
-   uv pip install "ai-dynamo[sglang]==0.7.0"  # or [vllm], [trtllm]
+   uv pip install "ai-dynamo[sglang]==0.7.0.post1"  # or [vllm], [trtllm]
 
 
 Pip from source
@@ -41,4 +41,4 @@ Pull and run prebuilt images from NVIDIA NGC (`nvcr.io`).
    docker run --rm -it \
      --gpus all \
      --network host \
-     nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0  # or vllm, tensorrtllm
+     nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1  # or vllm, tensorrtllm

--- a/docs/backends/trtllm/gpt-oss.md
+++ b/docs/backends/trtllm/gpt-oss.md
@@ -49,7 +49,7 @@ huggingface-cli download openai/gpt-oss-120b --exclude "original/*" --exclude "m
 
 Set the container image:
 ```bash
-export DYNAMO_CONTAINER_IMAGE=nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+export DYNAMO_CONTAINER_IMAGE=nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
 ```
 
 Launch the Dynamo TensorRT-LLM container with the necessary configurations:

--- a/docs/benchmarks/benchmarking.md
+++ b/docs/benchmarks/benchmarking.md
@@ -413,7 +413,7 @@ The benchmark job is configured directly in the YAML file.
 - **Model**: `Qwen/Qwen3-0.6B`
 - **Benchmark Name**: `qwen3-0p6b-vllm-agg`
 - **Service**: `vllm-agg-frontend:8000`
-- **Docker Image**: `nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0`
+- **Docker Image**: `nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1`
 
 ### Customizing the Job
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -52,8 +52,8 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 
 | **Python Package** | **Version** | glibc version                         | CUDA Version |
 | :----------------- | :---------- | :------------------------------------ | :----------- |
-| ai-dynamo          | 0.7.0       | >=2.28                                |              |
-| ai-dynamo-runtime  | 0.7.0       | >=2.28 (Python 3.12 has known issues) |              |
+| ai-dynamo          | 0.7.0.post1       | >=2.28                                |              |
+| ai-dynamo-runtime  | 0.7.0.post1       | >=2.28 (Python 3.12 has known issues) |              |
 | NIXL               | 0.7.1       | >=2.27                                | >=11.8       |
 
 ### Build Dependency
@@ -61,7 +61,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Build Dependency** | **Version as of Dynamo v0.7.0**                                                   |
 | :------------------- | :------------------------------------------------------------------------------- |
 | **SGLang**           | 0.5.3.post4                                                                      |
-| **TensorRT-LLM**     | 1.2.0rc2                                                                         |
+| **TensorRT-LLM**     | 1.2.0rc3                                                                         |
 | **vLLM**             | 0.11.0                                                                           |
 | **NIXL**             | 0.7.1                                                                            |
 
@@ -72,7 +72,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 ### CUDA Support by Framework
 | **Dynamo Version**   | **SGLang**              | **TensorRT-LLM**        | **vLLM**                |
 | :------------------- | :-----------------------| :-----------------------| :-----------------------|
-| **Dynamo 0.7.0**     | CUDA 12.8               | CUDA 13.0               | CUDA 12.8               |
+| **Dynamo 0.7.0.post1**     | CUDA 12.8               | CUDA 13.0               | CUDA 12.8               |
 
 ## Cloud Service Provider Compatibility
 

--- a/examples/backends/sglang/deploy/README.md
+++ b/examples/backends/sglang/deploy/README.md
@@ -61,7 +61,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+    image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
     workingDir: /workspace/examples/backends/sglang
     args:
       - "python3"
@@ -92,7 +92,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
 
 # Configure your model
 args:

--- a/examples/backends/sglang/deploy/agg.yaml
+++ b/examples/backends/sglang/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/agg_logging.yaml
+++ b/examples/backends/sglang/deploy/agg_logging.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-agg
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/agg_router.yaml
+++ b/examples/backends/sglang/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg-multinode.yaml
+++ b/examples/backends/sglang/deploy/disagg-multinode.yaml
@@ -22,7 +22,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
     decode:
       multinode:
         nodeCount: 2
@@ -35,7 +35,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3
@@ -72,7 +72,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg.yaml
+++ b/examples/backends/sglang/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3
@@ -61,7 +61,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/disagg_planner.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
     Planner:
       dynamoNamespace: dynamo
       envFromSecret: hf-token-secret
@@ -21,7 +21,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/components/src/dynamo/planner
           command:
           - python3
@@ -53,7 +53,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
             - python3
@@ -89,7 +89,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
             - python3

--- a/examples/backends/trtllm/deploy/README.md
+++ b/examples/backends/trtllm/deploy/README.md
@@ -89,7 +89,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+    image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
     workingDir: /workspace/examples/backends/trtllm
     args:
       - "python3"
@@ -141,7 +141,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
 
 # Configure your model and deployment settings
 args:

--- a/examples/backends/trtllm/deploy/agg-with-config.yaml
+++ b/examples/backends/trtllm/deploy/agg-with-config.yaml
@@ -34,7 +34,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: trtllm-agg
@@ -50,7 +50,7 @@ spec:
           configMap:
             name: nvidia-config
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/trtllm
           # mount the configmap as a volume
           volumeMounts:

--- a/examples/backends/trtllm/deploy/agg.yaml
+++ b/examples/backends/trtllm/deploy/agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: trtllm-agg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/agg_router.yaml
+++ b/examples/backends/trtllm/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/trtllm/deploy/disagg-multinode.yaml
@@ -98,7 +98,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/trttensorrtllmllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/trtllm
           command:
           - python3
@@ -130,7 +130,7 @@ spec:
             - name: nvidia-config
               mountPath: /workspace/
               readOnly: true
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/
           command:
           - python3
@@ -168,7 +168,7 @@ spec:
             - name: nvidia-config
               mountPath: /workspace/
               readOnly: true
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg.yaml
+++ b/examples/backends/trtllm/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
     TRTLLMPrefillWorker:
       dynamoNamespace: trtllm-disagg
       envFromSecret: hf-token-secret
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/
           command:
           - python3
@@ -51,7 +51,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/disagg_planner.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/trtllm
           command:
             - python3
@@ -38,7 +38,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/components/src/dynamo/planner
           ports:
             - name: metrics
@@ -89,7 +89,7 @@ spec:
       extraPodSpec:
         terminationGracePeriodSeconds: 600
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/
           command:
             - python3
@@ -116,7 +116,7 @@ spec:
       extraPodSpec:
         terminationGracePeriodSeconds: 600
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/
           command:
             - python3

--- a/examples/backends/trtllm/deploy/disagg_router.yaml
+++ b/examples/backends/trtllm/deploy/disagg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/trtltensorrtllmlm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/
           command:
           - python3
@@ -53,7 +53,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/vllm/deploy/README.md
+++ b/examples/backends/vllm/deploy/README.md
@@ -69,7 +69,7 @@ resources:
 ```yaml
 extraPodSpec:
   mainContainer:
-    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     workingDir: /workspace/examples/backends/vllm
     args:
       - "python3"
@@ -116,7 +116,7 @@ Edit the template to match your environment:
 
 ```yaml
 # Update image registry and tag
-image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
 
 # Configure your model
 args:

--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-agg-kvbm
@@ -31,7 +31,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/agg_router.yaml
+++ b/examples/backends/vllm/deploy/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/disagg-multinode.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -34,7 +34,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -57,7 +57,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg.yaml
+++ b/examples/backends/vllm/deploy/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -46,7 +46,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg-kvbm
       envFromSecret: hf-token-secret
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -56,7 +56,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg-kvbm-2p2d
       envFromSecret: hf-token-secret
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -56,7 +56,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg-kvbm-tp2
       envFromSecret: hf-token-secret
@@ -26,7 +26,7 @@ spec:
           gpu: "2"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -60,7 +60,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/disagg_planner.yaml
@@ -13,14 +13,14 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     Planner:
       dynamoNamespace: vllm-disagg-planner
       componentType: planner
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/components/src/dynamo/planner
           command:
           - python3
@@ -52,7 +52,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -72,7 +72,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -27,7 +27,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -47,7 +47,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/basics/kubernetes/Distributed_Inference/agg_router.yaml
+++ b/examples/basics/kubernetes/Distributed_Inference/agg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -35,7 +35,7 @@ spec:
             path: /YOUR/LOCAL/CACHE/FOLDER
             type: DirectoryOrCreate
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           volumeMounts:
           - name: local-model-cache
             mountPath: /root/.cache

--- a/examples/basics/kubernetes/Distributed_Inference/disagg_router.yaml
+++ b/examples/basics/kubernetes/Distributed_Inference/disagg_router.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -35,7 +35,7 @@ spec:
             path: /YOUR/LOCAL/CACHE/FOLDER
             type: DirectoryOrCreate
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           volumeMounts:
           - name: local-model-cache
@@ -63,7 +63,7 @@ spec:
             path: /YOUR/LOCAL/CACHE/FOLDER
             type: DirectoryOrCreate
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           volumeMounts:
           - name: local-model-cache

--- a/examples/deployments/ECS/task_definition_frontend.json
+++ b/examples/deployments/ECS/task_definition_frontend.json
@@ -3,7 +3,7 @@
     "containerDefinitions": [
         {
             "name": "dynamo-vllm-frontend",
-            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0",
+            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:AWS_REGION:AWS_ID:secret:ngc_nvcr_access"
             },

--- a/examples/deployments/ECS/task_definition_prefillworker.json
+++ b/examples/deployments/ECS/task_definition_prefillworker.json
@@ -3,7 +3,7 @@
     "containerDefinitions": [
         {
             "name": "dynamo-prefill",
-            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0",
+            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1",
             "repositoryCredentials": {
                 "credentialsParameter": "arn:aws:secretsmanager:AWS_REGION:AWS_ID:secret:ngc_access"
             },

--- a/examples/deployments/GKE/sglang/disagg.yaml
+++ b/examples/deployments/GKE/sglang/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
     decode:
       envFromSecret: hf-token-secret
       dynamoNamespace: sglang-disagg
@@ -24,7 +24,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
             - /bin/sh
@@ -47,7 +47,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/sglang
           command:
             - /bin/sh

--- a/examples/deployments/GKE/vllm/disagg.yaml
+++ b/examples/deployments/GKE/vllm/disagg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     VllmDecodeWorker:
       dynamoNamespace: vllm-disagg
       envFromSecret: hf-token-secret
@@ -27,7 +27,7 @@ spec:
         mainContainer:
           startupProbe:
             initialDelaySeconds: 180
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -49,7 +49,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/examples/multimodal/deploy/agg_llava.yaml
+++ b/examples/multimodal/deploy/agg_llava.yaml
@@ -14,7 +14,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     EncodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: agg-llava
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -42,7 +42,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -59,7 +59,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh

--- a/examples/multimodal/deploy/agg_qwen.yaml
+++ b/examples/multimodal/deploy/agg_qwen.yaml
@@ -14,7 +14,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     EncodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: agg-qwen
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -42,7 +42,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -59,7 +59,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1508,7 +1508,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-py3"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.7.0"
+version = "0.7.0+post1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1508,7 +1508,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-py3"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "dynamo-py3"
-version = "0.7.0"
+version = "0.7.0+post1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "dynamo-py3"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "ai-dynamo-runtime"
-version = "0.7.0"
+version = "0.7.0.post1"
 description = "Dynamo Inference Framework Runtime"
 readme = "README.md"
 authors = [

--- a/lib/kvbm/Cargo.toml
+++ b/lib/kvbm/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kvbm-py3"
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/kvbm/Cargo.toml
+++ b/lib/kvbm/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kvbm-py3"
-version = "0.7.0"
+version = "0.7.0+post1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/kvbm/pyproject.toml
+++ b/lib/kvbm/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "kvbm"
-version = "0.7.0"
+version = "0.7.0.post1"
 description = "Dynamo KVBM"
 readme = "README.md"
 authors = [

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0+post1"
+version = "0.7.0-post1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.0+post1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "ai-dynamo"
-version = "0.7.0"
+version = "0.7.0.post1"
 description = "Distributed Inference Framework"
 readme = "README.md"
 authors = [
@@ -13,7 +13,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "ai-dynamo-runtime==0.7.0",
+    "ai-dynamo-runtime==0.7.0.post1",
     "transformers>=4.56.0,<=4.57.1",
     "pytest>=8.3.4",
     "types-psutil>=7.0.0.20250218",

--- a/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
@@ -19,7 +19,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
     decode:
       dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
@@ -36,7 +36,7 @@ spec:
         size: 80Gi
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace
           command:
             - python3
@@ -81,7 +81,7 @@ spec:
         size: 80Gi
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /sgl-workspace/dynamo
           command:
             - python3

--- a/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
@@ -19,7 +19,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
     decode:
       dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
@@ -34,7 +34,7 @@ spec:
         size: 80Gi
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace
           command:
             - python3
@@ -74,7 +74,7 @@ spec:
         size: 80Gi
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0.post1
           workingDir: /workspace
           command:
             - python3

--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
@@ -129,7 +129,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           args:
           - |
             python3 -m dynamo.frontend --http-port 8000
@@ -161,7 +161,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/components/backends/trtllm
           # NOTE: If your PVCs (Persistent Volume Claims) are really slow,
           #       you might need to increase 'failureThreshold' below to allow more time for startup
@@ -219,7 +219,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           workingDir: /workspace/components/backends/trtllm
           # NOTE: If your PVCs (Persistent Volume Claims) are really slow,
           #       you might need to increase 'failureThreshold' below to allow more time for startup

--- a/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
@@ -46,7 +46,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
       replicas: 1
     TrtllmWorker:
       componentType: main
@@ -81,7 +81,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"

--- a/recipes/llama-3-70b/vllm/agg/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/agg/deploy.yaml
@@ -18,7 +18,7 @@ spec:
           mountPoint: /opt/models
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
       envs:
         - name: HF_HOME
@@ -47,7 +47,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml
@@ -18,7 +18,7 @@ spec:
           mountPoint: /opt/models
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
       envs:
         - name: HF_HOME
@@ -47,7 +47,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:
@@ -78,7 +78,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml
@@ -18,7 +18,7 @@ spec:
           mountPoint: /opt/models
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
       envs:
         - name: HF_HOME
@@ -59,7 +59,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
       replicas: 2
       resources:
@@ -102,7 +102,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml
@@ -62,7 +62,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
       replicas: 1
     TrtllmWorker:
       componentType: main
@@ -96,7 +96,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"

--- a/recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml
@@ -219,7 +219,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
       replicas: 1
     TrtllmPrefillWorker:
       componentType: worker
@@ -255,7 +255,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"
@@ -316,7 +316,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"

--- a/tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       dynamoNamespace: vllm-moe-agg
@@ -48,7 +48,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/tests/fault_tolerance/deploy/templates/vllm/moe_disagg.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_disagg.yaml
@@ -15,7 +15,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
     VllmDecodeWorker:
       dynamoNamespace: vllm-moe-disagg
       envFromSecret: hf-token-secret
@@ -51,7 +51,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -116,7 +116,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/tests/planner/perf_test_configs/agg_8b.yaml
+++ b/tests/planner/perf_test_configs/agg_8b.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -86,7 +86,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_2p2d.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_2p2d.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -86,7 +86,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -134,7 +134,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_3p1d.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_3p1d.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -86,7 +86,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -134,7 +134,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_planner.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_planner.yaml
@@ -41,7 +41,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -74,7 +74,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/components/src/dynamo/planner
           ports:
             - name: metrics
@@ -136,7 +136,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -191,7 +191,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/tests/planner/perf_test_configs/disagg_8b_tp2.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_tp2.yaml
@@ -38,7 +38,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -86,7 +86,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -134,7 +134,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/image_cache_daemonset.yaml
+++ b/tests/planner/perf_test_configs/image_cache_daemonset.yaml
@@ -20,7 +20,7 @@ spec:
       - name: nvcr-imagepullsecret
       containers:
       - name: image-cache
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
#### Overview:

Bump release versions for the 0.7.0.post1 release assets. 

Since this is a post1 release and this is branched off of release/0.7.0, This is a direct merge into the release branch.

Crates/Helm:
- Use version naming 0.7.0+post1 to account for build metadata since .post1 is not supported

Containers/Wheels:
- Use version naming 0.7.0.post1 to accurately reflect the code present in this branch. 

#### Details:

- Update versions for crates, wheels, and helm charts.

