### PR TITLE
feat: allow disabling nats deployment 

### DIFF
--- a/deploy/cloud/helm/platform/components/operator/templates/deployment.yaml
+++ b/deploy/cloud/helm/platform/components/operator/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
         {{- end }}
         {{- if .Values.natsAddr }}
           - --natsAddr={{ .Values.natsAddr }}
-        {{- else }}
+        {{- else if and .Values.nats .Values.nats.enabled }}
           - --natsAddr=nats://{{ .Release.Name }}-nats.{{ .Release.Namespace }}.svc.cluster.local:4222
         {{- end }}
         {{- if .Values.etcdAddr }}

--- a/deploy/cloud/helm/platform/components/operator/values.yaml
+++ b/deploy/cloud/helm/platform/components/operator/values.yaml
@@ -136,6 +136,11 @@ metricsService:
 
 natsAddr: ""
 etcdAddr: ""
+
+nats:
+  # Whether the NATS is enabled
+  enabled: true
+
 modelExpressURL: ""
 
 # Webhook configuration

--- a/deploy/cloud/helm/platform/values.yaml
+++ b/deploy/cloud/helm/platform/values.yaml
@@ -27,6 +27,10 @@ dynamo-operator:
   # -- etcd server address for operator state storage (leave empty to use the bundled etcd chart). Format: "http://hostname:port" or "https://hostname:port"
   etcdAddr: ""
 
+  nats:
+    # -- Whether the NATS is enabled
+    enabled: true
+
   # -- URL for the Model Express server if not deployed by this helm chart. This is ignored if Model Express server is installed by this helm chart (global.model-express.enabled is true).
   modelExpressURL: ""
   # -- Namespace access controls for the operator


### PR DESCRIPTION
#### Overview:

Disable any nats server deployment for the dynamo platform.  

resulting deployments will not have `NATS_SERVER` env var auto injected with following helm install argument - 
```
  --set "dynamo-operator.nats.enabled=false"
```

#### Details:

This code path is triggered if there is an externally managed nats:

1. k8s ops speicifies this in operator helm chart `.Values.natsAddr` 
2. operator caches the value
3. operator injects `NATS_SERVER` env variable in DGD 


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NATS messaging is now explicitly configurable and enabled by default in the operator deployment.

* **Bug Fixes**
  * Refined NATS auto-configuration to only activate when explicitly enabled, preventing unintended defaults when NATS is disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->