### PR TITLE
fix: add chat_template_kwargs alias for compatibility

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2191,8 +2191,7 @@ mod tests {
             "model": "test-model",
             "add_special_tokens": true,
             "documents": ["doc1"],
-            "chat_template": "custom",
-            "chat_template_kwargs": {"key": "val"}
+            "chat_template": "custom"
         }"#;
 
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json).unwrap();
@@ -2205,11 +2204,6 @@ mod tests {
         );
         assert!(request.unsupported_fields.contains_key("documents"));
         assert!(request.unsupported_fields.contains_key("chat_template"));
-        assert!(
-            request
-                .unsupported_fields
-                .contains_key("chat_template_kwargs")
-        );
 
         let result = validate_chat_completion_fields_generic(&request);
         assert!(result.is_err());
@@ -2221,7 +2215,6 @@ mod tests {
             assert!(msg.contains("add_special_tokens"));
             assert!(msg.contains("documents"));
             assert!(msg.contains("chat_template"));
-            assert!(msg.contains("chat_template_kwargs"));
         }
     }
 

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -44,7 +44,8 @@ pub struct NvCreateChatCompletionRequest {
     pub nvext: Option<NvExt>,
 
     /// Extra args to pass to the chat template rendering context
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Also accepts "chat_template_kwargs" as an alias for compatibility
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "chat_template_kwargs")]
     pub chat_template_args: Option<std::collections::HashMap<String, serde_json::Value>>,
 
     /// Runtime media decoding parameters.

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -45,7 +45,11 @@ pub struct NvCreateChatCompletionRequest {
 
     /// Extra args to pass to the chat template rendering context
     /// Also accepts "chat_template_kwargs" as an alias for compatibility
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "chat_template_kwargs")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "chat_template_kwargs"
+    )]
     pub chat_template_args: Option<std::collections::HashMap<String, serde_json::Value>>,
 
     /// Runtime media decoding parameters.

--- a/lib/llm/tests/test_chat_template_alias.rs
+++ b/lib/llm/tests/test_chat_template_alias.rs
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
+use dynamo_llm::preprocessor::prompt::PromptFormatter;
+use dynamo_llm::model_card::ModelDeploymentCard;
+
+// Common test template that uses enable_thinking variable
+const TEST_TEMPLATE: &str = r#"{%- for message in messages %}
+{%- if message['role'] == 'user' %}
+TEMPLATE_TEST{% if enable_thinking is defined and enable_thinking %}_THINKING{% endif %}| {{ message['content'] }}
+{%- elif message['role'] == 'assistant' %}
+<|assistant|>{{ message['content'] }}
+{%- endif %}
+{%- endfor %}
+<|assistant|>"#;
+
+#[test]
+fn test_chat_template_kwargs_alias() {
+    // Test that chat_template_kwargs is accepted as an alias
+    let json_with_kwargs = r#"{
+        "model": "test-model",
+        "messages": [],
+        "chat_template_kwargs": {
+            "enable_thinking": false
+        }
+    }"#;
+
+    let request: NvCreateChatCompletionRequest = serde_json::from_str(json_with_kwargs).unwrap();
+    assert!(request.chat_template_args.is_some());
+    assert_eq!(
+        request.chat_template_args.unwrap().get("enable_thinking"),
+        Some(&serde_json::json!(false))
+    );
+}
+
+#[test]
+fn test_chat_template_args_still_works() {
+    // Test that chat_template_args still works
+    let json_with_args = r#"{
+        "model": "test-model",
+        "messages": [],
+        "chat_template_args": {
+            "enable_thinking": true
+        }
+    }"#;
+
+    let request: NvCreateChatCompletionRequest = serde_json::from_str(json_with_args).unwrap();
+    assert!(request.chat_template_args.is_some());
+    assert_eq!(
+        request.chat_template_args.unwrap().get("enable_thinking"),
+        Some(&serde_json::json!(true))
+    );
+}
+
+#[test]
+fn test_both_fields_fails() {
+    // Test that when both are present, serde will fail with duplicate field error
+    // This test documents that behavior
+    let json_with_both = r#"{
+        "model": "test-model",
+        "messages": [],
+        "chat_template_args": {
+            "enable_thinking": true
+        },
+        "chat_template_kwargs": {
+            "enable_thinking": false
+        }
+    }"#;
+
+    // This will fail with duplicate field error
+    let result: Result<NvCreateChatCompletionRequest, _> = serde_json::from_str(json_with_both);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_template_rendering() {
+    // Test that both chat_template_args and chat_template_kwargs work in template rendering
+    
+    // Create formatter with common template
+    let mut mdc = ModelDeploymentCard::new("test-model".to_string());
+    mdc.set_chat_template(TEST_TEMPLATE.to_string());
+    
+    let formatter = match PromptFormatter::from_mdc(&mdc) {
+        Ok(PromptFormatter::OAI(formatter)) => formatter,
+        _ => {
+            println!("Skipping template test - unable to create OAI formatter");
+            return;
+        }
+    };
+
+    // Test cases: both field names with enable_thinking true/false
+    let test_cases = [
+        (r#"{
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }"#, false, "no template args"),
+        
+        (r#"{
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "chat_template_args": {
+                "enable_thinking": false
+            }
+        }"#, false, "chat_template_args with false"),
+        
+        (r#"{
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "chat_template_args": {
+                "enable_thinking": true
+            }
+        }"#, true, "chat_template_args with true"),
+        
+        (r#"{
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "chat_template_kwargs": {
+                "enable_thinking": false
+            }
+        }"#, false, "chat_template_kwargs with false"),
+        
+        (r#"{
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "chat_template_kwargs": {
+                "enable_thinking": true
+            }
+        }"#, true, "chat_template_kwargs with true"),
+    ];
+
+    for (json_request, expect_thinking, description) in test_cases {
+        // Parse request from JSON
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_request)
+            .unwrap_or_else(|e| panic!("Failed to parse {}: {}", description, e));
+        
+        // Render template
+        let output = formatter.render(&request)
+            .unwrap_or_else(|e| panic!("Failed to render {}: {}", description, e));
+        
+        // Verify output based on enable_thinking value
+        if expect_thinking {
+            assert!(output.contains("TEMPLATE_TEST_THINKING|"), 
+                "Expected _THINKING in output for {}, got: {}", description, output);
+        } else {
+            assert!(output.contains("TEMPLATE_TEST|"), 
+                "Expected base template marker for {}, got: {}", description, output);
+            assert!(!output.contains("_THINKING"), 
+                "Unexpected _THINKING in output for {}, got: {}", description, output);
+        }
+        
+        // All should contain the message content
+        assert!(output.contains("Hello"), 
+            "Expected 'Hello' in output for {}, got: {}", description, output);
+        
+        println!("✓ {} - output: {}", description, output.trim());
+    }
+}

--- a/lib/llm/tests/test_chat_template_alias.rs
+++ b/lib/llm/tests/test_chat_template_alias.rs
@@ -2,18 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
-use dynamo_llm::preprocessor::prompt::PromptFormatter;
-use dynamo_llm::model_card::ModelDeploymentCard;
-
-// Common test template that uses enable_thinking variable
-const TEST_TEMPLATE: &str = r#"{%- for message in messages %}
-{%- if message['role'] == 'user' %}
-TEMPLATE_TEST{% if enable_thinking is defined and enable_thinking %}_THINKING{% endif %}| {{ message['content'] }}
-{%- elif message['role'] == 'assistant' %}
-<|assistant|>{{ message['content'] }}
-{%- endif %}
-{%- endfor %}
-<|assistant|>"#;
 
 #[test]
 fn test_chat_template_kwargs_alias() {
@@ -76,83 +64,107 @@ fn test_both_fields_fails() {
 #[test]
 fn test_template_rendering() {
     // Test that both chat_template_args and chat_template_kwargs work in template rendering
-    
-    // Create formatter with common template
-    let mut mdc = ModelDeploymentCard::new("test-model".to_string());
-    mdc.set_chat_template(TEST_TEMPLATE.to_string());
-    
-    let formatter = match PromptFormatter::from_mdc(&mdc) {
-        Ok(PromptFormatter::OAI(formatter)) => formatter,
-        _ => {
-            println!("Skipping template test - unable to create OAI formatter");
-            return;
-        }
-    };
+    // This is a simplified test that focuses on the alias functionality
+    // without requiring complex template setup
 
     // Test cases: both field names with enable_thinking true/false
     let test_cases = [
-        (r#"{
+        (
+            r#"{
             "model": "test-model",
             "messages": [{"role": "user", "content": "Hello"}]
-        }"#, false, "no template args"),
-        
-        (r#"{
+        }"#,
+            None,
+            "no template args",
+        ),
+        (
+            r#"{
             "model": "test-model",
             "messages": [{"role": "user", "content": "Hello"}],
             "chat_template_args": {
                 "enable_thinking": false
             }
-        }"#, false, "chat_template_args with false"),
-        
-        (r#"{
+        }"#,
+            Some(false),
+            "chat_template_args with false",
+        ),
+        (
+            r#"{
             "model": "test-model",
             "messages": [{"role": "user", "content": "Hello"}],
             "chat_template_args": {
                 "enable_thinking": true
             }
-        }"#, true, "chat_template_args with true"),
-        
-        (r#"{
+        }"#,
+            Some(true),
+            "chat_template_args with true",
+        ),
+        (
+            r#"{
             "model": "test-model",
             "messages": [{"role": "user", "content": "Hello"}],
             "chat_template_kwargs": {
                 "enable_thinking": false
             }
-        }"#, false, "chat_template_kwargs with false"),
-        
-        (r#"{
+        }"#,
+            Some(false),
+            "chat_template_kwargs with false",
+        ),
+        (
+            r#"{
             "model": "test-model",
             "messages": [{"role": "user", "content": "Hello"}],
             "chat_template_kwargs": {
                 "enable_thinking": true
             }
-        }"#, true, "chat_template_kwargs with true"),
+        }"#,
+            Some(true),
+            "chat_template_kwargs with true",
+        ),
     ];
 
-    for (json_request, expect_thinking, description) in test_cases {
+    for (json_request, expected_enable_thinking, description) in test_cases {
         // Parse request from JSON
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json_request)
             .unwrap_or_else(|e| panic!("Failed to parse {}: {}", description, e));
-        
-        // Render template
-        let output = formatter.render(&request)
-            .unwrap_or_else(|e| panic!("Failed to render {}: {}", description, e));
-        
-        // Verify output based on enable_thinking value
-        if expect_thinking {
-            assert!(output.contains("TEMPLATE_TEST_THINKING|"), 
-                "Expected _THINKING in output for {}, got: {}", description, output);
-        } else {
-            assert!(output.contains("TEMPLATE_TEST|"), 
-                "Expected base template marker for {}, got: {}", description, output);
-            assert!(!output.contains("_THINKING"), 
-                "Unexpected _THINKING in output for {}, got: {}", description, output);
+
+        // Verify that chat_template_args is populated correctly (this is the key test)
+        match expected_enable_thinking {
+            None => {
+                assert!(
+                    request.chat_template_args.is_none(),
+                    "Expected no chat_template_args for {}, got: {:?}",
+                    description,
+                    request.chat_template_args
+                );
+            }
+            Some(expected_value) => {
+                let args = request
+                    .chat_template_args
+                    .as_ref()
+                    .expect(&format!("Expected chat_template_args for {}", description));
+
+                let enable_thinking = args.get("enable_thinking").expect(&format!(
+                    "Expected enable_thinking in args for {}",
+                    description
+                ));
+
+                let actual_value = enable_thinking.as_bool().expect(&format!(
+                    "Expected enable_thinking to be boolean for {}",
+                    description
+                ));
+
+                assert_eq!(
+                    actual_value, expected_value,
+                    "Expected enable_thinking={} for {}, got: {}",
+                    expected_value, description, actual_value
+                );
+            }
         }
-        
-        // All should contain the message content
-        assert!(output.contains("Hello"), 
-            "Expected 'Hello' in output for {}, got: {}", description, output);
-        
-        println!("✓ {} - output: {}", description, output.trim());
+
+        println!(
+            "✓ {} - chat_template_args: {:?}",
+            description, request.chat_template_args
+        );
     }
 }

--- a/lib/llm/tests/test_chat_template_args.rs
+++ b/lib/llm/tests/test_chat_template_args.rs
@@ -3,7 +3,6 @@
 
 use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
 
-
 #[test]
 fn test_both_fields_fails() {
     // Test that when both are present, serde will fail with duplicate field error

--- a/lib/llm/tests/test_chat_template_args.rs
+++ b/lib/llm/tests/test_chat_template_args.rs
@@ -3,43 +3,6 @@
 
 use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
 
-#[test]
-fn test_chat_template_kwargs_alias() {
-    // Test that chat_template_kwargs is accepted as an alias
-    let json_with_kwargs = r#"{
-        "model": "test-model",
-        "messages": [],
-        "chat_template_kwargs": {
-            "enable_thinking": false
-        }
-    }"#;
-
-    let request: NvCreateChatCompletionRequest = serde_json::from_str(json_with_kwargs).unwrap();
-    assert!(request.chat_template_args.is_some());
-    assert_eq!(
-        request.chat_template_args.unwrap().get("enable_thinking"),
-        Some(&serde_json::json!(false))
-    );
-}
-
-#[test]
-fn test_chat_template_args_still_works() {
-    // Test that chat_template_args still works
-    let json_with_args = r#"{
-        "model": "test-model",
-        "messages": [],
-        "chat_template_args": {
-            "enable_thinking": true
-        }
-    }"#;
-
-    let request: NvCreateChatCompletionRequest = serde_json::from_str(json_with_args).unwrap();
-    assert!(request.chat_template_args.is_some());
-    assert_eq!(
-        request.chat_template_args.unwrap().get("enable_thinking"),
-        Some(&serde_json::json!(true))
-    );
-}
 
 #[test]
 fn test_both_fields_fails() {
@@ -62,10 +25,9 @@ fn test_both_fields_fails() {
 }
 
 #[test]
-fn test_template_rendering() {
-    // Test that both chat_template_args and chat_template_kwargs work in template rendering
-    // This is a simplified test that focuses on the alias functionality
-    // without requiring complex template setup
+fn test_chat_template_args_rendering() {
+    // Test that both chat_template_args and chat_template_kwargs work correctly
+    // This test covers all the alias functionality cases
 
     // Test cases: both field names with enable_thinking true/false
     let test_cases = [


### PR DESCRIPTION
## Summary
Adds `chat_template_kwargs` as an alias for `chat_template_args` to support users following vLLM conventions.

## Problem
- Users send `chat_template_kwargs` (vLLM convention)
- Dynamo frontend only accepts `chat_template_args`  
- Request fails with unsupported field error

## Solution
- Added serde `alias` attribute to accept both field names
- Minimal one-line change with no behavioral differences
- Both field names now work transparently

## Changes
- ✅ Added `alias = "chat_template_kwargs"` to field attribute
- ✅ Added Rust tests to verify both field names work

## Testing
```rust
// Both of these now work:
{ "chat_template_args": {"enable_thinking": false} }
{ "chat_template_kwargs": {"enable_thinking": false} }
```

## Related Issue
Fixes DYN-1650

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat completion requests now support `chat_template_kwargs` as an alternative parameter name for specifying template rendering context arguments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->