### PR TITLE
feat(fault-injection): Add soft node affinity mode for GPU pod scheduling

### DIFF
--- a/tests/fault_tolerance/hardware/fault_injection_service/cuda_fault_injection/inject_into_pods.py
+++ b/tests/fault_tolerance/hardware/fault_injection_service/cuda_fault_injection/inject_into_pods.py
@@ -27,10 +27,31 @@ import os
 import subprocess
 import sys
 import time
+import warnings
+from contextlib import contextmanager
 from pathlib import Path
 
-from kubernetes import client, config
-from kubernetes.client.rest import ApiException
+# Suppress urllib3 deprecation warnings that break kubernetes client error handling
+# This is a known issue with kubernetes python client and urllib3 v2.x
+warnings.filterwarnings(
+    "ignore", message=".*HTTPResponse.getheaders.*", category=DeprecationWarning
+)
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="urllib3")
+
+from kubernetes import client, config  # noqa: E402
+from kubernetes.client.rest import ApiException  # noqa: E402
+
+
+@contextmanager
+def suppress_deprecation_warnings():
+    """Context manager to suppress deprecation warnings during kubernetes API calls.
+
+    The kubernetes client's exception handling calls deprecated urllib3 methods,
+    which can cause issues in certain Python/urllib3 version combinations.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        yield
 
 
 def get_library_path():
@@ -97,15 +118,22 @@ def create_cuda_fault_configmap(namespace, lib_path=None):
         )
 
         # Delete existing if present
-        try:
-            core_api.delete_namespaced_config_map("cuda-fault-injection-lib", namespace)
-            print("    → Deleted existing ConfigMap")
-            time.sleep(2)
-        except ApiException as e:
-            if e.status != 404:
-                print(f"    ⚠ Failed to delete existing ConfigMap: {e}")
+        with suppress_deprecation_warnings():
+            try:
+                core_api.delete_namespaced_config_map(
+                    "cuda-fault-injection-lib", namespace
+                )
+                print("    → Deleted existing ConfigMap")
+                time.sleep(2)
+            except ApiException as e:
+                if e.status != 404:
+                    print(f"    ⚠ Failed to delete existing ConfigMap: {e}")
+            except Exception:
+                # Ignore any other errors during cleanup (e.g., deprecation warnings raised as exceptions)
+                pass
         # Create new
-        core_api.create_namespaced_config_map(namespace, configmap)
+        with suppress_deprecation_warnings():
+            core_api.create_namespaced_config_map(namespace, configmap)
         print("[✓] ConfigMap created: cuda-fault-injection-lib")
         print("    → Source code will be compiled in init container (Linux-compatible)")
         return True
@@ -122,7 +150,8 @@ def delete_cuda_fault_configmap(namespace):
     """Delete the CUDA fault injection ConfigMap."""
     try:
         core_api = client.CoreV1Api()
-        core_api.delete_namespaced_config_map("cuda-fault-injection-lib", namespace)
+        with suppress_deprecation_warnings():
+            core_api.delete_namespaced_config_map("cuda-fault-injection-lib", namespace)
         print("[✓] ConfigMap deleted: cuda-fault-injection-lib")
         return True
     except ApiException as e:
@@ -139,7 +168,7 @@ def delete_cuda_fault_configmap(namespace):
 
 
 def _patch_service_for_injection(
-    service, enable, new_envs, use_configmap, target_node, lib_path
+    service, enable, new_envs, use_configmap, target_node, lib_path, soft_affinity=True
 ):
     """Apply injection patches to a single service.
 
@@ -150,19 +179,23 @@ def _patch_service_for_injection(
         use_configmap: Whether to use ConfigMap for library distribution
         target_node: Node to pin pods to (or None)
         lib_path: Path to the library in the container
+        soft_affinity: If True (default), use preferredDuringScheduling to allow pods
+                      to spill over to other nodes when target_node lacks capacity.
+                      If False, use requiredDuringScheduling which fails if node is full.
     """
     # Ensure extraPodSpec exists
     if "extraPodSpec" not in service:
         service["extraPodSpec"] = {}
     if "mainContainer" not in service["extraPodSpec"]:
         service["extraPodSpec"]["mainContainer"] = {}
-    if "env" not in service["extraPodSpec"]["mainContainer"]:
-        service["extraPodSpec"]["mainContainer"]["env"] = []
+    # DGD uses 'envs' at service level (NOT extraPodSpec.mainContainer.env)
+    if "envs" not in service:
+        service["envs"] = []
 
     # Remove existing LD_PRELOAD, CUDA_FAULT_INJECTION_ENABLED, and CUDA_XID_TYPE if present
-    service["extraPodSpec"]["mainContainer"]["env"] = [
+    service["envs"] = [
         env
-        for env in service["extraPodSpec"]["mainContainer"]["env"]
+        for env in service["envs"]
         if env.get("name")
         not in [
             "LD_PRELOAD",
@@ -173,7 +206,8 @@ def _patch_service_for_injection(
 
     # Add new environment variables if enabling
     if enable:
-        service["extraPodSpec"]["mainContainer"]["env"].extend(new_envs)
+        service["envs"].extend(new_envs)
+        print("      ✓ Added LD_PRELOAD and CUDA fault env vars")
 
     # Handle ConfigMap volume mount
     if use_configmap and enable:
@@ -181,11 +215,22 @@ def _patch_service_for_injection(
         if "volumes" not in service["extraPodSpec"]:
             service["extraPodSpec"]["volumes"] = []
 
-        # Remove existing volumes if present
+        # Remove ALL existing CUDA fault volumes if present (for idempotent re-application)
         service["extraPodSpec"]["volumes"] = [
             v
             for v in service["extraPodSpec"]["volumes"]
-            if v.get("name") not in ["cuda-fault-lib-source", "cuda-fault-lib"]
+            if v.get("name")
+            not in ["cuda-fault-lib-source", "cuda-fault-lib", "node-fault-marker"]
+        ]
+
+        # Remove existing CUDA fault volume mounts from mainContainer (for idempotent re-application)
+        if "volumeMounts" not in service["extraPodSpec"]["mainContainer"]:
+            service["extraPodSpec"]["mainContainer"]["volumeMounts"] = []
+        service["extraPodSpec"]["mainContainer"]["volumeMounts"] = [
+            vm
+            for vm in service["extraPodSpec"]["mainContainer"]["volumeMounts"]
+            if vm.get("name") not in ["cuda-fault-lib", "node-fault-marker"]
+            and vm.get("mountPath") not in ["/cuda-fault", "/host-fault"]
         ]
 
         # Add ConfigMap volume (source - base64 encoded)
@@ -224,18 +269,24 @@ def _patch_service_for_injection(
             if ic.get("name") not in ["decode-cuda-fault-lib", "compile-cuda-fault-lib"]
         ]
 
-        # Add init container to compile the library
+        # Add init container to compile the library and setup fault toggle
         service["extraPodSpec"]["initContainers"].append(
             {
                 "name": "compile-cuda-fault-lib",
                 "image": "gcc:latest",
                 "command": ["sh", "-c"],
                 "args": [
+                    # Compile the CUDA intercept library
                     "gcc -shared -fPIC -Wall -Wextra /source/cuda_intercept.c -o /dest/cuda_intercept.so -ldl && "
                     "chmod 755 /dest/cuda_intercept.so && "
                     "echo 'Compiled CUDA fault library for Linux' && "
                     "ls -lh /dest/cuda_intercept.so && "
-                    "file /dest/cuda_intercept.so"
+                    "file /dest/cuda_intercept.so && "
+                    # Initialize the toggle file with faults DISABLED (0)
+                    # The file is world-writable so main container can toggle it
+                    "echo '0' > /host-fault/cuda_fault_enabled && "
+                    "chmod 666 /host-fault/cuda_fault_enabled && "
+                    "echo 'Initialized fault toggle file (disabled)'"
                 ],
                 "volumeMounts": [
                     {
@@ -244,20 +295,13 @@ def _patch_service_for_injection(
                         "readOnly": True,
                     },
                     {"name": "cuda-fault-lib", "mountPath": "/dest"},
+                    {"name": "node-fault-marker", "mountPath": "/host-fault"},
                 ],
             }
         )
 
-        # Add volume mount to main container
-        if "volumeMounts" not in service["extraPodSpec"]["mainContainer"]:
-            service["extraPodSpec"]["mainContainer"]["volumeMounts"] = []
-
-        # Remove existing mount if present
-        service["extraPodSpec"]["mainContainer"]["volumeMounts"] = [
-            vm
-            for vm in service["extraPodSpec"]["mainContainer"]["volumeMounts"]
-            if vm.get("name") != "cuda-fault-lib"
-        ]
+        # Add volume mounts to main container
+        # (Note: existing mounts already removed earlier for idempotent re-application)
 
         # Add mount for compiled library
         service["extraPodSpec"]["mainContainer"]["volumeMounts"].append(
@@ -286,22 +330,50 @@ def _patch_service_for_injection(
         if "affinity" not in service["extraPodSpec"]:
             service["extraPodSpec"]["affinity"] = {}
 
-        service["extraPodSpec"]["affinity"]["nodeAffinity"] = {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
+        if soft_affinity:
+            # Soft affinity: prefer target node but allow spillover to other nodes
+            # This is useful when target node has limited GPU capacity (e.g., 4 GPUs)
+            # but you want to deploy more pods (e.g., 8 replicas).
+            # Pods will fill target node first (up to capacity), then schedule elsewhere.
+            service["extraPodSpec"]["affinity"]["nodeAffinity"] = {
+                "preferredDuringSchedulingIgnoredDuringExecution": [
                     {
-                        "matchExpressions": [
-                            {
-                                "key": "kubernetes.io/hostname",
-                                "operator": "In",
-                                "values": [target_node],
-                            }
-                        ]
+                        "weight": 100,  # High weight = strong preference
+                        "preference": {
+                            "matchExpressions": [
+                                {
+                                    "key": "kubernetes.io/hostname",
+                                    "operator": "In",
+                                    "values": [target_node],
+                                }
+                            ]
+                        },
                     }
                 ]
             }
-        }
-        print(f"      ✓ Added node affinity to pin pods to {target_node}")
+            print(
+                f"      ✓ Added SOFT node affinity (prefer {target_node}, allow spillover)"
+            )
+        else:
+            # Hard affinity: ALL pods MUST be scheduled on target node or fail
+            service["extraPodSpec"]["affinity"]["nodeAffinity"] = {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "kubernetes.io/hostname",
+                                    "operator": "In",
+                                    "values": [target_node],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+            print(
+                f"      ✓ Added HARD node affinity (ALL pods MUST be on {target_node})"
+            )
 
     elif not enable:
         # Remove ConfigMap volume and mount when disabling
@@ -347,6 +419,7 @@ def patch_deployment_env(
     target_node=None,
     xid_type=79,
     passthrough_mode=False,
+    soft_affinity=True,
 ):
     """Patch deployment to add/remove LD_PRELOAD environment variable.
 
@@ -360,6 +433,9 @@ def patch_deployment_env(
         xid_type: XID error type to simulate (79, 48, 94, 95, 43, 74). Default: 79
         passthrough_mode: If True, set CUDA_FAULT_INJECTION_ENABLED=0 (library loaded but disabled)
                          Allows baseline testing before enabling faults via toggle
+        soft_affinity: If True (default), use preferredDuringScheduling to allow pods
+                      to spill over to other nodes when target_node lacks capacity.
+                      If False, use requiredDuringScheduling which fails if node is full.
     """
     custom_api = client.CustomObjectsApi()
     apps_api = client.AppsV1Api()
@@ -369,13 +445,14 @@ def patch_deployment_env(
     dgd = None
     try:
         print(f"    → Attempting to get DynamoGraphDeployment: {deployment_name}")
-        dgd = custom_api.get_namespaced_custom_object(
-            group="nvidia.com",
-            version="v1alpha1",
-            namespace=namespace,
-            plural="dynamographdeployments",
-            name=deployment_name,
-        )
+        with suppress_deprecation_warnings():
+            dgd = custom_api.get_namespaced_custom_object(
+                group="nvidia.com",
+                version="v1alpha1",
+                namespace=namespace,
+                plural="dynamographdeployments",
+                name=deployment_name,
+            )
         is_dgd = True
         print("    ✓ Found DynamoGraphDeployment")
 
@@ -422,8 +499,19 @@ def patch_deployment_env(
                     {"name": "CUDA_XID_TYPE", "value": str(xid_type)},
                 ]
 
-            # Patch worker services (VllmDecodeWorker and VllmPrefillWorker)
-            services_to_patch = ["VllmDecodeWorker", "VllmPrefillWorker"]
+            # Patch worker services (supports vLLM, SGLang, and TensorRT-LLM naming)
+            # vLLM: VllmDecodeWorker, VllmPrefillWorker
+            # SGLang: decode, prefill
+            # TensorRT-LLM: TRTLLMDecodeWorker, TRTLLMPrefillWorker, TRTLLMWorker (agg)
+            services_to_patch = [
+                "VllmDecodeWorker",
+                "VllmPrefillWorker",  # vLLM
+                "decode",
+                "prefill",  # SGLang
+                "TRTLLMDecodeWorker",
+                "TRTLLMPrefillWorker",
+                "TRTLLMWorker",  # TensorRT-LLM
+            ]
             patched_services = []
 
             spec = dgd.get("spec", {})
@@ -458,7 +546,13 @@ def patch_deployment_env(
                     print(f"    → Patching service: {service_name}")
                     service = services[service_name]
                     _patch_service_for_injection(
-                        service, enable, new_envs, use_configmap, target_node, lib_path
+                        service,
+                        enable,
+                        new_envs,
+                        use_configmap,
+                        target_node,
+                        lib_path,
+                        soft_affinity=soft_affinity,
                     )
                     patched_services.append(service_name)
 
@@ -472,13 +566,14 @@ def patch_deployment_env(
                         print(f"      → Retry attempt {attempt + 1}/{max_retries}")
                         time.sleep(0.5 * attempt)  # Exponential backoff
                         # Re-fetch the latest version
-                        dgd = custom_api.get_namespaced_custom_object(
-                            group="nvidia.com",
-                            version="v1alpha1",
-                            namespace=namespace,
-                            plural="dynamographdeployments",
-                            name=deployment_name,
-                        )
+                        with suppress_deprecation_warnings():
+                            dgd = custom_api.get_namespaced_custom_object(
+                                group="nvidia.com",
+                                version="v1alpha1",
+                                namespace=namespace,
+                                plural="dynamographdeployments",
+                                name=deployment_name,
+                            )
                         # Re-apply the patches to fresh copy
                         for service_name in patched_services:
                             if service_name in dgd.get("spec", {}).get("services", {}):
@@ -490,16 +585,18 @@ def patch_deployment_env(
                                     use_configmap,
                                     target_node,
                                     lib_path,
+                                    soft_affinity=soft_affinity,
                                 )
 
-                    custom_api.patch_namespaced_custom_object(
-                        group="nvidia.com",
-                        version="v1alpha1",
-                        namespace=namespace,
-                        plural="dynamographdeployments",
-                        name=deployment_name,
-                        body=dgd,
-                    )
+                    with suppress_deprecation_warnings():
+                        custom_api.patch_namespaced_custom_object(
+                            group="nvidia.com",
+                            version="v1alpha1",
+                            namespace=namespace,
+                            plural="dynamographdeployments",
+                            name=deployment_name,
+                            body=dgd,
+                        )
                     break  # Success!
                 except ApiException as e:
                     if e.status == 409 and attempt < max_retries - 1:
@@ -526,18 +623,20 @@ def patch_deployment_env(
                 )
                 core_api = client.CoreV1Api()
                 try:
-                    worker_pods = core_api.list_namespaced_pod(
-                        namespace=namespace,
-                        label_selector=f"nvidia.com/dynamo-graph-deployment-name={deployment_name},nvidia.com/dynamo-component-type=worker",
-                    )
+                    with suppress_deprecation_warnings():
+                        worker_pods = core_api.list_namespaced_pod(
+                            namespace=namespace,
+                            label_selector=f"nvidia.com/dynamo-graph-deployment-name={deployment_name},nvidia.com/dynamo-component-type=worker",
+                        )
                     deleted_count = 0
                     for pod in worker_pods.items:
                         try:
-                            core_api.delete_namespaced_pod(
-                                name=pod.metadata.name,
-                                namespace=namespace,
-                                grace_period_seconds=0,
-                            )
+                            with suppress_deprecation_warnings():
+                                core_api.delete_namespaced_pod(
+                                    name=pod.metadata.name,
+                                    namespace=namespace,
+                                    grace_period_seconds=0,
+                                )
                             deleted_count += 1
                         except Exception as e:
                             print(
@@ -570,7 +669,8 @@ def patch_deployment_env(
     print("    → Not a DynamoGraphDeployment, trying standard Deployment...")
 
     try:
-        deployment = apps_api.read_namespaced_deployment(deployment_name, namespace)
+        with suppress_deprecation_warnings():
+            deployment = apps_api.read_namespaced_deployment(deployment_name, namespace)
     except ApiException as e:
         print(f"  Failed to read deployment {deployment_name}: {e}")
         return False
@@ -605,7 +705,8 @@ def patch_deployment_env(
             )
 
     try:
-        apps_api.patch_namespaced_deployment(deployment_name, namespace, deployment)
+        with suppress_deprecation_warnings():
+            apps_api.patch_namespaced_deployment(deployment_name, namespace, deployment)
         action = "enabled" if enable else "disabled"
         print(f"[✓] Deployment patched - CUDA fault injection {action}")
         return True
@@ -637,11 +738,12 @@ def get_worker_pods(deployment_name, namespace, node_name=None):
     dgd_label_selector = f"nvidia.com/dynamo-graph-deployment-name={deployment_name},nvidia.com/dynamo-component-type=worker"
 
     try:
-        pods = core_api.list_namespaced_pod(
-            namespace=namespace,
-            label_selector=dgd_label_selector,
-            field_selector=field_selector,
-        )
+        with suppress_deprecation_warnings():
+            pods = core_api.list_namespaced_pod(
+                namespace=namespace,
+                label_selector=dgd_label_selector,
+                field_selector=field_selector,
+            )
         if pods.items:
             return pods.items
     except ApiException as e:
@@ -650,7 +752,8 @@ def get_worker_pods(deployment_name, namespace, node_name=None):
     # Fallback: Try standard Deployment
     # Get the deployment to find its label selector
     try:
-        deployment = apps_api.read_namespaced_deployment(deployment_name, namespace)
+        with suppress_deprecation_warnings():
+            deployment = apps_api.read_namespaced_deployment(deployment_name, namespace)
 
         # Extract match labels from deployment spec
         if deployment.spec.selector and deployment.spec.selector.match_labels:
@@ -659,11 +762,12 @@ def get_worker_pods(deployment_name, namespace, node_name=None):
             ]
             std_label_selector = ",".join(label_parts)
 
-            pods = core_api.list_namespaced_pod(
-                namespace=namespace,
-                label_selector=std_label_selector,
-                field_selector=field_selector,
-            )
+            with suppress_deprecation_warnings():
+                pods = core_api.list_namespaced_pod(
+                    namespace=namespace,
+                    label_selector=std_label_selector,
+                    field_selector=field_selector,
+                )
             if pods.items:
                 return pods.items
     except ApiException as e:
@@ -713,7 +817,12 @@ def inject_into_running_pods(deployment_name, namespace, node_name=None):
 
 
 def inject_via_deployment_patch(
-    deployment_name, namespace, target_node=None, xid_type=79
+    deployment_name,
+    namespace,
+    target_node=None,
+    xid_type=79,
+    passthrough_mode=False,
+    soft_affinity=True,
 ):
     """Inject by patching deployment and rolling restart (persistent).
 
@@ -722,6 +831,10 @@ def inject_via_deployment_patch(
         namespace: Kubernetes namespace
         target_node: Optional node to pin pods to (simulates real XID behavior)
         xid_type: XID error type to simulate (79, 48, 94, 95, 43, 74)
+        passthrough_mode: If True, library loads but doesn't inject faults until toggled
+        soft_affinity: If True (default), use preferredDuringScheduling to allow pods
+                      to spill over to other nodes when target_node lacks capacity.
+                      If False, use requiredDuringScheduling which fails if node is full.
     """
     print("\n" + "=" * 80)
     print("Method 2: Patch Deployment (Persistent)")
@@ -754,38 +867,25 @@ def inject_via_deployment_patch(
         copy_library_to_pod(pod.metadata.name, namespace, lib_path)
 
     # Step 3: Patch deployment
-    print("\n[3/4] Patching deployment to enable CUDA fault injection...")
+    mode_str = (
+        "passthrough (toggle-controlled)"
+        if passthrough_mode
+        else "active (immediate crash)"
+    )
+    print(f"\n[3/4] Patching deployment to enable CUDA fault injection ({mode_str})...")
     if not patch_deployment_env(
         deployment_name,
         namespace,
         enable=True,
         target_node=target_node,
         xid_type=xid_type,
+        passthrough_mode=passthrough_mode,
+        soft_affinity=soft_affinity,
     ):
         return False
 
-    # Step 4: Trigger rolling restart
-    print("\n[4/4] Triggering pod restart...")
-
-    # For DynamoGraphDeployment, we need to delete pods to trigger restart
-    # (kubectl rollout restart doesn't work with custom resources)
-    core_api = client.CoreV1Api()
-
-    print(
-        f"[→] Deleting {len(pods)} worker pods to trigger restart with new env vars..."
-    )
-    for pod in pods:
-        try:
-            core_api.delete_namespaced_pod(
-                name=pod.metadata.name,
-                namespace=namespace,
-                grace_period_seconds=30,  # Graceful shutdown
-            )
-            print(f"    ✓ Deleted: {pod.metadata.name}")
-        except ApiException as e:
-            print(f"    ✗ Failed to delete {pod.metadata.name}: {e}")
-
-    print("\n[→] Waiting for new pods to start with CUDA fault injection...")
+    # Step 4: Wait for new pods (pods already deleted in step 3 by patch function)
+    print("\n[4/4] Waiting for new pods to start with CUDA fault injection...")
     time.sleep(10)
 
     # Wait for pods to be recreated
@@ -802,9 +902,18 @@ def inject_via_deployment_patch(
 
             if all_running:
                 print(f"\n[✓] All {len(new_pods)} pods restarted successfully")
-                print("[✓] CUDA fault injection is now ACTIVE")
-                print("\n⚠ Pods will crash with 'No CUDA-capable device' error")
-                print("   This simulates XID 79 (GPU falls off bus)")
+                if passthrough_mode:
+                    print("[✓] CUDA fault injection is in PASSTHROUGH mode")
+                    print(
+                        "\n   Pods are running normally. Use toggle to activate faults:"
+                    )
+                    print(
+                        "   curl -X POST 'http://localhost:8080/api/v1/faults/gpu/toggle-cuda?namespace=<ns>&enable=true'"
+                    )
+                else:
+                    print("[✓] CUDA fault injection is now ACTIVE")
+                    print("\n⚠ Pods will crash with 'No CUDA-capable device' error")
+                    print("   This simulates XID 79 (GPU falls off bus)")
                 return True
 
         time.sleep(5)
@@ -840,9 +949,10 @@ def remove_injection(deployment_name, namespace):
 
     for pod in pods:
         try:
-            core_api.delete_namespaced_pod(
-                name=pod.metadata.name, namespace=namespace, grace_period_seconds=30
-            )
+            with suppress_deprecation_warnings():
+                core_api.delete_namespaced_pod(
+                    name=pod.metadata.name, namespace=namespace, grace_period_seconds=30
+                )
             print(f"    ✓ Deleted: {pod.metadata.name}")
         except ApiException as e:
             print(f"    ✗ Failed to delete {pod.metadata.name}: {e}")
@@ -942,8 +1052,12 @@ Examples:
   python inject_into_pods.py --deployment vllm-v1-disagg-router --patch-deployment --xid-type 48
   python inject_into_pods.py --deployment vllm-v1-disagg-router --patch-deployment --xid-type 94
 
-  # Pin to specific node (simulates real XID behavior)
+  # Pin to specific node with SOFT affinity (DEFAULT - allows spillover)
+  # If node has 4 GPUs but 8 pods requested, 4 pods run on target node, 4 elsewhere
   python inject_into_pods.py --deployment vllm-v1-disagg-router --patch-deployment --node aks-a100a-36888584-vmss000003
+
+  # Pin to specific node with HARD affinity (ALL pods must fit or stay Pending)
+  python inject_into_pods.py --deployment vllm-v1-disagg-router --patch-deployment --node aks-a100a-36888584-vmss000003 --hard-affinity
 
   # Inject into running pods on specific node (temporary)
   python inject_into_pods.py --deployment vllm-v1-disagg-router --node aks-a100a-36888584-vmss000003
@@ -977,6 +1091,20 @@ Examples:
     )
     parser.add_argument("--remove", action="store_true", help="Remove injection")
     parser.add_argument("--verify", action="store_true", help="Verify injection status")
+    parser.add_argument(
+        "--passthrough",
+        action="store_true",
+        help="Load library in passthrough mode (CUDA_FAULT_INJECTION_ENABLED=0). "
+        "Use toggle file or API to enable faults later.",
+    )
+    parser.add_argument(
+        "--hard-affinity",
+        action="store_true",
+        help="Use HARD node affinity (requiredDuringScheduling). "
+        "All pods MUST be scheduled on target node or they will be Pending forever. "
+        "Default is SOFT affinity (preferredDuringScheduling) which allows pods "
+        "to spill over to other nodes when target node lacks GPU capacity.",
+    )
 
     args = parser.parse_args()
 
@@ -994,6 +1122,12 @@ Examples:
     print(f"Namespace:  {args.namespace}")
     if args.node:
         print(f"Node:       {args.node}")
+        affinity_mode = (
+            "HARD (required)"
+            if args.hard_affinity
+            else "SOFT (preferred, allows spillover)"
+        )
+        print(f"Affinity:   {affinity_mode}")
     if not args.remove and not args.verify:
         print(f"XID Type:   {args.xid_type}")
     print()
@@ -1004,7 +1138,12 @@ Examples:
         remove_injection(args.deployment, args.namespace)
     elif args.patch_deployment:
         inject_via_deployment_patch(
-            args.deployment, args.namespace, args.node, args.xid_type
+            args.deployment,
+            args.namespace,
+            args.node,
+            args.xid_type,
+            args.passthrough,
+            soft_affinity=not args.hard_affinity,
         )
     else:
         inject_into_running_pods(args.deployment, args.namespace, args.node)


### PR DESCRIPTION
#### Overview:

Adds soft node affinity mode for GPU pod scheduling during CUDA fault injection testing. This prevents deployment failures when the number of requested pods exceeds the GPU capacity of the target node.

#### Details:

**Problem:** When deploying 10 worker pods to a node with only 8 GPUs using hard node affinity (`requiredDuringScheduling`), the extra 2 pods would remain in `Pending` state indefinitely, causing deployment timeouts and test failures.

**Solution:** Implemented two affinity modes:

| Mode | Kubernetes Setting | Behavior |
|------|-------------------|----------|
| **Soft (default)** | `preferredDuringSchedulingIgnoredDuringExecution` | Pods prefer target node but spill to other nodes if full |
| **Hard (`--hard-affinity`)** | `requiredDuringSchedulingIgnoredDuringExecution` | All pods must fit on target node or stay Pending |

**Additional fixes:**
- Made patch operations idempotent by removing existing volumes/mounts before adding new ones (fixes `Duplicate value` API errors)
- Added `soft_affinity` parameter to the helper class for programmatic control

#### Where should the reviewer start?

1. `tests/fault_tolerance/hardware/fault_injection_service/cuda_fault_injection/inject_into_pods.py` - Look at `_patch_service_for_injection()` function for the soft/hard affinity logic
2. `tests/fault_tolerance/hardware/fault_injection_service/helpers/cuda_fault_injection.py` - Look at `patch_deployment_for_cuda_fault()` for the new `soft_affinity` parameter

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
Relates to ongoing HW FT initiative
