### PR TITLE
fix: sglang metrics and prefill router fix

### DIFF
--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -245,6 +245,7 @@ def setup_prometheus_registry(
         endpoint=generate_endpoint,
         registry=registry,
         metric_prefix_filters=["sglang:"],
+        add_prefix="sglang_",
     )
     return registry
 

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -96,6 +96,21 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             bootstrap_room = self._generate_bootstrap_room()
             logging.debug(f"Generated bootstrap_room locally: {bootstrap_room}")
 
+        bootstrap_info = {
+            "bootstrap_host": self.bootstrap_host,
+            "bootstrap_port": self.bootstrap_port,
+            "bootstrap_room": bootstrap_room,
+        }
+
+        # Yield bootstrap_info for PrefillRouter - required for async generator contract
+        # and Rust-side expects disaggregated_params in first output
+        yield {
+            "token_ids": [],
+            "text": None,
+            "finish_reason": None,
+            "disaggregated_params": bootstrap_info,
+        }
+
         input_param = self._get_input_param(inner_request)
 
         # Propagate trace context to SGLang

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -560,7 +560,7 @@ class MetricsPayload(BasePayload):
                 MetricCheck(
                     # Check: Minimum count of unique sglang:* metrics
                     name="sglang_*",
-                    pattern=lambda name: r"^sglang:\w+",
+                    pattern=lambda name: r"^sglang_\w+",
                     validator=lambda value: len(set(value))
                     >= 20,  # 80% of typical ~25 sglang metrics (excluding _bucket) as of 2025-10-22 (but will grow)
                     error_msg=lambda name, value: f"Expected at least 20 unique sglang:* metrics, but found only {len(set(value))}",

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -559,7 +559,7 @@ class MetricsPayload(BasePayload):
             metrics_to_check.append(
                 MetricCheck(
                     # Check: Minimum count of unique sglang:* metrics
-                    name="sglang:*",
+                    name="sglang_*",
                     pattern=lambda name: r"^sglang:\w+",
                     validator=lambda value: len(set(value))
                     >= 20,  # 80% of typical ~25 sglang metrics (excluding _bucket) as of 2025-10-22 (but will grow)


### PR DESCRIPTION
This PR addresses two issues: 
1. SGLang metrics were using sglang: prefix with colon separator while Dynamo metrics use underscore convention (dynamo_component_*), making it difficult to query all metrics together in Grafana. Added add_prefix="sglang_" to register_engine_metrics_callback() in publisher.py to transform metrics like sglang:num_running_reqs to sglang_num_running_reqs.
2. Restores the yield statement in PrefillWorkerHandler.generate() that was inadvertently removed in PR #5121, which broke disaggregated serving with 'coroutine' object has no attribute '__anext__' error. The yield is required because the Rust-side execute_prefill() expects an async generator with disaggregated_params in the first output, and the Python handler must still execute to generate KV cache even when bootstrap optimization pre-computes routing metadata.