### PR TITLE
feat: add remote transfers for object and file

### DIFF
--- a/lib/llm/src/block_manager/block/transfer.rs
+++ b/lib/llm/src/block_manager/block/transfer.rs
@@ -5,6 +5,7 @@ pub mod context;
 mod cuda;
 mod memcpy;
 mod nixl;
+mod remote;
 mod strategy;
 
 use super::*;
@@ -60,6 +61,9 @@ pub enum TransferError {
 
     #[error("Mismatched {0:?} worker ID: {1} != {2}")]
     MismatchedWorkerID(BlockTarget, usize, usize),
+
+    #[error("Transfer was cancelled")]
+    Cancelled,
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/lib/llm/src/block_manager/block/transfer/nixl.rs
+++ b/lib/llm/src/block_manager/block/transfer/nixl.rs
@@ -3,10 +3,17 @@
 
 use super::*;
 
+use super::remote::{RemoteBlockDescriptor, RemoteKey, RemoteStorageKind, RemoteTransferDirection};
+use crate::block_manager::config::RemoteTransferContext;
+use crate::block_manager::storage::nixl::NixlRegisterableStorage;
+use crate::block_manager::storage::{DiskStorage, ObjectStorage};
 use anyhow::Result;
-use nixl_sys::{MemoryRegion, NixlDescriptor, XferDescList, XferStatus};
+use nixl_sys::{
+    Agent as NixlAgent, MemType, MemoryRegion, NixlDescriptor, XferDescList, XferOp, XferRequest,
+    XferStatus,
+};
 use std::future::Future;
-
+use tokio_util::sync::CancellationToken;
 fn append_xfer_request<Source, Destination>(
     src: &Source,
     dst: &mut Destination,
@@ -148,5 +155,771 @@ where
         })))
     } else {
         Ok(Box::new(std::future::ready(())))
+    }
+}
+
+/// Execute a remote storage transfer (object storage or disk).
+///
+/// This function handles the NIXL-level execution of remote transfers.
+/// It supports both object storage and remote disk.
+///
+/// # Arguments
+///
+/// * `direction` - Whether this is an onboard (read) or offload (write)
+/// * `kind` - Type of remote storage (Object or Disk)
+/// * `descriptors` - Remote block descriptors with keys and sizes
+/// * `local_blocks` - Local host blocks (source for offload, destination for onboard)
+/// * `ctx` - Remote transfer context
+/// * `cancel_token` - Cancellation token for cooperative cancellation
+///
+/// # Returns
+///
+/// `Ok(())` on success, or `TransferError` on failure/cancellation.
+pub async fn execute_remote_transfer<LB>(
+    direction: RemoteTransferDirection,
+    kind: RemoteStorageKind,
+    descriptors: &[RemoteBlockDescriptor],
+    local_blocks: &[LB],
+    ctx: &RemoteTransferContext,
+    cancel_token: &CancellationToken,
+) -> Result<(), TransferError>
+where
+    LB: ReadableBlock + WritableBlock + Local,
+    <LB as StorageTypeProvider>::StorageType: NixlDescriptor,
+{
+    if descriptors.is_empty() || local_blocks.is_empty() {
+        return Ok(());
+    }
+
+    if descriptors.len() != local_blocks.len() {
+        return Err(TransferError::CountMismatch(
+            descriptors.len(),
+            local_blocks.len(),
+        ));
+    }
+
+    // Check for early cancellation
+    if cancel_token.is_cancelled() {
+        return Err(TransferError::Cancelled);
+    }
+
+    let nixl_agent_arc = ctx.nixl_agent();
+    let agent = nixl_agent_arc
+        .as_ref()
+        .as_ref()
+        .ok_or_else(|| TransferError::ExecutionError("NIXL agent not available".to_string()))?;
+
+    let num_blocks = descriptors.len();
+
+    // Get block size from first local block
+    let first_block = &local_blocks[0];
+    let block_size = first_block.block_data().block_view()?.size();
+
+    tracing::debug!(
+        "Remote transfer: {} blocks, direction={:?}, kind={:?}, block_size={}",
+        num_blocks,
+        direction,
+        kind,
+        block_size
+    );
+
+    match kind {
+        RemoteStorageKind::Object => {
+            execute_object_transfer(
+                agent,
+                direction,
+                descriptors,
+                local_blocks,
+                block_size,
+                ctx,
+                cancel_token,
+            )
+            .await
+        }
+        RemoteStorageKind::Disk => {
+            execute_disk_transfer(
+                agent,
+                direction,
+                descriptors,
+                local_blocks,
+                block_size,
+                ctx,
+                cancel_token,
+            )
+            .await
+        }
+    }
+}
+
+/// Execute object storage transfer.
+async fn execute_object_transfer<LB>(
+    agent: &NixlAgent,
+    direction: RemoteTransferDirection,
+    descriptors: &[RemoteBlockDescriptor],
+    local_blocks: &[LB],
+    block_size: usize,
+    ctx: &RemoteTransferContext,
+    cancel_token: &CancellationToken,
+) -> Result<(), TransferError>
+where
+    LB: ReadableBlock + WritableBlock + Local,
+    <LB as StorageTypeProvider>::StorageType: NixlDescriptor,
+{
+    let num_blocks = descriptors.len();
+    let _default_bucket = ctx.default_bucket().unwrap_or("default");
+
+    // Use a scope block to ensure all non-Send types are dropped before await
+    let (xfer_req, still_pending) = {
+        // Register ALL object storage regions with NIXL
+        let mut obj_storages = Vec::with_capacity(num_blocks);
+        let mut _registration_handles = Vec::with_capacity(num_blocks);
+
+        // TODO: Add support for string-based object keys via metadata in nixl-sys Rust bindings.
+        // For now, we pass the sequence hash (u64) directly as device_id.
+
+        for desc in descriptors.iter() {
+            let bucket = match desc.key() {
+                RemoteKey::Object(obj_key) => obj_key.bucket.as_str(),
+                _ => {
+                    return Err(TransferError::IncompatibleTypes(
+                        "Expected Object key for object storage transfer".to_string(),
+                    ));
+                }
+            };
+
+            // Use sequence hash directly as device_id - NIXL uses this as the object key
+            let object_key = desc.sequence_hash().ok_or_else(|| {
+                TransferError::ExecutionError(format!(
+                    "Descriptor missing sequence_hash: {:?}",
+                    desc.key()
+                ))
+            })?;
+
+            let obj_storage = ObjectStorage::new(bucket, object_key, block_size).map_err(|e| {
+                TransferError::ExecutionError(format!("Failed to create ObjectStorage: {:?}", e))
+            })?;
+
+            let handle = agent.register_memory(&obj_storage, None).map_err(|e| {
+                TransferError::ExecutionError(format!("Failed to register object storage: {:?}", e))
+            })?;
+
+            obj_storages.push(obj_storage);
+            _registration_handles.push(handle);
+        }
+
+        // Build transfer descriptor lists
+        let mut src_dl = XferDescList::new(MemType::Dram).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to create src_dl: {:?}", e))
+        })?;
+        let mut dst_dl = XferDescList::new(MemType::Object).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to create dst_dl: {:?}", e))
+        })?;
+
+        for (block, desc) in local_blocks.iter().zip(descriptors.iter()) {
+            let block_view = block.block_data().block_view()?;
+            let addr = unsafe { block_view.as_ptr() as usize };
+
+            src_dl.add_desc(addr, block_size, 0); // device_id=0 for host
+            dst_dl.add_desc(0, block_size, desc.sequence_hash().unwrap());
+        }
+
+        // Determine the transfer operation
+        let xfer_op = match direction {
+            RemoteTransferDirection::Offload => XferOp::Write,
+            RemoteTransferDirection::Onboard => XferOp::Read,
+        };
+
+        // Create transfer request
+        let agent_name = agent.name();
+        let xfer_req = agent
+            .create_xfer_req(xfer_op, &src_dl, &dst_dl, &agent_name, None)
+            .map_err(|e| {
+                TransferError::ExecutionError(format!("Failed to create xfer_req: {:?}", e))
+            })?;
+
+        let still_pending = agent.post_xfer_req(&xfer_req, None).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to post xfer_req: {:?}", e))
+        })?;
+
+        (xfer_req, still_pending)
+    };
+
+    // Wait for completion with cancellation support
+    if still_pending {
+        poll_transfer_completion(agent, &xfer_req, cancel_token).await?;
+    }
+
+    tracing::debug!(
+        "Object transfer complete: {} blocks, direction={:?}",
+        num_blocks,
+        direction
+    );
+
+    Ok(())
+}
+
+/// Execute disk storage transfer.
+async fn execute_disk_transfer<LB>(
+    agent: &NixlAgent,
+    direction: RemoteTransferDirection,
+    descriptors: &[RemoteBlockDescriptor],
+    local_blocks: &[LB],
+    block_size: usize,
+    _ctx: &RemoteTransferContext,
+    cancel_token: &CancellationToken,
+) -> Result<(), TransferError>
+where
+    LB: ReadableBlock + WritableBlock + Local,
+    <LB as StorageTypeProvider>::StorageType: NixlDescriptor,
+{
+    let num_blocks = descriptors.len();
+
+    // For Offload (write): create files
+    // For Onboard (read): open existing files
+    let create_files = matches!(direction, RemoteTransferDirection::Offload);
+
+    // Use a scope block to ensure all non-Send types are dropped before await
+    let (xfer_req, still_pending, _disk_storages) = {
+        // Dynamically create/open and register disk storage for each block
+        let mut disk_storages = Vec::with_capacity(num_blocks);
+
+        for desc in descriptors.iter() {
+            // Get file path from descriptor's DiskKey
+            let file_path = match desc.key() {
+                RemoteKey::Disk(disk_key) => disk_key.full_path(),
+                _ => {
+                    return Err(TransferError::IncompatibleTypes(
+                        "Expected Disk key for disk storage transfer".to_string(),
+                    ));
+                }
+            };
+
+            // Create or open DiskStorage at the specified path
+            // persist=true ensures files aren't deleted when DiskStorage is dropped
+            let mut disk_storage =
+                DiskStorage::new_at_path(&file_path, block_size, create_files, true).map_err(
+                    |e| {
+                        TransferError::ExecutionError(format!(
+                            "Failed to {} DiskStorage at {}: {:?}",
+                            if create_files { "create" } else { "open" },
+                            file_path,
+                            e
+                        ))
+                    },
+                )?;
+
+            // Register with NIXL - this makes it available for transfers
+            disk_storage.nixl_register(agent, None).map_err(|e| {
+                TransferError::ExecutionError(format!(
+                    "Failed to register disk storage {}: {:?}",
+                    file_path, e
+                ))
+            })?;
+
+            disk_storages.push(disk_storage);
+        }
+
+        // Build transfer descriptor lists for disk
+        let mut src_dl = XferDescList::new(MemType::Dram).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to create src_dl: {:?}", e))
+        })?;
+        let mut dst_dl = XferDescList::new(MemType::File).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to create dst_dl: {:?}", e))
+        })?;
+
+        for (block, disk_storage) in local_blocks.iter().zip(disk_storages.iter()) {
+            let block_view = block.block_data().block_view()?;
+            let addr = unsafe { block_view.as_ptr() as usize };
+
+            // Add DRAM source descriptor
+            let _ = src_dl.add_desc(addr, block_size, 0);
+
+            // Add FILE destination descriptor using the actual file descriptor
+            let fd = disk_storage.fd();
+            let _ = dst_dl.add_desc(0, block_size, fd);
+        }
+
+        // Determine the transfer operation
+        let xfer_op = match direction {
+            RemoteTransferDirection::Offload => XferOp::Write,
+            RemoteTransferDirection::Onboard => XferOp::Read,
+        };
+
+        // Create transfer request
+        let agent_name = agent.name();
+        let xfer_req = agent
+            .create_xfer_req(xfer_op, &src_dl, &dst_dl, &agent_name, None)
+            .map_err(|e| {
+                TransferError::ExecutionError(format!("Failed to create xfer_req: {:?}", e))
+            })?;
+
+        let still_pending = agent.post_xfer_req(&xfer_req, None).map_err(|e| {
+            TransferError::ExecutionError(format!("Failed to post xfer_req: {:?}", e))
+        })?;
+
+        // Return disk_storages to keep them alive during the transfer
+        (xfer_req, still_pending, disk_storages)
+    };
+
+    // Wait for completion with cancellation support
+    if still_pending {
+        poll_transfer_completion(agent, &xfer_req, cancel_token).await?;
+    }
+
+    tracing::debug!(
+        "Disk transfer complete: {} blocks, direction={:?}",
+        num_blocks,
+        direction
+    );
+
+    Ok(())
+}
+
+/// Poll for transfer completion with cancellation support.
+async fn poll_transfer_completion(
+    agent: &NixlAgent,
+    xfer_req: &XferRequest,
+    cancel_token: &CancellationToken,
+) -> Result<(), TransferError> {
+    let poll_interval = tokio::time::Duration::from_micros(100);
+
+    loop {
+        tokio::select! {
+            _ = cancel_token.cancelled() => {
+                return Err(TransferError::Cancelled);
+            }
+            _ = tokio::time::sleep(poll_interval) => {
+                let status = agent.get_xfer_status(xfer_req).map_err(|e| {
+                    TransferError::ExecutionError(format!("Failed to get transfer status: {:?}", e))
+                })?;
+
+                match status {
+                    XferStatus::Success => return Ok(()),
+                    XferStatus::InProgress => continue,
+                    // Handle other status values if they exist
+                    #[allow(unreachable_patterns)]
+                    other => {
+                        return Err(TransferError::ExecutionError(format!(
+                            "Transfer failed with status: {:?}",
+                            other
+                        )));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "testing-cuda", feature = "testing-nixl"))]
+mod tests {
+    use super::*;
+    use crate::block_manager::block::transfer::context::TransferContext;
+    use crate::block_manager::{
+        LayoutConfig,
+        block::{BasicMetadata, Block, BlockData, locality},
+        config::{RemoteStorageConfig, RemoteTransferContext},
+        layout::{BlockLayoutConfig, FullyContiguous, nixl::NixlLayout},
+        storage::{PinnedAllocator, PinnedStorage},
+    };
+    use cudarc::driver::CudaContext;
+    use std::sync::Arc;
+
+    // Shared NIXL agent with OBJ and POSIX backends
+    lazy_static::lazy_static! {
+        static ref TEST_AGENT: Arc<Option<NixlAgent>> = {
+            let agent = NixlAgent::new("nixl-transfer-test").expect("Failed to create NIXL agent");
+
+            // Create OBJ backend for object storage
+            if let Ok((_, params)) = agent.get_plugin_params("OBJ") {
+                match agent.create_backend("OBJ", &params) {
+                    Ok(_) => eprintln!("OBJ backend created"),
+                    Err(e) => eprintln!("OBJ backend failed: {}", e),
+                }
+            } else {
+                eprintln!("OBJ plugin not found");
+            }
+
+            // Create POSIX backend for disk storage
+            if let Ok((_, params)) = agent.get_plugin_params("POSIX") {
+                match agent.create_backend("POSIX", &params) {
+                    Ok(_) => eprintln!("POSIX backend created"),
+                    Err(e) => eprintln!("POSIX backend failed: {}", e),
+                }
+            } else {
+                eprintln!("POSIX plugin not found");
+            }
+
+            Arc::new(Some(agent))
+        };
+
+        static ref CUDA_CTX: Arc<CudaContext> = {
+            CudaContext::new(0).expect("Failed to create CUDA context")
+        };
+    }
+
+    fn create_test_layout(num_blocks: usize) -> FullyContiguous<PinnedStorage> {
+        let config = LayoutConfig::builder()
+            .num_blocks(num_blocks)
+            .num_layers(2)
+            .outer_dim(1)
+            .page_size(4)
+            .inner_dim(64)
+            .dtype_width_bytes(2)
+            .build()
+            .unwrap();
+
+        let allocator = PinnedAllocator::new().unwrap();
+        FullyContiguous::allocate(config, &allocator).unwrap()
+    }
+
+    fn create_transfer_context() -> Arc<TransferContext> {
+        let stream = CUDA_CTX.default_stream();
+        let handle = tokio::runtime::Handle::current();
+        Arc::new(TransferContext::new(
+            TEST_AGENT.clone(),
+            stream,
+            handle,
+            None,
+        ))
+    }
+
+    fn create_disk_remote_context(base: Arc<TransferContext>, path: &str) -> RemoteTransferContext {
+        RemoteTransferContext::new(base, RemoteStorageConfig::disk(path, false))
+    }
+
+    fn create_object_remote_context(
+        base: Arc<TransferContext>,
+        bucket: &str,
+    ) -> RemoteTransferContext {
+        RemoteTransferContext::new(base, RemoteStorageConfig::object(bucket))
+    }
+
+    #[tokio::test]
+    async fn test_execute_remote_transfer_empty_descriptors() {
+        let base_ctx = create_transfer_context();
+        let remote_ctx = create_disk_remote_context(base_ctx, "/tmp/nixl-test");
+        let cancel_token = CancellationToken::new();
+
+        let descriptors: Vec<RemoteBlockDescriptor> = vec![];
+        let local_blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = vec![];
+
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Disk,
+            &descriptors,
+            &local_blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_execute_remote_transfer_count_mismatch() {
+        let base_ctx = create_transfer_context();
+        let remote_ctx = create_disk_remote_context(base_ctx, "/tmp/nixl-test");
+        let cancel_token = CancellationToken::new();
+
+        // Create 2 descriptors but 1 block - should fail
+        let descriptors = vec![
+            RemoteBlockDescriptor::disk_from_hash("/tmp", 0x1234, 1024),
+            RemoteBlockDescriptor::disk_from_hash("/tmp", 0x5678, 1024),
+        ];
+
+        let mut layout = create_test_layout(1);
+        layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let layout = Arc::new(layout);
+        let blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..1)
+            .map(|i| {
+                let data = BlockData::new(layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Disk,
+            &descriptors,
+            &blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        assert!(matches!(result, Err(TransferError::CountMismatch(2, 1))));
+    }
+
+    #[tokio::test]
+    async fn test_execute_remote_transfer_early_cancellation() {
+        let base_ctx = create_transfer_context();
+        let remote_ctx = create_disk_remote_context(base_ctx, "/tmp/nixl-test");
+        let cancel_token = CancellationToken::new();
+
+        // Cancel before starting
+        cancel_token.cancel();
+
+        let descriptors = vec![RemoteBlockDescriptor::disk_from_hash("/tmp", 0x1234, 1024)];
+
+        let mut layout = create_test_layout(1);
+        layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let layout = Arc::new(layout);
+        let blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..1)
+            .map(|i| {
+                let data = BlockData::new(layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Disk,
+            &descriptors,
+            &blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        assert!(matches!(result, Err(TransferError::Cancelled)));
+    }
+
+    /// Test disk transfer using POSIX backend - writes data to disk and reads it back
+    #[tokio::test]
+    async fn test_posix_disk_transfer_roundtrip() {
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let base_path = temp_dir.path().to_str().unwrap().to_string();
+
+        let base_ctx = create_transfer_context();
+        let remote_ctx = create_disk_remote_context(base_ctx, &base_path);
+        let cancel_token = CancellationToken::new();
+
+        // Create blocks and fill with test data
+        let mut layout = create_test_layout(2);
+        layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let block_size = layout.layout_data_bytes() / layout.num_blocks();
+        let layout = Arc::new(layout);
+
+        let mut blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..2)
+            .map(|i| {
+                let data = BlockData::new(layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        // Fill blocks with recognizable pattern
+        for (i, block) in blocks.iter_mut().enumerate() {
+            let mut view = block.block_data_mut().block_view_mut().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+            for (j, byte) in slice.iter_mut().enumerate() {
+                *byte = ((i * 100 + j) % 256) as u8;
+            }
+        }
+
+        let descriptors: Vec<RemoteBlockDescriptor> = (0..2u64)
+            .map(|i| RemoteBlockDescriptor::disk_from_hash(&base_path, 0x1000 + i, block_size))
+            .collect();
+
+        // Offload (write to disk via POSIX)
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Disk,
+            &descriptors,
+            &blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        if result.is_err() {
+            eprintln!(
+                "POSIX disk transfer test skipped - backend may not be available: {:?}",
+                result
+            );
+            return;
+        }
+        assert!(result.is_ok(), "POSIX Offload failed: {:?}", result);
+
+        // Drop offload blocks to ensure we're not reusing cached memory
+        drop(blocks);
+
+        // Create fresh blocks for onboarding (different memory)
+        let mut onboard_layout = create_test_layout(2);
+        onboard_layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let onboard_layout = Arc::new(onboard_layout);
+
+        let mut onboard_blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..2)
+            .map(|i| {
+                let data = BlockData::new(onboard_layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        // Verify onboard blocks start zeroed (not containing our pattern)
+        for block in onboard_blocks.iter() {
+            let view = block.block_data().block_view().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+            assert!(
+                slice.iter().all(|&b| b == 0),
+                "Onboard blocks should start zeroed"
+            );
+        }
+
+        // Onboard (read from disk via POSIX) into fresh blocks
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Onboard,
+            RemoteStorageKind::Disk,
+            &descriptors,
+            &onboard_blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        assert!(result.is_ok(), "POSIX Onboard failed: {:?}", result);
+
+        // Verify data was restored to the new blocks
+        for (i, block) in onboard_blocks.iter().enumerate() {
+            let view = block.block_data().block_view().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+            for (j, &byte) in slice.iter().enumerate() {
+                let expected = ((i * 100 + j) % 256) as u8;
+                assert_eq!(
+                    byte, expected,
+                    "POSIX: Data mismatch at block {} byte {}",
+                    i, j
+                );
+            }
+        }
+        eprintln!("POSIX disk roundtrip transfer successful (using separate blocks for onboard)");
+    }
+
+    /// Test object storage transfer using OBJ backend - writes data to S3/object store and reads it back
+    #[tokio::test]
+    async fn test_obj_object_storage_transfer_roundtrip() {
+        let bucket =
+            std::env::var("NIXL_TEST_BUCKET").unwrap_or_else(|_| "nixl-test-bucket".to_string());
+
+        let base_ctx = create_transfer_context();
+        let remote_ctx = create_object_remote_context(base_ctx, &bucket);
+        let cancel_token = CancellationToken::new();
+
+        // Create blocks and fill with test data
+        let mut layout = create_test_layout(2);
+        layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let block_size = layout.layout_data_bytes() / layout.num_blocks();
+        let layout = Arc::new(layout);
+
+        let mut blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..2)
+            .map(|i| {
+                let data = BlockData::new(layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        for (i, block) in blocks.iter_mut().enumerate() {
+            let mut view = block.block_data_mut().block_view_mut().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts_mut(view.as_mut_ptr(), view.size()) };
+            for (j, byte) in slice.iter_mut().enumerate() {
+                *byte = ((i * 200 + j) % 256) as u8;
+            }
+        }
+
+        // Use unique sequence hashes for this test run
+        let test_id = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+
+        let descriptors: Vec<RemoteBlockDescriptor> = (0..2u64)
+            .map(|i| RemoteBlockDescriptor::object_from_hash(&bucket, test_id + i, block_size))
+            .collect();
+
+        // Offload (write to object storage via OBJ)
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Offload,
+            RemoteStorageKind::Object,
+            &descriptors,
+            &blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        if result.is_err() {
+            eprintln!(
+                "OBJ object storage test skipped - backend may not be available or S3 not configured: {:?}",
+                result
+            );
+            return;
+        }
+        assert!(result.is_ok(), "OBJ Offload failed: {:?}", result);
+
+        // Drop offload blocks to ensure we're not reusing cached memory
+        drop(blocks);
+
+        // Create fresh blocks for onboarding (different memory)
+        let mut onboard_layout = create_test_layout(2);
+        onboard_layout
+            .nixl_register(TEST_AGENT.as_ref().as_ref().unwrap(), None)
+            .unwrap();
+        let onboard_layout = Arc::new(onboard_layout);
+
+        let mut onboard_blocks: Vec<Block<PinnedStorage, locality::Local, BasicMetadata>> = (0..2)
+            .map(|i| {
+                let data = BlockData::new(onboard_layout.clone(), i, 0, 0);
+                Block::new(data, BasicMetadata::default()).unwrap()
+            })
+            .collect();
+
+        // Verify onboard blocks start zeroed (not containing our pattern)
+        for block in onboard_blocks.iter() {
+            let view = block.block_data().block_view().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+            assert!(
+                slice.iter().all(|&b| b == 0),
+                "Onboard blocks should start zeroed"
+            );
+        }
+
+        let result = execute_remote_transfer(
+            RemoteTransferDirection::Onboard,
+            RemoteStorageKind::Object,
+            &descriptors,
+            &onboard_blocks,
+            &remote_ctx,
+            &cancel_token,
+        )
+        .await;
+
+        assert!(result.is_ok(), "OBJ Onboard failed: {:?}", result);
+
+        // Verify data was restored to the new blocks
+        for (i, block) in onboard_blocks.iter().enumerate() {
+            let view = block.block_data().block_view().unwrap();
+            let slice = unsafe { std::slice::from_raw_parts(view.as_ptr(), view.size()) };
+            for (j, &byte) in slice.iter().enumerate() {
+                let expected = ((i * 200 + j) % 256) as u8;
+                assert_eq!(
+                    byte, expected,
+                    "OBJ: Data mismatch at block {} byte {}",
+                    i, j
+                );
+            }
+        }
+        eprintln!("OBJ object storage roundtrip transfer successful");
     }
 }

--- a/lib/llm/src/block_manager/block/transfer/remote.rs
+++ b/lib/llm/src/block_manager/block/transfer/remote.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Remote storage transfer abstractions for remote transfers.

--- a/lib/llm/src/block_manager/block/transfer/remote.rs
+++ b/lib/llm/src/block_manager/block/transfer/remote.rs
@@ -1,0 +1,548 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Remote storage transfer abstractions for remote transfers.
+//!
+//! This module provides the core types for remote storage transfers:
+//! - [`RemoteKey`] - Abstract key for remote storage (object or disk)
+//! - [`RemoteBlockDescriptor`] - Descriptor for a block in remote storage
+//! - [`RemoteTransferPipeline`] - Transfer pipeline configuration
+//! - [`RemoteTransferHandle`] - Handle for async transfer operations
+//!
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use super::TransferError;
+
+/// Kind of remote storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RemoteStorageKind {
+    Object,
+    Disk,
+}
+
+/// A key that identifies a block in remote storage.
+///
+/// This is an abstract type that can represent different addressing schemes:
+/// - Object storage: bucket + object key
+/// - Remote disk: path + offset/key
+///
+/// The key must be serializable for registry storage and network transmission.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RemoteKey {
+    /// Object storage
+    Object(ObjectKey),
+    /// Remote disk
+    Disk(DiskKey),
+}
+
+/// Key for object storage - bucket + object identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ObjectKey {
+    /// Bucket/container name
+    pub bucket: String,
+    /// Object key/path within bucket
+    pub key: String,
+}
+
+impl ObjectKey {
+    /// Create a new object key.
+    pub fn new(bucket: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            bucket: bucket.into(),
+            key: key.into(),
+        }
+    }
+
+    /// Create from sequence hash (common pattern: hash as hex string).
+    pub fn from_hash(bucket: impl Into<String>, hash: u64) -> Self {
+        Self {
+            bucket: bucket.into(),
+            key: format!("{:016x}", hash),
+        }
+    }
+
+    /// Get the hash if this key was created from a hash.
+    pub fn as_hash(&self) -> Option<u64> {
+        u64::from_str_radix(&self.key, 16).ok()
+    }
+}
+
+/// Key for remote disk storage - path + identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DiskKey {
+    /// Base path (mount point, share path, etc.)
+    pub path: String,
+    /// Block identifier within the path (could be filename, offset, etc.)
+    pub key: String,
+}
+
+impl DiskKey {
+    /// Create a new disk key.
+    pub fn new(path: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            key: key.into(),
+        }
+    }
+
+    /// Create from sequence hash.
+    pub fn from_hash(path: impl Into<String>, hash: u64) -> Self {
+        Self {
+            path: path.into(),
+            key: format!("{:016x}", hash),
+        }
+    }
+
+    /// Get full path (path + key).
+    pub fn full_path(&self) -> String {
+        format!("{}/{}", self.path, self.key)
+    }
+}
+
+impl RemoteKey {
+    /// Get the storage kind.
+    pub fn kind(&self) -> RemoteStorageKind {
+        match self {
+            RemoteKey::Object(_) => RemoteStorageKind::Object,
+            RemoteKey::Disk(_) => RemoteStorageKind::Disk,
+        }
+    }
+
+    /// Get the "raw" key portion (for NIXL device_id).
+    /// Returns hash of the key for use in NIXL descriptors.
+    pub fn nixl_device_id(&self) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Create object key.
+    pub fn object(bucket: impl Into<String>, key: impl Into<String>) -> Self {
+        RemoteKey::Object(ObjectKey::new(bucket, key))
+    }
+
+    /// Create disk key.
+    pub fn disk(path: impl Into<String>, key: impl Into<String>) -> Self {
+        RemoteKey::Disk(DiskKey::new(path, key))
+    }
+
+    /// Get the sequence hash if this is an object key created from a hash.
+    pub fn sequence_hash(&self) -> Option<u64> {
+        match self {
+            RemoteKey::Object(obj) => obj.as_hash(),
+            RemoteKey::Disk(disk) => u64::from_str_radix(&disk.key, 16).ok(),
+        }
+    }
+
+    /// Get the location (bucket for Object, path for Disk).
+    pub fn location(&self) -> &str {
+        match self {
+            RemoteKey::Object(obj) => &obj.bucket,
+            RemoteKey::Disk(disk) => &disk.path,
+        }
+    }
+
+    /// Get the key portion (object key or disk key).
+    pub fn key_str(&self) -> &str {
+        match self {
+            RemoteKey::Object(obj) => &obj.key,
+            RemoteKey::Disk(disk) => &disk.key,
+        }
+    }
+
+    /// Create object key from sequence hash (common pattern).
+    pub fn object_from_hash(bucket: impl Into<String>, hash: u64) -> Self {
+        RemoteKey::Object(ObjectKey::from_hash(bucket, hash))
+    }
+
+    /// Create disk key from sequence hash.
+    pub fn disk_from_hash(path: impl Into<String>, hash: u64) -> Self {
+        RemoteKey::Disk(DiskKey::from_hash(path, hash))
+    }
+}
+
+/// Core metadata associated with a remote block.
+#[derive(Debug, Clone, Copy)]
+pub struct RemoteBlockMetadata {
+    pub sequence_hash: u64,
+    pub stored_at: u64,
+}
+
+impl RemoteBlockMetadata {
+    pub fn new(sequence_hash: u64) -> Self {
+        Self {
+            sequence_hash,
+            stored_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64,
+        }
+    }
+    pub fn with_timestamp(sequence_hash: u64, stored_at: u64) -> Self {
+        Self {
+            sequence_hash,
+            stored_at,
+        }
+    }
+}
+
+/// Descriptor for a block in remote storage.
+///
+/// Unlike local blocks which have memory addresses, remote blocks
+/// are identified by keys. The descriptor includes both the key
+/// and size information needed for transfers.
+#[derive(Debug, Clone)]
+pub struct RemoteBlockDescriptor {
+    /// Key identifying the block in remote storage
+    key: RemoteKey,
+    /// Size of the block in bytes
+    size: usize,
+    /// Optional metadata
+    metadata: Option<RemoteBlockMetadata>,
+}
+
+impl RemoteBlockDescriptor {
+    /// Create a new descriptor with just key and size.
+    pub fn new(key: RemoteKey, size: usize) -> Self {
+        Self {
+            key,
+            size,
+            metadata: None,
+        }
+    }
+
+    /// Create with metadata.
+    pub fn with_metadata(key: RemoteKey, size: usize, metadata: RemoteBlockMetadata) -> Self {
+        Self {
+            key,
+            size,
+            metadata: Some(metadata),
+        }
+    }
+
+    pub fn object(bucket: impl Into<String>, key: impl Into<String>, size: usize) -> Self {
+        Self::new(RemoteKey::object(bucket, key), size)
+    }
+
+    pub fn object_from_hash(bucket: impl Into<String>, hash: u64, size: usize) -> Self {
+        let bucket = bucket.into();
+        let mut desc = Self::new(RemoteKey::Object(ObjectKey::from_hash(&bucket, hash)), size);
+        desc.metadata = Some(RemoteBlockMetadata::new(hash));
+        desc
+    }
+
+    pub fn disk(path: impl Into<String>, key: impl Into<String>, size: usize) -> Self {
+        Self::new(RemoteKey::disk(path, key), size)
+    }
+
+    pub fn disk_from_hash(path: impl Into<String>, hash: u64, size: usize) -> Self {
+        let path = path.into();
+        let mut desc = Self::new(RemoteKey::Disk(DiskKey::from_hash(&path, hash)), size);
+        desc.metadata = Some(RemoteBlockMetadata::new(hash));
+        desc
+    }
+
+    pub fn key(&self) -> &RemoteKey {
+        &self.key
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    pub fn kind(&self) -> RemoteStorageKind {
+        self.key.kind()
+    }
+
+    pub fn metadata(&self) -> Option<&RemoteBlockMetadata> {
+        self.metadata.as_ref()
+    }
+
+    pub fn set_metadata(&mut self, metadata: RemoteBlockMetadata) {
+        self.metadata = Some(metadata);
+    }
+
+    pub fn sequence_hash(&self) -> Option<u64> {
+        self.metadata.as_ref().map(|m| m.sequence_hash)
+    }
+}
+
+/// Direction of remote transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteTransferDirection {
+    Onboard,
+    Offload,
+}
+
+impl RemoteTransferDirection {
+    pub fn is_onboard(&self) -> bool {
+        matches!(self, Self::Onboard)
+    }
+    pub fn is_offload(&self) -> bool {
+        matches!(self, Self::Offload)
+    }
+}
+
+/// Defines a complete transfer pipeline for remote storage.
+///
+/// Supports:
+/// - Remote -> Local (onboard to host)
+/// - Local -> Remote (offload from host)
+/// - Remote -> Bounce -> Device (full onboard pipeline)
+/// - Device -> Bounce -> Remote (full offload pipeline)
+#[derive(Debug, Clone)]
+pub enum RemoteTransferPipeline {
+    Direct {
+        direction: RemoteTransferDirection,
+        remote_descriptors: Vec<RemoteBlockDescriptor>,
+    },
+
+    WithBounce {
+        direction: RemoteTransferDirection,
+        remote_descriptors: Vec<RemoteBlockDescriptor>,
+        bounce_block_ids: Vec<usize>,
+        device_block_ids: Vec<usize>,
+    },
+}
+
+impl RemoteTransferPipeline {
+    pub fn offload_direct(descriptors: Vec<RemoteBlockDescriptor>) -> Self {
+        Self::Direct {
+            direction: RemoteTransferDirection::Offload,
+            remote_descriptors: descriptors,
+        }
+    }
+
+    pub fn onboard_direct(descriptors: Vec<RemoteBlockDescriptor>) -> Self {
+        Self::Direct {
+            direction: RemoteTransferDirection::Onboard,
+            remote_descriptors: descriptors,
+        }
+    }
+
+    pub fn offload_with_bounce(
+        descriptors: Vec<RemoteBlockDescriptor>,
+        bounce_ids: Vec<usize>,
+        device_ids: Vec<usize>,
+    ) -> Self {
+        Self::WithBounce {
+            direction: RemoteTransferDirection::Offload,
+            remote_descriptors: descriptors,
+            bounce_block_ids: bounce_ids,
+            device_block_ids: device_ids,
+        }
+    }
+
+    pub fn onboard_with_bounce(
+        descriptors: Vec<RemoteBlockDescriptor>,
+        bounce_ids: Vec<usize>,
+        device_ids: Vec<usize>,
+    ) -> Self {
+        Self::WithBounce {
+            direction: RemoteTransferDirection::Onboard,
+            remote_descriptors: descriptors,
+            bounce_block_ids: bounce_ids,
+            device_block_ids: device_ids,
+        }
+    }
+
+    pub fn direction(&self) -> RemoteTransferDirection {
+        match self {
+            Self::Direct { direction, .. } => *direction,
+            Self::WithBounce { direction, .. } => *direction,
+        }
+    }
+
+    pub fn descriptors(&self) -> &[RemoteBlockDescriptor] {
+        match self {
+            Self::Direct {
+                remote_descriptors, ..
+            } => remote_descriptors,
+            Self::WithBounce {
+                remote_descriptors, ..
+            } => remote_descriptors,
+        }
+    }
+
+    pub fn has_bounce(&self) -> bool {
+        matches!(self, Self::WithBounce { .. })
+    }
+
+    pub fn num_blocks(&self) -> usize {
+        self.descriptors().len()
+    }
+}
+
+/// Strategy for remote transfers.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteTransferStrategy {
+    NixlObjectRead,
+    NixlObjectWrite,
+    NixlDiskRead,
+    NixlDiskWrite,
+    Invalid,
+}
+
+impl RemoteTransferStrategy {
+    pub fn is_read(&self) -> bool {
+        matches!(self, Self::NixlObjectRead | Self::NixlDiskRead)
+    }
+    pub fn is_write(&self) -> bool {
+        matches!(self, Self::NixlObjectWrite | Self::NixlDiskWrite)
+    }
+    pub fn is_object(&self) -> bool {
+        matches!(self, Self::NixlObjectRead | Self::NixlObjectWrite)
+    }
+    pub fn is_disk(&self) -> bool {
+        matches!(self, Self::NixlDiskRead | Self::NixlDiskWrite)
+    }
+
+    pub fn from_direction_and_kind(
+        direction: RemoteTransferDirection,
+        kind: RemoteStorageKind,
+    ) -> Self {
+        match (direction, kind) {
+            (RemoteTransferDirection::Onboard, RemoteStorageKind::Object) => Self::NixlObjectRead,
+            (RemoteTransferDirection::Offload, RemoteStorageKind::Object) => Self::NixlObjectWrite,
+            (RemoteTransferDirection::Onboard, RemoteStorageKind::Disk) => Self::NixlDiskRead,
+            (RemoteTransferDirection::Offload, RemoteStorageKind::Disk) => Self::NixlDiskWrite,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RemoteTransferHandle {
+    completion: oneshot::Receiver<Result<(), TransferError>>,
+    cancel_token: CancellationToken,
+}
+
+impl RemoteTransferHandle {
+    pub(crate) fn new(
+        completion: oneshot::Receiver<Result<(), TransferError>>,
+        cancel_token: CancellationToken,
+    ) -> Self {
+        Self {
+            completion,
+            cancel_token,
+        }
+    }
+
+    pub fn cancel(&self) {
+        self.cancel_token.cancel();
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel_token.is_cancelled()
+    }
+
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    pub async fn wait(self) -> Result<(), TransferError> {
+        self.completion
+            .await
+            .map_err(|_| TransferError::ExecutionError("Transfer task dropped".to_string()))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_object_key_from_hash() {
+        let key = ObjectKey::from_hash("my-bucket", 0x1234567890abcdef);
+        assert_eq!(key.bucket, "my-bucket");
+        assert_eq!(key.key, "1234567890abcdef");
+        assert_eq!(key.as_hash(), Some(0x1234567890abcdef));
+    }
+
+    #[test]
+    fn test_disk_key_full_path() {
+        let key = DiskKey::new("/mnt/nfs", "block_001");
+        assert_eq!(key.full_path(), "/mnt/nfs/block_001");
+    }
+
+    #[test]
+    fn test_remote_key_kind() {
+        let obj_key = RemoteKey::object("bucket", "key");
+        assert_eq!(obj_key.kind(), RemoteStorageKind::Object);
+
+        let disk_key = RemoteKey::disk("/path", "key");
+        assert_eq!(disk_key.kind(), RemoteStorageKind::Disk);
+    }
+
+    #[test]
+    fn test_remote_block_descriptor() {
+        let desc = RemoteBlockDescriptor::object_from_hash("bucket", 0x1234, 4096);
+        assert_eq!(desc.size(), 4096);
+        assert_eq!(desc.kind(), RemoteStorageKind::Object);
+        assert_eq!(desc.sequence_hash(), Some(0x1234));
+    }
+
+    #[test]
+    fn test_remote_transfer_pipeline() {
+        let descs = vec![
+            RemoteBlockDescriptor::object_from_hash("bucket", 0x1234, 4096),
+            RemoteBlockDescriptor::object_from_hash("bucket", 0x5678, 4096),
+        ];
+
+        // Direct offload
+        let pipeline = RemoteTransferPipeline::offload_direct(descs.clone());
+        assert_eq!(pipeline.direction(), RemoteTransferDirection::Offload);
+        assert!(!pipeline.has_bounce());
+        assert_eq!(pipeline.num_blocks(), 2);
+
+        // With bounce
+        let pipeline = RemoteTransferPipeline::onboard_with_bounce(descs, vec![0, 1], vec![10, 11]);
+        assert_eq!(pipeline.direction(), RemoteTransferDirection::Onboard);
+        assert!(pipeline.has_bounce());
+    }
+
+    #[test]
+    fn test_remote_transfer_strategy() {
+        assert!(RemoteTransferStrategy::NixlObjectRead.is_read());
+        assert!(RemoteTransferStrategy::NixlObjectRead.is_object());
+        assert!(!RemoteTransferStrategy::NixlObjectRead.is_write());
+        assert!(!RemoteTransferStrategy::NixlObjectRead.is_disk());
+
+        assert!(RemoteTransferStrategy::NixlDiskWrite.is_write());
+        assert!(RemoteTransferStrategy::NixlDiskWrite.is_disk());
+        assert_eq!(
+            RemoteTransferStrategy::from_direction_and_kind(
+                RemoteTransferDirection::Onboard,
+                RemoteStorageKind::Object,
+            ),
+            RemoteTransferStrategy::NixlObjectRead
+        );
+        assert_eq!(
+            RemoteTransferStrategy::from_direction_and_kind(
+                RemoteTransferDirection::Offload,
+                RemoteStorageKind::Disk,
+            ),
+            RemoteTransferStrategy::NixlDiskWrite
+        );
+    }
+
+    #[test]
+    fn test_remote_block_metadata() {
+        let meta = RemoteBlockMetadata::new(0x1234);
+        assert_eq!(meta.sequence_hash, 0x1234);
+        assert!(meta.stored_at > 0);
+    }
+
+    #[test]
+    fn test_remote_transfer_direction() {
+        assert!(RemoteTransferDirection::Onboard.is_onboard());
+        assert!(!RemoteTransferDirection::Onboard.is_offload());
+        assert!(RemoteTransferDirection::Offload.is_offload());
+        assert!(!RemoteTransferDirection::Offload.is_onboard());
+    }
+}

--- a/lib/llm/src/block_manager/storage/disk.rs
+++ b/lib/llm/src/block_manager/storage/disk.rs
@@ -27,6 +27,8 @@ pub struct DiskStorage {
     size: usize,
     handles: RegistrationHandles,
     unlinked: bool,
+    /// When true, the file is NOT unlinked on drop (for persistent storage use cases)
+    persist: bool,
 }
 
 impl Local for DiskStorage {}
@@ -323,6 +325,89 @@ impl DiskStorage {
             size,
             handles: RegistrationHandles::new(),
             unlinked: false,
+            persist: false, // Temp files are auto-cleaned
+        })
+    }
+
+    /// Create or open a DiskStorage at a specific path.
+    ///
+    /// This is used for remote disk transfers where the path is specified by the
+    /// transfer descriptor (e.g., from RemoteBlockDescriptor's DiskKey).
+    ///
+    /// # Arguments
+    /// * `path` - Full path to the file
+    /// * `size` - Size of the storage in bytes
+    /// * `create` - If true, create the file (O_CREAT). If false, file must exist.
+    /// * `persist` - If true, the file is NOT unlinked when DiskStorage is dropped.
+    ///               Use `true` for files that should outlive the DiskStorage instance.
+    pub fn new_at_path(
+        path: &str,
+        size: usize,
+        create: bool,
+        persist: bool,
+    ) -> Result<Self, StorageError> {
+        use nix::fcntl::{OFlag, open};
+        use nix::sys::stat::Mode;
+
+        // Ensure parent directory exists
+        if let Some(parent) = Path::new(path).parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    StorageError::AllocationFailed(format!(
+                        "Failed to create parent directory for {}: {}",
+                        path, e
+                    ))
+                })?;
+            }
+        }
+
+        // Build open flags
+        let mut flags = OFlag::O_RDWR | OFlag::O_CLOEXEC;
+        if create {
+            flags |= OFlag::O_CREAT;
+        }
+
+        // Optionally add O_DIRECT
+        let disable_o_direct = std::env::var(DISK_DISABLE_O_DIRECT_KEY).is_ok();
+        if !disable_o_direct {
+            flags |= OFlag::O_DIRECT;
+        }
+
+        // Open/create the file
+        let mode = Mode::from_bits_truncate(0o644);
+        let raw_fd = open(path, flags, mode).map_err(|e| {
+            StorageError::AllocationFailed(format!(
+                "Failed to {} file {}: {}",
+                if create { "create" } else { "open" },
+                path,
+                e
+            ))
+        })?;
+
+        // Allocate space if creating
+        if create {
+            allocate_file(raw_fd, size as u64).map_err(|e| {
+                unsafe { nix::libc::close(raw_fd) };
+                StorageError::AllocationFailed(format!("Failed to allocate file {}: {}", path, e))
+            })?;
+        }
+
+        tracing::info!(
+            "DiskStorage {} at path: fd={}, file={}, size={} bytes, persist={}",
+            if create { "created" } else { "opened" },
+            raw_fd,
+            path,
+            size,
+            persist
+        );
+
+        Ok(Self {
+            fd: raw_fd as u64,
+            file_name: path.to_string(),
+            size,
+            handles: RegistrationHandles::new(),
+            unlinked: false,
+            persist,
         })
     }
 
@@ -361,25 +446,35 @@ impl DiskStorage {
     pub fn unlinked(&self) -> bool {
         self.unlinked
     }
+
+    pub fn persist(&self) -> bool {
+        self.persist
+    }
 }
 
 impl Drop for DiskStorage {
     fn drop(&mut self) {
         tracing::warn!(
-            "DiskStorage being dropped: fd={}, file={}, size={} bytes, already_unlinked={}",
+            "DiskStorage being dropped: fd={}, file={}, size={} bytes, already_unlinked={}, persist={}",
             self.fd,
             self.file_name,
             self.size,
-            self.unlinked
+            self.unlinked,
+            self.persist
         );
 
         self.handles.release();
-        let _ = self.unlink();
+
+        // Only unlink if this is a temporary file (not persisted)
+        if !self.persist {
+            let _ = self.unlink();
+        }
 
         tracing::info!(
-            "DiskStorage dropped and cleaned up: fd={}, file={}",
+            "DiskStorage dropped and cleaned up: fd={}, file={}, persist={}",
             self.fd,
-            self.file_name
+            self.file_name,
+            self.persist
         );
     }
 }

--- a/lib/llm/src/block_manager/storage/nixl.rs
+++ b/lib/llm/src/block_manager/storage/nixl.rs
@@ -387,7 +387,12 @@ impl NixlRegisterableStorage for DiskStorage {
         }
 
         handle_nixl_register(self, agent, opt_args)?;
-        self.unlink()?;
+
+        // Only unlink if this is a temporary file (not persisted).
+        // For persistent files, we need to keep the path accessible for later reads.
+        if !self.persist() {
+            self.unlink()?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
#### Overview:

Implemented remote transfer support for object storage (S3/MinIO) and disk storage via NIXL backends. Added execute_remote_transfer() API with support for both OBJ and POSIX backends, enabling offload/onboard operations to remote storage.

#### Details:

**Remote Transfer Implementation:**

- Implemented execute_remote_transfer() function supporting both RemoteStorageKind::Object and RemoteStorageKind::Disk
- Added execute_object_transfer() for S3-compatible object storage via NIXL OBJ backend
- Added execute_disk_transfer() for disk storage via NIXL POSIX backend
- Implemented bidirectional transfers: Offload (write to remote) and Onboard (read from remote)

**DiskStorage Persistence:**
- Added persist field to DiskStorage to control file lifecycle for remote transfers
- Updated DiskStorage::new_at_path() with persist parameter
- Updated nixl_register() for DiskStorage to respect persist flag
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- relates to GitHub issue: #4887


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote block transfers via object and disk backends
  * Configurable remote storage options (object & disk)
  * Transfer pipelines with direct and bounce strategies
  * Transfer cancellation with cooperative polling and cancellation handling
  * Persistent disk storage option to preserve files beyond lifecycle

* **Bug Fixes**
  * Registration/drop logic respects persistence to avoid removing persisted files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->