### PR TITLE
test: refactor TCP server and add unit tests [4/n]

### DIFF
--- a/lib/runtime/src/pipeline/network/tcp.rs
+++ b/lib/runtime/src/pipeline/network/tcp.rs
@@ -20,6 +20,7 @@
 pub mod client;
 pub mod server;
 
+#[cfg(test)]
 pub mod test_utils;
 
 use super::ControlMessage;

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -795,7 +795,6 @@ mod tests {
         );
     }
 
-<<<<<<< HEAD
     /// Test that handle_reader handles Kill control message by calling context.kill()
     #[tokio::test]
     async fn test_handle_reader_kill_control_message() {
@@ -806,69 +805,6 @@ mod tests {
             alive_rx: _alive_rx,
             controller,
         } = reader_harness().await;
-=======
-    // ==================== handle_reader tests ====================
-
-    /// Helper to encode a control message to bytes using the TwoPartCodec
-    fn encode_control_message(msg: &ControlMessage) -> Bytes {
-        let msg_bytes = serde_json::to_vec(msg).unwrap();
-        let two_part_msg = TwoPartMessage::from_header(Bytes::from(msg_bytes));
-        TwoPartCodec::default()
-            .encode_message(two_part_msg)
-            .unwrap()
-    }
-
-    /// Test that handle_reader handles Stop control message by calling context.stop()
-    #[tokio::test]
-    async fn test_handle_reader_stop_control_message() {
-        use tokio::io::AsyncWriteExt;
-
-        let (client, server) = create_tcp_pair().await;
-        let (read_half, _write_half) = tokio::io::split(client);
-        let (_server_read, mut server_write) = tokio::io::split(server);
-
-        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
-        let (alive_tx, _alive_rx) = tokio::sync::oneshot::channel::<()>();
-        let controller = Arc::new(Controller::default());
-
-        // Spawn the reader task
-        let controller_clone = controller.clone();
-        let reader_handle =
-            tokio::spawn(
-                async move { handle_reader(framed_reader, controller_clone, alive_tx).await },
-            );
-
-        // Send Stop control message from server (write raw encoded bytes)
-        let encoded = encode_control_message(&ControlMessage::Stop);
-        server_write.write_all(&encoded).await.unwrap();
-        server_write.flush().await.unwrap();
-
-        // Shutdown the write side to send FIN and signal EOF to the client
-        server_write.shutdown().await.unwrap();
-
-        // Wait for reader to finish
-        let _ = reader_handle.await.unwrap();
-
-        // Verify that stop was called on the controller
-        assert!(
-            controller.is_stopped(),
-            "Controller should be stopped after receiving Stop message"
-        );
-    }
-
-    /// Test that handle_reader handles Kill control message by calling context.kill()
-    #[tokio::test]
-    async fn test_handle_reader_kill_control_message() {
-        use tokio::io::AsyncWriteExt;
-
-        let (client, server) = create_tcp_pair().await;
-        let (read_half, _write_half) = tokio::io::split(client);
-        let (_server_read, mut server_write) = tokio::io::split(server);
-
-        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
-        let (alive_tx, _alive_rx) = tokio::sync::oneshot::channel::<()>();
-        let controller = Arc::new(Controller::default());
->>>>>>> 5b52910c4 (test: unit test TCP client handle_reader)
 
         // Spawn the reader task
         let controller_clone = controller.clone();
@@ -878,7 +814,6 @@ mod tests {
             );
 
         // Send Kill control message from server
-<<<<<<< HEAD
         framed_server
             .send(control_message(&ControlMessage::Kill))
             .await
@@ -886,14 +821,6 @@ mod tests {
 
         // Close the framed server to signal EOF to the client
         framed_server.close().await.unwrap();
-=======
-        let encoded = encode_control_message(&ControlMessage::Kill);
-        server_write.write_all(&encoded).await.unwrap();
-        server_write.flush().await.unwrap();
-
-        // Shutdown the write side to send FIN and signal EOF to the client
-        server_write.shutdown().await.unwrap();
->>>>>>> 5b52910c4 (test: unit test TCP client handle_reader)
 
         // Wait for reader to finish
         let _ = reader_handle.await.unwrap();
@@ -908,7 +835,6 @@ mod tests {
     /// Test that handle_reader exits when alive channel is closed
     #[tokio::test]
     async fn test_handle_reader_exits_on_alive_channel_closed() {
-<<<<<<< HEAD
         let ReaderHarness {
             framed_reader,
             alive_tx,
@@ -916,15 +842,6 @@ mod tests {
             controller,
             ..
         } = reader_harness().await;
-=======
-        let (client, server) = create_tcp_pair().await;
-        let (read_half, _write_half) = tokio::io::split(client);
-        let (_server_read, _server_write) = tokio::io::split(server);
-
-        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
-        let (alive_tx, alive_rx) = tokio::sync::oneshot::channel::<()>();
-        let controller = Arc::new(Controller::default());
->>>>>>> 5b52910c4 (test: unit test TCP client handle_reader)
 
         // Spawn the reader task
         let reader_handle =
@@ -945,7 +862,6 @@ mod tests {
     /// Test that handle_reader exits when TCP stream is closed
     #[tokio::test]
     async fn test_handle_reader_exits_on_stream_closed() {
-<<<<<<< HEAD
         let ReaderHarness {
             mut framed_server,
             framed_reader,
@@ -953,27 +869,13 @@ mod tests {
             alive_rx: _alive_rx,
             controller,
         } = reader_harness().await;
-=======
-        let (client, server) = create_tcp_pair().await;
-        let (read_half, _write_half) = tokio::io::split(client);
-        let (_server_read, mut server_write) = tokio::io::split(server);
-
-        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
-        let (alive_tx, _alive_rx) = tokio::sync::oneshot::channel::<()>();
-        let controller = Arc::new(Controller::default());
->>>>>>> 5b52910c4 (test: unit test TCP client handle_reader)
 
         // Spawn the reader task
         let reader_handle =
             tokio::spawn(async move { handle_reader(framed_reader, controller, alive_tx).await });
 
-<<<<<<< HEAD
         // Close the framed server to signal EOF to the client
         framed_server.close().await.unwrap();
-=======
-        // Shutdown the write side to send FIN and signal EOF to the client
-        server_write.shutdown().await.unwrap();
->>>>>>> 5b52910c4 (test: unit test TCP client handle_reader)
 
         // Reader should exit due to stream closure
         let result = tokio::time::timeout(std::time::Duration::from_secs(1), reader_handle).await;
@@ -987,7 +889,6 @@ mod tests {
     /// Test that handle_reader handles multiple control messages in sequence
     #[tokio::test]
     async fn test_handle_reader_multiple_control_messages() {
-<<<<<<< HEAD
         let ReaderHarness {
             mut framed_server,
             framed_reader,
@@ -995,17 +896,6 @@ mod tests {
             alive_rx: _alive_rx,
             controller,
         } = reader_harness().await;
-=======
-        use tokio::io::AsyncWriteExt;
-
-        let (client, server) = create_tcp_pair().await;
-        let (read_half, _write_half) = tokio::io::split(client);
-        let (_server_read, mut server_write) = tokio::io::split(server);
-
-        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
-        let (alive_tx, _alive_rx) = tokio::sync::oneshot::channel::<()>();
-        let controller = Arc::new(Controller::default());
->>>>>>> 5b52910c4 (test: unit test TCP client handle_reader)
 
         // Spawn the reader task
         let controller_clone = controller.clone();
@@ -1015,7 +905,6 @@ mod tests {
             );
 
         // Send multiple Stop messages (first one will stop, subsequent ones are no-ops)
-<<<<<<< HEAD
         framed_server
             .send(control_message(&ControlMessage::Stop))
             .await
@@ -1027,15 +916,6 @@ mod tests {
 
         // Close the framed server to signal EOF to the client
         framed_server.close().await.unwrap();
-=======
-        let encoded = encode_control_message(&ControlMessage::Stop);
-        server_write.write_all(&encoded).await.unwrap();
-        server_write.write_all(&encoded).await.unwrap();
-        server_write.flush().await.unwrap();
-
-        // Shutdown the write side to send FIN and signal EOF to the client
-        server_write.shutdown().await.unwrap();
->>>>>>> 5b52910c4 (test: unit test TCP client handle_reader)
 
         // Wait for reader to finish
         let _ = reader_handle.await.unwrap();
@@ -1050,7 +930,6 @@ mod tests {
     /// Test handle_reader with Stop followed by Kill
     #[tokio::test]
     async fn test_handle_reader_stop_then_kill() {
-<<<<<<< HEAD
         let ReaderHarness {
             mut framed_server,
             framed_reader,
@@ -1058,17 +937,6 @@ mod tests {
             alive_rx: _alive_rx,
             controller,
         } = reader_harness().await;
-=======
-        use tokio::io::AsyncWriteExt;
-
-        let (client, server) = create_tcp_pair().await;
-        let (read_half, _write_half) = tokio::io::split(client);
-        let (_server_read, mut server_write) = tokio::io::split(server);
-
-        let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
-        let (alive_tx, _alive_rx) = tokio::sync::oneshot::channel::<()>();
-        let controller = Arc::new(Controller::default());
->>>>>>> 5b52910c4 (test: unit test TCP client handle_reader)
 
         // Spawn the reader task
         let controller_clone = controller.clone();
@@ -1078,7 +946,6 @@ mod tests {
             );
 
         // Send Stop first, then Kill
-<<<<<<< HEAD
         framed_server
             .send(control_message(&ControlMessage::Stop))
             .await
@@ -1090,16 +957,6 @@ mod tests {
 
         // Close the framed server to signal EOF to the client
         framed_server.close().await.unwrap();
-=======
-        let stop_encoded = encode_control_message(&ControlMessage::Stop);
-        let kill_encoded = encode_control_message(&ControlMessage::Kill);
-        server_write.write_all(&stop_encoded).await.unwrap();
-        server_write.write_all(&kill_encoded).await.unwrap();
-        server_write.flush().await.unwrap();
-
-        // Shutdown the write side to send FIN and signal EOF to the client
-        server_write.shutdown().await.unwrap();
->>>>>>> 5b52910c4 (test: unit test TCP client handle_reader)
 
         // Wait for reader to finish
         let _ = reader_handle.await.unwrap();
@@ -1110,7 +967,6 @@ mod tests {
             "Controller should be killed after receiving Kill message"
         );
     }
-<<<<<<< HEAD
 
     // ==================== create_response_stream tests ====================
 
@@ -1163,6 +1019,7 @@ mod tests {
         }
     }
 
+    /// Helper to create a ConnectionInfo for testing
     fn create_test_connection_info(
         address: &str,
         subject: &str,
@@ -1323,6 +1180,4 @@ mod tests {
         // Wait for server to complete
         server_handle.await.unwrap();
     }
-=======
->>>>>>> 5b52910c4 (test: unit test TCP client handle_reader)
 }

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -363,260 +363,257 @@ async fn tcp_listener(
 
         tokio::spawn(handle_connection(stream, state.clone()));
     }
+}
 
-    // #[instrument(level = "trace"), skip(state)]
-    // todo - clone before spawn and trace process_stream
-    async fn handle_connection(stream: tokio::net::TcpStream, state: Arc<Mutex<State>>) {
-        let result = process_stream(stream, state).await;
-        match result {
-            Ok(_) => tracing::trace!("successfully processed tcp connection"),
-            Err(e) => {
-                tracing::warn!("failed to handle tcp connection: {}", e);
-                #[cfg(debug_assertions)]
-                eprintln!("failed to handle tcp connection: {}", e);
-            }
+// #[instrument(level = "trace"), skip(state)]
+// todo - clone before spawn and trace process_stream
+async fn handle_connection(stream: tokio::net::TcpStream, state: Arc<Mutex<State>>) {
+    let result = process_stream(stream, state).await;
+    match result {
+        Ok(_) => tracing::trace!("successfully processed tcp connection"),
+        Err(e) => {
+            tracing::warn!("failed to handle tcp connection: {}", e);
+            #[cfg(debug_assertions)]
+            eprintln!("failed to handle tcp connection: {}", e);
         }
     }
+}
 
-    /// This method is responsible for the internal tcp stream handshake
-    /// The handshake will specialize the stream as a request/sender or response/receiver stream
-    async fn process_stream(stream: tokio::net::TcpStream, state: Arc<Mutex<State>>) -> Result<()> {
-        // split the socket in to a reader and writer
-        let (read_half, write_half) = tokio::io::split(stream);
+/// This method is responsible for the internal tcp stream handshake
+/// The handshake will specialize the stream as a request/sender or response/receiver stream
+async fn process_stream(stream: tokio::net::TcpStream, state: Arc<Mutex<State>>) -> Result<()> {
+    // split the socket in to a reader and writer
+    let (read_half, write_half) = tokio::io::split(stream);
 
-        // attach the codec to the reader and writer to get framed readers and writers
-        let mut framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
-        let framed_writer = FramedWrite::new(write_half, TwoPartCodec::default());
+    // attach the codec to the reader and writer to get framed readers and writers
+    let mut framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
+    let framed_writer = FramedWrite::new(write_half, TwoPartCodec::default());
 
-        // the internal tcp [`CallHomeHandshake`] connects the socket to the requester
-        // here we await this first message as a raw bytes two part message
-        let first_message = framed_reader
-            .next()
-            .await
-            .ok_or(error!("Connection closed without a ControlMessage"))??;
+    // the internal tcp [`CallHomeHandshake`] connects the socket to the requester
+    // here we await this first message as a raw bytes two part message
+    let first_message = framed_reader
+        .next()
+        .await
+        .ok_or(error!("Connection closed without a ControlMessage"))??;
 
-        // we await on the raw bytes which should come in as a header only message
-        // todo - improve error handling - check for no data
-        let handshake: CallHomeHandshake = match first_message.header() {
-            Some(header) => serde_json::from_slice(header).map_err(|e| {
-                error!(
-                    "Failed to deserialize the first message as a valid `CallHomeHandshake`: {e}",
-                )
-            })?,
-            None => {
-                return Err(error!("Expected ControlMessage, got DataMessage"));
-            }
-        };
+    // we await on the raw bytes which should come in as a header only message
+    // todo - improve error handling - check for no data
+    let handshake: CallHomeHandshake = match first_message.header() {
+        Some(header) => serde_json::from_slice(header).map_err(|e| {
+            error!("Failed to deserialize the first message as a valid `CallHomeHandshake`: {e}",)
+        })?,
+        None => {
+            return Err(error!("Expected ControlMessage, got DataMessage"));
+        }
+    };
 
-        // branch here to handle sender stream or receiver stream
-        match handshake.stream_type {
-            StreamType::Request => process_request_stream().await,
-            StreamType::Response => {
-                process_response_stream(handshake.subject, state, framed_reader, framed_writer)
-                    .await
-            }
+    // branch here to handle sender stream or receiver stream
+    match handshake.stream_type {
+        StreamType::Request => process_request_stream().await,
+        StreamType::Response => {
+            process_response_stream(handshake.subject, state, framed_reader, framed_writer).await
         }
     }
+}
 
-    async fn process_request_stream() -> Result<()> {
-        Ok(())
+async fn process_request_stream() -> Result<()> {
+    Ok(())
+}
+
+async fn process_response_stream(
+    subject: String,
+    state: Arc<Mutex<State>>,
+    mut reader: FramedRead<tokio::io::ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
+    writer: FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>,
+) -> Result<()> {
+    let response_stream = state
+        .lock()
+        .await
+        .rx_subjects
+        .remove(&subject)
+        .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
+
+    // unwrap response_stream
+    let RequestedRecvConnection {
+        context,
+        connection,
+    } = response_stream;
+
+    // the [`Prologue`]
+    // there must be a second control message it indicate the other segment's generate method was successful
+    let prologue = reader
+        .next()
+        .await
+        .ok_or(error!("Connection closed without a ControlMessge"))??;
+
+    // deserialize prologue
+    let prologue = match prologue.into_message_type() {
+        TwoPartMessageType::HeaderOnly(header) => {
+            let prologue: ResponseStreamPrologue = serde_json::from_slice(&header)
+                .map_err(|e| error!("Failed to deserialize ControlMessage: {}", e))?;
+            prologue
+        }
+        _ => {
+            panic!("Expected HeaderOnly ControlMessage; internally logic error")
+        }
+    };
+
+    // await the control message of GTG or Error, if error, then connection.send(Err(String)), which should fail the
+    // generate call chain
+    //
+    // note: this second control message might be delayed, but the expensive part of setting up the connection
+    // is both complete and ready for data flow; awaiting here is not a performance hit or problem and it allows
+    // us to trace the initial setup time vs the time to prologue
+    if let Some(error) = &prologue.error {
+        let _ = connection.send(Err(error.clone()));
+        return Err(error!("Received error prologue: {}", error));
     }
 
-    async fn process_response_stream(
-        subject: String,
-        state: Arc<Mutex<State>>,
-        mut reader: FramedRead<tokio::io::ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
-        writer: FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>,
-    ) -> Result<()> {
-        let response_stream = state
-            .lock().await
-            .rx_subjects
-            .remove(&subject)
-            .ok_or(error!("Subject not found: {}; upstream publisher specified a subject unknown to the downsteam subscriber", subject))?;
+    // we need to know the buffer size from the registration options; add this to the RequestRecvConnection object
+    let (response_tx, response_rx) = mpsc::channel(64);
 
-        // unwrap response_stream
-        let RequestedRecvConnection {
-            context,
-            connection,
-        } = response_stream;
-
-        // the [`Prologue`]
-        // there must be a second control message it indicate the other segment's generate method was successful
-        let prologue = reader
-            .next()
-            .await
-            .ok_or(error!("Connection closed without a ControlMessge"))??;
-
-        // deserialize prologue
-        let prologue = match prologue.into_message_type() {
-            TwoPartMessageType::HeaderOnly(header) => {
-                let prologue: ResponseStreamPrologue = serde_json::from_slice(&header)
-                    .map_err(|e| error!("Failed to deserialize ControlMessage: {}", e))?;
-                prologue
-            }
-            _ => {
-                panic!("Expected HeaderOnly ControlMessage; internally logic error")
-            }
-        };
-
-        // await the control message of GTG or Error, if error, then connection.send(Err(String)), which should fail the
-        // generate call chain
-        //
-        // note: this second control message might be delayed, but the expensive part of setting up the connection
-        // is both complete and ready for data flow; awaiting here is not a performance hit or problem and it allows
-        // us to trace the initial setup time vs the time to prologue
-        if let Some(error) = &prologue.error {
-            let _ = connection.send(Err(error.clone()));
-            return Err(error!("Received error prologue: {}", error));
-        }
-
-        // we need to know the buffer size from the registration options; add this to the RequestRecvConnection object
-        let (response_tx, response_rx) = mpsc::channel(64);
-
-        if connection
-            .send(Ok(crate::pipeline::network::StreamReceiver {
-                rx: response_rx,
-            }))
-            .is_err()
-        {
-            return Err(error!(
-                "The requester of the stream has been dropped before the connection was established"
-            ));
-        }
-
-        let (control_tx, control_rx) = mpsc::channel::<ControlMessage>(1);
-
-        // sender task
-        // issues control messages to the sender and when finished shuts down the socket
-        // this should be the last task to finish and must
-        let send_task = tokio::spawn(network_send_handler(writer, control_rx));
-
-        // forward task
-        let recv_task = tokio::spawn(network_receive_handler(
-            reader,
-            response_tx,
-            control_tx,
-            context.clone(),
+    if connection
+        .send(Ok(crate::pipeline::network::StreamReceiver {
+            rx: response_rx,
+        }))
+        .is_err()
+    {
+        return Err(error!(
+            "The requester of the stream has been dropped before the connection was established"
         ));
-
-        // check the results of each of the tasks
-        let (monitor_result, forward_result) = tokio::join!(send_task, recv_task);
-
-        monitor_result?;
-        forward_result?;
-
-        Ok(())
     }
 
-    async fn network_receive_handler(
-        mut framed_reader: FramedRead<tokio::io::ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
-        response_tx: mpsc::Sender<Bytes>,
-        control_tx: mpsc::Sender<ControlMessage>,
-        context: Arc<dyn AsyncEngineContext>,
-    ) {
-        // loop over reading the tcp stream and checking if the writer is closed
-        let mut can_stop = true;
-        loop {
-            tokio::select! {
-                biased;
+    let (control_tx, control_rx) = mpsc::channel::<ControlMessage>(1);
 
-                _ = response_tx.closed() => {
-                    tracing::trace!("response channel closed before the client finished writing data");
-                    control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
-                    break;
-                }
+    // sender task
+    // issues control messages to the sender and when finished shuts down the socket
+    // this should be the last task to finish and must
+    let send_task = tokio::spawn(network_send_handler(writer, control_rx));
 
-                _ = context.killed() => {
-                    tracing::trace!("context kill signal received; shutting down");
-                    control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
-                    break;
-                }
+    // forward task
+    let recv_task = tokio::spawn(network_receive_handler(
+        reader,
+        response_tx,
+        control_tx,
+        context.clone(),
+    ));
 
-                _ = context.stopped(), if can_stop => {
-                    tracing::trace!("context stop signal received; shutting down");
-                    can_stop = false;
-                    control_tx.send(ControlMessage::Stop).await.expect("the control channel should not be closed");
-                }
+    // check the results of each of the tasks
+    let (monitor_result, forward_result) = tokio::join!(send_task, recv_task);
 
-                msg = framed_reader.next() => {
-                    match msg {
-                        Some(Ok(msg)) => {
-                            let (header, data) = msg.into_parts();
+    monitor_result?;
+    forward_result?;
 
-                            // received a control message
-                            if !header.is_empty() {
-                                match process_control_message(header) {
-                                    Ok(ControlAction::Continue) => {}
-                                    Ok(ControlAction::Shutdown) => {
-                                        assert!(data.is_empty(), "received sentinel message with data; this should never happen");
-                                        tracing::trace!("received sentinel message; shutting down");
-                                        break;
-                                    }
-                                    Err(e) => {
-                                        // TODO(#171) - address fatal errors
-                                        panic!("{:?}", e);
-                                    }
+    Ok(())
+}
+
+async fn network_receive_handler(
+    mut framed_reader: FramedRead<tokio::io::ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
+    response_tx: mpsc::Sender<Bytes>,
+    control_tx: mpsc::Sender<ControlMessage>,
+    context: Arc<dyn AsyncEngineContext>,
+) {
+    // loop over reading the tcp stream and checking if the writer is closed
+    let mut can_stop = true;
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = response_tx.closed() => {
+                tracing::trace!("response channel closed before the client finished writing data");
+                control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                break;
+            }
+
+            _ = context.killed() => {
+                tracing::trace!("context kill signal received; shutting down");
+                control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                break;
+            }
+
+            _ = context.stopped(), if can_stop => {
+                tracing::trace!("context stop signal received; shutting down");
+                can_stop = false;
+                control_tx.send(ControlMessage::Stop).await.expect("the control channel should not be closed");
+            }
+
+            msg = framed_reader.next() => {
+                match msg {
+                    Some(Ok(msg)) => {
+                        let (header, data) = msg.into_parts();
+
+                        // received a control message
+                        if !header.is_empty() {
+                            match process_control_message(header) {
+                                Ok(ControlAction::Continue) => {}
+                                Ok(ControlAction::Shutdown) => {
+                                    assert!(data.is_empty(), "received sentinel message with data; this should never happen");
+                                    tracing::trace!("received sentinel message; shutting down");
+                                    break;
+                                }
+                                Err(e) => {
+                                    // TODO(#171) - address fatal errors
+                                    panic!("{:?}", e);
                                 }
                             }
+                        }
 
-                            if !data.is_empty()
-                                && let Err(err) = response_tx.send(data).await {
-                                    tracing::debug!("forwarding body/data message to response channel failed: {}", err);
-                                    control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
-                                    break;
-                                };
-                        }
-                        Some(Err(_)) => {
-                            // TODO(#171) - address fatal errors
-                            panic!("invalid message issued over socket; this should never happen");
-                        }
-                        None => {
-                            // this is allowed but we try to avoid it
-                            // the logic is that the client will tell us when its is done and the server
-                            // will close the connection naturally when the sentinel message is received
-                            // the client closing early represents a transport error outside the control of the
-                            // transport library
-                            tracing::trace!("tcp stream was closed by client");
-                            break;
-                        }
+                        if !data.is_empty()
+                            && let Err(err) = response_tx.send(data).await {
+                                tracing::debug!("forwarding body/data message to response channel failed: {}", err);
+                                control_tx.send(ControlMessage::Kill).await.expect("the control channel should not be closed");
+                                break;
+                            };
+                    }
+                    Some(Err(_)) => {
+                        // TODO(#171) - address fatal errors
+                        panic!("invalid message issued over socket; this should never happen");
+                    }
+                    None => {
+                        // this is allowed but we try to avoid it
+                        // the logic is that the client will tell us when its is done and the server
+                        // will close the connection naturally when the sentinel message is received
+                        // the client closing early represents a transport error outside the control of the
+                        // transport library
+                        tracing::trace!("tcp stream was closed by client");
+                        break;
                     }
                 }
+            }
 
+        }
+    }
+}
+
+async fn network_send_handler(
+    socket_tx: FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>,
+    control_rx: mpsc::Receiver<ControlMessage>,
+) {
+    let mut socket_tx: FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec> = socket_tx;
+    let mut control_rx = control_rx;
+
+    while let Some(control_msg) = control_rx.recv().await {
+        assert_ne!(
+            control_msg,
+            ControlMessage::Sentinel,
+            "received sentinel message; this should never happen"
+        );
+        let bytes = serde_json::to_vec(&control_msg).expect("failed to serialize control message");
+        let message = TwoPartMessage::from_header(bytes.into());
+        match socket_tx.send(message).await {
+            Ok(_) => tracing::debug!("issued control message {control_msg:?} to sender"),
+            Err(_) => {
+                tracing::debug!("failed to send control message {control_msg:?} to sender")
             }
         }
     }
 
-    async fn network_send_handler(
-        socket_tx: FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>,
-        control_rx: mpsc::Receiver<ControlMessage>,
-    ) {
-        let mut socket_tx = socket_tx;
-        let mut control_rx = control_rx;
-
-        while let Some(control_msg) = control_rx.recv().await {
-            assert_ne!(
-                control_msg,
-                ControlMessage::Sentinel,
-                "received sentinel message; this should never happen"
-            );
-            let bytes =
-                serde_json::to_vec(&control_msg).expect("failed to serialize control message");
-            let message = TwoPartMessage::from_header(bytes.into());
-            match socket_tx.send(message).await {
-                Ok(_) => tracing::debug!("issued control message {control_msg:?} to sender"),
-                Err(_) => {
-                    tracing::debug!("failed to send control message {control_msg:?} to sender")
-                }
-            }
-        }
-
-        let mut inner = socket_tx.into_inner();
-        if let Err(e) = inner.flush().await {
-            tracing::debug!("failed to flush socket: {}", e);
-        }
-        if let Err(e) = inner.shutdown().await {
-            tracing::debug!("failed to shutdown socket: {}", e);
-        }
+    let mut inner = socket_tx.into_inner();
+    if let Err(e) = inner.flush().await {
+        tracing::debug!("failed to flush socket: {}", e);
+    }
+    if let Err(e) = inner.shutdown().await {
+        tracing::debug!("failed to shutdown socket: {}", e);
     }
 }
 
@@ -647,6 +644,127 @@ mod tests {
     use super::*;
     use crate::engine::AsyncEngineContextProvider;
     use crate::pipeline::Context;
+    use crate::pipeline::context::Controller;
+    use crate::pipeline::network::ControlMessage;
+    use crate::pipeline::network::codec::TwoPartMessage;
+    use crate::pipeline::network::tcp::test_utils::create_tcp_pair;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // ==================== Test Setup Helpers ====================
+
+    /// Test fixture for network_send_handler tests
+    struct SendHandlerTestSetup {
+        server: tokio::net::TcpStream,
+        framed_writer: FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>,
+        control_tx: mpsc::Sender<ControlMessage>,
+        control_rx: mpsc::Receiver<ControlMessage>,
+    }
+
+    impl SendHandlerTestSetup {
+        async fn new() -> Self {
+            let (client, server) = create_tcp_pair().await;
+            let (_, write_half) = tokio::io::split(client);
+            let framed_writer = FramedWrite::new(write_half, TwoPartCodec::default());
+            let (control_tx, control_rx) = mpsc::channel::<ControlMessage>(1);
+
+            Self {
+                server,
+                framed_writer,
+                control_tx,
+                control_rx,
+            }
+        }
+
+        /// Spawn the handler and return components needed for testing
+        fn spawn_handler(
+            self,
+        ) -> (
+            tokio::task::JoinHandle<()>,
+            tokio::net::TcpStream,
+            mpsc::Sender<ControlMessage>,
+        ) {
+            let handle = tokio::spawn(network_send_handler(self.framed_writer, self.control_rx));
+            (handle, self.server, self.control_tx)
+        }
+    }
+
+    /// Test fixture for network_receive_handler tests
+    struct ReceiveHandlerTestSetup {
+        server_write: tokio::io::WriteHalf<tokio::net::TcpStream>,
+        framed_reader: FramedRead<tokio::io::ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
+        response_tx: mpsc::Sender<Bytes>,
+        response_rx: mpsc::Receiver<Bytes>,
+        control_tx: mpsc::Sender<ControlMessage>,
+        control_rx: mpsc::Receiver<ControlMessage>,
+        controller: Arc<Controller>,
+    }
+
+    impl ReceiveHandlerTestSetup {
+        async fn new() -> Self {
+            Self::with_response_channel_size(10).await
+        }
+
+        async fn with_response_channel_size(size: usize) -> Self {
+            let (client, server) = create_tcp_pair().await;
+            let (read_half, _write_half) = tokio::io::split(client);
+            let (_server_read, server_write) = tokio::io::split(server);
+
+            let framed_reader = FramedRead::new(read_half, TwoPartCodec::default());
+            let (response_tx, response_rx) = mpsc::channel::<Bytes>(size);
+            let (control_tx, control_rx) = mpsc::channel::<ControlMessage>(10);
+            let controller = Arc::new(Controller::default());
+
+            Self {
+                server_write,
+                framed_reader,
+                response_tx,
+                response_rx,
+                control_tx,
+                control_rx,
+                controller,
+            }
+        }
+
+        /// Spawn the handler and return components needed for testing
+        fn spawn_handler(
+            self,
+        ) -> (
+            tokio::task::JoinHandle<()>,
+            tokio::io::WriteHalf<tokio::net::TcpStream>,
+            mpsc::Receiver<Bytes>,
+            mpsc::Receiver<ControlMessage>,
+            Arc<Controller>,
+        ) {
+            let handle = tokio::spawn(network_receive_handler(
+                self.framed_reader,
+                self.response_tx,
+                self.control_tx,
+                self.controller.clone(),
+            ));
+            (
+                handle,
+                self.server_write,
+                self.response_rx,
+                self.control_rx,
+                self.controller,
+            )
+        }
+    }
+
+    /// Helper to encode a control message to bytes using the TwoPartCodec
+    fn encode_control_message(msg: &ControlMessage) -> Bytes {
+        let msg_bytes = serde_json::to_vec(msg).unwrap();
+        let two_part_msg = TwoPartMessage::from_header(Bytes::from(msg_bytes));
+        TwoPartCodec::default().encode_message(two_part_msg).unwrap()
+    }
+
+    /// Helper to encode a data message to bytes using the TwoPartCodec
+    fn encode_data_message(data: &[u8]) -> Bytes {
+        let two_part_msg = TwoPartMessage::from_data(Bytes::from(data.to_vec()));
+        TwoPartCodec::default().encode_message(two_part_msg).unwrap()
+    }
+
+    // ==================== Mock Resolvers ====================
 
     // Mock resolver that always fails to simulate the fallback scenario
     struct FailingIpResolver;
@@ -764,5 +882,324 @@ mod tests {
 
         // The server should work with the fallback IP
         assert!(socket_addr.port() > 0, "Server should have a valid port");
+    }
+
+    /// Test that network_send_handler sends control messages over the socket
+    #[tokio::test]
+    async fn test_network_send_handler_sends_control_messages() {
+        let setup = SendHandlerTestSetup::new().await;
+        let (handle, mut server, control_tx) = setup.spawn_handler();
+
+        // Send a Kill message
+        control_tx.send(ControlMessage::Kill).await.unwrap();
+        drop(control_tx);
+
+        // Wait for handler to complete
+        handle.await.unwrap();
+
+        // Read from server side to verify message was sent
+        let mut buffer = vec![0u8; 1024];
+        let n = server.read(&mut buffer).await.unwrap();
+
+        // Buffer should contain the Kill message
+        assert!(n > 0, "Expected control message to be written to the TCP stream");
+
+        let kill_json = serde_json::to_vec(&ControlMessage::Kill).unwrap();
+        assert!(
+            buffer[..n]
+                .windows(kill_json.len())
+                .any(|w| w == kill_json.as_slice()),
+            "Buffer should contain Kill message. Buffer: {:?}",
+            String::from_utf8_lossy(&buffer[..n])
+        );
+    }
+
+    /// Test that network_send_handler sends Stop message correctly
+    #[tokio::test]
+    async fn test_network_send_handler_sends_stop_message() {
+        let setup = SendHandlerTestSetup::new().await;
+        let (handle, mut server, control_tx) = setup.spawn_handler();
+
+        // Send a Stop message
+        control_tx.send(ControlMessage::Stop).await.unwrap();
+        drop(control_tx);
+
+        // Wait for handler to complete
+        handle.await.unwrap();
+
+        // Read from server side
+        let mut buffer = vec![0u8; 1024];
+        let n = server.read(&mut buffer).await.unwrap();
+
+        let stop_json = serde_json::to_vec(&ControlMessage::Stop).unwrap();
+        assert!(
+            buffer[..n]
+                .windows(stop_json.len())
+                .any(|w| w == stop_json.as_slice()),
+            "Buffer should contain Stop message"
+        );
+    }
+
+    /// Test that network_send_handler shuts down cleanly when channel closes
+    #[tokio::test]
+    async fn test_network_send_handler_shuts_down_on_channel_close() {
+        let setup = SendHandlerTestSetup::new().await;
+        let (handle, _server, control_tx) = setup.spawn_handler();
+
+        // Immediately close the channel without sending anything
+        drop(control_tx);
+
+        // Handler should complete without panicking
+        let result = handle.await;
+        assert!(result.is_ok(), "Handler should complete successfully when channel closes");
+    }
+
+    /// Test that network_send_handler panics on Sentinel (which should never be sent)
+    #[tokio::test]
+    #[should_panic(expected = "received sentinel message")]
+    async fn test_network_send_handler_panics_on_sentinel() {
+        let setup = SendHandlerTestSetup::new().await;
+
+        // Send a Sentinel message (which should cause a panic)
+        setup.control_tx.send(ControlMessage::Sentinel).await.unwrap();
+
+        // This should panic
+        network_send_handler(setup.framed_writer, setup.control_rx).await;
+    }
+
+    // ==================== network_receive_handler tests ====================
+
+    /// Test that network_receive_handler forwards data messages to response_tx
+    #[tokio::test]
+    async fn test_network_receive_handler_forwards_data() {
+        let setup = ReceiveHandlerTestSetup::new().await;
+        let (handle, mut server_write, mut response_rx, mut control_rx, _controller) =
+            setup.spawn_handler();
+
+        // Send data message from server
+        let test_data = b"hello world";
+        let encoded = encode_data_message(test_data);
+        server_write.write_all(&encoded).await.unwrap();
+        server_write.flush().await.unwrap();
+
+        // Send sentinel to gracefully close
+        let sentinel = encode_control_message(&ControlMessage::Sentinel);
+        server_write.write_all(&sentinel).await.unwrap();
+        server_write.flush().await.unwrap();
+        server_write.shutdown().await.unwrap();
+
+        // Wait for handler to complete
+        handle.await.unwrap();
+
+        // Verify data was forwarded
+        let received = response_rx.recv().await.unwrap();
+        assert_eq!(&received[..], test_data);
+
+        // No control messages should have been sent
+        assert!(control_rx.try_recv().is_err());
+    }
+
+    /// Test that network_receive_handler handles sentinel and shuts down
+    #[tokio::test]
+    async fn test_network_receive_handler_sentinel_shutdown() {
+        let setup = ReceiveHandlerTestSetup::new().await;
+        let (handle, mut server_write, _response_rx, _control_rx, _controller) =
+            setup.spawn_handler();
+
+        // Send sentinel message
+        let sentinel = encode_control_message(&ControlMessage::Sentinel);
+        server_write.write_all(&sentinel).await.unwrap();
+        server_write.flush().await.unwrap();
+        server_write.shutdown().await.unwrap();
+
+        // Handler should complete without error
+        let result = handle.await;
+        assert!(result.is_ok(), "Handler should complete successfully on sentinel");
+    }
+
+    /// Test that network_receive_handler sends Kill when response_tx is closed
+    #[tokio::test]
+    async fn test_network_receive_handler_response_channel_closed() {
+        let mut setup = ReceiveHandlerTestSetup::new().await;
+
+        // Drop the response receiver to close the channel before spawning
+        drop(setup.response_rx);
+
+        // Spawn the receive handler (response_rx already dropped)
+        let handle = tokio::spawn(network_receive_handler(
+            setup.framed_reader,
+            setup.response_tx,
+            setup.control_tx,
+            setup.controller,
+        ));
+
+        // Handler should complete
+        handle.await.unwrap();
+
+        // Should have sent Kill message
+        let control_msg = setup.control_rx.recv().await.unwrap();
+        assert!(
+            matches!(control_msg, ControlMessage::Kill),
+            "Expected Kill message when response channel is closed"
+        );
+    }
+
+    /// Test that network_receive_handler sends Kill when context is killed
+    #[tokio::test]
+    async fn test_network_receive_handler_context_killed() {
+        let setup = ReceiveHandlerTestSetup::new().await;
+        let (handle, _server_write, _response_rx, mut control_rx, controller) =
+            setup.spawn_handler();
+
+        // Kill the context
+        controller.kill();
+
+        // Handler should complete
+        handle.await.unwrap();
+
+        // Should have sent Kill message
+        let control_msg = control_rx.recv().await.unwrap();
+        assert!(
+            matches!(control_msg, ControlMessage::Kill),
+            "Expected Kill message when context is killed"
+        );
+    }
+
+    /// Test that network_receive_handler sends Stop when context is stopped
+    #[tokio::test]
+    async fn test_network_receive_handler_context_stopped() {
+        let setup = ReceiveHandlerTestSetup::new().await;
+        let (handle, mut server_write, _response_rx, mut control_rx, controller) =
+            setup.spawn_handler();
+
+        // Stop the context
+        controller.stop();
+
+        // recv() blocks until message arrives
+        let control_msg = control_rx.recv().await.expect("Control channel closed unexpectedly");
+        assert!(
+            matches!(control_msg, ControlMessage::Stop),
+            "Expected Stop message when context is stopped"
+        );
+
+        // Send sentinel to allow graceful shutdown
+        let sentinel = encode_control_message(&ControlMessage::Sentinel);
+        server_write.write_all(&sentinel).await.unwrap();
+        server_write.flush().await.unwrap();
+        server_write.shutdown().await.unwrap();
+
+        // Handler should complete
+        handle.await.unwrap();
+    }
+
+    /// Test that network_receive_handler handles TCP stream closed by client
+    #[tokio::test]
+    async fn test_network_receive_handler_tcp_stream_closed() {
+        let setup = ReceiveHandlerTestSetup::new().await;
+        let (handle, mut server_write, _response_rx, _control_rx, _controller) =
+            setup.spawn_handler();
+
+        // Close the server side (simulates client closing connection)
+        server_write.shutdown().await.unwrap();
+        drop(server_write);
+
+        // Handler should complete without panicking
+        let result = handle.await;
+        assert!(result.is_ok(), "Handler should complete when TCP stream is closed");
+    }
+
+    /// Test that network_receive_handler forwards multiple data messages
+    #[tokio::test]
+    async fn test_network_receive_handler_multiple_data_messages() {
+        let setup = ReceiveHandlerTestSetup::new().await;
+        let (handle, mut server_write, mut response_rx, _control_rx, _controller) =
+            setup.spawn_handler();
+
+        // Send multiple data messages
+        let messages = [b"message 1".as_slice(), b"message 2", b"message 3"];
+        for msg in &messages {
+            let encoded = encode_data_message(msg);
+            server_write.write_all(&encoded).await.unwrap();
+        }
+        server_write.flush().await.unwrap();
+
+        // Send sentinel to gracefully close
+        let sentinel = encode_control_message(&ControlMessage::Sentinel);
+        server_write.write_all(&sentinel).await.unwrap();
+        server_write.flush().await.unwrap();
+        server_write.shutdown().await.unwrap();
+
+        // Wait for handler to complete
+        handle.await.unwrap();
+
+        // Verify all messages were forwarded in order
+        for expected in &messages {
+            let received = response_rx.recv().await.unwrap();
+            assert_eq!(&received[..], *expected);
+        }
+    }
+
+    /// Test that network_receive_handler sends Kill when data forwarding fails
+    #[tokio::test]
+    async fn test_network_receive_handler_data_forward_failure() {
+        let mut setup = ReceiveHandlerTestSetup::with_response_channel_size(1).await;
+
+        // Drop the response receiver to cause send failures
+        drop(setup.response_rx);
+
+        // Spawn the receive handler
+        let handle = tokio::spawn(network_receive_handler(
+            setup.framed_reader,
+            setup.response_tx,
+            setup.control_tx,
+            setup.controller,
+        ));
+
+        // Send data message - this should fail to forward
+        let test_data = b"test data";
+        let encoded = encode_data_message(test_data);
+        setup.server_write.write_all(&encoded).await.unwrap();
+        setup.server_write.flush().await.unwrap();
+        setup.server_write.shutdown().await.unwrap();
+
+        // Wait for handler to complete
+        handle.await.unwrap();
+
+        // Should have sent Kill message due to forward failure
+        let control_msg = setup.control_rx.recv().await.unwrap();
+        assert!(
+            matches!(control_msg, ControlMessage::Kill),
+            "Expected Kill message when data forwarding fails"
+        );
+    }
+
+    /// Test that network_receive_handler only sends Stop once even if context.stopped() is called multiple times
+    #[tokio::test]
+    async fn test_network_receive_handler_stop_sent_only_once() {
+        let setup = ReceiveHandlerTestSetup::new().await;
+        let (handle, mut server_write, _response_rx, mut control_rx, controller) =
+            setup.spawn_handler();
+
+        // Stop the context
+        controller.stop();
+
+        // recv() blocks until message arrives
+        let control_msg = control_rx.recv().await.expect("Control channel closed unexpectedly");
+        assert!(matches!(control_msg, ControlMessage::Stop));
+
+        // Send sentinel to allow graceful shutdown
+        let sentinel = encode_control_message(&ControlMessage::Sentinel);
+        server_write.write_all(&sentinel).await.unwrap();
+        server_write.flush().await.unwrap();
+        server_write.shutdown().await.unwrap();
+
+        // Handler should complete
+        handle.await.unwrap();
+
+        // No additional control messages should be present (Stop should only be sent once)
+        assert!(
+            control_rx.try_recv().is_err(),
+            "Stop should only be sent once"
+        );
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/test_utils.rs
+++ b/lib/runtime/src/pipeline/network/tcp/test_utils.rs
@@ -19,3 +19,4 @@ pub async fn create_tcp_pair() -> (tokio::net::TcpStream, tokio::net::TcpStream)
 
     (client, server)
 }
+


### PR DESCRIPTION
This diff 

- moves nested functions of `tcp/server.rs` out 
- unit tests `network_receiver_handler` and `network_send_handler`

I self-reviewed the change, existing and new unit tests in `server.rs`. To my best knowledge, this PR should not introduce regression.