### PR TITLE
feat(operator): have Scaling Adapter disabled by default

### DIFF
--- a/deploy/helm/charts/crds/templates/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/helm/charts/crds/templates/nvidia.com_dynamocomponentdeployments.yaml
@@ -10279,12 +10279,12 @@ spec:
                     When enabled (default), replicas are managed via DGDSA and external autoscalers can scale
                     the service using the Scale subresource. When disabled, replicas can be modified directly.
                   properties:
-                    disable:
+                    enabled:
                       default: false
                       description: |-
-                        Disable indicates whether the ScalingAdapter should be disabled for this service.
-                        When false (default), a DGDSA is created and owns the replicas field.
-                        When true, no DGDSA is created and replicas can be modified directly in the DGD.
+                        Enabled indicates whether the ScalingAdapter should be enabled for this service.
+                        When true, a DGDSA is created and owns the replicas field.
+                        When false (default), no DGDSA is created and replicas can be modified directly in the DGD.
                       type: boolean
                   type: object
                 serviceName:

--- a/deploy/helm/charts/crds/templates/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/helm/charts/crds/templates/nvidia.com_dynamocomponentdeployments.yaml
@@ -10191,7 +10191,7 @@ spec:
                 replicas:
                   description: |-
                     Replicas is the desired number of Pods for this component.
-                    When scalingAdapter is enabled (default), this field is managed by the
+                    When scalingAdapter is enabled, this field is managed by the
                     DynamoGraphDeploymentScalingAdapter and should not be modified directly.
                   format: int32
                   minimum: 0
@@ -10276,7 +10276,7 @@ spec:
                 scalingAdapter:
                   description: |-
                     ScalingAdapter configures whether this service uses the DynamoGraphDeploymentScalingAdapter.
-                    When enabled (default), replicas are managed via DGDSA and external autoscalers can scale
+                    When enabled, replicas are managed via DGDSA and external autoscalers can scale
                     the service using the Scale subresource. When disabled, replicas can be modified directly.
                   properties:
                     enabled:

--- a/deploy/helm/charts/crds/templates/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/helm/charts/crds/templates/nvidia.com_dynamographdeployments.yaml
@@ -10326,7 +10326,7 @@ spec:
                       replicas:
                         description: |-
                           Replicas is the desired number of Pods for this component.
-                          When scalingAdapter is enabled (default), this field is managed by the
+                          When scalingAdapter is enabled, this field is managed by the
                           DynamoGraphDeploymentScalingAdapter and should not be modified directly.
                         format: int32
                         minimum: 0
@@ -10411,7 +10411,7 @@ spec:
                       scalingAdapter:
                         description: |-
                           ScalingAdapter configures whether this service uses the DynamoGraphDeploymentScalingAdapter.
-                          When enabled (default), replicas are managed via DGDSA and external autoscalers can scale
+                          When enabled, replicas are managed via DGDSA and external autoscalers can scale
                           the service using the Scale subresource. When disabled, replicas can be modified directly.
                         properties:
                           enabled:

--- a/deploy/helm/charts/crds/templates/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/helm/charts/crds/templates/nvidia.com_dynamographdeployments.yaml
@@ -10414,12 +10414,12 @@ spec:
                           When enabled (default), replicas are managed via DGDSA and external autoscalers can scale
                           the service using the Scale subresource. When disabled, replicas can be modified directly.
                         properties:
-                          disable:
+                          enabled:
                             default: false
                             description: |-
-                              Disable indicates whether the ScalingAdapter should be disabled for this service.
-                              When false (default), a DGDSA is created and owns the replicas field.
-                              When true, no DGDSA is created and replicas can be modified directly in the DGD.
+                              Enabled indicates whether the ScalingAdapter should be enabled for this service.
+                              When true, a DGDSA is created and owns the replicas field.
+                              When false (default), no DGDSA is created and replicas can be modified directly in the DGD.
                             type: boolean
                         type: object
                       serviceName:

--- a/deploy/operator/api/v1alpha1/common.go
+++ b/deploy/operator/api/v1alpha1/common.go
@@ -125,13 +125,13 @@ type ExtraPodSpec struct {
 }
 
 // ScalingAdapter configures whether a service uses the DynamoGraphDeploymentScalingAdapter
-// for replica management. When enabled (default), the DGDSA owns the replicas field and
+// for replica management. When enabled, the DGDSA owns the replicas field and
 // external autoscalers (HPA, KEDA, Planner) can control scaling via the Scale subresource.
 type ScalingAdapter struct {
-	// Disable indicates whether the ScalingAdapter should be disabled for this service.
-	// When false (default), a DGDSA is created and owns the replicas field.
-	// When true, no DGDSA is created and replicas can be modified directly in the DGD.
+	// Enabled indicates whether the ScalingAdapter should be enabled for this service.
+	// When true, a DGDSA is created and owns the replicas field.
+	// When false (default), no DGDSA is created and replicas can be modified directly in the DGD.
 	// +optional
 	// +kubebuilder:default=false
-	Disable bool `json:"disable,omitempty"`
+	Enabled bool `json:"enabled,omitempty"`
 }

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -111,14 +111,14 @@ type DynamoComponentDeploymentSharedSpec struct {
 	// ReadinessProbe to signal when the container is ready to receive traffic.
 	ReadinessProbe *corev1.Probe `json:"readinessProbe,omitempty"`
 	// Replicas is the desired number of Pods for this component.
-	// When scalingAdapter is enabled (default), this field is managed by the
+	// When scalingAdapter is enabled, this field is managed by the
 	// DynamoGraphDeploymentScalingAdapter and should not be modified directly.
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Multinode is the configuration for multinode components.
 	Multinode *MultinodeSpec `json:"multinode,omitempty"`
 	// ScalingAdapter configures whether this service uses the DynamoGraphDeploymentScalingAdapter.
-	// When enabled (default), replicas are managed via DGDSA and external autoscalers can scale
+	// When enabled, replicas are managed via DGDSA and external autoscalers can scale
 	// the service using the Scale subresource. When disabled, replicas can be modified directly.
 	// +optional
 	ScalingAdapter *ScalingAdapter `json:"scalingAdapter,omitempty"`

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
@@ -10279,12 +10279,12 @@ spec:
                     When enabled (default), replicas are managed via DGDSA and external autoscalers can scale
                     the service using the Scale subresource. When disabled, replicas can be modified directly.
                   properties:
-                    disable:
+                    enabled:
                       default: false
                       description: |-
-                        Disable indicates whether the ScalingAdapter should be disabled for this service.
-                        When false (default), a DGDSA is created and owns the replicas field.
-                        When true, no DGDSA is created and replicas can be modified directly in the DGD.
+                        Enabled indicates whether the ScalingAdapter should be enabled for this service.
+                        When true, a DGDSA is created and owns the replicas field.
+                        When false (default), no DGDSA is created and replicas can be modified directly in the DGD.
                       type: boolean
                   type: object
                 serviceName:

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
@@ -10191,7 +10191,7 @@ spec:
                 replicas:
                   description: |-
                     Replicas is the desired number of Pods for this component.
-                    When scalingAdapter is enabled (default), this field is managed by the
+                    When scalingAdapter is enabled, this field is managed by the
                     DynamoGraphDeploymentScalingAdapter and should not be modified directly.
                   format: int32
                   minimum: 0
@@ -10276,7 +10276,7 @@ spec:
                 scalingAdapter:
                   description: |-
                     ScalingAdapter configures whether this service uses the DynamoGraphDeploymentScalingAdapter.
-                    When enabled (default), replicas are managed via DGDSA and external autoscalers can scale
+                    When enabled, replicas are managed via DGDSA and external autoscalers can scale
                     the service using the Scale subresource. When disabled, replicas can be modified directly.
                   properties:
                     enabled:

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -10326,7 +10326,7 @@ spec:
                       replicas:
                         description: |-
                           Replicas is the desired number of Pods for this component.
-                          When scalingAdapter is enabled (default), this field is managed by the
+                          When scalingAdapter is enabled, this field is managed by the
                           DynamoGraphDeploymentScalingAdapter and should not be modified directly.
                         format: int32
                         minimum: 0
@@ -10411,7 +10411,7 @@ spec:
                       scalingAdapter:
                         description: |-
                           ScalingAdapter configures whether this service uses the DynamoGraphDeploymentScalingAdapter.
-                          When enabled (default), replicas are managed via DGDSA and external autoscalers can scale
+                          When enabled, replicas are managed via DGDSA and external autoscalers can scale
                           the service using the Scale subresource. When disabled, replicas can be modified directly.
                         properties:
                           enabled:

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -10414,12 +10414,12 @@ spec:
                           When enabled (default), replicas are managed via DGDSA and external autoscalers can scale
                           the service using the Scale subresource. When disabled, replicas can be modified directly.
                         properties:
-                          disable:
+                          enabled:
                             default: false
                             description: |-
-                              Disable indicates whether the ScalingAdapter should be disabled for this service.
-                              When false (default), a DGDSA is created and owns the replicas field.
-                              When true, no DGDSA is created and replicas can be modified directly in the DGD.
+                              Enabled indicates whether the ScalingAdapter should be enabled for this service.
+                              When true, a DGDSA is created and owns the replicas field.
+                              When false (default), no DGDSA is created and replicas can be modified directly in the DGD.
                             type: boolean
                         type: object
                       serviceName:

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -54,7 +54,7 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 		expectDeleted        []string         // adapter names that should be deleted
 	}{
 		{
-			name: "creates adapters for all services",
+			name: "creates adapters for services with scalingAdapter.enabled=true",
 			dgd: &v1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
@@ -64,9 +64,15 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
 						"Frontend": {
 							Replicas: ptr.To(int32(2)),
+							ScalingAdapter: &v1alpha1.ScalingAdapter{
+								Enabled: true,
+							},
 						},
 						"decode": {
 							Replicas: ptr.To(int32(3)),
+							ScalingAdapter: &v1alpha1.ScalingAdapter{
+								Enabled: true,
+							},
 						},
 					},
 				},
@@ -86,7 +92,11 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 				},
 				Spec: v1alpha1.DynamoGraphDeploymentSpec{
 					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
-						"worker": {},
+						"worker": {
+							ScalingAdapter: &v1alpha1.ScalingAdapter{
+								Enabled: true,
+							},
+						},
 					},
 				},
 			},
@@ -96,7 +106,7 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 			},
 		},
 		{
-			name: "skips adapter creation when disabled",
+			name: "skips adapter creation when not enabled",
 			dgd: &v1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
@@ -106,12 +116,13 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
 						"Frontend": {
 							Replicas: ptr.To(int32(2)),
+							ScalingAdapter: &v1alpha1.ScalingAdapter{
+								Enabled: true,
+							},
 						},
 						"decode": {
 							Replicas: ptr.To(int32(3)),
-							ScalingAdapter: &v1alpha1.ScalingAdapter{
-								Disable: true,
-							},
+							// No ScalingAdapter or Enabled=false means no adapter created
 						},
 					},
 				},
@@ -133,6 +144,9 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
 						"Frontend": {
 							Replicas: ptr.To(int32(2)),
+							ScalingAdapter: &v1alpha1.ScalingAdapter{
+								Enabled: true,
+							},
 						},
 					},
 				},
@@ -194,7 +208,7 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 			expectDeleted: []string{"test-dgd-removed"},
 		},
 		{
-			name: "deletes adapter when scalingAdapter.disable is set to true",
+			name: "deletes adapter when scalingAdapter.enabled is not set",
 			dgd: &v1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
@@ -205,9 +219,7 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
 						"Frontend": {
 							Replicas: ptr.To(int32(2)),
-							ScalingAdapter: &v1alpha1.ScalingAdapter{
-								Disable: true,
-							},
+							// No ScalingAdapter means adapter should be deleted
 						},
 					},
 				},
@@ -253,6 +265,9 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
 						"MyService": {
 							Replicas: ptr.To(int32(1)),
+							ScalingAdapter: &v1alpha1.ScalingAdapter{
+								Enabled: true,
+							},
 						},
 					},
 				},

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -110,14 +110,11 @@ func (v *DynamoGraphDeploymentValidator) validateReplicasChanges(old *nvidiacomv
 	var errs []error
 
 	for serviceName, newService := range v.deployment.Spec.Services {
-		// Check if scaling adapter is enabled for this service (enabled by default)
-		scalingAdapterEnabled := true
-		if newService.ScalingAdapter != nil && newService.ScalingAdapter.Disable {
-			scalingAdapterEnabled = false
-		}
+		// Check if scaling adapter is enabled for this service (disabled by default)
+		scalingAdapterEnabled := newService.ScalingAdapter != nil && newService.ScalingAdapter.Enabled
 
 		if !scalingAdapterEnabled {
-			// Scaling adapter is disabled, users can modify replicas directly
+			// Scaling adapter is not enabled, users can modify replicas directly
 			continue
 		}
 

--- a/docs/kubernetes/api_reference.md
+++ b/docs/kubernetes/api_reference.md
@@ -199,9 +199,9 @@ _Appears in:_
 | `extraPodSpec` _[ExtraPodSpec](#extrapodspec)_ | ExtraPodSpec allows to override the main pod spec configuration.<br />It is a k8s standard PodSpec. It also contains a MainContainer (standard k8s Container) field<br />that allows overriding the main container configuration. |  |  |
 | `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | LivenessProbe to detect and restart unhealthy containers. |  |  |
 | `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | ReadinessProbe to signal when the container is ready to receive traffic. |  |  |
-| `replicas` _integer_ | Replicas is the desired number of Pods for this component.<br />When scalingAdapter is enabled (default), this field is managed by the<br />DynamoGraphDeploymentScalingAdapter and should not be modified directly. |  | Minimum: 0 <br /> |
+| `replicas` _integer_ | Replicas is the desired number of Pods for this component.<br />When scalingAdapter is enabled, this field is managed by the<br />DynamoGraphDeploymentScalingAdapter and should not be modified directly. |  | Minimum: 0 <br /> |
 | `multinode` _[MultinodeSpec](#multinodespec)_ | Multinode is the configuration for multinode components. |  |  |
-| `scalingAdapter` _[ScalingAdapter](#scalingadapter)_ | ScalingAdapter configures whether this service uses the DynamoGraphDeploymentScalingAdapter.<br />When enabled (default), replicas are managed via DGDSA and external autoscalers can scale<br />the service using the Scale subresource. When disabled, replicas can be modified directly. |  |  |
+| `scalingAdapter` _[ScalingAdapter](#scalingadapter)_ | ScalingAdapter configures whether this service uses the DynamoGraphDeploymentScalingAdapter.<br />When enabled, replicas are managed via DGDSA and external autoscalers can scale<br />the service using the Scale subresource. When disabled, replicas can be modified directly. |  |  |
 
 
 #### DynamoComponentDeploymentSpec
@@ -237,9 +237,9 @@ _Appears in:_
 | `extraPodSpec` _[ExtraPodSpec](#extrapodspec)_ | ExtraPodSpec allows to override the main pod spec configuration.<br />It is a k8s standard PodSpec. It also contains a MainContainer (standard k8s Container) field<br />that allows overriding the main container configuration. |  |  |
 | `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | LivenessProbe to detect and restart unhealthy containers. |  |  |
 | `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#probe-v1-core)_ | ReadinessProbe to signal when the container is ready to receive traffic. |  |  |
-| `replicas` _integer_ | Replicas is the desired number of Pods for this component.<br />When scalingAdapter is enabled (default), this field is managed by the<br />DynamoGraphDeploymentScalingAdapter and should not be modified directly. |  | Minimum: 0 <br /> |
+| `replicas` _integer_ | Replicas is the desired number of Pods for this component.<br />When scalingAdapter is enabled, this field is managed by the<br />DynamoGraphDeploymentScalingAdapter and should not be modified directly. |  | Minimum: 0 <br /> |
 | `multinode` _[MultinodeSpec](#multinodespec)_ | Multinode is the configuration for multinode components. |  |  |
-| `scalingAdapter` _[ScalingAdapter](#scalingadapter)_ | ScalingAdapter configures whether this service uses the DynamoGraphDeploymentScalingAdapter.<br />When enabled (default), replicas are managed via DGDSA and external autoscalers can scale<br />the service using the Scale subresource. When disabled, replicas can be modified directly. |  |  |
+| `scalingAdapter` _[ScalingAdapter](#scalingadapter)_ | ScalingAdapter configures whether this service uses the DynamoGraphDeploymentScalingAdapter.<br />When enabled, replicas are managed via DGDSA and external autoscalers can scale<br />the service using the Scale subresource. When disabled, replicas can be modified directly. |  |  |
 
 
 #### DynamoGraphDeployment
@@ -747,7 +747,7 @@ _Appears in:_
 
 
 ScalingAdapter configures whether a service uses the DynamoGraphDeploymentScalingAdapter
-for replica management. When enabled (default), the DGDSA owns the replicas field and
+for replica management. When enabled, the DGDSA owns the replicas field and
 external autoscalers (HPA, KEDA, Planner) can control scaling via the Scale subresource.
 
 
@@ -758,7 +758,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `disable` _boolean_ | Disable indicates whether the ScalingAdapter should be disabled for this service.<br />When false (default), a DGDSA is created and owns the replicas field.<br />When true, no DGDSA is created and replicas can be modified directly in the DGD. | false |  |
+| `enabled` _boolean_ | Enabled indicates whether the ScalingAdapter should be enabled for this service.<br />When true, a DGDSA is created and owns the replicas field.<br />When false (default), no DGDSA is created and replicas can be modified directly in the DGD. | false |  |
 
 
 #### ServiceReplicaStatus


### PR DESCRIPTION
#### Overview:

Before the 0.8.0 release that will introduce the `DGDSA` custom resource, we want to change the API to have DGDSA creation per DGD service disabled by default. 

DGDSA is an advanced component for leveraging KEDA/HPA, so making it opt-in is more sensible. Furthermore, users that expect DGD replica edits won't have to modify their manifests with this update.

#### Details:

- Changed the sub-field `disabled` in `scalingAdapter` to `enabled` (default value should always be false). Updated downstream logic to respect enabled=false (default) => no DGDSA created, enabled=true => DGDSA created. 

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Renamed scaling adapter flag from scalingAdapter.disable to scalingAdapter.enabled. Use enabled: true to enable the scaling adapter (default is not enabled). When enabled, the adapter manages replicas; when not enabled, replicas can be modified directly.

* **Documentation**
  * Updated autoscaling docs and examples to reflect the new enabled flag and revised guidance for enabling or keeping the adapter disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->