### PR TITLE
chore: add test for diverging prefixes

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1953,7 +1953,7 @@ def _test_router_decisions(
             f"but found {len(keys_with_events_dp)} with events: {keys_with_events_dp}"
         )
 
-        # Verify: The routing key with events should have exactly 8 events (one unique per block)
+        # Verify: The routing key with events should have exactly 8 events (one per unique block)
         active_key_dp = keys_with_events_dp[0]
         num_events = len(events_by_key_dp[active_key_dp])
 
@@ -2000,12 +2000,12 @@ def _test_router_decisions(
             f"but found {len(keys_with_events_single)} with events: {keys_with_events_single}"
         )
 
-        # Verify: The routing key with events should have exactly 4 events (one per request)
+        # Verify: The routing key with events should have exactly 8 events (one per unique block)
         active_worker_id = keys_with_events_single[0]
         num_events = len(events_by_key_single[active_worker_id])
 
-        assert num_events == 4, (
-            f"Expected worker_id {active_worker_id} to have exactly 4 events, "
+        assert num_events == 8, (
+            f"Expected worker_id {active_worker_id} to have exactly 8 events, "
             f"but found {num_events} events"
         )
 

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1852,23 +1852,11 @@ def _test_router_decisions(
         # Send 3 requests with some shared prefixes and some divergent prefixes
         response_worker_ids: list[dict[str, Optional[int]]] = []
 
-<<<<<<< HEAD
-        for i in range(4):
-            # Add `block_size` new random tokens
-            new_tokens = [random.randint(1, 10000) for _ in range(block_size)]
-            cumulative_tokens.extend(new_tokens)
-||||||| parent of eef1dd3d6 (chore: add test for diverging prefixes)
-        for i in range(4):
-            # Add BLOCK_SIZE new random tokens
-            new_tokens = [random.randint(1, 10000) for _ in range(BLOCK_SIZE)]
-            cumulative_tokens.extend(new_tokens)
-=======
         num_blocks = 8
         blocks = [
-            [random.randint(1, 10000) for _ in range(BLOCK_SIZE)]
+            [random.randint(1, 10000) for _ in range(block_size)]
             for _ in range(num_blocks)
         ]
->>>>>>> eef1dd3d6 (chore: add test for diverging prefixes)
 
         requests = [
             blocks[0] + blocks[1] + blocks[2] + blocks[3],

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1953,12 +1953,12 @@ def _test_router_decisions(
             f"but found {len(keys_with_events_dp)} with events: {keys_with_events_dp}"
         )
 
-        # Verify: The routing key with events should have exactly 4 events (one per request)
+        # Verify: The routing key with events should have exactly 8 events (one unique per block)
         active_key_dp = keys_with_events_dp[0]
         num_events = len(events_by_key_dp[active_key_dp])
 
-        assert num_events == 4, (
-            f"Expected (worker_id, dp_rank) {active_key_dp} to have exactly 4 events, "
+        assert num_events == 8, (
+            f"Expected (worker_id, dp_rank) {active_key_dp} to have exactly 8 events, "
             f"but found {num_events} events"
         )
 

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -333,6 +333,8 @@ def test_sglang_kv_router_basic(
 
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.skip(reason="Broken by sglang changes")
+# TODO: Re-enable this test once https://github.com/sgl-project/sglang/pull/14934 is merged
 def test_router_decisions_sglang_multiple_workers(
     request, runtime_services, predownload_models, set_ucx_tls_no_mm
 ):


### PR DESCRIPTION
#### Overview:

Modify the common `_test_router_decisions` to cover a wider scenario of cases.

Previously, it tested:
1. [A]
2. [A,B]
3. [A,B,C]
4. [A,B,C,D]

And now, it tests:

1. Request 1: [A, B, C, D] → Forces to Worker 1, caches 4 blocks
2. Request 2: [A, B, E, F] → Shares [A, B] prefix, diverges from Request 1
3. Request 3: [A, B, C, D, G, H] → Should route to Worker 1 (has [A, B, C, D] cached)
    
This helps catch issues related to radix tree node-splitting.

This new test will fail until the below sglang PR is merged and brought into dynamo

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Depends on https://github.com/sgl-project/sglang/pull/14934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for router request handling validation, restructuring test scenarios to verify routing behavior with refined token sequence patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->