### PR TITLE
fix(llm): Transform OpenAI image_url to HuggingFace image type for LLaVa templates

### DIFF
--- a/lib/llm/src/preprocessor/prompt/template.rs
+++ b/lib/llm/src/preprocessor/prompt/template.rs
@@ -119,6 +119,10 @@ struct HfTokenizerConfigJsonFormatter {
     mixins: Arc<ContextMixins>,
     supports_add_generation_prompt: bool,
     requires_content_arrays: bool,
+    /// Whether the template expects HuggingFace image type format ('image') vs OpenAI format ('image_url').
+    /// Models like LLaVa use templates with `selectattr('type', 'equalto', 'image')` which
+    /// requires transforming OpenAI's 'image_url' to 'image'.
+    requires_hf_image_type: bool,
 }
 
 // /// OpenAI Standard Prompt Formatter


### PR DESCRIPTION
## Summary
This PR fixes issue #4501 where multimodal requests to LLaVa models crash with `AssertionError: Failed to apply prompt replacement for mm_items['image'][0]`.

### Root Cause
A field naming mismatch exists between what Dynamo sends and what LLaVa templates expect:
- **OpenAI API sends**: `type: "image_url"` with nested `image_url.url` field
- **LLaVa templates expect**: `type: "image"` (templates use `selectattr('type', 'equalto', 'image')`)

### Solution
Implemented template format detection similar to the existing `requires_content_arrays` pattern:

1. **Detection**: Added `detect_hf_image_type_usage()` function that tests if a template expects HuggingFace image format by rendering test messages with both formats and checking for image placeholder presence
2. **Configuration**: Added `requires_hf_image_type` field to `HfTokenizerConfigJsonFormatter` struct
3. **Normalization**: Added `normalize_multimodal_types()` function that transforms:
   - `image_url` → `image`
   - `audio_url` → `audio`
4. **Integration**: Applied normalization during template rendering when HF format is detected

### Changes
- `lib/llm/src/preprocessor/prompt/template.rs`: Added `requires_hf_image_type` field
- `lib/llm/src/preprocessor/prompt/template/formatters.rs`: Added detection function and tests
- `lib/llm/src/preprocessor/prompt/template/oai.rs`: Added normalization function, integration, and tests

## Test Plan
- [x] Added unit tests for `normalize_multimodal_types()` covering:
  - `image_url` → `image` transformation
  - `audio_url` → `audio` transformation
  - Mixed content handling
  - String content preservation
  - Text-only arrays preservation
- [x] Added unit tests for `detect_hf_image_type_usage()` covering:
  - LLaVa-style templates (should detect HF format)
  - Standard OpenAI-style templates (should not detect)
  - Text-only templates

Fixes #4501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and normalization of image and audio formats for HuggingFace-compatible templates, enabling broader model support.

* **Tests**
  * Introduced tests for format detection and multimodal content transformation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->