### PR TITLE
fix: always make nats_client as workaround for KV Router

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1579,6 +1579,14 @@ def _test_router_indexers_sync(
         state1 = json.loads(state1_json)
         state2 = json.loads(state2_json)
 
+        # Verify final tree dumps are non-zero length
+        assert (
+            len(state1) > 0
+        ), f"Expected non-zero tree dump from Router 1, got {len(state1)} events"
+        assert (
+            len(state2) > 0
+        ), f"Expected non-zero tree dump from Router 2, got {len(state2)} events"
+
         # Sort both states for comparison (order might differ due to HashMap iteration and sharding)
         def sort_key(event):
             data = event["event"]["data"]["stored"]

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -468,7 +468,7 @@ def test_kv_push_router_bindings(
     ],
     ids=["jetstream", "nats_core", "file"],
 )
-@pytest.mark.timeout(27)  # ~3x average (~8.93s), rounded up
+@pytest.mark.timeout(90)  # TODO: figure out the actual 3x average
 def test_indexers_sync(
     request,
     runtime_services_dynamic_ports,

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -463,10 +463,10 @@ def test_kv_push_router_bindings(
     "store_backend,use_nats_core,request_plane",
     [
         ("etcd", False, "nats"),  # JetStream mode
-        # ("etcd", True, "tcp"),  # ignored, needs unconditional nats_client
+        ("etcd", True, "tcp"),  # NATS Core mode with local indexer
         ("file", False, "nats"),  # File backend
     ],
-    ids=["jetstream", "file"],  # "nats_core" commented out to match commented test case
+    ids=["jetstream", "nats_core", "file"],
 )
 @pytest.mark.timeout(27)  # ~3x average (~8.93s), rounded up
 def test_indexers_sync(


### PR DESCRIPTION
#### Overview:

as titled, mainly for router gap detection functionality where the intended usage is for requests to go through TCP but nats server needs to be independently turned on and off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage with additional NATS configuration scenarios
  * Added validation checks for router state verification
  * Increased test timeouts for improved reliability

* **Improvements**
  * Enhanced connection handling to consistently attempt default configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->