### PR TITLE
docs: Simplified disaggregated serving examples

### DIFF
--- a/examples/basics/disaggregated_serving/README.md
+++ b/examples/basics/disaggregated_serving/README.md
@@ -22,9 +22,9 @@ This separation allows for:
 
 > [NOTE] This example requires having at least 2 GPUs -- one for Prefill and one for Decode
 
-Before running this example, ensure you: 
+Before running this example, ensure you:
 - Have docker and docker compose installed on your system
-- Have cloned this repository to your system (`git clone https://github.com/ai-dynamo/dynamo.git`) and you are in the same working directory as this README and the docker-compose.yml (`cd examples/basics/disaggregated_serving/`) 
+- Have cloned this repository to your system (`git clone https://github.com/ai-dynamo/dynamo.git`) and you are in the same working directory as this README and the docker-compose.yml (`cd examples/basics/disaggregated_serving/`)
 
 ## Components
 
@@ -90,7 +90,7 @@ Once dynamo is running and has loaded your model (in this example, Qwen/Qwen3-0.
 
 > [NOTE] If the curl command above returns a `503 - Service Unavailable`, Dynamo is likely still starting up. Wait until you see the log output from the Dynamo services has slowed down (you will still see periodic stats_responses sent to the NATS server in the logs after the Dynamo services have started up)
 
-### Notes 
+### Notes
 - We set `DYN_LOG=debug` to increase log verbosity so we can see disaggregation
 - We set CUDA_VISIBLE_DEVICES=0 or CUDA_VISIBLE_DEVICES=1 to ensure that each worker has a specific, dedicated GPU for their portion of disaggregated prefill/decode serving.
 

--- a/examples/basics/disaggregated_serving/README.md
+++ b/examples/basics/disaggregated_serving/README.md
@@ -1,6 +1,6 @@
 # P/D Disaggregated Serving Example
 
-This example demonstrates Dynamo's **Prefill/Decode Disaggregated Serving** architecture, where the prefill and decode phases of LLM inference are separated into specialized workers for enhanced performance, improved resource utilization, and better scalability.
+This example demonstrates Dynamo's **Prefill/Decode Disaggregated Serving** architecture, where the prefill and decode phases of LLM inference are separated into specialized workers for enhanced performance, improved resource utilization, and better scalability. It is intended to be the easiest way to deploy a single-node, non-production Dynamo deployment in its entirety (including supporting services) with either TensorRT-LLM or vLLM backends using a single `docker compose` command.
 
 ## What is P/D Disaggregated Serving?
 
@@ -20,25 +20,25 @@ This separation allows for:
 
 ## Prerequisites
 
-> [!NOTE]
-> This example requires having at least 2 GPUs -- one for Prefill and one for Decode
+> [NOTE] This example requires having at least 2 GPUs -- one for Prefill and one for Decode
 
-Before running this example, ensure you have the following services running:
+Before running this example, ensure you: 
+- Have docker and docker compose installed on your system
+- Have cloned this repository to your system (`git clone https://github.com/ai-dynamo/dynamo.git`) and you are in the same working directory as this README and the docker-compose.yml (`cd examples/basics/disaggregated_serving/`) 
+
+## Components
+
+etcd and NATS are used by Dynamo for discovery and communication. They will be started automatically alongside the Dynamo components
 
 - **etcd**: A distributed key-value store used for service discovery and metadata storage
 - **NATS**: A high-performance message broker for inter-component communication
 
-You can start these services using Docker Compose:
+Dynamo itself is composed of the three services below:
+- [Dynamo Frontend](/components/src/dynamo/frontend/README.md) - HTTP API endpoint that receives requests and forwards them to the decode worker. The frontend will automatically discover the prefill and decode workers through etcd service registry.
+- [Dynamo TRTLLM Decode Worker](/docs/backends/trtllm/README.md) - Specialized worker that handles requests and decides between local prefill for short inputs and and remote prefill for longer inputs
+- [Dynamo TRTLLM Prefill Worker](/docs/backends/trtllm/README.md) - Specialized worker for prefill phase execution, which 1) pulls prefill requests from the NATS queue, 2) executes prefill computation efficiently, and 3) transfers computed KV cache to decode workers via NIXL
 
-```bash
-docker compose -f deploy/docker-compose.yml up -d
-```
-
-## Components
-
-- [Frontend](/components/src/dynamo/frontend/README.md) - HTTP API endpoint that receives requests and forwards them to the decode worker
-- [vLLM Prefill Worker](/docs/backends/vllm/README.md) - Specialized worker for prefill phase execution
-- [vLLM Decode Worker](/docs/backends/vllm/README.md) - Specialized worker that handles requests and decides between local/remote prefill
+> [NOTE] This quickstart uses the TensorRT-LLM (TRTLLM) backend for the prefill and decode workers, but the configuration can be easily adapted for other backends like vLLM by using the appropriate Dynamo base docker image and modifying the startup command for your backend of choice. A working example for vllm is included in the `docker-compose-vllm.yml`.
 
 ```mermaid
 ---
@@ -58,88 +58,46 @@ flowchart TD
 
 ## Instructions
 
-There are four steps to deploy and use disaggregated serving with Dynamo.
+In order to run Dynamo, we must:
+1. Launch our supporting services, etcd and NATS
+2. Launch our Dynamo Frontend, Prefill, and Decode workers once the supporting services are up and running
 
-### 1. Launch Decode Worker
+We will launch all five services with a single command.
 
-**Open a new terminal** and start the decode worker:
+### Launch Steps
 
-```bash
-export DYN_LOG=debug # Increase log verbosity to see disaggregation
-CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm --model Qwen/Qwen3-0.6B
-```
+> [NOTE] this will use the TensorRT-LLM backend by default. If you want to use the vLLM backend, either rename the `docker-compose-vllm.yml` to `docker-compose.yml` before running `docker compose up -d` or replace all `docker compose...` commands with `docker compose -f docker-compose-vllm.yml...`
 
-This starts a decode worker that can receive requests and decide whether to:
-- Handle short prefills locally (fast path)
-- Send long prefills to remote prefill workers (disaggregated path)
+- Run `docker compose up -d`, which will pull all the necessary docker images and start all services in the appropriate order
 
-Leave this terminal running - it will show Decode Worker logs.
+### Post-Launch Steps
 
-### 2. Launch Prefill Worker
+You can run `docker compose logs -f` to follow log outputs in your terminal (to follow logs for a specific worker, for example the decode worker, you can run `docker compose logs -f dynamo-decode`)
 
-**Open another terminal** and start the prefill worker:
+Once dynamo is running and has loaded your model (in this example, Qwen/Qwen3-0.6b), you can send requests to test the disaggregated serving setup. To do so, open a new terminal and run the curl command below:
+  ```bash
+  curl -X POST http://localhost:8000/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{
+      "model": "Qwen/Qwen3-0.6B",
+      "messages": [
+        { "role": "user", "content": "Tell me a story about a cowardly cat" }
+      ],
+      "stream": false,
+      "max_tokens": 1028
+    }'
+  ```
 
-```bash
-export DYN_LOG=debug # Increase log verbosity to see disaggregation
-VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
-CUDA_VISIBLE_DEVICES=1 python -m dynamo.vllm --model Qwen/Qwen3-0.6B --disaggregation-mode prefill \
-  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
-  --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'
-```
+> [NOTE] If the curl command above returns a `503 - Service Unavailable`, Dynamo is likely still starting up. Wait until you see the log output from the Dynamo services has slowed down (you will still see periodic stats_responses sent to the NATS server in the logs after the Dynamo services have started up)
 
-This starts a specialized prefill worker that:
-- Pulls prefill requests from the NATS queue
-- Executes prefill computation efficiently
-- Transfers computed KV cache to decode workers via NIXL
-
-Leave this terminal running - it will show Prefill Worker logs.
-
-### 3. Launch Frontend
-
-**Open a third terminal** and start the frontend:
-
-```bash
-python -m dynamo.frontend --http-port 8000
-```
-
-The frontend will automatically discover the prefill and decode workers through etcd service registry.
-
-### 4. Send Requests
-
-Send requests to test the disaggregated serving setup:
-
-```bash
-curl -X POST http://localhost:8000/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "Qwen/Qwen3-0.6B",
-    "messages": [
-      { "role": "user", "content": "Tell me a story about a cowardly cat" }
-    ],
-    "stream": false,
-    "max_tokens": 1028
-  }'
-```
-
+### Notes 
+- We set `DYN_LOG=debug` to increase log verbosity so we can see disaggregation
+- We set CUDA_VISIBLE_DEVICES=0 or CUDA_VISIBLE_DEVICES=1 to ensure that each worker has a specific, dedicated GPU for their portion of disaggregated prefill/decode serving.
 
 ## Cleanup
 
-When you're done with the disaggregated serving example:
-
-### 1. Stop Dynamo Components
-
-In each terminal, press `Ctrl+C` to stop:
-- Frontend (terminal from step 3)
-- Prefill Worker (terminal from step 2)
-- Decode Worker (terminal from step 1)
-
-### 2. Stop Infrastructure Services
-
-Stop the etcd and NATS services:
-
-```bash
-docker compose -f deploy/docker-compose.yml down
-```
+To stop all services when you're done with the disaggregated serving example, simply run:
+- `docker compose down`
 
 ## Understand
 

--- a/examples/basics/disaggregated_serving/docker-compose-vllm.yml
+++ b/examples/basics/disaggregated_serving/docker-compose-vllm.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # This is the image that will be used for the Dynamo Frontend, Prefill, and Decode services
 x-dynamo-image: &DYNAMO_IMAGE nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
 

--- a/examples/basics/disaggregated_serving/docker-compose-vllm.yml
+++ b/examples/basics/disaggregated_serving/docker-compose-vllm.yml
@@ -99,4 +99,3 @@ services:
     ports:
       - 2379:2379  # this port exposes the http /metrics endpoint
       - 2380:2380
-  

--- a/examples/basics/disaggregated_serving/docker-compose-vllm.yml
+++ b/examples/basics/disaggregated_serving/docker-compose-vllm.yml
@@ -19,7 +19,7 @@ x-shared-environ: &shared-environ
   NATS_SERVER: "nats://nats-server:4222"
 
   # (Shared between services) You can modify the prefill and decode worker log output verbosity below
-  DYN_LOG: debug  
+  DYN_LOG: debug
 
 services:
   dynamo-frontend:
@@ -32,10 +32,10 @@ services:
     depends_on:
       - nats-server
       - etcd-server
-      
+
   dynamo-prefill:
     image: *DYNAMO_IMAGE
-    command: /bin/bash -c "python -m dynamo.vllm --model $$MODEL_NAME"
+    command: /bin/bash -c "python -m dynamo.vllm --model $$MODEL_NAME --is-prefill-worker"
     environment:
       <<: *shared-environ
       CUDA_VISIBLE_DEVICES: ${PREFILL_CUDA_VISIBLE_DEVICES:-0}
@@ -58,7 +58,7 @@ services:
 
   dynamo-decode:
     image: *DYNAMO_IMAGE
-    command: /bin/bash -c "python -m dynamo.vllm --model $$MODEL_NAME --is-prefill-worker"
+    command: /bin/bash -c "python -m dynamo.vllm --model $$MODEL_NAME"
     environment:
       <<: *shared-environ
       CUDA_VISIBLE_DEVICES: ${DECODE_CUDA_VISIBLE_DEVICES:-1}

--- a/examples/basics/disaggregated_serving/docker-compose-vllm.yml
+++ b/examples/basics/disaggregated_serving/docker-compose-vllm.yml
@@ -1,0 +1,99 @@
+# This is the image that will be used for the Dynamo Frontend, Prefill, and Decode services
+x-dynamo-image: &DYNAMO_IMAGE nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
+
+# The environment variables lifted to this top section are either ones that you may want to change or shared between multiple services
+#   Service-specific environment variables are included under their specific "environment:" sections
+x-shared-environ: &shared-environ
+  # (May want to change) Specify the model
+  MODEL_NAME: "Qwen/Qwen3-0.6B"
+
+  # (May want to change) If you have more than 2 gpus available, you can assign them to your prefill and decode workers below
+  PREFILL_CUDA_VISIBLE_DEVICES: 0
+  DECODE_CUDA_VISIBLE_DEVICES: 1
+
+  # (Shared between services) The ETCD/NATS variables below are set so that the other containers on the shared network can find them
+  ETCD_ENDPOINTS: "etcd-server:2379"
+  NATS_SERVER: "nats://nats-server:4222"
+
+  # (Shared between services) You can modify the prefill and decode worker log output verbosity below
+  DYN_LOG: debug  
+
+services:
+  dynamo-frontend:
+    image: *DYNAMO_IMAGE
+    command: python -m dynamo.frontend --http-port 8000
+    ports:
+      - 8000:8000
+    environment:
+      <<: *shared-environ
+    depends_on:
+      - nats-server
+      - etcd-server
+      
+  dynamo-prefill:
+    image: *DYNAMO_IMAGE
+    command: /bin/bash -c "python -m dynamo.vllm --model $$MODEL_NAME"
+    environment:
+      <<: *shared-environ
+      CUDA_VISIBLE_DEVICES: ${PREFILL_CUDA_VISIBLE_DEVICES:-0}
+      DYN_VLLM_KV_EVENT_PORT: 20081
+      VLLM_NIXL_SIDE_CHANNEL_PORT: 20097
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              count: all
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    ipc: host
+    depends_on:
+      - nats-server
+      - etcd-server
+
+  dynamo-decode:
+    image: *DYNAMO_IMAGE
+    command: /bin/bash -c "python -m dynamo.vllm --model $$MODEL_NAME --is-prefill-worker"
+    environment:
+      <<: *shared-environ
+      CUDA_VISIBLE_DEVICES: ${DECODE_CUDA_VISIBLE_DEVICES:-1}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              count: all
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    ipc: host
+    depends_on:
+      - nats-server
+      - etcd-server
+
+  nats-server:
+    image: nats:2.11.4
+    command: [ "-js", "--trace", "-m", "8222" ]
+    ports:
+      - 4222:4222
+      - 6222:6222
+      - 8222:8222  # the endpoints include /varz, /healthz, ...
+
+  etcd-server:
+    image: bitnamilegacy/etcd:3.6.1
+    environment:
+      ALLOW_NONE_AUTHENTICATION: "yes"
+      ETCD_NAME: "etcd-server"
+      ETCD_INITIAL_CLUSTER: "etcd-server=http://etcd-server:2380"
+      ETCD_INITIAL_CLUSTER_STATE: new
+      ETCD_INITIAL_ADVERTISE_PEER_URLS: "http://etcd-server:2380"
+      ETCD_ADVERTISE_CLIENT_URLS: "http://etcd-server:2379"
+      ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
+      ETCD_LISTEN_PEER_URLS: "http://0.0.0.0:2380"
+    ports:
+      - 2379:2379  # this port exposes the http /metrics endpoint
+      - 2380:2380
+  

--- a/examples/basics/disaggregated_serving/docker-compose-vllm.yml
+++ b/examples/basics/disaggregated_serving/docker-compose-vllm.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # This is the image that will be used for the Dynamo Frontend, Prefill, and Decode services
@@ -36,16 +36,16 @@ services:
 
   dynamo-prefill:
     image: *DYNAMO_IMAGE
-    command: > 
-      /bin/bash -c "python -m dynamo.vllm 
-      --model $$MODEL_NAME 
-      --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' 
-      --kv-events-config '{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:20081\",\"enable_kv_cache_events\":true}' 
-      --max-model-len $$MAX_MODEL_LEN 
-      --tensor-parallel-size $$TENSOR_PARALLEL_SIZE 
-      --max-num-seqs $$MAX_NUM_SEQS 
-      --enable-prefix-caching 
-      --prefix-caching-hash-algo sha256 
+    command: >
+      /bin/bash -c "python -m dynamo.vllm
+      --model $$MODEL_NAME
+      --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'
+      --kv-events-config '{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:20081\",\"enable_kv_cache_events\":true}'
+      --max-model-len $$MAX_MODEL_LEN
+      --tensor-parallel-size $$TENSOR_PARALLEL_SIZE
+      --max-num-seqs $$MAX_NUM_SEQS
+      --enable-prefix-caching
+      --prefix-caching-hash-algo sha256
       --disaggregation-mode prefill"
     environment:
       <<: *shared-environ
@@ -73,12 +73,12 @@ services:
   dynamo-decode:
     image: *DYNAMO_IMAGE
     command: >
-      /bin/bash -c "python -m dynamo.vllm 
-      --model $$MODEL_NAME 
-      --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' 
-      --max-model-len $$MAX_MODEL_LEN 
-      --tensor-parallel-size $$TENSOR_PARALLEL_SIZE 
-      --max-num-seqs $$MAX_NUM_SEQS 
+      /bin/bash -c "python -m dynamo.vllm
+      --model $$MODEL_NAME
+      --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'
+      --max-model-len $$MAX_MODEL_LEN
+      --tensor-parallel-size $$TENSOR_PARALLEL_SIZE
+      --max-num-seqs $$MAX_NUM_SEQS
       --enable-prefix-caching
       --prefix-caching-hash-algo sha256
       --disaggregation-mode decode"

--- a/examples/basics/disaggregated_serving/docker-compose-vllm.yml
+++ b/examples/basics/disaggregated_serving/docker-compose-vllm.yml
@@ -2,18 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This is the image that will be used for the Dynamo Frontend, Prefill, and Decode services
-x-dynamo-image: &DYNAMO_IMAGE nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.7.0.post1
+x-dynamo-image: &DYNAMO_IMAGE nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
 
 # The environment variables lifted to this top section are either ones that you may want to change or shared between multiple services
 #   Service-specific environment variables are included under their specific "environment:" sections
 x-shared-environ: &shared-environ
-  # (May want to change) Specify the model
+  # (May want to change) Specify the model and inference server settings
   MODEL_NAME: "Qwen/Qwen3-0.6B"
-
-  # (May want to change) If you have more than 2 gpus available, you can assign them to your prefill and decode workers below
-  PREFILL_CUDA_VISIBLE_DEVICES: 0
-  DECODE_CUDA_VISIBLE_DEVICES: 1
-
+  MAX_MODEL_LEN: 16384
+  MAX_NUM_SEQS: 16
+  TENSOR_PARALLEL_SIZE: 1
   # (Shared between services) The ETCD/NATS variables below are set so that the other containers on the shared network can find them
   ETCD_ENDPOINTS: "etcd-server:2379"
   NATS_SERVER: "nats://nats-server:4222"
@@ -29,17 +27,30 @@ services:
       - 8000:8000
     environment:
       <<: *shared-environ
+    volumes:
+      - frontend-cache:/home/dynamo/.cache/
+    restart: always
     depends_on:
       - nats-server
       - etcd-server
 
   dynamo-prefill:
     image: *DYNAMO_IMAGE
-    command: /bin/bash -c "python -m dynamo.vllm --model $$MODEL_NAME --is-prefill-worker"
+    command: > 
+      /bin/bash -c "python -m dynamo.vllm 
+      --model $$MODEL_NAME 
+      --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' 
+      --kv-events-config '{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:20081\",\"enable_kv_cache_events\":true}' 
+      --max-model-len $$MAX_MODEL_LEN 
+      --tensor-parallel-size $$TENSOR_PARALLEL_SIZE 
+      --max-num-seqs $$MAX_NUM_SEQS 
+      --enable-prefix-caching 
+      --prefix-caching-hash-algo sha256 
+      --disaggregation-mode prefill"
     environment:
       <<: *shared-environ
-      CUDA_VISIBLE_DEVICES: ${PREFILL_CUDA_VISIBLE_DEVICES:-0}
       DYN_VLLM_KV_EVENT_PORT: 20081
+      DYN_SYSTEM_PORT: 8081
       VLLM_NIXL_SIDE_CHANNEL_PORT: 20097
     deploy:
       resources:
@@ -47,32 +58,47 @@ services:
           devices:
             - driver: nvidia
               capabilities: [gpu]
-              count: all
+              device_ids: ['0']
     ulimits:
       memlock: -1
       stack: 67108864
     ipc: host
+    volumes:
+      - prefill-cache:/home/dynamo/.cache/
+    restart: always
     depends_on:
       - nats-server
       - etcd-server
 
   dynamo-decode:
     image: *DYNAMO_IMAGE
-    command: /bin/bash -c "python -m dynamo.vllm --model $$MODEL_NAME"
+    command: >
+      /bin/bash -c "python -m dynamo.vllm 
+      --model $$MODEL_NAME 
+      --kv-transfer-config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' 
+      --max-model-len $$MAX_MODEL_LEN 
+      --tensor-parallel-size $$TENSOR_PARALLEL_SIZE 
+      --max-num-seqs $$MAX_NUM_SEQS 
+      --enable-prefix-caching
+      --prefix-caching-hash-algo sha256
+      --disaggregation-mode decode"
     environment:
       <<: *shared-environ
-      CUDA_VISIBLE_DEVICES: ${DECODE_CUDA_VISIBLE_DEVICES:-1}
+      DYN_SYSTEM_PORT: 8082
     deploy:
       resources:
         reservations:
           devices:
             - driver: nvidia
               capabilities: [gpu]
-              count: all
+              device_ids: ['1']
     ulimits:
       memlock: -1
       stack: 67108864
     ipc: host
+    volumes:
+      - decode-cache:/home/dynamo/.cache/
+    restart: always
     depends_on:
       - nats-server
       - etcd-server
@@ -99,3 +125,8 @@ services:
     ports:
       - 2379:2379  # this port exposes the http /metrics endpoint
       - 2380:2380
+
+volumes:
+  frontend-cache:
+  prefill-cache:
+  decode-cache:

--- a/examples/basics/disaggregated_serving/docker-compose.yml
+++ b/examples/basics/disaggregated_serving/docker-compose.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # This is the image that will be used for the Dynamo Frontend, Prefill, and Decode services
 x-dynamo-image: &DYNAMO_IMAGE nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
 

--- a/examples/basics/disaggregated_serving/docker-compose.yml
+++ b/examples/basics/disaggregated_serving/docker-compose.yml
@@ -28,7 +28,6 @@ x-shared-environ: &shared-environ
 
 # This volume will mount the available trtllm engine_configs (available at dynamo/examples/backends/trtllm/engine_configs) into the dynamo containers at /workspace/engine_configs (assumes you are running your `docker compose` commands from the same directory as this docker-compose.yml file)
 x-shared-dynamo-engine-config-volume: &shared-config-volume ../../backends/trtllm/engine_configs/:/workspace/engine_configs/
-  
 
 services:
   dynamo-frontend:
@@ -41,11 +40,11 @@ services:
     depends_on:
       - nats-server
       - etcd-server
-      
+
   dynamo-prefill:
     image: *DYNAMO_IMAGE
     command: >
-      /bin/bash -c "python -m dynamo.trtllm 
+      /bin/bash -c "python -m dynamo.trtllm
       --model-path $$MODEL_NAME
       --served-model-name $$MODEL_NAME
       --extra-engine-args $$PREFILL_ENGINE_ARGS
@@ -74,8 +73,8 @@ services:
   dynamo-decode:
     image: *DYNAMO_IMAGE
     command: >
-      /bin/bash -c "python -m dynamo.trtllm 
-      --model-path $$MODEL_NAME 
+      /bin/bash -c "python -m dynamo.trtllm
+      --model-path $$MODEL_NAME
       --served-model-name $$MODEL_NAME
       --extra-engine-args $$DECODE_ENGINE_ARGS
       --modality $$MODALITY

--- a/examples/basics/disaggregated_serving/docker-compose.yml
+++ b/examples/basics/disaggregated_serving/docker-compose.yml
@@ -1,0 +1,122 @@
+# This is the image that will be used for the Dynamo Frontend, Prefill, and Decode services
+x-dynamo-image: &DYNAMO_IMAGE nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
+
+# The environment variables lifted to this top section are either ones that you may want to change or shared between multiple services
+#   Service-specific environment variables are included under their specific "environment:" sections
+x-shared-environ: &shared-environ
+  # (May want to change) Specify the model and path to the appropriate TRTLLM engine args below
+  MODEL_NAME: "Qwen/Qwen3-0.6B"
+  PREFILL_ENGINE_ARGS: "/workspace/engine_configs/qwen3/prefill.yaml"
+  DECODE_ENGINE_ARGS: "/workspace/engine_configs/qwen3/decode.yaml"
+
+  # (May want to change) If you have more than 2 gpus available, you can assign them to your prefill and decode workers below
+  PREFILL_CUDA_VISIBLE_DEVICES: 0
+  DECODE_CUDA_VISIBLE_DEVICES: 1
+
+  # (May want to change) If you want to use multimodal, you can set MODALITY to "multimodal"
+  MODALITY: "text"
+
+  # (Shared between services) The ETCD/NATS variables below are set so that the other containers on the shared network can find them
+  ETCD_ENDPOINTS: "etcd-server:2379"
+  NATS_SERVER: "nats://nats-server:4222"
+
+  # (Shared between services) You can modify the prefill and decode worker log output verbosity below
+  DYN_LOG: debug
+
+# This volume will mount the available trtllm engine_configs (available at dynamo/examples/backends/trtllm/engine_configs) into the dynamo containers at /workspace/engine_configs (assumes you are running your `docker compose` commands from the same directory as this docker-compose.yml file)
+x-shared-dynamo-engine-config-volume: &shared-config-volume ../../backends/trtllm/engine_configs/:/workspace/engine_configs/
+  
+
+services:
+  dynamo-frontend:
+    image: *DYNAMO_IMAGE
+    command: python -m dynamo.frontend --http-port 8000
+    ports:
+      - 8000:8000
+    environment:
+      <<: *shared-environ
+    depends_on:
+      - nats-server
+      - etcd-server
+      
+  dynamo-prefill:
+    image: *DYNAMO_IMAGE
+    command: >
+      /bin/bash -c "python -m dynamo.trtllm 
+      --model-path $$MODEL_NAME
+      --served-model-name $$MODEL_NAME
+      --extra-engine-args $$PREFILL_ENGINE_ARGS
+      --modality $$MODALITY
+      --disaggregation-mode prefill"
+    environment:
+      <<: *shared-environ
+      CUDA_VISIBLE_DEVICES: ${PREFILL_CUDA_VISIBLE_DEVICES:-0}
+    volumes:
+      - *shared-config-volume
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              count: all
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    ipc: host
+    depends_on:
+      - nats-server
+      - etcd-server
+
+  dynamo-decode:
+    image: *DYNAMO_IMAGE
+    command: >
+      /bin/bash -c "python -m dynamo.trtllm 
+      --model-path $$MODEL_NAME 
+      --served-model-name $$MODEL_NAME
+      --extra-engine-args $$DECODE_ENGINE_ARGS
+      --modality $$MODALITY
+      --disaggregation-mode decode"
+    environment:
+      <<: *shared-environ
+      CUDA_VISIBLE_DEVICES: ${DECODE_CUDA_VISIBLE_DEVICES:-1}
+    volumes:
+      - *shared-config-volume
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              count: all
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    ipc: host
+    depends_on:
+      - nats-server
+      - etcd-server
+
+  nats-server:
+    image: nats:2.11.4
+    command: [ "-js", "--trace", "-m", "8222" ]
+    ports:
+      - 4222:4222
+      - 6222:6222
+      - 8222:8222  # the endpoints include /varz, /healthz, ...
+
+  etcd-server:
+    image: bitnamilegacy/etcd:3.6.1
+    environment:
+      ALLOW_NONE_AUTHENTICATION: "yes"
+      ETCD_NAME: "etcd-server"
+      ETCD_INITIAL_CLUSTER: "etcd-server=http://etcd-server:2380"
+      ETCD_INITIAL_CLUSTER_STATE: new
+      ETCD_INITIAL_ADVERTISE_PEER_URLS: "http://etcd-server:2380"
+      ETCD_ADVERTISE_CLIENT_URLS: "http://etcd-server:2379"
+      ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
+      ETCD_LISTEN_PEER_URLS: "http://0.0.0.0:2380"
+    ports:
+      - 2379:2379  # this port exposes the http /metrics endpoint
+      - 2380:2380
+  

--- a/examples/basics/disaggregated_serving/docker-compose.yml
+++ b/examples/basics/disaggregated_serving/docker-compose.yml
@@ -122,4 +122,3 @@ services:
     ports:
       - 2379:2379  # this port exposes the http /metrics endpoint
       - 2380:2380
-  

--- a/examples/basics/disaggregated_serving/docker-compose.yml
+++ b/examples/basics/disaggregated_serving/docker-compose.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This is the image that will be used for the Dynamo Frontend, Prefill, and Decode services
-x-dynamo-image: &DYNAMO_IMAGE nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post1
+x-dynamo-image: &DYNAMO_IMAGE nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.1
 
 # The environment variables lifted to this top section are either ones that you may want to change or shared between multiple services
 #   Service-specific environment variables are included under their specific "environment:" sections
@@ -11,10 +11,6 @@ x-shared-environ: &shared-environ
   MODEL_NAME: "Qwen/Qwen3-0.6B"
   PREFILL_ENGINE_ARGS: "/workspace/engine_configs/qwen3/prefill.yaml"
   DECODE_ENGINE_ARGS: "/workspace/engine_configs/qwen3/decode.yaml"
-
-  # (May want to change) If you have more than 2 gpus available, you can assign them to your prefill and decode workers below
-  PREFILL_CUDA_VISIBLE_DEVICES: 0
-  DECODE_CUDA_VISIBLE_DEVICES: 1
 
   # (May want to change) If you want to use multimodal, you can set MODALITY to "multimodal"
   MODALITY: "text"
@@ -37,6 +33,7 @@ services:
       - 8000:8000
     environment:
       <<: *shared-environ
+    restart: always
     depends_on:
       - nats-server
       - etcd-server
@@ -52,7 +49,6 @@ services:
       --disaggregation-mode prefill"
     environment:
       <<: *shared-environ
-      CUDA_VISIBLE_DEVICES: ${PREFILL_CUDA_VISIBLE_DEVICES:-0}
     volumes:
       - *shared-config-volume
     deploy:
@@ -61,11 +57,12 @@ services:
           devices:
             - driver: nvidia
               capabilities: [gpu]
-              count: all
+              device_ids: ['0']
     ulimits:
       memlock: -1
       stack: 67108864
     ipc: host
+    restart: always
     depends_on:
       - nats-server
       - etcd-server
@@ -81,7 +78,6 @@ services:
       --disaggregation-mode decode"
     environment:
       <<: *shared-environ
-      CUDA_VISIBLE_DEVICES: ${DECODE_CUDA_VISIBLE_DEVICES:-1}
     volumes:
       - *shared-config-volume
     deploy:
@@ -90,11 +86,12 @@ services:
           devices:
             - driver: nvidia
               capabilities: [gpu]
-              count: all
+              device_ids: ['1']
     ulimits:
       memlock: -1
       stack: 67108864
     ipc: host
+    restart: always
     depends_on:
       - nats-server
       - etcd-server

--- a/examples/basics/disaggregated_serving/docker-compose.yml
+++ b/examples/basics/disaggregated_serving/docker-compose.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # This is the image that will be used for the Dynamo Frontend, Prefill, and Decode services


### PR DESCRIPTION
#### Overview:

This PR updates the disaggregated serving examples and readme to simplify setup by providing single-command docker compose setups for deploying all components of dynamo with either a TRTLLM or vLLM backend.

Previously, the quickstart guide required setting up the dependency services (etcd and NATS) with docker and separate additional steps to run dynamo directly on the host machine. This consolidates all setup steps into a single docker-compose.yml.

#### Details:

- Added a docker-compose.yml to examples/basics/disaggregated_serving for single-command Dynamo-with-TRTLLM-backend deployment
- Added a docker-compose-vllm.yml to examples/basics/disaggregated_serving for single-command Dynamo-with-vLLM-backend deployment
- Updated README in examples/basics/disaggregated_serving to simplify quickstart guide using docker compose 

#### Where should the reviewer start?

- examples/basics/disaggregated_serving/README
- examples/basics/disaggregated_serving/docker-compose.yml
- examples/basics/disaggregated_serving/docker-compose-vllm.yml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined deployment instructions with single docker-compose command for simplified single-node setup.
  * Enhanced README with clearer post-launch steps, logging guidance, and testing procedures.
  * Added instructions for switching between TensorRT-LLM and vLLM backends.

* **New Features**
  * Added vLLM backend configuration for disaggregated serving deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->