### PR TITLE
fix: trtllm has move to version 1.2+ to enable cuda graph testing; fixed path to config.yaml

### DIFF
--- a/tests/kvbm_integration/test_cuda_graph.py
+++ b/tests/kvbm_integration/test_cuda_graph.py
@@ -151,9 +151,6 @@ def send_completion_request(
 @pytest.mark.nightly
 @pytest.mark.slow
 @pytest.mark.gpu_1
-@pytest.mark.skip(
-    reason="Enable these tests once `main` dynamo upgrades to TRTLLM 1.2+"
-)
 def test_kvbm_without_cuda_graph_enabled(request, runtime_services):
     """
     End-to-end test for TRTLLM worker with cuda_graph_config not defined and
@@ -169,7 +166,7 @@ def test_kvbm_without_cuda_graph_enabled(request, runtime_services):
         logger.info("Frontend started.")
 
         engine_config_with_cuda_graph_and_kvbm = (
-            "tests/kvbm/engine_config_without_cuda_graph_and_kvbm.yaml"
+            "tests/kvbm_integration/engine_config_without_cuda_graph_and_kvbm.yaml"
         )
         logger.info("Starting worker...")
         with DynamoWorkerProcess(
@@ -190,9 +187,6 @@ def test_kvbm_without_cuda_graph_enabled(request, runtime_services):
 @pytest.mark.slow
 @pytest.mark.nightly
 @pytest.mark.gpu_1
-@pytest.mark.skip(
-    reason="Enable these tests once dynamo `main` upgrades to TRTLLM 1.2+"
-)
 def test_kvbm_with_cuda_graph_enabled(request, runtime_services):
     """
     End-to-end test for TRTLLM worker with cuda_graph_config defined and
@@ -208,7 +202,7 @@ def test_kvbm_with_cuda_graph_enabled(request, runtime_services):
         logger.info("Frontend started.")
 
         engine_config_with_cuda_graph_and_kvbm = (
-            "tests/kvbm/engine_config_with_cuda_graph_and_kvbm.yaml"
+            "tests/kvbm_integration/engine_config_with_cuda_graph_and_kvbm.yaml"
         )
         logger.info("Starting worker...")
         with DynamoWorkerProcess(

--- a/tests/kvbm_integration/test_cuda_graph.py
+++ b/tests/kvbm_integration/test_cuda_graph.py
@@ -165,12 +165,12 @@ def test_kvbm_without_cuda_graph_enabled(request, runtime_services):
     with DynamoFrontendProcess(request):
         logger.info("Frontend started.")
 
-        engine_config_with_cuda_graph_and_kvbm = (
+        engine_config_without_cuda_graph_and_kvbm = (
             "tests/kvbm_integration/engine_config_without_cuda_graph_and_kvbm.yaml"
         )
         logger.info("Starting worker...")
         with DynamoWorkerProcess(
-            request, "decode", engine_config_with_cuda_graph_and_kvbm
+            request, "decode", engine_config_without_cuda_graph_and_kvbm
         ) as worker:
             logger.info(f"Worker PID: {worker.get_pid()}")
 


### PR DESCRIPTION


#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This PR fixes the `kvbm_integration/test_cuda_graph.py` tests by (1) enabling them now that trtllm is 1.2+ on `main`, and (2) fixing the path to the config yamls used in the tests.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes DIS-1642


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled previously skipped integration tests to expand test coverage.
  * Updated test configuration file paths to align with reorganized integration test directory structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->