### PR TITLE
fix: add endpointslices RBAC permission for Planner service account

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/planner.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/planner.yaml
@@ -42,6 +42,9 @@ rules:
 - apiGroups: ["nvidia.com"]
   resources: ["dynamographdeploymentscalingadapters/scale"]
   verbs: ["patch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -74,4 +77,7 @@ rules:
 - apiGroups: ["nvidia.com"]
   resources: ["dynamographdeploymentscalingadapters/scale"]
   verbs: ["patch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
 {{- end }}

--- a/deploy/helm/charts/platform/components/operator/templates/planner.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/planner.yaml
@@ -45,6 +45,9 @@ rules:
 - apiGroups: ["discovery.k8s.io"]
   resources: ["endpointslices"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["nvidia.com"]
+  resources: ["dynamoworkermetadatas"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -80,4 +83,7 @@ rules:
 - apiGroups: ["discovery.k8s.io"]
   resources: ["endpointslices"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["nvidia.com"]
+  resources: ["dynamoworkermetadatas"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- end }}


### PR DESCRIPTION
#### Overview:

The Planner's RBAC was missing permission to list `endpointslices`, which it needs for Kubernetes service discovery to:
- Discover worker endpoints
- Monitor worker health
- Make scaling decisions

#### Details:

Added `endpointslices` to planner Role and ClusterRole

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform permissions to enable read access to Kubernetes endpoint information for improved service discovery capabilities across namespace and cluster-wide deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->