### PR TITLE
fix: have frontend populate "stop" field in OpenAI request

### DIFF
--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -238,7 +238,11 @@ impl OpenAIStopConditionsProvider for NvCreateCompletionRequest {
     }
 
     fn get_stop(&self) -> Option<Vec<String>> {
-        None
+        use dynamo_async_openai::types::Stop;
+        self.inner.stop.as_ref().map(|s| match s {
+            Stop::String(s) => vec![s.clone()],
+            Stop::StringArray(arr) => arr.clone(),
+        })
     }
 
     fn nvext(&self) -> Option<&NvExt> {
@@ -493,5 +497,34 @@ mod tests {
 
             assert_eq!(output_options.skip_special_tokens, Some(skip_value));
         }
+    }
+
+    #[test]
+    fn test_stop() {
+        let null_stop = json!({
+            "model": "test-model",
+            "prompt": "Hello, world!"
+        });
+        let request: NvCreateCompletionRequest =
+            serde_json::from_value(null_stop).expect("Failed to deserialize request");
+        assert_eq!(request.get_stop(), None);
+
+        let one_stop = json!({
+            "model": "test-model",
+            "prompt": "Hello, world!",
+            "stop": "foo"
+        });
+        let request: NvCreateCompletionRequest =
+            serde_json::from_value(one_stop).expect("Failed to deserialize request");
+        assert_eq!(request.get_stop(), Some(vec!["foo".to_string()]));
+
+        let many_stops = json!({
+            "model": "test-model",
+            "prompt": "Hello, world!",
+            "stop": ["foo", "bar"]
+        });
+        let request: NvCreateCompletionRequest =
+            serde_json::from_value(many_stops).expect("Failed to deserialize request");
+        assert_eq!(request.get_stop(), Some(vec!["foo".to_string(), "bar".to_string()]));
     }
 }


### PR DESCRIPTION
#### Overview:

Documented in https://github.com/ai-dynamo/dynamo/issues/4755

When frontend receives an OpenAI request, 

- it does deserialize it correctly so that `NvCreateCompletionRequest.inner.stop` has it
- it doesn't implement `get_stop` 

because of this, the `Preprocessor` is not able to build the `request` with proper `stop` field. Therefore the backend cannot honor the OpenAI request `stop`.

This PR fixes that.

#### Details:

Update `get_stop` function to return the values for the (backend) request builder.

#### Testing

- added unit test 
- test locally by running frontend and engine 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stop sequence handling in completion requests to properly process and return configured stop values.

* **Tests**
  * Added unit tests for stop sequence handling scenarios, including single, multiple, and no stop configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->