### PR TITLE
fix: preserve original model path for frontend config downloads

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -162,6 +162,11 @@ impl GenerationConfig {
     }
 }
 
+/// Check if our model only has config fields for a Mistral-format model.
+fn is_exclusively_mistral_model(directory: &Path) -> bool {
+    !directory.join("config.json").exists() && directory.join("params.json").exists()
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, Builder, Default)]
 pub struct ModelDeploymentCard {
     /// Human readable model name, e.g. "Meta Llama 3.1 8B Instruct"
@@ -359,7 +364,9 @@ impl ModelDeploymentCard {
                     .with_context(|| p.display().to_string())
             }
             None => {
-                anyhow::bail!("Blank ModelDeploymentCard does not have a tokenizer");
+                anyhow::bail!(
+                    "Blank ModelDeploymentCard does not have a tokenizer. Is this a mistral model? If so, the `--use-<framework>-tokenizer` flag in the engine command is required."
+                );
             }
         }
     }
@@ -508,8 +515,23 @@ impl ModelDeploymentCard {
                 // If neither of those are present let the engine default it
                 .unwrap_or(0);
 
+        let is_mistral_model = is_exclusively_mistral_model(local_path);
+
+        let (model_info, tokenizer, gen_config, prompt_formatter) = if !is_mistral_model {
+            (
+                Some(ModelInfoType::from_disk(local_path)?),
+                Some(TokenizerKind::from_disk(local_path)?),
+                GenerationConfig::from_disk(local_path).ok(),
+                PromptFormatterArtifact::from_disk(local_path)?,
+            )
+        } else {
+            (None, None, None, None)
+        };
+
         // Load chat template - either custom or from repo
-        let chat_template_file = if let Some(template_path) = custom_template_path {
+        let chat_template_file = if is_mistral_model {
+            None
+        } else if let Some(template_path) = custom_template_path {
             if !template_path.exists() {
                 anyhow::bail!(
                     "Custom template file does not exist: {}",
@@ -541,10 +563,10 @@ impl ModelDeploymentCard {
             slug: Slug::from_string(&display_name),
             display_name,
             source_model,
-            model_info: Some(ModelInfoType::from_disk(local_path)?),
-            tokenizer: Some(TokenizerKind::from_disk(local_path)?),
-            gen_config: GenerationConfig::from_disk(local_path).ok(), // optional
-            prompt_formatter: PromptFormatterArtifact::from_disk(local_path)?,
+            model_info,
+            tokenizer,
+            gen_config,
+            prompt_formatter,
             chat_template_file,
             prompt_context: None, // TODO - auto-detect prompt context
             context_length,

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -167,6 +167,13 @@ pub struct ModelDeploymentCard {
     /// Human readable model name, e.g. "Meta Llama 3.1 8B Instruct"
     pub display_name: String,
 
+    /// Original model source path used for downloading (e.g., HuggingFace repo ID).
+    /// This is preserved separately from display_name which may be customized via
+    /// --served-model-name. Used by download_config() to fetch model files.
+    /// See: https://github.com/ai-dynamo/dynamo/issues/4748
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_model: Option<String>,
+
     // Cache the Slugified display_name so we can share references to it
     slug: Slug,
 
@@ -395,7 +402,11 @@ impl ModelDeploymentCard {
         }
 
         let ignore_weights = true;
-        let local_path = crate::hub::from_hf(&self.display_name, ignore_weights).await?;
+        // Use source_model for downloading if available, otherwise fall back to display_name.
+        // source_model preserves the original HF repo ID even when display_name is customized
+        // via --served-model-name. See: https://github.com/ai-dynamo/dynamo/issues/4748
+        let model_for_download = self.source_model.as_deref().unwrap_or(&self.display_name);
+        let local_path = crate::hub::from_hf(model_for_download, ignore_weights).await?;
 
         self.update_dir(&local_path);
         Ok(())
@@ -522,9 +533,14 @@ impl ModelDeploymentCard {
         };
 
         let display_name = local_path.display().to_string();
+        // Preserve the original model path for downloading purposes.
+        // This is crucial when display_name is later overwritten with --served-model-name.
+        // See: https://github.com/ai-dynamo/dynamo/issues/4748
+        let source_model = Some(display_name.clone());
         Ok(Self {
             slug: Slug::from_string(&display_name),
             display_name,
+            source_model,
             model_info: Some(ModelInfoType::from_disk(local_path)?),
             tokenizer: Some(TokenizerKind::from_disk(local_path)?),
             gen_config: GenerationConfig::from_disk(local_path).ok(), // optional


### PR DESCRIPTION
## Summary

This PR fixes the frontend model download bug where the frontend pod incorrectly attempts to download models from HuggingFace using the `--served-model-name` argument value instead of the `--model` argument value.

### Changes

- Added `source_model` field to `ModelDeploymentCard` struct to preserve the original HuggingFace model repository path
- Updated `download_config()` to use `source_model` when available, with fallback to `display_name` for backwards compatibility
- Set `source_model` during MDC creation in `from_repo_checkout()`

### Root Cause

When deploying with `--model nvidia/Cosmos-Reason1-7B --served-model-name cosmos-reason1-7b`:
1. Backend creates MDC with `display_name` set to "cosmos-reason1-7b" (the served name)
2. Frontend receives MDC and calls `download_config()`  
3. `download_config()` was using `display_name` ("cosmos-reason1-7b") for HF download
4. HuggingFace returns 401 because "cosmos-reason1-7b" is not a valid repo ID

### Solution

The new `source_model` field preserves the original model path (e.g., "nvidia/Cosmos-Reason1-7B") separately from `display_name`. The `download_config()` method now uses `source_model` for downloads when available.

## Test Plan

- [ ] Deploy model with custom `--served-model-name` different from HF repo
- [ ] Verify frontend correctly downloads config using original model path
- [ ] Verify `/v1/models` returns the served model name (not the HF path)
- [ ] Verify backwards compatibility with existing deployments (where `source_model` is None)

Fixes: https://github.com/ai-dynamo/dynamo/issues/4748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models now retain references to their original source repositories, ensuring source metadata persists even when display names are customized for deployment.

* **Bug Fixes**
  * Download resolution has been improved to prioritize original source model references over display names, resulting in more reliable model retrieval across different configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->