### PR TITLE
fix: Don't set min_tokens when ignore_eos is true

### DIFF
--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -254,7 +254,6 @@ pub struct StopConditions {
 impl StopConditions {
     pub fn apply_ignore_eos(&mut self) {
         if self.ignore_eos.unwrap_or(false) {
-            self.min_tokens = self.max_tokens;
             self.stop = None;
             self.stop_token_ids_hidden = None;
         }


### PR DESCRIPTION
## Summary
Cherry-pick of #4872 to release/0.7.1

- Fixes token constraint handling when ignoring end-of-sequence markers
- Removes setting `min_tokens` when `ignore_eos` is true, allowing independent configuration

## Original PR
https://github.com/ai-dynamo/dynamo/pull/4872

## Cherry-pick of
Merge commit: 664b458ac5bf2241223746210c13c97739bea211