### PR TITLE
fix: dev container to be able to compile after base image change

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -586,10 +586,47 @@ COPY --from=dynamo_base --chmod=775 /usr/local/rustup /usr/local/rustup
 COPY --from=dynamo_base --chmod=775 /usr/local/cargo /usr/local/cargo
 RUN chmod g+w /usr/local/rustup /usr/local/cargo
 
-# Install maturin, for maturin develop
+ARG ARCH
+ARG ARCH_ALT
+
+# Copy UCX and NIXL libraries for dev stage compilation
+# The upstream SGLang runtime image doesn't include NIXL, but cargo build needs to link against
+# -lnixl, -lnixl_build, and -lnixl_common. Runtime stage doesn't need this since it uses pre-built
+# wheels, but dev stage needs it for maturin develop and cargo build from source.
+COPY --from=wheel_builder /usr/local/ucx /usr/local/ucx
+COPY --from=wheel_builder /opt/nvidia/nvda_nixl /opt/nvidia/nvda_nixl
+COPY --from=wheel_builder /opt/nvidia/nvda_nixl/lib64/. /opt/nvidia/nvda_nixl/lib/${ARCH_ALT}-linux-gnu/
+
+# Set NIXL environment variables for compilation
+ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
+    NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib/${ARCH_ALT}-linux-gnu \
+    NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib/${ARCH_ALT}-linux-gnu/plugins
+
+# Update LD_LIBRARY_PATH to include NIXL libraries for the linker
+ENV LD_LIBRARY_PATH=\
+${NIXL_LIB_DIR}:\
+${NIXL_PLUGIN_DIR}:\
+/usr/local/ucx/lib:\
+/usr/local/ucx/lib/ucx:\
+${LD_LIBRARY_PATH}
+
+# Create virtual environment for maturin develop (required by maturin develop command)
+# Match VLLM/TRTLLM dev container behavior
+# Use python3 (3.12) from upstream SGLang image
+RUN mkdir -p /opt/dynamo/venv && \
+    python3 -m venv /opt/dynamo/venv
+
+ENV VIRTUAL_ENV=/opt/dynamo/venv \
+    PATH="/opt/dynamo/venv/bin:${PATH}"
+
+# Install uv for maturin develop --uv
+COPY --from=dynamo_base /bin/uv /opt/dynamo/venv/bin/uv
+
+# Uninstall broken maturin from upstream runtime image, then reinstall properly in venv
 # Editable install of dynamo
-COPY pyproject.toml README.md hatch_build.py /workspace/
-RUN pip install maturin[patchelf] && \
+COPY --chown=dynamo:0 --chmod=664 pyproject.toml README.md hatch_build.py /workspace/
+RUN pip uninstall -y maturin && \
+    pip install maturin[patchelf] && \
     pip install --no-deps -e .
 
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -611,23 +611,27 @@ ${NIXL_PLUGIN_DIR}:\
 ${LD_LIBRARY_PATH}
 
 # Create virtual environment for maturin develop (required by maturin develop command)
-# Match VLLM/TRTLLM dev container behavior
-# Use python3 (3.12) from upstream SGLang image
+# Use --system-site-packages to inherit sglang, torch, etc. from upstream
 RUN mkdir -p /opt/dynamo/venv && \
-    python3 -m venv /opt/dynamo/venv
+    python3 -m venv --system-site-packages /opt/dynamo/venv
 
 ENV VIRTUAL_ENV=/opt/dynamo/venv \
     PATH="/opt/dynamo/venv/bin:${PATH}"
 
-# Install uv for maturin develop --uv
-COPY --from=dynamo_base /bin/uv /opt/dynamo/venv/bin/uv
+# Copy all packages from runtime stage user site-packages into venv
+# This includes ai-dynamo-runtime, kubernetes, and all other dependencies
+# Use --no-preserve=mode so copied files inherit umask 002 (group-writable)
+RUN cp -r --no-preserve=mode /home/dynamo/.local/lib/python3.12/site-packages/* \
+          /opt/dynamo/venv/lib/python3.12/site-packages/
 
-# Uninstall broken maturin from upstream runtime image, then reinstall properly in venv
-# Editable install of dynamo
+# Install maturin and uv into venv for development
+# Uninstall broken maturin from upstream, then reinstall properly into venv
+COPY --from=dynamo_base /bin/uv /opt/dynamo/venv/bin/uv
+RUN pip install --ignore-installed maturin[patchelf]
+
+# Editable install of dynamo components
 COPY --chown=dynamo:0 --chmod=664 pyproject.toml README.md hatch_build.py /workspace/
-RUN pip uninstall -y maturin && \
-    pip install maturin[patchelf] && \
-    pip install --no-deps -e .
+RUN pip install --no-deps -e .
 
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -877,7 +877,7 @@ RUN chmod g+w /usr/local/rustup /usr/local/cargo
 RUN uv pip install --no-cache maturin[patchelf]
 
 # Editable install of dynamo
-COPY pyproject.toml README.md hatch_build.py /workspace/
+COPY --chown=dynamo:0 --chmod=664 pyproject.toml README.md hatch_build.py /workspace/
 RUN uv pip install --no-cache --no-deps -e .
 
 CMD []

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -793,7 +793,7 @@ RUN chmod g+w /usr/local/rustup /usr/local/cargo
 
 # Install maturin, for maturin develop
 # Editable install of dynamo
-COPY pyproject.toml README.md hatch_build.py /workspace/
+COPY --chown=dynamo:0 --chmod=664 pyproject.toml README.md hatch_build.py /workspace/
 RUN uv pip install maturin[patchelf] && \
     uv pip install --no-deps -e .
 

--- a/container/README.md
+++ b/container/README.md
@@ -47,17 +47,17 @@ Below is a summary of the general file structure for the framework Dockerfile st
 |  /${FRAMEWORK_INSTALL} | Built framework (→ runtime)
 | **STAGE: runtime** | **FROM ${RUNTIME_IMAGE}** |
 |  /usr/local/cuda/{bin,include,nvvm}/ | COPY from dynamo_base |
-|  /usr/bin/nats-server | COPY from dynamo_runtime |
-|  /usr/local/bin/etcd/ | COPY from dynamo_runtime |
-|  /usr/local/ucx/ | COPY from dynamo_runtime |
+|  /usr/bin/nats-server | COPY from dynamo_base |
+|  /usr/local/bin/etcd/ | COPY from dynamo_base |
+|  /usr/local/ucx/ | COPY from wheel_builder |
 |  /opt/nvidia/nvda_nixl/ | COPY from wheel_builder |
 |  /opt/dynamo/wheelhouse/ | COPY from wheel_builder |
 |  /opt/dynamo/venv/ | COPY from framework |
 |  /opt/vllm/ | COPY from framework |
 |  /workspace/{tests,examples,deploy}/ |COPY from build context |
 | **STAGE: dev** | **FROM runtime** |
-|  /usr/local/rustup/ | COPY from dynamo_runtime |
-|  /usr/local/cargo/ | COPY from dynamo_runtime |
+|  /usr/local/rustup/ | COPY from dynamo_base |
+|  /usr/local/cargo/ | COPY from dynamo_base |
 </details>
 
 ### Why Containerization?
@@ -90,6 +90,8 @@ The `build.sh` and `run.sh` scripts are convenience wrappers that simplify commo
 | **Rust Toolchain** | None (uses pre-built wheels) | System install (`/usr/local/rustup`, `/usr/local/cargo`) | System install (`/usr/local/rustup`, `/usr/local/cargo`) |
 | **Cargo Target** | None | `/workspace/target` | `/workspace/target` |
 | **Python Env** | venv (`/opt/dynamo/venv`) for vllm/trtllm, system site-packages for sglang | venv (`/opt/dynamo/venv`) for vllm/trtllm, system site-packages for sglang | venv (`/opt/dynamo/venv`) for vllm/trtllm, system site-packages for sglang |
+
+**Note (SGLang)**: SGLang runtime uses system site-packages, but the `dev` image creates `/opt/dynamo/venv` (and `local-dev` inherits it from `dev`) for build tooling like `maturin`.
 
 ## Usage Guidelines
 


### PR DESCRIPTION
#### Overview:

Fix dev container builds after the upstream SGLang base image change removed NIXL dependencies.
This restores the missing link-time libraries/env so `cargo` and `maturin develop` work again in the SGLang dev stage.

#### Details:

- Add UCX + NIXL artifacts into the SGLang dev stage and configure `NIXL_*` + `LD_LIBRARY_PATH` so Rust linking succeeds.
- Create a dedicated venv for the SGLang dev stage and reinstall `maturin[patchelf]` to avoid broken upstream tooling.

#### Where should the reviewer start?

container/Dockerfile.sglang (dev stage changes around NIXL/UCX copies, env vars, venv + maturin install)

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)

[3e0459fb0](https://github.com/ai-dynamo/dynamo/commit/3e0459fb0124c38c46820e0e68089c7c4d50ea28) removed NIXL dependencies and broke the dev stage.

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container build infrastructure with enhanced architecture-aware setup capabilities, optimized library path management for better system compatibility, and streamlined Python virtual environment configuration across multiple services
  * Standardized file ownership and permissions in container build processes to improve consistency and enforce security best practices throughout the build pipeline

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->