### PR TITLE
test: Include a timeout marker to all Cancellation / Migration E2E tests

### DIFF
--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -21,6 +21,13 @@ from tests.utils.payloads import check_health_generate, check_models_api
 
 logger = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.sglang,
+    pytest.mark.e2e,
+    pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
+    pytest.mark.nightly,
+]
+
 
 class DynamoWorkerProcess(ManagedProcess):
     """Process manager for Dynamo worker with SGLang backend"""
@@ -146,11 +153,7 @@ class DynamoWorkerProcess(ManagedProcess):
         return False
 
 
-@pytest.mark.e2e
-@pytest.mark.sglang
 @pytest.mark.gpu_1
-@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.nightly
 @pytest.mark.xfail(strict=False)
 def test_request_cancellation_sglang_aggregated(
     request, runtime_services, predownload_models
@@ -236,11 +239,7 @@ def test_request_cancellation_sglang_aggregated(
                 logger.info(f"{description} detected successfully")
 
 
-@pytest.mark.e2e
-@pytest.mark.sglang
 @pytest.mark.gpu_2
-@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.nightly
 def test_request_cancellation_sglang_decode_cancel(
     request, runtime_services, predownload_models
 ):

--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -153,6 +153,7 @@ class DynamoWorkerProcess(ManagedProcess):
         return False
 
 
+@pytest.mark.timeout(160)  # 3x average
 @pytest.mark.gpu_1
 @pytest.mark.xfail(strict=False)
 def test_request_cancellation_sglang_aggregated(
@@ -239,6 +240,7 @@ def test_request_cancellation_sglang_aggregated(
                 logger.info(f"{description} detected successfully")
 
 
+@pytest.mark.timeout(185)  # 3x average
 @pytest.mark.gpu_2
 def test_request_cancellation_sglang_decode_cancel(
     request, runtime_services, predownload_models

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -26,6 +26,7 @@ pytestmark = [
     pytest.mark.gpu_1,
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
+    pytest.mark.nightly,
 ]
 
 
@@ -134,7 +135,6 @@ class DynamoWorkerProcess(ManagedProcess):
         return False
 
 
-@pytest.mark.nightly
 def test_request_cancellation_trtllm_aggregated(
     request, runtime_services, predownload_models
 ):
@@ -208,7 +208,6 @@ def test_request_cancellation_trtllm_aggregated(
                 logger.info(f"{description} detected successfully")
 
 
-@pytest.mark.nightly
 def test_request_cancellation_trtllm_decode_cancel(
     request, runtime_services, predownload_models
 ):
@@ -281,7 +280,6 @@ def test_request_cancellation_trtllm_decode_cancel(
                 )
 
 
-@pytest.mark.nightly
 def test_request_cancellation_trtllm_prefill_cancel(
     request, runtime_services, predownload_models
 ):

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -135,6 +135,7 @@ class DynamoWorkerProcess(ManagedProcess):
         return False
 
 
+@pytest.mark.timeout(140)  # 3x average
 def test_request_cancellation_trtllm_aggregated(
     request, runtime_services, predownload_models
 ):
@@ -208,6 +209,7 @@ def test_request_cancellation_trtllm_aggregated(
                 logger.info(f"{description} detected successfully")
 
 
+@pytest.mark.timeout(350)  # 3x average
 def test_request_cancellation_trtllm_decode_cancel(
     request, runtime_services, predownload_models
 ):
@@ -280,6 +282,7 @@ def test_request_cancellation_trtllm_decode_cancel(
                 )
 
 
+@pytest.mark.timeout(350)  # 3x average
 def test_request_cancellation_trtllm_prefill_cancel(
     request, runtime_services, predownload_models
 ):
@@ -362,6 +365,7 @@ def test_request_cancellation_trtllm_prefill_cancel(
                 )
 
 
+@pytest.mark.timeout(350)  # 3x average
 @pytest.mark.xfail(
     reason="May fail due to unknown reason with TRT-LLM or backend implementation",
     strict=False,

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -20,6 +20,14 @@ from tests.utils.payloads import check_health_generate, check_models_api
 
 logger = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.vllm,
+    pytest.mark.gpu_1,
+    pytest.mark.e2e,
+    pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
+    pytest.mark.nightly,
+]
+
 
 class DynamoWorkerProcess(ManagedProcess):
     """Process manager for Dynamo worker with vLLM backend"""
@@ -120,11 +128,6 @@ class DynamoWorkerProcess(ManagedProcess):
         return False
 
 
-@pytest.mark.vllm
-@pytest.mark.gpu_1
-@pytest.mark.e2e
-@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.nightly
 def test_request_cancellation_vllm_aggregated(
     request, runtime_services, predownload_models
 ):
@@ -198,11 +201,6 @@ def test_request_cancellation_vllm_aggregated(
                 logger.info(f"{description} detected successfully")
 
 
-@pytest.mark.vllm
-@pytest.mark.gpu_1
-@pytest.mark.e2e
-@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.nightly
 def test_request_cancellation_vllm_decode_cancel(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):
@@ -272,11 +270,6 @@ def test_request_cancellation_vllm_decode_cancel(
                 )
 
 
-@pytest.mark.vllm
-@pytest.mark.gpu_1
-@pytest.mark.e2e
-@pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
-@pytest.mark.nightly
 def test_request_cancellation_vllm_prefill_cancel(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -128,6 +128,7 @@ class DynamoWorkerProcess(ManagedProcess):
         return False
 
 
+@pytest.mark.timeout(110)  # 3x average
 def test_request_cancellation_vllm_aggregated(
     request, runtime_services, predownload_models
 ):
@@ -201,6 +202,7 @@ def test_request_cancellation_vllm_aggregated(
                 logger.info(f"{description} detected successfully")
 
 
+@pytest.mark.timeout(150)  # 3x average
 def test_request_cancellation_vllm_decode_cancel(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):
@@ -270,6 +272,7 @@ def test_request_cancellation_vllm_decode_cancel(
                 )
 
 
+@pytest.mark.timeout(150)  # 3x average
 def test_request_cancellation_vllm_prefill_cancel(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -108,6 +108,7 @@ class DynamoWorkerProcess(ManagedProcess):
         return False
 
 
+@pytest.mark.timeout(235)  # 3x average
 def test_request_migration_sglang_worker_failure(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):
@@ -199,6 +200,7 @@ def test_request_migration_sglang_graceful_shutdown(
                 verify_migration_occurred(frontend)
 
 
+@pytest.mark.timeout(135)  # 3x average
 def test_no_request_migration_sglang_worker_failure(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -109,6 +109,10 @@ class DynamoWorkerProcess(ManagedProcess):
 
 
 @pytest.mark.timeout(235)  # 3x average
+@pytest.mark.xfail(
+    reason="For some reason both replicas received the request where only one should",
+    strict=False,
+)
 def test_request_migration_sglang_worker_failure(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):
@@ -201,6 +205,10 @@ def test_request_migration_sglang_graceful_shutdown(
 
 
 @pytest.mark.timeout(135)  # 3x average
+@pytest.mark.xfail(
+    reason="For some reason both replicas received the request where only one should",
+    strict=False,
+)
 def test_no_request_migration_sglang_worker_failure(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -104,6 +104,7 @@ class DynamoWorkerProcess(ManagedProcess):
         return False
 
 
+@pytest.mark.timeout(290)  # 3x average
 def test_request_migration_trtllm_worker_failure(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):
@@ -195,6 +196,7 @@ def test_request_migration_trtllm_graceful_shutdown(
                 verify_migration_occurred(frontend)
 
 
+@pytest.mark.timeout(185)  # 3x average
 def test_no_request_migration_trtllm_worker_failure(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -105,6 +105,10 @@ class DynamoWorkerProcess(ManagedProcess):
 
 
 @pytest.mark.timeout(290)  # 3x average
+@pytest.mark.xfail(
+    reason="For some reason both replicas received the request where only one should",
+    strict=False,
+)
 def test_request_migration_trtllm_worker_failure(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):
@@ -197,6 +201,10 @@ def test_request_migration_trtllm_graceful_shutdown(
 
 
 @pytest.mark.timeout(185)  # 3x average
+@pytest.mark.xfail(
+    reason="For some reason both replicas received the request where only one should",
+    strict=False,
+)
 def test_no_request_migration_trtllm_worker_failure(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -108,6 +108,7 @@ class DynamoWorkerProcess(ManagedProcess):
         return False
 
 
+@pytest.mark.timeout(290)  # 3x average
 def test_request_migration_vllm_worker_failure(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):
@@ -151,6 +152,7 @@ def test_request_migration_vllm_worker_failure(
                 verify_migration_occurred(frontend)
 
 
+@pytest.mark.timeout(280)  # 3x average
 def test_request_migration_vllm_graceful_shutdown(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):
@@ -198,6 +200,7 @@ def test_request_migration_vllm_graceful_shutdown(
                 verify_migration_occurred(frontend)
 
 
+@pytest.mark.timeout(150)  # 3x average
 def test_no_request_migration_vllm_worker_failure(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):
@@ -257,6 +260,7 @@ def test_no_request_migration_vllm_worker_failure(
                     ), f"Unexpected migration message: {e}"
 
 
+@pytest.mark.timeout(140)  # 3x average
 def test_no_request_migration_vllm_graceful_shutdown(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):


### PR DESCRIPTION
#### Overview:

Add a timeout marker to each Cancellation / Migration E2E tests for all 3 backends.

The goal is to help developers quickly identify if a test has hang, without waiting for more than a few minutes which the test should have concluded if it would to pass.

#### Details:

For each E2E test in Cancellation / Migration, a new timeout marker sets to 3x the time it would normally take is added.

Small changes:
* A small refactoring that common pytest markers on each test file is grouped to a common variable at the top.
* Mark TRT-LLM and SGLang migration tests to allow to fail, given they intermittently fail on CI for reasons still unknown at this time.

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added explicit timeout constraints to fault tolerance tests for cancellation and migration scenarios to prevent indefinite execution.
  * Improved test marker organization by consolidating module-level pytest configuration for better maintainability across multiple inference engine implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->