### PR TITLE
Ace/value error handling

### DIFF
--- a/lib/llm/src/audit/stream.rs
+++ b/lib/llm/src/audit/stream.rs
@@ -64,7 +64,7 @@ where
                                 let _ = tx.send(final_resp);
                             }
                             Err(e) => {
-                                tracing::warn!("audit: aggregation failed: {e}");
+                                tracing::warn!("audit: aggregation failed: {:?}", e);
                             }
                         }
                     });
@@ -123,7 +123,7 @@ where
                 final_response_to_one_chunk_stream(final_resp)
             }
             Err(e) => {
-                tracing::warn!("fold aggregation failed: {e}");
+                tracing::warn!("fold aggregation failed: {:?}", e);
                 let fallback = NvCreateChatCompletionResponse {
                     id: String::new(),
                     created: 0,
@@ -237,6 +237,7 @@ pub fn final_response_to_one_chunk_stream(
         id: None,
         event: None,
         comment: None,
+        error_code: None,
     };
     Box::pin(futures::stream::once(async move { annotated }))
 }

--- a/lib/llm/src/engines.rs
+++ b/lib/llm/src/engines.rs
@@ -160,12 +160,12 @@ impl
                 // we are returning characters not tokens, so there will be some postprocessing overhead
                 tokio::time::sleep(*TOKEN_ECHO_DELAY).await;
                 let response = deltas.create_choice(0, Some(c.to_string()), None, None);
-                yield Annotated{ id: Some(id.to_string()), data: Some(response), event: None, comment: None };
+                yield Annotated{ id: Some(id.to_string()), data: Some(response), event: None, comment: None, error_code: None };
                 id += 1;
             }
 
             let response = deltas.create_choice(0, None, Some(dynamo_async_openai::types::FinishReason::Stop), None);
-            yield Annotated { id: Some(id.to_string()), data: Some(response), event: None, comment: None };
+            yield Annotated { id: Some(id.to_string()), data: Some(response), event: None, comment: None, error_code: None };
         };
 
         Ok(ResponseStream::new(Box::pin(output), ctx))
@@ -193,11 +193,11 @@ impl
             for c in chars_string.chars() {
                 tokio::time::sleep(*TOKEN_ECHO_DELAY).await;
                 let response = deltas.create_choice(0, Some(c.to_string()), None, None);
-                yield Annotated{ id: Some(id.to_string()), data: Some(response), event: None, comment: None };
+                yield Annotated{ id: Some(id.to_string()), data: Some(response), event: None, comment: None, error_code: None };
                 id += 1;
             }
             let response = deltas.create_choice(0, None, Some(dynamo_async_openai::types::CompletionFinishReason::Stop), None);
-            yield Annotated { id: Some(id.to_string()), data: Some(response), event: None, comment: None };
+            yield Annotated { id: Some(id.to_string()), data: Some(response), event: None, comment: None, error_code: None };
 
         };
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1001,22 +1001,22 @@ async fn chat_completions(
         let response =
             NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
                 .await
-                .map_err(|e| {
+                .map_err(|(code, msg)| {
                     tracing::error!(
                         request_id,
                         "Failed to fold chat completions stream for: {:?}",
-                        e
+                        msg
                     );
-                    // Return 400 Bad Request for Python ValueError exceptions
-                    if e.contains("ValueError") {
+                    // Use the error code if provided, otherwise default to 500
+                    if let Some(code) = code {
                         ErrorMessage::from_http_error(HttpError {
-                            code: 400,
-                            message: format!("Failed to fold chat completions stream: {}", e),
+                            code,
+                            message: format!("Failed to fold chat completions stream: {}", msg),
                         })
                     } else {
                         ErrorMessage::internal_server_error(&format!(
                             "Failed to fold chat completions stream: {}",
-                            e
+                            msg
                         ))
                     }
                 })?;
@@ -1234,22 +1234,22 @@ async fn responses(
     let response =
         NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
             .await
-            .map_err(|e| {
+            .map_err(|(code, msg)| {
                 tracing::error!(
                     request_id,
                     "Failed to fold chat completions stream for: {:?}",
-                    e
+                    msg
                 );
-                // Return 400 Bad Request for Python ValueError exceptions
-                if e.contains("ValueError") {
+                // Use the error code if provided, otherwise default to 500
+                if let Some(code) = code {
                     ErrorMessage::from_http_error(HttpError {
-                        code: 400,
-                        message: format!("Failed to fold chat completions stream: {}", e),
+                        code,
+                        message: format!("Failed to fold chat completions stream: {}", msg),
                     })
                 } else {
                     ErrorMessage::internal_server_error(&format!(
                         "Failed to fold chat completions stream: {}",
-                        e
+                        msg
                     ))
                 }
             })?;

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -708,6 +708,7 @@ impl OpenAIPreprocessor {
                             data,
                             event: Some(ANNOTATION_LLM_METRICS.to_string()),
                             comment: annotation.comment,
+                            error_code: None,
                         };
 
                         tracing::trace!(

--- a/lib/llm/src/protocols/codec.rs
+++ b/lib/llm/src/protocols/codec.rs
@@ -108,6 +108,7 @@ where
             id: value.id,
             event: value.event,
             comment: value.comments,
+            error_code: None,
         })
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -680,6 +680,7 @@ impl JailedStream {
                     id,
                     event,
                     comment,
+                    error_code: None,
                 }]
             }
             EmissionMode::SingleChoicePerChunk => {
@@ -695,6 +696,7 @@ impl JailedStream {
                             id: id.clone(),
                             event: event.clone(),
                             comment: comment.clone(),
+                            error_code: None,
                         }
                     })
                     .collect()

--- a/lib/llm/src/protocols/openai/embeddings/aggregator.rs
+++ b/lib/llm/src/protocols/openai/embeddings/aggregator.rs
@@ -18,7 +18,7 @@ pub struct DeltaAggregator {
     /// The accumulated embeddings response.
     response: Option<NvCreateEmbeddingResponse>,
     /// Optional error message if an error occurs during aggregation.
-    error: Option<String>,
+    error: Option<(Option<u16>, String)>,
 }
 
 impl Default for DeltaAggregator {
@@ -54,8 +54,8 @@ impl DeltaAggregator {
                 // Attempt to unwrap the delta, capturing any errors.
                 let delta = match delta.ok() {
                     Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
+                    Err((code, error)) => {
+                        aggregator.error = Some((code, error));
                         return aggregator;
                     }
                 };
@@ -85,7 +85,7 @@ impl DeltaAggregator {
             .await;
 
         // Return early if an error was encountered.
-        if let Some(error) = aggregator.error {
+        if let Some((_code, error)) = aggregator.error {
             return Err(error);
         }
 


### PR DESCRIPTION
#### Overview:

Add ValueError handling
Propagate 400 error code when python generator raise ValueError

#### Details:

Python async generator might perform some validations and raises exception such as ValueError. Dynamo receives the exception and response 500 error. 
This PR add logic to catch ValueError from python generator and propagate 400 error to the response.

Logic for grpc hasn't been implemented yet.

#### Where should the reviewer start?

**lib/bindings/python/rust/engine.rs**:
- [lines: 131-133](https://github.com/ai-dynamo/dynamo/pull/4890/files#diff-7e44c5fad880f0b42dc6ff0a0e4cd73d2301aadebad7e21e02b77c6d4079690fR131-R133) Add ValueError into ResponseProcessingError
- [lines: 257-265](https://github.com/ai-dynamo/dynamo/pull/4890/files#diff-7e44c5fad880f0b42dc6ff0a0e4cd73d2301aadebad7e21e02b77c6d4079690fR257-R265): assign code 400 if exception is ValueError

**lib/llm/src/http/service/openai.rs**: error code propagation

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
