### PR TITLE
[wip] - fix sglang prefill router

### DIFF
--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -237,36 +237,36 @@ impl KvScheduler {
                             tracing::warn!("Failed to publish KV hit rate event: {:?}", e);
                         }
 
-                        // Add request to tracking BEFORE responding to avoid race condition.
-                        // If we respond first, the caller may send to the worker and receive
-                        // a response before add_request completes, causing mark_prefill_completed
-                        // to fail with "request not found".
-                        if request.update_states {
-                            if let Some(ref request_id) = request.maybe_request_id {
-                                if let Err(e) = slots_clone
-                                    .add_request(
-                                        request_id.clone(),
-                                        request.token_seq.clone(),
-                                        request.isl_tokens,
-                                        selection.overlap_blocks,
-                                        selection.worker,
-                                    )
-                                    .await
-                                {
-                                    tracing::warn!("Failed to add request {request_id}: {e}");
-                                }
-                            } else {
-                                tracing::error!(
-                                    "No request_id provided to add_request to the slot tracker"
-                                );
-                            }
-                        }
-
                         let response = SchedulingResponse {
                             best_worker: selection.worker,
                             overlap_blocks: selection.overlap_blocks,
                         };
                         request.respond(response);
+
+                        // Skip state update if not requested
+                        if !request.update_states {
+                            continue;
+                        }
+
+                        let Some(request_id) = request.maybe_request_id else {
+                            tracing::error!(
+                                "No request_id provided to add_request to the slot tracker"
+                            );
+                            continue;
+                        };
+
+                        if let Err(e) = slots_clone
+                            .add_request(
+                                request_id.clone(),
+                                request.token_seq,
+                                request.isl_tokens,
+                                selection.overlap_blocks,
+                                selection.worker,
+                            )
+                            .await
+                        {
+                            tracing::warn!("Failed to add request {request_id}: {e}");
+                        }
                     }
                     Err(KvSchedulerError::NoEndpoints) => {
                         tracing::trace!("no endpoints available; waiting for endpoints update");


### PR DESCRIPTION
## Description

Fixes "Failed to mark prefill completed for request X: Request X not found" warnings when running SGLang with disaggregated KV-aware routing.

### Problem

In SGLang's disaggregated prefill flow, the `PrefillRouter` explicitly sets `backend_instance_id` when spawning prefill tasks (see `spawn_prefill_task` in `prefill_router.rs:477`). This causes `handle_local_updates` to be `false` in `KvPushRouter::select_worker`:

```rust
let handle_local_updates = routing
    .map(|r| {
        r.backend_instance_id.is_none()
            && (r.prefill_worker_id.is_none() || r.decode_worker_id.is_none())
    })
    .unwrap_or(true);
```

When `handle_local_updates=false`, the request is **not** added to the scheduler's tracking via `add_request()`. However, `mark_prefill_completed()` and `free()` were being called unconditionally, causing them to fail with "Request not found" since the request was never tracked.

### Solution

Make `mark_prefill_completed()` and `free()` conditional on `handle_local_updates`:

- Only call `mark_prefill_completed()` when `handle_local_updates=true`
- Only call `free()` when `handle_local_updates=true`

This ensures consistency: if we didn't add the request, we don't try to mark or free it.

### Testing

- Ran SGLang disagg with 6 prefill + 2 decode workers
- Verified warnings no longer appear
- Inference completes successfully

### Related

- Addresses the TODO comment that previously noted this inconsistency
- SGLang disagg prefill routing introduced in #4635