### PR TITLE
fix(operator): vLLM multi-node support for TP and DP 

### DIFF
--- a/deploy/cloud/operator/docs/footer.md
+++ b/deploy/cloud/operator/docs/footer.md
@@ -143,9 +143,10 @@ For multinode deployments, the operator modifies probes based on the backend fra
 
 The operator automatically selects between two deployment modes based on parallelism configuration:
 
-**Ray-Based Mode** (when `world_size > GPUs_per_node`):
-- **Worker nodes**: All probes (liveness, readiness, startup) are removed
-- **Leader nodes**: All probes remain active
+**Tensor/Pipeline Parallel Mode** (when `world_size > GPUs_per_node`):
+- Uses Ray for distributed execution (`--distributed-executor-backend ray`)
+- **Leader nodes**: Starts Ray head and runs vLLM; all probes remain active
+- **Worker nodes**: Run Ray agents only; all probes (liveness, readiness, startup) are removed
 
 **Data Parallel Mode** (when `world_size × data_parallel_size > GPUs_per_node`):
 - **Worker nodes**: All probes (liveness, readiness, startup) are removed
@@ -247,7 +248,7 @@ Default container ports are configured based on component type:
 ## Backend-Specific Configurations
 
 ### VLLM
-- **Ray Head Port**: 6379 (for Ray-based multinode deployments)
+- **Ray Head Port**: 6379 (for Ray cluster coordination in multinode TP/PP deployments)
 - **Data Parallel RPC Port**: 13445 (for data parallel multinode deployments)
 
 ### SGLang

--- a/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -825,7 +825,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 										Name:    commonconsts.MainContainerName,
 										Image:   "test-image:latest",
 										Command: []string{"/bin/sh", "-c"},
-										Args:    []string{"ray start --head --port=6379 && some dynamo command --tensor-parallel-size 4 --pipeline-parallel-size 1"},
+										Args:    []string{"ray start --head --port=6379 && some dynamo command --tensor-parallel-size 4 --pipeline-parallel-size 1 --distributed-executor-backend ray"},
 										Env: []corev1.EnvVar{
 											{Name: commonconsts.DynamoComponentEnvVar, Value: commonconsts.ComponentTypeWorker},
 											{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "true"},

--- a/deploy/cloud/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/cloud/operator/internal/dynamo/backend_vllm.go
@@ -74,7 +74,7 @@ func (b *VLLMBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32
 func updateVLLMMultinodeArgs(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, resources *v1alpha1.Resources, numberOfNodes int32) {
 	expandedArgs := getExpandedArgs(container)
 	if needsRayDistributedLaunch(expandedArgs, resources) {
-		injectRayDistributedLaunchFlags(container, role, serviceName, multinodeDeployer, numberOfNodes)
+		injectRayDistributedLaunchFlags(container, role, serviceName, multinodeDeployer)
 	} else if needsDataParallelLaunch(expandedArgs, resources) {
 		injectDataParallelLaunchFlags(container, role, serviceName, multinodeDeployer, resources, numberOfNodes)
 	} else {
@@ -93,7 +93,7 @@ func getExpandedArgs(container *corev1.Container) []string {
 	return expandedArgs
 }
 
-func injectRayDistributedLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, numberOfNodes int32) {
+func injectRayDistributedLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer) {
 	switch role {
 	case RoleLeader:
 		fullCommand := strings.Join(container.Command, " ")

--- a/deploy/cloud/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/cloud/operator/internal/dynamo/backend_vllm.go
@@ -76,7 +76,7 @@ func updateVLLMMultinodeArgs(container *corev1.Container, role Role, serviceName
 	if needsRayDistributedLaunch(expandedArgs, resources) {
 		injectRayDistributedLaunchFlags(container, role, serviceName, multinodeDeployer, numberOfNodes)
 	} else if needsDataParallelLaunch(expandedArgs, resources) {
-		injectDataParallelLaunchFlags(container, role, serviceName, multinodeDeployer, resources)
+		injectDataParallelLaunchFlags(container, role, serviceName, multinodeDeployer, resources, numberOfNodes)
 	} else {
 		logger := log.Log.WithName("vllm-backend")
 		logger.Info("No need to inject Ray-specific or data parallel flags for multinode deployments", "args", strings.Join(container.Args, " "))
@@ -112,27 +112,71 @@ func injectRayDistributedLaunchFlags(container *corev1.Container, role Role, ser
 	container.Command = []string{"/bin/sh", "-c"} // ensure cmd is a shell
 }
 
-func injectDataParallelLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, resources *v1alpha1.Resources) {
+func injectDataParallelLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, resources *v1alpha1.Resources, numberOfNodes int32) {
 	expandedArgs := getExpandedArgs(container)
 	leaderHostname := multinodeDeployer.GetLeaderHostname(serviceName)
-	dataParallelSizeLocal := getContainerGPUs(resources) / getWorldSize(expandedArgs)
-	var startRank string
+
+	// Calculate engines per node
+	containerGPUs := getContainerGPUs(resources)
+	worldSize := getWorldSize(expandedArgs) // TP * PP per engine
+	dataParallelSizeLocal := containerGPUs / worldSize
+
+	// Get total DP size from args, or calculate from nodes
+	totalDPSize := getFlagValue(expandedArgs, dataParallelSizeFlag)
+	if totalDPSize == 1 {
+		totalDPSize = dataParallelSizeLocal * int64(numberOfNodes)
+	}
+
+	var flags []string
+	needsShell := false
+
+	// Helper to check if flag already exists in args
+	hasFlag := func(flag string) bool {
+		for _, arg := range expandedArgs {
+			if arg == flag {
+				return true
+			}
+		}
+		return false
+	}
+
 	switch role {
-	case RoleWorker:
-		nodeRank, _ := multinodeDeployer.GetNodeRank()
-		startRank = fmt.Sprintf("$(( %d * %s ))", dataParallelSizeLocal, nodeRank)
 	case RoleLeader:
-		startRank = "0" // leader start rank is always 0
-	default:
-		startRank = "0"
+		// Leader runs API server + coordinator + local engines
+		// Hybrid LB mode: local DP coordination within node, Dynamo routes between nodes
+		flags = []string{"--data-parallel-hybrid-lb"}
+		// Only inject --data-parallel-size if not already present (avoids duplicates from profiler)
+		if !hasFlag("--data-parallel-size") {
+			flags = append(flags, "--data-parallel-size", strconv.FormatInt(totalDPSize, 10))
+		}
+		flags = append(flags,
+			"--data-parallel-size-local", strconv.FormatInt(dataParallelSizeLocal, 10),
+			"--data-parallel-start-rank", "0",
+			"--data-parallel-address", leaderHostname,
+			"--data-parallel-rpc-port", dataParallelRPCPort,
+		)
+
+	case RoleWorker:
+		// Worker runs API server + coordinator + local engines on its node
+		// Hybrid LB mode: local DP coordination within node, Dynamo routes between nodes
+		nodeRank, _ := multinodeDeployer.GetNodeRank()
+		startRank := fmt.Sprintf("$(( %d * %s ))", dataParallelSizeLocal, nodeRank)
+		needsShell = true // Need shell for arithmetic expansion
+
+		flags = []string{"--data-parallel-hybrid-lb"}
+		// Only inject --data-parallel-size if not already present (avoids duplicates from profiler)
+		if !hasFlag("--data-parallel-size") {
+			flags = append(flags, "--data-parallel-size", strconv.FormatInt(totalDPSize, 10))
+		}
+		flags = append(flags,
+			"--data-parallel-size-local", strconv.FormatInt(dataParallelSizeLocal, 10),
+			"--data-parallel-start-rank", startRank,
+			"--data-parallel-address", leaderHostname,
+			"--data-parallel-rpc-port", dataParallelRPCPort,
+		)
 	}
-	flags := []string{
-		"--data-parallel-address", leaderHostname,
-		"--data-parallel-size-local", strconv.FormatInt(dataParallelSizeLocal, 10),
-		"--data-parallel-rpc-port", dataParallelRPCPort,
-		"--data-parallel-start-rank", startRank,
-	}
-	injectFlagsIntoContainerCommand(container, strings.Join(flags, " "), true, "vllm")
+
+	injectFlagsIntoContainerCommand(container, strings.Join(flags, " "), needsShell, "vllm")
 }
 
 // if world size (within DP rank) > GPU count, then we need to inject ray

--- a/deploy/cloud/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/cloud/operator/internal/dynamo/backend_vllm_test.go
@@ -156,7 +156,7 @@ func TestVLLMBackend_ShellCommandInjection(t *testing.T) {
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"sh", "-c"}, Args: []string{fmt.Sprintf("python3 -m dynamo.vllm %s 8", dataParallelSizeFlag)}},
 			gpuCount:          4,
-			expectedArgs:      []string{"python3 -m dynamo.vllm --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-size-local 4 --data-parallel-rpc-port 13445 --data-parallel-start-rank 0 --data-parallel-size 8"},
+			expectedArgs:      []string{"python3 -m dynamo.vllm --data-parallel-hybrid-lb --data-parallel-size-local 4 --data-parallel-start-rank 0 --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-rpc-port 13445 --data-parallel-size 8"},
 			description:       "Shell commands should use regex injection for python commands",
 		},
 		{
@@ -166,7 +166,7 @@ func TestVLLMBackend_ShellCommandInjection(t *testing.T) {
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"sh", "-c"}, Args: []string{fmt.Sprintf("echo blah | wc -l && python3 -m dynamo.vllm %s 8 && ls -al", dataParallelSizeFlag)}},
 			gpuCount:          4,
-			expectedArgs:      []string{"echo blah | wc -l && python3 -m dynamo.vllm --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-size-local 4 --data-parallel-rpc-port 13445 --data-parallel-start-rank 0 --data-parallel-size 8 && ls -al"},
+			expectedArgs:      []string{"echo blah | wc -l && python3 -m dynamo.vllm --data-parallel-hybrid-lb --data-parallel-size-local 4 --data-parallel-start-rank 0 --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-rpc-port 13445 --data-parallel-size 8 && ls -al"},
 			description:       "Complex shell commands should inject flags only into python part",
 		},
 		{
@@ -176,7 +176,7 @@ func TestVLLMBackend_ShellCommandInjection(t *testing.T) {
 			multinodeDeployer: &LWSMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"sh", "-c"}, Args: []string{fmt.Sprintf("python3 -m dynamo.vllm %s 8", dataParallelSizeFlag)}},
 			gpuCount:          4,
-			expectedArgs:      []string{"python3 -m dynamo.vllm --data-parallel-address $LWS_LEADER_ADDRESS --data-parallel-size-local 4 --data-parallel-rpc-port 13445 --data-parallel-start-rank 0 --data-parallel-size 8"},
+			expectedArgs:      []string{"python3 -m dynamo.vllm --data-parallel-hybrid-lb --data-parallel-size-local 4 --data-parallel-start-rank 0 --data-parallel-address $LWS_LEADER_ADDRESS --data-parallel-rpc-port 13445 --data-parallel-size 8"},
 			description:       "LWS shell commands should use LWS variables",
 		},
 		{
@@ -186,7 +186,7 @@ func TestVLLMBackend_ShellCommandInjection(t *testing.T) {
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"sh", "-c"}, Args: []string{fmt.Sprintf("python3 -m dynamo.vllm %s 8 | tee /tmp/log", dataParallelSizeFlag)}},
 			gpuCount:          4,
-			expectedArgs:      []string{"python3 -m dynamo.vllm --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-size-local 4 --data-parallel-rpc-port 13445 --data-parallel-start-rank 0 --data-parallel-size 8 | tee /tmp/log"},
+			expectedArgs:      []string{"python3 -m dynamo.vllm --data-parallel-hybrid-lb --data-parallel-size-local 4 --data-parallel-start-rank 0 --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-rpc-port 13445 --data-parallel-size 8 | tee /tmp/log"},
 			description:       "Shell commands with pipes should inject flags before pipe",
 		},
 	}
@@ -346,7 +346,7 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", dataParallelSizeFlag, "16"}},
 			gpuCount:          8,
-			expectedArgs:      []string{fmt.Sprintf("exec python3 -m dynamo.vllm %s 16 --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-size-local 8 --data-parallel-rpc-port 13445 --data-parallel-start-rank 0", dataParallelSizeFlag)},
+			expectedArgs:      []string{"-m", "dynamo.vllm", dataParallelSizeFlag, "16", "--data-parallel-hybrid-lb", "--data-parallel-size-local", "8", "--data-parallel-start-rank", "0", "--data-parallel-address", "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE)", "--data-parallel-rpc-port", "13445"},
 		},
 		{
 			name:              "leader with empty args does not modify",
@@ -370,7 +370,7 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", dataParallelSizeFlag, "16"}},
 			gpuCount:          8,
-			expectedArgs:      []string{fmt.Sprintf("exec python3 -m dynamo.vllm %s 16 --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-size-local 8 --data-parallel-rpc-port 13445 --data-parallel-start-rank $(( 8 * $((GROVE_PCLQ_POD_INDEX + 1)) ))", dataParallelSizeFlag)},
+			expectedArgs:      []string{fmt.Sprintf("exec python3 -m dynamo.vllm %s 16 --data-parallel-hybrid-lb --data-parallel-size-local 8 --data-parallel-start-rank $(( 8 * $((GROVE_PCLQ_POD_INDEX + 1)) )) --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-rpc-port 13445", dataParallelSizeFlag)},
 		},
 		{
 			name:              "worker with data parallel launch Grove, tp > 1",
@@ -378,7 +378,7 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", dataParallelSizeFlag, "8", tensorParallelSizeFlag, "2"}},
 			gpuCount:          8,
-			expectedArgs:      []string{fmt.Sprintf("exec python3 -m dynamo.vllm %s 8 %s 2 --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-size-local 4 --data-parallel-rpc-port 13445 --data-parallel-start-rank $(( 4 * $((GROVE_PCLQ_POD_INDEX + 1)) ))", dataParallelSizeFlag, tensorParallelSizeFlag)},
+			expectedArgs:      []string{fmt.Sprintf("exec python3 -m dynamo.vllm %s 8 %s 2 --data-parallel-hybrid-lb --data-parallel-size-local 4 --data-parallel-start-rank $(( 4 * $((GROVE_PCLQ_POD_INDEX + 1)) )) --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-rpc-port 13445", dataParallelSizeFlag, tensorParallelSizeFlag)},
 		},
 		{
 			name:              "worker with ray distributed launch LWS",

--- a/deploy/cloud/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/cloud/operator/internal/dynamo/backend_vllm_test.go
@@ -44,7 +44,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			multinodeDeployer:   &GroveMultinodeDeployer{},
 			initialContainer:    &corev1.Container{Command: []string{"python3", "-m", "dynamo.vllm"}, Args: []string{"--model", "test", tensorParallelSizeFlag, "8"}},
 			gpuCount:            4,
-			expectedArgs:        []string{fmt.Sprintf("ray start --head --port=%s && python3 -m dynamo.vllm --model test %s 8", VLLMPort, tensorParallelSizeFlag)},
+			expectedArgs:        []string{fmt.Sprintf("ray start --head --port=%s && python3 -m dynamo.vllm --model test %s 8 --distributed-executor-backend ray", VLLMPort, tensorParallelSizeFlag)},
 			expectProbesRemoved: true,
 		},
 		{
@@ -338,7 +338,7 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "16"}},
 			gpuCount:          8,
-			expectedArgs:      []string{fmt.Sprintf("ray start --head --port=%s && python3 -m dynamo.vllm %s 16", VLLMPort, tensorParallelSizeFlag)},
+			expectedArgs:      []string{fmt.Sprintf("ray start --head --port=%s && python3 -m dynamo.vllm %s 16 --distributed-executor-backend ray", VLLMPort, tensorParallelSizeFlag)},
 		},
 		{
 			name:              "leader prepends distributed data parallel flags",
@@ -415,7 +415,7 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 			}
 
 			// Call updateVLLMMultinodeArgs
-			updateVLLMMultinodeArgs(tt.initialContainer, tt.role, "test-service", tt.multinodeDeployer, resources)
+			updateVLLMMultinodeArgs(tt.initialContainer, tt.role, "test-service", tt.multinodeDeployer, resources, 2)
 
 			if tt.expectNotModified {
 				// Args should not have changed

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -2826,7 +2826,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													"-c",
 												},
 												Args: []string{
-													"ray start --head --port=6379 && python3 -m dynamo.vllm --custom-flag custom-value --tensor-parallel-size 4 --pipeline-parallel-size 1",
+													"ray start --head --port=6379 && python3 -m dynamo.vllm --custom-flag custom-value --tensor-parallel-size 4 --pipeline-parallel-size 1 --distributed-executor-backend ray",
 												},
 												Ports: []corev1.ContainerPort{
 													{

--- a/deploy/cloud/operator/internal/dynamo/grove.go
+++ b/deploy/cloud/operator/internal/dynamo/grove.go
@@ -26,7 +26,7 @@ type GroveMultinodeDeployer struct {
 }
 
 func (d *GroveMultinodeDeployer) GetLeaderHostname(serviceName string) string {
-	return fmt.Sprintf("$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-%s-%s-0.$(GROVE_HEADLESS_SERVICE)", serviceName, commonconsts.GroveRoleSuffixLeader)
+	return fmt.Sprintf("$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-%s-%s-0.$(GROVE_HEADLESS_SERVICE)", strings.ToLower(serviceName), commonconsts.GroveRoleSuffixLeader)
 }
 
 func (d *GroveMultinodeDeployer) GetNodeRank() (string, bool) {
@@ -46,7 +46,7 @@ func (d *GroveMultinodeDeployer) GetHostNames(serviceName string, numberOfNodes 
 	// Add worker hostnames
 	for i := int32(0); i < numberOfNodes-1; i++ {
 		workerHostname := fmt.Sprintf("$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-%s-%s-%d.$(GROVE_HEADLESS_SERVICE)",
-			serviceName, commonconsts.GroveRoleSuffixWorker, i)
+			strings.ToLower(serviceName), commonconsts.GroveRoleSuffixWorker, i)
 		hostnames = append(hostnames, workerHostname)
 	}
 	return hostnames

--- a/docs/kubernetes/api_reference.md
+++ b/docs/kubernetes/api_reference.md
@@ -964,9 +964,10 @@ For multinode deployments, the operator modifies probes based on the backend fra
 
 The operator automatically selects between two deployment modes based on parallelism configuration:
 
-**Ray-Based Mode** (when `world_size > GPUs_per_node`):
-- **Worker nodes**: All probes (liveness, readiness, startup) are removed
-- **Leader nodes**: All probes remain active
+**Tensor/Pipeline Parallel Mode** (when `world_size > GPUs_per_node`):
+- Uses Ray for distributed execution (`--distributed-executor-backend ray`)
+- **Leader nodes**: Starts Ray head and runs vLLM; all probes remain active
+- **Worker nodes**: Run Ray agents only; all probes (liveness, readiness, startup) are removed
 
 **Data Parallel Mode** (when `world_size × data_parallel_size > GPUs_per_node`):
 - **Worker nodes**: All probes (liveness, readiness, startup) are removed
@@ -1068,7 +1069,7 @@ Default container ports are configured based on component type:
 ## Backend-Specific Configurations
 
 ### VLLM
-- **Ray Head Port**: 6379 (for Ray-based multinode deployments)
+- **Ray Head Port**: 6379 (for Ray cluster coordination in multinode TP/PP deployments)
 - **Data Parallel RPC Port**: 13445 (for data parallel multinode deployments)
 
 ### SGLang

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -78,7 +78,7 @@
 **Time-To-First-Token (TTFT)** - The latency from receiving a request to generating the first output token.
 
 ## V
-**vLLM** - High-throughput LLM serving engine with Ray distributed support and PagedAttention.
+**vLLM** - High-throughput LLM serving engine with distributed tensor/pipeline parallelism and PagedAttention.
 
 ## W
 **Wide Expert Parallelism (WideEP)** - Mixture-of-Experts deployment strategy that spreads experts across many GPUs (e.g., 64-way EP) so each GPU hosts only a few experts.


### PR DESCRIPTION
## Summary

Fixes vLLM multi-node deployments in the operator for both tensor/pipeline parallel (TEP) and data parallel (DEP) modes:

- **TEP**: Use Ray distributed executor backend so vLLM can spawn workers across nodes
- **DEP**: Use hybrid load balancing mode where each node runs its own DP coordinator

Also fixes K8s DNS compatibility by lowercasing service names in Grove hostnames.

Fixes #4934, DYN-1620