### PR TITLE
feat(fault-injection): add kernel launch interception and toggle override logic

### DIFF
--- a/tests/fault_tolerance/hardware/fault_injection_service/cuda_fault_injection/cuda_intercept.c
+++ b/tests/fault_tolerance/hardware/fault_injection_service/cuda_fault_injection/cuda_intercept.c
@@ -71,8 +71,8 @@ static void
 get_fault_config(int* inject, int* xid_type, cudaError_t* error_code)
 {
   static int initialized = 0;
-  static int env_inject = 0;       // From environment variable (initial state)
-  static int cached_xid = 79;      // Default to XID 79
+  static int env_inject = 0;   // From environment variable (initial state)
+  static int cached_xid = 79;  // Default to XID 79
   static cudaError_t cached_error = cudaErrorNoDevice;
 
   if (!initialized) {
@@ -329,8 +329,7 @@ cudaGetDeviceProperties(cudaDeviceProp* prop, int device)
 
 // Intercept: Kernel launch (CRITICAL for inference)
 cudaError_t
-cudaLaunchKernel(const void* func, dim3 gridDim, dim3 blockDim,
-                 void** args, size_t sharedMem, cudaStream_t stream)
+cudaLaunchKernel(const void* func, dim3 gridDim, dim3 blockDim, void** args, size_t sharedMem, cudaStream_t stream)
 {
   if (should_inject_fault()) {
     cudaError_t error = get_error_code();


### PR DESCRIPTION
#### Overview:
Extend CUDA intercept library with kernel launch interception and toggle file override behavior.

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
- **New type definitions**: Add `cudaStream_t`, `dim3` struct for kernel launch support
- **Toggle override logic**: Change runtime toggle to ALWAYS override env var (enables passthrough mode → toggle activation workflow)
- **New intercepted functions**:
  - `cudaLaunchKernel()`: Intercept kernel launches (critical for inference fault injection)
  - `cudaMemcpyAsync()`: Intercept async memory copies (commonly used in inference)
  - `cudaStreamSynchronize()`: Intercept stream sync calls

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?
- **File:** `tests/fault_tolerance/hardware/fault_injection_service/cuda_fault_injection/cuda_intercept.c`
- **Lines:** 30-35 (new types), 113-120 (toggle override comment), 325-380 (new kernel interception functions)
- **Key change:** passthrough → toggle workflow
<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Ongoing FT initiative


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended fault injection testing capabilities to cover additional GPU operations commonly used in inference workloads, including kernel launches, asynchronous memory transfers, and stream synchronization operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->