### PR TITLE
fix: [lora] refactor and clean up tests/examples for lora

### DIFF
--- a/examples/backends/vllm/launch/lora/agg_lora.sh
+++ b/examples/backends/vllm/launch/lora/agg_lora.sh
@@ -13,7 +13,6 @@ export AWS_ALLOW_HTTP=true
 # Dynamo LoRA Configuration
 export DYN_LORA_ENABLED=true
 export DYN_LORA_PATH=/tmp/dynamo_loras_minio
-export DYN_LOG=debug
 
 mkdir -p $DYN_LORA_PATH
 

--- a/examples/backends/vllm/launch/lora/agg_lora.sh
+++ b/examples/backends/vllm/launch/lora/agg_lora.sh
@@ -4,14 +4,6 @@
 set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
-# Follow the README.md instructions to setup MinIO or upload the LoRA to s3/minio
-# Adjust these values to match your local MinIO or S3 setup
-
-
-# load math lora to minio
-# LORA_NAME=Neural-Hacker/Qwen3-Math-Reasoning-LoRA HF_LORA_REPO=Neural-Hacker/Qwen3-Math-Reasoning-LoRA ./setup_minio.sh
-
-
 export AWS_ENDPOINT=http://localhost:9000
 export AWS_ACCESS_KEY_ID=minioadmin
 export AWS_SECRET_ACCESS_KEY=minioadmin
@@ -22,7 +14,6 @@ export AWS_ALLOW_HTTP=true
 export DYN_LORA_ENABLED=true
 export DYN_LORA_PATH=/tmp/dynamo_loras_minio
 export DYN_LOG=debug
-# export DYN_LOG_LEVEL=debug
 
 mkdir -p $DYN_LORA_PATH
 
@@ -63,7 +54,7 @@ curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen3-0.6B",
-    "messages": [{"role": "user", "content": "Solve (x*x - x + 1 = 0) for x"}],
+    "messages": [{"role": "user", "content": "What is deep learning?"}],
     "max_tokens": 300,
     "temperature": 0.0
   }'

--- a/examples/backends/vllm/launch/lora/agg_lora_router.sh
+++ b/examples/backends/vllm/launch/lora/agg_lora_router.sh
@@ -4,12 +4,6 @@
 set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
-# Follow the README.md instructions to setup MinIO or upload the LoRA to s3/minio
-# Adjust these values to match your local MinIO or S3 setup
-
-# load math lora to minio
-# LORA_NAME=Neural-Hacker/Qwen3-Math-Reasoning-LoRA HF_LORA_REPO=Neural-Hacker/Qwen3-Math-Reasoning-LoRA ./setup_minio.sh
-
 export AWS_ENDPOINT=http://localhost:9000
 export AWS_ACCESS_KEY_ID=minioadmin
 export AWS_SECRET_ACCESS_KEY=minioadmin
@@ -118,7 +112,7 @@ curl localhost:8000/v1/chat/completions \
     "total_tokens": 226,
     "prompt_tokens_details": {
       "audio_tokens": null,
-      "cached_tokens": 192
+      "cached_tokens": 192              # tokens that were cached from the previous request.
     }
   },
   "nvext": {

--- a/examples/backends/vllm/launch/lora/agg_lora_router.sh
+++ b/examples/backends/vllm/launch/lora/agg_lora_router.sh
@@ -13,8 +13,6 @@ export AWS_ALLOW_HTTP=true
 # Dynamo LoRA Configuration
 export DYN_LORA_ENABLED=true
 export DYN_LORA_PATH=/tmp/dynamo_loras_minio
-export DYN_LOG=debug
-# export DYN_LOG_LEVEL=debug
 
 mkdir -p $DYN_LORA_PATH
 

--- a/tests/serve/conftest.py
+++ b/tests/serve/conftest.py
@@ -86,8 +86,8 @@ def minio_lora_service():
         local_path = service.download_lora()
         service.upload_lora(local_path)
 
-        # Clean up downloaded files (keep MinIO running)
-        service.cleanup_temp()
+        # Clean up downloaded files (keep MinIO data intact)
+        service.cleanup_download()
 
         yield config
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -275,8 +275,6 @@ class LoraTestChatPayload(ChatPayload):
     def _ensure_lora_loaded(self) -> None:
         """Ensure the LoRA adapter is loaded before making inference requests"""
         if not self._lora_loaded:
-            import time
-
             import requests
 
             # Import the load_lora_adapter function
@@ -293,13 +291,12 @@ class LoraTestChatPayload(ChatPayload):
             # Wait for the LoRA model to appear in /v1/models
             models_url = f"http://{self.host}:{self.port}/v1/models"
             start_time = time.time()
-            max_wait = 60  # 1 minute timeout
 
             logger.info(
                 f"Waiting for LoRA model '{self.lora_name}' to appear in /v1/models..."
             )
 
-            while time.time() - start_time < max_wait:
+            while time.time() - start_time < self.timeout:
                 try:
                     response = requests.get(models_url, timeout=5)
                     if response.status_code == 200:
@@ -323,7 +320,7 @@ class LoraTestChatPayload(ChatPayload):
                 time.sleep(1)
 
             raise RuntimeError(
-                f"Timeout: LoRA model '{self.lora_name}' did not appear in /v1/models within {max_wait}s"
+                f"Timeout: LoRA model '{self.lora_name}' did not appear in /v1/models within {self.timeout}s"
             )
 
     def url(self) -> str:

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -21,6 +21,8 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
+import requests
+
 from dynamo import prometheus_names  # type: ignore[attr-defined]
 
 logger = logging.getLogger(__name__)
@@ -275,8 +277,6 @@ class LoraTestChatPayload(ChatPayload):
     def _ensure_lora_loaded(self) -> None:
         """Ensure the LoRA adapter is loaded before making inference requests"""
         if not self._lora_loaded:
-            import requests
-
             # Import the load_lora_adapter function
             # Note: This import is done here to avoid circular dependencies
             from tests.serve.lora_utils import load_lora_adapter

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -241,6 +241,98 @@ class ToolCallingChatPayload(ChatPayload):
 
 
 @dataclass
+class LoraTestChatPayload(ChatPayload):
+    """
+    Chat payload that loads a LoRA adapter before sending inference requests.
+
+    This payload first loads the specified LoRA adapter via the system API,
+    then sends chat completion requests using the LoRA model.
+    """
+
+    def __init__(
+        self,
+        body: dict,
+        lora_name: str,
+        s3_uri: str,
+        system_port: int = 8081,
+        repeat_count: int = 1,
+        expected_response: Optional[list] = None,
+        expected_log: Optional[list] = None,
+        timeout: int = 60,
+    ):
+        super().__init__(
+            body=body,
+            repeat_count=repeat_count,
+            expected_response=expected_response or [],
+            expected_log=expected_log or [],
+            timeout=timeout,
+        )
+        self.system_port = system_port
+        self.lora_name = lora_name
+        self.s3_uri = s3_uri
+        self._lora_loaded = False
+
+    def _ensure_lora_loaded(self) -> None:
+        """Ensure the LoRA adapter is loaded before making inference requests"""
+        if not self._lora_loaded:
+            import time
+
+            import requests
+
+            # Import the load_lora_adapter function
+            # Note: This import is done here to avoid circular dependencies
+            from tests.serve.lora_utils import load_lora_adapter
+
+            load_lora_adapter(
+                system_port=self.system_port,
+                lora_name=self.lora_name,
+                s3_uri=self.s3_uri,
+                timeout=self.timeout,
+            )
+
+            # Wait for the LoRA model to appear in /v1/models
+            models_url = f"http://{self.host}:{self.port}/v1/models"
+            start_time = time.time()
+            max_wait = 60  # 1 minute timeout
+
+            logger.info(
+                f"Waiting for LoRA model '{self.lora_name}' to appear in /v1/models..."
+            )
+
+            while time.time() - start_time < max_wait:
+                try:
+                    response = requests.get(models_url, timeout=5)
+                    if response.status_code == 200:
+                        data = response.json()
+                        models = data.get("data", [])
+                        model_ids = [m.get("id", "") for m in models]
+
+                        if self.lora_name in model_ids:
+                            logger.info(
+                                f"LoRA model '{self.lora_name}' is now available"
+                            )
+                            self._lora_loaded = True
+                            return
+
+                        logger.debug(
+                            f"Available models: {model_ids}, waiting for '{self.lora_name}'..."
+                        )
+                except requests.RequestException as e:
+                    logger.debug(f"Error checking /v1/models: {e}")
+
+                time.sleep(1)
+
+            raise RuntimeError(
+                f"Timeout: LoRA model '{self.lora_name}' did not appear in /v1/models within {max_wait}s"
+            )
+
+    def url(self) -> str:
+        """Load LoRA before first request, then return URL"""
+        self._ensure_lora_loaded()
+        return super().url()
+
+
+@dataclass
 class CompletionPayload(BasePayload):
     """Payload for completions endpoint."""
 


### PR DESCRIPTION
#### Overview:

1. test refactor: move LoraTestChatPayload to tests/utils/payloads
2. test clean up: remove minio data after tests
3. clean up examples

- closes DEP-692


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Examples**
  * Cleaned up setup comments and removed commented logging hints; updated a sample prompt from a math query to a general "What is deep learning?" example.

* **Tests**
  * Streamlined LoRA-related test flow and payloads; added a dedicated test payload that ensures adapters are loaded before requests.
  * Adjusted test cleanup to better target downloaded artifacts.

* **Refactor**
  * Consolidated temporary download handling and unified cleanup routines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->