### PR TITLE
feat(fault-injection): add multi-backend support and target node filtering to toggle

### DIFF
--- a/tests/fault_tolerance/hardware/fault_injection_service/helpers/cuda_fault_injection.py
+++ b/tests/fault_tolerance/hardware/fault_injection_service/helpers/cuda_fault_injection.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
#### Overview:
Extend CUDA fault helper to support all backend types and add target node filtering for soft affinity scenarios.

#### Details:
- **`cleanup_cuda_spec_without_restart()`**: Expand default `service_names` to include vLLM, SGLang, and TensorRT-LLM worker patterns
- **`enable_cuda_faults_via_toggle()`**: 
  - Add `target_node` parameter for soft affinity filtering
  - Filter to only worker pods (skip frontends that don't have CUDA library)
  - Skip pods not on target node when using soft affinity
  - Add detailed logging for skipped pods with reasons


#### Where should the reviewer start?
- **File:** `tests/fault_tolerance/hardware/fault_injection_service/helpers/cuda_fault_injection.py`
- **Methods:** `cleanup_cuda_spec_without_restart()` (lines 231-245), `enable_cuda_faults_via_toggle()` (lines 398-485)
- **Key addition:** Worker pod filtering logic at lines 431-465

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Dependent on PR #5166


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded fault injection testing to support multiple backends including vLLM, SGLang, and TensorRT-LLM.
  * Implemented pod filtering by node affinity and added stricter validation requirements.
  * Enhanced error diagnostics with improved logging and detailed failure reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->