### PR TITLE
fix: Allow requests to include audio contents before text

### DIFF
--- a/examples/multimodal/components/processor.py
+++ b/examples/multimodal/components/processor.py
@@ -204,11 +204,15 @@ class Processor(ProcessMixIn):
         if "<prompt>" not in template:
             raise ValueError("prompt_template must contain '<prompt>' placeholder")
 
-        # Safely extract user text
-        try:
-            user_text = raw_request.messages[0].content[0].text
-        except (IndexError, AttributeError) as e:
-            raise ValueError(f"Invalid message structure: {e}")
+        # Safely extract user text - find the text content item
+        user_text = None
+        for message in raw_request.messages:
+            for item in message.content:
+                if item.type == "text":
+                    user_text = item.text
+                    break
+        if user_text is None:
+            raise ValueError("No text content found in the request messages")
 
         prompt = template.replace("<prompt>", user_text)
 


### PR DESCRIPTION
#### Overview:

Relaxes the search for text content in multimodal request.

#### Details:


The multimodal processor raises ValueError: Invalid message structure: 'AudioContent' object has no attribute 'text' when processing requests where the text content is not the first item in the content array.
The [processor.py](https://github.com/ai-dynamo/dynamo/blob/release/0.8.0/examples/multimodal/components/processor.py) hardcodes access to content[0].text, assuming the first content item in a multimodal request is always of type text. However, according to the OpenAI multimodal API specification, the content array can contain items in any order. When audio/image/video content appears before text content, the processor fails.

The change removes the restriction that text should appear before audio.

#### Where should the reviewer start?

processor.py



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message parsing to handle varying content structures more reliably, reducing the risk of extraction failures when processing different message formats. Enhanced error handling to provide clear feedback when expected content is not found.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->