### PR TITLE
fix: Fix kvbm nixl connector for vllm upgrade

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
@@ -124,6 +124,9 @@ class PdConnector(MultiConnector):
         return metadata
 
     def bind_connector_metadata(self, connector_metadata: PdConnectorMetadata) -> None:
+        # Must call super() to set _connector_metadata so has_connector_metadata() returns True
+        # This is required for save_kv_layer to be called during the forward pass
+        super().bind_connector_metadata(connector_metadata)
         assert isinstance(connector_metadata, PdConnectorMetadata)
         if connector_metadata.extra_async_saves:
             self._extra_async_saves.update(connector_metadata.extra_async_saves)


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This PR fixed:

1. The `PdConnector` class was missing the `get_handshake_metadata()` method override. In vLLM v0.12.0, the KV transfer handshake flow requires:
- Worker side: `connector.get_handshake_metadata()` is called to get `NixlAgentMetadata`
- Engine core: The metadata is collected from all workers and passed to `set_xfer_handshake_metadata()`
- NIXL handshake listener: Uses this metadata to respond to decode workers
Since PdConnector didn't override `get_handshake_metadata()`, it returned None (from the base class), causing the handshake listener to start with an empty encoded_data dictionary.

2. Call super() to set _connector_metadata. This is required for `save_kv_layer` to be called during the forward pass, ensuring offloading happening.

closes DIS-1182

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added handshake metadata retrieval capability for distributed system connectors, enabling proper metadata exchange during initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->