### PR TITLE
chore: fix default affinities value in operator helm chart

### DIFF
--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -104,7 +104,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 | dynamo-operator.namespaceRestriction.enabled | bool | `false` | Whether to restrict operator to specific namespaces. By default, the operator will run with cluster-wide permissions. Only 1 instance of the operator should be deployed in the cluster. If you want to deploy multiple operator instances, you can set this to true and specify the target namespace (by default, the target namespace is the helm release namespace). |
 | dynamo-operator.namespaceRestriction.targetNamespace | string | `nil` | Target namespace for operator deployment (leave empty for current namespace) |
 | dynamo-operator.controllerManager.tolerations | list | `[]` | Node tolerations for controller manager pods |
-| dynamo-operator.controllerManager.affinity | list | `[]` | Affinity for controller manager pods |
+| dynamo-operator.controllerManager.affinity | object | `{}` | Affinity for controller manager pods |
 | dynamo-operator.controllerManager.leaderElection.id | string | `""` | Leader election ID for cluster-wide coordination. WARNING: All cluster-wide operators must use the SAME ID to prevent split-brain. Different IDs would allow multiple leaders simultaneously. |
 | dynamo-operator.controllerManager.leaderElection.namespace | string | `""` | Namespace for leader election leases (only used in cluster-wide mode). If empty, defaults to kube-system for cluster-wide coordination. All cluster-wide operators should use the SAME namespace for proper leader election. |
 | dynamo-operator.controllerManager.manager.image.repository | string | `"nvcr.io/nvidia/ai-dynamo/kubernetes-operator"` | Official NVIDIA Dynamo operator image repository |

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -55,7 +55,7 @@ dynamo-operator:
     tolerations: []
 
     # -- Affinity for controller manager pods
-    affinity: []
+    affinity: {}
 
     # Leader election configuration for cluster-wide coordination
     leaderElection:


### PR DESCRIPTION
Affinities shouldn't have the default value be a list (`[]`) but instead it should be an object (`{}`). If its a list you get the following warning when doing helm installs or helm upgrades:

```
helm upgrade dynamo-platform ./dynamo-platform -n dynamo-system -f values.yaml
coalesce.go:301: warning: destination for dynamo-platform.dynamo-operator.controllerManager.affinity is a table. Ignoring non-table value ([])
coalesce.go:301: warning: destination for dynamo-platform.dynamo-operator.controllerManager.affinity is a table. Ignoring non-table value ([])
```

This PR swaps `[]` with `{}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the controller manager affinity configuration structure in Helm deployment charts. The affinity field format has been changed from a list-based structure to an object-based structure. If you use custom affinity configurations, update your Helm values files to align with the new format for compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->