### PR TITLE
feat: add runtime sanity checks for runtime images

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -160,9 +160,10 @@ runs:
 
         # Run the sanity check script inside the container
         # The script is located in /workspace/deploy/sanity_check.py in runtime containers
+        set +e
         docker run --rm "$IMAGE_TAG" python /workspace/deploy/sanity_check.py --runtime-check --no-gpu-check
-
         SANITY_CHECK_EXIT_CODE=$?
+        set -e
         if [ ${SANITY_CHECK_EXIT_CODE} -ne 0 ]; then
           echo "ERROR: Sanity check failed - ai-dynamo packages not properly installed"
           exit ${SANITY_CHECK_EXIT_CODE}

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -151,6 +151,25 @@ runs:
         # Exit with the build's exit code
         exit ${BUILD_EXIT_CODE}
 
+    - name: Run Sanity Check on Runtime Image
+      if: inputs.target == 'runtime'
+      shell: bash
+      run: |
+        IMAGE_TAG="${{ steps.build.outputs.image_tag }}"
+        echo "Running sanity check on image: $IMAGE_TAG"
+
+        # Run the sanity check script inside the container
+        # The script is located in /workspace/deploy/sanity_check.py in runtime containers
+        docker run --rm "$IMAGE_TAG" python /workspace/deploy/sanity_check.py --runtime-check --no-gpu-check
+
+        SANITY_CHECK_EXIT_CODE=$?
+        if [ ${SANITY_CHECK_EXIT_CODE} -ne 0 ]; then
+          echo "ERROR: Sanity check failed - ai-dynamo packages not properly installed"
+          exit ${SANITY_CHECK_EXIT_CODE}
+        else
+          echo "✅ Sanity check passed"
+        fi
+
     - name: Capture Build Metrics
       id: metrics
       shell: bash


### PR DESCRIPTION
#### Overview:

Wire `deploy/sanity_check.py` into the runtime Docker GitHub Action.
Fix the script’s runtime mode to validate installed `ai-dynamo-runtime` / `ai-dynamo` even when no workspace is present.

#### Details:

- Add a step in `.github/actions/docker-build/action.yml` to run `deploy/sanity_check.py --runtime-check` on built runtime images and fail on sanity-check errors.
- Update `deploy/sanity_check.py` to support runtime-only containers by importing key runtime/framework modules and surfacing clear failures when they are missing.

#### Where should the reviewer start?

- Review `deploy/sanity_check.py` for the runtime-check behavior.
- Then check `.github/actions/docker-build/action.yml` for how the step plugs into the build.

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)



/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated sanity checks for runtime Docker images during builds.
  * Added `--runtime` and `--no-gpu-check` command-line options for sanity checks.

* **Improvements**
  * Enhanced runtime environment validation when workspace is unavailable.
  * Improved GPU detection handling with optional skipping capability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->