### PR TITLE
feat: add option to use vllm tokenizer

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -68,6 +68,8 @@ class Config:
     mm_prompt_template: str = "USER: <image>\n<prompt> ASSISTANT:"
     # dump config to file
     dump_config_to: Optional[str] = None
+    # tokenizer options
+    use_vllm_tokenizer: bool = False
 
     def has_connector(self, connector_name: str) -> bool:
         """
@@ -201,6 +203,15 @@ def parse_args() -> Config:
         default=os.environ.get("DYN_REQUEST_PLANE", "nats"),
         help="Determines how requests are distributed from routers to workers. 'tcp' is fastest [nats|http|tcp]",
     )
+    parser.add_argument(
+        "--use-vllm-tokenizer",
+        action="store_true",
+        help=(
+            "Use vLLM's built-in tokenizer instead of Dynamo's Rust tokenizer. "
+            "This is required for models that use non-standard tokenizers (e.g., Mistral's tekken tokenizer). "
+            "When enabled, only /v1/chat/completions endpoint will be available."
+        ),
+    )
     add_config_dump_args(parser)
 
     parser = AsyncEngineArgs.add_cli_args(parser)
@@ -303,6 +314,7 @@ def parse_args() -> Config:
     config.mm_prompt_template = args.mm_prompt_template
     config.store_kv = args.store_kv
     config.request_plane = args.request_plane
+    config.use_vllm_tokenizer = args.use_vllm_tokenizer
 
     # Validate custom Jinja template file exists if provided
     if config.custom_jinja_template is not None:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details: Some models like `mistralai/Mistral-Small-3.2-24B-Instruct-2506` use a different tokenizer format (tekken) which is currently not supported. However vllm does support it so while we should add support long term in rust in the short term we should allow users to work around by just using the vllm tokenizer. This PR adds that option.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--use-vllm-tokenizer` CLI flag to optionally use vLLM's tokenizer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->