### PR TITLE
feat: KVBM Object Support - add obj plugin deps

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -186,7 +186,12 @@ RUN yum groupinstall -y 'Development Tools' &&  \
         numactl-devel \
         # Libfabric support
         hwloc \
-        hwloc-devel
+        hwloc-devel \
+        libcurl-devel \
+        openssl-devel \
+        libuuid-devel \
+        zlib-devel
+         
 
 # Ensure a modern protoc is available (required for --experimental_allow_proto3_optional)
 RUN set -eux; \
@@ -348,6 +353,28 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     /tmp/use-sccache.sh show-stats "LIBFABRIC" && \
     echo "/usr/local/libfabric/lib" > /etc/ld.so.conf.d/libfabric.conf && \
     ldconfig
+
+# Build and install AWS SDK C++ (required for NIXL OBJ backend / S3 support)
+ARG AWS_SDK_CPP_VERSION=1.11.581
+RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+    export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${ARCH}}" && \
+    git clone --recurse-submodules --depth 1 --branch ${AWS_SDK_CPP_VERSION} \
+        https://github.com/aws/aws-sdk-cpp.git /tmp/aws-sdk-cpp && \
+    mkdir -p /tmp/aws-sdk-cpp/build && \
+    cd /tmp/aws-sdk-cpp/build && \
+    cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_ONLY="s3" \
+        -DENABLE_TESTING=OFF \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_SHARED_LIBS=ON && \
+    make -j$(nproc) && \
+    make install && \
+    cd / && \
+    rm -rf /tmp/aws-sdk-cpp && \
+    ldconfig && \
+    /tmp/use-sccache.sh show-stats "AWS SDK C++"
 
 # build and install nixl
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
@@ -642,6 +669,13 @@ COPY --chown=dynamo: --from=wheel_builder $NIXL_PREFIX $NIXL_PREFIX
 COPY --chown=dynamo: --from=wheel_builder /opt/nvidia/nvda_nixl/lib64/. ${NIXL_LIB_DIR}/
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
 COPY --chown=dynamo: --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
+
+# Copy AWS SDK C++ libraries (required for NIXL OBJ backend / S3 support)
+COPY --chown=dynamo: --from=wheel_builder /usr/local/lib64/libaws* /usr/local/lib/
+COPY --chown=dynamo: --from=wheel_builder /usr/local/lib64/libs2n* /usr/local/lib/
+COPY --chown=dynamo: --from=wheel_builder /usr/lib64/libcrypto.so.1.1* /usr/local/lib/
+COPY --chown=dynamo: --from=wheel_builder /usr/lib64/libssl.so.1.1* /usr/local/lib/
+
 ENV PATH=/usr/local/ucx/bin:$PATH
 
 # Copy ffmpeg
@@ -715,6 +749,37 @@ RUN chmod g+w /workspace /workspace/* /opt/dynamo /opt/dynamo/* ${VIRTUAL_ENV} &
     chmod 755 /opt/dynamo/.launch_screen && \
     echo 'source /opt/dynamo/venv/bin/activate' >> /etc/bash.bashrc && \
     echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc
+
+# Fix library symlinks that Docker COPY dereferenced (COPY always follows symlinks)
+# This recreates proper symlinks to save space and suppress ldconfig warnings
+RUN cd /usr/local/lib && \
+    # libaws-c-common: .so.1 should symlink to .so.1.0.0
+    if [ -f libaws-c-common.so.1.0.0 ] && [ ! -L libaws-c-common.so.1 ]; then \
+        rm -f libaws-c-common.so.1 libaws-c-common.so && \
+        ln -s libaws-c-common.so.1.0.0 libaws-c-common.so.1 && \
+        ln -s libaws-c-common.so.1 libaws-c-common.so; \
+    fi && \
+    # libaws-c-s3: .so.0unstable should symlink to .so.1.0.0
+    if [ -f libaws-c-s3.so.1.0.0 ] && [ ! -L libaws-c-s3.so.0unstable ]; then \
+        rm -f libaws-c-s3.so.0unstable libaws-c-s3.so && \
+        ln -s libaws-c-s3.so.1.0.0 libaws-c-s3.so.0unstable && \
+        ln -s libaws-c-s3.so.0unstable libaws-c-s3.so; \
+    fi && \
+    # libs2n: .so.1 should symlink to .so.1.0.0
+    if [ -f libs2n.so.1.0.0 ] && [ ! -L libs2n.so.1 ]; then \
+        rm -f libs2n.so.1 libs2n.so && \
+        ln -s libs2n.so.1.0.0 libs2n.so.1 && \
+        ln -s libs2n.so.1 libs2n.so; \
+    fi && \
+    # OpenSSL 1.1: check for versioned files (e.g., .so.1.1.1k)
+    for lib in libcrypto libssl; do \
+        versioned=$(ls -1 ${lib}.so.1.1.* 2>/dev/null | head -1); \
+        if [ -n "$versioned" ] && [ ! -L "${lib}.so.1.1" ]; then \
+            rm -f "${lib}.so.1.1" && \
+            ln -s "$(basename "$versioned")" "${lib}.so.1.1"; \
+        fi; \
+    done && \
+    ldconfig
 
 USER dynamo
 ARG DYNAMO_COMMIT_SHA

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -191,7 +191,7 @@ RUN yum groupinstall -y 'Development Tools' &&  \
         openssl-devel \
         libuuid-devel \
         zlib-devel
-         
+
 
 # Ensure a modern protoc is available (required for --experimental_allow_proto3_optional)
 RUN set -eux; \


### PR DESCRIPTION
#### Overview:

Add NIXL object storage plugin support (S3 backend) to the vLLM container image.

#### Details:

- Copies AWS SDK C++ libraries required for NIXL OBJ backend / S3 support
- Includes libaws-c-*, libs2n, and OpenSSL 1.1 dependencies from wheel_builder stage
- Fixes library symlinks that Docker COPY dereferences (resolves ldconfig warnings and reduces image size)
- Enables S3-based object storage and data transfer via NIXL

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
- container/Dockerfile.vllm - lines 673-677 (AWS SDK library COPY commands)
- container/Dockerfile.vllm - lines 753-783 (symlink fix under USER root)
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: #4887 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added AWS SDK C++ with S3 support integration to the container build environment.
  * Extended system dependencies to include libraries for improved compatibility.
  * Configured library symlinks and paths for AWS and OpenSSL components across runtime and development stages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->