### PR TITLE
fix: NIXL CUDA12 + CUDA13 build

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -199,7 +199,7 @@ ENV CUDA_PATH=/usr/local/cuda \
 ARG PYTHON_VERSION
 ENV VIRTUAL_ENV=/workspace/.venv
 RUN uv venv ${VIRTUAL_ENV} --python $PYTHON_VERSION && \
-    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf]
+    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf] tomlkit
 
 ARG NIXL_UCX_REF
 ARG NIXL_REF
@@ -344,8 +344,16 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
     fi && \
     source ${VIRTUAL_ENV}/bin/activate && \
-    git clone --depth 1 --branch ${NIXL_REF} "https://github.com/ai-dynamo/nixl.git" && \
+    git clone "https://github.com/ai-dynamo/nixl.git" && \
     cd nixl && \
+    git checkout ${NIXL_REF} && \
+    CUDA_MAJOR=$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | cut -d'.' -f1) && \
+    if [ "$CUDA_MAJOR" -ne 12 ] && [ "$CUDA_MAJOR" -ne 13 ]; then \
+        echo "Invalid CUDA_MAJOR: '$CUDA_MAJOR'" && \
+        exit 1; \
+    fi && \
+    PKG_NAME="nixl-cu${CUDA_MAJOR}" && \
+    ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml && \
     mkdir build && \
     meson setup build/ --prefix=/opt/nvidia/nvda_nixl --buildtype=release \
     -Dcudapath_lib="/usr/local/cuda/lib64" \
@@ -375,7 +383,7 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
     fi && \
     cd /workspace/nixl && \
-    uv build . --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
+    uv build . --wheel --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
 
 # Copy source code (order matters for layer caching)
 COPY pyproject.toml README.md LICENSE Cargo.toml Cargo.lock rust-toolchain.toml hatch_build.py /opt/dynamo/

--- a/container/Dockerfile.aws
+++ b/container/Dockerfile.aws
@@ -43,7 +43,10 @@ RUN mkdir -p /tmp/efa && \
     apt-get update && \
     ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify && \
     rm -rf /tmp/efa && \
+    rm -rf /opt/amazon/aws-ofi-nccl && \
     ldconfig
+
+ENV EFA_VERSION="${EFA_VERSION}"
 
 USER dynamo
 
@@ -78,7 +81,10 @@ RUN mkdir -p /tmp/efa && \
     apt-get update && \
     ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify && \
     rm -rf /tmp/efa && \
+    rm -rf /opt/amazon/aws-ofi-nccl && \
     ldconfig
+
+ENV EFA_VERSION="${EFA_VERSION}"
 
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -212,7 +212,7 @@ ENV CUDA_PATH=/usr/local/cuda \
 ARG PYTHON_VERSION
 ENV VIRTUAL_ENV=/workspace/.venv
 RUN uv venv ${VIRTUAL_ENV} --python $PYTHON_VERSION && \
-    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf]
+    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf] tomlkit
 
 ARG NIXL_UCX_REF
 ARG NIXL_REF
@@ -356,8 +356,16 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
     fi && \
     source ${VIRTUAL_ENV}/bin/activate && \
-    git clone --depth 1 --branch ${NIXL_REF} "https://github.com/ai-dynamo/nixl.git" && \
+    git clone "https://github.com/ai-dynamo/nixl.git" && \
     cd nixl && \
+    git checkout ${NIXL_REF} && \
+    CUDA_MAJOR=$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | cut -d'.' -f1) && \
+    if [ "$CUDA_MAJOR" -ne 12 ] && [ "$CUDA_MAJOR" -ne 13 ]; then \
+        echo "Invalid CUDA_MAJOR: '$CUDA_MAJOR'" && \
+        exit 1; \
+    fi && \
+    PKG_NAME="nixl-cu${CUDA_MAJOR}" && \
+    ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml && \
     mkdir build && \
     meson setup build/ --prefix=/opt/nvidia/nvda_nixl --buildtype=release \
     -Dcudapath_lib="/usr/local/cuda/lib64" \
@@ -387,7 +395,7 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
     fi && \
     cd /workspace/nixl && \
-    uv build . --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
+    uv build . --wheel --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
 
 # Copy source code (order matters for layer caching)
 COPY pyproject.toml README.md LICENSE Cargo.toml Cargo.lock rust-toolchain.toml hatch_build.py /opt/dynamo/
@@ -481,12 +489,15 @@ RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/loca
 # Pattern: COPY --chmod=775 <path>; chmod g+w <path> done later as root because COPY --chmod only affects <path>/*, not <path>
 COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
+COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
+COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
 
 ENV SGLANG_VERSION="${RUNTIME_IMAGE_TAG%%-*}"
 RUN --mount=type=bind,source=.,target=/mnt/local_src \
     pip install --no-cache-dir --break-system-packages \
         /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
         /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
+        /opt/dynamo/wheelhouse/nixl/nixl*.whl \
         sglang==${SGLANG_VERSION}
 
 # Install common and test dependencies

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -223,7 +223,7 @@ ENV CUDA_PATH=/usr/local/cuda \
 ARG PYTHON_VERSION
 ENV VIRTUAL_ENV=/workspace/.venv
 RUN uv venv ${VIRTUAL_ENV} --python $PYTHON_VERSION && \
-    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf]
+    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf] tomlkit
 
 ARG NIXL_UCX_REF
 ARG NIXL_REF
@@ -367,8 +367,16 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
     fi && \
     source ${VIRTUAL_ENV}/bin/activate && \
-    git clone --depth 1 --branch ${NIXL_REF} "https://github.com/ai-dynamo/nixl.git" && \
+    git clone "https://github.com/ai-dynamo/nixl.git" && \
     cd nixl && \
+    git checkout ${NIXL_REF} && \
+    CUDA_MAJOR=$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | cut -d'.' -f1) && \
+    if [ "$CUDA_MAJOR" -ne 12 ] && [ "$CUDA_MAJOR" -ne 13 ]; then \
+        echo "Invalid CUDA_MAJOR: '$CUDA_MAJOR'" && \
+        exit 1; \
+    fi && \
+    PKG_NAME="nixl-cu${CUDA_MAJOR}" && \
+    ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml && \
     mkdir build && \
     meson setup build/ --prefix=/opt/nvidia/nvda_nixl --buildtype=release \
     -Dcudapath_lib="/usr/local/cuda/lib64" \
@@ -398,7 +406,7 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
     fi && \
     cd /workspace/nixl && \
-    uv build . --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
+    uv build . --wheel --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
 
 # Copy source code (order matters for layer caching)
 COPY pyproject.toml README.md LICENSE Cargo.toml Cargo.lock rust-toolchain.toml hatch_build.py /opt/dynamo/
@@ -747,6 +755,8 @@ $NIXL_PLUGIN_DIR:\
 $TENSORRT_LIB_DIR:\
 /opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/torch/lib:\
 /opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/torch_tensorrt/lib:\
+/usr/local/cuda/lib:\
+/usr/local/cuda/lib64:\
 $LD_LIBRARY_PATH
 ENV NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
 ENV OPAL_PREFIX=/opt/hpcx/ompi

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -229,7 +229,7 @@ ENV CUDA_PATH=/usr/local/cuda \
 ARG PYTHON_VERSION
 ENV VIRTUAL_ENV=/workspace/.venv
 RUN uv venv ${VIRTUAL_ENV} --python $PYTHON_VERSION && \
-    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf]
+    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf] tomlkit
 
 ARG NIXL_UCX_REF
 ARG NIXL_REF
@@ -395,8 +395,16 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
     fi && \
     source ${VIRTUAL_ENV}/bin/activate && \
-    git clone --depth 1 --branch ${NIXL_REF} "https://github.com/ai-dynamo/nixl.git" && \
+    git clone "https://github.com/ai-dynamo/nixl.git" && \
     cd nixl && \
+    git checkout ${NIXL_REF} && \
+    CUDA_MAJOR=$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | cut -d'.' -f1) && \
+    if [ "$CUDA_MAJOR" -ne 12 ] && [ "$CUDA_MAJOR" -ne 13 ]; then \
+        echo "Invalid CUDA_MAJOR: '$CUDA_MAJOR'" && \
+        exit 1; \
+    fi && \
+    PKG_NAME="nixl-cu${CUDA_MAJOR}" && \
+    ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml && \
     mkdir build && \
     meson setup build/ --prefix=/opt/nvidia/nvda_nixl --buildtype=release \
     -Dcudapath_lib="/usr/local/cuda/lib64" \
@@ -426,7 +434,7 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
         export CMAKE_CUDA_COMPILER_LAUNCHER="sccache"; \
     fi && \
     cd /workspace/nixl && \
-    uv build . --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
+    uv build . --wheel --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
 
 # Copy source code (order matters for layer caching)
 COPY pyproject.toml README.md LICENSE Cargo.toml Cargo.lock rust-toolchain.toml hatch_build.py /opt/dynamo/

--- a/container/build.sh
+++ b/container/build.sh
@@ -120,7 +120,8 @@ SGLANG_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 SGLANG_BASE_IMAGE_TAG="25.06-cuda12.9-devel-ubuntu24.04"
 SGLANG_BASE_IMAGE_TAG_CU13="25.11-cuda13.0-devel-ubuntu24.04"
 SGLANG_CUDA_VERSION="12.9.1"
-SGLANG_PYTHON_VERSION="3.12"
+SGLANG_CUDA_VERSION_CU13="13.0.1"
+SGLANG_RUNTIME_IMAGE_TAG_CU13="v0.5.7-cu130-runtime"
 
 # GAIE (Gateway API Inference Extension) configuration for frontend (required for EPP binary for frontend image)
 GAIE_REPO_URL="https://github.com/kubernetes-sigs/gateway-api-inference-extension.git"

--- a/container/build.sh
+++ b/container/build.sh
@@ -120,8 +120,7 @@ SGLANG_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 SGLANG_BASE_IMAGE_TAG="25.06-cuda12.9-devel-ubuntu24.04"
 SGLANG_BASE_IMAGE_TAG_CU13="25.11-cuda13.0-devel-ubuntu24.04"
 SGLANG_CUDA_VERSION="12.9.1"
-SGLANG_CUDA_VERSION_CU13="13.0.1"
-SGLANG_RUNTIME_IMAGE_TAG_CU13="v0.5.7-cu130-runtime"
+SGLANG_PYTHON_VERSION="3.12"
 
 # GAIE (Gateway API Inference Extension) configuration for frontend (required for EPP binary for frontend image)
 GAIE_REPO_URL="https://github.com/kubernetes-sigs/gateway-api-inference-extension.git"
@@ -178,6 +177,14 @@ get_options() {
                 echo "INFO: Setting CUDA_VERSION to $2"
                 CUDA_VERSION=$2
                 BUILD_ARGS+=" --build-arg CUDA_VERSION=$2 "
+                shift
+            else
+                missing_requirement "$1"
+            fi
+            ;;
+        --nixl-ref)
+            if [ "$2" ]; then
+                NIXL_REF=$2
                 shift
             else
                 missing_requirement "$1"


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
TensorRT-LLM (trtllm) container file is based on CUDA13, NIXL python build will not produce cu13 wheel files.
This might apply the same for building vLLM with CUDA13, the NIXL python build will not produce the correct wheel files and it will fetch wheel files from pypi.

This PR introduce the following changes:

1. Introduce capability to Dockerfile to support NIXL_REF as commit and not just a tagged version.
2. Correctly build nixl wheel files and use them in runtime (vllm, trtllm, sglang)
3. Add a new arg to `build.sh` to support providing a NIXL REF (commit or tag) `--nixl-ref`
4. Fix AWS Dockerfile to remove the `/opt/amazon/aws-ofi-nccl` library to avoid conflicts with updated EFA installer one.

#### Details:

<!-- Describe the changes made in this PR. -->

Align with NIXL [build instructions for python CUDA13](https://github.com/ai-dynamo/nixl/tree/main?tab=readme-ov-file#python-interface)

Currently, added an `ls /opt/dynamo/dist/nixl` checkpoint
You can see that it downloads the nixl python packages and doesn't use the built one, which do not exists
```
#80 44.20 nixl_cu12-0.7.1-cp312-cp312-linux_x86_64.whl
#80 44.20 nixl_cu12-0.7.1.tar.gz
...
...
#98 [runtime 35/43] RUN uv pip install       --no-cache       /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl       /opt/dynamo/wheelhouse/ai_dynamo*any.whl       /opt/dynamo/wheelhouse/nixl/nixl*.whl &&     if [ "true" = "true" ]; then         KVBM_WHEEL=$(ls /opt/dynamo/wheelhouse/kvbm*.whl 2>/dev/null | head -1);         if [ -z "$KVBM_WHEEL" ]; then             echo "ERROR: ENABLE_KVBM is true but no KVBM wheel found in wheelhouse" >&2;             exit 1;         fi;         uv pip install --no-cache "$KVBM_WHEEL";     fi &&     cd /workspace/benchmarks &&     UV_GIT_LFS=1 uv pip install --no-cache . &&     chmod -R g+w /workspace/benchmarks
#98 0.380 Using Python 3.12.3 environment at: /opt/dynamo/venv
#98 0.784 Resolved 64 packages in 354ms
#98 0.801 Downloading kubernetes (1.9MiB)
#98 0.802 Downloading uvloop (4.2MiB)
#98 0.803 Downloading nixl-cu13 (32.8MiB)
...
...
```
After fix it produced a nixl-cu13 wheel file, it will still download nixl-cu12 as kvbm doesn't have cuda13 support and it requires nixl-cu12.
```
#35 30.43 nixl_cu13-0.7.1-cp312-cp312-linux_x86_64.whl
...
...
#98 [runtime 35/43] RUN uv pip install       --no-cache       /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl       /opt/dynamo/wheelhouse/ai_dynamo*any.whl       /opt/dynamo/wheelhouse/nixl/nixl*.whl &&     if [ "true" = "true" ]; then         KVBM_WHEEL=$(ls /opt/dynamo/wheelhouse/kvbm*.whl 2>/dev/null | head -1);         if [ -z "$KVBM_WHEEL" ]; then             echo "ERROR: ENABLE_KVBM is true but no KVBM wheel found in wheelhouse" >&2;             exit 1;         fi;         uv pip install --no-cache "$KVBM_WHEEL";     fi &&     cd /workspace/benchmarks &&     UV_GIT_LFS=1 uv pip install --no-cache . &&     chmod -R g+w /workspace/benchmarks
#98 0.378 Using Python 3.12.3 environment at: /opt/dynamo/venv
#98 0.779 Resolved 63 packages in 352ms
#98 0.801 Downloading kubernetes (1.9MiB)
#98 0.801 Downloading uvloop (4.2MiB)
#98 0.909  Downloaded uvloop
#98 0.999  Downloaded kubernetes
#98 1.008 Prepared 22 packages in 226ms
#98 1.010 Uninstalled 1 package in 2ms
#98 1.053 Installed 22 packages in 42ms
#98 1.053  + ai-dynamo==0.7.0 (from file:///opt/dynamo/wheelhouse/ai_dynamo-0.7.0-py3-none-any.whl)
#98 1.053  + ai-dynamo-runtime==0.7.0 (from file:///opt/dynamo/wheelhouse/ai_dynamo_runtime-0.7.0-cp310-abi3-manylinux_2_28_x86_64.whl)
#98 1.053  + cachetools==6.2.4
#98 1.053  - click==8.3.1
#98 1.053  + click==8.1.8
#98 1.053  + durationpy==0.10
#98 1.053  + google-auth==2.45.0
#98 1.053  + iniconfig==2.3.0
#98 1.053  + kubernetes==32.0.1
#98 1.053  + nixl==0.7.1 (from file:///opt/dynamo/wheelhouse/nixl/nixl-0.7.1-py3-none-any.whl)
#98 1.053  + nixl-cu13==0.7.1 (from file:///opt/dynamo/wheelhouse/nixl/nixl_cu13-0.7.1-cp312-cp312-linux_x86_64.whl)
...
...
#98 1.154 Using Python 3.12.3 environment at: /opt/dynamo/venv
#98 1.293 Resolved 19 packages in 136ms
#98 1.297 Downloading nixl-cu12 (38.3MiB)
#98 1.711  Downloaded nixl-cu12
#98 1.711 Prepared 2 packages in 417ms
#98 1.761 Installed 2 packages in 49ms
#98 1.762  + kvbm==0.7.0 (from file:///opt/dynamo/wheelhouse/kvbm-0.7.0-cp310-abi3-manylinux_2_28_x86_64.whl)
#98 1.762  + nixl-cu12==0.8.0
...
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build configuration and dependencies to improve system library integration and build consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->