### PR TITLE
feat: Pass tool definitions to parsers

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -470,6 +470,7 @@ pub struct JailedStream {
     jail_start_sequences: Vec<String>,
     jail_end_sequences: Vec<String>,
     tool_call_parser: Option<String>,
+    tool_definitions: Option<Vec<dynamo_parsers::tool_calling::ToolDefinition>>,
     emission_mode: EmissionMode,
     marker_matcher: MarkerMatcher,
     jail_mode: JailMode,
@@ -758,8 +759,13 @@ impl JailedStream {
                 } else if early_exit {
                     // For early exit, find where the complete tool call ends
                     if let Some(parser) = &self.tool_call_parser {
-                        if let Ok((_, _)) =
-                            try_tool_call_parse_aggregate(accumulated_content, Some(parser)).await
+                        let tools_slice = self.tool_definitions.as_deref();
+                        if let Ok((_, _)) = try_tool_call_parse_aggregate(
+                            accumulated_content,
+                            Some(parser),
+                            tools_slice,
+                        )
+                        .await
                         {
                             let split_pos =
                                 find_tool_call_end_position(accumulated_content, Some(parser));
@@ -814,9 +820,11 @@ impl JailedStream {
         match &self.jail_mode {
             JailMode::MarkerBased => {
                 // Traditional marker-based tool call parsing
+                let tools_slice = self.tool_definitions.as_deref();
                 if let Ok((tool_calls, normal_text)) = try_tool_call_parse_aggregate(
                     accumulated_content,
                     self.tool_call_parser.as_deref(),
+                    tools_slice,
                 )
                 .await
                     && !tool_calls.is_empty()
@@ -952,7 +960,8 @@ impl JailedStream {
     async fn should_exit_jail_early(&self, accumulated: &str) -> bool {
         if let Some(ref parser) = self.tool_call_parser {
             // Try to parse - if successful and we have complete tool calls, exit early
-            match try_tool_call_parse_aggregate(accumulated, Some(parser)).await {
+            let tools_slice = self.tool_definitions.as_deref();
+            match try_tool_call_parse_aggregate(accumulated, Some(parser), tools_slice).await {
                 Ok((tool_calls, _normal_text)) => {
                     let result = !tool_calls.is_empty();
                     return result;
@@ -1034,6 +1043,7 @@ pub struct JailedStreamBuilder {
     jail_start_sequences: Vec<String>,
     jail_end_sequences: Vec<String>,
     tool_call_parser: Option<String>,
+    tool_definitions: Option<Vec<dynamo_parsers::tool_calling::ToolDefinition>>,
     emission_mode: EmissionMode,
     jail_mode: JailMode,
 }
@@ -1045,6 +1055,7 @@ impl JailedStreamBuilder {
             jail_start_sequences: Vec::new(),
             jail_end_sequences: Vec::new(),
             tool_call_parser: None,
+            tool_definitions: None,
             emission_mode: EmissionMode::default(),
             jail_mode: JailMode::MarkerBased,
         }
@@ -1085,6 +1096,15 @@ impl JailedStreamBuilder {
     /// Set the tool call parser to use for detection and parsing
     pub fn tool_call_parser(mut self, parser: impl Into<String>) -> Self {
         self.tool_call_parser = Some(parser.into());
+        self
+    }
+
+    /// Set the tool definitions for runtime validation and parsing
+    pub fn tool_definitions(
+        mut self,
+        tools: Vec<dynamo_parsers::tool_calling::ToolDefinition>,
+    ) -> Self {
+        self.tool_definitions = Some(tools);
         self
     }
 
@@ -1198,6 +1218,7 @@ impl JailedStreamBuilder {
             jail_start_sequences: self.jail_start_sequences,
             jail_end_sequences: self.jail_end_sequences,
             tool_call_parser: self.tool_call_parser,
+            tool_definitions: self.tool_definitions,
             emission_mode: self.emission_mode,
             marker_matcher,
             jail_mode: self.jail_mode,

--- a/lib/llm/tests/parallel_tool_call_integration.rs
+++ b/lib/llm/tests/parallel_tool_call_integration.rs
@@ -197,7 +197,7 @@ async fn test_parallel_tool_call_parsing() {
 
     // Parse the tool calls using the hermes parser (works well with <tool_call> format)
     let (tool_calls, remaining_content) =
-        detect_and_parse_tool_call(&response_content, Some("hermes"))
+        detect_and_parse_tool_call(&response_content, Some("hermes"), None)
             .await
             .expect("Should successfully parse tool calls");
 
@@ -239,7 +239,7 @@ async fn test_parallel_tool_call_with_explicit_parser() {
 
     for parser in parsers_to_test {
         let (tool_calls, remaining_content) =
-            detect_and_parse_tool_call(&response_content, Some(parser))
+            detect_and_parse_tool_call(&response_content, Some(parser), None)
                 .await
                 .unwrap_or_else(|e| panic!("Should successfully parse with {parser} parser: {e}"));
 
@@ -267,7 +267,7 @@ async fn test_parallel_tool_call_with_explicit_parser() {
 async fn test_tool_call_json_structure() {
     let response_content = get_mock_response_content();
 
-    let (tool_calls, _) = detect_and_parse_tool_call(&response_content, Some("hermes"))
+    let (tool_calls, _) = detect_and_parse_tool_call(&response_content, Some("hermes"), None)
         .await
         .expect("Should parse tool calls");
 
@@ -288,7 +288,7 @@ async fn test_tool_call_json_structure() {
 async fn test_openai_compatibility_structure() {
     let response_content = get_mock_response_content();
 
-    let (tool_calls, _) = detect_and_parse_tool_call(&response_content, Some("hermes"))
+    let (tool_calls, _) = detect_and_parse_tool_call(&response_content, Some("hermes"), None)
         .await
         .expect("Should parse tool calls");
 
@@ -335,7 +335,7 @@ async fn test_parallel_tool_call_error_handling() {
 {"invalid_json": }
 </tool_call>"#;
 
-    let result = detect_and_parse_tool_call(malformed_content, Some("hermes")).await;
+    let result = detect_and_parse_tool_call(malformed_content, Some("hermes"), None).await;
 
     // Should handle partial parsing gracefully
     match result {
@@ -368,7 +368,7 @@ async fn test_empty_tool_calls() {
     let content_without_tools = "This is just a regular response without any tool calls.";
 
     let (tool_calls, remaining_content) =
-        detect_and_parse_tool_call(content_without_tools, Some("hermes"))
+        detect_and_parse_tool_call(content_without_tools, Some("hermes"), None)
             .await
             .expect("Should handle content without tool calls");
 
@@ -412,7 +412,7 @@ async fn test_deepseek_v3_1_tool_call_parsing() {
 
     // Parse the tool calls using the deepseek_v3_1 parser
     let (tool_calls, remaining_content) =
-        detect_and_parse_tool_call(response_content, Some("deepseek_v3_1"))
+        detect_and_parse_tool_call(response_content, Some("deepseek_v3_1"), None)
             .await
             .expect("Should successfully parse deepseek_v3_1 tool calls");
 

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -2045,6 +2045,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_jailed_stream_qwen3_coder_multiple_params() {
+        use dynamo_parsers::tool_calling::ToolDefinition;
+
         let chunks = vec![
             create_mock_response_chunk("Let me search for that. ".to_string(), 0),
             create_mock_response_chunk(
@@ -2054,9 +2056,23 @@ mod tests {
             create_mock_response_chunk(" Searching now.".to_string(), 0),
         ];
 
+        // Define the web_search tool with its parameters
+        let tool_defs = vec![ToolDefinition {
+            name: "web_search".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "max_results": {"type": "integer"},
+                    "filter": {"type": "string"},
+                },
+            })),
+        }];
+
         let input_stream = stream::iter(chunks);
         let jail = JailedStream::builder()
             .tool_call_parser("qwen3_coder")
+            .tool_definitions(tool_defs)
             .build();
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;

--- a/lib/llm/tests/test_reasoning_parser.rs
+++ b/lib/llm/tests/test_reasoning_parser.rs
@@ -487,6 +487,7 @@ mod tests {
         let tool_parsed_stream = OpenAIPreprocessor::apply_tool_calling_jail(
             Some("nemotron_deci".to_string()),
             None, // No tool_choice in this test
+            None, // No tool_definitions in this test
             reasoning_parsed_stream,
         );
 
@@ -600,6 +601,7 @@ mod tests {
         let tool_parsed_stream = OpenAIPreprocessor::apply_tool_calling_jail(
             Some("harmony".to_string()),
             None, // No tool_choice in this test
+            None, // No tool_definitions in this test
             reasoning_parsed_stream,
         );
 

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -160,6 +160,7 @@ async fn parse_response_stream(
             Box::pin(OpenAIPreprocessor::apply_tool_calling_jail(
                 Some(tool_parser),
                 None, // No tool_choice in this test
+                None, // No tool_definitions in this test
                 stream,
             ))
         } else {

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -7,6 +7,7 @@ use regex::RegexBuilder;
 use serde_json::Value;
 use uuid::Uuid;
 
+use super::super::ToolDefinition;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
@@ -165,6 +166,7 @@ fn try_parse_normal_text(input: &str, start_token: &str) -> String {
 pub fn try_tool_call_parse_basic_json(
     message: &str,
     config: &JsonParserConfig,
+    _tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     // Log the config we are using
     tracing::debug!("Using JSON parser config: {:?}", config);

--- a/lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
@@ -5,6 +5,7 @@ use regex::RegexBuilder;
 use serde_json::Value;
 use uuid::Uuid;
 
+use super::super::ToolDefinition;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
@@ -119,6 +120,7 @@ fn parse_single_tool_call_v3_1(
 pub fn parse_tool_calls_deepseek_v3_1(
     message: &str,
     config: &JsonParserConfig,
+    _tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     // Format Structure:
     // <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>{function_name}<｜tool▁sep｜>{json_arguments}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
@@ -275,7 +277,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
         assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 2);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -293,7 +295,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
         assert_eq!(
             content,
             Some("The following tool call retrieves weather information: ".to_string())
@@ -311,7 +313,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
         assert_eq!(content, Some(text.to_string()));
         assert_eq!(result.len(), 0);
     }
@@ -323,7 +325,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
         assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 3);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -349,7 +351,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
         assert_eq!(content, Some(text.trim().to_string()));
         assert_eq!(result.len(), 0);
     }
@@ -362,7 +364,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
         assert_eq!(content, Some(text.trim().to_string()));
         assert_eq!(result.len(), 0);
     }
@@ -388,7 +390,7 @@ mod tests {
         };
 
         let (tool_call_results, normal_content) =
-            parse_tool_calls_deepseek_v3_1(text, &config).unwrap();
+            parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
 
         assert_eq!(tool_call_results.len(), 1);
 

--- a/lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs
@@ -5,6 +5,7 @@ use regex::RegexBuilder;
 use serde_json::Value;
 use uuid::Uuid;
 
+use super::super::ToolDefinition;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
@@ -129,6 +130,7 @@ fn parse_single_tool_call_v3(block: &str, separator_tokens: &[String]) -> Option
 pub fn parse_tool_calls_deepseek_v3(
     message: &str,
     config: &JsonParserConfig,
+    _tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     // Format Structure:
     // <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>{type}<｜tool▁sep｜>{function_name}\n```json\n{json_arguments}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
@@ -285,7 +287,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
         assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 2);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -306,7 +308,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
         assert_eq!(
             content,
             Some("The following tool call retrieves weather information: ".to_string())
@@ -327,7 +329,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
         assert_eq!(content, Some(text.to_string()));
         assert_eq!(result.len(), 0);
     }
@@ -348,7 +350,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
         assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 3);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -377,7 +379,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
         assert_eq!(content, Some(text.trim().to_string()));
         assert_eq!(result.len(), 0);
     }
@@ -399,7 +401,7 @@ mod tests {
             super::super::config::ParserConfig::Json(cfg) => cfg,
             _ => panic!("Expected JSON parser config"),
         };
-        let (result, content) = parse_tool_calls_deepseek_v3(text, &config).unwrap();
+        let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
         assert_eq!(content, Some(text.trim().to_string()));
         assert_eq!(result.len(), 0);
     }
@@ -428,7 +430,7 @@ mod tests {
         };
 
         let (tool_call_results, normal_content) =
-            parse_tool_calls_deepseek_v3(text, &config).unwrap();
+            parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
 
         assert_eq!(tool_call_results.len(), 1);
 

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -33,11 +33,12 @@ impl Default for JsonParserType {
 pub fn try_tool_call_parse_json(
     message: &str,
     config: &JsonParserConfig,
+    tools: Option<&[super::ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     match config.parser_type {
-        JsonParserType::Basic => try_tool_call_parse_basic_json(message, config),
-        JsonParserType::DeepseekV3 => parse_tool_calls_deepseek_v3(message, config),
-        JsonParserType::DeepseekV31 => parse_tool_calls_deepseek_v3_1(message, config),
+        JsonParserType::Basic => try_tool_call_parse_basic_json(message, config, tools),
+        JsonParserType::DeepseekV3 => parse_tool_calls_deepseek_v3(message, config, tools),
+        JsonParserType::DeepseekV31 => parse_tool_calls_deepseek_v3_1(message, config, tools),
     }
 }
 

--- a/lib/parsers/src/tool_calling/mod.rs
+++ b/lib/parsers/src/tool_calling/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use serde_json::Value;
+
 pub mod config;
 pub mod dsml;
 pub mod harmony;
@@ -12,6 +14,13 @@ pub mod response;
 pub mod tests;
 pub mod tools;
 pub mod xml;
+
+/// Represents a tool definition with function schema.
+#[derive(Debug, Clone)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub parameters: Option<Value>,
+}
 
 // Re-export main types and functions for convenience
 pub use config::{JsonParserConfig, ParserConfig, ToolCallConfig, XmlParserConfig};

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::ToolDefinition;
 use super::config::{ParserConfig, ToolCallConfig};
 use super::dsml::{
     detect_tool_call_start_dsml, find_tool_call_end_position_dsml, try_tool_call_parse_dsml,
@@ -53,27 +54,28 @@ pub fn get_available_tool_parsers() -> Vec<&'static str> {
 pub async fn try_tool_call_parse(
     message: &str,
     config: &ToolCallConfig,
+    tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     // Use match statement (Rust's switch statement) to call the appropriate parser
     match &config.parser_config {
         ParserConfig::Json(json_config) => {
-            let (results, normal_content) = try_tool_call_parse_json(message, json_config)?;
+            let (results, normal_content) = try_tool_call_parse_json(message, json_config, tools)?;
             Ok((results, normal_content))
         }
         ParserConfig::Harmony(json_config) => {
             let (results, normal_content) =
-                parse_tool_calls_harmony_complete(message, json_config).await?;
+                parse_tool_calls_harmony_complete(message, json_config, tools).await?;
             Ok((results, normal_content))
         }
         ParserConfig::Pythonic => {
-            let (results, normal_content) = try_tool_call_parse_pythonic(message)?;
+            let (results, normal_content) = try_tool_call_parse_pythonic(message, tools)?;
             Ok((results, normal_content))
         }
         ParserConfig::Typescript => {
             anyhow::bail!("Typescript parser not implemented");
         }
         ParserConfig::Xml(xml_config) => {
-            let (results, normal_content) = try_tool_call_parse_xml(message, xml_config)?;
+            let (results, normal_content) = try_tool_call_parse_xml(message, xml_config, tools)?;
             Ok((results, normal_content))
         }
         ParserConfig::Dsml(dsml_config) => {
@@ -87,6 +89,7 @@ pub async fn try_tool_call_parse(
 pub async fn detect_and_parse_tool_call(
     message: &str,
     parser_str: Option<&str>,
+    tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     // Get the tool parser map
     let parser_map = get_tool_parser_map();
@@ -99,7 +102,7 @@ pub async fn detect_and_parse_tool_call(
 
     match parser_map.get(parser_key) {
         Some(config) => {
-            let (results, normal_content) = try_tool_call_parse(message, config).await?;
+            let (results, normal_content) = try_tool_call_parse(message, config, tools).await?;
             Ok((results, normal_content))
         }
         None => anyhow::bail!(
@@ -213,7 +216,7 @@ mod tests {
     #[tokio::test]
     async fn parses_single_parameters_object() {
         let input = r#"{ "name": "hello", "parameters": { "x": 1, "y": 2 } }"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -228,7 +231,7 @@ mod tests {
     #[tokio::test]
     async fn parses_single_arguments_object() {
         let input = r#"{ "name": "world", "arguments": { "a": "abc", "b": 42 } }"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -243,7 +246,7 @@ mod tests {
     #[tokio::test]
     async fn parses_vec_of_parameters() {
         let input = r#"[{ "name": "first", "parameters": { "a": 1 } }, { "name": "second", "parameters": { "b": 2 } }]"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -260,7 +263,7 @@ mod tests {
     #[tokio::test]
     async fn parses_vec_of_arguments() {
         let input = r#"[{ "name": "alpha", "arguments": { "a": "x" } }, { "name": "omega", "arguments": { "z": "y" } }]"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -278,7 +281,7 @@ mod tests {
     async fn parses_toolcall_wrapped_payload() {
         let input =
             r#"<TOOLCALL>[{ "name": "wrapped", "parameters": { "foo": "bar" } }]</TOOLCALL>"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -301,6 +304,7 @@ mod tests {
                     ..Default::default()
                 }),
             },
+            None,
         )
         .await
         .unwrap();
@@ -315,7 +319,7 @@ mod tests {
     #[tokio::test]
     async fn returns_none_on_invalid_input() {
         let input = r#"not even json"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("not even json".to_string()));
@@ -325,7 +329,7 @@ mod tests {
     #[tokio::test]
     async fn returns_none_on_valid_json_wrong_shape() {
         let input = r#"{ "foo": "bar" }"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("{ \"foo\": \"bar\" }".to_string()));
@@ -340,7 +344,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
 </think>
 
 <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}]</TOOLCALL>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
         assert!(!result.is_empty());
@@ -355,7 +359,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     #[tokio::test]
     async fn test_nvidia_llama3_nemotron_super_49b_simple_with_no_think() {
         let input = r#"<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}]</TOOLCALL>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
         assert!(!result.is_empty());
@@ -375,7 +379,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
 
 <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}, {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}]</TOOLCALL>"#;
         let config = ToolCallConfig::nemotron_deci();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("<think>\nOkay, the user is asking for the weather in San Francisco in Fahrenheit. Let me check the tools available.\n</think>".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -406,7 +410,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
   </TOOLCALL>
   "#;
         let config = ToolCallConfig::nemotron_deci();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("<think>\nOkay, the user is asking for the weather in San Francisco in Fahrenheit. Let me check the tools available.\n</think>".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -425,7 +429,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         let input = r#"<tool_call>
 {"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}
 </tool_call>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -442,7 +446,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         let input = r#"Hey How are you? <tool_call>
 {"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}
 </tool_call>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
@@ -455,7 +459,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         let input = r#"<tool_call>
 {"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}
 </tool_call>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -477,7 +481,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
 </tool_call>
 "#;
         let config = ToolCallConfig::hermes();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -501,7 +505,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
 </tool_call>
 "#;
         let config = ToolCallConfig::hermes();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -529,7 +533,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
 </tool_call>
 "#;
         let config = ToolCallConfig::hermes();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -555,7 +559,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
                 ..Default::default()
             }),
         };
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -569,7 +573,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     async fn test_mistralai_mistral_7b_instruct_v03_simple() {
         let input = r#" [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -583,7 +587,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     async fn test_mistralai_mistral_7b_instruct_v03_simple_with_normal_text() {
         let input = r#"Hey How are you? [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -602,7 +606,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         "unit": "fahrenheit"}}]
         "#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -616,7 +620,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     async fn test_mistralai_mistral_7b_instruct_v03_multiple() {
         let input = r#" [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}, {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -634,7 +638,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     async fn test_mistralai_mistral_7b_instruct_v03_multiple_with_normal_text() {
         let input = r#"Hey How are you? [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}, {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -660,7 +664,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         "fahrenheit"}}]
         "#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -678,7 +682,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     async fn test_mistralai_mistral_7b_instruct_v03_single_with_start_token() {
         let input = r#"[TOOL_CALLS] [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -692,7 +696,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     async fn test_mistralai_mistral_7b_instruct_v03_single_with_start_token_with_normal_text() {
         let input = r#"Hey How are you? [TOOL_CALLS] [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -712,7 +716,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         "unit": "fahrenheit"}}]
         "#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -726,7 +730,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     async fn test_mistralai_mistral_7b_instruct_v03_single_with_start_token_multiple() {
         let input = r#"[TOOL_CALLS] [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}, {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -745,7 +749,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
      {
         let input = r#"Hey How are you? [TOOL_CALLS] [{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}, {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}]"#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -773,7 +777,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         "fahrenheit"}}]
         "#;
         let config = ToolCallConfig::mistral();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -790,7 +794,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     #[tokio::test]
     async fn test_meta_llama_llama31_8b_instruct_simple() {
         let input = r#"{"name": "get_weather", "parameters": {"location": "San Francisco, CA", "unit": "fahrenheit"}}"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::mistral())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::mistral(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -805,7 +809,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     #[tokio::test]
     async fn test_meta_llama_llama31_8b_instruct_simple_with_normal_text() {
         let input = r#"Hey How are you? {"name": "get_weather", "parameters": {"location": "San Francisco, CA", "unit": "fahrenheit"}}"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::mistral())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::mistral(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
@@ -823,7 +827,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         {"name": "get_weather",
         "parameters": {"location": "San Francisco, CA", "unit": "fahrenheit"}}
         "#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("llama3_json"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("llama3_json"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -838,7 +842,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     #[tokio::test]
     async fn test_meta_llama_llama31_8b_instruct_with_python_tag() {
         let input = r#"<|python_tag|>{ "name": "get_weather", "parameters": {"location": "San Francisco, CA", "unit": "fahrenheit" } }"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("llama3_json"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("llama3_json"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -853,7 +857,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     #[tokio::test]
     async fn test_meta_llama_llama31_8b_instruct_with_python_tag_with_normal_text() {
         let input = r#"Hey How are you? <|python_tag|>{ "name": "get_weather", "parameters": {"location": "San Francisco, CA", "unit": "fahrenheit" } }"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("llama3_json"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("llama3_json"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
@@ -871,7 +875,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         <|python_tag|>
         {"name": "get_weather", "parameters": {"location": "San Francisco, CA", "unit": "fahrenheit"}}
         "#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("llama3_json"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("llama3_json"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -891,7 +895,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         <|python_tag|>
         {"name": "get_weather", "parameters": {"location": "New York, NY", "unit": "fahrenheit" }}
         "#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("llama3_json"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("llama3_json"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -911,7 +915,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     async fn test_detect_and_parse_tool_call_error_handling() {
         // Unknown parser string should return an error
         let input = r#"{"name": "get_weather", "arguments": {"location": "San Francisco, CA"}}"#;
-        let result = detect_and_parse_tool_call(input, Some("unknown_parser")).await;
+        let result = detect_and_parse_tool_call(input, Some("unknown_parser"), None).await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -922,7 +926,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
 
         // Known parser, but invalid input (not JSON) should return Ok(None)
         let input = "not a json";
-        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("not a json".to_string()));
@@ -930,7 +934,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
 
         // Known parser, but valid JSON with wrong shape should return Ok(None)
         let input = r#"{"foo": "bar"}"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"), None)
             .await
             .unwrap();
         assert_eq!(content, Some(r#"{"foo": "bar"}"#.to_string()));
@@ -945,7 +949,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
 - **Summer (June to August)**: Average highs range from the mid-60s to low 70s Fahrenheit, with cooler mornings and evenings. Coastal areas may be cooler than inland spots.
 
 Remember, San Francisco weather can be quite unpredictable, particularly with its famous fog, which can significantly lower temperatures. Always check a local weather forecast for the most accurate and up-to-date information."#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::default(), None)
             .await
             .unwrap();
         assert_eq!(content, Some(input.to_string()));
@@ -958,7 +962,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
 {"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}
 ]</tool_calls>"#;
         let config = ToolCallConfig::jamba();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -975,7 +979,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
 {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "celsius"}}
 ]</tool_calls>"#;
         let config = ToolCallConfig::jamba();
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -1003,7 +1007,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
                 ..Default::default()
             }),
         };
-        let (result, content) = try_tool_call_parse(input, &config).await.unwrap();
+        let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -1016,7 +1020,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     #[tokio::test]
     async fn test_detect_and_parse_tool_call_default_parser_nemotron_deci() {
         let input = r#"<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}]</TOOLCALL>"#;
-        let (result, content) = detect_and_parse_tool_call(input, None).await.unwrap();
+        let (result, content) = detect_and_parse_tool_call(input, None, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -1029,7 +1033,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     #[tokio::test]
     async fn test_detect_and_parse_tool_call_default_parser_nemotron_deci_multiple() {
         let input = r#"<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}, {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}]</TOOLCALL>"#;
-        let (result, content) = detect_and_parse_tool_call(input, None).await.unwrap();
+        let (result, content) = detect_and_parse_tool_call(input, None, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -1047,7 +1051,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     async fn test_detect_and_parse_tool_call_default_parser_nemotron_deci_multiple_with_normal_text()
      {
         let input = r#"Hey How are you? <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit"}}, {"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}]</TOOLCALL>"#;
-        let (result, content) = detect_and_parse_tool_call(input, None).await.unwrap();
+        let (result, content) = detect_and_parse_tool_call(input, None, None).await.unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -1064,7 +1068,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     #[tokio::test]
     async fn test_detect_and_parse_tool_call_default_parser_llama3_json_with_python_tag() {
         let input = r#"<|python_tag|>{ "name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit" } }"#;
-        let (result, content) = detect_and_parse_tool_call(input, None).await.unwrap();
+        let (result, content) = detect_and_parse_tool_call(input, None, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -1078,7 +1082,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     async fn test_detect_and_parse_tool_call_default_parser_llama3_json_with_python_tag_with_normal_text()
      {
         let input = r#"Hey How are you? <|python_tag|>{ "name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit" } }"#;
-        let (result, content) = detect_and_parse_tool_call(input, None).await.unwrap();
+        let (result, content) = detect_and_parse_tool_call(input, None, None).await.unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -1099,7 +1103,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
           {"location": "San Francisco, CA",
           "unit": "fahrenheit" }}
         "#;
-        let (result, content) = detect_and_parse_tool_call(input, None).await.unwrap();
+        let (result, content) = detect_and_parse_tool_call(input, None, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -1117,7 +1121,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
          {"location": "San Francisco, CA",
           "unit": "fahrenheit" }}
         "#;
-        let (result, content) = detect_and_parse_tool_call(input, None).await.unwrap();
+        let (result, content) = detect_and_parse_tool_call(input, None, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 1);
@@ -1130,7 +1134,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     #[tokio::test]
     async fn test_detect_and_parse_tool_call_default_parser_llama3_json_without_python_tag() {
         let input = r#"{ "name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit" } }"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::mistral())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::mistral(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1146,7 +1150,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     async fn test_detect_and_parse_tool_call_default_parser_llama3_json_without_python_tag_with_normal_text()
      {
         let input = r#"Hey How are you? { "name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "fahrenheit" } }"#;
-        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::mistral())
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::mistral(), None)
             .await
             .unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
@@ -1162,7 +1166,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     async fn test_phi4_single_function_call() {
         let input =
             r#"functools[{"name": "get_country_capital", "arguments": {"country": "Poland"}}]"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1175,7 +1179,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     #[tokio::test]
     async fn test_phi4_single_function_call_with_normal_text() {
         let input = r#"Hey How are you? functools[{"name": "get_country_capital", "arguments": {"country": "Poland"}}]"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
@@ -1191,7 +1195,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
   {"name": "get_country_capital", "arguments": {"country": "Poland"}},
   {"name": "get_population", "arguments": {"city": "Warsaw"}}
 ]"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1212,7 +1216,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
   {"name": "get_country_capital", "arguments": {"country": "Poland"}},
   {"name": "get_population", "arguments": {"city": "Warsaw"}}
 ]"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
@@ -1232,7 +1236,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         let input = r#"functools[{"name": "get_weather_forecast", "arguments":
         {"location": {"city": "San Francisco",
         "state": "CA"}, "date": "2023-10-05"}}]"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1249,7 +1253,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         let input = r#"Hey How are you? functools[{"name": "get_weather_forecast", "arguments":
         {"location": {"city": "San Francisco",
         "state": "CA"}, "date": "2023-10-05"}}]"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
@@ -1265,7 +1269,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     async fn test_phi4_function_call_with_parameters_instead_of_arguments() {
         let input = r#"functools[{"name": "calculate_distance",
          "parameters": {"from": "New York", "to": "Los Angeles"}}]"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1280,7 +1284,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     async fn test_phi4_function_call_with_parameters_instead_of_arguments_with_normal_text() {
         let input = r#"Hey How are you? functools[{"name": "calculate_distance",
          "parameters": {"from": "New York", "to": "Los Angeles"}}]"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
@@ -1296,7 +1300,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         // Reproduce the issue where "functools" appears in content field
         // This might happen when there's malformed JSON or parsing issues
         let input = r#"functools{"name": "get_weather","arguments":{"location":"San Francisco"}}"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         // Content should be empty, not contain "functools"
@@ -1312,7 +1316,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         // Test the case where only the token appears without JSON
         // This case is less critical but shouldn't leak the full token
         let input = r#"functools"#;
-        let (result, _content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, _content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         // Content may contain the token if no valid JSON follows, but shouldn't crash
@@ -1325,7 +1329,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     async fn test_phi4_token_with_invalid_json() {
         // Test the case where token is followed by invalid JSON
         let input = r#"functools{invalid json}"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         // Content should be empty, not contain "functools" or leak the token
@@ -1381,7 +1385,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         // are correctly treated as normal content, not tool calls
 
         let input = r#"funk music is great"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         // Should be treated as normal content, not tool call
@@ -1402,7 +1406,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         // Test words that start with "func" but are not "functools"
 
         let input = r#"The function works well"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         assert_eq!(
@@ -1413,7 +1417,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         assert_eq!(content, Some("The function works well".to_string()));
 
         let input = r#"functional programming"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("phi4"), None)
             .await
             .unwrap();
         assert_eq!(
@@ -1438,7 +1442,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         ];
 
         for test_input in test_cases {
-            let (result, content) = detect_and_parse_tool_call(test_input, Some("phi4"))
+            let (result, content) = detect_and_parse_tool_call(test_input, Some("phi4"), None)
                 .await
                 .unwrap();
             assert_eq!(
@@ -1468,7 +1472,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         ];
 
         for test_input in test_cases {
-            let (result, content) = detect_and_parse_tool_call(test_input, Some("phi4"))
+            let (result, content) = detect_and_parse_tool_call(test_input, Some("phi4"), None)
                 .await
                 .unwrap();
             assert_eq!(
@@ -1489,7 +1493,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     #[tokio::test]
     async fn test_pythonic_parser_basic_with_constants() {
         let input = r#"[get_weather(location="San Francisco", unit="fahrenheit"), get_weather(location="New York", unit="fahrenheit")]"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("pythonic"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("pythonic"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1508,7 +1512,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     #[ignore]
     async fn test_pythonic_parser_with_constants_and_normal_text() {
         let input = r#"Hey How are you? [get_weather(location="San Francisco", unit="fahrenheit"), get_weather(location="New York", unit="fahrenheit")]"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("pythonic"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("pythonic"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("Hey How are you?".to_string()));
@@ -1528,7 +1532,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     async fn test_harmony_parser_basic() {
         let input = r#"
         <|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("harmony"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("harmony"), None)
             .await
             .unwrap();
         assert_eq!(
@@ -1551,7 +1555,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
 ```json
 {"location": "Paris"}
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("deepseek_v3"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("deepseek_v3"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1567,7 +1571,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     #[tokio::test]
     async fn test_deepseek_v3_1_parser_basic() {
         let input = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Paris"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("deepseek_v3_1"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("deepseek_v3_1"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1588,9 +1592,10 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
 </｜DSML｜invoke>
 </｜DSML｜function_calls>"#;
 
-        let (tool_calls, normal_text) = detect_and_parse_tool_call(input, Some("deepseek_v3_2"))
-            .await
-            .expect("Failed to parse");
+        let (tool_calls, normal_text) =
+            detect_and_parse_tool_call(input, Some("deepseek_v3_2"), None)
+                .await
+                .expect("Failed to parse");
 
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].function.name, "get_datetime");
@@ -1614,7 +1619,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
 </｜DSML｜invoke>
 </｜DSML｜function_calls>"#;
 
-        let (tool_calls, _) = detect_and_parse_tool_call(input, Some("deepseek_v3_2"))
+        let (tool_calls, _) = detect_and_parse_tool_call(input, Some("deepseek_v3_2"), None)
             .await
             .expect("Failed to parse");
 
@@ -1642,7 +1647,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
 </｜DSML｜invoke>
 </｜DSML｜function_calls>"#;
 
-        let (tool_calls, _) = detect_and_parse_tool_call(input, Some("deepseek_v3_2"))
+        let (tool_calls, _) = detect_and_parse_tool_call(input, Some("deepseek_v3_2"), None)
             .await
             .expect("Failed to parse");
 
@@ -1660,7 +1665,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     async fn test_hermes_parser_without_new_line() {
         let input = r#"<tool_call>{"name": "get_weather", "arguments": {"location": "San Francisco, CA", "unit": "celsius"}}</tool_call>"
         "#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1743,7 +1748,7 @@ mod parallel_tool_calling_tests {
     {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}
 ]</TOOLCALL>"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -1759,7 +1764,7 @@ mod parallel_tool_calling_tests {
     {"name": "get_current_weather", "arguments": {"city": "Seattle", "state": "WA", "unit": "fahrenheit"}}
 ]</TOOLCALL>"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -1777,7 +1782,7 @@ mod parallel_tool_calling_tests {
     {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}
 ]</TOOLCALL>"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -1821,7 +1826,7 @@ fahrenheit
 </function>
 </tool_call>"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
 
@@ -1837,7 +1842,7 @@ fahrenheit
     async fn test_parallel_xlam_format_pure_json() {
         let input = r#"[{"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}, {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}]"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("mistral"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("mistral"), None)
             .await
             .unwrap();
 
@@ -1852,7 +1857,7 @@ fahrenheit
     {"name": "get_current_weather", "arguments": {"city": "Orlando", "state": "FL", "unit": "fahrenheit"}}
 ]"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("mistral"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("mistral"), None)
             .await
             .unwrap();
 
@@ -1879,7 +1884,7 @@ fahrenheit
 ]</TOOLCALL>"#;
 
         let (result, content) =
-            detect_and_parse_tool_call(input_nemotron_format, Some("nemotron_deci"))
+            detect_and_parse_tool_call(input_nemotron_format, Some("nemotron_deci"), None)
                 .await
                 .unwrap();
 
@@ -1896,7 +1901,7 @@ fahrenheit
         // Test with harmony parser for multiple tool calls
         let input = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"city": "Dallas", "state": "TX", "unit": "fahrenheit"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"city": "Orlando", "state": "FL", "unit": "fahrenheit"}<|call|>"#;
 
-        let (result, _content) = detect_and_parse_tool_call(input, Some("harmony"))
+        let (result, _content) = detect_and_parse_tool_call(input, Some("harmony"), None)
             .await
             .unwrap();
 
@@ -1920,7 +1925,7 @@ fahrenheit
     {"name": "web_search", "arguments": {"query": "Orlando Florida attractions", "max_results": 5}}
 ]</TOOLCALL>"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -1952,7 +1957,7 @@ fahrenheit
     {"name": "get_current_weather", "arguments": {"city": "Orlando", "invalid_field": 123}}
 ]</TOOLCALL>"#;
 
-        let (result, _content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, _content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -1971,7 +1976,7 @@ fahrenheit
     async fn test_parallel_empty_array() {
         let input = r#"<TOOLCALL>[]</TOOLCALL>"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -1989,7 +1994,7 @@ fahrenheit
     {"name": "get_current_weather", "arguments": {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}
 ]</TOOLCALL>"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2012,7 +2017,7 @@ fahrenheit
     {"name": "get_current_weather", "arguments": {"city": "Miami", "state": "FL", "unit": "fahrenheit"}}
 ]</TOOLCALL>"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2056,7 +2061,7 @@ fahrenheit
     }
 ]</TOOLCALL>"#;
 
-        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2134,7 +2139,7 @@ fahrenheit
     {"name": "web_search", "arguments": {"query": "weather forecast", "max_results": 3}}
 ]</TOOLCALL>"#;
 
-        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2151,7 +2156,7 @@ fahrenheit
     {"name": "function_three", "arguments": {"param5": {"nested": "object"}}}
 ][/TOOL_CALLS]"#;
 
-        let (result, _) = detect_and_parse_tool_call(input, Some("mistral"))
+        let (result, _) = detect_and_parse_tool_call(input, Some("mistral"), None)
             .await
             .unwrap();
 
@@ -2181,7 +2186,7 @@ fahrenheit
         let input = format!("<TOOLCALL>[{}]</TOOLCALL>", tool_calls.join(","));
 
         let start = std::time::Instant::now();
-        let (result, _) = detect_and_parse_tool_call(&input, Some("nemotron_deci"))
+        let (result, _) = detect_and_parse_tool_call(&input, Some("nemotron_deci"), None)
             .await
             .unwrap();
         let duration = start.elapsed();
@@ -2208,7 +2213,7 @@ fahrenheit
             large_data, large_data
         );
 
-        let (result, _) = detect_and_parse_tool_call(&input, Some("nemotron_deci"))
+        let (result, _) = detect_and_parse_tool_call(&input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2237,7 +2242,7 @@ fahrenheit
     {"name": "process_unicode", "arguments": {"data": "café naïve résumé", "encoding": "utf-8"}}
 ]</TOOLCALL>"#;
 
-        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2267,7 +2272,7 @@ fahrenheit
     {"name": "regex_pattern", "arguments": {"pattern": "\\d{3}-\\d{3}-\\d{4}", "test_string": "Phone: 123-456-7890"}}
 ]</TOOLCALL>"#;
 
-        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2293,7 +2298,7 @@ fahrenheit
     {"name": "object_test", "arguments": {"empty_object": {}, "nested": {"level1": {"level2": {"value": "deep"}}}}}
 ]</TOOLCALL>"#;
 
-        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2341,7 +2346,7 @@ fahrenheit
     }
 ]</TOOLCALL>"#;
 
-        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2377,7 +2382,7 @@ fahrenheit
         ];
 
         for (input, parser) in test_cases {
-            let (result, _) = detect_and_parse_tool_call(&input, Some(parser))
+            let (result, _) = detect_and_parse_tool_call(&input, Some(parser), None)
                 .await
                 .unwrap_or_else(|e| panic!("Failed to parse with {}: {}", parser, e));
             assert_eq!(
@@ -2404,7 +2409,7 @@ fahrenheit
     {"name": "single_call", "arguments": {"test": true}}
 ]</TOOLCALL>"#;
 
-        let (result, _) = detect_and_parse_tool_call(input_single, Some("nemotron_deci"))
+        let (result, _) = detect_and_parse_tool_call(input_single, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2422,7 +2427,7 @@ fahrenheit
 
         let input_many = format!("<TOOLCALL>[{}]</TOOLCALL>", many_calls.join(","));
 
-        let (result, _) = detect_and_parse_tool_call(&input_many, Some("nemotron_deci"))
+        let (result, _) = detect_and_parse_tool_call(&input_many, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2451,7 +2456,7 @@ fahrenheit
     {"name": "good_call_4", "arguments": {"param": "value4"}}
 ]</TOOLCALL>"#;
 
-        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"))
+        let (result, _) = detect_and_parse_tool_call(input, Some("nemotron_deci"), None)
             .await
             .unwrap();
 
@@ -2608,7 +2613,7 @@ pwd && ls
 </parameter>
 </function>
 </tool_call>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -2633,7 +2638,7 @@ fahrenheit
 </parameter>
 </function>
 </tool_call>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -2657,7 +2662,7 @@ fahrenheit
 </parameter>
 </function>
 </tool_call> Let me get that information for you."#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
         assert_eq!(
@@ -2702,7 +2707,7 @@ fahrenheit
 </parameter>
 </function>
 </tool_call>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -2730,9 +2735,20 @@ fahrenheit
 </parameter>
 </function>
 </tool_call>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
-            .await
-            .unwrap();
+        let tools = vec![ToolDefinition {
+            name: "process_data".to_string(),
+            parameters: Some(serde_json::json!({
+                "properties": {
+                    "config": {
+                        "type": "array"
+                    }
+                }
+            })),
+        }];
+        let (result, content) =
+            detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
+                .await
+                .unwrap();
         assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 1);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -2757,7 +2773,17 @@ true
 </parameter>
 </function>
 </tool_call>"#;
-        let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let tools = vec![ToolDefinition {
+            name: "calculate".to_string(),
+            parameters: Some(serde_json::json!({
+                "properties": {
+                    "x": {"type": "int"},
+                    "y": {"type": "float"},
+                    "enabled": {"type": "bool"},
+                }
+            })),
+        }];
+        let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
@@ -2771,7 +2797,7 @@ true
     #[tokio::test]
     async fn test_qwen3_coder_no_tool_calls() {
         let input = "This is just normal text without any tool calls.";
-        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
         assert_eq!(result.len(), 0);
@@ -2781,7 +2807,7 @@ true
     #[tokio::test]
     async fn test_qwen3_coder_compact_format() {
         let input = r#"<tool_call><function=search><parameter=query>rust programming</parameter><parameter=limit>10</parameter></function></tool_call>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -2789,7 +2815,7 @@ true
         let (name, args) = extract_name_and_args(result[0].clone());
         assert_eq!(name, "search");
         assert_eq!(args["query"], "rust programming");
-        assert_eq!(args["limit"], 10);
+        assert_eq!(args["limit"], "10");
     }
 
     #[tokio::test]
@@ -2801,7 +2827,7 @@ true
 </parameter>
 </function>
 </tool_call>"#;
-        let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
@@ -2833,7 +2859,7 @@ Seattle
 </parameter>
 </function>
 </tool_call>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
             .await
             .unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -2869,9 +2895,20 @@ weather forecasting
 </parameter>
 </function>
 </tool_call>"#;
-        let (result, content) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
-            .await
-            .unwrap();
+        let tools = vec![ToolDefinition {
+            name: "web_search".to_string(),
+            parameters: Some(serde_json::json!({
+                "properties": {
+                    "max_results": {
+                        "type": "uint"
+                    }
+                }
+            })),
+        }];
+        let (result, content) =
+            detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
+                .await
+                .unwrap();
         assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 2);
 
@@ -2887,7 +2924,7 @@ weather forecasting
     }
 
     #[tokio::test]
-    async fn test_qwen3_coder_array_parameter_value() {
+    async fn test_qwen3_coder_array_parameter_value_without_tool_definition() {
         let input = r#"<tool_call>
 <function=process_list>
 <parameter=items>
@@ -2895,7 +2932,36 @@ weather forecasting
 </parameter>
 </function>
 </tool_call>"#;
-        let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"))
+        let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "process_list");
+        // The default is to return it as a string.
+        assert_eq!(args["items"], serde_json::json!("[1, 2, 3, 4, 5]"));
+    }
+
+    #[tokio::test]
+    async fn test_qwen3_coder_array_parameter_value_with_tool_definition() {
+        let input = r#"<tool_call>
+<function=process_list>
+<parameter=items>
+[1, 2, 3, 4, 5]
+</parameter>
+</function>
+</tool_call>"#;
+        let tools = vec![ToolDefinition {
+            name: "process_list".to_string(),
+            parameters: Some(serde_json::json!({
+                "properties": {
+                    "items": {
+                        "type": "array"
+                    }
+                }
+            })),
+        }];
+        let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
             .await
             .unwrap();
         assert_eq!(result.len(), 1);

--- a/lib/parsers/src/tool_calling/pythonic/pythonic_parser.rs
+++ b/lib/parsers/src/tool_calling/pythonic/pythonic_parser.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::super::ToolDefinition;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 use regex::Regex;
 use rustpython_parser::{
@@ -161,6 +162,7 @@ fn const_expr(e: &Expr) -> Result<Value, Box<dyn std::error::Error>> {
 
 pub fn try_tool_call_parse_pythonic(
     message: &str,
+    _tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let stripped = strip_text(message).trim().to_string();
 
@@ -263,7 +265,7 @@ mod tests {
     #[test]
     fn test_parse_tool_call_parse_pythonic_basic() {
         let message = "[foo(a=1, b=2), bar(x=3)]";
-        let (result, content) = try_tool_call_parse_pythonic(message).unwrap();
+        let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -279,7 +281,7 @@ mod tests {
     #[test]
     fn test_parse_tool_call_parse_pythonic_with_text() {
         let message = "Hey yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
-        let (result, content) = try_tool_call_parse_pythonic(message).unwrap();
+        let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
         assert_eq!(content, Some("Hey yo !".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -295,7 +297,7 @@ mod tests {
     #[test]
     fn test_parse_tool_call_parse_pythonic_with_text_and_new_line() {
         let message = "Hey \n yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
-        let (result, content) = try_tool_call_parse_pythonic(message).unwrap();
+        let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
         assert_eq!(content, Some("Hey \n yo !".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -311,7 +313,7 @@ mod tests {
     #[test]
     fn test_parse_tool_call_parse_pythonic_with_no_calls() {
         let message = "Hey \n yo !";
-        let (result, content) = try_tool_call_parse_pythonic(message).unwrap();
+        let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
         assert_eq!(content, Some("Hey \n yo !".to_string()));
         assert!(result.is_empty());
         assert_eq!(result.len(), 0)
@@ -320,7 +322,7 @@ mod tests {
     #[test]
     fn test_parse_tool_call_parse_pythonic_with_python_tags() {
         let message = "<|python_start|>[foo(a=1, b=2), bar(x=3)]<|python_end|>";
-        let (result, content) = try_tool_call_parse_pythonic(message).unwrap();
+        let (result, content) = try_tool_call_parse_pythonic(message, None).unwrap();
         assert_eq!(content, Some("".to_string()));
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
@@ -336,7 +338,7 @@ mod tests {
     #[test]
     fn test_parse_tool_call_parse_pythonic_with_list_arg_values() {
         let message = "[foo(a=[1, 2, 3], b=2), bar(x=[3, 4, 5])]";
-        let (result, _) = try_tool_call_parse_pythonic(message).unwrap();
+        let (result, _) = try_tool_call_parse_pythonic(message, None).unwrap();
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
         let (name, args) = extract_name_and_args(result[0].clone());
@@ -351,7 +353,7 @@ mod tests {
     #[test]
     fn test_parse_tool_call_parse_pythonic_with_dict_arg_values() {
         let message = "[foo(a={'a': 1, 'b': 2}, b=2), bar(x={'x': 3, 'y': {'e': 'f'}})]";
-        let (result, _) = try_tool_call_parse_pythonic(message).unwrap();
+        let (result, _) = try_tool_call_parse_pythonic(message, None).unwrap();
         assert!(!result.is_empty());
         assert_eq!(result.len(), 2);
         let (name, args) = extract_name_and_args(result[0].clone());

--- a/lib/parsers/src/tool_calling/tools.rs
+++ b/lib/parsers/src/tool_calling/tools.rs
@@ -10,6 +10,7 @@ pub use super::parsers::detect_and_parse_tool_call;
 pub async fn try_tool_call_parse_aggregate(
     message: &str,
     parser_str: Option<&str>,
+    tools: Option<&[super::ToolDefinition]>,
 ) -> anyhow::Result<(
     Vec<dynamo_async_openai::types::ChatCompletionMessageToolCall>,
     Option<String>,
@@ -19,7 +20,7 @@ pub async fn try_tool_call_parse_aggregate(
     } else {
         tracing::info!("Using tool parser: {:?}", parser_str);
     }
-    let (parsed, content) = detect_and_parse_tool_call(message, parser_str).await?;
+    let (parsed, content) = detect_and_parse_tool_call(message, parser_str, tools).await?;
     if parsed.is_empty() {
         return Ok((vec![], content));
     }
@@ -47,11 +48,12 @@ pub async fn try_tool_call_parse_aggregate(
 pub async fn try_tool_call_parse_stream(
     message: &str,
     parser_str: Option<&str>,
+    tools: Option<&[super::ToolDefinition]>,
 ) -> anyhow::Result<(
     Vec<dynamo_async_openai::types::ChatCompletionMessageToolCallChunk>,
     Option<String>,
 )> {
-    let (parsed, content) = detect_and_parse_tool_call(message, parser_str).await?;
+    let (parsed, content) = detect_and_parse_tool_call(message, parser_str, tools).await?;
     if parsed.is_empty() {
         return Ok((vec![], content));
     }


### PR DESCRIPTION
#### Overview:

This PR extends parsers to accept a `ToolDefinition` struct that contains, amongst other things, the information necessary to ensure tool call arguments are serialized per the type included by the request's tool definitions.

#### Details:

* Why?

The qwen3_coder parser (and potentially other parsers) need access to the tool's type declarations to correctly parse parameter values.
Without this information, all parameter values are treated based on heuristics, causing type mismatches that fail tool calling benchmarks like BFCL-3.

For example, when a tool parameter is defined as:
  - type: "integer" -> the value "42" should be parsed as the number 42.
  - type: "string" -> the value "42" should be parsed as the string
    "42".
  - type: "array" -> the value "[1, 2, 3]" should be parsed as an
    array (list) [1, 2, 3].
  - type: "str" -> the value "[1, 2, 3]" should be parsed as a string
    representation "[1, 2, 3]"

Without schema information, parsers have no way to distinguish between these cases.

* What?

This commit threads tool definitions through the entire parsing pipeline:

1. Extracts tool schemas from OpenAI request format at the API boundary
2. Converts to internal `ToolDefinition` format (name + JSON schema)
3. Passes definitions through `JailedStream` and parser configuration
4. Makes definitions available to individual parsers (XML, JSON, etc.)

The XML parser now uses these definitions to perform schema-aware type conversion, matching the behavior of the reference Python implementation in vLLM.

* Impact

- Parsers that don't need schema information (JSON, DSML, etc.) can ignore the new optional parameter.
- XML-based parsers (`qwen3_coder`) gain correct type handling.
- Backward compatible: passing None for `tool_definitions` maintains existing behavior.
- All existing tests updated to pass None where schema is not needed.

#### Where should the reviewer start?

Unit tests

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Tool definitions with parameter metadata can now be supplied to improve tool call parsing and validation across multiple formats.
- Parameter values are now automatically converted to correct types based on provided parameter schemas, enabling more accurate tool call handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->