### PR TITLE
chore: do not assume QUEUE_NAME for event stream anymore

### DIFF
--- a/lib/runtime/src/transports/nats.rs
+++ b/lib/runtime/src/transports/nats.rs
@@ -416,9 +416,6 @@ pub fn url_to_bucket_and_key(url: &Url) -> anyhow::Result<(String, String)> {
     Ok((bucket.to_string(), key.to_string()))
 }
 
-/// Default queue name for publishing events
-pub const QUEUE_NAME: &str = "queue";
-
 /// A queue implementation using NATS JetStream
 pub struct NatsQueue {
     /// The name of the stream to use for the queue
@@ -863,16 +860,6 @@ impl EventPublisher for NatsQueue {
         event_name: impl AsRef<str> + Send + Sync,
         bytes: Vec<u8>,
     ) -> Result<()> {
-        // We expect the stream to be always suffixed with "queue"
-        // This suffix itself is nothing special, just a repo standard
-        if event_name.as_ref() != QUEUE_NAME {
-            tracing::warn!(
-                "Expected event_name to be '{}', but got '{}'",
-                QUEUE_NAME,
-                event_name.as_ref()
-            );
-        }
-
         let subject = format!("{}.{}", self.subject(), event_name.as_ref());
 
         // Note: enqueue_task requires &mut self, but EventPublisher requires &self


### PR DESCRIPTION
#### Overview:

as titled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified NATS transport layer by removing internal validation logic and cleaning up unused constants. No impact on message publishing or event processing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->