### PR TITLE
fix: turn off DYN_HEALTH_CHECK_ENABLED

### DIFF
--- a/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/cloud/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -829,7 +829,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 										Env: []corev1.EnvVar{
 											{Name: commonconsts.DynamoComponentEnvVar, Value: commonconsts.ComponentTypeWorker},
 											{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
-											{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "true"},
+											{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "false"},
 											{Name: commonconsts.DynamoNamespaceEnvVar, Value: "default"},
 											{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "test-lws-deploy"},
 											{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: "default"},
@@ -964,7 +964,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 										Env: []corev1.EnvVar{
 											{Name: commonconsts.DynamoComponentEnvVar, Value: commonconsts.ComponentTypeWorker},
 											{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
-											{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "true"},
+											{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "false"},
 											{Name: commonconsts.DynamoNamespaceEnvVar, Value: "default"},
 											{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "test-lws-deploy"},
 											{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: "default"},

--- a/deploy/cloud/operator/internal/dynamo/component_worker.go
+++ b/deploy/cloud/operator/internal/dynamo/component_worker.go
@@ -88,7 +88,7 @@ func (w *WorkerDefaults) GetBaseContainer(context ComponentContext) (corev1.Cont
 		},
 		{
 			Name:  "DYN_HEALTH_CHECK_ENABLED",
-			Value: "true",
+			Value: "false",
 		},
 	}...)
 

--- a/deploy/cloud/operator/internal/dynamo/graph_test.go
+++ b/deploy/cloud/operator/internal/dynamo/graph_test.go
@@ -1993,7 +1993,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													},
 													{
 														Name:  "DYN_HEALTH_CHECK_ENABLED",
-														Value: "true",
+														Value: "false",
 													},
 													{
 														Name:  "DYN_PARENT_DGD_K8S_NAME",
@@ -2186,7 +2186,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													},
 													{
 														Name:  "DYN_HEALTH_CHECK_ENABLED",
-														Value: "true",
+														Value: "false",
 													},
 													{
 														Name:  "DYN_PARENT_DGD_K8S_NAME",
@@ -2950,7 +2950,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													},
 													{
 														Name:  "DYN_HEALTH_CHECK_ENABLED",
-														Value: "true",
+														Value: "false",
 													},
 													{
 														Name:  "DYN_PARENT_DGD_K8S_NAME",
@@ -3130,7 +3130,7 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													},
 													{
 														Name:  "DYN_HEALTH_CHECK_ENABLED",
-														Value: "true",
+														Value: "false",
 													},
 													{
 														Name:  "DYN_PARENT_DGD_K8S_NAME",
@@ -5138,7 +5138,7 @@ func TestGenerateBasePodSpec_Worker(t *testing.T) {
 							{Name: "ANOTHER_CONTAINER_ENV", Value: "true"},
 							{Name: commonconsts.DynamoComponentEnvVar, Value: "worker"},
 							{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
-							{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "true"},
+							{Name: "DYN_HEALTH_CHECK_ENABLED", Value: "false"},
 							{Name: commonconsts.DynamoNamespaceEnvVar, Value: ""},
 							{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "test-deployment"},
 							{Name: "DYN_PARENT_DGD_K8S_NAMESPACE", Value: "default"},


### PR DESCRIPTION
#### Overview:

This PR disables the canary health check feature in Kubernetes deployments until we resolve the underlying race conditions causing intermittent failures.

#### Details:

Set DYN_HEALTH_CHECK_ENABLED=false for worker components in Kubernetes operator


Multiple race conditions exist between:

- Instance registration in discovery (etcd/k8s)
- NATS endpoint subscription establishment
- Health check requests being sent

The primary issue is that the health check manager starts immediately when DistributedRuntime is created, before NATS endpoints have fully established their subscriptions. This creates a timing window where:

- Discovery reports an instance as available
- Health check attempts to send a request
- NATS subscription is not yet ready → "no responders" error

Additional race conditions include:

- instance_source vs instance_avail synchronization lag between watch stream updates and async task processing
- Insufficient delay (10ms) for async tasks to establish NATS subscriptions in resource-constrained environments

#### Where should the reviewer start?

deploy/cloud/operator/internal/dynamo/component_worker.go - Verify DYN_HEALTH_CHECK_ENABLED=false is set for worker components

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-1185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Modified worker container health check settings to disable automatic health monitoring during deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->