### PR TITLE
fix: sccache compiler launcher errors when sccache is disabled

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -292,6 +292,8 @@ ARG ENABLE_KVBM
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
+    export CC=$(which gcc) && \
+    export CXX=$(which g++) && \
     source ${VIRTUAL_ENV}/bin/activate && \
     cd /opt/dynamo && \
     uv build --wheel --out-dir /opt/dynamo/dist && \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -214,9 +214,11 @@ ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${ARCH}}" && \
-    export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CUDA_COMPILER_LAUNCHER="sccache" && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
+    fi && \
     cd /usr/local/src && \
      git clone https://github.com/openucx/ucx.git && \
      cd ucx && 			     \

--- a/container/Dockerfile.local_dev
+++ b/container/Dockerfile.local_dev
@@ -39,7 +39,9 @@ RUN apt-get update && apt-get install -y \
     # File utilities
     tree fd-find ripgrep \
     # Shell utilities
-    zsh fish bash-completion
+    zsh fish bash-completion \
+    # User management
+    sudo gnupg2 gnupg1
 
 # Install awk separately with fault tolerance
 # awk is a virtual package with multiple implementations (gawk, mawk, original-awk).
@@ -67,8 +69,7 @@ RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu2404/$
 
 # https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
 # Configure user with sudo access for Dev Container workflows
-RUN apt-get install -y sudo gnupg2 gnupg1 \
-    && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
+RUN echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     && mkdir -p /home/$USERNAME \
     # Handle GID conflicts: if target GID exists and it's not our group, remove it
@@ -76,7 +77,7 @@ RUN apt-get install -y sudo gnupg2 gnupg1 \
     # Create group if it doesn't exist, otherwise modify existing group
     && (getent group $USERNAME > /dev/null 2>&1 && groupmod -g $USER_GID $USERNAME || groupadd -g $USER_GID $USERNAME) \
     && usermod -u $USER_UID -g $USER_GID -G 0 $USERNAME \
-    && chown -R $USERNAME:$USERNAME /home/$USERNAME \
+    && chown $USERNAME:$USER_GID /home/$USERNAME \
     && chsh -s /bin/bash $USERNAME
 
 

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -218,9 +218,11 @@ ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${ARCH}}" && \
-    export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CUDA_COMPILER_LAUNCHER="sccache" && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
+    fi && \
     cd /usr/local/src && \
      git clone https://github.com/openucx/ucx.git && \
      cd ucx && 			     \
@@ -294,9 +296,11 @@ ARG ENABLE_KVBM
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
-    export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
-    export RUSTC_WRAPPER="sccache" && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
+        export RUSTC_WRAPPER="sccache"; \
+    fi && \
     source ${VIRTUAL_ENV}/bin/activate && \
     cd /opt/dynamo && \
     uv build --wheel --out-dir /opt/dynamo/dist && \

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -301,6 +301,8 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
         export RUSTC_WRAPPER="sccache"; \
     fi && \
+    export CC=$(which gcc) && \
+    export CXX=$(which g++) && \
     source ${VIRTUAL_ENV}/bin/activate && \
     cd /opt/dynamo && \
     uv build --wheel --out-dir /opt/dynamo/dist && \

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -239,9 +239,11 @@ ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${ARCH}}" && \
-    export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CUDA_COMPILER_LAUNCHER="sccache" && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
+    fi && \
     cd /usr/local/src && \
      git clone https://github.com/openucx/ucx.git && \
      cd ucx && 			     \
@@ -315,9 +317,11 @@ ARG ENABLE_KVBM
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
-    export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
-    export RUSTC_WRAPPER="sccache" && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
+        export RUSTC_WRAPPER="sccache"; \
+    fi && \
     source ${VIRTUAL_ENV}/bin/activate && \
     cd /opt/dynamo && \
     uv build --wheel --out-dir /opt/dynamo/dist && \

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -322,6 +322,8 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
         export RUSTC_WRAPPER="sccache"; \
     fi && \
+    export CC=$(which gcc) && \
+    export CXX=$(which g++) && \
     source ${VIRTUAL_ENV}/bin/activate && \
     cd /opt/dynamo && \
     uv build --wheel --out-dir /opt/dynamo/dist && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -241,9 +241,11 @@ ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${ARCH}}" && \
-    export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CUDA_COMPILER_LAUNCHER="sccache" && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
+    fi && \
     cd /usr/local/src && \
      git clone https://github.com/openucx/ucx.git && \
      cd ucx && 			     \
@@ -317,9 +319,11 @@ ARG ENABLE_KVBM
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
-    export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
-    export RUSTC_WRAPPER="sccache" && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
+        export RUSTC_WRAPPER="sccache"; \
+    fi && \
     source ${VIRTUAL_ENV}/bin/activate && \
     cd /opt/dynamo && \
     uv build --wheel --out-dir /opt/dynamo/dist && \
@@ -433,9 +437,11 @@ RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
-    export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
-    export CMAKE_CUDA_COMPILER_LAUNCHER="sccache" && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export CMAKE_C_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
+        export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
+    fi && \
         cp /tmp/deps/vllm/install_vllm.sh /tmp/install_vllm.sh && \
         chmod +x /tmp/install_vllm.sh && \
         /tmp/install_vllm.sh --vllm-ref $VLLM_REF --max-jobs $MAX_JOBS --arch $ARCH --installation-dir /opt ${DEEPGEMM_REF:+--deepgemm-ref "$DEEPGEMM_REF"} ${FLASHINF_REF:+--flashinf-ref "$FLASHINF_REF"} ${LMCACHE_REF:+--lmcache-ref "$LMCACHE_REF"} --cuda-version $CUDA_VERSION && \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -324,6 +324,8 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CXX_COMPILER_LAUNCHER="sccache" && \
         export RUSTC_WRAPPER="sccache"; \
     fi && \
+    export CC=$(which gcc) && \
+    export CXX=$(which g++) && \
     source ${VIRTUAL_ENV}/bin/activate && \
     cd /opt/dynamo && \
     uv build --wheel --out-dir /opt/dynamo/dist && \

--- a/container/build.sh
+++ b/container/build.sh
@@ -552,16 +552,12 @@ fi
 # Add NIXL_REF as a build argument
 BUILD_ARGS+=" --build-arg NIXL_REF=${NIXL_REF} "
 
-# Function to build local-dev image with header
+# Function to build local-dev image
 build_local_dev_with_header() {
     local dev_base_image="$1"
     local tags="$2"
     local success_msg="$3"
     local header_title="$4"
-
-    echo "======================================"
-    echo "$header_title"
-    echo "======================================"
 
     # Get user info right before using it
     USER_UID=${CUSTOM_UID:-$(id -u)}
@@ -575,7 +571,8 @@ build_local_dev_with_header() {
         exit 1
     fi
 
-    echo "Building new local-dev image from: $dev_base_image"
+    echo ""
+    echo "Now building new local-dev image from: $dev_base_image"
     echo "User 'dynamo' will have UID: $USER_UID, GID: $USER_GID"
 
     # Show the docker command being executed if not in dry-run mode
@@ -602,8 +599,8 @@ build_local_dev_with_header() {
     # Show usage instructions
     echo ""
     echo "To run the local-dev image as the local user ($USER_UID/$USER_GID):"
-    # Extract the last tag from the tags string
-    last_tag=$(echo "$tags" | grep -o -- '--tag [^ ]*' | tail -1 | cut -d' ' -f2)
+    # Extract the first tag from the tags string (the full version tag, not the latest tag)
+    last_tag=$(echo "$tags" | grep -o -- '--tag [^ ]*' | head -1 | cut -d' ' -f2)
     # Calculate relative path to run.sh from current working directory
     # Get the directory where build.sh is located
     build_dir="$(dirname "${BASH_SOURCE[0]}")"
@@ -948,7 +945,9 @@ elif [[ "${LOCAL_DEV_BUILD:-}" == "true" ]]; then
         LOCAL_DEV_TAGS+=" --tag ${LATEST_TAG_NAME}-local-dev"
     fi
 
-    build_local_dev_with_header "$DEV_IMAGE" "$LOCAL_DEV_TAGS" "Successfully built local-dev images" "Starting Build 3: Local-Dev Image"
+    # Extract first tag for success message
+    FIRST_TAG=$(echo "$LOCAL_DEV_TAGS" | grep -o -- '--tag [^ ]*' | head -1 | cut -d' ' -f2)
+    build_local_dev_with_header "$DEV_IMAGE" "$LOCAL_DEV_TAGS" "Successfully built $FIRST_TAG" "Building Local-Dev Image"
 fi
 
 


### PR DESCRIPTION
#### Overview:

Fixes build errors caused by sccache compiler launcher variables being set even when sccache is disabled. Adds conditional checks before exporting CMAKE_*_COMPILER_LAUNCHER and RUSTC_WRAPPER across all framework Dockerfiles.

#### Details:

- Add `if [ "$USE_SCCACHE" = "true" ]` conditional before setting compiler launchers in all Dockerfiles (base, sglang, trtllm, vllm)
- Improve build.sh local-dev output formatting and tag selection for run instructions

#### Where should the reviewer start?

Focus on the sccache conditional checks in `container/Dockerfile*` files (lines ~244 and ~320 in framework Dockerfiles). Verify that the conditional logic properly gates the compiler launcher exports.

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Compiler launcher configuration now conditionally applies based on sccache enablement across multiple containers, improving build flexibility.
  * Enhanced local development container with improved user management, including better permission and package handling.

* **Chores**
  * Refined build script output messaging and tag extraction logic for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->