### PR TITLE
fix(helm): warning in values.yaml for operator affinity

### DIFF
--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -55,7 +55,7 @@ dynamo-operator:
     tolerations: []
 
     # -- Affinity for controller manager pods
-    affinity: []
+    affinity: {}
 
     # Leader election configuration for cluster-wide coordination
     leaderElection:


### PR DESCRIPTION
#### Overview:

When attempting to specify `controllerManager.affinity` in the values.yaml for the platform helm chart, you get the following error.

```
tom:~/Dynamo/repos/dynamo/deploy/helm/charts (tmonty12/dep-701-dgd-restart) $ helm upgrade dynamo-platform -n tm ./platform -f ~/Dynamo/k8s/nebius-values.yaml
coalesce.go:301: warning: destination for dynamo-platform.dynamo-operator.controllerManager.affinity is a table. Ignoring non-table value ([])
coalesce.go:301: warning: destination for dynamo-platform.dynamo-operator.controllerManager.affinity is a table. Ignoring non-table value ([])
```

Setting the default value to `{}` as an object allows Helm to properly merge with the defaults and user provided values - warnings go away.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes affinity configuration for improved deployment flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->