### PR TITLE
refactor: frontend/test_vllm.py to use shared dynamic ports

### DIFF
--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -600,11 +600,6 @@ class DynamoFrontendProcess(ManagedProcess):
     ):
         # TODO: Refactor remaining duplicate "DynamoFrontendProcess" helpers in tests to
         # use this shared implementation (and delete the copies):
-        # - tests/frontend/test_vllm.py
-        # - tests/router/common.py
-        # - tests/router/test_router_e2e_with_vllm.py
-        # - tests/router/test_router_e2e_with_sglang.py
-        # - tests/router/test_router_e2e_with_trtllm.py
         # - tests/fault_tolerance/cancellation/utils.py
         # - tests/fault_tolerance/migration/utils.py
         # - tests/fault_tolerance/etcd_ha/utils.py


### PR DESCRIPTION
#### Overview:

Refactors the frontend vLLM tests to use shared dynamic-port fixtures and the shared `DynamoFrontendProcess` implementation. This improves parallel-safety and reduces flaky behavior from port collisions or overly-broad process cleanup.

#### Details:

- Update `tests/frontend/test_vllm.py` to use `runtime_services_dynamic_ports` and `ServicePorts` for all frontend/worker URLs
- Add per-test `pytest.mark.timeout(...)` annotations based on measured runtimes and record total suite wall time in the test file header
- Move shared port wiring into `tests/conftest.py` via `dynamo_dynamic_ports` + `num_system_ports`, using `ServicePorts` from `tests/utils/port_utils.py`
- Prevent a Tokio runtime drop panic during tokenizer/encoding initialization in the parsers layer

#### Where should the reviewer start?

tests/frontend/test_vllm.py
tests/conftest.py
tests/utils/managed_process.py
tests/utils/port_utils.py
lib/parsers/src/reasoning/gpt_oss_parser.rs

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)

DIS-1193, DIS-1194

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use dynamic port configuration instead of hardcoded service endpoints.
  * Improved test fixture lifecycle management for better test isolation.

* **Chores**
  * Cleaned up obsolete comments from test utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->