### PR TITLE
fix: handle race condition during concurrent LoRA load calls

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import os
 import tempfile
+import threading
 import time
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
@@ -256,6 +257,8 @@ class BaseWorkerHandler(ABC):
         self.lora_name_to_path: dict[str, str] = {}
         # Per-LoRA locks to prevent concurrent load operations for the same LoRA
         self._lora_load_locks: dict[str, asyncio.Lock] = {}
+        # Guard lock-map access in case handlers are invoked from multiple threads.
+        self._lora_load_locks_guard = threading.Lock()
 
         self.use_vllm_tokenizer = use_vllm_tokenizer
 
@@ -310,6 +313,15 @@ class BaseWorkerHandler(ABC):
         """Add a temporary directory to be cleaned up later."""
         if temp_dir is not None:
             self.temp_dirs.append(temp_dir)
+
+    def _get_lora_lock(self, lora_name: str) -> asyncio.Lock:
+        """Get/create the per-LoRA lock without eagerly allocating a new lock each call."""
+        with self._lora_load_locks_guard:
+            lock = self._lora_load_locks.get(lora_name)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._lora_load_locks[lora_name] = lock
+            return lock
 
     async def load_lora(self, request=None):
         """
@@ -372,131 +384,142 @@ class BaseWorkerHandler(ABC):
                 }
                 return
 
-            # Acquire per-LoRA lock to prevent concurrent load operations for the same LoRA
-            async with self._lora_load_locks.setdefault(lora_name, asyncio.Lock()):
-                # Check if already loaded (idempotency check after acquiring lock)
-                # Another concurrent request may have loaded this LoRA while we waited
-                if lora_name in self.lora_id_for_name:
-                    lora_id = self.lora_id_for_name[lora_name]
+            # Serialize load/unload operations per lora_name.
+            lock = self._get_lora_lock(lora_name)
+            async with lock:
+                try:
+                    # Check if already loaded (idempotency check after acquiring lock).
+                    # Another concurrent request may have loaded this LoRA while we waited.
+                    if lora_name in self.lora_id_for_name:
+                        lora_id = self.lora_id_for_name[lora_name]
+                        logger.info(
+                            f"LoRA adapter already loaded (concurrent request completed): "
+                            f"{lora_name} with ID {lora_id}"
+                        )
+                        yield {
+                            "status": "success",
+                            "message": f"LoRA adapter '{lora_name}' already loaded",
+                            "lora_name": lora_name,
+                            "lora_id": lora_id,
+                        }
+                        return
+
                     logger.info(
-                        f"LoRA adapter already loaded (concurrent request completed): "
-                        f"{lora_name} with ID {lora_id}"
+                        f"Downloading LoRA adapter: {lora_name} from {lora_uri}"
                     )
+                    download_result = await lora_manager.download_lora(lora_uri)
+
+                    if download_result["status"] != "success":
+                        yield {
+                            "status": "error",
+                            "message": f"Failed to download LoRA: {download_result.get('message', 'Unknown error')}",
+                        }
+                        return
+
+                    lora_path = download_result["local_path"]
+                    logger.debug(f"LoRA downloaded to: {lora_path}")
+
+                    # Generate deterministic ID from lora_name before using it
+                    lora_id = lora_name_to_id(lora_name)
+
+                    # Add the LoRA to the engine
+                    await self.engine_client.add_lora(
+                        LoRARequest(
+                            lora_name=lora_name,
+                            lora_int_id=lora_id,
+                            lora_path=lora_path,
+                        )
+                    )
+
+                    # Track the LoRA
+                    self.lora_id_for_name[lora_name] = lora_id
+                    self.lora_name_to_path[lora_name] = lora_path
+                    logger.info(
+                        f"Successfully loaded LoRA adapter: {lora_name} with ID {lora_id}"
+                    )
+
+                    # Publish LoRA as a ModelDeploymentCard with format:
+                    # v1/mdc/{namespace}/{component}/{endpoint}/{instance_id}/{lora_slug}
+                    # This allows the frontend to discover it and route correctly to the worker instance
+                    if self.generate_endpoint is not None and self.config is not None:
+                        logger.debug(
+                            f"Publishing LoRA '{lora_name}' ModelDeploymentCard to {self.generate_endpoint}"
+                        )
+                        try:
+                            logger.debug(
+                                f"Publishing LoRA '{lora_name}' ModelDeploymentCard"
+                            )
+
+                            # Mark this as a LoRA in user_data
+                            user_data = {
+                                "lora_adapter": True,
+                                "lora_id": lora_id,
+                            }
+
+                            # Publish with format: v1/mdc/dynamo/backend/generate/{instance_id}/{lora_slug}
+                            await register_llm(
+                                model_input=ModelInput.Tokens,
+                                model_type=ModelType.Chat | ModelType.Completions,
+                                endpoint=self.generate_endpoint,
+                                model_path=self.config.model,
+                                kv_cache_block_size=self.config.engine_args.block_size,
+                                user_data=user_data,
+                                lora_name=lora_name,
+                                base_model_path=self.config.model,
+                            )
+                            logger.info(
+                                f"Successfully published LoRA '{lora_name}' ModelDeploymentCard"
+                            )
+                        except Exception as e:
+                            logger.exception(
+                                f"Failed to publish LoRA {lora_name} ModelDeploymentCard: {e}"
+                            )
+
+                            # Rollback: remove the LoRA from the engine to maintain consistency
+                            try:
+                                logger.debug(
+                                    f"Rolling back: removing LoRA '{lora_name}' from engine"
+                                )
+                                await self.engine_client.remove_lora(lora_id)
+                                # Remove from tracking dictionaries
+                                if lora_name in self.lora_id_for_name:
+                                    del self.lora_id_for_name[lora_name]
+                                if lora_name in self.lora_name_to_path:
+                                    del self.lora_name_to_path[lora_name]
+                                logger.debug(
+                                    f"Successfully rolled back LoRA '{lora_name}'"
+                                )
+                            except Exception as rollback_error:
+                                logger.exception(
+                                    f"Failed to rollback LoRA {lora_name}: {rollback_error}"
+                                )
+
+                            # Return error status since registration failed
+                            yield {
+                                "status": "error",
+                                "message": f"Failed to register LoRA '{lora_name}' in discovery registry: {str(e)}",
+                                "lora_name": lora_name,
+                            }
+                            return
+                    else:
+                        logger.debug(
+                            f"Cannot publish LoRA '{lora_name}': generate_endpoint={self.generate_endpoint}, config={self.config}"
+                        )
+
                     yield {
                         "status": "success",
-                        "message": f"LoRA adapter '{lora_name}' already loaded",
+                        "message": f"LoRA adapter '{lora_name}' loaded successfully",
                         "lora_name": lora_name,
                         "lora_id": lora_id,
                     }
-                    return
-
-                logger.info(f"Downloading LoRA adapter: {lora_name} from {lora_uri}")
-                download_result = await lora_manager.download_lora(lora_uri)
-
-                if download_result["status"] != "success":
-                    yield {
-                        "status": "error",
-                        "message": f"Failed to download LoRA: {download_result.get('message', 'Unknown error')}",
-                    }
-                    return
-
-                lora_path = download_result["local_path"]
-                logger.debug(f"LoRA downloaded to: {lora_path}")
-
-                # Generate deterministic ID from lora_name before using it
-                lora_id = lora_name_to_id(lora_name)
-
-                # Add the LoRA to the engine
-                await self.engine_client.add_lora(
-                    LoRARequest(
-                        lora_name=lora_name, lora_int_id=lora_id, lora_path=lora_path
-                    )
-                )
-
-                # Track the LoRA
-                self.lora_id_for_name[lora_name] = lora_id
-                self.lora_name_to_path[lora_name] = lora_path
-                logger.info(
-                    f"Successfully loaded LoRA adapter: {lora_name} with ID {lora_id}"
-                )
-
-                # Publish LoRA as a ModelDeploymentCard with format:
-                # v1/mdc/{namespace}/{component}/{endpoint}/{instance_id}/{lora_slug}
-                # This allows the frontend to discover it and route correctly to the worker instance
-
-                if self.generate_endpoint is not None and self.config is not None:
-                    logger.debug(
-                        f"Publishing LoRA '{lora_name}' ModelDeploymentCard to {self.generate_endpoint}"
-                    )
-                    try:
-                        logger.debug(
-                            f"Publishing LoRA '{lora_name}' ModelDeploymentCard"
-                        )
-
-                        # Mark this as a LoRA in user_data
-                        user_data = {
-                            "lora_adapter": True,
-                            "lora_id": lora_id,
-                        }
-
-                        # Publish with format: v1/mdc/dynamo/backend/generate/{instance_id}/{lora_slug}
-                        await register_llm(
-                            model_input=ModelInput.Tokens,
-                            model_type=ModelType.Chat | ModelType.Completions,
-                            endpoint=self.generate_endpoint,
-                            model_path=self.config.model,
-                            kv_cache_block_size=self.config.engine_args.block_size,
-                            user_data=user_data,
-                            lora_name=lora_name,
-                            base_model_path=self.config.model,
-                        )
-                        logger.info(
-                            f"Successfully published LoRA '{lora_name}' ModelDeploymentCard"
-                        )
-                    except Exception as e:
-                        logger.exception(
-                            f"Failed to publish LoRA {lora_name} ModelDeploymentCard: {e}"
-                        )
-
-                        # Rollback: remove the LoRA from the engine to maintain consistency
-                        try:
-                            logger.debug(
-                                f"Rolling back: removing LoRA '{lora_name}' from engine"
-                            )
-                            await self.engine_client.remove_lora(lora_id)
-                            # Remove from tracking dictionaries
-                            if lora_name in self.lora_id_for_name:
-                                del self.lora_id_for_name[lora_name]
-                            if lora_name in self.lora_name_to_path:
-                                del self.lora_name_to_path[lora_name]
-                            # Clean up the per-LoRA lock to prevent memory accumulation
+                finally:
+                    # Avoid lock-map growth on failed loads: if this attempt did not leave the LoRA
+                    # loaded, remove the lock entry (best-effort).
+                    if lora_name not in self.lora_id_for_name:
+                        if self._lora_load_locks.get(lora_name) is lock:
                             self._lora_load_locks.pop(lora_name, None)
-                            logger.debug(f"Successfully rolled back LoRA '{lora_name}'")
-                        except Exception as rollback_error:
-                            logger.exception(
-                                f"Failed to rollback LoRA {lora_name}: {rollback_error}"
-                            )
-
-                        # Return error status since registration failed
-                        yield {
-                            "status": "error",
-                            "message": f"Failed to register LoRA '{lora_name}' in discovery registry: {str(e)}",
-                            "lora_name": lora_name,
-                        }
-                        return
-                else:
-                    logger.debug(
-                        f"Cannot publish LoRA '{lora_name}': generate_endpoint={self.generate_endpoint}, config={self.config}"
-                    )
-
-                yield {
-                    "status": "success",
-                    "message": f"LoRA adapter '{lora_name}' loaded successfully",
-                    "lora_name": lora_name,
-                    "lora_id": lora_id,
-                }
         except Exception as e:
-            logger.error(f"Failed to load LoRA adapter: {e}")
+            logger.exception(f"Failed to load LoRA adapter: {e}")
             yield {"status": "error", "message": str(e)}
 
     async def unload_lora(self, request=None):
@@ -522,92 +545,99 @@ class BaseWorkerHandler(ABC):
                 }
                 return
 
-            # Check if the LoRA exists
-            if lora_name not in self.lora_id_for_name:
-                yield {
-                    "status": "error",
-                    "message": f"LoRA adapter '{lora_name}' not found. Available LoRAs: {list(self.lora_id_for_name.keys())}",
-                }
-                return
-
-            logger.debug(f"Unloading LoRA adapter: {lora_name}")
-            lora_id = self.lora_id_for_name[lora_name]
-            lora_path = self.lora_name_to_path.get(lora_name)
-
-            await self.engine_client.remove_lora(lora_id)
-
-            # Remove from tracking dictionaries
-            del self.lora_id_for_name[lora_name]
-            if lora_name in self.lora_name_to_path:
-                del self.lora_name_to_path[lora_name]
-
-            # Unregister the LoRA model from the model registry (outside lock)
-            if self.generate_endpoint is not None:
-                logger.debug(f"Unregistering LoRA '{lora_name}' ModelDeploymentCard")
+            # Serialize load/unload operations per lora_name.
+            lock = self._get_lora_lock(lora_name)
+            async with lock:
                 try:
-                    await unregister_llm(
-                        endpoint=self.generate_endpoint,
-                        lora_name=lora_name,
-                    )
-                    logger.info(
-                        f"Successfully unregistered LoRA '{lora_name}' ModelDeploymentCard"
-                    )
-                except Exception as e:
-                    import traceback
+                    # Check if the LoRA exists *after* waiting for any in-progress load.
+                    if lora_name not in self.lora_id_for_name:
+                        yield {
+                            "status": "error",
+                            "message": f"LoRA adapter '{lora_name}' not found. Available LoRAs: {list(self.lora_id_for_name.keys())}",
+                        }
+                        return
 
-                    logger.error(
-                        f"Failed to unregister LoRA {lora_name} ModelDeploymentCard: {e}"
-                    )
-                    logger.debug(f"Traceback: {traceback.format_exc()}")
+                    logger.debug(f"Unloading LoRA adapter: {lora_name}")
+                    lora_id = self.lora_id_for_name[lora_name]
+                    lora_path = self.lora_name_to_path.get(lora_name)
 
-                    # Rollback: re-add the LoRA to the engine to maintain consistency
-                    try:
+                    await self.engine_client.remove_lora(lora_id)
+
+                    # Remove from tracking dictionaries
+                    del self.lora_id_for_name[lora_name]
+                    if lora_name in self.lora_name_to_path:
+                        del self.lora_name_to_path[lora_name]
+
+                    # Unregister the LoRA model from the model registry
+                    if self.generate_endpoint is not None:
                         logger.debug(
-                            f"Rolling back: re-adding LoRA '{lora_name}' to engine"
+                            f"Unregistering LoRA '{lora_name}' ModelDeploymentCard"
                         )
-                        await self.engine_client.add_lora(
-                            LoRARequest(
+                        try:
+                            await unregister_llm(
+                                endpoint=self.generate_endpoint,
                                 lora_name=lora_name,
-                                lora_int_id=lora_id,
-                                lora_path=lora_path,
                             )
-                        )
-                        # Re-add to tracking dictionaries
-                        self.lora_id_for_name[lora_name] = lora_id
-                        if lora_path:
-                            self.lora_name_to_path[lora_name] = lora_path
-                        logger.debug(f"Successfully rolled back LoRA '{lora_name}'")
-                    except Exception as rollback_error:
-                        logger.error(
-                            f"Failed to rollback LoRA {lora_name}: {rollback_error}"
+                            logger.info(
+                                f"Successfully unregistered LoRA '{lora_name}' ModelDeploymentCard"
+                            )
+                        except Exception as e:
+                            logger.exception(
+                                f"Failed to unregister LoRA {lora_name} ModelDeploymentCard: {e}"
+                            )
+
+                            # Rollback: re-add the LoRA to the engine to maintain consistency
+                            try:
+                                logger.debug(
+                                    f"Rolling back: re-adding LoRA '{lora_name}' to engine"
+                                )
+                                await self.engine_client.add_lora(
+                                    LoRARequest(
+                                        lora_name=lora_name,
+                                        lora_int_id=lora_id,
+                                        lora_path=lora_path,
+                                    )
+                                )
+                                # Re-add to tracking dictionaries
+                                self.lora_id_for_name[lora_name] = lora_id
+                                if lora_path:
+                                    self.lora_name_to_path[lora_name] = lora_path
+                                logger.debug(
+                                    f"Successfully rolled back LoRA '{lora_name}'"
+                                )
+                            except Exception as rollback_error:
+                                logger.exception(
+                                    f"Failed to rollback LoRA {lora_name}: {rollback_error}"
+                                )
+
+                            # Return error status since unregistration failed
+                            yield {
+                                "status": "error",
+                                "message": f"Failed to unregister LoRA '{lora_name}' from discovery registry: {str(e)}",
+                                "lora_name": lora_name,
+                            }
+                            return
+                    else:
+                        logger.debug(
+                            f"Cannot unregister LoRA '{lora_name}': generate_endpoint={self.generate_endpoint}"
                         )
 
-                    # Return error status since unregistration failed
+                    logger.info(
+                        f"Successfully unloaded LoRA adapter: {lora_name} with ID {lora_id}"
+                    )
                     yield {
-                        "status": "error",
-                        "message": f"Failed to unregister LoRA '{lora_name}' from discovery registry: {str(e)}",
+                        "status": "success",
+                        "message": f"LoRA adapter '{lora_name}' unloaded successfully",
                         "lora_name": lora_name,
+                        "lora_id": lora_id,
                     }
-                    return
-            else:
-                logger.debug(
-                    f"Cannot unregister LoRA '{lora_name}': generate_endpoint={self.generate_endpoint}"
-                )
-
-            # Clean up the per-LoRA lock only after confirmed success
-            self._lora_load_locks.pop(lora_name, None)
-
-            logger.info(
-                f"Successfully unloaded LoRA adapter: {lora_name} with ID {lora_id}"
-            )
-            yield {
-                "status": "success",
-                "message": f"LoRA adapter '{lora_name}' unloaded successfully",
-                "lora_name": lora_name,
-                "lora_id": lora_id,
-            }
+                finally:
+                    # Remove lock entry once the LoRA is not loaded (or never was).
+                    if lora_name not in self.lora_id_for_name:
+                        if self._lora_load_locks.get(lora_name) is lock:
+                            self._lora_load_locks.pop(lora_name, None)
         except Exception as e:
-            logger.error(f"Failed to unload LoRA adapter: {e}")
+            logger.exception(f"Failed to unload LoRA adapter: {e}")
             yield {"status": "error", "message": str(e)}
 
     async def list_loras(self, request=None):

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -254,6 +254,8 @@ class BaseWorkerHandler(ABC):
         # LoRA tracking
         self.lora_id_for_name: dict[str, int] = {}
         self.lora_name_to_path: dict[str, str] = {}
+        # Per-LoRA locks to prevent concurrent load operations for the same LoRA
+        self._lora_load_locks: dict[str, asyncio.Lock] = {}
 
         self.use_vllm_tokenizer = use_vllm_tokenizer
 
@@ -320,6 +322,9 @@ class BaseWorkerHandler(ABC):
                 "uri": str  # e.g., "s3://bucket/path" or "file:///path"
             }
         }
+
+        This method is idempotent - concurrent calls for the same LoRA will be
+        serialized and only one load operation will happen.
         """
         try:
             if request is None:
@@ -367,110 +372,130 @@ class BaseWorkerHandler(ABC):
                 }
                 return
 
-            logger.info(f"Downloading LoRA adapter: {lora_name} from {lora_uri}")
-            download_result = await lora_manager.download_lora(lora_uri)
-
-            if download_result["status"] != "success":
-                yield {
-                    "status": "error",
-                    "message": f"Failed to download LoRA: {download_result.get('message', 'Unknown error')}",
-                }
-                return
-
-            lora_path = download_result["local_path"]
-            logger.debug(f"LoRA downloaded to: {lora_path}")
-
-            # Generate deterministic ID from lora_name before using it
-            lora_id = lora_name_to_id(lora_name)
-
-            # Add the LoRA to the engine
-            await self.engine_client.add_lora(
-                LoRARequest(
-                    lora_name=lora_name, lora_int_id=lora_id, lora_path=lora_path
-                )
-            )
-
-            # Track the LoRA
-            self.lora_id_for_name[lora_name] = lora_id
-            self.lora_name_to_path[lora_name] = lora_path
-            logger.info(
-                f"Successfully loaded LoRA adapter: {lora_name} with ID {lora_id}"
-            )
-
-            # Publish LoRA as a ModelDeploymentCard with format:
-            # v1/mdc/{namespace}/{component}/{endpoint}/{instance_id}/{lora_slug}
-            # This allows the frontend to discover it and route correctly to the worker instance
-
-            if self.generate_endpoint is not None and self.config is not None:
-                logger.debug(
-                    f"Publishing LoRA '{lora_name}' ModelDeploymentCard to {self.generate_endpoint}"
-                )
-                try:
-                    logger.debug(f"Publishing LoRA '{lora_name}' ModelDeploymentCard")
-
-                    # Mark this as a LoRA in user_data
-                    user_data = {
-                        "lora_adapter": True,
+            # Acquire per-LoRA lock to prevent concurrent load operations for the same LoRA
+            async with self._lora_load_locks.setdefault(lora_name, asyncio.Lock()):
+                # Check if already loaded (idempotency check after acquiring lock)
+                # Another concurrent request may have loaded this LoRA while we waited
+                if lora_name in self.lora_id_for_name:
+                    lora_id = self.lora_id_for_name[lora_name]
+                    logger.info(
+                        f"LoRA adapter already loaded (concurrent request completed): "
+                        f"{lora_name} with ID {lora_id}"
+                    )
+                    yield {
+                        "status": "success",
+                        "message": f"LoRA adapter '{lora_name}' already loaded",
+                        "lora_name": lora_name,
                         "lora_id": lora_id,
                     }
+                    return
 
-                    # Publish with format: v1/mdc/dynamo/backend/generate/{instance_id}/{lora_slug}
-                    await register_llm(
-                        model_input=ModelInput.Tokens,
-                        model_type=ModelType.Chat | ModelType.Completions,
-                        endpoint=self.generate_endpoint,
-                        model_path=self.config.model,
-                        kv_cache_block_size=self.config.engine_args.block_size,
-                        user_data=user_data,
-                        lora_name=lora_name,
-                        base_model_path=self.config.model,
-                    )
-                    logger.info(
-                        f"Successfully published LoRA '{lora_name}' ModelDeploymentCard"
-                    )
-                except Exception as e:
-                    import traceback
+                logger.info(f"Downloading LoRA adapter: {lora_name} from {lora_uri}")
+                download_result = await lora_manager.download_lora(lora_uri)
 
-                    logger.error(
-                        f"Failed to publish LoRA {lora_name} ModelDeploymentCard: {e}"
-                    )
-                    logger.debug(f"Traceback: {traceback.format_exc()}")
-
-                    # Rollback: remove the LoRA from the engine to maintain consistency
-                    try:
-                        logger.debug(
-                            f"Rolling back: removing LoRA '{lora_name}' from engine"
-                        )
-                        await self.engine_client.remove_lora(lora_id)
-                        # Remove from tracking dictionaries
-                        if lora_name in self.lora_id_for_name:
-                            del self.lora_id_for_name[lora_name]
-                        if lora_name in self.lora_name_to_path:
-                            del self.lora_name_to_path[lora_name]
-                        logger.debug(f"Successfully rolled back LoRA '{lora_name}'")
-                    except Exception as rollback_error:
-                        logger.error(
-                            f"Failed to rollback LoRA {lora_name}: {rollback_error}"
-                        )
-
-                    # Return error status since registration failed
+                if download_result["status"] != "success":
                     yield {
                         "status": "error",
-                        "message": f"Failed to register LoRA '{lora_name}' in discovery registry: {str(e)}",
-                        "lora_name": lora_name,
+                        "message": f"Failed to download LoRA: {download_result.get('message', 'Unknown error')}",
                     }
                     return
-            else:
-                logger.debug(
-                    f"Cannot publish LoRA '{lora_name}': generate_endpoint={self.generate_endpoint}, config={self.config}"
+
+                lora_path = download_result["local_path"]
+                logger.debug(f"LoRA downloaded to: {lora_path}")
+
+                # Generate deterministic ID from lora_name before using it
+                lora_id = lora_name_to_id(lora_name)
+
+                # Add the LoRA to the engine
+                await self.engine_client.add_lora(
+                    LoRARequest(
+                        lora_name=lora_name, lora_int_id=lora_id, lora_path=lora_path
+                    )
                 )
 
-            yield {
-                "status": "success",
-                "message": f"LoRA adapter '{lora_name}' loaded successfully",
-                "lora_name": lora_name,
-                "lora_id": lora_id,
-            }
+                # Track the LoRA
+                self.lora_id_for_name[lora_name] = lora_id
+                self.lora_name_to_path[lora_name] = lora_path
+                logger.info(
+                    f"Successfully loaded LoRA adapter: {lora_name} with ID {lora_id}"
+                )
+
+                # Publish LoRA as a ModelDeploymentCard with format:
+                # v1/mdc/{namespace}/{component}/{endpoint}/{instance_id}/{lora_slug}
+                # This allows the frontend to discover it and route correctly to the worker instance
+
+                if self.generate_endpoint is not None and self.config is not None:
+                    logger.debug(
+                        f"Publishing LoRA '{lora_name}' ModelDeploymentCard to {self.generate_endpoint}"
+                    )
+                    try:
+                        logger.debug(
+                            f"Publishing LoRA '{lora_name}' ModelDeploymentCard"
+                        )
+
+                        # Mark this as a LoRA in user_data
+                        user_data = {
+                            "lora_adapter": True,
+                            "lora_id": lora_id,
+                        }
+
+                        # Publish with format: v1/mdc/dynamo/backend/generate/{instance_id}/{lora_slug}
+                        await register_llm(
+                            model_input=ModelInput.Tokens,
+                            model_type=ModelType.Chat | ModelType.Completions,
+                            endpoint=self.generate_endpoint,
+                            model_path=self.config.model,
+                            kv_cache_block_size=self.config.engine_args.block_size,
+                            user_data=user_data,
+                            lora_name=lora_name,
+                            base_model_path=self.config.model,
+                        )
+                        logger.info(
+                            f"Successfully published LoRA '{lora_name}' ModelDeploymentCard"
+                        )
+                    except Exception as e:
+                        import traceback
+
+                        logger.error(
+                            f"Failed to publish LoRA {lora_name} ModelDeploymentCard: {e}"
+                        )
+                        logger.debug(f"Traceback: {traceback.format_exc()}")
+
+                        # Rollback: remove the LoRA from the engine to maintain consistency
+                        try:
+                            logger.debug(
+                                f"Rolling back: removing LoRA '{lora_name}' from engine"
+                            )
+                            await self.engine_client.remove_lora(lora_id)
+                            # Remove from tracking dictionaries
+                            if lora_name in self.lora_id_for_name:
+                                del self.lora_id_for_name[lora_name]
+                            if lora_name in self.lora_name_to_path:
+                                del self.lora_name_to_path[lora_name]
+                            logger.debug(f"Successfully rolled back LoRA '{lora_name}'")
+                        except Exception as rollback_error:
+                            logger.error(
+                                f"Failed to rollback LoRA {lora_name}: {rollback_error}"
+                            )
+
+                        # Return error status since registration failed
+                        yield {
+                            "status": "error",
+                            "message": f"Failed to register LoRA '{lora_name}' in discovery registry: {str(e)}",
+                            "lora_name": lora_name,
+                        }
+                        return
+                else:
+                    logger.debug(
+                        f"Cannot publish LoRA '{lora_name}': generate_endpoint={self.generate_endpoint}, config={self.config}"
+                    )
+
+                yield {
+                    "status": "success",
+                    "message": f"LoRA adapter '{lora_name}' loaded successfully",
+                    "lora_name": lora_name,
+                    "lora_id": lora_id,
+                }
         except Exception as e:
             logger.error(f"Failed to load LoRA adapter: {e}")
             yield {"status": "error", "message": str(e)}
@@ -516,6 +541,8 @@ class BaseWorkerHandler(ABC):
             del self.lora_id_for_name[lora_name]
             if lora_name in self.lora_name_to_path:
                 del self.lora_name_to_path[lora_name]
+            # Clean up the per-LoRA lock to prevent memory accumulation
+            self._lora_load_locks.pop(lora_name, None)
 
             # Unregister the LoRA model from the model registry (outside lock)
             if self.generate_endpoint is not None:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -454,12 +454,9 @@ class BaseWorkerHandler(ABC):
                             f"Successfully published LoRA '{lora_name}' ModelDeploymentCard"
                         )
                     except Exception as e:
-                        import traceback
-
-                        logger.error(
+                        logger.exception(
                             f"Failed to publish LoRA {lora_name} ModelDeploymentCard: {e}"
                         )
-                        logger.debug(f"Traceback: {traceback.format_exc()}")
 
                         # Rollback: remove the LoRA from the engine to maintain consistency
                         try:
@@ -472,9 +469,11 @@ class BaseWorkerHandler(ABC):
                                 del self.lora_id_for_name[lora_name]
                             if lora_name in self.lora_name_to_path:
                                 del self.lora_name_to_path[lora_name]
+                            # Clean up the per-LoRA lock to prevent memory accumulation
+                            self._lora_load_locks.pop(lora_name, None)
                             logger.debug(f"Successfully rolled back LoRA '{lora_name}'")
                         except Exception as rollback_error:
-                            logger.error(
+                            logger.exception(
                                 f"Failed to rollback LoRA {lora_name}: {rollback_error}"
                             )
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -540,8 +540,6 @@ class BaseWorkerHandler(ABC):
             del self.lora_id_for_name[lora_name]
             if lora_name in self.lora_name_to_path:
                 del self.lora_name_to_path[lora_name]
-            # Clean up the per-LoRA lock to prevent memory accumulation
-            self._lora_load_locks.pop(lora_name, None)
 
             # Unregister the LoRA model from the model registry (outside lock)
             if self.generate_endpoint is not None:
@@ -595,6 +593,9 @@ class BaseWorkerHandler(ABC):
                 logger.debug(
                     f"Cannot unregister LoRA '{lora_name}': generate_endpoint={self.generate_endpoint}"
                 )
+
+            # Clean up the per-LoRA lock only after confirmed success
+            self._lora_load_locks.pop(lora_name, None)
 
             logger.info(
                 f"Successfully unloaded LoRA adapter: {lora_name} with ID {lora_id}"

--- a/lib/llm/src/lora/cache.rs
+++ b/lib/llm/src/lora/cache.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use blake3;
+use blake3::hash as blake3_hash;
 use std::path::PathBuf;
 
 use dynamo_runtime::config::environment_names::llm;
@@ -68,7 +68,7 @@ impl LoRACache {
             })
             .collect::<String>();
 
-        let hash = blake3::hash(uri.as_bytes()).to_string();
+        let hash = blake3_hash(uri.as_bytes()).to_string();
         let hash32 = &hash[..32];
         format!("{scheme}_{hash32}")
     }

--- a/lib/llm/src/lora/downloader.rs
+++ b/lib/llm/src/lora/downloader.rs
@@ -3,22 +3,32 @@
 
 use super::{cache::LoRACache, source::LoRASource};
 use anyhow::Result;
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use tokio::sync::Mutex;
 
 pub struct LoRADownloader {
     sources: Vec<Arc<dyn LoRASource>>,
     cache: LoRACache,
+    /// Per-URI locks to prevent concurrent downloads to the same path.
+    download_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
 }
 
 impl LoRADownloader {
     pub fn new(sources: Vec<Arc<dyn LoRASource>>, cache: LoRACache) -> Self {
-        Self { sources, cache }
+        Self {
+            sources,
+            cache,
+            download_locks: Mutex::new(HashMap::new()),
+        }
     }
 
     /// Download LoRA if not in cache, return local path
     ///
     /// For local file:// URIs, this will return the original path without copying.
     /// For remote URIs (s3://, gcs://, etc.), this will download to cache.
+    ///
+    /// This method is safe to call concurrently for the same URI - only one download
+    /// will happen at a time, and other callers will wait and reuse the cached result.
     pub async fn download_if_needed(&self, lora_uri: &str) -> Result<PathBuf> {
         // For local file:// URIs, don't use cache - just validate and return
         if lora_uri.starts_with("file://") {
@@ -37,11 +47,37 @@ impl LoRADownloader {
         // For remote URIs, use the URI as the cache key
         let cache_key = self.uri_to_cache_key(lora_uri);
 
-        // Check cache first
+        // Fast path: check cache without holding the download lock
         if self.cache.is_cached(&cache_key) && self.cache.validate_cached(&cache_key)? {
             tracing::debug!("LoRA found in cache: {}", cache_key);
             return Ok(self.cache.get_cache_path(&cache_key));
         }
+
+        // Acquire per-URI download lock to prevent concurrent downloads of the same URI.
+        // The HashMap lock is held only briefly to get/create the per-URI lock, then released.
+        // This allows different URIs to download in parallel while same-URI downloads are serialized.
+        let lock = self
+            .download_locks
+            .lock()
+            .await
+            .entry(cache_key.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        let _guard = lock.lock().await;
+
+        // Double-check: another concurrent call may have completed the download while we waited
+        if self.cache.is_cached(&cache_key) && self.cache.validate_cached(&cache_key)? {
+            tracing::debug!(
+                "LoRA found in cache after acquiring lock (downloaded by concurrent request): {}",
+                cache_key
+            );
+            return Ok(self.cache.get_cache_path(&cache_key));
+        }
+
+        tracing::info!(
+            "Downloading LoRA (no concurrent download in progress): {}",
+            lora_uri
+        );
 
         // Try sources in order
         let dest_path = self.cache.get_cache_path(&cache_key);

--- a/lib/llm/src/lora/downloader.rs
+++ b/lib/llm/src/lora/downloader.rs
@@ -3,14 +3,21 @@
 
 use super::{cache::LoRACache, source::LoRASource};
 use anyhow::Result;
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, Weak},
+};
 use tokio::sync::Mutex;
 
 pub struct LoRADownloader {
     sources: Vec<Arc<dyn LoRASource>>,
     cache: LoRACache,
     /// Per-URI locks to prevent concurrent downloads to the same path.
-    download_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+    ///
+    /// Uses `Weak` to avoid unbounded growth: once no task holds the per-URI lock `Arc`,
+    /// the entry becomes removable and will be opportunistically cleaned up.
+    download_locks: Mutex<HashMap<String, Weak<Mutex<()>>>>,
 }
 
 impl LoRADownloader {
@@ -55,50 +62,72 @@ impl LoRADownloader {
         }
 
         // Acquire per-URI download lock to prevent concurrent downloads of the same URI.
-        // The HashMap lock is held only briefly to get/create the per-URI lock, then released.
+        //
+        // The map lock is held only briefly to get/create the per-URI lock, then released.
         // This allows different URIs to download in parallel while same-URI downloads are serialized.
-        let lock = self
-            .download_locks
-            .lock()
-            .await
-            .entry(cache_key.clone())
-            .or_insert_with(|| Arc::new(Mutex::new(())))
-            .clone();
-        let _guard = lock.lock().await;
+        //
+        // We store `Weak` values in the map so entries can be cleaned up once no task is using them.
+        let lock_arc: Arc<Mutex<()>> = {
+            let mut locks = self.download_locks.lock().await;
+            if let Some(existing) = locks.get(&cache_key).and_then(|w| w.upgrade()) {
+                existing
+            } else {
+                let created = Arc::new(Mutex::new(()));
+                locks.insert(cache_key.clone(), Arc::downgrade(&created));
+                created
+            }
+        };
 
-        // Double-check: another concurrent call may have completed the download while we waited.
-        if self.cache.is_cached(&cache_key) && self.cache.validate_cached(&cache_key)? {
-            tracing::debug!(
-                "LoRA found in cache after acquiring lock (downloaded by concurrent request): {}",
-                cache_key
+        let result: Result<PathBuf> = async {
+            let _guard = lock_arc.lock().await;
+
+            // Double-check: another concurrent call may have completed the download while we waited.
+            if self.cache.is_cached(&cache_key) && self.cache.validate_cached(&cache_key)? {
+                tracing::debug!(
+                    "LoRA found in cache after acquiring lock (downloaded by concurrent request): {}",
+                    cache_key
+                );
+                return Ok(self.cache.get_cache_path(&cache_key));
+            }
+
+            tracing::info!(
+                "Downloading LoRA (no concurrent download in progress): {}",
+                lora_uri
             );
-            return Ok(self.cache.get_cache_path(&cache_key));
-        }
 
-        tracing::info!(
-            "Downloading LoRA (no concurrent download in progress): {}",
-            lora_uri
-        );
+            // Try sources in order
+            let dest_path = self.cache.get_cache_path(&cache_key);
 
-        // Try sources in order
-        let dest_path = self.cache.get_cache_path(&cache_key);
-
-        for source in &self.sources {
-            if let Ok(exists) = source.exists(lora_uri).await
-                && exists
-            {
-                let downloaded_path = source.download(lora_uri, &dest_path).await?;
-                if self.cache.validate_cached(&cache_key)? {
-                    return Ok(downloaded_path);
-                } else {
-                    tracing::warn!(
-                        "Downloaded LoRA at {} failed validation",
-                        downloaded_path.display()
-                    );
+            for source in &self.sources {
+                if let Ok(exists) = source.exists(lora_uri).await
+                    && exists
+                {
+                    let downloaded_path = source.download(lora_uri, &dest_path).await?;
+                    if self.cache.validate_cached(&cache_key)? {
+                        return Ok(downloaded_path);
+                    } else {
+                        tracing::warn!(
+                            "Downloaded LoRA at {} failed validation",
+                            downloaded_path.display()
+                        );
+                    }
                 }
             }
-        }
 
-        anyhow::bail!("LoRA {} not found in any source", lora_uri)
+            anyhow::bail!("LoRA {} not found in any source", lora_uri)
+        }
+        .await;
+
+        // Drop our strong ref before cleanup so the last caller can remove the map entry.
+        drop(lock_arc);
+        self.cleanup_stale_download_locks().await;
+
+        result
+    }
+
+    /// Clean up all stale entries from the download locks map.
+    async fn cleanup_stale_download_locks(&self) {
+        let mut locks = self.download_locks.lock().await;
+        locks.retain(|_, w| w.upgrade().is_some());
     }
 }


### PR DESCRIPTION
#### Overview:

handle race condition during concurrent LoRA load calls

### Summary of changes in this branch

- **LoRA cache key hardened** (`lib/llm/src/lora/cache.rs`)
  - Replaced lossy URI→cache-key mapping with collision-resistant, filesystem-safe keys: `{scheme}_{blake3(uri)[..32]}`.
  - Updated unit tests

- **Concurrent-safe LoRA downloading (Rust)** (`lib/llm/src/lora/downloader.rs`)
  - Added per-URI download serialization to prevent duplicate concurrent downloads.
  - Prevented unbounded lock-map growth by storing `Weak` per-key locks and periodically cleaning stale entries.

- **Concurrent-safe LoRA load/unload (Python vLLM handler)** (`components/src/dynamo/vllm/handlers.py`)
  - Serialized `unload_lora` with `load_lora` using a shared per-`lora_name` lock.
  - Added lock-map cleanup on failure paths to avoid accumulating unused locks.
  - Added a thread-safe guard around lock creation to avoid multi-thread races.
  - Improved exception logging (`logger.exception`) and minor formatting fixes.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- fixes: https://nvbugspro.nvidia.com/bug/5767388
- closes: DYN-1662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added per-resource concurrency control to prevent duplicate concurrent loads and downloads for the same LoRA/URI.
  * Ensured idempotent load flow with early-return for already-loaded resources and explicit cleanup of per-resource locks on unload/rollback.
  * Added rollback paths on publish failures to remove partial state and improve stability.
  * Improved logging and error handling for clearer tracing of load/download operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->