### PR TITLE
feat: make planner use DGD Scaling Adapters

### DIFF
--- a/deploy/cloud/helm/platform/components/operator/templates/planner.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/planner.yaml
@@ -39,6 +39,9 @@ rules:
 - apiGroups: ["nvidia.com"]
   resources: ["dynamocomponentdeployments", "dynamographdeployments"]
   verbs: ["get", "list", "create", "update", "patch"]
+- apiGroups: ["nvidia.com"]
+  resources: ["dynamographdeploymentscalingadapters/scale"]
+  verbs: ["patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -68,4 +71,7 @@ rules:
 - apiGroups: ["nvidia.com"]
   resources: ["dynamocomponentdeployments", "dynamographdeployments"]
   verbs: ["get", "list", "create", "update", "patch"]
+- apiGroups: ["nvidia.com"]
+  resources: ["dynamographdeploymentscalingadapters/scale"]
+  verbs: ["patch"]
 {{- end }}


### PR DESCRIPTION
#### Overview:

make planner scale DGD Scaling Adapters.

Now that DGDSA have been introduced, planner should use these adapters to scale up/down DGD services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Service scaling now uses an improved scaling mechanism with automatic fallback support.

* **Tests**
  * Expanded test coverage for service scaling scenarios, fallback behavior, and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->