### PR TITLE
fix: relax pydantic requirements

### DIFF
--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -12,7 +12,7 @@
 
 # For Multimodal EPD (required for device_map="auto" in vision model loading)
 accelerate==1.12.0
-aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@cf4deb94b40b0b27df3837c63c30b784fc30c320
+aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@7f7ad5e248f3eaa4a0b74a069095828a4f356e60
 aiofiles==24.1.0
 aiperf @ git+https://github.com/ai-dynamo/aiperf.git@4d3fa29403c8f75da22a14f1f7b3aeb27db9288f
 av==15.0.0
@@ -39,7 +39,7 @@ prometheus-api-client==0.6.0
 prometheus_client==0.23.1
 prophet==1.2.1
 protobuf==5.29.5
-pydantic>=2.11.4,<2.13  # aiconfigurator 0.4.0 needs ~=2.11.4, vllm==0.11.1 depends on pydantic>=2.12.0
+pydantic>=2.11.4,<2.13  # vllm==0.12.0 depends on pydantic>=2.12.0
 pyright==1.1.407
 PyYAML==6.0.3
 scikit-learn==1.7.2

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -12,7 +12,7 @@
 
 # For Multimodal EPD (required for device_map="auto" in vision model loading)
 accelerate==1.12.0
-aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@5554d2eb8206738c66048bf2d72183e9bcd85759
+aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@cf4deb94b40b0b27df3837c63c30b784fc30c320
 aiofiles==24.1.0
 aiperf @ git+https://github.com/ai-dynamo/aiperf.git@4d3fa29403c8f75da22a14f1f7b3aeb27db9288f
 av==15.0.0

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -39,7 +39,7 @@ prometheus-api-client==0.6.0
 prometheus_client==0.23.1
 prophet==1.2.1
 protobuf==5.29.5
-pydantic>=2.11.4,<2.12  # Required by aiconfigurator==0.4.0
+pydantic>=2.11.4,<2.13  # aiconfigurator 0.4.0 needs ~=2.11.4, vllm==0.11.1 depends on pydantic>=2.12.0
 pyright==1.1.407
 PyYAML==6.0.3
 scikit-learn==1.7.2

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -26,7 +26,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "pydantic>=2.10.6,<=2.11.7",
+    "pydantic>=2.10.6,<=2.13",
     "uvloop>=0.21.0",
 ]
 classifiers = [


### PR DESCRIPTION
#### Overview:

This PR should fix this conflict:
```
Because ai-dynamo-runtime==0.7.0+f49d6873e depends on pydantic>=2.10.6,<=2.11.7 and vllm==0.11.1 depends on pydantic>=2.12.0, we can conclude that ai-dynamo-runtime==0.7.0+f49d6873e and
      vllm==0.11.1 are incompatible.
```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to support a broader compatibility range.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->