### PR TITLE
fix: add timeout to tests before lora to unblock

### DIFF
--- a/lib/bindings/python/tests/test_kv_bindings.py
+++ b/lib/bindings/python/tests/test_kv_bindings.py
@@ -37,6 +37,7 @@ async def distributed_runtime():
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)  # Expected: ~1s, timeout set to 5x for safety
 async def test_radix_tree_binding(distributed_runtime):
     """Test RadixTree binding directly with store event and find matches"""
     import json
@@ -103,6 +104,7 @@ async def test_radix_tree_binding(distributed_runtime):
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)  # Expected: ~1s, timeout set to 5x for safety
 @pytest.mark.parametrize("num_threads", [2, 3, 5, 128])
 @pytest.mark.parametrize("prepopulate_worker_ids", [True, False])
 @pytest.mark.parametrize("expiration_duration_secs", [None])
@@ -205,6 +207,7 @@ async def test_radix_tree_thread_safety(
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)  # Expected: ~1s, timeout set to 5x for safety
 async def test_event_handler(distributed_runtime):
     kv_block_size = 32
     namespace = "kv_test"
@@ -247,6 +250,7 @@ async def test_event_handler(distributed_runtime):
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)  # Expected: ~1s, timeout set to 5x for safety
 async def test_approx_kv_indexer(distributed_runtime):
     """Test ApproxKvIndexer with TTL-based block tracking"""
     kv_block_size = 32

--- a/lib/bindings/python/tests/test_kv_bindings.py
+++ b/lib/bindings/python/tests/test_kv_bindings.py
@@ -36,9 +36,8 @@ async def distributed_runtime():
     runtime.shutdown()
 
 
-@pytest.mark.asyncio
 @pytest.mark.timeout(5)  # Expected: ~1s, timeout set to 5x for safety
-async def test_radix_tree_binding(distributed_runtime):
+def test_radix_tree_binding():
     """Test RadixTree binding directly with store event and find matches"""
     import json
 
@@ -103,14 +102,12 @@ async def test_radix_tree_binding(distributed_runtime):
     )
 
 
-@pytest.mark.asyncio
 @pytest.mark.timeout(5)  # Expected: ~1s, timeout set to 5x for safety
 @pytest.mark.parametrize("num_threads", [2, 3, 5, 128])
 @pytest.mark.parametrize("prepopulate_worker_ids", [True, False])
 @pytest.mark.parametrize("expiration_duration_secs", [None])
 @pytest.mark.parametrize("is_threaded", [True, False])
-async def test_radix_tree_thread_safety(
-    distributed_runtime,
+def test_radix_tree_thread_safety(
     num_threads,
     prepopulate_worker_ids,
     expiration_duration_secs,


### PR DESCRIPTION
#### Overview:

Added 5-second timeouts to KV bindings tests to prevent CI hangs and provide faster failure feedback.

#### Details:

- Added `@pytest.mark.timeout(5)` to 4 async tests that typically complete in ~1s
- Prevents indefinite hangs from deadlocks or resource issues

#### Where should the reviewer start?

`lib/bindings/python/tests/test_kv_bindings.py` - verify timeout values are reasonable

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Converted key-value binding tests from asynchronous to synchronous execution, streamlining test infrastructure and reducing external dependencies where applicable.
  * Applied timeout markers to remaining async tests to enhance reliability and ensure consistent, predictable test execution behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->