### PR TITLE
fix: make kubernetes backed discovery default

### DIFF
--- a/deploy/cloud/helm/crds/templates/nvidia.com_dynamoworkermetadatas.yaml
+++ b/deploy/cloud/helm/crds/templates/nvidia.com_dynamoworkermetadatas.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dynamoworkermetadatas.nvidia.com
+spec:
+  group: nvidia.com
+  names:
+    kind: DynamoWorkerMetadata
+    listKind: DynamoWorkerMetadataList
+    plural: dynamoworkermetadatas
+    singular: dynamoworkermetadata
+    shortNames:
+      - dwm
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: DynamoWorkerMetadata stores discovery metadata for a Dynamo worker pod
+          properties:
+            apiVersion:
+              type: string
+              description: APIVersion defines the versioned schema of this representation
+            kind:
+              type: string
+              description: Kind is a string value representing the REST resource
+            metadata:
+              type: object
+            spec:
+              type: object
+              description: Spec contains the worker metadata
+              required:
+                - data
+              properties:
+                data:
+                  type: object
+                  description: Raw JSON blob containing DiscoveryMetadata
+                  x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+

--- a/deploy/cloud/helm/platform/components/operator/templates/_validation.tpl
+++ b/deploy/cloud/helm/platform/components/operator/templates/_validation.tpl
@@ -104,11 +104,11 @@ Validation for configuration consistency
 {{- end -}}
 
 {{/*
-Validation for discoverBackend configuration
+Validation for discoveryBackend configuration
 */}}
 {{- define "dynamo-operator.validateDiscoveryBackend" -}}
 {{- $discoveryBackend := .Values.discoveryBackend -}}
-{{- if and (ne $discoveryBackend "") (ne $discoveryBackend "kubernetes") -}}
-  {{- fail (printf "VALIDATION ERROR: discoveryBackend must be either an empty string (defaults to ETCD) or 'kubernetes'. Got: '%s'" $discoveryBackend) -}}
+{{- if and (ne $discoveryBackend "kubernetes") (ne $discoveryBackend "etcd") -}}
+  {{- fail (printf "VALIDATION ERROR: discoveryBackend must be 'kubernetes' (default) or 'etcd'. Got: '%s'" $discoveryBackend) -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/cloud/helm/platform/values.yaml
+++ b/deploy/cloud/helm/platform/values.yaml
@@ -42,8 +42,8 @@ dynamo-operator:
       # Interval for renewing the namespace scope marker lease (namespace-restricted mode only). The namespace-restricted operator renews its lease at this interval to signal it's still running.
       renewInterval: 10s
 
-  # -- The Dynamo discovery backend to use. By default, will rely on ETCD for discovery. Can be set to "kubernetes" to use Kubernetes API for service discovery. --
-  discoveryBackend: ""
+  # -- The Dynamo discovery backend to use. Default is "kubernetes" for Kubernetes API service discovery. Set to "etcd" to use ETCD for discovery. --
+  discoveryBackend: "kubernetes"
 
   # Controller manager configuration
   controllerManager:

--- a/deploy/cloud/operator/cmd/main.go
+++ b/deploy/cloud/operator/cmd/main.go
@@ -201,8 +201,8 @@ func main() {
 		"Interval for renewing namespace scope marker lease (namespace-restricted mode only)")
 	flag.StringVar(&operatorVersion, "operator-version", "unknown",
 		"Version of the operator (used in lease holder identity)")
-	flag.StringVar(&discoveryBackend, "discovery-backend", "",
-		"Discovery backend to use: empty string (default, uses ETCD) or 'kubernetes' (uses Kubernetes API)")
+	flag.StringVar(&discoveryBackend, "discovery-backend", "kubernetes",
+		"Discovery backend to use: 'kubernetes' (default, uses Kubernetes API) or 'etcd' (uses ETCD)")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -215,16 +215,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Validate discoverBackend value
-	if discoveryBackend != "" && discoveryBackend != "kubernetes" {
-		setupLog.Error(nil, "invalid discover-backend value, must be empty string or 'kubernetes'", "value", discoveryBackend)
+	// Validate discoveryBackend value
+	if discoveryBackend != "kubernetes" && discoveryBackend != "etcd" {
+		setupLog.Error(nil, "invalid discovery-backend value, must be 'kubernetes' or 'etcd'", "value", discoveryBackend)
 		os.Exit(1)
 	}
-	if discoveryBackend != "" {
-		setupLog.Info("Discovery backend configured", "backend", discoveryBackend)
-	} else {
-		setupLog.Info("Discovery backend configured", "backend", "etcd (default)")
-	}
+	setupLog.Info("Discovery backend configured", "backend", discoveryBackend)
 
 	// Validate modelExpressURL if provided
 	if modelExpressURL != "" {

--- a/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -845,6 +845,11 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 													FieldPath: "metadata.namespace",
 												},
 											}},
+											{Name: "POD_UID", ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.uid",
+												},
+											}},
 											{Name: "TEST_ENV_FROM_DYNAMO_COMPONENT_DEPLOYMENT_SPEC", Value: "test_value_from_dynamo_component_deployment_spec"},
 											{Name: "TEST_ENV_FROM_EXTRA_POD_SPEC", Value: "test_value_from_extra_pod_spec"},
 										},
@@ -972,6 +977,11 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 											{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
 												FieldRef: &corev1.ObjectFieldSelector{
 													FieldPath: "metadata.namespace",
+												},
+											}},
+											{Name: "POD_UID", ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.uid",
 												},
 											}},
 											{Name: "TEST_ENV_FROM_DYNAMO_COMPONENT_DEPLOYMENT_SPEC", Value: "test_value_from_dynamo_component_deployment_spec"},

--- a/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -828,6 +828,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 										Args:    []string{"ray start --head --port=6379 && some dynamo command --tensor-parallel-size 4 --pipeline-parallel-size 1"},
 										Env: []corev1.EnvVar{
 											{Name: commonconsts.DynamoComponentEnvVar, Value: commonconsts.ComponentTypeWorker},
+											{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
 											{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "true"},
 											{Name: commonconsts.DynamoNamespaceEnvVar, Value: "default"},
 											{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "test-lws-deploy"},
@@ -962,6 +963,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 										Args:    []string{"ray start --address=$LWS_LEADER_ADDRESS:6379 --block"},
 										Env: []corev1.EnvVar{
 											{Name: commonconsts.DynamoComponentEnvVar, Value: commonconsts.ComponentTypeWorker},
+											{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
 											{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "true"},
 											{Name: commonconsts.DynamoNamespaceEnvVar, Value: "default"},
 											{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "test-lws-deploy"},

--- a/deploy/cloud/operator/internal/controller_common/predicate.go
+++ b/deploy/cloud/operator/internal/controller_common/predicate.go
@@ -77,7 +77,7 @@ type Config struct {
 	// ExcludedNamespaces is a thread-safe set of namespaces to exclude (cluster-wide mode only)
 	ExcludedNamespaces ExcludedNamespacesInterface
 
-	// DiscoveryBackend is the discovery backend to use. By default, will rely on ETCD for discovery. Can be set to "kubernetes" to use Kubernetes API for service discovery.
+	// DiscoveryBackend is the discovery backend to use. Default is "kubernetes" for Kubernetes API service discovery. Set to "etcd" to use ETCD for discovery.
 	DiscoveryBackend string
 
 	// WebhooksEnabled indicates whether admission webhooks are enabled

--- a/deploy/cloud/operator/internal/discovery/resource.go
+++ b/deploy/cloud/operator/internal/discovery/resource.go
@@ -17,6 +17,7 @@ const (
 	kindServiceAccount = "ServiceAccount"
 	apiGroupRBAC       = "rbac.authorization.k8s.io"
 	apiGroupCore       = ""
+	apiGroupNvidia     = "nvidia.com"
 )
 
 func GetK8sDiscoveryServiceAccountName(dgdName string) string {
@@ -61,6 +62,11 @@ func GetK8sDiscoveryRole(dgdName string, namespace string) *rbacv1.Role {
 				APIGroups: []string{"discovery.k8s.io"},
 				Resources: []string{"endpointslices"},
 				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{apiGroupNvidia},
+				Resources: []string{"dynamoworkermetadatas"},
+				Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 			},
 		},
 	}

--- a/deploy/cloud/operator/internal/dynamo/component_common.go
+++ b/deploy/cloud/operator/internal/dynamo/component_common.go
@@ -104,6 +104,14 @@ func (b *BaseComponentDefaults) getCommonContainer(context ComponentContext) cor
 				},
 			},
 		},
+		{
+			Name: "POD_UID",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.uid",
+				},
+			},
+		},
 	}
 
 	if context.DiscoveryBackend != "" {

--- a/deploy/cloud/operator/internal/dynamo/component_common.go
+++ b/deploy/cloud/operator/internal/dynamo/component_common.go
@@ -114,10 +114,11 @@ func (b *BaseComponentDefaults) getCommonContainer(context ComponentContext) cor
 		},
 	}
 
-	if context.DiscoveryBackend != "" {
+	// Set discovery backend env var to "kubernetes" unless explicitly set to "etcd"
+	if context.DiscoveryBackend != "etcd" {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
-			Value: context.DiscoveryBackend,
+			Value: "kubernetes",
 		})
 	}
 

--- a/deploy/cloud/operator/internal/dynamo/component_planner_test.go
+++ b/deploy/cloud/operator/internal/dynamo/component_planner_test.go
@@ -64,6 +64,11 @@ func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
 							FieldPath: "metadata.namespace",
 						},
 					}},
+					{Name: "POD_UID", ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.uid",
+						},
+					}},
 					{Name: "PLANNER_PROMETHEUS_PORT", Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort)},
 				},
 			},

--- a/deploy/cloud/operator/internal/dynamo/component_planner_test.go
+++ b/deploy/cloud/operator/internal/dynamo/component_planner_test.go
@@ -69,6 +69,7 @@ func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
 							FieldPath: "metadata.uid",
 						},
 					}},
+					{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
 					{Name: "PLANNER_PROMETHEUS_PORT", Value: fmt.Sprintf("%d", commonconsts.DynamoPlannerMetricsPort)},
 				},
 			},

--- a/deploy/cloud/operator/internal/dynamo/graph.go
+++ b/deploy/cloud/operator/internal/dynamo/graph.go
@@ -433,10 +433,7 @@ func GenerateComponentService(ctx context.Context, dynamoDeployment *v1alpha1.Dy
 	if isK8sDiscoveryEnabled {
 		service.Labels = map[string]string{
 			commonconsts.KubeLabelDynamoDiscoveryBackend: "kubernetes",
-		}
-		// Discovery is enabled for non frontend components
-		if component.ComponentType != commonconsts.ComponentTypeFrontend {
-			service.Labels[commonconsts.KubeLabelDynamoDiscoveryEnabled] = commonconsts.KubeLabelValueTrue
+			commonconsts.KubeLabelDynamoDiscoveryEnabled: commonconsts.KubeLabelValueTrue,
 		}
 	}
 	return service, nil

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -1412,6 +1412,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														},
 													},
 													{
+														Name: "POD_UID",
+														ValueFrom: &corev1.EnvVarSource{
+															FieldRef: &corev1.ObjectFieldSelector{
+																FieldPath: "metadata.uid",
+															},
+														},
+													},
+													{
 														Name:  "ETCD_ENDPOINTS",
 														Value: "etcd-address",
 													},
@@ -1607,6 +1615,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														ValueFrom: &corev1.EnvVarSource{
 															FieldRef: &corev1.ObjectFieldSelector{
 																FieldPath: "metadata.namespace",
+															},
+														},
+													},
+													{
+														Name: "POD_UID",
+														ValueFrom: &corev1.EnvVarSource{
+															FieldRef: &corev1.ObjectFieldSelector{
+																FieldPath: "metadata.uid",
 															},
 														},
 													},
@@ -1991,6 +2007,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 															},
 														},
 													},
+													{
+														Name: "POD_UID",
+														ValueFrom: &corev1.EnvVarSource{
+															FieldRef: &corev1.ObjectFieldSelector{
+																FieldPath: "metadata.uid",
+															},
+														},
+													},
 												},
 												Resources: corev1.ResourceRequirements{
 													Requests: corev1.ResourceList{
@@ -2172,6 +2196,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 															},
 														},
 													},
+													{
+														Name: "POD_UID",
+														ValueFrom: &corev1.EnvVarSource{
+															FieldRef: &corev1.ObjectFieldSelector{
+																FieldPath: "metadata.uid",
+															},
+														},
+													},
 												},
 												Resources: corev1.ResourceRequirements{
 													Requests: corev1.ResourceList{
@@ -2324,6 +2356,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														ValueFrom: &corev1.EnvVarSource{
 															FieldRef: &corev1.ObjectFieldSelector{
 																FieldPath: "metadata.namespace",
+															},
+														},
+													},
+													{
+														Name: "POD_UID",
+														ValueFrom: &corev1.EnvVarSource{
+															FieldRef: &corev1.ObjectFieldSelector{
+																FieldPath: "metadata.uid",
 															},
 														},
 													},
@@ -2486,6 +2526,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														ValueFrom: &corev1.EnvVarSource{
 															FieldRef: &corev1.ObjectFieldSelector{
 																FieldPath: "metadata.namespace",
+															},
+														},
+													},
+													{
+														Name: "POD_UID",
+														ValueFrom: &corev1.EnvVarSource{
+															FieldRef: &corev1.ObjectFieldSelector{
+																FieldPath: "metadata.uid",
 															},
 														},
 													},
@@ -2900,6 +2948,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 															},
 														},
 													},
+													{
+														Name: "POD_UID",
+														ValueFrom: &corev1.EnvVarSource{
+															FieldRef: &corev1.ObjectFieldSelector{
+																FieldPath: "metadata.uid",
+															},
+														},
+													},
 												},
 												Resources: corev1.ResourceRequirements{
 													Requests: corev1.ResourceList{
@@ -3068,6 +3124,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 															},
 														},
 													},
+													{
+														Name: "POD_UID",
+														ValueFrom: &corev1.EnvVarSource{
+															FieldRef: &corev1.ObjectFieldSelector{
+																FieldPath: "metadata.uid",
+															},
+														},
+													},
 												},
 												Resources: corev1.ResourceRequirements{
 													Requests: corev1.ResourceList{
@@ -3220,6 +3284,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														ValueFrom: &corev1.EnvVarSource{
 															FieldRef: &corev1.ObjectFieldSelector{
 																FieldPath: "metadata.namespace",
+															},
+														},
+													},
+													{
+														Name: "POD_UID",
+														ValueFrom: &corev1.EnvVarSource{
+															FieldRef: &corev1.ObjectFieldSelector{
+																FieldPath: "metadata.uid",
 															},
 														},
 													},
@@ -3389,6 +3461,14 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														ValueFrom: &corev1.EnvVarSource{
 															FieldRef: &corev1.ObjectFieldSelector{
 																FieldPath: "metadata.namespace",
+															},
+														},
+													},
+													{
+														Name: "POD_UID",
+														ValueFrom: &corev1.EnvVarSource{
+															FieldRef: &corev1.ObjectFieldSelector{
+																FieldPath: "metadata.uid",
 															},
 														},
 													},
@@ -5020,6 +5100,11 @@ func TestGenerateBasePodSpec_Worker(t *testing.T) {
 							{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
 								FieldRef: &corev1.ObjectFieldSelector{
 									FieldPath: "metadata.namespace",
+								},
+							}},
+							{Name: "POD_UID", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.uid",
 								},
 							}},
 						},

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -1432,6 +1432,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: commonconsts.ComponentTypeFrontend,
 													},
 													{
+														Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
+														Value: "kubernetes",
+													},
+													{
 														Name:  "DYN_PARENT_DGD_K8S_NAME",
 														Value: "test-dynamo-graph-deployment",
 													},
@@ -1581,6 +1585,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													{
 														Name:  commonconsts.DynamoComponentEnvVar,
 														Value: commonconsts.ComponentTypePlanner,
+													},
+													{
+														Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
+														Value: "kubernetes",
 													},
 													{
 														Name:  "DYN_PARENT_DGD_K8S_NAME",
@@ -1980,6 +1988,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: commonconsts.ComponentTypeWorker,
 													},
 													{
+														Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
+														Value: "kubernetes",
+													},
+													{
 														Name:  "DYN_HEALTH_CHECK_ENABLED",
 														Value: "true",
 													},
@@ -2169,6 +2181,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: commonconsts.ComponentTypeWorker,
 													},
 													{
+														Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
+														Value: "kubernetes",
+													},
+													{
 														Name:  "DYN_HEALTH_CHECK_ENABLED",
 														Value: "true",
 													},
@@ -2336,6 +2352,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: commonconsts.ComponentTypeFrontend,
 													},
 													{
+														Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
+														Value: "kubernetes",
+													},
+													{
 														Name:  "DYN_PARENT_DGD_K8S_NAME",
 														Value: "test-dynamo-graph-deployment",
 													},
@@ -2500,6 +2520,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													{
 														Name:  commonconsts.DynamoComponentEnvVar,
 														Value: commonconsts.ComponentTypePlanner,
+													},
+													{
+														Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
+														Value: "kubernetes",
 													},
 													{
 														Name:  "DYN_PARENT_DGD_K8S_NAME",
@@ -2921,6 +2945,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: commonconsts.ComponentTypeWorker,
 													},
 													{
+														Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
+														Value: "kubernetes",
+													},
+													{
 														Name:  "DYN_HEALTH_CHECK_ENABLED",
 														Value: "true",
 													},
@@ -3097,6 +3125,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 														Value: commonconsts.ComponentTypeWorker,
 													},
 													{
+														Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
+														Value: "kubernetes",
+													},
+													{
 														Name:  "DYN_HEALTH_CHECK_ENABLED",
 														Value: "true",
 													},
@@ -3262,6 +3294,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													{
 														Name:  commonconsts.DynamoComponentEnvVar,
 														Value: commonconsts.ComponentTypeFrontend,
+													},
+													{
+														Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
+														Value: "kubernetes",
 													},
 													{
 														Name:  "DYN_PARENT_DGD_K8S_NAME",
@@ -3435,6 +3471,10 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													{
 														Name:  commonconsts.DynamoComponentEnvVar,
 														Value: commonconsts.ComponentTypePlanner,
+													},
+													{
+														Name:  commonconsts.DynamoDiscoveryBackendEnvVar,
+														Value: "kubernetes",
 													},
 													{
 														Name:  "DYN_PARENT_DGD_K8S_NAME",
@@ -4972,7 +5012,7 @@ func TestGenerateBasePodSpec_DiscoverBackend(t *testing.T) {
 		wantEnvVar       string
 	}{
 		{
-			name: "Discover backend should be set",
+			name: "Kubernetes discovery backend should set env var to kubernetes",
 			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
 				Annotations: map[string]string{
 					commonconsts.KubeAnnotationDynamoDiscoveryBackend: "kubernetes",
@@ -4981,29 +5021,39 @@ func TestGenerateBasePodSpec_DiscoverBackend(t *testing.T) {
 			wantEnvVar: "kubernetes",
 		},
 		{
-			name: "Discover backend should override the controller config",
+			name: "Kubernetes discovery from controller config should set env var to kubernetes",
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				Annotations: map[string]string{},
+			},
+			controllerConfig: controller_common.Config{
+				DiscoveryBackend: "kubernetes",
+			},
+			wantEnvVar: "kubernetes",
+		},
+		{
+			name: "Etcd discovery backend annotation should not set env var",
 			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
 				Annotations: map[string]string{
-					commonconsts.KubeAnnotationDynamoDiscoveryBackend: "test",
+					commonconsts.KubeAnnotationDynamoDiscoveryBackend: "etcd",
 				},
 			},
 			controllerConfig: controller_common.Config{
-				DiscoveryBackend: "etcd",
+				DiscoveryBackend: "kubernetes",
 			},
-			wantEnvVar: "test",
+			wantEnvVar: "", // etcd is the runtime default, no env var needed
 		},
 		{
-			name: "Discover backend should be set by the controller config",
+			name: "Etcd discovery from controller config should not set env var",
 			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
 				Annotations: map[string]string{},
 			},
 			controllerConfig: controller_common.Config{
 				DiscoveryBackend: "etcd",
 			},
-			wantEnvVar: "etcd",
+			wantEnvVar: "", // etcd is the runtime default, no env var needed
 		},
 		{
-			name: "Discover backend empty string",
+			name: "Empty discovery backend defaults to kubernetes",
 			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
 				Annotations: map[string]string{
 					commonconsts.KubeAnnotationDynamoDiscoveryBackend: "",
@@ -5012,10 +5062,12 @@ func TestGenerateBasePodSpec_DiscoverBackend(t *testing.T) {
 			controllerConfig: controller_common.Config{
 				DiscoveryBackend: "",
 			},
+			wantEnvVar: "kubernetes", // empty defaults to kubernetes
 		},
 		{
-			name:      "Discover backend not set",
-			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			name:       "Discovery backend not set defaults to kubernetes",
+			component:  &v1alpha1.DynamoComponentDeploymentSharedSpec{},
+			wantEnvVar: "kubernetes", // not set defaults to kubernetes
 		},
 	}
 	secretsRetriever := &mockSecretsRetriever{}
@@ -5085,6 +5137,7 @@ func TestGenerateBasePodSpec_Worker(t *testing.T) {
 							{Name: "ANOTHER_COMPONENTENV", Value: "true"},
 							{Name: "ANOTHER_CONTAINER_ENV", Value: "true"},
 							{Name: commonconsts.DynamoComponentEnvVar, Value: "worker"},
+							{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
 							{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "true"},
 							{Name: commonconsts.DynamoNamespaceEnvVar, Value: ""},
 							{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "test-deployment"},


### PR DESCRIPTION
#### Overview:

This PR does 2 things:

1. It adds the DynamoWorkerMetadata CR to the Dynamo Helm chart
2. It makes Kubernetes backed discovery the default for Dynamo (in k8s envs)