### PR TITLE
fix: block on notification of at least one runtime config

### DIFF
--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod model_manager;
-pub use model_manager::{ModelManager, ModelManagerError};
+pub use model_manager::{ModelManager, ModelManagerError, RuntimeConfigsWithNotify};
 
 mod watcher;
 pub use watcher::{ModelUpdate, ModelWatcher};

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use dashmap::DashMap;
 use derive_builder::Builder;
 use dynamo_runtime::{
     component::{Client, Endpoint},
@@ -39,6 +38,7 @@ pub use prefill_router::PrefillRouter;
 use worker_query::WorkerQueryClient;
 
 use crate::{
+    discovery::RuntimeConfigsWithNotify,
     kv_router::{
         approx::PruneConfig,
         indexer::{KvIndexer, KvIndexerInterface, KvRouterError, OverlapScores, RouterEvent},
@@ -281,7 +281,7 @@ impl KvRouter {
     pub async fn new(
         endpoint: Endpoint,
         client: Client,
-        workers_with_configs: Arc<DashMap<protocols::WorkerId, Option<ModelRuntimeConfig>>>,
+        workers_with_configs: Arc<RuntimeConfigsWithNotify>,
         block_size: u32,
         selector: Option<Box<dyn WorkerSelector + Send + Sync>>,
         kv_router_config: Option<KvRouterConfig>,
@@ -290,8 +290,6 @@ impl KvRouter {
         let kv_router_config = kv_router_config.unwrap_or_default();
         let component = endpoint.component();
         let cancellation_token = component.drt().primary_token();
-
-        let instance_ids_rx = client.instance_avail_watcher();
 
         // Watch for runtime config updates via discovery interface
         // (still needed for WorkerQueryClient and background tasks)
@@ -339,8 +337,7 @@ impl KvRouter {
         let scheduler = KvScheduler::start(
             component.clone(),
             block_size,
-            instance_ids_rx,
-            workers_with_configs,
+            workers_with_configs.clone(),
             selector,
             kv_router_config.router_replica_sync,
             consumer_id.clone(),
@@ -354,39 +351,24 @@ impl KvRouter {
         tracing::info!("Worker query client initialized");
 
         // Start KV event subscriber background process (only when use_kv_events is enabled)
-        // We block here until at least one worker runtime config is registered,
-        // then spawn the subscriber. This ensures the router is ready before accepting requests.
+        // model_manager.get_or_create_runtime_config_watcher() guarantees at least one worker exists.
         if kv_router_config.use_kv_events
             && let Indexer::KvIndexer(ref kv_indexer) = indexer
         {
-            let mut runtime_configs_rx_clone = runtime_configs_rx.clone();
+            // model_manager guarantees workers_with_configs is populated
+            let count = workers_with_configs.configs.len();
+            assert!(
+                count > 0,
+                "workers_with_configs should have at least one worker"
+            );
 
-            // Wait for at least one worker runtime config to be registered
-            tracing::info!("Waiting for at least one worker runtime config to be registered...");
-            let (all_local_indexer, count) = loop {
-                {
-                    let configs = runtime_configs_rx_clone.borrow();
-                    if !configs.is_empty() {
-                        let all_local_indexer = configs.values().all(|c| c.enable_local_indexer);
-                        break (all_local_indexer, configs.len());
-                    }
-                }
+            let all_local_indexer = workers_with_configs
+                .configs
+                .iter()
+                .filter_map(|r| r.value().as_ref().map(|c| c.enable_local_indexer))
+                .all(|b| b);
 
-                // Wait for changes to runtime_configs
-                tokio::select! {
-                    _ = cancellation_token.cancelled() => {
-                        tracing::debug!("KvRouter startup cancelled while waiting for workers");
-                        anyhow::bail!("KvRouter startup cancelled");
-                    }
-                    result = runtime_configs_rx_clone.changed() => {
-                        if result.is_err() {
-                            tracing::debug!("Runtime configs channel closed");
-                            anyhow::bail!("Runtime configs channel closed before any workers registered");
-                        }
-                    }
-                }
-            };
-            tracing::info!("Found {count} worker runtime config(s), starting KV event subscriber");
+            tracing::info!("Found {count} worker(s), starting KV event subscriber");
 
             // Start subscriber - setup runs synchronously, then spawns background loop internally
             if all_local_indexer {

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::discovery::RuntimeConfigsWithNotify;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 use anyhow::Result;
-use dashmap::DashMap;
 use dynamo_runtime::component::Component;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_runtime::traits::events::EventPublisher;
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::watch;
 
 use super::KV_HIT_RATE_SUBJECT;
 use super::KvRouterConfig;
@@ -97,16 +96,17 @@ impl KvScheduler {
     pub async fn start(
         component: Component,
         block_size: u32,
-        instance_ids_rx: watch::Receiver<Vec<u64>>,
-        workers_with_configs: Arc<DashMap<WorkerId, Option<ModelRuntimeConfig>>>,
+        workers_with_configs: Arc<RuntimeConfigsWithNotify>,
         selector: Option<Box<dyn WorkerSelector + Send + Sync>>,
         replica_sync: bool,
         router_uuid: String,
     ) -> Result<Self, KvSchedulerError> {
         let selector = selector.unwrap_or(Box::new(DefaultWorkerSelector::default()));
 
-        // Get initial workers from DashMap for slot initialization
+        // Get initial workers from DashMap for slot initialization.
+        // ModelManager guarantees at least one worker is present before KvRouter::new() is called.
         let initial_workers: HashMap<WorkerId, Option<ModelRuntimeConfig>> = workers_with_configs
+            .configs
             .iter()
             .map(|r| (*r.key(), r.value().clone()))
             .collect();
@@ -119,33 +119,29 @@ impl KvScheduler {
             router_uuid,
         ));
 
-        // Spawn background task to monitor workers_with_configs changes and update slots
+        // Spawn background task to sync slots with DashMap when notified of changes.
+        // ModelManager's watcher updates the DashMap and notifies; we wait on notify here.
         let slots_monitor = slots.clone();
         let workers_monitor = workers_with_configs.clone();
-        let mut instance_ids_monitor_rx = instance_ids_rx.clone();
         let monitor_cancel_token = component.drt().child_token();
         tokio::spawn(async move {
             tracing::trace!("KvScheduler workers monitoring task started");
             let mut last_workers: HashSet<WorkerId> = HashSet::new();
 
             loop {
-                // Wait for instance changes (ModelManager handles config updates to the DashMap)
+                // Wait for notification or cancellation
                 tokio::select! {
                     _ = monitor_cancel_token.cancelled() => {
                         tracing::trace!("KvScheduler workers monitoring task shutting down");
                         break;
                     }
-                    result = instance_ids_monitor_rx.changed() => {
-                        if result.is_err() {
-                            tracing::warn!("instance IDs watch sender shutdown in KvScheduler monitor");
-                            break;
-                        }
-                    }
+                    _ = workers_monitor.notify.notified() => {}
                 }
 
                 // Get current workers from DashMap
                 let current_workers: HashMap<WorkerId, Option<ModelRuntimeConfig>> =
                     workers_monitor
+                        .configs
                         .iter()
                         .map(|r| (*r.key(), r.value().clone()))
                         .collect();
@@ -156,13 +152,8 @@ impl KvScheduler {
                 if current_worker_ids != last_workers {
                     slots_monitor.update_workers(current_workers);
                     last_workers = current_worker_ids;
-                    tracing::trace!(
-                        "KvScheduler: Updated slots with {} workers",
-                        last_workers.len()
-                    );
                 }
             }
-            tracing::trace!("KvScheduler workers monitoring task shutting down");
         });
 
         let slots_clone = slots.clone();
@@ -202,6 +193,7 @@ impl KvScheduler {
 
                 // Read the current workers configuration from DashMap
                 let workers: HashMap<WorkerId, Option<ModelRuntimeConfig>> = workers_scheduler
+                    .configs
                     .iter()
                     .map(|r| (*r.key(), r.value().clone()))
                     .collect();


### PR DESCRIPTION
#### Overview:

`runtime_configs` in `model_manager.rs` needs to wait for at least one instance to be ready


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal synchronization and configuration management for system stability.
  * Simplified worker discovery and initialization process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->