### PR TITLE
feat: Support a dynamic default max_tokens for TensorRT-LLM backend

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -81,6 +81,7 @@ class RequestHandlerConfig:
     encoder_cache_capacity_gb: float = 0  # Encoder cache capacity in GB
     disable_request_abort: bool = True
     additional_metrics: Optional["AdditionalMetricsCollector"] = None
+    max_seq_len: Optional[int] = None
 
 
 class HandlerBase(BaseGenerativeHandler):
@@ -111,6 +112,7 @@ class HandlerBase(BaseGenerativeHandler):
         self.shutdown_event = config.shutdown_event
         self.disable_request_abort = config.disable_request_abort
         self.additional_metrics = config.additional_metrics
+        self.max_seq_len = config.max_seq_len
 
     def check_error(self, result: dict) -> bool:
         """
@@ -749,8 +751,18 @@ class HandlerBase(BaseGenerativeHandler):
                     )
 
         max_tokens = request["stop_conditions"]["max_tokens"]
-        if max_tokens:
+        if max_tokens is not None:
             sampling_params.max_tokens = max_tokens
+        elif self.max_seq_len is not None:
+            if self.multimodal_processor and processed_input is not None:
+                logging.debug(
+                    "Skipping dynamic max_tokens default for multimodal request..."
+                )
+            else:
+                token_ids = request.get("token_ids", [])
+                input_length = len(token_ids)
+                dynamic_default = max(1, self.max_seq_len - input_length)
+                sampling_params.max_tokens = dynamic_default
 
         ignore_eos = request["stop_conditions"].get("ignore_eos")
         if ignore_eos:

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -478,6 +478,7 @@ async def init_llm_worker(
             encoder_cache_capacity_gb=config.multimodal_embedding_cache_capacity_gb,
             disable_request_abort=config.disable_request_abort,
             additional_metrics=additional_metrics,
+            max_seq_len=config.max_seq_len,
         )
 
         # Register the model with runtime config


### PR DESCRIPTION
## Overview

When `max_tokens` is not specified in a request, the TensorRT-LLM backend uses `SamplingParams()` default of 32 tokens. This is too low for many use cases, especially reasoning models like GPT-OSS which need to generate thinking content before producing the final answer.

This causes incomplete responses where generation stops mid-reasoning with `finish_reason: "length"`, never reaching the final output.

## Solution

This PR mirrors the fix applied to the vLLM backend in #4156 by calculating a dynamic default `max_tokens` based on the model's `max_seq_len` minus the input length:

```python
dynamic_default = max(1, self.max_seq_len - input_length)
```

## Changes

- Add `max_seq_len: Optional[int]` to `RequestHandlerConfig` dataclass
- Store `max_seq_len` in `HandlerBase.__init__`
- Calculate dynamic default in `generate_locally()` when `max_tokens` is not provided
- Pass `max_seq_len` from config in `main.py`

## Where should the reviewer start?

`components/src/dynamo/trtllm/request_handlers/handler_base.py` - the core logic is in `generate_locally()`

## Testing

Tested with GPT-OSS 120B reasoning model:
- **Before**: Generation stops after ~32 tokens with `finish_reason: "length"`, never producing final answer
- **After**: Full reasoning + final answer generated with `finish_reason: "stop"`

## Related

- #4156 - Same fix for vLLM backend (this PR brings parity to TensorRT-LLM)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic maximum token calculation. When maximum tokens are not explicitly specified, the system now automatically computes an optimal value based on the configured sequence length limit and input length, improving token generation management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->