### PR TITLE
refactor: router tests to be pytest-xdist parallel safe

### DIFF
--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -284,6 +284,7 @@ class DisaggMockerProcess:
         self._process.__exit__(exc_type, exc_val, exc_tb)
 
 
+@pytest.mark.timeout(42)  # ~3x average (~13.80s), rounded up
 def test_mocker_kv_router(
     request, runtime_services_dynamic_ports, predownload_tokenizers
 ):
@@ -326,6 +327,7 @@ def test_mocker_kv_router(
 
 
 @pytest.mark.parametrize("store_backend", ["etcd", "file"])
+@pytest.mark.timeout(60)  # ~3x average (~19.86s), rounded up
 def test_mocker_two_kv_router(
     request,
     runtime_services_dynamic_ports,
@@ -381,6 +383,7 @@ def test_mocker_two_kv_router(
 
 
 @pytest.mark.skip(reason="Flaky, temporarily disabled")
+@pytest.mark.timeout(60)  # ~3x average (~19.86s), rounded up (when enabled)
 def test_mocker_kv_router_overload_503(
     request, runtime_services_dynamic_ports, predownload_tokenizers
 ):
@@ -418,6 +421,7 @@ def test_mocker_kv_router_overload_503(
             mockers.__exit__(None, None, None)
 
 
+@pytest.mark.timeout(22)  # ~3x average (~7.10s), rounded up
 def test_kv_push_router_bindings(
     request, runtime_services_dynamic_ports, predownload_tokenizers
 ):
@@ -464,7 +468,7 @@ def test_kv_push_router_bindings(
     ],
     ids=["jetstream", "file"],  # "nats_core" commented out to match commented test case
 )
-@pytest.mark.timeout(120)  # Typically ~20s; fail fast on hangs in CI/xdist.
+@pytest.mark.timeout(27)  # ~3x average (~8.93s), rounded up
 def test_indexers_sync(
     request,
     runtime_services_dynamic_ports,
@@ -532,6 +536,7 @@ def test_indexers_sync(
             mockers.__exit__(None, None, None)
 
 
+@pytest.mark.timeout(42)  # ~3x average (~13.80s), rounded up
 def test_query_instance_id_returns_worker_and_tokens(
     request, runtime_services_dynamic_ports, predownload_tokenizers
 ):
@@ -567,6 +572,7 @@ def test_query_instance_id_returns_worker_and_tokens(
 
 
 @pytest.mark.parametrize("use_nats_core", [False, True], ids=["jetstream", "nats_core"])
+@pytest.mark.timeout(29)  # ~3x average (~9.55s), rounded up
 def test_router_decisions(
     request, runtime_services_dynamic_ports, predownload_tokenizers, use_nats_core
 ):
@@ -616,6 +622,7 @@ def test_router_decisions(
 
 
 @pytest.mark.parametrize("registration_order", ["prefill_first", "decode_first"])
+@pytest.mark.timeout(59)  # ~3x average (~19.51s), rounded up
 def test_router_decisions_disagg(
     request, runtime_services_dynamic_ports, predownload_tokenizers, registration_order
 ):
@@ -716,6 +723,7 @@ def test_router_decisions_disagg(
 
 
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
+@pytest.mark.timeout(39)  # ~3x average (~12.84s), rounded up
 def test_busy_threshold_endpoint(
     request, runtime_services_dynamic_ports, predownload_tokenizers, request_plane
 ):

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -1,13 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Parallelization: Hermetic tests (xdist-safe via dynamic ports + per-test namespaces).
+# Tested on: Linux container.
+# Combined pre_merge wall time (this file):
+# - Serialized: 304.01s.
+# - Parallel (-n auto): 34.55s (269.46s saved, 8.80x).
 import logging
 import os
-from contextlib import nullcontext
 from typing import Any, Dict, Optional
 
 import pytest
 
-from tests.conftest import EtcdServer, NatsServer
 from tests.router.common import (  # utilities
     _test_busy_threshold_endpoint,
     _test_python_router_bindings,
@@ -23,6 +27,7 @@ from tests.router.common import (  # utilities
 )
 from tests.utils.constants import ROUTER_MODEL_NAME
 from tests.utils.managed_process import ManagedProcess
+from tests.utils.port_utils import allocate_ports, deallocate_ports
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +37,7 @@ pytestmark = [
     pytest.mark.pre_merge,
     pytest.mark.gpu_0,
     pytest.mark.integration,
+    pytest.mark.parallel,
     pytest.mark.model(MODEL_NAME),
 ]
 NUM_MOCKERS = 2
@@ -48,48 +54,20 @@ def get_unique_ports(
     request_plane: str = "nats",
     registration_order: str = "prefill_first",
 ) -> list[int]:
-    """Generate unique ports for parallel test execution.
+    """Allocate random free ports for xdist-safe router tests.
 
-    Ports are unique based on:
-    - Test function name (each test gets a base offset)
-    - Parametrization value (etcd=0, file=50; nats=0, tcp=25; prefill_first=0, decode_first=10)
-    - Port index (for multi-port tests)
+    This replaces the previous "test-name offset" scheme with the shared flock-backed
+    allocator from `tests.utils.port_utils`, which avoids collisions across pytest-xdist
+    worker processes.
 
-    Args:
-        request: Pytest request fixture
-        num_ports: Number of ports needed (1 for single router, 2 for two routers)
-        store_backend: Storage backend parameter ("etcd" or "file")
-        request_plane: Request plane parameter ("nats" or "tcp")
-        registration_order: Registration order parameter ("prefill_first" or "decode_first")
-
-    Returns:
-        List of unique port numbers
+    Notes:
+    - The extra parameters are kept for call-site compatibility (they no longer affect
+      the chosen ports).
+    - Ports are released at the end of the test via a pytest finalizer.
     """
-    # Get test name without parametrization suffix
-    test_name = request.node.name.split("[")[0]
-
-    # Base offsets per test function (ensures each test gets unique range)
-    test_offsets = {
-        "test_mocker_kv_router": 0,
-        "test_mocker_two_kv_router": 100,
-        "test_mocker_kv_router_overload_503": 200,
-        "test_query_instance_id_returns_worker_and_tokens": 300,
-        "test_router_decisions_disagg": 400,
-        "test_busy_threshold_endpoint": 500,
-    }
-
-    base_offset = test_offsets.get(test_name, 0)
-
-    # Parametrization offset (etcd=0, file=50; nats=0, tcp=25; prefill_first=0, decode_first=10)
-    store_offset = 0 if store_backend == "etcd" else 50
-    plane_offset = 0 if request_plane == "nats" else 25
-    order_offset = 0 if registration_order == "prefill_first" else 10
-
-    # Generate ports
-    ports = [
-        BASE_PORT + base_offset + store_offset + plane_offset + order_offset + i
-        for i in range(num_ports)
-    ]
+    _ = (store_backend, request_plane, registration_order)
+    ports = allocate_ports(num_ports, BASE_PORT)
+    request.addfinalizer(lambda: deallocate_ports(ports))
     return ports
 
 
@@ -306,8 +284,9 @@ class DisaggMockerProcess:
         self._process.__exit__(exc_type, exc_val, exc_tb)
 
 
-@pytest.mark.parallel
-def test_mocker_kv_router(request, runtime_services_session, predownload_tokenizers):
+def test_mocker_kv_router(
+    request, runtime_services_dynamic_ports, predownload_tokenizers
+):
     """
     Test KV router with multiple mocker engine instances.
     This test doesn't require GPUs and runs quickly for pre-merge validation.
@@ -316,7 +295,7 @@ def test_mocker_kv_router(request, runtime_services_session, predownload_tokeniz
     # runtime_services starts etcd and nats
     logger.info("Starting mocker KV router test")
 
-    # Create mocker args dictiona: FixtureRequestry: tuple[NatsServer, EtcdServer]: NoneType
+    # Create mocker args dictionary
     mocker_args = {"speedup_ratio": SPEEDUP_RATIO, "block_size": BLOCK_SIZE}
 
     try:
@@ -346,11 +325,10 @@ def test_mocker_kv_router(request, runtime_services_session, predownload_tokeniz
             mockers.__exit__(None, None, None)
 
 
-@pytest.mark.parallel
 @pytest.mark.parametrize("store_backend", ["etcd", "file"])
 def test_mocker_two_kv_router(
     request,
-    runtime_services_session,
+    runtime_services_dynamic_ports,
     predownload_tokenizers,
     file_storage_backend,
     store_backend,
@@ -402,10 +380,9 @@ def test_mocker_two_kv_router(
             mockers.__exit__(None, None, None)
 
 
-@pytest.mark.parallel
 @pytest.mark.skip(reason="Flaky, temporarily disabled")
 def test_mocker_kv_router_overload_503(
-    request, runtime_services_session, predownload_tokenizers
+    request, runtime_services_dynamic_ports, predownload_tokenizers
 ):
     """Test that KV router returns 503 when mocker workers are overloaded."""
     logger.info("Starting mocker KV router overload test for 503 status")
@@ -441,9 +418,8 @@ def test_mocker_kv_router_overload_503(
             mockers.__exit__(None, None, None)
 
 
-@pytest.mark.parallel
 def test_kv_push_router_bindings(
-    request, runtime_services_session, predownload_tokenizers
+    request, runtime_services_dynamic_ports, predownload_tokenizers
 ):
     """Test KvPushRouter Python bindings with mocker engines."""
     logger.info("Starting KvPushRouter bindings test")
@@ -488,8 +464,10 @@ def test_kv_push_router_bindings(
     ],
     ids=["jetstream", "file"],  # "nats_core" commented out to match commented test case
 )
+@pytest.mark.timeout(120)  # Typically ~20s; fail fast on hangs in CI/xdist.
 def test_indexers_sync(
     request,
+    runtime_services_dynamic_ports,
     predownload_tokenizers,
     file_storage_backend,
     store_backend,
@@ -511,54 +489,51 @@ def test_indexers_sync(
         f"use_nats_core={use_nats_core}, request_plane={request_plane}"
     )
 
-    # Start NATS manually (needed for all variants - KV event sync)
-    with NatsServer(request) as nats_server:
-        # Start etcd if needed
-        etcd_ctx = EtcdServer(request) if store_backend == "etcd" else nullcontext()
-        with etcd_ctx:
-            # Create mocker args dictionary
-            mocker_args = {
-                "speedup_ratio": SPEEDUP_RATIO,
-                "block_size": BLOCK_SIZE,
-                "enable_local_indexer": use_nats_core,
-            }
+    # Use the dynamic-port fixture to avoid hardcoded localhost:4222/2379 in parallel runs.
+    nats_process, _etcd_process = runtime_services_dynamic_ports
 
-            try:
-                # Start mocker instances
-                logger.info(f"Starting {NUM_MOCKERS} mocker instances")
-                mockers = MockerProcess(
-                    request,
-                    mocker_args=mocker_args,
-                    num_mockers=NUM_MOCKERS,
-                    store_backend=store_backend,
-                    request_plane=request_plane,
-                )
-                logger.info(f"All mockers using endpoint: {mockers.endpoint}")
-                mockers.__enter__()
+    # Create mocker args dictionary
+    mocker_args = {
+        "speedup_ratio": SPEEDUP_RATIO,
+        "block_size": BLOCK_SIZE,
+        "enable_local_indexer": use_nats_core,
+    }
 
-                # Use the common test implementation (creates its own runtimes for each router)
-                # Note: Consumer verification is done inside _test_router_indexers_sync while routers are alive
-                _test_router_indexers_sync(
-                    engine_workers=mockers,
-                    block_size=BLOCK_SIZE,
-                    model_name=MODEL_NAME,
-                    num_workers=NUM_MOCKERS,
-                    store_backend=store_backend,
-                    request_plane=request_plane,
-                    test_nats_interruption=use_nats_core,
-                    nats_server=nats_server if use_nats_core else None,
-                )
+    try:
+        # Start mocker instances
+        logger.info(f"Starting {NUM_MOCKERS} mocker instances")
+        mockers = MockerProcess(
+            request,
+            mocker_args=mocker_args,
+            num_mockers=NUM_MOCKERS,
+            store_backend=store_backend,
+            request_plane=request_plane,
+        )
+        logger.info(f"All mockers using endpoint: {mockers.endpoint}")
+        mockers.__enter__()
 
-                logger.info("Indexers sync test completed successfully")
+        # Use the common test implementation (creates its own runtimes for each router)
+        # Note: Consumer verification is done inside _test_router_indexers_sync while routers are alive
+        _test_router_indexers_sync(
+            engine_workers=mockers,
+            block_size=BLOCK_SIZE,
+            model_name=MODEL_NAME,
+            num_workers=NUM_MOCKERS,
+            store_backend=store_backend,
+            request_plane=request_plane,
+            test_nats_interruption=use_nats_core,
+            nats_server=nats_process if use_nats_core else None,
+        )
 
-            finally:
-                if "mockers" in locals():
-                    mockers.__exit__(None, None, None)
+        logger.info("Indexers sync test completed successfully")
+
+    finally:
+        if "mockers" in locals():
+            mockers.__exit__(None, None, None)
 
 
-@pytest.mark.parallel
 def test_query_instance_id_returns_worker_and_tokens(
-    request, runtime_services_session, predownload_tokenizers
+    request, runtime_services_dynamic_ports, predownload_tokenizers
 ):
     """Test query_instance_id annotation with mocker engines."""
     logger.info("Starting KV router query_instance_id annotation test")
@@ -591,10 +566,9 @@ def test_query_instance_id_returns_worker_and_tokens(
             mockers.__exit__(None, None, None)
 
 
-@pytest.mark.parallel
 @pytest.mark.parametrize("use_nats_core", [False, True], ids=["jetstream", "nats_core"])
 def test_router_decisions(
-    request, runtime_services_session, predownload_tokenizers, use_nats_core
+    request, runtime_services_dynamic_ports, predownload_tokenizers, use_nats_core
 ):
     """Validate KV cache prefix reuse and dp_rank routing by sending progressive requests with overlapping prefixes.
 
@@ -641,10 +615,9 @@ def test_router_decisions(
             mockers.__exit__(None, None, None)
 
 
-@pytest.mark.parallel
 @pytest.mark.parametrize("registration_order", ["prefill_first", "decode_first"])
 def test_router_decisions_disagg(
-    request, runtime_services_session, predownload_tokenizers, registration_order
+    request, runtime_services_dynamic_ports, predownload_tokenizers, registration_order
 ):
     """Validate KV cache prefix reuse in disaggregated prefill-decode setup.
 
@@ -742,10 +715,9 @@ def test_router_decisions_disagg(
             prefill_workers.__exit__(None, None, None)
 
 
-@pytest.mark.parallel
 @pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True)
 def test_busy_threshold_endpoint(
-    request, runtime_services_session, predownload_tokenizers, request_plane
+    request, runtime_services_dynamic_ports, predownload_tokenizers, request_plane
 ):
     """Test that the /busy_threshold endpoint can be hit and responds correctly.
 

--- a/tests/router/test_router_e2e_with_trtllm.py
+++ b/tests/router/test_router_e2e_with_trtllm.py
@@ -1,5 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Timing notes (measured in a TRT-LLM-enabled container):
+# - GPU-1 subset (`-m "gpu_1"`): 136.36s total for 3 tests.
+# These tests load a real model and can be slow/flaky when GPU resources are contended,
+# so we set explicit pytest timeouts to fail fast on hangs (see per-test markers below).
 import logging
 import os
 import time
@@ -14,7 +19,9 @@ from tests.router.common import (  # utilities
     generate_random_suffix,
     get_runtime,
 )
+from tests.utils.constants import DefaultPort
 from tests.utils.managed_process import ManagedProcess
+from tests.utils.port_utils import allocate_ports, deallocate_ports
 
 logger = logging.getLogger(__name__)
 
@@ -26,11 +33,15 @@ pytestmark = [
     pytest.mark.trtllm,
     pytest.mark.model(MODEL_NAME),
 ]
-PORTS = [
-    8011,
-    8022,
-]  # Frontend ports: use PORTS[0] for single router, PORTS for multi-router
 NUM_REQUESTS = 10
+
+
+def allocate_frontend_ports(request, count: int) -> list[int]:
+    """Allocate random free frontend ports for xdist-safe execution."""
+    ports = allocate_ports(count, DefaultPort.FRONTEND.value)
+    request.addfinalizer(lambda: deallocate_ports(ports))
+    return ports
+
 
 # Shared test payload for all tests
 TEST_PAYLOAD: Dict[str, Any] = {
@@ -265,8 +276,9 @@ class TRTLLMProcess:
 
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.timeout(150)  # ~3x average (~45s/test), rounded up
 def test_trtllm_kv_router_basic(
-    request, runtime_services, predownload_models, set_ucx_tls_no_mm
+    request, runtime_services_dynamic_ports, predownload_models, set_ucx_tls_no_mm
 ):
     """
     Quick e2e sanity test for KV router with TRT-LLM engine instances.
@@ -289,11 +301,12 @@ def test_trtllm_kv_router_basic(
         trtllm_workers.__enter__()
 
         # Run basic router test (starts router internally and waits for workers to be ready)
+        frontend_port = allocate_frontend_ports(request, 1)[0]
         _test_router_basic(
             engine_workers=trtllm_workers,
             block_size=TRTLLM_BLOCK_SIZE,
             request=request,
-            frontend_port=PORTS[0],
+            frontend_port=frontend_port,
             test_payload=TEST_PAYLOAD,
             num_requests=NUM_REQUESTS,
             frontend_timeout=180,  # 3 minutes should be plenty for TinyLlama
@@ -307,8 +320,9 @@ def test_trtllm_kv_router_basic(
 
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.timeout(150)  # ~3x average (~45s/test), rounded up
 def test_router_decisions_trtllm_multiple_workers(
-    request, runtime_services, predownload_models, set_ucx_tls_no_mm
+    request, runtime_services_dynamic_ports, predownload_models, set_ucx_tls_no_mm
 ):
     # runtime_services starts etcd and nats
     logger.info("Starting TRT-LLM router prefix reuse test with two workers")
@@ -353,8 +367,9 @@ def test_router_decisions_trtllm_multiple_workers(
 
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.timeout(150)  # ~3x average (~45s/test), rounded up
 def test_trtllm_indexers_sync(
-    request, runtime_services, predownload_models, set_ucx_tls_no_mm
+    request, runtime_services_dynamic_ports, predownload_models, set_ucx_tls_no_mm
 ):
     """
     Test that two KV routers have synchronized indexer states after processing requests

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -1,5 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Timing notes (measured locally):
+# - GPU-1 subset (`-m "gpu_1 and not gpu_2"`): 130.43s total for 3 tests.
+# These tests load a real model and can be slow/flaky when GPU resources are contended,
+# so we set explicit pytest timeouts to fail fast on hangs (see per-test markers below).
 import logging
 import os
 import time
@@ -14,7 +19,9 @@ from tests.router.common import (  # utilities
     generate_random_suffix,
     get_runtime,
 )
+from tests.utils.constants import DefaultPort
 from tests.utils.managed_process import ManagedProcess
+from tests.utils.port_utils import allocate_ports, deallocate_ports
 
 logger = logging.getLogger(__name__)
 
@@ -26,12 +33,16 @@ pytestmark = [
     pytest.mark.model(MODEL_NAME),
 ]
 SPEEDUP_RATIO = 10.0
-PORTS = [
-    8011,
-    8022,
-]  # Frontend ports: use PORTS[0] for single router, PORTS for multi-router
 NUM_REQUESTS = 10
 BLOCK_SIZE = 16
+
+
+def allocate_frontend_ports(request, count: int) -> list[int]:
+    """Allocate random free frontend ports for xdist-safe execution."""
+    ports = allocate_ports(count, DefaultPort.FRONTEND.value)
+    request.addfinalizer(lambda: deallocate_ports(ports))
+    return ports
+
 
 # Shared test payload for all tests
 TEST_PAYLOAD: Dict[str, Any] = {
@@ -306,8 +317,9 @@ class VLLMProcess:
 
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.timeout(150)  # ~3x average (~43s/test), rounded up
 def test_vllm_kv_router_basic(
-    request, runtime_services, predownload_models, set_ucx_tls_no_mm
+    request, runtime_services_dynamic_ports, predownload_models, set_ucx_tls_no_mm
 ):
     """
     Quick e2e sanity test for KV router with vLLM engine instances.
@@ -330,11 +342,12 @@ def test_vllm_kv_router_basic(
         vllm_workers.__enter__()
 
         # Run basic router test (starts router internally and waits for workers to be ready)
+        frontend_port = allocate_frontend_ports(request, 1)[0]
         _test_router_basic(
             engine_workers=vllm_workers,
             block_size=BLOCK_SIZE,
             request=request,
-            frontend_port=PORTS[0],
+            frontend_port=frontend_port,
             test_payload=TEST_PAYLOAD,
             num_requests=NUM_REQUESTS,
             frontend_timeout=180,  # 3 minutes should be plenty for TinyLlama
@@ -348,8 +361,9 @@ def test_vllm_kv_router_basic(
 
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.timeout(150)  # ~3x average (~43s/test), rounded up
 def test_router_decisions_vllm_multiple_workers(
-    request, runtime_services, predownload_models, set_ucx_tls_no_mm
+    request, runtime_services_dynamic_ports, predownload_models, set_ucx_tls_no_mm
 ):
     # runtime_services starts etcd and nats
     logger.info("Starting vLLM router prefix reuse test with two workers")
@@ -386,8 +400,9 @@ def test_router_decisions_vllm_multiple_workers(
 
 
 @pytest.mark.gpu_2
+@pytest.mark.timeout(600)  # 10 min max (multi-GPU + DP startup variance)
 def test_router_decisions_vllm_dp(
-    request, runtime_services, predownload_models, set_ucx_tls_no_mm
+    request, runtime_services_dynamic_ports, predownload_models, set_ucx_tls_no_mm
 ):
     """Validate KV cache prefix reuse with vLLM by sending progressive requests with overlapping prefixes.
     Same flow as test_router_decisions_vllm_multiple_workers; force first request to (worker_id, dp_rank=1).
@@ -430,8 +445,9 @@ def test_router_decisions_vllm_dp(
 
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.timeout(150)  # ~3x average (~43s/test), rounded up
 def test_vllm_indexers_sync(
-    request, runtime_services, predownload_models, set_ucx_tls_no_mm
+    request, runtime_services_dynamic_ports, predownload_models, set_ucx_tls_no_mm
 ):
     """
     Test that two KV routers have synchronized indexer states after processing requests

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -602,10 +602,6 @@ class DynamoFrontendProcess(ManagedProcess):
         # - tests/frontend/test_completion_mocker_engine.py
         # - tests/frontend/grpc/test_tensor_parameters.py
         # - tests/frontend/grpc/test_tensor_mocker_engine.py
-        # - tests/router/common.py
-        # - tests/router/test_router_e2e_with_vllm.py
-        # - tests/router/test_router_e2e_with_sglang.py
-        # - tests/router/test_router_e2e_with_trtllm.py
         # - tests/fault_tolerance/cancellation/utils.py
         # - tests/fault_tolerance/migration/utils.py
         # - tests/fault_tolerance/etcd_ha/utils.py


### PR DESCRIPTION
#### Overview:

Refactor router E2E tests to be pytest-xdist safe by switching to per-test NATS/etcd and dynamic frontend ports. This reduces port/service collisions in parallel runs and adds explicit timeouts + timing notes for the GPU router suites.

#### Details:

- Use `runtime_services_dynamic_ports` for vLLM/TRT-LLM/SGLang router E2E tests (per-test NATS/etcd on random ports).
- Allocate frontend ports dynamically in vLLM/TRT-LLM/SGLang router E2E tests.
- Router common helpers read NATS address from `NATS_SERVER` (instead of hard-coded `localhost:4222`).
- Add/tighten pytest timeouts and record measured timings for router test suites.
- Mocker router suite timing: serial 304.01s, parallel (`-n auto`) 34.55s (269.46s saved, 8.80x).

#### Where should the reviewer start?

tests/router/common.py
tests/conftest.py
tests/router/test_router_e2e_with_mockers.py
tests/router/test_router_e2e_with_vllm.py
tests/router/test_router_e2e_with_trtllm.py
tests/router/test_router_e2e_with_sglang.py

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)

DIS-1193, DIS-1194

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test infrastructure with dynamic port allocation to enable efficient parallel test execution and improved overall resource management.
  * Improved test isolation and reliability for concurrent testing scenarios.
  * Added comprehensive documentation to test fixtures describing parallelization safety and per-test isolation implications.
  * Updated test configurations with timeout markers for faster failure detection and better diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->