### PR TITLE
feat: implement dp rank aware routing for agg/disagg

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -141,7 +141,6 @@ async def init(runtime: DistributedRuntime, config: Config):
     )
     handler.register_engine_routes(runtime)
 
-    print(f"Config: {config}")
     health_check_payload = SglangHealthCheckPayload(
         engine, use_text_input=dynamo_args.use_sglang_tokenizer
     ).to_dict()

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -193,7 +193,9 @@ class DynamoSglangPublisher:
             # Determine number of DP ranks to subscribe to
             # With DP attention enabled, each attn_dp_rank publishes to its own port
             dp_size = getattr(self.server_args, "dp_size", 1) or 1
-            enable_dp_attention = getattr(self.server_args, "enable_dp_attention", False)
+            enable_dp_attention = getattr(
+                self.server_args, "enable_dp_attention", False
+            )
 
             if enable_dp_attention and dp_size > 1:
                 # Subscribe to all DP rank ports
@@ -220,7 +222,9 @@ class DynamoSglangPublisher:
                     zmq_endpoint=zmq_ep,
                     enable_local_indexer=self.dynamo_args.enable_local_indexer,
                 )
-                logging.info(f"Setting up ZMQ kv event subscriber for dp_rank={dp_rank} at {zmq_ep}")
+                logging.info(
+                    f"Setting up ZMQ kv event subscriber for dp_rank={dp_rank} at {zmq_ep}"
+                )
                 publisher = ZmqKvEventPublisher(
                     component=self.component, config=zmq_config
                 )

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -119,6 +119,13 @@ async def _get_runtime_config(
     runtime_config.tool_call_parser = dynamo_args.tool_call_parser
     runtime_config.enable_local_indexer = dynamo_args.enable_local_indexer
 
+    # Set data_parallel_size for DP attention mode
+    # This enables the router to correctly track per-(worker_id, dp_rank) pairs
+    dp_size = getattr(server_args, "dp_size", 1) or 1
+    runtime_config.data_parallel_size = dp_size
+    if dp_size > 1:
+        logging.info(f"Registering with data_parallel_size={dp_size}")
+
     # Set bootstrap endpoint for disaggregated serving (prefill workers)
     bootstrap_host, bootstrap_port = _get_bootstrap_info_for_config(engine)
     if bootstrap_host and bootstrap_port:

--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -25,9 +25,9 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
         logging.info("Embedding worker handler initialized")
 
     def cleanup(self):
+        super().cleanup()
         self.engine.shutdown()
         logging.info("Engine shutdown")
-        super().cleanup()
 
     async def generate(self, request: dict, context: Context):
         """

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -214,7 +214,9 @@ class BaseWorkerHandler(ABC):
             if not children:
                 return
 
-            logging.info(f"Sending SIGTERM to {len(children)} child processes for graceful shutdown")
+            logging.debug(
+                f"Sending SIGTERM to {len(children)} child processes for graceful shutdown"
+            )
 
             # Send SIGTERM to allow atexit handlers to run
             for child in children:
@@ -227,7 +229,9 @@ class BaseWorkerHandler(ABC):
             gone, alive = psutil.wait_procs(children, timeout=timeout)
 
             if alive:
-                logging.warning(f"{len(alive)} child processes didn't terminate gracefully, will be killed by engine.shutdown()")
+                logging.warning(
+                    f"{len(alive)} child processes didn't terminate gracefully, will be killed by engine.shutdown()"
+                )
             else:
                 logging.info("All child processes terminated gracefully")
 

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -42,6 +42,7 @@ class BaseWorkerHandler(ABC):
         self.engine = engine
         self.config = config
         self.generate_endpoint = generate_endpoint
+        self.publisher = publisher
         if publisher is not None:
             self.metrics_publisher = publisher.metrics_publisher
             self.kv_publisher = publisher.kv_publisher
@@ -183,8 +184,55 @@ class BaseWorkerHandler(ABC):
         pass
 
     def cleanup(self) -> None:
-        """Cleanup resources. Override in subclasses as needed."""
-        pass
+        """Cleanup resources. Override in subclasses as needed.
+
+        Subclasses should call super().cleanup() FIRST, then engine.shutdown().
+        This ensures graceful child termination before SIGKILL.
+        """
+        self._graceful_shutdown_children()
+        if self.publisher is not None:
+            self.publisher.cleanup()
+
+    def _graceful_shutdown_children(self, timeout: float = 5.0) -> None:
+        """Gracefully terminate child processes before engine.shutdown() kills them.
+
+        SGLang's engine.shutdown() uses SIGKILL which doesn't allow cleanup.
+        We send SIGTERM first to allow ZMQ sockets and other resources to close properly.
+        """
+        import os
+
+        try:
+            import psutil
+        except ImportError:
+            logging.warning("psutil not available, skipping graceful child shutdown")
+            return
+
+        try:
+            parent = psutil.Process(os.getpid())
+            children = parent.children(recursive=True)
+
+            if not children:
+                return
+
+            logging.info(f"Sending SIGTERM to {len(children)} child processes for graceful shutdown")
+
+            # Send SIGTERM to allow atexit handlers to run
+            for child in children:
+                try:
+                    child.terminate()  # SIGTERM
+                except psutil.NoSuchProcess:
+                    pass
+
+            # Wait for graceful termination
+            gone, alive = psutil.wait_procs(children, timeout=timeout)
+
+            if alive:
+                logging.warning(f"{len(alive)} child processes didn't terminate gracefully, will be killed by engine.shutdown()")
+            else:
+                logging.info("All child processes terminated gracefully")
+
+        except Exception as e:
+            logging.warning(f"Error during graceful child shutdown: {e}")
 
     def _get_input_param(self, request: Dict[str, Any]) -> Dict[str, Any]:
         request_input = self.input_param_manager.get_input_param(

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -126,6 +126,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 self._get_trace_header(context) if self.enable_trace else None
             )
 
+            # Extract dp_rank from routing info (set by KV router)
+            routing = request.get("routing") or {}
+            dp_rank = routing.get("dp_rank")
+
             decode = await self.engine.async_generate(
                 **input_param,
                 sampling_params=sampling_params,
@@ -135,6 +139,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 bootstrap_room=bootstrap_info["bootstrap_room"],
                 external_trace_header=trace_header,
                 rid=trace_id,
+                data_parallel_rank=dp_rank,
             )
 
             if self.skip_tokenizer_init:

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -50,9 +50,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
     def cleanup(self) -> None:
         """Shutdown the engine and cleanup resources."""
+        super().cleanup()
         self.engine.shutdown()
         logging.info("Engine shutdown")
-        super().cleanup()
 
     def _build_sampling_params(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """Build sampling params from request format.

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -161,6 +161,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 self._get_trace_header(context) if self.enable_trace else None
             )
 
+            # Extract dp_rank from routing info (set by KV router)
+            routing = request.get("routing") or {}
+            dp_rank = routing.get("dp_rank")
+
             agg = await self.engine.async_generate(
                 **input_param,
                 image_data=image_data,
@@ -168,6 +172,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 stream=True,
                 external_trace_header=trace_header,
                 rid=trace_id,
+                data_parallel_rank=dp_rank,
             )
             if self.skip_tokenizer_init:
                 async for out in self._process_token_stream(agg, context):

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -49,9 +49,9 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 task.cancel()
         self._consume_tasks.clear()
 
+        super().cleanup()
         self.engine.shutdown()
         logging.info("Prefill engine shutdown")
-        super().cleanup()
 
     async def generate(
         self, request: Dict[str, Any], context: Context

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -400,9 +400,9 @@ class MultimodalWorkerHandler(BaseWorkerHandler):
         return bootstrap_info
 
     def cleanup(self):
+        super().cleanup()
         self.engine.shutdown()
         logger.info("Multimodal worker engine shutdown")
-        super().cleanup()
 
 
 class MultimodalPrefillWorkerHandler(BaseWorkerHandler):
@@ -515,6 +515,6 @@ class MultimodalPrefillWorkerHandler(BaseWorkerHandler):
             pass
 
     def cleanup(self):
+        super().cleanup()
         self.engine.shutdown()
         logger.info("Multimodal prefill engine shutdown")
-        super().cleanup()

--- a/tests/router/test_router_dp_attention.py
+++ b/tests/router/test_router_dp_attention.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+E2E test for DP attention KV events.
+
+Tests that when running SGLang with DP attention mode (--enable-dp-attention):
+1. All DP ranks publish KV events via ZMQ
+2. Dynamo receives events from all DP ranks
+3. Routing decisions work correctly with dp_rank metadata
+
+With --tp 4 --dp-size 4 --enable-dp-attention:
+- attn_tp_size = tp_size // dp_size = 4 // 4 = 1
+- All 4 schedulers have attn_tp_rank = 0 (KV events enabled for all)
+- Each scheduler publishes to port: base_port + attn_dp_rank
+- Ports: 5557, 5558, 5559, 5560 (all unique)
+
+The test verifies:
+- KV events are received with dp_rank metadata
+- Events come from all DP ranks (not just rank 0)
+- Router correctly routes based on prefix cache and dp_rank
+"""
+
+import logging
+import os
+import time
+from typing import Any, Dict, Optional
+
+import pytest
+
+from tests.router.common import (
+    _test_router_decisions,
+    generate_random_suffix,
+    get_runtime,
+)
+from tests.utils.constants import DefaultPort
+from tests.utils.managed_process import ManagedProcess
+from tests.utils.port_utils import allocate_ports, deallocate_ports
+
+logger = logging.getLogger(__name__)
+
+# Model that supports DP attention with MLA
+MODEL_NAME = "silence09/DeepSeek-R1-Small-2layers"
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.sglang,
+    pytest.mark.model(MODEL_NAME),
+    pytest.mark.gpu_4,  # Requires 4 GPUs for tp=4, dp=4
+]
+
+PAGE_SIZE = 16
+
+
+def allocate_frontend_ports(request, count: int) -> list[int]:
+    """Allocate random free frontend ports for xdist-safe execution."""
+    ports = allocate_ports(count, DefaultPort.FRONTEND.value)
+    request.addfinalizer(lambda: deallocate_ports(ports))
+    return ports
+
+
+# Shared test payload
+TEST_PAYLOAD: Dict[str, Any] = {
+    "model": MODEL_NAME,
+    "messages": [
+        {
+            "role": "user",
+            "content": "Hello, how are you today?",
+        }
+    ],
+    "stream": True,
+    "max_tokens": 10,
+}
+
+# SGLang configuration for DP attention
+# tp=4, dp=4 with enable-dp-attention
+SGLANG_DP_ATTENTION_ARGS: Dict[str, Any] = {
+    "page_size": PAGE_SIZE,
+    "model": MODEL_NAME,
+    "context_length": 1024,
+    "disable_cuda_graph": True,
+    # DP attention specific
+    "tp_size": 4,
+    "dp_size": 4,
+    "enable_dp_attention": True,
+}
+
+
+class SGLangDPAttentionProcess:
+    """Manages SGLang with DP attention mode for testing KV events from all ranks.
+
+    Unlike standard DP mode where each process is a separate DP rank,
+    DP attention mode runs a single process with all DP ranks inside.
+    Each internal scheduler publishes KV events to a unique ZMQ port.
+    """
+
+    def __init__(
+        self,
+        request,
+        sglang_args: Optional[Dict[str, Any]] = None,
+        base_kv_port: int = 5557,
+        request_plane: str = "nats",
+        store_backend: str = "etcd",
+    ):
+        """Initialize SGLang with DP attention mode.
+
+        Args:
+            request: pytest request fixture for log directory
+            sglang_args: Configuration dict with:
+                - page_size: KV cache page size
+                - model: Model name/path
+                - tp_size: Tensor parallel size
+                - dp_size: Data parallel size
+                - enable_dp_attention: Enable attention parallelism
+            base_kv_port: Base port for ZMQ KV events (each dp_rank adds offset)
+            request_plane: Request plane to use ("nats" or "tcp")
+            store_backend: Storage backend ("etcd" or "file")
+        """
+        namespace_suffix = generate_random_suffix()
+        self.namespace = f"test-namespace-{namespace_suffix}"
+        self.component_name = "backend"
+        self.endpoint = f"dyn://{self.namespace}.{self.component_name}.generate"
+        self.store_backend = store_backend
+
+        if sglang_args is None:
+            sglang_args = SGLANG_DP_ATTENTION_ARGS.copy()
+
+        self.page_size = sglang_args.get("page_size", PAGE_SIZE)
+        self.model = sglang_args.get("model", MODEL_NAME)
+        self.tp_size = sglang_args.get("tp_size", 4)
+        self.dp_size = sglang_args.get("dp_size", 4)
+        self.enable_dp_attention = sglang_args.get("enable_dp_attention", True)
+        self.context_length = sglang_args.get("context_length", 1024)
+        self.disable_cuda_graph = sglang_args.get("disable_cuda_graph", True)
+
+        self.base_kv_port = base_kv_port
+        self.model_name = self.model
+
+        # With DP attention, number of workers = 1 (single process with all ranks)
+        # But instance_ids will return dp_size separate instances
+        self.num_workers = 1
+        self.data_parallel_size = self.dp_size
+
+        # Build command for DP attention mode
+        command = [
+            "python3",
+            "-m",
+            "dynamo.sglang",
+            "--model-path",
+            self.model,
+            "--page-size",
+            str(self.page_size),
+            "--tp",
+            str(self.tp_size),
+            "--dp-size",
+            str(self.dp_size),
+            "--enable-dp-attention",
+            "--trust-remote-code",
+        ]
+
+        if self.disable_cuda_graph:
+            command.append("--disable-cuda-graph")
+
+        if self.context_length:
+            command.extend(["--context-length", str(self.context_length)])
+
+        # KV events config - base port, each scheduler will offset by attn_dp_rank
+        kv_events_config = f'{{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:{base_kv_port}"}}'
+        command.extend(["--kv-events-config", kv_events_config])
+
+        env = os.environ.copy()
+        env_vars = {
+            "CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in range(self.tp_size)),
+            "DYN_NAMESPACE": self.namespace,
+            "DYN_REQUEST_PLANE": request_plane,
+            "PYTHONHASHSEED": "0",
+        }
+
+        if self.store_backend == "file" and "DYN_FILE_KV" in os.environ:
+            env_vars["DYN_FILE_KV"] = os.environ["DYN_FILE_KV"]
+
+        env.update(env_vars)
+
+        self._process = ManagedProcess(
+            command=command,
+            env=env,
+            timeout=180,  # DP attention needs more time to initialize
+            display_output=True,
+            health_check_ports=[],
+            health_check_urls=[],
+            log_dir=request.node.name,
+            terminate_existing=False,
+        )
+
+        logger.info(
+            f"Created SGLang DP attention process: tp={self.tp_size}, dp={self.dp_size}, "
+            f"kv_base_port={base_kv_port}, endpoint={self.endpoint}"
+        )
+
+    def __enter__(self):
+        logger.info(f"Starting SGLang DP attention process...")
+        self._process.__enter__()
+
+        # Wait additional time for all schedulers to initialize ZMQ publishers
+        logger.info("Waiting for all ZMQ publishers to start...")
+        time.sleep(10)
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        logger.info("Stopping SGLang DP attention process")
+        self._process.__exit__(exc_type, exc_val, exc_tb)
+        time.sleep(2)
+
+
+@pytest.mark.gpu_4
+@pytest.mark.timeout(300)  # 5 minutes for DP attention initialization
+@pytest.mark.parametrize("request_plane", ["nats"], indirect=True)
+def test_dp_attention_kv_events_all_ranks(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    set_ucx_tls_no_mm,
+    request_plane,
+):
+    """
+    Test that KV events are received from all DP attention ranks.
+
+    Configuration: --tp 4 --dp-size 4 --enable-dp-attention
+
+    This test verifies:
+    1. All 4 schedulers start ZMQ publishers on unique ports
+    2. KV events include dp_rank metadata
+    3. Router can route requests based on prefix cache per dp_rank
+    """
+    logger.info("Starting DP attention KV events test")
+
+    try:
+        # Start SGLang with DP attention
+        sglang_workers = SGLangDPAttentionProcess(
+            request,
+            sglang_args=SGLANG_DP_ATTENTION_ARGS,
+            base_kv_port=5557,
+            request_plane=request_plane,
+        )
+        logger.info(f"Using namespace: {sglang_workers.namespace}")
+        sglang_workers.__enter__()
+
+        # Get runtime and create endpoint
+        runtime = get_runtime(request_plane=request_plane)
+        namespace = runtime.namespace(sglang_workers.namespace)
+        component = namespace.component("backend")
+        endpoint = component.endpoint("generate")
+
+        # Run router decisions test with DP rank verification
+        _test_router_decisions(
+            sglang_workers,
+            endpoint,
+            MODEL_NAME,
+            request,
+            test_dp_rank=True,  # Enable DP rank testing
+            block_size=PAGE_SIZE,
+        )
+
+    finally:
+        if "sglang_workers" in locals():
+            sglang_workers.__exit__(None, None, None)
+
+
+@pytest.mark.gpu_4
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("request_plane", ["nats"], indirect=True)
+def test_dp_attention_zmq_ports_bound(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    set_ucx_tls_no_mm,
+    request_plane,
+):
+    """
+    Verify that all DP attention ranks bind to unique ZMQ ports.
+
+    With tp=4, dp=4, enable_dp_attention:
+    - Scheduler 0 (attn_dp_rank=0) -> port 5557
+    - Scheduler 1 (attn_dp_rank=1) -> port 5558
+    - Scheduler 2 (attn_dp_rank=2) -> port 5559
+    - Scheduler 3 (attn_dp_rank=3) -> port 5560
+    """
+    import socket
+
+    logger.info("Starting DP attention ZMQ ports test")
+
+    try:
+        sglang_workers = SGLangDPAttentionProcess(
+            request,
+            sglang_args=SGLANG_DP_ATTENTION_ARGS,
+            base_kv_port=5557,
+            request_plane=request_plane,
+        )
+        sglang_workers.__enter__()
+
+        # Check that all 4 ZMQ ports are bound
+        bound_ports = []
+        for i in range(4):
+            port = 5557 + i
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            result = sock.connect_ex(('127.0.0.1', port))
+            sock.close()
+
+            if result == 0:
+                bound_ports.append(port)
+                logger.info(f"Port {port} is bound (attn_dp_rank={i})")
+            else:
+                logger.warning(f"Port {port} is NOT bound (attn_dp_rank={i})")
+
+        # Verify all 4 ports are bound
+        assert len(bound_ports) == 4, (
+            f"Expected all 4 ZMQ ports (5557-5560) to be bound, "
+            f"but only found: {bound_ports}"
+        )
+
+        logger.info(f"SUCCESS: All 4 ZMQ ports bound: {bound_ports}")
+
+    finally:
+        if "sglang_workers" in locals():
+            sglang_workers.__exit__(None, None, None)

--- a/tests/router/test_router_dp_attention.py
+++ b/tests/router/test_router_dp_attention.py
@@ -198,7 +198,7 @@ class SGLangDPAttentionProcess:
         )
 
     def __enter__(self):
-        logger.info(f"Starting SGLang DP attention process...")
+        logger.info("Starting SGLang DP attention process...")
         self._process.__enter__()
 
         # Wait additional time for all schedulers to initialize ZMQ publishers
@@ -304,7 +304,7 @@ def test_dp_attention_zmq_ports_bound(
         for i in range(4):
             port = 5557 + i
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            result = sock.connect_ex(('127.0.0.1', port))
+            result = sock.connect_ex(("127.0.0.1", port))
             sock.close()
 
             if result == 0:


### PR DESCRIPTION
## Summary

This PR fixes DP attention support in Dynamo's SGLang integration with four key improvements:

1. **Multi-port ZMQ subscription**: Subscribe to all DP attention ZMQ ports for KV events (not just the base port) - co-authored by @huitianbai
2. **DP rank routing**: Wire up `data_parallel_rank` parameter to SGLang's `async_generate` so KV router's DP rank selection takes effect
3. **DP size registration**: Register `data_parallel_size` with discovery service so the router can correctly track per-(worker_id, dp_rank) pairs
4. **Multi-node ZMQ bind support**: Hybrid bind/connect logic for multi-node DP attention setups

## Changes

### Multi-port ZMQ subscription
**`components/src/dynamo/sglang/publisher.py`**:
- Import SGLang's `ZmqEventPublisher` to use its `offset_endpoint_port()` function
- Modify `init_kv_event_publish()` to detect DP attention mode and create multiple ZMQ subscribers
- Add helper function `format_zmq_endpoint()` for IPv6 address handling
- Add `cleanup()` method for proper ZMQ resource cleanup

### DP rank routing
**`components/src/dynamo/sglang/request_handlers/llm/decode_handler.py`**:
- Extract `dp_rank` from routing info (set by KV router)
- Pass `data_parallel_rank=dp_rank` to `async_generate()` for both aggregated and disaggregated flows

### DP size registration
**`components/src/dynamo/sglang/register.py`**:
- Read `dp_size` from SGLang server args
- Set `runtime_config.data_parallel_size` when registering with discovery
- This enables the router to correctly track per-(worker_id, dp_rank) pairs

### Multi-node ZMQ bind support
**`lib/llm/src/kv_router/publisher.rs`**:
- Add `bind: bool` field to `KvEventSourceConfig::Zmq` enum
- Add `bind: bool` parameter to `start_zmq_listener()` function
- Socket setup: `if bind { socket.bind() } else { socket.connect() }`

**`lib/bindings/python/rust/llm/kv.rs`**:
- Add `bind: bool` field to `ZmqKvEventPublisherConfig` (default: `false`)

**`components/src/dynamo/sglang/publisher.py`**:
- Add hybrid bind/connect logic based on DP rank locality
- Only create subscribers on head node (`node_rank == 0`)

### Tests
**`tests/router/test_router_dp_attention.py`** (new):
- E2E test for DP attention with KV events from all ranks
- Test to verify all ZMQ ports are bound

## Architecture

### Single-node DP Attention
```
SGLang Schedulers (DP attention mode):
  Scheduler 0 (attn_dp_rank=0) → ZMQ PUB tcp://*:5557
  Scheduler 1 (attn_dp_rank=1) → ZMQ PUB tcp://*:5558
  Scheduler 2 (attn_dp_rank=2) → ZMQ PUB tcp://*:5559
  Scheduler 3 (attn_dp_rank=3) → ZMQ PUB tcp://*:5560

Dynamo Subscribers (this fix):
  ZmqKvEventPublisher[0] → CONNECTS to tcp://IP:5557
  ZmqKvEventPublisher[1] → CONNECTS to tcp://IP:5558
  ZmqKvEventPublisher[2] → CONNECTS to tcp://IP:5559
  ZmqKvEventPublisher[3] → CONNECTS to tcp://IP:5560

KV Router → selects dp_rank → passed to async_generate()
```

### Multi-node DP Attention (Hybrid Bind/Connect)

When DP attention spans multiple nodes, ZMQ KV events don't work because:
- SGLang's heuristic: wildcard (`*`) → BIND, specific IP → CONNECT
- Dynamo always CONNECTs - never binds
- When both use specific IP, both CONNECT and nobody BINDs

**Solution**: Hybrid bind/connect based on DP rank locality:
- Local DP ranks (on same node as Dynamo): SGLang binds, Dynamo connects
- Remote DP ranks (on other nodes): Dynamo binds, SGLang connects

```
2 nodes, 4 DP ranks (2 per node):
  local_dp_size = 4 // 2 = 2

Node 0 (Dynamo + SGLang DP 0,1)          Node 1 (SGLang DP 2,3 only)
┌────────────────────────────┐          ┌────────────────────────────┐
│  Dynamo creates 4 subs:    │          │  SGLang schedulers:        │
│                            │          │                            │
│  DP 0: bind=False          │          │                            │
│        CONNECT  ◄──────────┼── BIND   │  DP 0 (local to node 0)    │
│  DP 1: bind=False          │          │                            │
│        CONNECT  ◄──────────┼── BIND   │  DP 1 (local to node 0)    │
│                            │          │                            │
│  DP 2: bind=True           │          │  DP 2: CONNECT ──────────┐ │
│        BIND    ────────────┼──────────┼──────────────────────────┘ │
│  DP 3: bind=True           │          │  DP 3: CONNECT ──────────┐ │
│        BIND    ────────────┼──────────┼──────────────────────────┘ │
└────────────────────────────┘          └────────────────────────────┘

Logic: bind = (dp_rank >= local_dp_size)
  - DP 0,1: dp_rank < 2 → bind=False (Dynamo connects, SGLang binds)
  - DP 2,3: dp_rank >= 2 → bind=True (Dynamo binds, SGLang connects)
```

## Test plan

- [x] Verify all ZMQ ports are bound with `--enable-dp-attention`
- [x] Verify Dynamo creates multiple ZMQ subscribers (one per port)
- [x] Verify KV events are received from all DP ranks
- [x] Verify `data_parallel_rank` is passed to SGLang
- [x] Verify `data_parallel_size` is registered with discovery
- [ ] Run e2e tests: `pytest tests/router/test_router_dp_attention.py -v`

Co-authored-by: huitianbai <huitianbai@gmail.com>

closes: DYN-1818