### PR TITLE
fix: Don't set min_tokens when ignore_eos is true (#4872)

### DIFF
--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -254,7 +254,6 @@ pub struct StopConditions {
 impl StopConditions {
     pub fn apply_ignore_eos(&mut self) {
         if self.ignore_eos.unwrap_or(false) {
-            self.min_tokens = self.max_tokens;
             self.stop = None;
             self.stop_token_ids_hidden = None;
         }


### PR DESCRIPTION
## Cherry-pick: fix: Don't set min_tokens when ignore_eos is true

### Description

Cherry-pick of #4872 to `release/0.7.0.post2`

**Original PR:** https://github.com/ai-dynamo/dynamo/pull/4872
**Merge commit:** `664b458ac`

This fix addresses an issue where the `min_tokens` parameter was being set even when `ignore_eos` was true. The fix ensures that `min_tokens` is not set in such cases, preventing potential conflicts or unintended behavior.

### Changes

- Removed setting `min_tokens` when `ignore_eos` is true in `lib/llm/src/protocols/common.rs`

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- Original PR was tested and merged to main

### Checklist

- [x] Cherry-picked from main (merge commit: `664b458ac`)
- [x] DCO sign-off included
- [x] No conflicts during cherry-pick

