### PR TITLE
fix ucx crate dep in dev container

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -312,6 +312,7 @@ COPY components/ /opt/dynamo/components/
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
+    export PKG_CONFIG_PATH=/usr/local/ucx/lib/pkgconfig:${PKG_CONFIG_PATH} && \
     source ${VIRTUAL_ENV}/bin/activate && \
     cd /opt/dynamo && \
     uv build --wheel --out-dir /opt/dynamo/dist && \


### PR DESCRIPTION
#### Overview:

Fix KVBM Python bindings build failure caused by UCX library not being found via pkg-config, resulting in ucx1-sys attempting to build UCX from source without -fPIC.

#### Details:

When building the kvbm-py3 Python bindings with ENABLE_KVBM=true, the build fails with linker errors:
```rust-lld: error: relocation R_X86_64_32 cannot be used against symbol 'ucs_sys_get_lib_info'; recompile with -fPIC```

The root cause is that ucx1-sys (a dependency of async-ucx) uses pkg-config to locate the UCX library. Since UCX is installed to /usr/local/ucx (a non-standard location), pkg-config cannot find it without PKG_CONFIG_PATH being set. When pkg-config fails, ucx1-sys falls back to building UCX from source without -fPIC, which causes linking failures when creating the Python shared library (cdylib).
Fix: Added ```export PKG_CONFIG_PATH=/usr/local/ucx/lib/pkgconfig:${PKG_CONFIG_PATH}``` before the maturin build step so that ucx1-sys can locate and use the pre-installed system UCX library.
