### PR TITLE
feat(tests): Add hardware fault injection support to ManagedDeployment

### DIFF
--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -264,6 +264,20 @@ class DeploymentSpec:
         for service in services:
             service.image = image
 
+    def set_dynamo_namespace(self, dynamo_ns: str):
+        """Set the dynamoNamespace for all services.
+
+        This provides logical isolation within a Kubernetes namespace,
+        ensuring services only discover and communicate with each other.
+
+        Args:
+            dynamo_ns: The dynamo namespace to set for all services
+        """
+        for service_name, service_spec in self._deployment_spec["spec"][
+            "services"
+        ].items():
+            service_spec["dynamoNamespace"] = dynamo_ns
+
     def set_tensor_parallel(self, tp_size: int, service_names: Optional[list] = None):
         """Scale deployment for different tensor parallel configurations
 


### PR DESCRIPTION
#### Overview:
Integrates HWFaultManager into ManagedDeployment to enable GPU fault tolerance testing with CUDA error injection and XID simulation.

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
- Added `enable_hw_faults` and `hw_fault_config` parameters to dataclass
- Added `_hw_fault_manager` initialization in `__aenter__` 
- Added wrapper methods: `setup_cuda_passthrough()`, `toggle_cuda_faults()`, `inject_hw_fault()`, `get_hw_fault_target_node()`, `remove_node_affinity()`, `is_node_cordoned()`, `wait_for_all_pods_ready()`, `wait_for_pods_on_healthy_nodes()`, `collect_metrics()`
- Added HW fault cleanup in `_cleanup()`

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?
- HWFaultManager import
- Namespace isolation ~line 250
- HW fault methods ~line 900+

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to: Hardware fault tolerance test infrastructure
- Merge after:
    - #4826
    - #4833
    - #4830
