### PR TITLE
fix(sglang): remove otel for emebedding models

### DIFF
--- a/examples/backends/sglang/launch/agg_embed.sh
+++ b/examples/backends/sglang/launch/agg_embed.sh
@@ -12,20 +12,15 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Parse command line arguments
-ENABLE_OTEL=false
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --enable-otel)
-            ENABLE_OTEL=true
-            shift
-            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
-            echo "  --enable-otel        Enable OpenTelemetry tracing"
             echo "  -h, --help           Show this help message"
             echo ""
             echo "Note: System metrics are enabled by default on port 8081 (worker)"
+            echo "Note: OpenTelemetry tracing is not yet supported for embedding models"
             exit 0
             ;;
         *)
@@ -36,23 +31,13 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Enable tracing if requested
-TRACE_ARGS=()
-if [ "$ENABLE_OTEL" = true ]; then
-    export DYN_LOGGING_JSONL=true
-    export OTEL_EXPORT_ENABLED=1
-    export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-http://localhost:4317}
-    TRACE_ARGS+=(--enable-trace --otlp-traces-endpoint localhost:4317)
-fi
-
 # run ingress
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
-OTEL_SERVICE_NAME=dynamo-frontend \
 python3 -m dynamo.frontend &
 DYNAMO_PID=$!
 
 # run worker
-OTEL_SERVICE_NAME=dynamo-worker-embedding DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
 python3 -m dynamo.sglang \
   --embedding-worker \
   --model-path Qwen/Qwen3-Embedding-4B \
@@ -61,5 +46,4 @@ python3 -m dynamo.sglang \
   --tp 1 \
   --trust-remote-code \
   --use-sglang-tokenizer \
-  --enable-metrics \
-  "${TRACE_ARGS[@]}"
+  --enable-metrics


### PR DESCRIPTION
Based on https://github.com/sgl-project/sglang/pull/15814#discussion_r2646773661 I'm realizing that embedding doesn't have proper tracing support. The tracing PIC in SGL will implement it in a different PR. Solution here is to not enable tracing support for embedding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `--enable-otel` flag and related OpenTelemetry configuration from the embedding script. OpenTelemetry tracing is not yet supported for embedding models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->