### PR TITLE
fix: Use MASTER_ADDR for NATS_SERVER in multinode dsr1_dep script

### DIFF
--- a/examples/backends/vllm/launch/dsr1_dep.sh
+++ b/examples/backends/vllm/launch/dsr1_dep.sh
@@ -82,7 +82,7 @@ echo "  Model name: $MODEL"
 trap 'echo Cleaning up...; kill 0' EXIT
 
 # Explicitly set NATS server for KV event publishing
-export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
+export NATS_SERVER="${NATS_SERVER:-nats://${MASTER_ADDR}:4222}"
 
 # run ingress if it's node 0
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)


### PR DESCRIPTION
## Summary
- Update `dsr1_dep.sh` to use `MASTER_ADDR` instead of `localhost` for NATS_SERVER in multinode deployments
- Ensures proper NATS connectivity when the master node is on a different host
- Maintains backward compatibility with localhost default

## Background
The `dsr1_dep.sh` script supports multinode deployments via the `--master-addr` parameter, but was still hardcoded to use `localhost` for NATS_SERVER. This caused connectivity issues in true multinode scenarios where worker nodes needed to connect to NATS on the master node.

## Changes
- Modified NATS_SERVER assignment from `${NATS_SERVER:-nats://localhost:4222}` to `${NATS_SERVER:-nats://${MASTER_ADDR}:4222}`
- Leverages existing `MASTER_ADDR` variable that defaults to "localhost" but can be overridden via `--master-addr` flag

## Test plan
- [x] Verify single node deployment still works (MASTER_ADDR defaults to localhost)
- [x] Verify multinode deployment can use custom master address
- [x] Verify environment variable override still works via NATS_SERVER
- [ ] Test actual multinode deployment with worker nodes connecting to master NATS

## Compatibility
✅ **Fully backward compatible**
- Single node: Works exactly as before (MASTER_ADDR="localhost" by default)  
- Custom NATS: Can still override via NATS_SERVER environment variable
- Multinode: Now properly uses the specified master node address

🤖 Generated with [Claude Code](https://claude.ai/code)