### PR TITLE
refactor: simplify, remove --dev-image option from build.sh

### DIFF
--- a/container/README.md
+++ b/container/README.md
@@ -161,23 +161,6 @@ The `build.sh` script is responsible for building Docker images for different AI
 ./build.sh --build-arg CUSTOM_ARG=value
 ```
 
-### build.sh --dev-image - Local Development Image Builder
-
-The `build.sh --dev-image` option takes a dev image and then builds a local-dev image, which contains proper local user permissions. It also includes extra developer utilities (debugging tools, text editors, system monitors, etc.).
-
-**Common Usage Examples:**
-
-```bash
-# Build local-dev image from dev image dynamo:latest-vllm
-./build.sh --dev-image dynamo:latest-vllm --framework vllm
-
-# Build with custom tag from dev image dynamo:latest-vllm
-./build.sh --dev-image dynamo:latest-vllm --framework vllm --tag my-local:dev
-
-# Dry run to see what would be built
-./build.sh --dev-image dynamo:latest-vllm --framework vllm --dry-run
-```
-
 ### Building the Frontend Image
 
 The frontend image is a specialized container that includes the Dynamo components (NATS, etcd, dynamo, NIXL, etc) along with the Endpoint Picker (EPP) for Kubernetes Gateway API Inference Extension integration. This image is primarily used for inference gateway deployments.


### PR DESCRIPTION
#### Overview:

Removes the `--dev-image` input from `build.sh`. The main build now always executes, and `--target local-dev` builds both images in one command.

#### Details:

- Removed `--dev-image` argument parsing, validation, and workflow
- Main docker build always executes (not conditional)
- Simplified `--uid`/`--gid` validation to only work with `--target local-dev`
- Removed `--dev-image` documentation section

#### Where should the reviewer start?

`container/build.sh` - argument parsing and main build flow simplification


/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed --dev-image documentation from build guide

* **Refactor**
  * Removed --dev-image build option support
  * Simplified argument validation: --uid/--gid options now only work with --target local-dev
  * Consolidated build flow with unified handling across all build targets

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->