### PR TITLE
fix: Remove debug logging from aiperf benchmarking

### DIFF
--- a/benchmarks/llm/perf.sh
+++ b/benchmarks/llm/perf.sh
@@ -236,7 +236,6 @@ for concurrency in "${concurrency_array[@]}"; do
     --random-seed 100 \
     --artifact-dir ${artifact_dir} \
     --ui simple \
-    -v \
     -H 'Authorization: Bearer NOT USED' \
     -H 'Accept: text/event-stream'
 

--- a/docs/backends/trtllm/gpt-oss.md
+++ b/docs/backends/trtllm/gpt-oss.md
@@ -430,7 +430,6 @@ aiperf profile \
     --num-dataset-entries 8000 \
     --random-seed 100 \
     --artifact-dir /tmp/benchmark-results \
-    -v \
     -H 'Authorization: Bearer NOT USED' \
     -H 'Accept: text/event-stream'
 ```

--- a/examples/backends/trtllm/performance_sweeps/scripts/bench.sh
+++ b/examples/backends/trtllm/performance_sweeps/scripts/bench.sh
@@ -174,7 +174,6 @@ for concurrency in ${concurrency_list}; do
 	    --num-dataset-entries ${num_prompts} \
     	--random-seed 100 \
     	--artifact-dir ${artifacts_dir} \
-    	-v \
     	-H 'Authorization: Bearer NOT USED' \
     	-H 'Accept: text/event-stream'
     echo "Benchmark with concurrency ${concurrency} done"

--- a/examples/deployments/router_standalone/perf.sh
+++ b/examples/deployments/router_standalone/perf.sh
@@ -47,6 +47,5 @@ aiperf profile \
   --request-count ${num_requests} \
   --num-dataset-entries ${num_unique_prompts} \
   --random-seed ${seed} \
-  -v \
   -H 'Authorization: Bearer NOT USED' \
   -H 'Accept: text/event-stream'

--- a/tests/planner/README.md
+++ b/tests/planner/README.md
@@ -286,8 +286,7 @@ aiperf profile \
   --streaming \
   --input-file /workspace/rr-5-45_i3000o300.jsonl \ # path to the generated load dataset \
   --custom-dataset-type mooncake_trace \
-  --goodput "time_to_first_token:200 inter_token_latency:10" \
-  -v
+  --goodput "time_to_first_token:200 inter_token_latency:10"
 ```
 
 > [!NOTE]


### PR DESCRIPTION
#### Overview:

The debug logging is causing profiling timeout errors at high concurrencies like 2048 for DS R1 model on GB200. 

check the nvbug: 5657652


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark and documentation examples to reduce command output verbosity across AIPerf invocations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->