### PR TITLE
fix(runtime): add proper IPv6 address formatting for socket bindings

### DIFF
--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -247,10 +247,9 @@ pub fn build_transport_type(
             let rpc_root =
                 std::env::var("DYN_HTTP_RPC_ROOT_PATH").unwrap_or_else(|_| "/v1/rpc".to_string());
 
-            let http_endpoint = format!(
-                "http://{http_host}:{http_port}{rpc_root}/{}",
-                endpoint_id.name
-            );
+            // Format host:port correctly for IPv6 addresses
+            let host_port = crate::utils::format_socket_addr(&http_host, http_port);
+            let http_endpoint = format!("http://{host_port}{rpc_root}/{}", endpoint_id.name);
 
             TransportType::Http(http_endpoint)
         }
@@ -263,7 +262,8 @@ pub fn build_transport_type(
 
             // Include endpoint name for proper TCP routing
             // TCP client parses this format and adds x-endpoint-path header for server-side routing
-            let tcp_endpoint = format!("{}:{}/{}", tcp_host, tcp_port, endpoint_id.name);
+            let tcp_endpoint =
+                crate::utils::format_socket_addr_with_path(&tcp_host, tcp_port, &endpoint_id.name);
 
             TransportType::Tcp(tcp_endpoint)
         }

--- a/lib/runtime/src/pipeline/network/manager.rs
+++ b/lib/runtime/src/pipeline/network/manager.rs
@@ -224,9 +224,10 @@ impl NetworkManager {
     async fn create_http_server(&self) -> Result<Arc<dyn RequestPlaneServer>> {
         use super::ingress::http_endpoint::SharedHttpServer;
 
-        let bind_addr = format!("{}:{}", self.config.http_host, self.config.http_port)
-            .parse()
-            .map_err(|e| anyhow::anyhow!("Invalid HTTP bind address: {}", e))?;
+        let bind_addr =
+            crate::utils::format_socket_addr(&self.config.http_host, self.config.http_port)
+                .parse()
+                .map_err(|e| anyhow::anyhow!("Invalid HTTP bind address: {}", e))?;
 
         tracing::info!(
             bind_addr = %bind_addr,
@@ -250,9 +251,10 @@ impl NetworkManager {
     async fn create_tcp_server(&self) -> Result<Arc<dyn RequestPlaneServer>> {
         use super::ingress::shared_tcp_endpoint::SharedTcpServer;
 
-        let bind_addr = format!("{}:{}", self.config.tcp_host, self.config.tcp_port)
-            .parse()
-            .map_err(|e| anyhow::anyhow!("Invalid TCP bind address: {}", e))?;
+        let bind_addr =
+            crate::utils::format_socket_addr(&self.config.tcp_host, self.config.tcp_port)
+                .parse()
+                .map_err(|e| anyhow::anyhow!("Invalid TCP bind address: {}", e))?;
 
         tracing::info!(
             bind_addr = %bind_addr,

--- a/lib/runtime/src/utils.rs
+++ b/lib/runtime/src/utils.rs
@@ -12,4 +12,7 @@ pub mod tasks;
 pub mod typed_prefix_watcher;
 
 pub use graceful_shutdown::GracefulShutdownTracker;
-pub use ip_resolver::{get_http_rpc_host_from_env, get_tcp_rpc_host_from_env};
+pub use ip_resolver::{
+    format_socket_addr, format_socket_addr_with_path, get_http_rpc_host_from_env,
+    get_tcp_rpc_host_from_env,
+};


### PR DESCRIPTION
#### Overview:

Problem:
When the system auto-detected an IPv6 address for TCP/HTTP RPC binding, it would format the address incorrectly as "IPv6:port" instead of the required "[IPv6]:port" format, causing "invalid socket address syntax" errors.
```
2025-12-06T19:39:40.743041Z  INFO dynamo_runtime::health_check: Health
check task started for: generate
2025-12-06T19:39:40.743162Z ERROR main.init_prefill: Failed to serve
endpoints: Invalid TCP bind address: invalid socket address syntax
2025-12-06T19:39:40.743234Z  INFO main.init_prefill: Metrics task
successfully cancelled
2025-12-06T19:39:40.751089Z DEBUG dynamo_runtime::transports::nats:
Stream namespace-dynamo-component-prefill-kv-events is ready
2025-12-06T19:39:40.801681Z  INFO prefill_handler.cleanup: Prefill
engine shutdown
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/sgl-workspace/dynamo/components/src/dynamo/sglang/__main__.py",
line 7, in <module>
    main()
  File "/sgl-workspace/dynamo/components/src/dynamo/sglang/main.py",
line 530, in main
    uvloop.run(worker())
  File "/usr/local/lib/python3.12/dist-packages/uvloop/__init__.py",
line 109, in run
    return __asyncio.run(
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in
uvloop.loop.Loop.run_until_complete
  File "/usr/local/lib/python3.12/dist-packages/uvloop/__init__.py",
line 61, in wrapper
    return await main
           ^^^^^^^^^^
  File "/sgl-workspace/dynamo/components/src/dynamo/sglang/main.py",
line 99, in worker
    await init_prefill(runtime, config)
  File "/sgl-workspace/dynamo/components/src/dynamo/sglang/main.py",
line 255, in init_prefill
    await asyncio.gather(*tasks)
Exception: Invalid TCP bind address: invalid socket address syntax
```

Solution:
Add helper functions for proper socket address formatting that detect IPv6 addresses and wrap them in brackets automatically.


#### Details:
Changes:
- Add `format_socket_addr(host, port)` function in utils/ip_resolver.rs that properly handles IPv4, IPv6, and hostname addresses
- Add `format_socket_addr_with_path(host, port, path)` for TCP endpoints that include routing path information
- Update pipeline/network/manager.rs to use format_socket_addr() for HTTP and TCP server bind addresses
- Update component/endpoint.rs to use the new functions for building HTTP and TCP transport endpoints
- Export new functions from utils module
- Add comprehensive unit tests for IPv4, IPv6, bracketed IPv6, hostnames, and path handling

Examples of correct formatting:
- 192.168.1.1:8080   -> 192.168.1.1:8080 (unchanged)
- ::1:8080           -> [::1]:8080 (fixed)
- 2001:db8::1:9999   -> [2001:db8::1]:9999 (fixed)
- [::1]:8080

#### Where should the reviewer start?

`lib/runtime/src/utils/ip_resolver.rs` -> `lib/runtime/src/component/endpoint.rs` -> `lib/runtime/src/pipeline/network/manager.rs`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: N/A
