### PR TITLE
fix: Don't recursively drop blocks in KVBM

### DIFF
--- a/lib/llm/src/block_manager/block.rs
+++ b/lib/llm/src/block_manager/block.rs
@@ -650,6 +650,26 @@ impl<S: Storage, L: LocalityProvider, M: BlockMetadata> Drop for MutableBlock<S,
         {
             tracing::warn!("block pool shutdown before block was returned");
         }
+
+        // Iteratively drop the parent chain to avoid stack overflow.
+        // Without this, dropping a leaf block with thousands of ancestors would cause
+        // thousands of nested drop() calls, overflowing the stack.
+        let mut current_parent = self.parent.take();
+        while let Some(arc_parent) = current_parent {
+            // Try to get exclusive ownership of the parent
+            match Arc::try_unwrap(arc_parent) {
+                Ok(mut parent) => {
+                    // We own this parent exclusively - take its parent to continue the chain.
+                    // When `parent` drops at the end of this scope, its `parent` field is None,
+                    // so no recursive drop occurs.
+                    current_parent = parent.parent.take();
+                }
+                Err(_) => {
+                    // Someone else has a reference to this parent, they'll handle the drop
+                    break;
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
A `MutableBlock` holds an `Option<Arc<MutableBlock>>`. When we drop 1000s of blocks all at once, the drop methods get called recursively, which causes stack overflows + segfaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management to prevent stack overflow errors when handling deeply nested data structures, enhancing system stability during cleanup operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->