### PR TITLE
feat(fault-injection): switch to GHCR images and remove Azure node affinity

### DIFF
--- a/tests/fault_tolerance/hardware/fault_injection_service/deploy/api-service.yaml
+++ b/tests/fault_tolerance/hardware/fault_injection_service/deploy/api-service.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/fault_tolerance/hardware/fault_injection_service/deploy/api-service.yaml
+++ b/tests/fault_tolerance/hardware/fault_injection_service/deploy/api-service.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -74,20 +74,15 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              # Require GPU nodes (A100 pools)
+              # Require GPU nodes
               - key: nvidia.com/gpu.present
                 operator: In
                 values:
                 - "true"
-              # Prefer stable instance types
-              - key: node.kubernetes.io/instance-type
-                operator: In
-                values:
-                - Standard_ND96amsr_A100_v4
       containers:
       - name: api
-        # Replace with your Azure Container Registry (ACR)
-        image: dynamoci.azurecr.io/fault-injection-api:latest
+        # GHCR image (public)
+        image: ghcr.io/ai-dynamo/fault-injection-api:latest
         imagePullPolicy: Always
         ports:
         - name: http

--- a/tests/fault_tolerance/hardware/fault_injection_service/deploy/gpu-fault-injector-kernel.yaml
+++ b/tests/fault_tolerance/hardware/fault_injection_service/deploy/gpu-fault-injector-kernel.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/fault_tolerance/hardware/fault_injection_service/deploy/gpu-fault-injector-kernel.yaml
+++ b/tests/fault_tolerance/hardware/fault_injection_service/deploy/gpu-fault-injector-kernel.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -70,9 +70,8 @@ spec:
 
       containers:
       - name: gpu-fault-injector
-        # UPDATE: Replace with your Azure Container Registry (ACR)
-        # Example: yourregistry.azurecr.io/gpu-fault-injector:latest
-        image: dynamoci.azurecr.io/gpu-fault-injector:latest
+        # GHCR image (public)
+        image: ghcr.io/ai-dynamo/gpu-fault-injector:latest
         imagePullPolicy: Always
 
         # PRIVILEGED MODE - Required for kernel-level operations


### PR DESCRIPTION
#### Overview:
Update fault injection service manifests to use public GHCR images and remove Azure-specific configuration.

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
**api-service.yaml:**
- Change image: `dynamoci.azurecr.io/fault-injection-api:latest` → `ghcr.io/ai-dynamo/fault-injection-api:latest`
- Remove Azure instance type affinity: Delete `node.kubernetes.io/instance-type: Standard_ND96amsr_A100_v4` selector
- Keep only `nvidia.com/gpu.present: "true"` for GPU node scheduling

**gpu-fault-injector-kernel.yaml:**
- Change image: `dynamoci.azurecr.io/gpu-fault-injector:latest` → `ghcr.io/ai-dynamo/gpu-fault-injector:latest`

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?
- **File:** `tests/fault_tolerance/hardware/fault_injection_service/deploy/api-service.yaml`
- **Lines:** 77-85 (affinity removal), 89 (image change)

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Reates to ongoing FT initiative


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated fault injection service and GPU fault injector deployment configurations to use public container registries.
  * Simplified GPU node scheduling requirements, removing specific instance-type constraints.
  * Streamlined node affinity checks to verify only GPU availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->