### PR TITLE
fix: remove small --gpu-memory-utilization to avoid OOM due to vllm upgrade

### DIFF
--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -40,8 +40,6 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-8B
-            - --gpu-memory-utilization
-            - "0.45"
             - --max-model-len
             - "32000"
             - --enforce-eager

--- a/examples/backends/vllm/deploy/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm.yaml
@@ -33,8 +33,6 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-8B
-            - --gpu-memory-utilization
-            - "0.3"
             - --max-model-len
             - "32000"
             - --enforce-eager
@@ -65,8 +63,6 @@ spec:
             - --model
             - Qwen/Qwen3-8B
             - --is-prefill-worker
-            - --gpu-memory-utilization
-            - "0.3"
             - --max-model-len
             - "32000"
             - --enforce-eager

--- a/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
@@ -33,8 +33,6 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-8B
-            - --gpu-memory-utilization
-            - "0.3"
             - --max-model-len
             - "32000"
             - --enforce-eager
@@ -65,8 +63,6 @@ spec:
             - --model
             - Qwen/Qwen3-8B
             - --is-prefill-worker
-            - --gpu-memory-utilization
-            - "0.3"
             - --max-model-len
             - "32000"
             - --enforce-eager


### PR DESCRIPTION
#### Overview:

Due to vLLM version upgrade, to serve the same model, it would take more VRAM. Removing --gpu-memory-utilization, which was set due to benchmarking purpose, to avoid OOM in the long run.

closes [DIS-1170](https://linear.app/nvidia/issue/DIS-1170/dynamorelease071vllmkvbm-disagg-kvbm-fails-in-071-torch-peak-memory)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vLLM deployment configuration examples by removing GPU memory utilization parameters from worker configurations across multiple deployment scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->