### PR TITLE
fix: Use conditional assignment for NATS_SERVER in launch scripts

### DIFF
--- a/examples/backends/sglang/launch/agg_router.sh
+++ b/examples/backends/sglang/launch/agg_router.sh
@@ -46,7 +46,7 @@ if [ "$ENABLE_OTEL" = true ]; then
 fi
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run ingress
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)

--- a/examples/backends/sglang/launch/disagg_router.sh
+++ b/examples/backends/sglang/launch/disagg_router.sh
@@ -47,7 +47,7 @@ if [ "$ENABLE_OTEL" = true ]; then
 fi
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # Start frontend with KV routing
 # The frontend will automatically detect prefill workers and activate an internal prefill router

--- a/examples/backends/sglang/launch/disagg_same_gpu.sh
+++ b/examples/backends/sglang/launch/disagg_same_gpu.sh
@@ -36,7 +36,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run ingress with KV router mode for disaggregated setup
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)

--- a/examples/backends/trtllm/launch/agg_router.sh
+++ b/examples/backends/trtllm/launch/agg_router.sh
@@ -18,7 +18,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run frontend
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)

--- a/examples/backends/trtllm/launch/disagg_router.sh
+++ b/examples/backends/trtllm/launch/disagg_router.sh
@@ -21,7 +21,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run frontend with KV routing for cache-aware optimization
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)

--- a/examples/backends/vllm/launch/agg_kvbm_router.sh
+++ b/examples/backends/vllm/launch/agg_kvbm_router.sh
@@ -11,7 +11,7 @@ export PYTHONHASHSEED=0
 MODEL="Qwen/Qwen3-0.6B"
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run frontend + KV router
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)

--- a/examples/backends/vllm/launch/agg_router.sh
+++ b/examples/backends/vllm/launch/agg_router.sh
@@ -12,7 +12,7 @@ MODEL="Qwen/Qwen3-0.6B"
 BLOCK_SIZE=64
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run frontend + KV router
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)

--- a/examples/backends/vllm/launch/dep.sh
+++ b/examples/backends/vllm/launch/dep.sh
@@ -5,7 +5,7 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run ingress
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)

--- a/examples/backends/vllm/launch/disagg_kvbm_2p2d.sh
+++ b/examples/backends/vllm/launch/disagg_kvbm_2p2d.sh
@@ -5,7 +5,7 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run ingress with KV router
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)

--- a/examples/backends/vllm/launch/disagg_kvbm_router.sh
+++ b/examples/backends/vllm/launch/disagg_kvbm_router.sh
@@ -11,7 +11,7 @@ export PYTHONHASHSEED=0
 MODEL="Qwen/Qwen3-0.6B"
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
 python -m dynamo.frontend \

--- a/examples/backends/vllm/launch/disagg_lmcache.sh
+++ b/examples/backends/vllm/launch/disagg_lmcache.sh
@@ -5,7 +5,7 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run ingress with KV router
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)

--- a/examples/backends/vllm/launch/disagg_router.sh
+++ b/examples/backends/vllm/launch/disagg_router.sh
@@ -12,7 +12,7 @@ MODEL="Qwen/Qwen3-0.6B"
 BLOCK_SIZE=64
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # Start frontend with KV routing
 # The frontend will automatically detect prefill workers and activate an internal prefill router

--- a/examples/backends/vllm/launch/disagg_router_gaudi.sh
+++ b/examples/backends/vllm/launch/disagg_router_gaudi.sh
@@ -17,7 +17,7 @@ NIXL_BUFFER_DEVICE=cpu
 VLLM_NIXL_BACKEND=UCX
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # Start frontend with KV routing
 # The frontend will automatically detect prefill workers and activate an internal prefill router

--- a/examples/backends/vllm/launch/dsr1_dep.sh
+++ b/examples/backends/vllm/launch/dsr1_dep.sh
@@ -82,7 +82,7 @@ echo "  Model name: $MODEL"
 trap 'echo Cleaning up...; kill 0' EXIT
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run ingress if it's node 0
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)

--- a/examples/backends/vllm/launch/lora/agg_lora_router.sh
+++ b/examples/backends/vllm/launch/lora/agg_lora_router.sh
@@ -24,7 +24,7 @@ MODEL="Qwen/Qwen3-0.6B"
 BLOCK_SIZE=64
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="nats://localhost:4222"
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
 
 # run frontend + KV router
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)


### PR DESCRIPTION
## Summary
- Update 15 launch scripts to use conditional assignment for NATS_SERVER
- Only sets NATS_SERVER if not already defined, allowing environment variable override
- Preserves existing HEAD_NODE_IP pattern in multinode srun scripts

## Changes
Modified launch scripts to use `${NATS_SERVER:-nats://localhost:4222}` instead of hardcoded assignment for:
- trtllm launch scripts (2 files)
- sglang launch scripts (3 files) 
- vllm launch scripts (10 files)

## Test plan
- [x] Verify all localhost pattern scripts use conditional assignment
- [x] Verify srun scripts with HEAD_NODE_IP pattern remain unchanged
- [x] Scripts maintain backward compatibility (default behavior unchanged)
- [ ] Test that environment variable override works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)