### PR TITLE
fix: prefill discovery

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -141,6 +141,7 @@ impl ModelManager {
     pub fn has_model_any(&self, model: &str) -> bool {
         self.chat_completion_engines.read().contains(model)
             || self.completion_engines.read().contains(model)
+            || self.prefill_engines.read().contains(model)
     }
 
     pub fn model_display_names(&self) -> HashSet<String> {


### PR DESCRIPTION
#### Overview:

Added `prefill_engines` to `has_model_any()` so that duplicate prefill worker registrations are properly skipped instead of erroring when no decode worker has registered first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model availability detection to comprehensively check all engine types, ensuring more accurate model status reporting across the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->