### PR TITLE
fix: increase gpu-memory-utilization to 0.95 for dsr1_dep

### DIFF
--- a/examples/backends/vllm/launch/dsr1_dep.sh
+++ b/examples/backends/vllm/launch/dsr1_dep.sh
@@ -107,7 +107,7 @@ for ((i=0; i<GPUS_PER_NODE; i++)); do
         --max-model-len 4096 \
         --data-parallel-address $MASTER_ADDR \
         --data-parallel-rpc-port 13345 \
-        --gpu-memory-utilization 0.9 \
+        --gpu-memory-utilization 0.95 \
         --enforce-eager 2>&1 | tee $LOG_DIR/dsr1_dep_${dp_rank}.log &
 done
 


### PR DESCRIPTION
## Summary
- Increases `--gpu-memory-utilization` from 0.9 to 0.95 in dsr1_dep.sh launch script

## Problem
vLLM 0.12.0 + DeepEP 1.2.1 increased non-torch forward memory by ~1.15 GiB compared to vLLM 0.11.0, causing KV cache allocation to fail with negative available memory (-0.48 GiB).

| Metric                      | 0.7.1       | 0.8.0       | Diff       |
|-----------------------------|-------------|-------------|------------|
| vLLM Version                | 0.11.0      | 0.12.0      | -          |
| DeepEP Version              | 1.1.0       | 1.2.1       | -          |
| non-torch forward increase  | 6.32 GiB    | 7.47 GiB    | +1.15 GiB  |
| Total non KV cache memory   | 70.37 GiB   | 71.68 GiB   | +1.31 GiB  |
| Available KV cache          | 0.83 GiB    | -0.48 GiB   | -1.31 GiB  |

## Solution
Increasing gpu-memory-utilization from 0.9 to 0.95 recovers ~4 GiB on 80GB GPUs.

| Metric | Before (0.9) | After (0.95) |
|--------|--------------|--------------|
| Available KV cache | -0.48 GiB | 3.47 GiB |
| Status | FAILED | SUCCESS |

## Test plan
- [x] Reproduced the bug with 0.9 gpu-memory-utilization on 2-node H100 cluster
- [x] Verified fix with 0.95 gpu-memory-utilization - KV cache allocation succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GPU memory utilization threshold from 90% to 95% for optimized resource allocation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->