### PR TITLE
test: make serve tests xdist-safe with dynamic ports

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -268,6 +268,13 @@ def parse_args():
 
 
 async def async_main():
+    # The system status server port is a worker concern.
+    #
+    # Serve tests set DYN_SYSTEM_PORT for the worker, but aggregated launch scripts
+    # start `dynamo.frontend` first. If the frontend inherits DYN_SYSTEM_PORT, it can
+    # bind that port before the worker, causing port conflicts and/or scraping the
+    # wrong metrics endpoint.
+    os.environ.pop("DYN_SYSTEM_PORT", None)
     flags = parse_args()
     dump_config(flags.dump_config_to, flags)
 

--- a/examples/backends/sglang/launch/disagg.sh
+++ b/examples/backends/sglang/launch/disagg.sh
@@ -54,7 +54,9 @@ DYNAMO_PID=$!
 #AssertionError: Prefill round robin balance is required when dp size > 1. Please make sure that the prefill instance is launched with `--load-balance-method round_robin` and `--prefill-round-robin-balance` is set for decode server.
 
 # run prefill worker
-OTEL_SERVICE_NAME=dynamo-worker-prefill DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_PREFILL:-8081} \
+# Use DYN_SYSTEM_PORT1/2 instead of *_PREFILL/*_DECODE env names so test
+# harnesses can set one simple pair for disaggregated deployments.
+OTEL_SERVICE_NAME=dynamo-worker-prefill DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 python3 -m dynamo.sglang \
   --model-path silence09/DeepSeek-R1-Small-2layers \
   --served-model-name silence09/DeepSeek-R1-Small-2layers \
@@ -72,7 +74,7 @@ python3 -m dynamo.sglang \
 PREFILL_PID=$!
 
 # run decode worker
-OTEL_SERVICE_NAME=dynamo-worker-decode DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_DECODE:-8082} \
+OTEL_SERVICE_NAME=dynamo-worker-decode DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 CUDA_VISIBLE_DEVICES=2,3 python3 -m dynamo.sglang \
   --model-path silence09/DeepSeek-R1-Small-2layers \
   --served-model-name silence09/DeepSeek-R1-Small-2layers \

--- a/examples/backends/sglang/launch/disagg_router.sh
+++ b/examples/backends/sglang/launch/disagg_router.sh
@@ -56,7 +56,9 @@ python3 -m dynamo.frontend \
 DYNAMO_PID=$!
 
 # run prefill router
-OTEL_SERVICE_NAME=dynamo-router-prefill DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_PREFILL_ROUTER:-8081} \
+# Use numeric DYN_SYSTEM_PORT{N} env vars so launchers/test harnesses can set
+# ports without encoding role names (prefill/decode) in the env var.
+OTEL_SERVICE_NAME=dynamo-router-prefill DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 python3 -m dynamo.router \
   --endpoint dynamo.prefill.generate \
   --block-size 64 \
@@ -65,7 +67,7 @@ python3 -m dynamo.router \
 PREFILL_ROUTER_PID=$!
 
 # run prefill worker
-OTEL_SERVICE_NAME=dynamo-worker-prefill-1 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_PREFILL_WORKER1:-8082} \
+OTEL_SERVICE_NAME=dynamo-worker-prefill-1 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 python3 -m dynamo.sglang \
   --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
   --served-model-name deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
@@ -81,7 +83,7 @@ python3 -m dynamo.sglang \
 PREFILL_PID=$!
 
 # run prefill worker
-OTEL_SERVICE_NAME=dynamo-worker-prefill-2 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_PREFILL_WORKER2:-8083} \
+OTEL_SERVICE_NAME=dynamo-worker-prefill-2 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT3:-8083} \
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
   --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
   --served-model-name deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
@@ -97,7 +99,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
 PREFILL_PID=$!
 
 # run decode worker
-OTEL_SERVICE_NAME=dynamo-worker-decode-1 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_DECODE_WORKER1:-8084} \
+OTEL_SERVICE_NAME=dynamo-worker-decode-1 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT4:-8084} \
 CUDA_VISIBLE_DEVICES=3 python3 -m dynamo.sglang \
   --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
   --served-model-name deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
@@ -113,7 +115,7 @@ CUDA_VISIBLE_DEVICES=3 python3 -m dynamo.sglang \
 PREFILL_PID=$!
 
 # run decode worker
-OTEL_SERVICE_NAME=dynamo-worker-decode-2 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_DECODE_WORKER2:-8085} \
+OTEL_SERVICE_NAME=dynamo-worker-decode-2 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT5:-8085} \
 CUDA_VISIBLE_DEVICES=2 python3 -m dynamo.sglang \
   --model-path deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
   --served-model-name deepseek-ai/DeepSeek-R1-Distill-Llama-8B \

--- a/examples/backends/vllm/launch/agg_router.sh
+++ b/examples/backends/vllm/launch/agg_router.sh
@@ -19,6 +19,11 @@ python -m dynamo.frontend \
 
 # run workers
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag
+#
+# If multiple workers are launched, they must not share the same system/metrics port.
+# Use DYN_SYSTEM_PORT{1,2} so tests/launchers can provide a simple numbered port set.
+#
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
@@ -26,6 +31,8 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --connector none \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
 
+VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
     --model $MODEL \

--- a/examples/backends/vllm/launch/agg_router.sh
+++ b/examples/backends/vllm/launch/agg_router.sh
@@ -31,7 +31,6 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --connector none \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
 
-VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \

--- a/examples/backends/vllm/launch/disagg.sh
+++ b/examples/backends/vllm/launch/disagg.sh
@@ -9,8 +9,10 @@ trap 'echo Cleaning up...; kill 0' EXIT
 python -m dynamo.frontend &
 
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag
-CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --enforce-eager &
+ DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
+ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --enforce-eager &
 
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 DYN_VLLM_KV_EVENT_PORT=20081 \
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \

--- a/examples/backends/vllm/launch/disagg_same_gpu.sh
+++ b/examples/backends/vllm/launch/disagg_same_gpu.sh
@@ -48,7 +48,9 @@ DYNAMO_PID=$!
 
 # run decode worker with metrics on port 8081
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag
-DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+# For disaggregated deployments we standardize on DYN_SYSTEM_PORT1/2 instead of
+# *_PREFILL/*_DECODE env names so test harnesses can set one simple pair.
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 CUDA_VISIBLE_DEVICES=0 \
 python3 -m dynamo.vllm \
   --model Qwen/Qwen3-0.6B \
@@ -66,7 +68,7 @@ echo "Waiting for decode worker to initialize..."
 sleep 10
 
 # run prefill worker with metrics on port 8082 (foreground)
-DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_PREFILL:-8082} \
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 DYN_VLLM_KV_EVENT_PORT=20081 \
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=0 \

--- a/examples/backends/vllm/launch/lora/agg_lora.sh
+++ b/examples/backends/vllm/launch/lora/agg_lora.sh
@@ -17,11 +17,12 @@ export DYN_LORA_PATH=/tmp/dynamo_loras_minio
 mkdir -p $DYN_LORA_PATH
 
 # run ingress
-python -m dynamo.frontend --http-port=8000 &
+# dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var.
+python -m dynamo.frontend &
 
 # run worker
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag
-DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=8081 \
+DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
     python -m dynamo.vllm --model Qwen/Qwen3-0.6B --enforce-eager  \
     --connector none  \
     --enable-lora  \

--- a/examples/backends/vllm/launch/lora/agg_lora_router.sh
+++ b/examples/backends/vllm/launch/lora/agg_lora_router.sh
@@ -31,7 +31,7 @@ python -m dynamo.frontend \
 
 # run workers
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag
-DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=8082 \
+DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
@@ -41,7 +41,7 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --max-lora-rank 64 \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
 
-DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=8081 \
+DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
     --model $MODEL \

--- a/tests/serve/conftest.py
+++ b/tests/serve/conftest.py
@@ -1,14 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-
 import os
+import shutil
+from dataclasses import dataclass
+from typing import Generator
 
 import pytest
 from pytest_httpserver import HTTPServer
 
 from dynamo.common.utils.paths import WORKSPACE_DIR
 from tests.serve.lora_utils import MinioLoraConfig, MinioService
+from tests.utils.constants import DefaultPort
+from tests.utils.port_utils import allocate_port, allocate_ports, deallocate_ports
 
 # Shared constants for multimodal testing
 IMAGE_SERVER_PORT = 8765
@@ -16,6 +20,38 @@ MULTIMODAL_IMG_PATH = os.path.join(
     WORKSPACE_DIR, "lib/llm/tests/data/media/llm-optimize-deploy-graphic.png"
 )
 MULTIMODAL_IMG_URL = f"http://localhost:{IMAGE_SERVER_PORT}/llm-graphic.png"
+
+
+@dataclass(frozen=True)
+class ServicePorts:
+    frontend_port: int
+    system_port1: int
+    system_port2: int
+
+
+@pytest.fixture(scope="function")
+def dynamo_dynamic_ports() -> Generator[ServicePorts, None, None]:
+    """Allocate per-test ports for serve-style deployments.
+
+    - frontend_port: OpenAI-compatible HTTP ingress (dynamo.frontend)
+    - system_port1/system_port2: worker metrics/system ports (used by some scripts)
+
+    Note: some disaggregated launch scripts can spawn more than two workers; if/when
+    serve tests start exercising those scripts, we'll extend this fixture to allocate
+    additional system ports (e.g. system_port3+ / DYN_SYSTEM_PORT3+).
+    """
+
+    frontend_port = allocate_port(DefaultPort.FRONTEND.value)
+    system_ports = allocate_ports(2, DefaultPort.SYSTEM1.value)
+    ports = [frontend_port, *system_ports]
+    try:
+        yield ServicePorts(
+            frontend_port=frontend_port,
+            system_port1=system_ports[0],
+            system_port2=system_ports[1],
+        )
+    finally:
+        deallocate_ports(ports)
 
 
 @pytest.fixture(scope="session")
@@ -72,6 +108,12 @@ def minio_lora_service():
             # Use config.get_env_vars() for environment setup
             # Use config.get_s3_uri() to get the S3 URI for loading LoRA
     """
+    # LoRA serve tests spin up a local MinIO via Docker. Some environments are
+    # intentionally minimal (e.g. vLLM-only containers) and do not include the
+    # docker CLI, in which case we skip the LoRA tests.
+    if shutil.which("docker") is None:
+        pytest.skip("LoRA serve tests require the docker CLI (MinIO container).")
+
     config = MinioLoraConfig()
     service = MinioService(config)
 

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -8,6 +8,7 @@ avoid importing from conftest and to keep values consistent.
 """
 
 import os
+from enum import IntEnum
 
 QWEN = "Qwen/Qwen3-0.6B"
 LLAMA = "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"  # on an l4 gpu, must limit --max-seq-len, otherwise it will not fit
@@ -20,6 +21,16 @@ TEST_MODELS = [
     GPT_OSS,
     QWEN_EMBEDDING,
 ]
+
+
+# Default ports used by test payloads/scripts when not overridden.
+# Tests that need xdist-safety should allocate real ports via fixtures and map
+# these defaults to per-test ports at runtime.
+class DefaultPort(IntEnum):
+    FRONTEND = 8000
+    SYSTEM1 = 8081
+    SYSTEM2 = 8082
+
 
 # Env-driven defaults for specific test groups
 # Allows overriding via environment variables

--- a/tests/utils/engine_process.py
+++ b/tests/utils/engine_process.py
@@ -10,12 +10,15 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from tests.utils.constants import DefaultPort
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import BasePayload, check_health_generate, check_models_api
 
 logger = logging.getLogger(__name__)
 
-FRONTEND_PORT = 8000
+FRONTEND_PORT = (
+    DefaultPort.FRONTEND.value
+)  # Do NOT use this in tests! Use allocate_port() instead.
 
 
 class EngineResponseError(Exception):
@@ -43,7 +46,7 @@ class EngineConfig:
     script_name: Optional[str] = None
     command: Optional[List[str]] = None
     script_args: Optional[List[str]] = None
-    models_port: int = 8000
+    frontend_port: int = DefaultPort.FRONTEND.value
     timeout: int = 600
     delayed_start: int = 0
     env: Dict[str, str] = field(default_factory=dict)
@@ -174,9 +177,12 @@ class EngineProcess(ManagedProcess):
             working_dir=config.directory,
             health_check_ports=[],
             health_check_urls=[
-                (f"http://localhost:{config.models_port}/v1/models", check_models_api),
                 (
-                    f"http://localhost:{config.models_port}/health",
+                    f"http://localhost:{config.frontend_port}/v1/models",
+                    check_models_api,
+                ),
+                (
+                    f"http://localhost:{config.frontend_port}/health",
                     check_health_generate,
                 ),
             ],

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -4,6 +4,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from tests.utils.client import send_request
+from tests.utils.constants import DefaultPort
 from tests.utils.payloads import (
     ChatPayload,
     ChatPayloadWithLogprobs,
@@ -115,7 +116,7 @@ def metric_payload_default(
     repeat_count: int = 1,
     expected_log: Optional[List[str]] = None,
     backend: Optional[str] = None,
-    port: int = 8081,
+    port: int = DefaultPort.SYSTEM1.value,
 ) -> MetricsPayload:
     return MetricsPayload(
         body={},


### PR DESCRIPTION
#### Overview:

Make serve tests xdist-safe by using dynamically allocated ports for the frontend and worker system/metrics endpoints, avoiding port collisions during parallel runs.

#### Details:

- Allocate per-test frontend + system ports and plumb them through the serve test harness
- Standardize default port constants via `tests/utils/constants.py::DefaultPort`
- Ensure the frontend does not bind `DYN_SYSTEM_PORT*` (worker-only)
- Update launch scripts/tests to use numeric system port env vars (`DYN_SYSTEM_PORT1`, `DYN_SYSTEM_PORT2`)

#### Where should the reviewer start?

tests/serve/common.py
tests/serve/conftest.py
tests/serve/test_vllm.py

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)

Relates to DIS-1022

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic port allocation in test deployments to prevent port conflicts.
  * Enabled multi-worker deployments with separate, configurable system ports via environment variables (DYN_SYSTEM_PORT1, DYN_SYSTEM_PORT2).
  * Introduced standardized port configuration using DYN_HTTP_PORT for frontend and DYN_SYSTEM_PORT for system metrics.

* **Chores**
  * Unified port naming conventions across deployment scripts for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->