### PR TITLE
fix: OTEL_EXPORT_ENABLED truthy values support (#5129) (Cherry Pick)

### DIFF
--- a/lib/bindings/kvbm/src/lib.rs
+++ b/lib/bindings/kvbm/src/lib.rs
@@ -9,7 +9,7 @@ use std::{fmt::Display, sync::Arc};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-use dynamo_runtime::{self as rs, RuntimeConfig, logging, traits::DistributedRuntimeProvider};
+use dynamo_runtime::{self as rs, RuntimeConfig, logging, traits::DistributedRuntimeProvider, config};
 
 use dynamo_llm::{self as llm_rs};
 
@@ -23,9 +23,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Initialize tokio runtime first to avoid panics when OTEL_EXPORT_ENABLED=1
     init_pyo3_tokio_rt();
 
-    if std::env::var("OTEL_EXPORT_ENABLED")
-        .map(|v| v == "1")
-        .unwrap_or(false)
+    if config::env_is_truthy("OTEL_EXPORT_ENABLED")
     {
         // OTLP batch exporter needs runtime context to spawn background tasks
         let handle = get_current_tokio_handle();

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -22,6 +22,7 @@ use std::{
 use tokio::sync::Mutex;
 use tracing::Instrument;
 
+use dynamo_runtime::config;
 use dynamo_runtime::config::environment_names::logging::otlp as env_otlp;
 use dynamo_runtime::{
     self as rs, logging,
@@ -126,10 +127,7 @@ fn create_request_context(
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Initialize logging early unless OTEL export is enabled (which requires tokio runtime)
-    if std::env::var(env_otlp::OTEL_EXPORT_ENABLED)
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
+    if config::env_is_truthy(env_otlp::OTEL_EXPORT_ENABLED) {
         eprintln!(
             "Warning: OTEL_EXPORT_ENABLED detected. Logging initialization deferred until runtime is available. Early logs may be dropped."
         );
@@ -562,10 +560,7 @@ impl DistributedRuntime {
 
         // Initialize logging in context where tokio runtime is available
         // otel exporter requires it
-        if std::env::var(env_otlp::OTEL_EXPORT_ENABLED)
-            .map(|v| v == "1")
-            .unwrap_or(false)
-        {
+        if config::env_is_truthy(env_otlp::OTEL_EXPORT_ENABLED) {
             runtime.secondary().block_on(async {
                 rs::logging::init();
             });


### PR DESCRIPTION
## Summary
Cherry-pick of PR #5129 to `release/0.8.0` branch.

**Original PR**: https://github.com/ai-dynamo/dynamo/pull/5129  
**Issues Fixed**: DYN-1690, DYN-1646

## Problem
Setting `OTEL_EXPORT_ENABLED=true` caused Tokio runtime panics during module import due to inconsistent environment variable validation between bindings and runtime layers.

## Root Cause
- **Bindings layer**: Used hardcoded check `v == "1"` only
- **Runtime layer**: Used `env_is_truthy()` accepting multiple values (`true`, `1`, `on`, `yes`)

This mismatch caused bindings to initialize logging immediately when `OTEL_EXPORT_ENABLED=true`, but runtime would try to create OTLP exporters requiring Tokio context → **"no reactor running" panic**.

## Solution 
Change hardcoded `v == "1"` checks to use `config::env_is_truthy()` for consistency.

## Files Changed
- `lib/bindings/python/rust/lib.rs`: Use `config::env_is_truthy()`
- `lib/bindings/kvbm/src/lib.rs`: Use `config::env_is_truthy()`

## Impact
✅ **Users can now use `OTEL_EXPORT_ENABLED=true` as documented without panics**  
✅ **All truthy values work consistently**: `true`, `TRUE`, `True`, `1`, `on`, `yes`  
✅ **No breaking changes**: Existing `OTEL_EXPORT_ENABLED=1` continues to work

## Cherry-pick Details
- **Commit**: `5b3d1334102d1f6c1bcec97643dc1d840fce2cfe`
- **Clean cherry-pick**: No conflicts
- **Target**: `release/0.8.0` branch

🤖 Generated with [Claude Code](https://claude.ai/code)