### PR TITLE
docs: Update TensorRT-LLM install prerequisites for 1.2.0rc5

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/
 
 > [!Note]
 > Ensure that you select a PyTorch container image version that matches the version of TensorRT-LLM you are using.
-> For example, if you are using `tensorrt-llm==1.1.0rc5`, use the PyTorch container image version `25.06`.
+> For example, if you are using `tensorrt-llm==1.2.0rc5`, use the appropriate PyTorch container image version.
 > To find the correct PyTorch container version for your desired `tensorrt-llm` release, visit the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) on GitHub. Switch to the branch that matches your `tensorrt-llm` version, and look for the `BASE_TAG` line to identify the recommended PyTorch container tag.
 
 > [!Important]
@@ -244,13 +244,13 @@ It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/
 ### Install prerequisites
 
 ```
-# Optional step: Only required for Blackwell and Grace Hopper
-uv pip install torch==2.7.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
-
-# Required until the trtllm version is bumped to include this pinned dependency itself
-uv pip install "cuda-python>=12,<13"
+# By default, PyTorch CUDA 12.8 package is installed. Install PyTorch CUDA 13.0 package to align with the CUDA version used for building TensorRT LLM wheels.
+uv pip install torch==2.9.0 torchvision --index-url https://download.pytorch.org/whl/cu130
 
 sudo apt-get -y install libopenmpi-dev
+
+# Optional step: Only required for disaggregated serving
+sudo apt-get -y install libzmq3-dev
 ```
 
 > [!Tip]

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/
 
 > [!Note]
 > Ensure that you select a PyTorch container image version that matches the version of TensorRT-LLM you are using.
-> For example, if you are using `tensorrt-llm==1.2.0rc5`, use the appropriate PyTorch container image version.
+> For example, if you are using `tensorrt-llm==1.2.0`, use the PyTorch container image version `25.10`.
 > To find the correct PyTorch container version for your desired `tensorrt-llm` release, visit the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) on GitHub. Switch to the branch that matches your `tensorrt-llm` version, and look for the `BASE_TAG` line to identify the recommended PyTorch container tag.
 
 > [!Important]
@@ -244,7 +244,7 @@ It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/
 ### Install prerequisites
 
 ```
-# By default, PyTorch CUDA 12.8 package is installed. Install PyTorch CUDA 13.0 package to align with the CUDA version used for building TensorRT LLM wheels.
+# Optional step: Only required for non-container installations. The PyTorch 25.10 container already includes PyTorch 2.9.0 with CUDA 13.0.
 uv pip install torch==2.9.0 torchvision --index-url https://download.pytorch.org/whl/cu130
 
 sudo apt-get -y install libopenmpi-dev

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/
 
 > [!Note]
 > Ensure that you select a PyTorch container image version that matches the version of TensorRT-LLM you are using.
-> For example, if you are using `tensorrt-llm==1.2.0`, use the PyTorch container image version `25.10`.
+> For example, if you are using `tensorrt-llm==1.2.0rc5`, use the PyTorch container image version `25.10`.
 > To find the correct PyTorch container version for your desired `tensorrt-llm` release, visit the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) on GitHub. Switch to the branch that matches your `tensorrt-llm` version, and look for the `BASE_TAG` line to identify the recommended PyTorch container tag.
 
 > [!Important]


### PR DESCRIPTION
## Summary
- Update README TensorRT-LLM installation prerequisites to align with tensorrt-llm==1.2.0rc5 official documentation
- PyTorch version: 2.7.1 → 2.9.0
- CUDA wheel: cu128 → cu130
- Remove cuda-python requirement (no longer needed)
- Add libzmq3-dev for disaggregated serving
- Remove torchaudio from install command

## Reference
- Linear: [DYN-1682](https://linear.app/nvidia/issue/DYN-1682)
- Official TensorRT-LLM docs: https://nvidia.github.io/TensorRT-LLM/1.2.0rc5/installation/linux.html

## Test plan
- [ ] Verify documentation renders correctly on GitHub
- [ ] Test pip install commands work with tensorrt-llm==1.2.0rc5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TensorRT-LLM container setup guidance with newer versions (TensorRT-LLM 1.2.0rc5)
  * Revised CUDA/PyTorch alignment requirements to use CUDA 13.0 and PyTorch 2.9.0 with cu130
  * Added optional installation option for disaggregated serving package

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->