### PR TITLE
feat: De-tokenize in the worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,7 +2663,7 @@ dependencies = [
  "bytes",
  "candle-core 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
- "clap 4.5.52",
+ "clap 4.5.53",
  "criterion 0.3.6",
  "cudarc",
  "dashmap 5.5.3",
@@ -4065,8 +4065,8 @@ checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs",
  "futures",
- "indicatif 0.17.11",
  "http 1.4.0",
+ "indicatif 0.17.11",
  "libc",
  "log",
  "num_cpus",

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -776,8 +776,6 @@ impl Endpoint {
 
         let ingress = match &self.model_card.lock().take() {
             Some(card) => {
-                tracing::debug!("+++ New way");
-
                 // JSON in and out, to communicate with Python
                 let json_in_out = SegmentSource::<
                     SingleIn<serde_json::Value>,
@@ -797,10 +795,7 @@ impl Endpoint {
                     .map_err(to_pyerr)?;
                 JsonServerStreamingIngress::for_pipeline(pipeline).map_err(to_pyerr)?
             }
-            None => {
-                tracing::debug!("--- Old way");
-                JsonServerStreamingIngress::for_engine(engine.clone()).map_err(to_pyerr)?
-            }
+            None => JsonServerStreamingIngress::for_engine(engine.clone()).map_err(to_pyerr)?,
         };
 
         // Convert Python dict to serde_json::Value if provided and validate it's an object

--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -128,8 +128,6 @@ impl
     ) -> Result<ManyOut<Annotated<serde_json::Value>>> {
         let context = request.context();
         let typed_request = request.try_map(serde_json::from_value::<PreprocessedRequest>)?;
-        //let typed_request: PreprocessedRequest = serde_json::from_value(request.content().clone())?;
-        // self.generate(typed_request, next).await?;
         let typed_stream = <Backend as Operator<
             SingleIn<PreprocessedRequest>,
             ManyOut<Annotated<BackendOutput>>,

--- a/lib/llm/src/entrypoint/input.rs
+++ b/lib/llm/src/entrypoint/input.rs
@@ -140,7 +140,7 @@ pub async fn run_input(
             batch::run(drt, path, engine_config).await?;
         }
         Input::Endpoint(path) => {
-            endpoint::run(drt, path, engine_config).await?;
+            endpoint::run(drt, path, engine_config, None).await?;
         }
     }
     Ok(())

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -426,6 +426,7 @@ impl LocalModel {
 
     /// Attach this model to the endpoint. This registers it on the network
     /// allowing ingress to discover it.
+    /// Returns the ModelDeploymentCard we registered.
     ///
     /// For base models, pass `lora_name = None`.
     /// For LoRA adapters, pass `lora_name = Some("adapter-name")`.
@@ -435,7 +436,7 @@ impl LocalModel {
         model_type: ModelType,
         model_input: ModelInput,
         lora_name: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<ModelDeploymentCard> {
         self.card.model_type = model_type;
         self.card.model_input = model_input;
 
@@ -467,7 +468,7 @@ impl LocalModel {
         )?;
         let _instance = discovery.register(spec).await?;
 
-        Ok(())
+        Ok(self.card.clone())
     }
 
     /// Helper associated function to detach a model from an endpoint

--- a/lib/runtime/src/pipeline/context.rs
+++ b/lib/runtime/src/pipeline/context.rs
@@ -12,7 +12,7 @@ use super::registry::Registry;
 
 pub struct Context<T: Data> {
     current: T,
-    controller: Arc<Controller>, //todo: hold this as an arc
+    controller: Arc<Controller>,
     registry: Registry,
     stages: Vec<String>,
 }

--- a/lib/runtime/src/pipeline/nodes/sources/base.rs
+++ b/lib/runtime/src/pipeline/nodes/sources/base.rs
@@ -61,7 +61,7 @@ impl<In: PipelineIO + Sync, Out: PipelineIO> AsyncEngine<In, Out, Error> for Fro
         let (tx, rx) = oneshot::channel::<Out>();
         {
             let mut sinks = self.sinks.lock().unwrap();
-            sinks.insert(request.id().to_string(), tx);
+            sinks.insert(request.id(), tx);
         }
         self.on_next(request, private::Token {}).await?;
         Ok(rx.await.map_err(|_| PipelineError::DetachedStreamSender)?)

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -961,7 +961,7 @@ mod integration_tests {
 
                 // Now create a namespace, component, and endpoint to make the system healthy
                 let namespace = drt.namespace("ns1234").unwrap();
-                let mut component = namespace.component("comp1234").unwrap();
+                let component = namespace.component("comp1234").unwrap();
 
                 // Create a simple test handler
                 use crate::pipeline::{async_trait, network::Ingress, AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, SingleIn};


### PR DESCRIPTION
Add a `Backend` layer to the pipeline on the worker side. This handles de-tokenization.

Note that this only adds it for the python engines. The Rust engines (mocker and dynamo-run) already did this.

`register_llm` now saves the `ModelDeploymentCard` (MDC) that we registered in the bindings `Endpoint`. It is retrieved by `serve_endpoint` and used to get the tokenizer to build the pipeline. Ideally the MDC would be on the main Rust `Endpoint`, but that is in lib/runtime so it doesn't know about LLMs.

This PRs leaves `Backend` in the frontend. It already detects if the request is de-tokenized and short-circuits, so this doesn't slow us down. In a later PR we can remove that. It involves changes to the router,

Also removed some noisy Discovery debug statements.

De-tokenization is one of the most expensive operations we do in the frontend, and there are usually many more worker machines than frontends, so move de-tokenization to the worker CPUs. As the `Backend` name implies it was originally designed to work like this, just took us some time to get there.

Design: https://github.com/ai-dynamo/enhancements/pull/50/files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model card storage and retrieval support for endpoints
  * Introduced JSON-based communication pipeline support for enhanced flexibility
  * Added metrics labels configuration capability for endpoint monitoring

* **Improvements**
  * Changed startup sequence to register models before serving endpoints, improving initialization reliability
  * Removed unnecessary debug logging for cleaner operational output

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->