### PR TITLE
fix: use channel to avoid race condition from async nats registration task

### DIFF
--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -414,7 +414,16 @@ impl DistributedRuntime {
     /// DEPRECATED: This method exists only for NATS request plane support.
     /// Once everything uses the TCP request plane, this can be removed along with
     /// the NATS service registration infrastructure.
-    pub fn register_nats_service(&self, component: Component) {
+    ///
+    /// Returns a receiver that signals when the NATS service registration is complete.
+    /// The caller should use `blocking_recv()` to wait for completion.
+    pub fn register_nats_service(
+        &self,
+        component: Component,
+    ) -> tokio::sync::mpsc::Receiver<Result<(), String>> {
+        // Create a oneshot-style channel (capacity 1) to signal completion
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<(), String>>(1);
+
         let drt = self.clone();
         self.runtime().secondary().spawn(async move {
             let service_name = component.service_name();
@@ -431,11 +440,16 @@ impl DistributedRuntime {
                 // The NATS service is per component, but it is called from `serve_endpoint`, and there
                 // are often multiple endpoints for a component (e.g. `clear_kv_blocks` and `generate`).
                 tracing::trace!("Service {service_name} already exists");
+                // Signal success - service already exists
+                let _ = tx.send(Ok(())).await;
                 return;
             }
 
             let Some(nats_client) = drt.nats_client.as_ref() else {
                 tracing::error!("Cannot create NATS service without NATS.");
+                let _ = tx
+                    .send(Err("Cannot create NATS service without NATS".to_string()))
+                    .await;
                 return;
             };
             let description = None;
@@ -449,6 +463,7 @@ impl DistributedRuntime {
                 Ok(service) => service,
                 Err(err) => {
                     tracing::error!(error = %err, component = service_name, "Failed to build NATS service");
+                    let _ = tx.send(Err(format!("Failed to build NATS service: {err}"))).await;
                     return;
                 }
             };
@@ -468,7 +483,12 @@ impl DistributedRuntime {
                 // are often multiple endpoints for a component (e.g. `clear_kv_blocks` and `generate`).
                 // TODO: Is this still true?
             }
+
+            // Signal completion - service registered successfully
+            let _ = tx.send(Ok(())).await;
         });
+
+        rx
     }
 }
 


### PR DESCRIPTION
#### Overview:

This PR fixes race condition with nats stats service initializations

fixes: https://github.com/ai-dynamo/dynamo/issues/4753
closes: DYN-1541

#### Details 

* Root cause : `Write path` happens in a background job in asynchronously (fire & fortget task) and `Read path` during endpoint registration may/may-not find the service entry due to async / non-blocking nature of write/read path.

in PR ( https://github.com/ai-dynamo/dynamo/pull/4513)  write path for  add_stats_service  was moved from

- from [synchronous](https://github.com/ai-dynamo/dynamo/commit/f05f7629f#diff-f211ff34656da2ac111a1b346b1402d3221c1013b4255ee07316a5a6a42c0947L91-L95) awaits

```
component.add_stats_service().await?
```

- to async secondary runtime as a [background task](https://github.com/ai-dynamo/dynamo/commit/f05f7629f#diff-6802c89f8e7a78c1dfa7f7ab1806dcc1f0e2e18a5c261442264600497f8d8839R437)
```
component.drt().runtime().secondary().spawn(async move {
                if let Err(err) = c.add_stats_service().await {
```

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NATS service registration handling to ensure proper initialization before services are accessed, enhancing reliability in distributed deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service registration now provides a completion signal and can be awaited, returning success or a clear error when registration fails.
  * Improves reliability during startup by ensuring services are registered before being used and surfaces registration errors for easier troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->