### PR TITLE
fix: restoring KVBM wheel generation for `framework=none` and add CI validation 

### DIFF
--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -179,14 +179,6 @@ jobs:
           azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
           azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
 
-      - name: Verify KVBM wheel exists in vLLM image
-        if: ${{ matrix.platform.arch != 'arm64' }}
-        shell: bash
-        run: |
-          echo "Verifying KVBM wheel is present in vLLM image..."
-          docker run --rm ${{ steps.build-image.outputs.image_tag }} \
-            bash -c 'ls -la /opt/dynamo/wheelhouse/kvbm*.whl && python -c "import kvbm; print(\"✓ KVBM imported successfully\")"'
-
       - name: Run tests
         if: ${{ matrix.platform.arch != 'arm64' }}
         uses: ./.github/actions/pytest
@@ -302,14 +294,6 @@ jobs:
           azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
           azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
           azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
-
-      - name: Verify KVBM wheel exists in TRT-LLM image
-        if: ${{ matrix.platform.arch != 'arm64' }}
-        shell: bash
-        run: |
-          echo "Verifying KVBM wheel is present in TRT-LLM image..."
-          docker run --rm ${{ steps.build-image.outputs.image_tag }} \
-            bash -c 'ls -la /opt/dynamo/wheelhouse/kvbm*.whl && python -c "import kvbm; print(\"✓ KVBM imported successfully\")"'
 
       - name: Run tests
         if: ${{ matrix.platform.arch != 'arm64' }}

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -179,6 +179,14 @@ jobs:
           azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
           azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
 
+      - name: Verify KVBM wheel exists in vLLM image
+        if: ${{ matrix.platform.arch != 'arm64' }}
+        shell: bash
+        run: |
+          echo "Verifying KVBM wheel is present in vLLM image..."
+          docker run --rm ${{ steps.build-image.outputs.image_tag }} \
+            bash -c 'ls -la /opt/dynamo/wheelhouse/kvbm*.whl && python -c "import kvbm; print(\"✓ KVBM imported successfully\")"'
+
       - name: Run tests
         if: ${{ matrix.platform.arch != 'arm64' }}
         uses: ./.github/actions/pytest
@@ -294,6 +302,14 @@ jobs:
           azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
           azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
           azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+
+      - name: Verify KVBM wheel exists in TRT-LLM image
+        if: ${{ matrix.platform.arch != 'arm64' }}
+        shell: bash
+        run: |
+          echo "Verifying KVBM wheel is present in TRT-LLM image..."
+          docker run --rm ${{ steps.build-image.outputs.image_tag }} \
+            bash -c 'ls -la /opt/dynamo/wheelhouse/kvbm*.whl && python -c "import kvbm; print(\"✓ KVBM imported successfully\")"'
 
       - name: Run tests
         if: ${{ matrix.platform.arch != 'arm64' }}

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -97,6 +97,46 @@ jobs:
             ${{ env.PYTEST_XML_FILE }}
             ${{ env.PYTEST_PARALLEL_XML_FILE }}
 
+  kvbm-wheel-test:
+    runs-on:
+        group: Fastchecker
+    name: KVBM Wheel Generation Test
+    env:
+      CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}_kvbm
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to NGC
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+        run: |
+          echo "${{ secrets.NGC_CI_ACCESS_TOKEN }}" | docker login nvcr.io -u '$oauthtoken' --password-stdin
+      - name: Define Image Tag
+        id: define_image_tag
+        run: |
+          echo "image_tag=dynamo:kvbm-test" >> $GITHUB_OUTPUT
+      - name: Build image with KVBM enabled
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: |
+          ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target dev --framework none --enable-kvbm
+      - name: Verify KVBM wheel exists
+        run: |
+          docker run --rm ${{ steps.define_image_tag.outputs.image_tag }} \
+            bash -c 'ls -la /opt/dynamo/wheelhouse/kvbm*.whl'
+      - name: Verify KVBM wheel can be imported
+        run: |
+          docker run --rm ${{ steps.define_image_tag.outputs.image_tag }} \
+            bash -c 'python -c "import kvbm; from kvbm import BlockManager, KvbmLeader, KvbmWorker; print(\"✓ KVBM imported successfully\")"'
+      - name: List all wheels for debugging
+        if: always()
+        run: |
+          docker run --rm ${{ steps.define_image_tag.outputs.image_tag }} \
+            bash -c 'echo "=== All wheels in /opt/dynamo/wheelhouse/ ===" && find /opt/dynamo/wheelhouse/ -name "*.whl" -type f'
+
   event_file:
     name: "Event File"
     runs-on: ubuntu-latest

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
         run: |
-          ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target dev --framework none
+          ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target dev --framework none --enable-kvbm
       - name: Start services with docker-compose
         working-directory: ./deploy
         run: |
@@ -96,46 +96,6 @@ jobs:
           path: |
             ${{ env.PYTEST_XML_FILE }}
             ${{ env.PYTEST_PARALLEL_XML_FILE }}
-
-  kvbm-wheel-test:
-    runs-on:
-        group: Fastchecker
-    name: KVBM Wheel Generation Test
-    env:
-      CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_${{ github.job }}_kvbm
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to NGC
-        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
-        run: |
-          echo "${{ secrets.NGC_CI_ACCESS_TOKEN }}" | docker login nvcr.io -u '$oauthtoken' --password-stdin
-      - name: Define Image Tag
-        id: define_image_tag
-        run: |
-          echo "image_tag=dynamo:kvbm-test" >> $GITHUB_OUTPUT
-      - name: Build image with KVBM enabled
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
-        run: |
-          ./container/build.sh --tag ${{ steps.define_image_tag.outputs.image_tag }} --target dev --framework none --enable-kvbm
-      - name: Verify KVBM wheel exists
-        run: |
-          docker run --rm ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c 'ls -la /opt/dynamo/wheelhouse/kvbm*.whl'
-      - name: Verify KVBM wheel can be imported
-        run: |
-          docker run --rm ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c 'python -c "import kvbm; from kvbm import BlockManager, KvbmLeader, KvbmWorker; print(\"✓ KVBM imported successfully\")"'
-      - name: List all wheels for debugging
-        if: always()
-        run: |
-          docker run --rm ${{ steps.define_image_tag.outputs.image_tag }} \
-            bash -c 'echo "=== All wheels in /opt/dynamo/wheelhouse/ ===" && find /opt/dynamo/wheelhouse/ -name "*.whl" -type f'
 
   event_file:
     name: "Event File"

--- a/container/build.sh
+++ b/container/build.sh
@@ -125,6 +125,10 @@ NIXL_UCX_EFA_REF=9d2b88a1f67faf9876f267658bd077b379b8bb76
 
 NO_CACHE=""
 
+# KVBM (KV Cache Block Manager) - default disabled, enabled automatically for VLLM/TRTLLM
+# or can be explicitly enabled via --enable-kvbm flag
+ENABLE_KVBM=false
+
 # sccache configuration for S3
 USE_SCCACHE=""
 SCCACHE_BUCKET=""
@@ -802,13 +806,12 @@ fi
 
 # ENABLE_KVBM: Used in base Dockerfile for block-manager feature.
 #              Declared but not currently used in Dockerfile.{vllm,trtllm}.
+# Force KVBM to be enabled for VLLM and TRTLLM frameworks
 if [[ $FRAMEWORK == "VLLM" ]] || [[ $FRAMEWORK == "TRTLLM" ]]; then
     echo "Forcing enable_kvbm to true in ${FRAMEWORK} image build"
     ENABLE_KVBM=true
-elif [[ -z "${ENABLE_KVBM}" ]]; then
-    # Only set to false if not explicitly set by user via --enable-kvbm
-    ENABLE_KVBM=false
 fi
+# For other frameworks, ENABLE_KVBM defaults to false unless --enable-kvbm flag was provided
 
 if [  ! -z ${ENABLE_KVBM} ]; then
     echo "Enabling the KVBM in the dynamo image"

--- a/container/build.sh
+++ b/container/build.sh
@@ -805,7 +805,8 @@ fi
 if [[ $FRAMEWORK == "VLLM" ]] || [[ $FRAMEWORK == "TRTLLM" ]]; then
     echo "Forcing enable_kvbm to true in ${FRAMEWORK} image build"
     ENABLE_KVBM=true
-else
+elif [[ -z "${ENABLE_KVBM}" ]]; then
+    # Only set to false if not explicitly set by user via --enable-kvbm
     ENABLE_KVBM=false
 fi
 

--- a/container/build.sh
+++ b/container/build.sh
@@ -813,8 +813,8 @@ if [[ $FRAMEWORK == "VLLM" ]] || [[ $FRAMEWORK == "TRTLLM" ]]; then
 fi
 # For other frameworks, ENABLE_KVBM defaults to false unless --enable-kvbm flag was provided
 
-if [  ! -z ${ENABLE_KVBM} ]; then
-    echo "Enabling the KVBM in the dynamo image"
+if [[ ${ENABLE_KVBM} == "true" ]]; then
+    echo "Enabling KVBM in the dynamo image"
     BUILD_ARGS+=" --build-arg ENABLE_KVBM=${ENABLE_KVBM} "
 fi
 

--- a/tests/dependencies/test_kvbm_imports.py
+++ b/tests/dependencies/test_kvbm_imports.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests to verify KVBM package and wheels are properly installed."""
+
+import subprocess
+
+import pytest
+
+
+@pytest.mark.pre_merge
+def test_kvbm_wheel_exists():
+    """Verify KVBM wheel file exists in expected location."""
+    result = subprocess.run(
+        ["bash", "-c", "ls /opt/dynamo/wheelhouse/kvbm*.whl"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"KVBM wheel not found in /opt/dynamo/wheelhouse/\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+    assert "kvbm" in result.stdout, f"Expected kvbm wheel in output, got: {result.stdout}"
+
+
+@pytest.mark.pre_merge
+def test_kvbm_imports():
+    """Verify KVBM package can be imported."""
+    try:
+        import kvbm
+
+        assert kvbm is not None
+    except ImportError as e:
+        pytest.fail(f"Failed to import kvbm: {e}")
+
+
+@pytest.mark.pre_merge
+def test_kvbm_core_classes():
+    """Verify KVBM core classes are available."""
+    try:
+        from kvbm import BlockManager, KvbmLeader, KvbmWorker
+
+        assert BlockManager is not None, "BlockManager class not available"
+        assert KvbmLeader is not None, "KvbmLeader class not available"
+        assert KvbmWorker is not None, "KvbmWorker class not available"
+    except ImportError as e:
+        pytest.fail(f"Failed to import KVBM core classes: {e}")

--- a/tests/dependencies/test_kvbm_imports.py
+++ b/tests/dependencies/test_kvbm_imports.py
@@ -8,9 +8,9 @@ import subprocess
 import pytest
 
 
-@pytest.mark.pre_merge
-def test_kvbm_wheel_exists():
-    """Verify KVBM wheel file exists in expected location."""
+# Helper functions for KVBM verification
+def _check_kvbm_wheel_exists():
+    """Helper to verify KVBM wheel file exists in expected location."""
     result = subprocess.run(
         ["bash", "-c", "ls /opt/dynamo/wheelhouse/kvbm*.whl"],
         capture_output=True,
@@ -27,25 +27,58 @@ def test_kvbm_wheel_exists():
     ), f"Expected kvbm wheel in output, got: {result.stdout}"
 
 
-@pytest.mark.pre_merge
-def test_kvbm_imports():
-    """Verify KVBM package can be imported."""
+def _check_kvbm_imports():
+    """Helper to verify KVBM package and core classes can be imported."""
     try:
         import kvbm
-
-        assert kvbm is not None
-    except ImportError as e:
-        pytest.fail(f"Failed to import kvbm: {e}")
-
-
-@pytest.mark.pre_merge
-def test_kvbm_core_classes():
-    """Verify KVBM core classes are available."""
-    try:
         from kvbm import BlockManager, KvbmLeader, KvbmWorker
 
+        assert kvbm is not None, "kvbm module is None"
         assert BlockManager is not None, "BlockManager class not available"
         assert KvbmLeader is not None, "KvbmLeader class not available"
         assert KvbmWorker is not None, "KvbmWorker class not available"
     except ImportError as e:
-        pytest.fail(f"Failed to import KVBM core classes: {e}")
+        pytest.fail(f"Failed to import KVBM package or core classes: {e}")
+
+
+# Base tests (no framework markers) - run in main job with --framework none --enable-kvbm
+@pytest.mark.pre_merge
+def test_kvbm_wheel_exists():
+    """Verify KVBM wheel file exists in expected location."""
+    _check_kvbm_wheel_exists()
+
+
+@pytest.mark.pre_merge
+def test_kvbm_imports():
+    """Verify KVBM package and core classes can be imported."""
+    _check_kvbm_imports()
+
+
+# vLLM-specific tests - run in vLLM job (vLLM auto-enables KVBM)
+@pytest.mark.pre_merge
+@pytest.mark.vllm
+def test_kvbm_wheel_exists_vllm():
+    """Verify KVBM wheel exists in vLLM image."""
+    _check_kvbm_wheel_exists()
+
+
+@pytest.mark.pre_merge
+@pytest.mark.vllm
+def test_kvbm_imports_vllm():
+    """Verify KVBM package and core classes can be imported in vLLM image."""
+    _check_kvbm_imports()
+
+
+# TRT-LLM-specific tests - run in TRT-LLM job (TRT-LLM auto-enables KVBM)
+@pytest.mark.pre_merge
+@pytest.mark.trtllm
+def test_kvbm_wheel_exists_trtllm():
+    """Verify KVBM wheel exists in TRT-LLM image."""
+    _check_kvbm_wheel_exists()
+
+
+@pytest.mark.pre_merge
+@pytest.mark.trtllm
+def test_kvbm_imports_trtllm():
+    """Verify KVBM package and core classes can be imported in TRT-LLM image."""
+    _check_kvbm_imports()

--- a/tests/dependencies/test_kvbm_imports.py
+++ b/tests/dependencies/test_kvbm_imports.py
@@ -22,7 +22,9 @@ def test_kvbm_wheel_exists():
         f"stdout: {result.stdout}\n"
         f"stderr: {result.stderr}"
     )
-    assert "kvbm" in result.stdout, f"Expected kvbm wheel in output, got: {result.stdout}"
+    assert (
+        "kvbm" in result.stdout
+    ), f"Expected kvbm wheel in output, got: {result.stdout}"
 
 
 @pytest.mark.pre_merge


### PR DESCRIPTION
#### Overview:

This PR fixes KVBM wheel generation when using `--enable-kvbm` with `--framework none` and adds comprehensive CI tests to validate KVBM wheels are built correctly across all frameworks.

#### Details:

Problem                                                                                                                                                                                  

Previously, the build script would ignore the --enable-kvbm flag when using --framework none, unconditionally setting ENABLE_KVBM=false for non-VLLM/TRTLLM frameworks. This prevented users from building KVBM wheels in base images without a specific framework.                                                                                                   

Additionally, there were no CI tests to catch regressions in KVBM wheel generation.                                                                                                      

Changes                                                                                                                                                                                  
                                                                                                                                                                                           
  1. Fixed build script logic (container/build.sh)                                                                                                                                         
                                                                                                                                                                                           
  - Added explicit default: Set ENABLE_KVBM=false at script initialization for clarity (line 130)                                                                                          
  - Fixed flag handling: Modified framework logic to respect user's explicit --enable-kvbm flag                                                                                            
    - VLLM/TRTLLM: Force ENABLE_KVBM=true (existing behavior)                                                                                                                              
    - Other frameworks: Respect user's flag or default to false (fixed behavior)                                                                                                           
  - Simplified logic: Only pass build arg when ENABLE_KVBM == "true" (more idiomatic and efficient)                                                                                        
                                                                                                                                                                                           
  2. Added comprehensive pytest-based CI validation       
  New test file (tests/dependencies/test_kvbm_imports.py):                                                                                                                                 
  - 2 helper functions for reusable verification logic:
    - _check_kvbm_wheel_exists() - Verifies wheel file exists at /opt/dynamo/wheelhouse/kvbm*.whl
    - _check_kvbm_imports() - Verifies KVBM package and core classes can be imported
  - 6 test functions marked with @pytest.mark.pre_merge across 3 contexts:
    - Base tests (no framework markers) - Run in main job with --framework none --enable-kvbm:
        - test_kvbm_wheel_exists()
      - test_kvbm_imports()
    - vLLM tests (@pytest.mark.vllm) - Run in vLLM job:
        - test_kvbm_wheel_exists_vllm()
      - test_kvbm_imports_vllm()
    - TRT-LLM tests (@pytest.mark.trtllm) - Run in TRT-LLM job:
        - test_kvbm_wheel_exists_trtllm()
      - test_kvbm_imports_trtllm()

  Updated main build (container-validation-dynamo.yml):
  - Modified build command to include --enable-kvbm flag
  - KVBM tests automatically run as part of existing pytest suite
  - Seamlessly integrated into main "Build and Test - dynamo" workflow                                         

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container validation workflows to verify KVBM wheel presence and functionality in built images.
  * Updated build scripts to support KVBM feature enablement for vLLM and TRT-LLM frameworks.

* **Tests**
  * Added new test job to validate KVBM wheel generation and import capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->