### PR TITLE
fix: correct the doc to point to pre-deployment/ path

### DIFF
--- a/docs/kubernetes/installation_guide.md
+++ b/docs/kubernetes/installation_guide.md
@@ -121,10 +121,10 @@ export RELEASE_VERSION=0.x.x # any version of Dynamo 0.3.2+ listed at https://gi
 Before proceeding, run the pre-deployment check script to verify your cluster meets all requirements:
 
 ```bash
-./deploy/cloud/pre-deployment/pre-deployment-check.sh
+./deploy/pre-deployment/pre-deployment-check.sh
 ```
 
-This script validates kubectl connectivity, default StorageClass configuration, and GPU node availability. See [Pre-Deployment Checks](../../deploy/cloud/pre-deployment/README.md) for details.
+This script validates kubectl connectivity, default StorageClass configuration, and GPU node availability. See [Pre-Deployment Checks](../../deploy/pre-deployment/README.md) for details.
 
 > **No cluster?** See [Minikube Setup](deployment/minikube.md) for local development.
 


### PR DESCRIPTION
#### Overview:

Fix the Kubernetes installation guide to reference the correct pre-deployment check script location under `deploy/pre-deployment/`.

#### Details:

- Update the command path to `./deploy/pre-deployment/pre-deployment-check.sh`
- Update the “Pre-Deployment Checks” doc link to `../../deploy/pre-deployment/README.md`

#### Where should the reviewer start?

docs/kubernetes/installation_guide.md

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)

[#4895](https://github.com/ai-dynamo/dynamo/pull/4895)

/coderabbit profile chill