### PR TITLE
fix: CI test containers network should be isolated from each other

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -63,9 +63,13 @@ runs:
           echo "No GPU detected, running in CPU-only mode"
         fi
 
+        # DO NOT USE --network host: Test containers will share the same network namespace,
+        # causing port conflicts (e.g., multiple tests trying to bind to 8000, 8081, 8082).
+        # This leads to intermittent failures when tests run in parallel or sequentially.
+        # Use --network bridge (default) to isolate each container's network.
         docker run ${GPU_FLAGS} --rm -w /workspace \
           --cpus=${NUM_CPUS} \
-          --network host \
+          --network bridge \
           --name ${{ env.CONTAINER_ID }}_pytest \
           ${{ inputs.image_tag }} \
           bash -c "mkdir -p /workspace/test-results && pytest -v --tb=short --basetemp=/tmp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --durations=10 -m \"${{ inputs.pytest_marks }}\""


### PR DESCRIPTION
#### Overview:

We should never use `--network host` when running containers on a node that could be shared by other containers, ensuring network level isolation between containers that are independent from each other. Otherwise, PR 1 running test could be talking to servers started by tests from PR 2, making any pass/fail reported by the CI untrustworthy.

#### Details:

Replace `--network host` to `--network bridge`.

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure by updating container networking configuration to prevent port conflicts during test execution. Added clarifying documentation comments for future maintenance reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->