### PR TITLE
docs: Add Nemotron-253B multi-node aggregated serving recipe

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -19,6 +19,7 @@ Production-tested Kubernetes deployment recipes for LLM inference using NVIDIA D
 | **[DeepSeek-R1](deepseek-r1/sglang/disagg-8gpu/)** | SGLang | Disagg WideEP | 8x H200 | ✅ | ❌ | Benchmark recipe pending | ❌ |
 | **[DeepSeek-R1](deepseek-r1/sglang/disagg-16gpu/)** | SGLang | Disagg WideEP | 16x H200 | ✅ | ❌ | Benchmark recipe pending | ❌ |
 | **[DeepSeek-R1](deepseek-r1/trtllm/disagg/wide_ep/gb200/)** | TensorRT-LLM | Disagg WideEP (GB200) | 32+4 GB200 | ✅ | ✅ |Multi-node: 8 decode + 1 prefill nodes | ❌ |
+| **[Nemotron-253B](nemotron-253b/vllm/agg-multi-node/)** | vLLM | Agg (Multi-Node) | 16x H100 (2 nodes) | ✅ | ❌ | Large Model Multi-node Aggregated Serving (No Prefill) | ❌ |
 
 **Legend:**
 - **Deployment**: ✅ = Complete `deploy.yaml` manifest available | ❌ = Missing or incomplete

--- a/recipes/nemotron-253b/model-cache/model-cache.yaml
+++ b/recipes/nemotron-253b/model-cache/model-cache.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nemotron-253b-model-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 600Gi
+  storageClassName: "your-storage-class-name"
+

--- a/recipes/nemotron-253b/model-cache/model-download.yaml
+++ b/recipes/nemotron-253b/model-cache/model-download.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.12-slim
+          command: ["sh", "-c"]
+          env:
+            - name: HF_TOKEN
+              value: "hf_api_key"  # update if needed
+            - name: MODEL_NAME
+              value: "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1"
+            - name: HF_HOME
+              value: /model-store
+            - name: HF_HUB_ENABLE_HF_TRANSFER
+              value: "0"
+            - name: HF_HUB_DISABLE_PROGRESS_BARS
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub
+              python3 -c "
+              from huggingface_hub import snapshot_download
+              import os
+              snapshot_download(
+                  '$MODEL_NAME',
+                  local_dir='/model-store/nemotron-253b',
+                  token=os.environ['HF_TOKEN']
+              )
+              print('Download complete!')
+              "
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: nemotron-253b-model-cache
+

--- a/recipes/nemotron-253b/vllm/agg-multi-node/deploy.yaml
+++ b/recipes/nemotron-253b/vllm/agg-multi-node/deploy.yaml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: nemotron-253b-dgx
+spec:
+  backendFramework: vllm
+  services:
+    Frontend:
+      componentType: frontend
+      dynamoNamespace: nemotron-253b-dgx
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace/components/backends/vllm
+      replicas: 1
+
+    VllmWorker:
+      componentType: worker
+      dynamoNamespace: nemotron-253b-dgx
+      sharedMemory:
+        size: 200Gi
+      # 2 nodes x 8 GPUs = 16 GPUs total (TP=8, PP=2)
+      replicas: 1
+      multinode:
+        nodeCount: 2
+      resources:
+        limits:
+          gpu: "8"
+        requests:
+          gpu: "8"
+      extraPodSpec:
+        runtimeClassName: nvidia
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: nemotron-253b-model-cache
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace/components/backends/vllm
+          volumeMounts:
+            - name: model-cache
+              mountPath: /models
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            failureThreshold: 720  # 120 minutes (2 hours) for 253B model
+            periodSeconds: 10
+          env:
+            - name: SERVED_MODEL_NAME
+              value: "nemotron-253b-ultra"
+            - name: HF_TOKEN
+              value: "hf_api_key"  # update if needed
+            - name: NCCL_DEBUG
+              value: "INFO"
+            - name: HF_HUB_DISABLE_PROGRESS_BARS
+              value: "1"
+            - name: HF_HUB_ENABLE_HF_TRANSFER
+              value: "0"
+            - name: VLLM_HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - >-
+              export RAY_NODE_IP=$VLLM_HOST_IP &&
+              python3 -m dynamo.vllm
+              --model /models/nemotron-253b
+              --served-model-name nemotron-253b-ultra
+              --tensor-parallel-size 8
+              --pipeline-parallel-size 2
+              --data-parallel-size 1
+              --disable-log-requests
+              --gpu-memory-utilization 0.95
+              --trust-remote-code
+              --enforce-eager
+              --distributed-executor-backend ray
+              --connector none
+
+
+


### PR DESCRIPTION
**Overview:**
This PR adds a tested recipe for deploying NVIDIA's Llama-3.1-Nemotron-Ultra-253B-v1 model using vLLM in a multi-node aggregated serving configuration (decode-only, no prefill). The recipe has been validated on 2 DGX nodes with 16x H100 GPUs using tensor parallelism (TP=8) and pipeline parallelism (PP=2).

**Details:**
This PR introduces the following changes:

New Recipe Structure:
Added recipes/nemotron-253b/ directory following standard Dynamo recipe conventions
Created model-cache/model-cache.yaml - PVC configuration for 600Gi storage
Created model-cache/model-download.yaml - HuggingFace download job for the 253B model
Created vllm/agg-multi-node/deploy.yaml - DynamoGraphDeployment manifest for multi-node serving

Key Configuration:
Multi-node deployment: 2 nodes × 8 GPUs per node (16 H100 GPUs total)
Parallelization: TP=8, PP=2, DP=1
Decode-only architecture (no prefill separation)
GPU memory utilization: 95%
Startup probe timeout: 2 hours (appropriate for 253B model loading)

Documentation:
Updated recipes/README.md with Nemotron-253B entry in the available recipes table

**Where should the reviewer start?**
recipes/README.md - Review the new table entry (line 22) to ensure proper formatting and accurate metadata
recipes/nemotron-253b/vllm/agg-multi-node/deploy.yaml - Main deployment manifest with multi-node configuration, parallelization settings, and resource specifications
recipes/nemotron-253b/model-cache/model-download.yaml - Verify HuggingFace model download configuration and token handling
Verify overall directory structure matches the standard pattern in CONTRIBUTING.md

**Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)**
Relates to: Community recipe contributions for large model serving. There are some customers who are interested in large model serving using ONLY decode (aggregated) across more than one node so as to allow for KV-Cache sharing across nodes. Current recipes, to my understanding do not cover this situation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Nemotron-253B to available recipes with complete deployment configurations.
  * Included model download automation and multi-node distributed serving setup with vLLM.

* **Documentation**
  * Updated recipes README to list Nemotron-253B with corresponding framework and deployment details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->