### PR TITLE
chore(pipeline): Move migration outside of backend

### DIFF
--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -271,13 +271,13 @@ where
     // Link with prefill chooser including backward edge for response flow
     let engine = frontend
         .link(preprocessor_op.forward_edge())?
-        .link(backend.forward_edge())?
         .link(migration.forward_edge())?
+        .link(backend.forward_edge())?
         .link(prefill_op.forward_edge())?
         .link(service_backend)?
         .link(prefill_op.backward_edge())?
-        .link(migration.backward_edge())?
         .link(backend.backward_edge())?
+        .link(migration.backward_edge())?
         .link(preprocessor_op.backward_edge())?
         .link(frontend)?;
 


### PR DESCRIPTION
`Backend` is going to move to, well, the backend (worker). Migration now works from `BackendOutput` not `LLMEngineOutput`.

The router also needs to change, but PrefillRouter (`prefill_op`) complicates matters. We need to change it and the router at the same time, once the worker returns `BackendOutput` over the wire instead of `LLMEngineOutput`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal pipeline sequencing to improve component interaction flow
  * Standardized output type handling throughout the migration layer for consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->