### PR TITLE
feat: graceful exit leading to 500 and connection errors - liveness-return-false if-cancelled

### DIFF
--- a/lib/llm/src/http/service/health.rs
+++ b/lib/llm/src/http/service/health.rs
@@ -38,8 +38,19 @@ pub fn live_check_router(
 }
 
 async fn live_handler(
-    axum::extract::State(_state): axum::extract::State<Arc<service_v2::State>>,
+    axum::extract::State(state): axum::extract::State<Arc<service_v2::State>>,
 ) -> impl IntoResponse {
+    // Check if the http service is being cancelled/shutdown
+    if state.is_cancelled() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "status": "shutting_down",
+                "message": "Service is shutting down"
+            })),
+        );
+    }
+
     (
         StatusCode::OK,
         Json(json!({

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -225,6 +225,9 @@ pub mod llm {
     /// HTTP body size limit in MB
     pub const DYN_HTTP_BODY_LIMIT_MB: &str = "DYN_HTTP_BODY_LIMIT_MB";
 
+    pub const DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS: &str =
+        "DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS";
+
     /// Enable LoRA adapter support (set to "true" to enable)
     pub const DYN_LORA_ENABLED: &str = "DYN_LORA_ENABLED";
 


### PR DESCRIPTION
Signed-off-by: michaelfeil <me@michaelfeil.eu>

#### Overview:

Imagine the following problem:
- something internally performs runtime.shutdown()
- e.g. ctrl+c event
- requests should be drained now. 
- /ready or /live route stilly returns ready until the last millisecond.

This pattern of a hard cut off is not a good preStop technique.

Best:
- receive cancellation
- leave http server up for a couple of seconds. Respond to /live probes as false, so you are starting to signal k8s that you are not ready.
- close http server, exclusivy drain the  http requests
- once all requests are drained complete the graceful exit



<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Health check endpoint now returns 503 SERVICE_UNAVAILABLE during service shutdown to enable proper traffic routing.
  * Added 5-second grace period after shutdown signal to allow in-flight requests to complete before full service termination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->