### PR TITLE
docs: fix tracing doc ZMQ port conflict

### DIFF
--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -68,11 +68,13 @@ Run the vLLM disaggregated script with tracing enabled:
 # Navigate to vLLM launch directory
 cd examples/backends/vllm/launch
 
-# Run disaggregated deployment (modify the script to export env vars first)
+# Export tracing env vars, then run the disaggregated deployment script.
 ./disagg.sh
 ```
 
-**Note:** You may need to modify `disagg.sh` to export the tracing environment variables before starting each component:
+**Note:** `disagg.sh` sets additional per-worker port environment variables (e.g., `DYN_VLLM_KV_EVENT_PORT`,
+`VLLM_NIXL_SIDE_CHANNEL_PORT`) to avoid ZMQ "Address already in use" conflicts when multiple workers run on the
+same host. If you run the components manually, make sure you mirror those port settings.
 
 ```bash
 #!/bin/bash
@@ -88,15 +90,18 @@ export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317
 export OTEL_SERVICE_NAME=dynamo-frontend
 python -m dynamo.frontend --router-mode kv &
 
-# Run decode worker, make sure to wait for start up
+# Run decode/ingress worker (make sure to wait for start up)
 export OTEL_SERVICE_NAME=dynamo-worker-decode
-CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
+DYN_SYSTEM_PORT=8081 CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \
     --enforce-eager \
     --otlp-traces-endpoint="$OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" &
 
 # Run prefill worker, make sure to wait for start up
 export OTEL_SERVICE_NAME=dynamo-worker-prefill
+DYN_SYSTEM_PORT=8082 \
+DYN_VLLM_KV_EVENT_PORT=20081 \
+VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \
     --enforce-eager \

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -72,9 +72,8 @@ cd examples/backends/vllm/launch
 ./disagg.sh
 ```
 
-**Note:** `disagg.sh` sets additional per-worker port environment variables (e.g., `DYN_VLLM_KV_EVENT_PORT`,
-`VLLM_NIXL_SIDE_CHANNEL_PORT`) to avoid ZMQ "Address already in use" conflicts when multiple workers run on the
-same host. If you run the components manually, make sure you mirror those port settings.
+**Note:** the example vLLM `disagg.sh` sets additional per-worker port environment variables (e.g., `DYN_VLLM_KV_EVENT_PORT`,
+`VLLM_NIXL_SIDE_CHANNEL_PORT`) to avoid ZMQ "Address already in use" conflicts when multiple workers run on the same host. If you run the components manually, make sure you mirror those port settings.
 
 ```bash
 #!/bin/bash
@@ -90,7 +89,7 @@ export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317
 export OTEL_SERVICE_NAME=dynamo-frontend
 python -m dynamo.frontend --router-mode kv &
 
-# Run decode/ingress worker (make sure to wait for start up)
+# Run decode worker, make sure to wait for start up
 export OTEL_SERVICE_NAME=dynamo-worker-decode
 DYN_SYSTEM_PORT=8081 CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \


### PR DESCRIPTION
#### Overview:

Prevents the ZMQ “Address already in use” port conflict when starting the prefill worker.

#### Details:

- Update `docs/observability/tracing.md` disaggregated example to include `DYN_SYSTEM_PORT`, `DYN_VLLM_KV_EVENT_PORT`, and `VLLM_NIXL_SIDE_CHANNEL_PORT`.
- Add a note explaining that per-worker port overrides are required to avoid ZMQ conflicts on a single host.

#### Where should the reviewer start?

docs/observability/tracing.md

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)

Relates to DIS-1226

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions to clarify environment variable setup for enabling tracing in distributed deployments
  * Enhanced documentation on per-worker port configuration to prevent conflicts when running multiple workers
  * Improved clarity on deployment steps and procedures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->