### PR TITLE
fix: Add comment to address pynvml import warning

### DIFF
--- a/examples/backends/vllm/launch/agg.sh
+++ b/examples/backends/vllm/launch/agg.sh
@@ -24,6 +24,8 @@ done
 
 # run ingress
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
+# found warning of pynvml being imported instead of nvidia-ml-py, so please address this import
+# correctly to suppress the warning.
 python -m dynamo.frontend &
 
 # run worker


### PR DESCRIPTION
Added a note to address the pynvml import warning.

#### Overview: Import of nvidia-ml-py needed instead of pynvml.

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details: Observed a warning message when running the agg.sh script on the backend examples of vllm. The warning message is "The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml previously, please report this to the maintainers of the package that installed pynvml for you."  

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start? Added a comment in the agg.sh script file to indicate the problem to be corrected.

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to) Not sure of prior issues.

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor documentation update to internal backend configuration script with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->