### PR TITLE
fix: fix lora script name in docs and update setup_minio.sh script to work across HF cli package versions

### DIFF
--- a/examples/backends/vllm/launch/lora/README.md
+++ b/examples/backends/vllm/launch/lora/README.md
@@ -75,7 +75,7 @@ LORA_NAME="my-lora" \
 Start the Dynamo frontend and worker with LoRA support enabled:
 
 ```bash
-./agg_lora_s3.sh
+./agg_lora.sh
 ```
 
 This will:
@@ -259,7 +259,7 @@ curl -X POST http://localhost:8081/v1/loras \
 
 ### Using Different Base Models
 
-To use a different base model, modify the `--model` parameter in `agg_lora_s3.sh`:
+To use a different base model, modify the `--model` parameter in `agg_lora.sh`:
 
 ```bash
 python -m dynamo.vllm --model meta-llama/Llama-2-7b-hf --enable-lora --max-lora-rank 64
@@ -271,7 +271,7 @@ Ensure your LoRAs are compatible with the chosen base model.
 
 ### Stop Services
 
-Press `Ctrl+C` in the terminal running `agg_lora_s3.sh` to stop Dynamo services.
+Press `Ctrl+C` in the terminal running `agg_lora.sh` to stop Dynamo services.
 
 ### Stop MinIO
 


### PR DESCRIPTION
#### Overview:

1. fix lora script name (from incorrect: `agg_lora_s3` to correct: `agg_lora.sh`) in docs

2. update `setup_minio.sh` script to work across HF cli package versions
Starting from HF v0.34.0, the `huggingface-cli` command is deprecated in favor of `hf`.
Please refer to https://huggingface.co/blog/hf-cli for more details.


- closes DYN-1663
- fixes : https://nvbugspro.nvidia.com/bug/5767516


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LoRA setup documentation with corrected script references throughout guides.

* **Improvements**
  * Enhanced automatic detection of Hugging Face CLI variants during setup.
  * Improved LoRA download logic to dynamically select the appropriate CLI tool.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->