### PR TITLE
feat: SLA Planner configuration support for DEP and TEP VLLM

### DIFF
--- a/benchmarks/profiler/profile_sla.py
+++ b/benchmarks/profiler/profile_sla.py
@@ -284,7 +284,9 @@ async def run_profile(args):
                     deployment_clients.append(client)  # Track for cleanup
                     await client.create_deployment(prefill_config_fn)
                     logger.info("Waiting for deployment to be ready...")
-                    await client.wait_for_deployment_ready()
+                    await client.wait_for_deployment_ready(
+                        timeout=getattr(args, "deployment_timeout", 1800)
+                    )
                     logger.info("Deployment is ready")
 
                     logger.info("Getting deployment logs...")
@@ -387,7 +389,9 @@ async def run_profile(args):
                     deployment_clients.append(client)  # Track for cleanup
                     await client.create_deployment(decode_config_fn)
                     logger.info("Waiting for deployment to be ready...")
-                    await client.wait_for_deployment_ready()
+                    await client.wait_for_deployment_ready(
+                        timeout=getattr(args, "deployment_timeout", 1800)
+                    )
                     logger.info("Deployment is ready")
 
                     logger.info("Getting deployment logs...")
@@ -603,7 +607,9 @@ async def run_profile(args):
             await client.create_deployment(prefill_config_fn)
             logger.info("Waiting for deployment to be ready...")
             try:
-                await client.wait_for_deployment_ready()
+                await client.wait_for_deployment_ready(
+                    timeout=getattr(args, "deployment_timeout", 1800)
+                )
                 logger.info("Deployment is ready")
 
                 skip_profile = False

--- a/benchmarks/profiler/utils/config.py
+++ b/benchmarks/profiler/utils/config.py
@@ -40,6 +40,7 @@ class Container(BaseModel):
     workingDir: Optional[str] = None
     command: Optional[list[str]] = None
     args: Optional[list[str]] = None
+    resources: Optional[dict] = None  # For RDMA/custom resources in extraPodSpec.mainContainer
     model_config = {"extra": "allow"}
 
 

--- a/benchmarks/profiler/utils/config.py
+++ b/benchmarks/profiler/utils/config.py
@@ -40,7 +40,7 @@ class Container(BaseModel):
     workingDir: Optional[str] = None
     command: Optional[list[str]] = None
     args: Optional[list[str]] = None
-    resources: Optional[dict] = None  # For RDMA/custom resources in extraPodSpec.mainContainer
+    resources: Optional[dict] = None  # For RDMA/custom resources
     model_config = {"extra": "allow"}
 
 

--- a/benchmarks/profiler/utils/config_modifiers/vllm.py
+++ b/benchmarks/profiler/utils/config_modifiers/vllm.py
@@ -64,7 +64,6 @@ class VllmV1ConfigModifier(BaseConfigModifier):
         cfg = Config.model_validate(config)
 
         # MoE flags (--enable-expert-parallel) are set in set_config_tep_size/set_config_dep_size
-        _ = is_moe_model
 
         # set metadata name
         cfg.metadata.name = "agg"

--- a/benchmarks/profiler/utils/config_modifiers/vllm.py
+++ b/benchmarks/profiler/utils/config_modifiers/vllm.py
@@ -67,7 +67,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
         _ = is_moe_model
 
         # set metadata name
-        cfg.metadata.name = "vllm-agg"
+        cfg.metadata.name = "agg"
 
         # disable planner
         if "Planner" in cfg.spec.services:

--- a/benchmarks/profiler/utils/plot.py
+++ b/benchmarks/profiler/utils/plot.py
@@ -209,10 +209,19 @@ def plot_decode_3d_surface(
     xi = np.linspace(min(x_kv_usage), max(x_kv_usage), 100)
     yi = np.linspace(min(y_context_length), max(y_context_length), 100)
     X, Y = np.meshgrid(xi, yi)
-    Z_itl = griddata((x_kv_usage, y_context_length), z_itl, (X, Y), method="cubic")
-    Z_thpt = griddata(
-        (x_kv_usage, y_context_length), z_thpt_per_gpu, (X, Y), method="cubic"
-    )
+
+    # Try cubic interpolation first, fallback to linear if Qhull error occurs
+    try:
+        Z_itl = griddata((x_kv_usage, y_context_length), z_itl, (X, Y), method="cubic")
+        Z_thpt = griddata(
+            (x_kv_usage, y_context_length), z_thpt_per_gpu, (X, Y), method="cubic"
+        )
+    except Exception as e:
+        logger.warning(f"Cubic interpolation failed: {e}. Falling back to linear.")
+        Z_itl = griddata((x_kv_usage, y_context_length), z_itl, (X, Y), method="linear")
+        Z_thpt = griddata(
+            (x_kv_usage, y_context_length), z_thpt_per_gpu, (X, Y), method="linear"
+        )
 
     # Plot ITL surface
     fig = plt.figure(figsize=(12, 10))

--- a/benchmarks/profiler/utils/profiler_argparse.py
+++ b/benchmarks/profiler/utils/profiler_argparse.py
@@ -84,6 +84,7 @@ def create_profiler_parser() -> argparse.Namespace:
             serviceName: String (service name, default: "")
             model: String (served model name)
             dgdImage: String (container image to use for DGD components (frontend, planner, workers), overrides images in config file)
+            deploymentTimeout: Int (maximum time to wait for deployment to become ready in seconds, default: 1800)
             modelCache:
                 pvcName: String (name of the PVC to mount the model cache,
                     if not provided, model must be HF name and will download from HF, default: "")
@@ -174,6 +175,12 @@ def create_profiler_parser() -> argparse.Namespace:
         type=str,
         default=_get(deployment_cfg, "dgdImage", "dgd_image", ""),
         help="Container image to use for DGD components (frontend, planner, workers). Overrides images in config file.",
+    )
+    parser.add_argument(
+        "--deployment-timeout",
+        type=int,
+        default=_get(deployment_cfg, "deploymentTimeout", "deployment_timeout", 1800),
+        help="Maximum time to wait for deployment to become ready in seconds (default: 1800)",
     )
 
     parser.add_argument(


### PR DESCRIPTION
relates to: DYN-1457 Adding vLLM support in MOE planner profiler

#### Overview:

Extends the MOE planner profiler to support  TEP (tensor expert parallel) and DEP (data expert parallel) configs with the vllm backend

#### Details:

Files modified:

benchmarks/profiler/utils/config_modifiers/vllm.py

Test plan: SLA profiler runs of MoE models using vllm backend

#### Where should the reviewer start?

benchmarks/profiler/utils/config_modifiers/vllm.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- DYN-1457 Adding vLLM support in MOE planner profiler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mixture of Experts (MoE) model support to configuration utilities
  * Implemented tensor-parallel and data-parallel sizing configuration for distributed inference
  * Enhanced multinode resource handling for advanced parallelism scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->