### PR TITLE
fix: Truncate HttpError message to first 8192 characters

### DIFF
--- a/lib/bindings/python/rust/http.rs
+++ b/lib/bindings/python/rust/http.rs
@@ -138,6 +138,12 @@ impl HttpAsyncEngine {
     }
 }
 
+#[derive(FromPyObject)]
+struct HttpError {
+    code: u16,
+    message: String,
+}
+
 #[async_trait]
 impl<Req, Resp> AsyncEngine<SingleIn<Req>, ManyOut<Annotated<Resp>>, Error> for HttpAsyncEngine
 where
@@ -153,18 +159,10 @@ where
             Err(e) => {
                 if let Some(py_err) = e.downcast_ref::<PyErr>() {
                     Python::with_gil(|py| {
-                        let err_val = py_err.clone_ref(py).into_value(py);
-                        let bound_err = err_val.bind(py);
-
-                        // check: Py03 exceptions cannot be cross-compiled, so we duck-type by name
-                        // and fields.
-                        if let Ok(type_name) = bound_err.get_type().name()
-                            && type_name.to_string().contains("HttpError")
-                            && let (Ok(code), Ok(message)) =
-                                (bound_err.getattr("code"), bound_err.getattr("message"))
-                            && let (Ok(code), Ok(message)) =
-                                (code.extract::<u16>(), message.extract::<String>())
-                        {
+                        // With the Stable ABI, we can't subclass Python's built-in exceptions in PyO3, so instead we
+                        // implement the exception in Python and use duck typing / assume that it's an HttpError if
+                        // the code and message are present.
+                        if let Ok(HttpError { code, message }) = py_err.value(py).extract() {
                             // SSE panics if there are carriage returns or newlines
                             let message = message.replace(['\r', '\n'], "");
                             return Err(http_error::HttpError { code, message })?;

--- a/lib/bindings/python/rust/http.rs
+++ b/lib/bindings/python/rust/http.rs
@@ -160,8 +160,8 @@ where
                 if let Some(py_err) = e.downcast_ref::<PyErr>() {
                     Python::with_gil(|py| {
                         // With the Stable ABI, we can't subclass Python's built-in exceptions in PyO3, so instead we
-                        // implement the exception in Python and use duck typing / assume that it's an HttpError if
-                        // the code and message are present.
+                        // implement the exception in Python and assume that it's an HttpError if the code and message
+                        // are present.
                         if let Ok(HttpError { code, message }) = py_err.value(py).extract() {
                             // SSE panics if there are carriage returns or newlines
                             let message = message.replace(['\r', '\n'], "");

--- a/lib/bindings/python/src/dynamo/llm/exceptions.py
+++ b/lib/bindings/python/src/dynamo/llm/exceptions.py
@@ -3,13 +3,29 @@
 
 # flake8: noqa
 
+_MAX_MESSAGE_LENGTH = 8192
+
 
 class HttpError(Exception):
     def __init__(self, code: int, message: str):
-        if not (isinstance(code, int) and 0 <= code < 600):
+        # These ValueErrors are easier to trace to here than the TypeErrors that
+        # would be raised otherwise.
+        if not isinstance(code, int):
+            raise ValueError("HttpError status code must be an integer")
+
+        if not isinstance(message, str):
+            raise ValueError("HttpError message must be a string")
+
+        if not (0 <= code < 600):
             raise ValueError("HTTP status code must be an integer between 0 and 599")
-        if not (isinstance(message, str) and 0 < len(message) <= 8192):
-            raise ValueError("HTTP error message must be a string of length <= 8192")
+
+        if len(message) > _MAX_MESSAGE_LENGTH:
+            print(
+                f"HttpError message length {len(message)} exceeds max length {_MAX_MESSAGE_LENGTH}, truncating..."
+            )
+            message = message[: (_MAX_MESSAGE_LENGTH - 3)] + "..."
+
         self.code = code
         self.message = message
+
         super().__init__(f"HTTP {code}: {message}")

--- a/lib/bindings/python/src/dynamo/llm/exceptions.py
+++ b/lib/bindings/python/src/dynamo/llm/exceptions.py
@@ -3,6 +3,10 @@
 
 # flake8: noqa
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 _MAX_MESSAGE_LENGTH = 8192
 
 
@@ -10,7 +14,7 @@ class HttpError(Exception):
     def __init__(self, code: int, message: str):
         # These ValueErrors are easier to trace to here than the TypeErrors that
         # would be raised otherwise.
-        if not isinstance(code, int):
+        if not isinstance(code, int) or isinstance(code, bool):
             raise ValueError("HttpError status code must be an integer")
 
         if not isinstance(message, str):
@@ -20,7 +24,7 @@ class HttpError(Exception):
             raise ValueError("HTTP status code must be an integer between 0 and 599")
 
         if len(message) > _MAX_MESSAGE_LENGTH:
-            print(
+            logger.warning(
                 f"HttpError message length {len(message)} exceeds max length {_MAX_MESSAGE_LENGTH}, truncating..."
             )
             message = message[: (_MAX_MESSAGE_LENGTH - 3)] + "..."

--- a/lib/bindings/python/tests/test_http_error.py
+++ b/lib/bindings/python/tests/test_http_error.py
@@ -18,3 +18,19 @@ def test_raise_http_error():
 def test_invalid_http_error_code():
     with pytest.raises(ValueError):
         HttpError(1700, "Invalid Code")
+
+
+def test_invalid_http_error_message():
+    with pytest.raises(ValueError):
+        # The second argument must be a string, not bytes.
+        HttpError(400, b"Bad Request")
+
+
+def test_long_http_error_message():
+    message = ("A" * 8192) + "B"
+    error = HttpError(400, message)
+    assert len(error.message) == 8192
+
+    # Ensure the exception string uses the truncated message too.
+    assert message[:8189] in str(error)
+    assert "B" not in str(error)


### PR DESCRIPTION
#### Overview:

Prior to this fix, instantiating an `HttpError` with a long error message would yield a `ValueError` that doesn't include any of the original message, making it more difficult to trace the source of the issue.

With this fix, we truncate the message instead to maintain some context.

#### Details:

A few changes:
- Truncates the HttpError message field in the constructor
- Adds tests for message truncation and passing a non-str value for message
- Simplifies the logic for extracting `code` and `message` from the `py_err` and drops the `name=HttpError` check.

#### Where should the reviewer start?

The truncation logic is in `exceptions.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTTP error handling with stricter input validation for error codes and messages.
  * Implemented automatic truncation of excessively long error messages to improve performance and stability.

* **Tests**
  * Added test coverage for HTTP error validation and message truncation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->