### PR TITLE
feat(tests): register hw_faults pytest marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ def pytest_configure(config):
         "custom_build: marks tests that require custom builds or special setup (e.g., MoE models)",
         "k8s: marks tests as requiring Kubernetes",
         "fault_tolerance: marks tests as fault tolerance tests",
+        "hw_faults: marks tests as hardware fault injection tests (XID, CUDA errors)",
     ]
     for marker in markers:
         config.addinivalue_line("markers", marker)


### PR DESCRIPTION
#### Overview:
Adds `hw_faults` marker to pytest configuration.
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
Registers `hw_faults` marker in `tests/conftest.py`, which
- Enables \`pytest -m hw_faults\` to run only HW fault tests
- Enables \`pytest -m 'not hw_faults'\` to exclude them
- Prevents 'unknown marker' warnings

#### Where should the reviewer start?
`pytest_configure` function in `tests/conftest.py`
<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Contributes to [linear issue](https://linear.app/nvidia/issue/OPS-2142/ci-integration-hardware-fault-injection-manageddeployments) to create a basis for HW FT integration into CI