### PR TITLE
feat: object - distributed registry 

### DIFF
--- a/lib/llm/src/block_manager/distributed.rs
+++ b/lib/llm/src/block_manager/distributed.rs
@@ -6,6 +6,7 @@ mod utils;
 mod zmq;
 
 mod leader;
+pub mod registry;
 mod worker;
 
 pub use leader::{KvbmLeader, KvbmLeaderConfig, KvbmLeaderNumBlocksConfig};

--- a/lib/llm/src/block_manager/distributed/registry/README.md
+++ b/lib/llm/src/block_manager/distributed/registry/README.md
@@ -341,7 +341,7 @@ registry/
     +-- codec.rs        # RegistryCodec trait + BinaryCodec (versioned)
     +-- registry.rs     # Registry trait + RegistryClient
     +-- hub.rs          # Generic RegistryHub with lease management
-    +-- lease.rs        # LeaseManager for race condition prevention and unecessary writes
+    +-- lease.rs        # LeaseManager for race condition prevention and unnecessary writes
     +-- error.rs        # RegistryError types
     +-- zmq_transport.rs  # ZMQ client transport (with HWM)
     +-- zmq_hub.rs        # ZMQ hub server

--- a/lib/llm/src/block_manager/distributed/registry/README.md
+++ b/lib/llm/src/block_manager/distributed/registry/README.md
@@ -1,0 +1,355 @@
+# Distributed Registry
+
+A pluggable, high-performance registry for tracking and deduplicating data blocks across distributed workers.
+
+## Overview
+
+When running distributed workloads where multiple workers may store data to shared storage (S3, GCS, local filesystem, etc.), coordination is needed to avoid redundant storage. Without it, multiple workers might store the same data blocks, wasting storage and bandwidth.
+
+The **Distributed Registry** solves this by providing a centralized catalog that tracks which blocks have been stored, enabling **cross-worker deduplication**.
+
+```
++-------------+     +-------------+     +-------------+
+|  Worker 1   |     |  Worker 2   |     |  Worker 3   |
++------+------+     +------+------+     +------+------+
+       |                   |                   |
+       +-------------------+-------------------+
+                           |
+                    +------v------+
+                    |   Registry  |
+                    |     Hub     |
+                    +------+------+
+                           |
+                    +------v------+
+                    |   Storage   |
+                    |  (any type) |
+                    +-------------+
+```
+
+## Key Concepts
+
+### Deduplication Flow
+
+1. **Worker wants to store blocks** - Asks registry "can I store these hashes?"
+2. **Registry checks** - Returns `Granted`, `AlreadyStored`, or `Leased` for each hash
+3. **Worker stores only `Granted` blocks** - Skips duplicates
+4. **Worker registers stored blocks** - Registry records them for future queries
+
+### Lease-Based Claiming
+
+To prevent race conditions where two workers try to store the same block simultaneously, the hub uses **lease-based claiming**:
+
+- `Granted` - You have exclusive rights to store this block (lease granted)
+- `AlreadyStored` - Another worker already stored it (skip)
+- `Leased` - Another worker is currently storing it (wait or skip)
+
+Leases expire after a configurable timeout (default: 30s) if the worker fails to complete the upload.
+
+```rust
+use registry::core::{hub, HashMapStorage, NoMetadata};
+use std::time::Duration;
+
+// Configure lease TTL using the builder
+let storage = HashMapStorage::<u64, u64>::new();
+let registry_hub = hub::<u64, u64, NoMetadata, _>(storage)
+    .lease_ttl(Duration::from_secs(60))
+    .lease_cleanup_interval(Duration::from_secs(10))
+    .build();
+
+// Access lease stats
+let stats = registry_hub.stats();
+println!("Active leases: {}", stats.lease_stats.active);
+println!("Leases granted: {}", stats.lease_stats.granted);
+println!("Leases expired: {}", stats.lease_stats.expired);
+```
+
+## Architecture
+
+The registry uses a **pluggable architecture** with trait-based abstractions:
+
+```
++-----------------------------------------------------------+
+|                        Client                              |
+|  +---------+  +---------+  +---------+  +------------+    |
+|  |   Key   |  |  Value  |  |Metadata |  |   Codec    |    |
+|  |  (u64)  |  |  (u64)  |  |  (None) |  |  (Binary)  |    |
+|  +----+----+  +----+----+  +----+----+  +-----+------+    |
+|       +--------------+-----------+-----------+            |
+|                      |                                    |
+|               +------v------+                             |
+|               |  Transport  |                             |
+|               |  (ZMQ/etc)  |                             |
+|               +-------------+                             |
++-----------------------------------------------------------+
+                       |
+                +------v------+
+                |     Hub     |
+                |  (Server)   |
+                | +---------+ |
+                | | Storage | |
+                | |(HashMap)| |
+                | +---------+ |
+                +-------------+
+```
+
+### Core Traits
+
+| Trait | Purpose | Implementations |
+|-------|---------|-----------------|
+| `RegistryKey` | Hash/identifier for blocks | `u64`, `Key128`, `PositionalKey`, `CompositeKey` |
+| `RegistryValue` | What's stored with the key | `u64`, `StorageLocation` |
+| `RegistryMetadata` | Optional metadata | `NoMetadata`, `TimestampMetadata`, `PositionMetadata` |
+| `Storage` | Key-value backend | `HashMapStorage` |
+| `Eviction` | Cache eviction policy | `NoEviction`, `TailEviction` |
+| `RegistryTransport` | Network communication | `InProcessTransport`, `ZmqTransport` |
+| `RegistryCodec` | Message serialization | `BinaryCodec` (versioned) |
+
+### ZMQ Communication Pattern
+
+```
+Client                              Hub
+  |                                  |
+  |<------- DEALER/ROUTER --------->|  (Queries: request/response)
+  |                                  |
+  |<------- PUSH/PULL ------------>|  (Registrations: fire-and-forget)
+  |                                  |
+```
+
+- **DEALER/ROUTER**: Bidirectional request/response for queries
+- **PUSH/PULL**: Many-to-one for fire-and-forget registrations
+
+## Usage
+
+### Using the Builder Pattern
+
+The recommended way to create clients and hubs:
+
+```rust
+use registry::core::{client, hub, HashMapStorage, NoMetadata, ZmqTransport};
+use std::time::Duration;
+
+// Create a client with any transport
+let transport = ZmqTransport::connect_to("hub-host", 5555, 5556)?;
+let registry_client = client::<u64, u64, NoMetadata, _>(transport)
+    .batch_size(50)
+    .batch_timeout(Duration::from_millis(20))
+    .build();
+
+// Create a hub with any storage backend
+let storage = HashMapStorage::<u64, u64>::new();
+let registry_hub = hub::<u64, u64, NoMetadata, _>(storage)
+    .lease_ttl(Duration::from_secs(60))
+    .lease_cleanup_interval(Duration::from_secs(10))
+    .build();
+```
+
+### Client Operations
+
+```rust
+use registry::core::{client, NoMetadata, Registry};
+
+let registry_client = client::<u64, u64, NoMetadata, _>(transport).build();
+
+// Check what can be stored
+let result = registry_client.can_offload(&[hash1, hash2, hash3]).await?;
+// result.can_offload: hashes you should store (lease granted)
+// result.already_stored: skip these
+// result.leased: another worker is storing these (wait or skip)
+
+// After storing, register the blocks
+registry_client.register(&[(hash1, value1, NoMetadata)]).await?;
+registry_client.flush().await?;
+
+// Find matching blocks
+let matches = registry_client.match_prefix(&hashes).await?;
+```
+
+### Serving a Hub
+
+```rust
+use registry::core::{hub, HashMapStorage, NoMetadata, ZmqHubTransport, ZmqHubConfig};
+
+let storage = HashMapStorage::<u64, u64>::new();
+let registry_hub = hub::<u64, u64, NoMetadata, _>(storage)
+    .lease_ttl(Duration::from_secs(30))
+    .build();
+
+// Serve with ZMQ transport
+let mut transport = ZmqHubTransport::bind(ZmqHubConfig::default())?;
+registry_hub.serve(&mut transport).await?;
+```
+
+### Batch Registration with Timeout
+
+The client batches registrations for efficiency. Batches are flushed when:
+- Batch size threshold is reached (default: 100)
+- Batch timeout expires (default: 10ms)
+
+```rust
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+use registry::core::{client, NoMetadata};
+
+let registry_client = Arc::new(
+    client::<u64, u64, NoMetadata, _>(transport)
+        .batch_size(50)
+        .batch_timeout(Duration::from_millis(20))
+        .build()
+);
+
+// Start background flush task
+let cancel = CancellationToken::new();
+let _flush_task = registry_client.start_batch_flush_task(cancel.clone());
+
+// Registrations are automatically batched and flushed
+registry_client.register(&[(hash1, value1, NoMetadata)]).await?;
+
+// On shutdown
+cancel.cancel();
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DYN_REGISTRY_ENABLE` | Enable distributed registry | `false` |
+| `DYN_REGISTRY_CLIENT_QUERY_ADDR` | Hub query address | `tcp://localhost:5555` |
+| `DYN_REGISTRY_CLIENT_REGISTER_ADDR` | Hub registration address | `tcp://localhost:5556` |
+| `DYN_REGISTRY_CLIENT_NAMESPACE` | Client namespace identifier | `default` |
+| `DYN_REGISTRY_CLIENT_BATCH_SIZE` | Batch size before flush | `100` |
+| `DYN_REGISTRY_CLIENT_BATCH_TIMEOUT_MS` | Batch timeout in ms | `10` |
+| `DYN_REGISTRY_CLIENT_REQUEST_TIMEOUT_MS` | Request timeout in ms | `5000` |
+| `DYN_REGISTRY_CLIENT_LOCAL_CACHE` | Local cache capacity | `0` |
+| `DYN_REGISTRY_HUB_QUERY_ADDR` | Hub bind address for queries | `tcp://*:5555` |
+| `DYN_REGISTRY_HUB_REGISTER_ADDR` | Hub bind address for registrations | `tcp://*:5556` |
+| `DYN_REGISTRY_HUB_CAPACITY` | Max entries in registry | `1000000` |
+| `DYN_REGISTRY_HUB_LEASE_TIMEOUT_SECS` | Lease TTL in seconds | `30` |
+
+### Backpressure Configuration
+
+ZMQ sockets use high-water marks (HWM) to prevent unbounded memory growth:
+
+```rust
+use registry::core::ZmqTransportConfig;
+
+// Default: 10,000 messages per socket
+let config = ZmqTransportConfig::default();
+
+// Custom HWM for memory-constrained systems
+let config = ZmqTransportConfig::new(query_addr, push_addr)
+    .with_hwm(1000);  // Buffer only 1,000 messages
+
+// Fine-grained control
+let config = ZmqTransportConfig::new(query_addr, push_addr)
+    .with_dealer_hwm(5000)   // Queries
+    .with_push_hwm(20000);   // Registrations
+```
+
+| HWM Value | Behavior Under Load |
+|-----------|---------------------|
+| Low (1K) | May drop messages under heavy load |
+| Default (10K) | Balanced for most workloads |
+| High (100K) | Higher memory usage, higher latency |
+
+## Protocol Versioning
+
+The wire protocol includes a version byte:
+
+```
+[version:1][type:1][count:4][...data...]
+```
+
+Current version: `PROTOCOL_VERSION = 1`
+
+Messages without a valid version byte are rejected.
+
+## Error Handling
+
+The library provides structured error types:
+
+```rust
+use registry::core::{RegistryError, RegistryResult};
+
+match result {
+    Err(RegistryError::Timeout { duration_ms }) => {
+        println!("Request timed out after {}ms", duration_ms);
+    }
+    Err(RegistryError::LeaseConflict { key_debug }) => {
+        println!("Lease conflict for key: {}", key_debug);
+    }
+    Err(RegistryError::DecodeError { context, expected, got }) => {
+        println!("Decode error in {}: expected {}, got {}", context, expected, got);
+    }
+    _ => {}
+}
+```
+
+## Eviction Strategies
+
+### TailEviction (Prefix-Aware)
+
+For sequence-based data where blocks form chains:
+
+```
+Block 1 -> Block 2 -> Block 3 -> Block 4
+(root)                          (leaf)
+```
+
+When evicting, remove **leaves first** (tail-first) to avoid orphaning children:
+
+```rust
+use registry::core::{HashMapStorage, TailEviction};
+
+let storage = HashMapStorage::new();
+let evictable = TailEviction::new(storage, 10_000); // capacity
+
+// Insert with parent tracking
+evictable.insert_with_parent(block_hash, value, Some(parent_hash));
+
+// Eviction removes deepest leaves first
+let evicted = evictable.evict(100);
+```
+
+## Testing
+
+```bash
+# Run all registry tests
+cargo test --lib -- registry::core
+
+# Run ZMQ integration tests (requires network)
+cargo test --lib -- test_zmq --ignored
+```
+
+## Module Structure
+
+```
+registry/
++-- mod.rs              # Module exports
++-- config.rs           # Configuration structs
++-- README.md           # This file
++-- core/
+    +-- mod.rs          # Core exports
+    +-- key.rs          # RegistryKey trait + implementations
+    +-- value.rs        # RegistryValue trait + implementations
+    +-- metadata.rs     # RegistryMetadata trait + implementations
+    +-- storage.rs      # Storage trait + HashMapStorage
+    +-- eviction.rs     # Eviction trait + TailEviction
+    +-- transport.rs    # RegistryTransport trait + InProcessTransport
+    +-- codec.rs        # RegistryCodec trait + BinaryCodec (versioned)
+    +-- registry.rs     # Registry trait + RegistryClient
+    +-- hub.rs          # Generic RegistryHub with lease management
+    +-- lease.rs        # LeaseManager for race condition prevention and unecessary writes
+    +-- error.rs        # RegistryError types
+    +-- zmq_transport.rs  # ZMQ client transport (with HWM)
+    +-- zmq_hub.rs        # ZMQ hub server
+    +-- hub_transport.rs  # Hub transport traits (with HWM)
+    +-- builder.rs        # Builder patterns
+    +-- tests.rs          # Integration tests
+```
+
+## License
+
+Apache-2.0

--- a/lib/llm/src/block_manager/distributed/registry/README.md
+++ b/lib/llm/src/block_manager/distributed/registry/README.md
@@ -53,7 +53,6 @@ use std::time::Duration;
 let storage = HashMapStorage::<u64, u64>::new();
 let registry_hub = hub::<u64, u64, NoMetadata, _>(storage)
     .lease_ttl(Duration::from_secs(60))
-    .lease_cleanup_interval(Duration::from_secs(10))
     .build();
 
 // Access lease stats
@@ -139,7 +138,6 @@ let registry_client = client::<u64, u64, NoMetadata, _>(transport)
 let storage = HashMapStorage::<u64, u64>::new();
 let registry_hub = hub::<u64, u64, NoMetadata, _>(storage)
     .lease_ttl(Duration::from_secs(60))
-    .lease_cleanup_interval(Duration::from_secs(10))
     .build();
 ```
 

--- a/lib/llm/src/block_manager/distributed/registry/README.md
+++ b/lib/llm/src/block_manager/distributed/registry/README.md
@@ -8,7 +8,7 @@ When running distributed workloads where multiple workers may store data to shar
 
 The **Distributed Registry** solves this by providing a centralized catalog that tracks which blocks have been stored, enabling **cross-worker deduplication**.
 
-```
+```text
 +-------------+     +-------------+     +-------------+
 |  Worker 1   |     |  Worker 2   |     |  Worker 3   |
 +------+------+     +------+------+     +------+------+
@@ -66,7 +66,7 @@ println!("Leases expired: {}", stats.lease_stats.expired);
 
 The registry uses a **pluggable architecture** with trait-based abstractions:
 
-```
+```text
 +-----------------------------------------------------------+
 |                        Client                              |
 |  +---------+  +---------+  +---------+  +------------+    |
@@ -105,7 +105,7 @@ The registry uses a **pluggable architecture** with trait-based abstractions:
 
 ### ZMQ Communication Pattern
 
-```
+```text
 Client                              Hub
   |                                  |
   |<------- DEALER/ROUTER --------->|  (Queries: request/response)
@@ -256,7 +256,7 @@ let config = ZmqTransportConfig::new(query_addr, push_addr)
 
 The wire protocol includes a version byte:
 
-```
+```text
 [version:1][type:1][count:4][...data...]
 ```
 
@@ -291,7 +291,7 @@ match result {
 
 For sequence-based data where blocks form chains:
 
-```
+```text
 Block 1 -> Block 2 -> Block 3 -> Block 4
 (root)                          (leaf)
 ```
@@ -323,7 +323,7 @@ cargo test --lib -- test_zmq --ignored
 
 ## Module Structure
 
-```
+```text
 registry/
 +-- mod.rs              # Module exports
 +-- config.rs           # Configuration structs

--- a/lib/llm/src/block_manager/distributed/registry/config.rs
+++ b/lib/llm/src/block_manager/distributed/registry/config.rs
@@ -296,4 +296,3 @@ mod tests {
         assert_eq!(config.request_timeout, Duration::from_secs(10));
     }
 }
-

--- a/lib/llm/src/block_manager/distributed/registry/config.rs
+++ b/lib/llm/src/block_manager/distributed/registry/config.rs
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration types for the distributed registry.
+
+use std::time::Duration;
+
+/// Hub configuration for the registry server.
+///
+/// # Example
+/// ```ignore
+/// let config = RegistryHubConfig {
+///     capacity: 1_000_000,
+///     query_addr: "tcp://*:5555".to_string(),
+///     register_addr: "tcp://*:5556".to_string(),
+///     lease_timeout: Duration::from_secs(30),
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct RegistryHubConfig {
+    /// Registry capacity (number of entries).
+    pub capacity: u64,
+
+    /// ZMQ ROUTER socket address for queries (DEALER/ROUTER pattern).
+    ///
+    /// Workers send queries here and wait for responses.
+    /// Example: "tcp://*:5555" or "tcp://0.0.0.0:5555"
+    pub query_addr: String,
+
+    /// ZMQ PULL socket address for registrations (PUSH/PULL pattern).
+    ///
+    /// Workers publish registrations here (fire-and-forget).
+    /// Example: "tcp://*:5556" or "tcp://0.0.0.0:5556"
+    pub register_addr: String,
+
+    /// Lease timeout for `can_offload` claims.
+    ///
+    /// When a worker calls `can_offload`, it gets exclusive leases on the
+    /// returned hashes. If the worker doesn't call `register` within this
+    /// timeout, the leases expire and other workers can claim them.
+    ///
+    /// Default: 30 seconds
+    pub lease_timeout: Duration,
+}
+
+impl Default for RegistryHubConfig {
+    fn default() -> Self {
+        Self {
+            capacity: 1_000_000,
+            query_addr: "tcp://*:5555".to_string(),
+            register_addr: "tcp://*:5556".to_string(),
+            lease_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+impl RegistryHubConfig {
+    /// Create a new config with specified capacity.
+    pub fn with_capacity(capacity: u64) -> Self {
+        Self {
+            capacity,
+            ..Default::default()
+        }
+    }
+
+    /// Create config from environment variables.
+    ///
+    /// Environment variables:
+    /// - `DYN_REGISTRY_HUB_CAPACITY`: Registry capacity (default: 1000000)
+    /// - `DYN_REGISTRY_HUB_QUERY_ADDR`: Query address (default: tcp://*:5555)
+    /// - `DYN_REGISTRY_HUB_REGISTER_ADDR`: Register address (default: tcp://*:5556)
+    /// - `DYN_REGISTRY_HUB_LEASE_TIMEOUT_SECS`: Lease timeout in seconds (default: 30)
+    pub fn from_env() -> Self {
+        Self {
+            capacity: std::env::var("DYN_REGISTRY_HUB_CAPACITY")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(1_000_000),
+            query_addr: std::env::var("DYN_REGISTRY_HUB_QUERY_ADDR")
+                .unwrap_or_else(|_| "tcp://*:5555".to_string()),
+            register_addr: std::env::var("DYN_REGISTRY_HUB_REGISTER_ADDR")
+                .unwrap_or_else(|_| "tcp://*:5556".to_string()),
+            lease_timeout: Duration::from_secs(
+                std::env::var("DYN_REGISTRY_HUB_LEASE_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(30),
+            ),
+        }
+    }
+
+    /// Set lease timeout.
+    pub fn with_lease_timeout(mut self, timeout: Duration) -> Self {
+        self.lease_timeout = timeout;
+        self
+    }
+}
+
+/// Client configuration for registry workers.
+///
+/// # Example
+/// ```ignore
+/// let config = RegistryClientConfig {
+///     hub_query_addr: "tcp://leader:5555".to_string(),
+///     hub_register_addr: "tcp://leader:5556".to_string(),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct RegistryClientConfig {
+    /// Hub query address to connect to (DEALER/ROUTER pattern).
+    ///
+    /// Example: "tcp://leader:5555" or "tcp://192.168.1.100:5555"
+    pub hub_query_addr: String,
+
+    /// Hub register address to connect to (PUSH/PULL pattern).
+    ///
+    /// Example: "tcp://leader:5556" or "tcp://192.168.1.100:5556"
+    pub hub_register_addr: String,
+
+    /// Namespace for this worker's storage.
+    ///
+    /// Used as part of the registry key to enable cross-instance deduplication.
+    /// Can represent a bucket, directory, or any storage-specific identifier.
+    /// Example: "worker-0", "instance-abc123", "/mnt/cache/worker-0"
+    pub namespace: String,
+
+    /// Batch size for registrations before auto-flush.
+    ///
+    /// Registrations are batched for efficiency. When the batch reaches
+    /// this size, it's automatically sent to the hub.
+    pub batch_size: usize,
+
+    /// Batch timeout before auto-flush.
+    ///
+    /// If a batch has been pending for this duration without reaching
+    /// `batch_size`, it's automatically flushed.
+    pub batch_timeout: Duration,
+
+    /// Request timeout for queries.
+    ///
+    /// How long to wait for a response from the hub before timing out.
+    pub request_timeout: Duration,
+
+    /// Optional local cache capacity (0 = disabled).
+    ///
+    /// If > 0, the client maintains a local Moka cache to reduce
+    /// network round-trips for frequently accessed hashes.
+    pub local_cache_capacity: u64,
+}
+
+impl Default for RegistryClientConfig {
+    fn default() -> Self {
+        Self {
+            hub_query_addr: "tcp://localhost:5555".to_string(),
+            hub_register_addr: "tcp://localhost:5556".to_string(),
+            namespace: "default".to_string(),
+            batch_size: 100,
+            batch_timeout: Duration::from_millis(10),
+            request_timeout: Duration::from_secs(5),
+            local_cache_capacity: 0,
+        }
+    }
+}
+
+impl RegistryClientConfig {
+    /// Check if distributed registry is enabled via environment.
+    ///
+    /// Returns true if `DYN_REGISTRY_ENABLE=1` or `DYN_REGISTRY_ENABLE=true`
+    pub fn is_enabled() -> bool {
+        std::env::var("DYN_REGISTRY_ENABLE")
+            .map(|v| v == "1" || v.to_lowercase() == "true")
+            .unwrap_or(false)
+    }
+
+    /// Create config connecting to a specific hub address.
+    pub fn connect_to(hub_host: &str, query_port: u16, register_port: u16) -> Self {
+        Self {
+            hub_query_addr: format!("tcp://{}:{}", hub_host, query_port),
+            hub_register_addr: format!("tcp://{}:{}", hub_host, register_port),
+            ..Default::default()
+        }
+    }
+
+    /// Create config from environment variables.
+    ///
+    /// Environment variables:
+    /// - `DYN_REGISTRY_ENABLE`: Set to "1" or "true" to enable distributed registry
+    /// - `DYN_REGISTRY_CLIENT_QUERY_ADDR`: Query address (default: tcp://localhost:5555)
+    /// - `DYN_REGISTRY_CLIENT_REGISTER_ADDR`: Register address (default: tcp://localhost:5556)
+    /// - `DYN_REGISTRY_CLIENT_NAMESPACE`: Namespace identifier (default: "default")
+    /// - `DYN_REGISTRY_CLIENT_BATCH_SIZE`: Batch size (default: 100)
+    /// - `DYN_REGISTRY_CLIENT_BATCH_TIMEOUT_MS`: Batch timeout in ms (default: 10)
+    /// - `DYN_REGISTRY_CLIENT_REQUEST_TIMEOUT_MS`: Request timeout in ms (default: 5000)
+    /// - `DYN_REGISTRY_CLIENT_LOCAL_CACHE`: Local cache capacity (default: 0)
+    pub fn from_env() -> Self {
+        Self {
+            hub_query_addr: std::env::var("DYN_REGISTRY_CLIENT_QUERY_ADDR")
+                .unwrap_or_else(|_| "tcp://localhost:5555".to_string()),
+            hub_register_addr: std::env::var("DYN_REGISTRY_CLIENT_REGISTER_ADDR")
+                .unwrap_or_else(|_| "tcp://localhost:5556".to_string()),
+            namespace: std::env::var("DYN_REGISTRY_CLIENT_NAMESPACE")
+                .unwrap_or_else(|_| "default".to_string()),
+            batch_size: std::env::var("DYN_REGISTRY_CLIENT_BATCH_SIZE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(100),
+            batch_timeout: Duration::from_millis(
+                std::env::var("DYN_REGISTRY_CLIENT_BATCH_TIMEOUT_MS")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(10),
+            ),
+            request_timeout: Duration::from_millis(
+                std::env::var("DYN_REGISTRY_CLIENT_REQUEST_TIMEOUT_MS")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(5000),
+            ),
+            local_cache_capacity: std::env::var("DYN_REGISTRY_CLIENT_LOCAL_CACHE")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0),
+        }
+    }
+
+    /// Enable local caching with specified capacity.
+    pub fn with_local_cache(mut self, capacity: u64) -> Self {
+        self.local_cache_capacity = capacity;
+        self
+    }
+
+    /// Set batch size.
+    pub fn with_batch_size(mut self, size: usize) -> Self {
+        self.batch_size = size;
+        self
+    }
+
+    /// Set request timeout.
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
+    /// Set namespace.
+    pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.namespace = namespace.into();
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hub_config_default() {
+        let config = RegistryHubConfig::default();
+        assert_eq!(config.capacity, 1_000_000);
+        assert_eq!(config.query_addr, "tcp://*:5555");
+        assert_eq!(config.register_addr, "tcp://*:5556");
+    }
+
+    #[test]
+    fn test_hub_config_with_capacity() {
+        let config = RegistryHubConfig::with_capacity(500_000);
+        assert_eq!(config.capacity, 500_000);
+    }
+
+    #[test]
+    fn test_client_config_default() {
+        let config = RegistryClientConfig::default();
+        assert_eq!(config.hub_query_addr, "tcp://localhost:5555");
+        assert_eq!(config.hub_register_addr, "tcp://localhost:5556");
+        assert_eq!(config.batch_size, 100);
+        assert_eq!(config.batch_timeout, Duration::from_millis(10));
+        assert_eq!(config.local_cache_capacity, 0);
+    }
+
+    #[test]
+    fn test_client_config_connect_to() {
+        let config = RegistryClientConfig::connect_to("leader.local", 6000, 6001);
+        assert_eq!(config.hub_query_addr, "tcp://leader.local:6000");
+        assert_eq!(config.hub_register_addr, "tcp://leader.local:6001");
+    }
+
+    #[test]
+    fn test_client_config_builder() {
+        let config = RegistryClientConfig::default()
+            .with_local_cache(10_000)
+            .with_batch_size(50)
+            .with_request_timeout(Duration::from_secs(10));
+
+        assert_eq!(config.local_cache_capacity, 10_000);
+        assert_eq!(config.batch_size, 50);
+        assert_eq!(config.request_timeout, Duration::from_secs(10));
+    }
+}
+

--- a/lib/llm/src/block_manager/distributed/registry/core/builder.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/builder.rs
@@ -25,9 +25,7 @@ use super::value::RegistryValue;
 ///
 /// # Example
 ///
-/// ```ignore
-/// use registry::core::{ClientBuilder, BinaryCodec, NoMetadata};
-///
+/// ```text
 /// let client = ClientBuilder::new(transport, BinaryCodec::new())
 ///     .batch_size(50)
 ///     .batch_timeout(Duration::from_millis(20))
@@ -97,9 +95,7 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
-/// use registry::core::{HubBuilder, BinaryCodec, HashMapStorage, NoMetadata, HubConfig};
-///
+/// ```text
 /// let hub = HubBuilder::new(storage, BinaryCodec::new())
 ///     .lease_ttl(Duration::from_secs(60))
 ///     .build();
@@ -179,7 +175,7 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```text
 /// let client = client(transport)
 ///     .batch_size(50)
 ///     .build();
@@ -198,7 +194,7 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```text
 /// let hub = hub(storage)
 ///     .lease_ttl(Duration::from_secs(60))
 ///     .build();

--- a/lib/llm/src/block_manager/distributed/registry/core/builder.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/builder.rs
@@ -231,7 +231,9 @@ mod tests {
                 Some(QueryType::CanOffload(keys)) => {
                     let statuses: Vec<_> = keys.iter().map(|_| OffloadStatus::Granted).collect();
                     let mut buf = Vec::new();
-                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf).unwrap();
+                    codec
+                        .encode_response(&ResponseType::CanOffload(statuses), &mut buf)
+                        .unwrap();
                     buf
                 }
                 _ => Vec::new(),

--- a/lib/llm/src/block_manager/distributed/registry/core/builder.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/builder.rs
@@ -231,7 +231,7 @@ mod tests {
                 Some(QueryType::CanOffload(keys)) => {
                     let statuses: Vec<_> = keys.iter().map(|_| OffloadStatus::Granted).collect();
                     let mut buf = Vec::new();
-                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf);
+                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf).unwrap();
                     buf
                 }
                 _ => Vec::new(),

--- a/lib/llm/src/block_manager/distributed/registry/core/builder.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/builder.rs
@@ -21,7 +21,6 @@ use super::storage::Storage;
 use super::transport::RegistryTransport;
 use super::value::RegistryValue;
 
-
 /// Builder for constructing a `RegistryClient`.
 ///
 /// # Example
@@ -185,9 +184,7 @@ where
 ///     .batch_size(50)
 ///     .build();
 /// ```
-pub fn client<K, V, M, T>(
-    transport: T,
-) -> ClientBuilder<K, V, M, T, BinaryCodec<K, V, M>>
+pub fn client<K, V, M, T>(transport: T) -> ClientBuilder<K, V, M, T, BinaryCodec<K, V, M>>
 where
     K: RegistryKey,
     V: RegistryValue,
@@ -206,9 +203,7 @@ where
 ///     .lease_ttl(Duration::from_secs(60))
 ///     .build();
 /// ```
-pub fn hub<K, V, M, S>(
-    storage: S,
-) -> HubBuilder<K, V, M, S, BinaryCodec<K, V, M>>
+pub fn hub<K, V, M, S>(storage: S) -> HubBuilder<K, V, M, S, BinaryCodec<K, V, M>>
 where
     K: RegistryKey,
     V: RegistryValue,
@@ -222,8 +217,8 @@ where
 mod tests {
     use super::*;
     use crate::block_manager::distributed::registry::core::{
-        HashMapStorage, NoMetadata, InProcessTransport, QueryType, OffloadStatus, ResponseType,
-        Registry,
+        HashMapStorage, InProcessTransport, NoMetadata, OffloadStatus, QueryType, Registry,
+        ResponseType,
     };
 
     #[tokio::test]

--- a/lib/llm/src/block_manager/distributed/registry/core/builder.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/builder.rs
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Builder patterns for registry components.
+//!
+//! Provides ergonomic construction of registry clients and hubs with
+//! sensible defaults and fluent configuration.
+
+use std::marker::PhantomData;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use super::codec::{BinaryCodec, RegistryCodec};
+use super::hub::RegistryHub;
+use super::hub_transport::HubTransport;
+use super::key::RegistryKey;
+use super::metadata::RegistryMetadata;
+use super::registry::RegistryClient;
+use super::storage::Storage;
+use super::transport::RegistryTransport;
+use super::value::RegistryValue;
+
+
+/// Builder for constructing a `RegistryClient`.
+///
+/// # Example
+///
+/// ```ignore
+/// use registry::core::{ClientBuilder, BinaryCodec, NoMetadata};
+///
+/// let client = ClientBuilder::new(transport, BinaryCodec::new())
+///     .batch_size(50)
+///     .batch_timeout(Duration::from_millis(20))
+///     .build();
+/// ```
+pub struct ClientBuilder<K, V, M, T, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+    C: RegistryCodec<K, V, M>,
+{
+    transport: T,
+    codec: C,
+    batch_size: usize,
+    batch_timeout: Duration,
+    _phantom: PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M, T, C> ClientBuilder<K, V, M, T, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+    C: RegistryCodec<K, V, M>,
+{
+    /// Create a new client builder with the given transport and codec.
+    pub fn new(transport: T, codec: C) -> Self {
+        Self {
+            transport,
+            codec,
+            batch_size: 100,
+            batch_timeout: Duration::from_millis(10),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Set the batch size for registrations.
+    ///
+    /// When this many registrations are pending, they are automatically flushed.
+    /// Default: 100
+    pub fn batch_size(mut self, size: usize) -> Self {
+        self.batch_size = size;
+        self
+    }
+
+    /// Set the batch timeout for registrations.
+    ///
+    /// Pending registrations are flushed after this duration even if
+    /// the batch size hasn't been reached. Default: 10ms
+    pub fn batch_timeout(mut self, timeout: Duration) -> Self {
+        self.batch_timeout = timeout;
+        self
+    }
+
+    /// Build the registry client.
+    pub fn build(self) -> RegistryClient<K, V, M, T, C> {
+        RegistryClient::new(self.transport, self.codec)
+            .with_batch_size(self.batch_size)
+            .with_batch_timeout(self.batch_timeout)
+    }
+}
+
+/// Builder for constructing a `RegistryHub`.
+///
+/// # Example
+///
+/// ```ignore
+/// use registry::core::{HubBuilder, BinaryCodec, HashMapStorage, NoMetadata, HubConfig};
+///
+/// let hub = HubBuilder::new(storage, BinaryCodec::new())
+///     .lease_ttl(Duration::from_secs(60))
+///     .build();
+/// ```
+pub struct HubBuilder<K, V, M, S, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V>,
+    C: RegistryCodec<K, V, M>,
+{
+    storage: S,
+    codec: C,
+    lease_ttl: Duration,
+    lease_cleanup_interval: Duration,
+    _phantom: PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M, S, C> HubBuilder<K, V, M, S, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V>,
+    C: RegistryCodec<K, V, M>,
+{
+    /// Create a new hub builder with the given storage and codec.
+    pub fn new(storage: S, codec: C) -> Self {
+        Self {
+            storage,
+            codec,
+            lease_ttl: Duration::from_secs(30),
+            lease_cleanup_interval: Duration::from_secs(5),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Set the lease TTL for can_offload claims.
+    ///
+    /// Leases expire after this duration if not converted to registrations.
+    /// Default: 30 seconds
+    pub fn lease_ttl(mut self, ttl: Duration) -> Self {
+        self.lease_ttl = ttl;
+        self
+    }
+
+    /// Set the lease cleanup interval.
+    ///
+    /// Expired leases are cleaned up at this interval.
+    /// Default: 5 seconds
+    pub fn lease_cleanup_interval(mut self, interval: Duration) -> Self {
+        self.lease_cleanup_interval = interval;
+        self
+    }
+
+    /// Build the registry hub.
+    pub fn build(self) -> RegistryHub<K, V, M, S, C> {
+        use super::hub::HubConfig;
+        let config = HubConfig {
+            lease_ttl: self.lease_ttl,
+            lease_cleanup_interval: self.lease_cleanup_interval,
+        };
+        RegistryHub::with_config(self.storage, self.codec, config)
+    }
+
+    /// Build and serve the hub with the given transport.
+    ///
+    /// This consumes the builder and starts serving requests.
+    pub async fn serve<T: HubTransport>(self, transport: &mut T) -> Result<()> {
+        let hub = self.build();
+        hub.serve(transport).await
+    }
+}
+
+/// Convenience function to create a client builder with binary codec.
+///
+/// # Example
+///
+/// ```ignore
+/// let client = client(transport)
+///     .batch_size(50)
+///     .build();
+/// ```
+pub fn client<K, V, M, T>(
+    transport: T,
+) -> ClientBuilder<K, V, M, T, BinaryCodec<K, V, M>>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+{
+    ClientBuilder::new(transport, BinaryCodec::new())
+}
+
+/// Convenience function to create a hub builder with binary codec.
+///
+/// # Example
+///
+/// ```ignore
+/// let hub = hub(storage)
+///     .lease_ttl(Duration::from_secs(60))
+///     .build();
+/// ```
+pub fn hub<K, V, M, S>(
+    storage: S,
+) -> HubBuilder<K, V, M, S, BinaryCodec<K, V, M>>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V>,
+{
+    HubBuilder::new(storage, BinaryCodec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_manager::distributed::registry::core::{
+        HashMapStorage, NoMetadata, InProcessTransport, QueryType, OffloadStatus, ResponseType,
+        Registry,
+    };
+
+    #[tokio::test]
+    async fn test_client_builder() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let (transport, _rx) = InProcessTransport::new(move |data| {
+            let query = codec.decode_query(data);
+            match query {
+                Some(QueryType::CanOffload(keys)) => {
+                    let statuses: Vec<_> = keys.iter().map(|_| OffloadStatus::Granted).collect();
+                    let mut buf = Vec::new();
+                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf);
+                    buf
+                }
+                _ => Vec::new(),
+            }
+        });
+
+        let built_client: RegistryClient<u64, u64, NoMetadata, _, _> = client(transport)
+            .batch_size(50)
+            .batch_timeout(Duration::from_millis(20))
+            .build();
+
+        let result = built_client.can_offload(&[1, 2, 3]).await.unwrap();
+        assert_eq!(result.can_offload.len(), 3);
+    }
+
+    #[test]
+    fn test_hub_builder() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+
+        let built_hub: RegistryHub<u64, u64, NoMetadata, _, _> = hub(storage)
+            .lease_ttl(Duration::from_secs(60))
+            .lease_cleanup_interval(Duration::from_secs(10))
+            .build();
+
+        assert!(built_hub.is_empty());
+
+        // Verify lease TTL was set
+        assert_eq!(built_hub.lease_manager().ttl(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_builder_with_custom_codec() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let built_hub = HubBuilder::new(storage, codec)
+            .lease_ttl(Duration::from_secs(120))
+            .build();
+
+        assert_eq!(built_hub.lease_manager().ttl(), Duration::from_secs(120));
+    }
+}

--- a/lib/llm/src/block_manager/distributed/registry/core/builder.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/builder.rs
@@ -240,9 +240,8 @@ mod tests {
     fn test_hub_builder() {
         let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
 
-        let built_hub: RegistryHub<u64, u64, NoMetadata, _, _> = hub(storage)
-            .lease_ttl(Duration::from_secs(60))
-            .build();
+        let built_hub: RegistryHub<u64, u64, NoMetadata, _, _> =
+            hub(storage).lease_ttl(Duration::from_secs(60)).build();
 
         assert!(built_hub.is_empty());
 

--- a/lib/llm/src/block_manager/distributed/registry/core/codec.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/codec.rs
@@ -1,0 +1,495 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Codec trait and implementations.
+
+use std::marker::PhantomData;
+
+use super::error::{RegistryError, RegistryResult};
+use super::key::RegistryKey;
+use super::metadata::RegistryMetadata;
+use super::value::RegistryValue;
+
+/// Current protocol version.
+pub const PROTOCOL_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum MessageType {
+    Register = 1,
+    CanOffload = 2,
+    Match = 3,
+    CanOffloadResponse = 4,
+    MatchResponse = 5,
+}
+
+impl TryFrom<u8> for MessageType {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Register),
+            2 => Ok(Self::CanOffload),
+            3 => Ok(Self::Match),
+            4 => Ok(Self::CanOffloadResponse),
+            5 => Ok(Self::MatchResponse),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum OffloadStatus {
+    Granted = 0,
+    AlreadyStored = 1,
+    Leased = 2,
+}
+
+impl TryFrom<u8> for OffloadStatus {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Granted),
+            1 => Ok(Self::AlreadyStored),
+            2 => Ok(Self::Leased),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum QueryType<K> {
+    CanOffload(Vec<K>),
+    Match(Vec<K>),
+}
+
+#[derive(Debug, Clone)]
+pub enum ResponseType<K, V, M> {
+    CanOffload(Vec<OffloadStatus>),
+    Match(Vec<(K, V, M)>),
+}
+
+pub trait RegistryCodec<K, V, M>: Send + Sync
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+{
+    fn encode_register(&self, entries: &[(K, V, M)], buf: &mut Vec<u8>);
+    fn decode_register(&self, data: &[u8]) -> Option<Vec<(K, V, M)>>;
+
+    fn encode_query(&self, query: &QueryType<K>, buf: &mut Vec<u8>);
+    fn decode_query(&self, data: &[u8]) -> Option<QueryType<K>>;
+
+    fn encode_response(&self, response: &ResponseType<K, V, M>, buf: &mut Vec<u8>);
+    fn decode_response(&self, data: &[u8]) -> Option<ResponseType<K, V, M>>;
+
+    /// Decode with detailed error information.
+    fn decode_register_result(&self, data: &[u8]) -> RegistryResult<Vec<(K, V, M)>> {
+        self.decode_register(data).ok_or_else(|| RegistryError::DecodeError {
+            context: "register",
+            expected: "valid register message".to_string(),
+            got: format!("{} bytes", data.len()),
+        })
+    }
+
+    /// Decode query with detailed error information.
+    fn decode_query_result(&self, data: &[u8]) -> RegistryResult<QueryType<K>> {
+        self.decode_query(data).ok_or_else(|| RegistryError::DecodeError {
+            context: "query",
+            expected: "valid query message".to_string(),
+            got: format!("{} bytes", data.len()),
+        })
+    }
+
+    /// Decode response with detailed error information.
+    fn decode_response_result(&self, data: &[u8]) -> RegistryResult<ResponseType<K, V, M>> {
+        self.decode_response(data).ok_or_else(|| RegistryError::DecodeError {
+            context: "response",
+            expected: "valid response message".to_string(),
+            got: format!("{} bytes", data.len()),
+        })
+    }
+}
+
+/// Binary codec for fixed-size keys and values.
+///
+/// Wire format (versioned):
+/// ```text
+/// [version:1][type:1][count:4][...entries...]
+/// ```
+pub struct BinaryCodec<K, V, M> {
+    _phantom: PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M> BinaryCodec<K, V, M> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Check protocol version in message header.
+    fn check_version(data: &[u8]) -> Option<()> {
+        if data.len() < 2 {
+            return None;
+        }
+        let version = data[0];
+        if version != PROTOCOL_VERSION {
+            tracing::warn!(
+                expected = PROTOCOL_VERSION,
+                got = version,
+                "Protocol version mismatch"
+            );
+            return None;
+        }
+        Some(())
+    }
+
+    /// Version byte offset (always 1 since version byte is required).
+    #[inline]
+    fn header_offset(_data: &[u8]) -> usize {
+        1
+    }
+}
+
+impl<K, V, M> Default for BinaryCodec<K, V, M> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V, M> RegistryCodec<K, V, M> for BinaryCodec<K, V, M>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+{
+    fn encode_register(&self, entries: &[(K, V, M)], buf: &mut Vec<u8>) {
+        buf.push(PROTOCOL_VERSION);
+        buf.push(MessageType::Register as u8);
+        buf.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+        for (k, v, m) in entries {
+            let kb = k.to_bytes();
+            let vb = v.to_bytes();
+            let mb = m.to_bytes();
+            buf.extend_from_slice(&(kb.len() as u16).to_le_bytes());
+            buf.extend_from_slice(&kb);
+            buf.extend_from_slice(&(vb.len() as u16).to_le_bytes());
+            buf.extend_from_slice(&vb);
+            buf.extend_from_slice(&(mb.len() as u16).to_le_bytes());
+            buf.extend_from_slice(&mb);
+        }
+    }
+
+    fn decode_register(&self, data: &[u8]) -> Option<Vec<(K, V, M)>> {
+        Self::check_version(data)?;
+        let offset = Self::header_offset(data);
+        let data = &data[offset..];
+
+        if data.len() < 5 || data[0] != MessageType::Register as u8 {
+            return None;
+        }
+        let count = u32::from_le_bytes(data[1..5].try_into().ok()?) as usize;
+        let mut entries = Vec::with_capacity(count);
+        let mut pos = 5;
+
+        for _ in 0..count {
+            if pos + 2 > data.len() {
+                return None;
+            }
+            let klen = u16::from_le_bytes(data[pos..pos + 2].try_into().ok()?) as usize;
+            pos += 2;
+            if pos + klen > data.len() {
+                return None;
+            }
+            let k = K::from_bytes(&data[pos..pos + klen])?;
+            pos += klen;
+
+            if pos + 2 > data.len() {
+                return None;
+            }
+            let vlen = u16::from_le_bytes(data[pos..pos + 2].try_into().ok()?) as usize;
+            pos += 2;
+            if pos + vlen > data.len() {
+                return None;
+            }
+            let v = V::from_bytes(&data[pos..pos + vlen])?;
+            pos += vlen;
+
+            if pos + 2 > data.len() {
+                return None;
+            }
+            let mlen = u16::from_le_bytes(data[pos..pos + 2].try_into().ok()?) as usize;
+            pos += 2;
+            if pos + mlen > data.len() {
+                return None;
+            }
+            let m = M::from_bytes(&data[pos..pos + mlen])?;
+            pos += mlen;
+
+            entries.push((k, v, m));
+        }
+
+        Some(entries)
+    }
+
+    fn encode_query(&self, query: &QueryType<K>, buf: &mut Vec<u8>) {
+        buf.push(PROTOCOL_VERSION);
+        match query {
+            QueryType::CanOffload(keys) => {
+                buf.push(MessageType::CanOffload as u8);
+                buf.extend_from_slice(&(keys.len() as u32).to_le_bytes());
+                for k in keys {
+                    let kb = k.to_bytes();
+                    buf.extend_from_slice(&(kb.len() as u16).to_le_bytes());
+                    buf.extend_from_slice(&kb);
+                }
+            }
+            QueryType::Match(keys) => {
+                buf.push(MessageType::Match as u8);
+                buf.extend_from_slice(&(keys.len() as u32).to_le_bytes());
+                for k in keys {
+                    let kb = k.to_bytes();
+                    buf.extend_from_slice(&(kb.len() as u16).to_le_bytes());
+                    buf.extend_from_slice(&kb);
+                }
+            }
+        }
+    }
+
+    fn decode_query(&self, data: &[u8]) -> Option<QueryType<K>> {
+        Self::check_version(data)?;
+        let offset = Self::header_offset(data);
+        let data = &data[offset..];
+
+        if data.len() < 5 {
+            return None;
+        }
+        let msg_type = MessageType::try_from(data[0]).ok()?;
+        let count = u32::from_le_bytes(data[1..5].try_into().ok()?) as usize;
+        let mut keys = Vec::with_capacity(count);
+        let mut pos = 5;
+
+        for _ in 0..count {
+            if pos + 2 > data.len() {
+                return None;
+            }
+            let klen = u16::from_le_bytes(data[pos..pos + 2].try_into().ok()?) as usize;
+            pos += 2;
+            if pos + klen > data.len() {
+                return None;
+            }
+            keys.push(K::from_bytes(&data[pos..pos + klen])?);
+            pos += klen;
+        }
+
+        match msg_type {
+            MessageType::CanOffload => Some(QueryType::CanOffload(keys)),
+            MessageType::Match => Some(QueryType::Match(keys)),
+            _ => None,
+        }
+    }
+
+    fn encode_response(&self, response: &ResponseType<K, V, M>, buf: &mut Vec<u8>) {
+        buf.push(PROTOCOL_VERSION);
+        match response {
+            ResponseType::CanOffload(statuses) => {
+                buf.push(MessageType::CanOffloadResponse as u8);
+                buf.extend_from_slice(&(statuses.len() as u32).to_le_bytes());
+                for s in statuses {
+                    buf.push(*s as u8);
+                }
+            }
+            ResponseType::Match(entries) => {
+                buf.push(MessageType::MatchResponse as u8);
+                buf.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+                for (k, v, m) in entries {
+                    let kb = k.to_bytes();
+                    let vb = v.to_bytes();
+                    let mb = m.to_bytes();
+                    buf.extend_from_slice(&(kb.len() as u16).to_le_bytes());
+                    buf.extend_from_slice(&kb);
+                    buf.extend_from_slice(&(vb.len() as u16).to_le_bytes());
+                    buf.extend_from_slice(&vb);
+                    buf.extend_from_slice(&(mb.len() as u16).to_le_bytes());
+                    buf.extend_from_slice(&mb);
+                }
+            }
+        }
+    }
+
+    fn decode_response(&self, data: &[u8]) -> Option<ResponseType<K, V, M>> {
+        Self::check_version(data)?;
+        let offset = Self::header_offset(data);
+        let data = &data[offset..];
+
+        if data.len() < 5 {
+            return None;
+        }
+        let msg_type = MessageType::try_from(data[0]).ok()?;
+        let count = u32::from_le_bytes(data[1..5].try_into().ok()?) as usize;
+
+        match msg_type {
+            MessageType::CanOffloadResponse => {
+                if data.len() < 5 + count {
+                    return None;
+                }
+                let statuses: Option<Vec<_>> = data[5..5 + count]
+                    .iter()
+                    .map(|&b| OffloadStatus::try_from(b).ok())
+                    .collect();
+                Some(ResponseType::CanOffload(statuses?))
+            }
+            MessageType::MatchResponse => {
+                let mut entries = Vec::with_capacity(count);
+                let mut pos = 5;
+
+                for _ in 0..count {
+                    if pos + 2 > data.len() {
+                        return None;
+                    }
+                    let klen = u16::from_le_bytes(data[pos..pos + 2].try_into().ok()?) as usize;
+                    pos += 2;
+                    if pos + klen > data.len() {
+                        return None;
+                    }
+                    let k = K::from_bytes(&data[pos..pos + klen])?;
+                    pos += klen;
+
+                    if pos + 2 > data.len() {
+                        return None;
+                    }
+                    let vlen = u16::from_le_bytes(data[pos..pos + 2].try_into().ok()?) as usize;
+                    pos += 2;
+                    if pos + vlen > data.len() {
+                        return None;
+                    }
+                    let v = V::from_bytes(&data[pos..pos + vlen])?;
+                    pos += vlen;
+
+                    if pos + 2 > data.len() {
+                        return None;
+                    }
+                    let mlen = u16::from_le_bytes(data[pos..pos + 2].try_into().ok()?) as usize;
+                    pos += 2;
+                    if pos + mlen > data.len() {
+                        return None;
+                    }
+                    let m = M::from_bytes(&data[pos..pos + mlen])?;
+                    pos += mlen;
+
+                    entries.push((k, v, m));
+                }
+
+                Some(ResponseType::Match(entries))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_manager::distributed::registry::core::metadata::NoMetadata;
+
+    #[test]
+    fn test_register_roundtrip() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let entries = vec![(1u64, 100u64, NoMetadata), (2, 200, NoMetadata)];
+
+        let mut buf = Vec::new();
+        codec.encode_register(&entries, &mut buf);
+
+        // Check version byte is present
+        assert_eq!(buf[0], PROTOCOL_VERSION);
+
+        let decoded = codec.decode_register(&buf).unwrap();
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0].0, 1);
+        assert_eq!(decoded[0].1, 100);
+        assert_eq!(decoded[1].0, 2);
+        assert_eq!(decoded[1].1, 200);
+    }
+
+    #[test]
+    fn test_query_roundtrip() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let query = QueryType::CanOffload(vec![1u64, 2, 3]);
+        let mut buf = Vec::new();
+        codec.encode_query(&query, &mut buf);
+
+        // Check version byte is present
+        assert_eq!(buf[0], PROTOCOL_VERSION);
+
+        let decoded = codec.decode_query(&buf).unwrap();
+        match decoded {
+            QueryType::CanOffload(keys) => assert_eq!(keys, vec![1, 2, 3]),
+            _ => panic!("wrong type"),
+        }
+
+        let query = QueryType::Match(vec![4u64, 5]);
+        buf.clear();
+        codec.encode_query(&query, &mut buf);
+        let decoded = codec.decode_query(&buf).unwrap();
+        match decoded {
+            QueryType::Match(keys) => assert_eq!(keys, vec![4, 5]),
+            _ => panic!("wrong type"),
+        }
+    }
+
+    #[test]
+    fn test_response_roundtrip() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let response = ResponseType::CanOffload(vec![
+            OffloadStatus::Granted,
+            OffloadStatus::AlreadyStored,
+            OffloadStatus::Leased,
+        ]);
+        let mut buf = Vec::new();
+        codec.encode_response(&response, &mut buf);
+
+        // Check version byte is present
+        assert_eq!(buf[0], PROTOCOL_VERSION);
+
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&buf).unwrap();
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                assert_eq!(statuses.len(), 3);
+                assert_eq!(statuses[0], OffloadStatus::Granted);
+                assert_eq!(statuses[1], OffloadStatus::AlreadyStored);
+                assert_eq!(statuses[2], OffloadStatus::Leased);
+            }
+            _ => panic!("wrong type"),
+        }
+
+        let response: ResponseType<u64, u64, NoMetadata> =
+            ResponseType::Match(vec![(1, 100, NoMetadata), (2, 200, NoMetadata)]);
+        buf.clear();
+        codec.encode_response(&response, &mut buf);
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&buf).unwrap();
+        match decoded {
+            ResponseType::Match(entries) => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].0, 1);
+                assert_eq!(entries[0].1, 100);
+            }
+            _ => panic!("wrong type"),
+        }
+    }
+
+    #[test]
+    fn test_decode_result_error() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let result = codec.decode_register_result(&[]);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("register"));
+    }
+}

--- a/lib/llm/src/block_manager/distributed/registry/core/codec.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/codec.rs
@@ -83,7 +83,11 @@ where
     fn encode_query(&self, query: &QueryType<K>, buf: &mut Vec<u8>) -> RegistryResult<()>;
     fn decode_query(&self, data: &[u8]) -> Option<QueryType<K>>;
 
-    fn encode_response(&self, response: &ResponseType<K, V, M>, buf: &mut Vec<u8>) -> RegistryResult<()>;
+    fn encode_response(
+        &self,
+        response: &ResponseType<K, V, M>,
+        buf: &mut Vec<u8>,
+    ) -> RegistryResult<()>;
     fn decode_response(&self, data: &[u8]) -> Option<ResponseType<K, V, M>>;
 
     /// Decode with detailed error information.
@@ -323,7 +327,11 @@ where
         }
     }
 
-    fn encode_response(&self, response: &ResponseType<K, V, M>, buf: &mut Vec<u8>) -> RegistryResult<()> {
+    fn encode_response(
+        &self,
+        response: &ResponseType<K, V, M>,
+        buf: &mut Vec<u8>,
+    ) -> RegistryResult<()> {
         buf.push(PROTOCOL_VERSION);
         match response {
             ResponseType::CanOffload(statuses) => {

--- a/lib/llm/src/block_manager/distributed/registry/core/codec.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/codec.rs
@@ -88,29 +88,32 @@ where
 
     /// Decode with detailed error information.
     fn decode_register_result(&self, data: &[u8]) -> RegistryResult<Vec<(K, V, M)>> {
-        self.decode_register(data).ok_or_else(|| RegistryError::DecodeError {
-            context: "register",
-            expected: "valid register message".to_string(),
-            got: format!("{} bytes", data.len()),
-        })
+        self.decode_register(data)
+            .ok_or_else(|| RegistryError::DecodeError {
+                context: "register",
+                expected: "valid register message".to_string(),
+                got: format!("{} bytes", data.len()),
+            })
     }
 
     /// Decode query with detailed error information.
     fn decode_query_result(&self, data: &[u8]) -> RegistryResult<QueryType<K>> {
-        self.decode_query(data).ok_or_else(|| RegistryError::DecodeError {
-            context: "query",
-            expected: "valid query message".to_string(),
-            got: format!("{} bytes", data.len()),
-        })
+        self.decode_query(data)
+            .ok_or_else(|| RegistryError::DecodeError {
+                context: "query",
+                expected: "valid query message".to_string(),
+                got: format!("{} bytes", data.len()),
+            })
     }
 
     /// Decode response with detailed error information.
     fn decode_response_result(&self, data: &[u8]) -> RegistryResult<ResponseType<K, V, M>> {
-        self.decode_response(data).ok_or_else(|| RegistryError::DecodeError {
-            context: "response",
-            expected: "valid response message".to_string(),
-            got: format!("{} bytes", data.len()),
-        })
+        self.decode_response(data)
+            .ok_or_else(|| RegistryError::DecodeError {
+                context: "response",
+                expected: "valid response message".to_string(),
+                got: format!("{} bytes", data.len()),
+            })
     }
 }
 

--- a/lib/llm/src/block_manager/distributed/registry/core/error.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/error.rs
@@ -54,16 +54,28 @@ impl fmt::Display for RegistryError {
                 expected,
                 got,
             } => {
-                write!(f, "decode error in {}: expected {}, got {}", context, expected, got)
+                write!(
+                    f,
+                    "decode error in {}: expected {}, got {}",
+                    context, expected, got
+                )
             }
             Self::VersionMismatch { expected, got } => {
-                write!(f, "protocol version mismatch: expected {}, got {}", expected, got)
+                write!(
+                    f,
+                    "protocol version mismatch: expected {}, got {}",
+                    expected, got
+                )
             }
             Self::InvalidMessageType { got } => {
                 write!(f, "invalid message type: {}", got)
             }
             Self::MessageTooShort { expected, got } => {
-                write!(f, "message too short: expected {} bytes, got {}", expected, got)
+                write!(
+                    f,
+                    "message too short: expected {} bytes, got {}",
+                    expected, got
+                )
             }
             Self::TransportError { message } => {
                 write!(f, "transport error: {}", message)
@@ -106,8 +118,10 @@ mod tests {
 
     #[test]
     fn test_version_mismatch() {
-        let err = RegistryError::VersionMismatch { expected: 1, got: 2 };
+        let err = RegistryError::VersionMismatch {
+            expected: 1,
+            got: 2,
+        };
         assert!(err.to_string().contains("version mismatch"));
     }
 }
-

--- a/lib/llm/src/block_manager/distributed/registry/core/error.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/error.rs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Error types for the distributed registry.
+
+use std::fmt;
+
+/// Errors that can occur during registry operations.
+#[derive(Debug)]
+pub enum RegistryError {
+    /// Failed to encode a message.
+    EncodeError { context: &'static str },
+
+    /// Failed to decode a message.
+    DecodeError {
+        context: &'static str,
+        expected: String,
+        got: String,
+    },
+
+    /// Protocol version mismatch.
+    VersionMismatch { expected: u8, got: u8 },
+
+    /// Invalid message type.
+    InvalidMessageType { got: u8 },
+
+    /// Message too short.
+    MessageTooShort { expected: usize, got: usize },
+
+    /// Transport error.
+    TransportError { message: String },
+
+    /// Hub disconnected.
+    Disconnected,
+
+    /// Request timed out.
+    Timeout { duration_ms: u64 },
+
+    /// Lease conflict - key is leased by another client.
+    LeaseConflict { key_debug: String },
+
+    /// Storage error.
+    StorageError { message: String },
+}
+
+impl fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EncodeError { context } => {
+                write!(f, "encode error: {}", context)
+            }
+            Self::DecodeError {
+                context,
+                expected,
+                got,
+            } => {
+                write!(f, "decode error in {}: expected {}, got {}", context, expected, got)
+            }
+            Self::VersionMismatch { expected, got } => {
+                write!(f, "protocol version mismatch: expected {}, got {}", expected, got)
+            }
+            Self::InvalidMessageType { got } => {
+                write!(f, "invalid message type: {}", got)
+            }
+            Self::MessageTooShort { expected, got } => {
+                write!(f, "message too short: expected {} bytes, got {}", expected, got)
+            }
+            Self::TransportError { message } => {
+                write!(f, "transport error: {}", message)
+            }
+            Self::Disconnected => {
+                write!(f, "hub disconnected")
+            }
+            Self::Timeout { duration_ms } => {
+                write!(f, "request timed out after {}ms", duration_ms)
+            }
+            Self::LeaseConflict { key_debug } => {
+                write!(f, "lease conflict for key: {}", key_debug)
+            }
+            Self::StorageError { message } => {
+                write!(f, "storage error: {}", message)
+            }
+        }
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
+/// Result type for registry operations.
+pub type RegistryResult<T> = Result<T, RegistryError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        let err = RegistryError::DecodeError {
+            context: "register message",
+            expected: "4 bytes for count".to_string(),
+            got: "2 bytes".to_string(),
+        };
+        assert!(err.to_string().contains("register message"));
+        assert!(err.to_string().contains("4 bytes"));
+    }
+
+    #[test]
+    fn test_version_mismatch() {
+        let err = RegistryError::VersionMismatch { expected: 1, got: 2 };
+        assert!(err.to_string().contains("version mismatch"));
+    }
+}
+

--- a/lib/llm/src/block_manager/distributed/registry/core/events.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/events.rs
@@ -373,9 +373,9 @@ impl EventBusConfig {
             }),
             other => Err(EventBusConfigError {
                 backend: other.to_string(),
-                message: format!(
+                message:
                     "Unknown backend. Supported: 'in_process'. Reserved: 'zmq', 'nats', 'redis'"
-                ),
+                        .to_string(),
             }),
         }
     }
@@ -470,9 +470,9 @@ mod tests {
             backend: "zmq".to_string(),
             ..Default::default()
         };
-        let result = config.build();
-        assert!(result.is_err());
-        let err = result.unwrap_err();
+        let Err(err) = config.build() else {
+            panic!("ZMQ should return error");
+        };
         assert_eq!(err.backend, "zmq");
         assert!(err.message.contains("not yet implemented"));
 
@@ -481,27 +481,29 @@ mod tests {
             backend: "nats".to_string(),
             ..Default::default()
         };
-        let result = config.build();
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().backend, "nats");
+        let Err(err) = config.build() else {
+            panic!("NATS should return error");
+        };
+        assert_eq!(err.backend, "nats");
 
         // Redis - reserved but not implemented
         let config = EventBusConfig {
             backend: "redis".to_string(),
             ..Default::default()
         };
-        let result = config.build();
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().backend, "redis");
+        let Err(err) = config.build() else {
+            panic!("Redis should return error");
+        };
+        assert_eq!(err.backend, "redis");
 
         // Unknown backend
         let config = EventBusConfig {
             backend: "unknown_backend".to_string(),
             ..Default::default()
         };
-        let result = config.build();
-        assert!(result.is_err());
-        let err = result.unwrap_err();
+        let Err(err) = config.build() else {
+            panic!("Unknown backend should return error");
+        };
         assert_eq!(err.backend, "unknown_backend");
         assert!(err.message.contains("Unknown backend"));
     }

--- a/lib/llm/src/block_manager/distributed/registry/core/events.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/events.rs
@@ -1,0 +1,411 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Event bus infrastructure for registry events.
+//!
+//! Provides a pub/sub event system for broadcasting cache events to workers
+//! and interested components. Events are fire-and-forget, enabling real-time
+//! coordination across the cluster.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────────────────┐
+//! │                         DISTRIBUTED EVENT BUS                                │
+//! │                                                                              │
+//! │   Pluggable Backends:  InProcess │ ZMQ PUB/SUB │ NATS │ Redis │ etc.        │
+//! └─────────────────────────────────────────────────────────────────────────────┘
+//!          ▲              ▲              ▲              ▲              ▲
+//!          │              │              │              │              │
+//!     ┌────┴────┐    ┌────┴────┐    ┌────┴────┐    ┌────┴────┐    ┌────┴────┐
+//!     │Worker 1 │    │Worker 2 │    │Worker 3 │    │Registry │    │ Metrics │
+//!     │ emit()  │    │ emit()  │    │ emit()  │    │   Hub   │    │ Service │
+//!     │on_event │    │on_event │    │on_event │    │on_event │    │on_event │
+//!     └─────────┘    └─────────┘    └─────────┘    └─────────┘    └─────────┘
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+/// Topic/channel for event routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EventTopic {
+    /// Cache hit/miss events (for eviction decisions)
+    CacheAccess,
+    /// Block lifecycle events (offload, evict, invalidate)
+    BlockLifecycle,
+    /// Cluster membership changes
+    ClusterMembership,
+    /// Metrics and telemetry
+    Metrics,
+}
+
+/// Storage tier for events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum StorageTier {
+    /// G1 - GPU memory
+    Device = 0,
+    /// G2 - CPU pinned memory
+    Host = 1,
+    /// G3 - Local disk
+    Disk = 2,
+    /// G4 - Remote storage (object/shared disk)
+    Remote = 3,
+}
+
+/// Remote storage type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum StorageType {
+    Object,
+    Disk,
+}
+
+/// Reason for eviction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EvictionReason {
+    /// Hit capacity limit
+    Capacity,
+    /// Least recently used
+    Lru,
+    /// Least frequently used
+    Lfu,
+    /// Explicit eviction request
+    Manual,
+    /// Worker shutting down
+    Shutdown,
+}
+
+/// Core event types - extensible with #[non_exhaustive].
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RegistryEvent {
+    // ═══════════════════════════════════════════════════════════════════
+    // CACHE ACCESS EVENTS (Topic: CacheAccess)
+    // ═══════════════════════════════════════════════════════════════════
+    /// Cache hit - block was found and used
+    CacheHit {
+        sequence_hashes: Vec<u64>,
+        tier: StorageTier,
+        worker_id: u64,
+        timestamp_ms: u64,
+    },
+
+    /// Cache miss - block was not found
+    CacheMiss {
+        sequence_hashes: Vec<u64>,
+        tier: StorageTier,
+        worker_id: u64,
+    },
+
+    // ═══════════════════════════════════════════════════════════════════
+    // BLOCK LIFECYCLE EVENTS (Topic: BlockLifecycle)
+    // ═══════════════════════════════════════════════════════════════════
+    /// Blocks offloaded to remote storage
+    BlocksOffloaded {
+        sequence_hashes: Vec<u64>,
+        storage_type: StorageType,
+        location: String,
+        worker_id: u64,
+    },
+
+    /// Blocks onboarded from remote storage
+    BlocksOnboarded {
+        sequence_hashes: Vec<u64>,
+        storage_type: StorageType,
+        location: String,
+        worker_id: u64,
+    },
+
+    /// Blocks evicted from a tier
+    BlocksEvicted {
+        sequence_hashes: Vec<u64>,
+        tier: StorageTier,
+        worker_id: u64,
+        reason: EvictionReason,
+    },
+
+    /// Blocks invalidated (e.g., NoSuchKey error)
+    BlocksInvalidated {
+        sequence_hashes: Vec<u64>,
+        reason: String,
+        worker_id: u64,
+    },
+
+    // ═══════════════════════════════════════════════════════════════════
+    // CLUSTER EVENTS (Topic: ClusterMembership)
+    // ═══════════════════════════════════════════════════════════════════
+    /// Worker joined the cluster
+    WorkerJoined { worker_id: u64 },
+
+    /// Worker left the cluster
+    WorkerLeft { worker_id: u64, graceful: bool },
+}
+
+impl RegistryEvent {
+    /// Get the topic for this event.
+    pub fn topic(&self) -> EventTopic {
+        match self {
+            RegistryEvent::CacheHit { .. } | RegistryEvent::CacheMiss { .. } => {
+                EventTopic::CacheAccess
+            }
+            RegistryEvent::BlocksOffloaded { .. }
+            | RegistryEvent::BlocksOnboarded { .. }
+            | RegistryEvent::BlocksEvicted { .. }
+            | RegistryEvent::BlocksInvalidated { .. } => EventTopic::BlockLifecycle,
+            RegistryEvent::WorkerJoined { .. } | RegistryEvent::WorkerLeft { .. } => {
+                EventTopic::ClusterMembership
+            }
+        }
+    }
+
+    /// Get current timestamp in milliseconds.
+    pub fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+}
+
+/// Trait for event bus implementations.
+#[async_trait]
+pub trait EventBus: Send + Sync {
+    /// Publish an event (fire-and-forget).
+    async fn publish(&self, event: RegistryEvent) -> Result<()>;
+
+    /// Subscribe to events on a topic.
+    fn subscribe(&self, topic: EventTopic) -> EventReceiver;
+
+    /// Batch publish for efficiency.
+    async fn publish_batch(&self, events: Vec<RegistryEvent>) -> Result<()> {
+        for event in events {
+            self.publish(event).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Event receiver for subscriptions.
+pub type EventReceiver = broadcast::Receiver<RegistryEvent>;
+
+/// In-process event bus implementation.
+///
+/// Uses tokio broadcast channels for zero-copy event distribution.
+/// Suitable for single-node deployments or testing.
+pub struct InProcessEventBus {
+    channels: RwLock<HashMap<EventTopic, broadcast::Sender<RegistryEvent>>>,
+    channel_capacity: usize,
+}
+
+impl InProcessEventBus {
+    /// Create a new in-process event bus.
+    pub fn new(channel_capacity: usize) -> Self {
+        Self {
+            channels: RwLock::new(HashMap::new()),
+            channel_capacity,
+        }
+    }
+
+    fn get_or_create_channel(&self, topic: EventTopic) -> broadcast::Sender<RegistryEvent> {
+        {
+            let channels = self.channels.read();
+            if let Some(sender) = channels.get(&topic) {
+                return sender.clone();
+            }
+        }
+
+        let mut channels = self.channels.write();
+        channels
+            .entry(topic)
+            .or_insert_with(|| broadcast::channel(self.channel_capacity).0)
+            .clone()
+    }
+}
+
+impl Default for InProcessEventBus {
+    fn default() -> Self {
+        Self::new(1024)
+    }
+}
+
+#[async_trait]
+impl EventBus for InProcessEventBus {
+    async fn publish(&self, event: RegistryEvent) -> Result<()> {
+        let topic = event.topic();
+        let sender = self.get_or_create_channel(topic);
+        // Ignore send errors (no subscribers is fine for fire-and-forget)
+        let _ = sender.send(event);
+        Ok(())
+    }
+
+    fn subscribe(&self, topic: EventTopic) -> EventReceiver {
+        let sender = self.get_or_create_channel(topic);
+        sender.subscribe()
+    }
+}
+
+/// Event handler trait for processing received events.
+#[async_trait]
+pub trait EventHandler: Send + Sync {
+    /// Handle a received event.
+    async fn on_event(&self, event: RegistryEvent) -> Result<()>;
+}
+
+/// Spawn a background task to process events from a subscription.
+pub fn spawn_event_handler<H: EventHandler + 'static>(
+    mut receiver: EventReceiver,
+    handler: Arc<H>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match receiver.recv().await {
+                Ok(event) => {
+                    if let Err(e) = handler.on_event(event).await {
+                        tracing::warn!(error = %e, "Event handler error");
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(skipped = n, "Event handler lagged, skipped events");
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::debug!("Event channel closed, handler shutting down");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+/// Configuration for the event bus.
+#[derive(Debug, Clone)]
+pub struct EventBusConfig {
+    /// Backend type: "in_process", "zmq", "nats", "redis"
+    pub backend: String,
+    /// Channel capacity for in-process bus
+    pub channel_capacity: usize,
+    /// Connection URL (for network backends)
+    pub url: Option<String>,
+}
+
+impl Default for EventBusConfig {
+    fn default() -> Self {
+        Self {
+            backend: "in_process".to_string(),
+            channel_capacity: 1024,
+            url: None,
+        }
+    }
+}
+
+impl EventBusConfig {
+    /// Create from environment variables.
+    ///
+    /// Environment variables:
+    /// - `DYN_EVENT_BUS_BACKEND`: "in_process", "zmq", "nats", "redis"
+    /// - `DYN_EVENT_BUS_CAPACITY`: Channel capacity (default: 1024)
+    /// - `DYN_EVENT_BUS_URL`: Connection URL for network backends
+    pub fn from_env() -> Self {
+        let backend =
+            std::env::var("DYN_EVENT_BUS_BACKEND").unwrap_or_else(|_| "in_process".to_string());
+
+        let channel_capacity = std::env::var("DYN_EVENT_BUS_CAPACITY")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1024);
+
+        let url = std::env::var("DYN_EVENT_BUS_URL").ok();
+
+        Self {
+            backend,
+            channel_capacity,
+            url,
+        }
+    }
+
+    /// Build an event bus from this configuration.
+    pub fn build(&self) -> Box<dyn EventBus> {
+        // Future: Add ZMQ, NATS, Redis backends based on self.backend
+        let _ = self.backend.as_str(); // Reserved for future backend selection
+        Box::new(InProcessEventBus::new(self.channel_capacity))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[tokio::test]
+    async fn test_in_process_event_bus() {
+        let bus = InProcessEventBus::new(100);
+
+        // Subscribe before publishing
+        let mut receiver = bus.subscribe(EventTopic::CacheAccess);
+
+        // Publish event
+        let event = RegistryEvent::CacheHit {
+            sequence_hashes: vec![1, 2, 3],
+            tier: StorageTier::Host,
+            worker_id: 0,
+            timestamp_ms: RegistryEvent::now_ms(),
+        };
+        bus.publish(event.clone()).await.unwrap();
+
+        // Receive event
+        let received = receiver.recv().await.unwrap();
+        match received {
+            RegistryEvent::CacheHit {
+                sequence_hashes, ..
+            } => {
+                assert_eq!(sequence_hashes, vec![1, 2, 3]);
+            }
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_event_handler() {
+        struct TestHandler {
+            count: AtomicU64,
+        }
+
+        #[async_trait]
+        impl EventHandler for TestHandler {
+            async fn on_event(&self, _event: RegistryEvent) -> Result<()> {
+                self.count.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+
+        let bus = InProcessEventBus::new(100);
+        let handler = Arc::new(TestHandler {
+            count: AtomicU64::new(0),
+        });
+
+        let receiver = bus.subscribe(EventTopic::CacheAccess);
+        let _task = spawn_event_handler(receiver, handler.clone());
+
+        // Publish events
+        for i in 0..5 {
+            bus.publish(RegistryEvent::CacheHit {
+                sequence_hashes: vec![i],
+                tier: StorageTier::Host,
+                worker_id: 0,
+                timestamp_ms: RegistryEvent::now_ms(),
+            })
+            .await
+            .unwrap();
+        }
+
+        // Give handler time to process
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        assert_eq!(handler.count.load(Ordering::Relaxed), 5);
+    }
+}

--- a/lib/llm/src/block_manager/distributed/registry/core/eviction.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/eviction.rs
@@ -332,4 +332,3 @@ mod tests {
         assert_eq!(evicted, vec![1]);
     }
 }
-

--- a/lib/llm/src/block_manager/distributed/registry/core/eviction.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/eviction.rs
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Eviction policies.
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::RwLock;
+
+use super::storage::Storage;
+
+/// Eviction policy wrapping a storage backend.
+pub trait Eviction<K, V>: Storage<K, V> {
+    fn evict(&self, count: usize) -> Vec<K>;
+    fn capacity(&self) -> usize;
+}
+
+/// No eviction - storage grows unbounded.
+pub struct NoEviction<S> {
+    inner: S,
+}
+
+impl<S> NoEviction<S> {
+    pub fn new(storage: S) -> Self {
+        Self { inner: storage }
+    }
+}
+
+impl<K, V, S: Storage<K, V>> Storage<K, V> for NoEviction<S> {
+    fn insert(&self, key: K, value: V) {
+        self.inner.insert(key, value);
+    }
+
+    fn get(&self, key: &K) -> Option<V> {
+        self.inner.get(key)
+    }
+
+    fn contains(&self, key: &K) -> bool {
+        self.inner.contains(key)
+    }
+
+    fn remove(&self, key: &K) -> Option<V> {
+        self.inner.remove(key)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn clear(&self) {
+        self.inner.clear();
+    }
+}
+
+impl<K, V, S: Storage<K, V>> Eviction<K, V> for NoEviction<S> {
+    fn evict(&self, _count: usize) -> Vec<K> {
+        Vec::new()
+    }
+
+    fn capacity(&self) -> usize {
+        usize::MAX
+    }
+}
+
+/// Entry for ordering in eviction set.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct EvictionEntry<K: Ord + Copy> {
+    priority: i64,
+    insertion_id: u64,
+    key: K,
+}
+
+/// Tail-first eviction using parent tracking from metadata.
+///
+/// Evicts deepest nodes first to avoid orphaning children.
+/// Parent relationships are tracked separately from storage.
+pub struct TailEviction<K, V, S>
+where
+    K: Eq + Hash + Ord + Copy + Send + Sync,
+    V: Clone + Send + Sync,
+    S: Storage<K, V>,
+{
+    inner: S,
+    capacity: usize,
+    parents: RwLock<HashMap<K, Option<K>>>,
+    children: RwLock<HashMap<K, HashSet<K>>>,
+    depths: RwLock<HashMap<K, u32>>,
+    leaves: RwLock<BTreeSet<EvictionEntry<K>>>,
+    insertion_counter: AtomicU64,
+    _phantom: PhantomData<V>,
+}
+
+impl<K, V, S> TailEviction<K, V, S>
+where
+    K: Eq + Hash + Ord + Copy + Send + Sync,
+    V: Clone + Send + Sync,
+    S: Storage<K, V>,
+{
+    pub fn new(storage: S, capacity: usize) -> Self {
+        Self {
+            inner: storage,
+            capacity,
+            parents: RwLock::new(HashMap::new()),
+            children: RwLock::new(HashMap::new()),
+            depths: RwLock::new(HashMap::new()),
+            leaves: RwLock::new(BTreeSet::new()),
+            insertion_counter: AtomicU64::new(0),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Insert with parent tracking for eviction ordering.
+    pub fn insert_with_parent(&self, key: K, value: V, parent: Option<K>) {
+        let mut parents = self.parents.write();
+        let mut children = self.children.write();
+        let mut depths = self.depths.write();
+        let mut leaves = self.leaves.write();
+
+        let depth = match parent {
+            Some(parent_key) => {
+                leaves.retain(|e| e.key != parent_key);
+                children.entry(parent_key).or_default().insert(key);
+                depths.get(&parent_key).copied().unwrap_or(0) + 1
+            }
+            None => 0,
+        };
+
+        parents.insert(key, parent);
+        depths.insert(key, depth);
+        leaves.insert(EvictionEntry {
+            priority: -(depth as i64),
+            insertion_id: self.insertion_counter.fetch_add(1, Ordering::Relaxed),
+            key,
+        });
+
+        drop(parents);
+        drop(children);
+        drop(depths);
+        drop(leaves);
+
+        self.inner.insert(key, value);
+        self.maybe_evict();
+    }
+
+    fn maybe_evict(&self) {
+        while self.inner.len() > self.capacity {
+            if self.evict_one().is_none() {
+                break;
+            }
+        }
+    }
+
+    fn evict_one(&self) -> Option<K> {
+        let key = {
+            let leaves = self.leaves.read();
+            leaves.iter().next().map(|e| e.key)?
+        };
+
+        self.remove(&key);
+        Some(key)
+    }
+}
+
+impl<K, V, S> Storage<K, V> for TailEviction<K, V, S>
+where
+    K: Eq + Hash + Ord + Copy + Send + Sync,
+    V: Clone + Send + Sync,
+    S: Storage<K, V>,
+{
+    fn insert(&self, key: K, value: V) {
+        self.insert_with_parent(key, value, None);
+    }
+
+    fn get(&self, key: &K) -> Option<V> {
+        self.inner.get(key)
+    }
+
+    fn contains(&self, key: &K) -> bool {
+        self.inner.contains(key)
+    }
+
+    fn remove(&self, key: &K) -> Option<V> {
+        let mut parents = self.parents.write();
+        let mut children = self.children.write();
+        let mut depths = self.depths.write();
+        let mut leaves = self.leaves.write();
+
+        let _depth = depths.remove(key).unwrap_or(0);
+        let parent = parents.remove(key).flatten();
+
+        leaves.retain(|e| &e.key != key);
+
+        if let Some(parent_key) = parent {
+            if let Some(parent_children) = children.get_mut(&parent_key) {
+                parent_children.remove(key);
+                if parent_children.is_empty() {
+                    children.remove(&parent_key);
+                    if let Some(&parent_depth) = depths.get(&parent_key) {
+                        leaves.insert(EvictionEntry {
+                            priority: -(parent_depth as i64),
+                            insertion_id: self.insertion_counter.fetch_add(1, Ordering::Relaxed),
+                            key: parent_key,
+                        });
+                    }
+                }
+            }
+        }
+
+        if let Some(my_children) = children.remove(key) {
+            for child in my_children {
+                if let Some(child_parent) = parents.get_mut(&child) {
+                    *child_parent = None;
+                }
+                if let Some(child_depth) = depths.get_mut(&child) {
+                    *child_depth = 0;
+                }
+            }
+        }
+
+        drop(parents);
+        drop(children);
+        drop(depths);
+        drop(leaves);
+
+        self.inner.remove(key)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn clear(&self) {
+        self.parents.write().clear();
+        self.children.write().clear();
+        self.depths.write().clear();
+        self.leaves.write().clear();
+        self.inner.clear();
+    }
+}
+
+impl<K, V, S> Eviction<K, V> for TailEviction<K, V, S>
+where
+    K: Eq + Hash + Ord + Copy + Send + Sync,
+    V: Clone + Send + Sync,
+    S: Storage<K, V>,
+{
+    fn evict(&self, count: usize) -> Vec<K> {
+        let mut evicted = Vec::with_capacity(count);
+        for _ in 0..count {
+            if let Some(key) = self.evict_one() {
+                evicted.push(key);
+            } else {
+                break;
+            }
+        }
+        evicted
+    }
+
+    fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_manager::distributed::registry::core::storage::HashMapStorage;
+
+    #[test]
+    fn test_tail_eviction_basic() {
+        let storage = HashMapStorage::new();
+        let evictable = TailEviction::new(storage, 100);
+
+        evictable.insert(1, 100);
+        evictable.insert(2, 200);
+
+        assert_eq!(evictable.get(&1), Some(100));
+        assert_eq!(evictable.get(&2), Some(200));
+        assert_eq!(evictable.len(), 2);
+    }
+
+    #[test]
+    fn test_tail_eviction_with_parents() {
+        let storage = HashMapStorage::new();
+        let evictable = TailEviction::new(storage, 100);
+
+        evictable.insert_with_parent(1, 100, None);
+        evictable.insert_with_parent(2, 200, Some(1));
+        evictable.insert_with_parent(3, 300, Some(2));
+
+        assert_eq!(evictable.len(), 3);
+
+        let evicted = evictable.evict(1);
+        assert_eq!(evicted, vec![3]);
+        assert_eq!(evictable.len(), 2);
+        assert!(evictable.contains(&1));
+        assert!(evictable.contains(&2));
+        assert!(!evictable.contains(&3));
+    }
+
+    #[test]
+    fn test_tail_eviction_capacity() {
+        let storage = HashMapStorage::new();
+        let evictable = TailEviction::new(storage, 3);
+
+        evictable.insert_with_parent(1, 100, None);
+        evictable.insert_with_parent(2, 200, Some(1));
+        evictable.insert_with_parent(3, 300, Some(2));
+        assert_eq!(evictable.len(), 3);
+
+        evictable.insert_with_parent(4, 400, Some(3));
+        assert_eq!(evictable.len(), 3);
+
+        assert!(evictable.contains(&1));
+        assert!(evictable.contains(&2));
+    }
+
+    #[test]
+    fn test_remove_makes_parent_leaf() {
+        let storage = HashMapStorage::new();
+        let evictable = TailEviction::new(storage, 100);
+
+        evictable.insert_with_parent(1, 100, None);
+        evictable.insert_with_parent(2, 200, Some(1));
+
+        evictable.remove(&2);
+
+        let evicted = evictable.evict(1);
+        assert_eq!(evicted, vec![1]);
+    }
+}
+

--- a/lib/llm/src/block_manager/distributed/registry/core/eviction.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/eviction.rs
@@ -214,8 +214,16 @@ where
                 if let Some(child_parent) = parents.get_mut(&child) {
                     *child_parent = None;
                 }
+                // Remove old eviction entry with stale priority
+                leaves.retain(|e| e.key != child);
                 if let Some(child_depth) = depths.get_mut(&child) {
                     *child_depth = 0;
+                    // Re-insert with updated priority (depth 0)
+                    leaves.insert(EvictionEntry {
+                        priority: 0,
+                        insertion_id: self.insertion_counter.fetch_add(1, Ordering::Relaxed),
+                        key: child,
+                    });
                 }
             }
         }

--- a/lib/llm/src/block_manager/distributed/registry/core/hub.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/hub.rs
@@ -4,8 +4,8 @@
 //! Registry hub (server-side) implementation.
 
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -187,9 +187,18 @@ where
 
                 debug!(
                     num_keys = keys.len(),
-                    granted = statuses.iter().filter(|s| **s == OffloadStatus::Granted).count(),
-                    already_stored = statuses.iter().filter(|s| **s == OffloadStatus::AlreadyStored).count(),
-                    leased = statuses.iter().filter(|s| **s == OffloadStatus::Leased).count(),
+                    granted = statuses
+                        .iter()
+                        .filter(|s| **s == OffloadStatus::Granted)
+                        .count(),
+                    already_stored = statuses
+                        .iter()
+                        .filter(|s| **s == OffloadStatus::AlreadyStored)
+                        .count(),
+                    leased = statuses
+                        .iter()
+                        .filter(|s| **s == OffloadStatus::Leased)
+                        .count(),
                     "Processed can_offload query"
                 );
 
@@ -267,7 +276,8 @@ where
 }
 
 /// Create a simple hub with HashMap storage and binary codec.
-pub fn simple_hub<K, V, M>() -> RegistryHub<K, V, M, super::storage::HashMapStorage<K, V>, super::codec::BinaryCodec<K, V, M>>
+pub fn simple_hub<K, V, M>()
+-> RegistryHub<K, V, M, super::storage::HashMapStorage<K, V>, super::codec::BinaryCodec<K, V, M>>
 where
     K: RegistryKey,
     V: RegistryValue,
@@ -282,10 +292,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::block_manager::distributed::registry::core::hub_transport::InProcessHubTransport;
     use crate::block_manager::distributed::registry::core::{
         BinaryCodec, HashMapStorage, NoMetadata,
     };
-    use crate::block_manager::distributed::registry::core::hub_transport::InProcessHubTransport;
 
     #[tokio::test]
     async fn test_hub_can_offload() {
@@ -310,7 +320,8 @@ mod tests {
         client_codec.encode_query(&QueryType::CanOffload(vec![1, 2, 3, 4]), &mut query_buf);
 
         let response = handle.request(&query_buf).await.unwrap();
-        let decoded: ResponseType<u64, u64, NoMetadata> = client_codec.decode_response(&response).unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> =
+            client_codec.decode_response(&response).unwrap();
 
         match decoded {
             ResponseType::CanOffload(statuses) => {
@@ -349,7 +360,8 @@ mod tests {
         client_codec.encode_query(&QueryType::CanOffload(vec![1, 2]), &mut query_buf);
 
         let response = handle.request(&query_buf).await.unwrap();
-        let decoded: ResponseType<u64, u64, NoMetadata> = client_codec.decode_response(&response).unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> =
+            client_codec.decode_response(&response).unwrap();
 
         match decoded {
             ResponseType::CanOffload(statuses) => {
@@ -418,7 +430,8 @@ mod tests {
         client_codec.encode_query(&QueryType::Match(vec![1, 2, 5]), &mut query_buf);
 
         let response = handle.request(&query_buf).await.unwrap();
-        let decoded: ResponseType<u64, u64, NoMetadata> = client_codec.decode_response(&response).unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> =
+            client_codec.decode_response(&response).unwrap();
 
         match decoded {
             ResponseType::Match(entries) => {

--- a/lib/llm/src/block_manager/distributed/registry/core/hub.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/hub.rs
@@ -202,8 +202,12 @@ where
                     "Processed can_offload query"
                 );
 
-                self.codec
-                    .encode_response(&ResponseType::CanOffload(statuses), &mut response_buf);
+                if let Err(e) = self
+                    .codec
+                    .encode_response(&ResponseType::CanOffload(statuses), &mut response_buf)
+                {
+                    warn!("Failed to encode response: {}", e);
+                }
             }
             QueryType::Match(keys) => {
                 let entries: Vec<_> = keys
@@ -217,8 +221,12 @@ where
                     "Processed match query"
                 );
 
-                self.codec
-                    .encode_response(&ResponseType::Match(entries), &mut response_buf);
+                if let Err(e) = self
+                    .codec
+                    .encode_response(&ResponseType::Match(entries), &mut response_buf)
+                {
+                    warn!("Failed to encode response: {}", e);
+                }
             }
         }
 
@@ -317,7 +325,7 @@ mod tests {
         // Client query
         let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
         let mut query_buf = Vec::new();
-        client_codec.encode_query(&QueryType::CanOffload(vec![1, 2, 3, 4]), &mut query_buf);
+        client_codec.encode_query(&QueryType::CanOffload(vec![1, 2, 3, 4]), &mut query_buf).unwrap();
 
         let response = handle.request(&query_buf).await.unwrap();
         let decoded: ResponseType<u64, u64, NoMetadata> =
@@ -357,7 +365,7 @@ mod tests {
 
         let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
         let mut query_buf = Vec::new();
-        client_codec.encode_query(&QueryType::CanOffload(vec![1, 2]), &mut query_buf);
+        client_codec.encode_query(&QueryType::CanOffload(vec![1, 2]), &mut query_buf).unwrap();
 
         let response = handle.request(&query_buf).await.unwrap();
         let decoded: ResponseType<u64, u64, NoMetadata> =
@@ -397,7 +405,7 @@ mod tests {
         // Register the key
         let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
         let mut reg_buf = Vec::new();
-        client_codec.encode_register(&[(1, 100, NoMetadata)], &mut reg_buf);
+        client_codec.encode_register(&[(1, 100, NoMetadata)], &mut reg_buf).unwrap();
 
         handle.publish(&reg_buf).unwrap();
 
@@ -427,7 +435,7 @@ mod tests {
 
         let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
         let mut query_buf = Vec::new();
-        client_codec.encode_query(&QueryType::Match(vec![1, 2, 5]), &mut query_buf);
+        client_codec.encode_query(&QueryType::Match(vec![1, 2, 5]), &mut query_buf).unwrap();
 
         let response = handle.request(&query_buf).await.unwrap();
         let decoded: ResponseType<u64, u64, NoMetadata> =
@@ -462,7 +470,7 @@ mod tests {
 
         let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
         let mut reg_buf = Vec::new();
-        client_codec.encode_register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)], &mut reg_buf);
+        client_codec.encode_register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)], &mut reg_buf).unwrap();
 
         handle.publish(&reg_buf).unwrap();
 

--- a/lib/llm/src/block_manager/distributed/registry/core/hub.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/hub.rs
@@ -1,0 +1,460 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Registry hub (server-side) implementation.
+
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use tracing::{debug, warn};
+
+use super::codec::{OffloadStatus, QueryType, RegistryCodec, ResponseType};
+use super::hub_transport::{ClientId, HubMessage, HubTransport};
+use super::key::RegistryKey;
+use super::lease::{LeaseManager, LeaseStats};
+use super::metadata::RegistryMetadata;
+use super::storage::Storage;
+use super::value::RegistryValue;
+
+/// Statistics for the registry hub.
+#[derive(Debug, Clone, Default)]
+pub struct HubStats {
+    pub queries_received: u64,
+    pub registrations_received: u64,
+    pub entries_stored: u64,
+    pub lease_stats: LeaseStats,
+}
+
+/// Configuration for the registry hub.
+#[derive(Debug, Clone)]
+pub struct HubConfig {
+    /// Lease TTL for can_offload claims.
+    pub lease_ttl: Duration,
+    /// Interval for cleaning up expired leases.
+    pub lease_cleanup_interval: Duration,
+}
+
+impl Default for HubConfig {
+    fn default() -> Self {
+        Self {
+            lease_ttl: Duration::from_secs(30),
+            lease_cleanup_interval: Duration::from_secs(5),
+        }
+    }
+}
+
+/// Registry hub server.
+///
+/// Handles incoming queries and registrations from clients.
+/// Now includes lease-based claiming to prevent race conditions.
+pub struct RegistryHub<K, V, M, S, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V>,
+    C: RegistryCodec<K, V, M>,
+{
+    storage: S,
+    codec: C,
+    lease_manager: Arc<LeaseManager<K>>,
+    queries_received: AtomicU64,
+    registrations_received: AtomicU64,
+    _phantom: PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M, S, C> RegistryHub<K, V, M, S, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V>,
+    C: RegistryCodec<K, V, M>,
+{
+    /// Create a new registry hub with the given storage and codec.
+    pub fn new(storage: S, codec: C) -> Self {
+        Self::with_config(storage, codec, HubConfig::default())
+    }
+
+    /// Create a new registry hub with custom configuration.
+    pub fn with_config(storage: S, codec: C, config: HubConfig) -> Self {
+        Self {
+            storage,
+            codec,
+            lease_manager: Arc::new(LeaseManager::new(config.lease_ttl)),
+            queries_received: AtomicU64::new(0),
+            registrations_received: AtomicU64::new(0),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Get a reference to the lease manager.
+    pub fn lease_manager(&self) -> &Arc<LeaseManager<K>> {
+        &self.lease_manager
+    }
+
+    /// Get current statistics.
+    pub fn stats(&self) -> HubStats {
+        HubStats {
+            queries_received: self.queries_received.load(Ordering::Relaxed),
+            registrations_received: self.registrations_received.load(Ordering::Relaxed),
+            entries_stored: self.storage.len() as u64,
+            lease_stats: self.lease_manager.stats(),
+        }
+    }
+
+    /// Get the number of entries in storage.
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    /// Check if storage is empty.
+    pub fn is_empty(&self) -> bool {
+        self.storage.is_empty()
+    }
+
+    /// Insert directly into storage (for testing/seeding).
+    pub fn storage_insert(&self, key: K, value: V) {
+        self.storage.insert(key, value);
+    }
+
+    /// Generate a client ID from ClientId bytes.
+    fn client_id_to_u64(client: &ClientId) -> u64 {
+        let bytes = client.as_bytes();
+        if bytes.len() >= 8 {
+            u64::from_le_bytes(bytes[0..8].try_into().unwrap_or([0; 8]))
+        } else {
+            // Hash short client IDs
+            let mut hash: u64 = 0;
+            for (i, &b) in bytes.iter().enumerate() {
+                hash ^= (b as u64) << ((i % 8) * 8);
+            }
+            hash
+        }
+    }
+
+    /// Process a single message.
+    async fn process_message<T: HubTransport>(
+        &self,
+        transport: &mut T,
+        message: HubMessage,
+    ) -> Result<()> {
+        match message {
+            HubMessage::Query { client, data } => {
+                self.queries_received.fetch_add(1, Ordering::Relaxed);
+
+                let client_id = Self::client_id_to_u64(&client);
+                let response = self.handle_query(&data, client_id);
+                transport.respond(&client, &response).await?;
+            }
+            HubMessage::Publish { data } => {
+                self.registrations_received.fetch_add(1, Ordering::Relaxed);
+                self.handle_registration(&data);
+            }
+        }
+        Ok(())
+    }
+
+    /// Handle a query message.
+    fn handle_query(&self, data: &[u8], client_id: u64) -> Vec<u8> {
+        let mut response_buf = Vec::new();
+
+        let Some(query) = self.codec.decode_query(data) else {
+            warn!("Failed to decode query");
+            return response_buf;
+        };
+
+        match query {
+            QueryType::CanOffload(keys) => {
+                let statuses: Vec<_> = keys
+                    .iter()
+                    .map(|k| {
+                        // Check if already stored
+                        if self.storage.contains(k) {
+                            return OffloadStatus::AlreadyStored;
+                        }
+
+                        // Try to acquire a lease
+                        match self.lease_manager.try_acquire(*k, client_id) {
+                            Some(_) => OffloadStatus::Granted,
+                            None => OffloadStatus::Leased,
+                        }
+                    })
+                    .collect();
+
+                debug!(
+                    num_keys = keys.len(),
+                    granted = statuses.iter().filter(|s| **s == OffloadStatus::Granted).count(),
+                    already_stored = statuses.iter().filter(|s| **s == OffloadStatus::AlreadyStored).count(),
+                    leased = statuses.iter().filter(|s| **s == OffloadStatus::Leased).count(),
+                    "Processed can_offload query"
+                );
+
+                self.codec
+                    .encode_response(&ResponseType::CanOffload(statuses), &mut response_buf);
+            }
+            QueryType::Match(keys) => {
+                let entries: Vec<_> = keys
+                    .iter()
+                    .filter_map(|k| self.storage.get(k).map(|v| (*k, v, M::default())))
+                    .collect();
+
+                debug!(
+                    requested = keys.len(),
+                    matched = entries.len(),
+                    "Processed match query"
+                );
+
+                self.codec
+                    .encode_response(&ResponseType::Match(entries), &mut response_buf);
+            }
+        }
+
+        response_buf
+    }
+
+    /// Handle a registration message.
+    fn handle_registration(&self, data: &[u8]) {
+        let Some(entries) = self.codec.decode_register(data) else {
+            warn!("Failed to decode registration");
+            return;
+        };
+
+        let count = entries.len();
+        for (key, value, _metadata) in entries {
+            // Release any lease for this key
+            self.lease_manager.release(&key);
+            // Store the entry
+            self.storage.insert(key, value);
+        }
+
+        debug!(
+            registered = count,
+            total_entries = self.storage.len(),
+            "Processed registration"
+        );
+    }
+
+    /// Serve requests until an error occurs or shutdown.
+    ///
+    /// This is the main loop for the hub.
+    pub async fn serve<T: HubTransport>(&self, transport: &mut T) -> Result<()> {
+        tracing::info!(transport = transport.name(), "Registry hub starting");
+
+        loop {
+            match transport.recv().await {
+                Ok(message) => {
+                    if let Err(e) = self.process_message(transport, message).await {
+                        warn!(error = %e, "Error processing message");
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Transport error, shutting down");
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// Process a single message (for testing or custom loops).
+    pub async fn process_one<T: HubTransport>(&self, transport: &mut T) -> Result<()> {
+        let message = transport.recv().await?;
+        self.process_message(transport, message).await
+    }
+}
+
+/// Create a simple hub with HashMap storage and binary codec.
+pub fn simple_hub<K, V, M>() -> RegistryHub<K, V, M, super::storage::HashMapStorage<K, V>, super::codec::BinaryCodec<K, V, M>>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+{
+    RegistryHub::new(
+        super::storage::HashMapStorage::new(),
+        super::codec::BinaryCodec::new(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_manager::distributed::registry::core::{
+        BinaryCodec, HashMapStorage, NoMetadata,
+    };
+    use crate::block_manager::distributed::registry::core::hub_transport::InProcessHubTransport;
+
+    #[tokio::test]
+    async fn test_hub_can_offload() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let hub = RegistryHub::new(storage, codec);
+
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        // Spawn hub to handle one request
+        let hub_task = tokio::spawn(async move {
+            hub.process_one(&mut transport).await.unwrap();
+            hub
+        });
+
+        // Client query
+        let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let mut query_buf = Vec::new();
+        client_codec.encode_query(&QueryType::CanOffload(vec![1, 2, 3, 4]), &mut query_buf);
+
+        let response = handle.request(&query_buf).await.unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> = client_codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                assert_eq!(statuses.len(), 4);
+                assert_eq!(statuses[0], OffloadStatus::AlreadyStored); // 1 exists
+                assert_eq!(statuses[1], OffloadStatus::AlreadyStored); // 2 exists
+                assert_eq!(statuses[2], OffloadStatus::Granted); // 3 doesn't exist
+                assert_eq!(statuses[3], OffloadStatus::Granted); // 4 doesn't exist
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        let hub = hub_task.await.unwrap();
+        assert_eq!(hub.stats().queries_received, 1);
+    }
+
+    #[tokio::test]
+    async fn test_hub_lease_conflict() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let hub = RegistryHub::new(storage, codec);
+
+        // First client acquires lease for key 1
+        hub.lease_manager.try_acquire(1, 100);
+
+        // Create transport with different client ID
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        let hub_task = tokio::spawn(async move {
+            hub.process_one(&mut transport).await.unwrap();
+            hub
+        });
+
+        let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let mut query_buf = Vec::new();
+        client_codec.encode_query(&QueryType::CanOffload(vec![1, 2]), &mut query_buf);
+
+        let response = handle.request(&query_buf).await.unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> = client_codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                assert_eq!(statuses.len(), 2);
+                // Key 1 should be Leased (held by client 100)
+                assert_eq!(statuses[0], OffloadStatus::Leased);
+                // Key 2 should be Granted (new lease for this client)
+                assert_eq!(statuses[1], OffloadStatus::Granted);
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        hub_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_hub_registration_releases_lease() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let hub = RegistryHub::new(storage, codec);
+
+        // Client acquires lease
+        hub.lease_manager.try_acquire(1, 100);
+        assert!(hub.lease_manager.is_leased(&1));
+
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        let hub_task = tokio::spawn(async move {
+            hub.process_one(&mut transport).await.unwrap();
+            hub
+        });
+
+        // Register the key
+        let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let mut reg_buf = Vec::new();
+        client_codec.encode_register(&[(1, 100, NoMetadata)], &mut reg_buf);
+
+        handle.publish(&reg_buf).unwrap();
+
+        let hub = hub_task.await.unwrap();
+
+        // Lease should be released and key stored
+        assert!(!hub.lease_manager.is_leased(&1));
+        assert!(hub.storage.contains(&1));
+    }
+
+    #[tokio::test]
+    async fn test_hub_match() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+        storage.insert(3, 300);
+
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let hub = RegistryHub::new(storage, codec);
+
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        let hub_task = tokio::spawn(async move {
+            hub.process_one(&mut transport).await.unwrap();
+            hub
+        });
+
+        let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let mut query_buf = Vec::new();
+        client_codec.encode_query(&QueryType::Match(vec![1, 2, 5]), &mut query_buf);
+
+        let response = handle.request(&query_buf).await.unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> = client_codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::Match(entries) => {
+                assert_eq!(entries.len(), 2); // Only 1 and 2 exist
+                assert_eq!(entries[0], (1, 100, NoMetadata));
+                assert_eq!(entries[1], (2, 200, NoMetadata));
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        hub_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_hub_registration() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let hub = RegistryHub::new(storage, codec);
+
+        assert!(hub.is_empty());
+
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        let hub_task = tokio::spawn(async move {
+            hub.process_one(&mut transport).await.unwrap();
+            hub
+        });
+
+        let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+        let mut reg_buf = Vec::new();
+        client_codec.encode_register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)], &mut reg_buf);
+
+        handle.publish(&reg_buf).unwrap();
+
+        let hub = hub_task.await.unwrap();
+        assert_eq!(hub.len(), 2);
+        assert_eq!(hub.stats().registrations_received, 1);
+    }
+}

--- a/lib/llm/src/block_manager/distributed/registry/core/hub.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/hub.rs
@@ -325,7 +325,9 @@ mod tests {
         // Client query
         let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
         let mut query_buf = Vec::new();
-        client_codec.encode_query(&QueryType::CanOffload(vec![1, 2, 3, 4]), &mut query_buf).unwrap();
+        client_codec
+            .encode_query(&QueryType::CanOffload(vec![1, 2, 3, 4]), &mut query_buf)
+            .unwrap();
 
         let response = handle.request(&query_buf).await.unwrap();
         let decoded: ResponseType<u64, u64, NoMetadata> =
@@ -365,7 +367,9 @@ mod tests {
 
         let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
         let mut query_buf = Vec::new();
-        client_codec.encode_query(&QueryType::CanOffload(vec![1, 2]), &mut query_buf).unwrap();
+        client_codec
+            .encode_query(&QueryType::CanOffload(vec![1, 2]), &mut query_buf)
+            .unwrap();
 
         let response = handle.request(&query_buf).await.unwrap();
         let decoded: ResponseType<u64, u64, NoMetadata> =
@@ -405,7 +409,9 @@ mod tests {
         // Register the key
         let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
         let mut reg_buf = Vec::new();
-        client_codec.encode_register(&[(1, 100, NoMetadata)], &mut reg_buf).unwrap();
+        client_codec
+            .encode_register(&[(1, 100, NoMetadata)], &mut reg_buf)
+            .unwrap();
 
         handle.publish(&reg_buf).unwrap();
 
@@ -435,7 +441,9 @@ mod tests {
 
         let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
         let mut query_buf = Vec::new();
-        client_codec.encode_query(&QueryType::Match(vec![1, 2, 5]), &mut query_buf).unwrap();
+        client_codec
+            .encode_query(&QueryType::Match(vec![1, 2, 5]), &mut query_buf)
+            .unwrap();
 
         let response = handle.request(&query_buf).await.unwrap();
         let decoded: ResponseType<u64, u64, NoMetadata> =
@@ -470,7 +478,9 @@ mod tests {
 
         let client_codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
         let mut reg_buf = Vec::new();
-        client_codec.encode_register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)], &mut reg_buf).unwrap();
+        client_codec
+            .encode_register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)], &mut reg_buf)
+            .unwrap();
 
         handle.publish(&reg_buf).unwrap();
 

--- a/lib/llm/src/block_manager/distributed/registry/core/hub.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/hub.rs
@@ -33,15 +33,12 @@ pub struct HubStats {
 pub struct HubConfig {
     /// Lease TTL for can_offload claims.
     pub lease_ttl: Duration,
-    /// Interval for cleaning up expired leases.
-    pub lease_cleanup_interval: Duration,
 }
 
 impl Default for HubConfig {
     fn default() -> Self {
         Self {
             lease_ttl: Duration::from_secs(30),
-            lease_cleanup_interval: Duration::from_secs(5),
         }
     }
 }

--- a/lib/llm/src/block_manager/distributed/registry/core/hub_transport.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/hub_transport.rs
@@ -1,0 +1,333 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Server-side transport traits and implementations.
+
+use std::collections::VecDeque;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use parking_lot::Mutex;
+use tmq::{pull, router, Context, Message, Multipart};
+use tokio::sync::mpsc;
+
+/// Opaque client identifier for routing responses.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ClientId(Vec<u8>);
+
+impl ClientId {
+    pub fn new(id: Vec<u8>) -> Self {
+        Self(id)
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Message received by the hub.
+#[derive(Debug)]
+pub enum HubMessage {
+    /// Query from a client (needs response).
+    Query { client: ClientId, data: Vec<u8> },
+    /// Published registration (fire-and-forget).
+    Publish { data: Vec<u8> },
+}
+
+/// Server-side transport for the registry hub.
+///
+/// Note: Not `Sync` because ZMQ sockets can't be shared across threads.
+/// The hub uses `&mut self` and is owned by a single serve task.
+#[async_trait]
+pub trait HubTransport: Send {
+    /// Receive the next message (query or publish).
+    async fn recv(&mut self) -> Result<HubMessage>;
+
+    /// Send a response to a specific client.
+    async fn respond(&mut self, client: &ClientId, data: &[u8]) -> Result<()>;
+
+    /// Get the transport name.
+    fn name(&self) -> &'static str;
+}
+
+/// In-process hub transport for testing.
+pub struct InProcessHubTransport {
+    query_rx: mpsc::UnboundedReceiver<(ClientId, Vec<u8>)>,
+    query_response_tx: mpsc::UnboundedSender<(ClientId, Vec<u8>)>,
+    publish_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+}
+
+/// Handle for clients to communicate with InProcessHubTransport.
+pub struct InProcessClientHandle {
+    query_tx: mpsc::UnboundedSender<(ClientId, Vec<u8>)>,
+    query_response_rx: Mutex<mpsc::UnboundedReceiver<(ClientId, Vec<u8>)>>,
+    publish_tx: mpsc::UnboundedSender<Vec<u8>>,
+    client_id: ClientId,
+}
+
+impl InProcessHubTransport {
+    /// Create a new in-process hub transport and client handle.
+    pub fn new() -> (Self, InProcessClientHandle) {
+        let (query_tx, query_rx) = mpsc::unbounded_channel();
+        let (response_tx, response_rx) = mpsc::unbounded_channel();
+        let (publish_tx, publish_rx) = mpsc::unbounded_channel();
+
+        let transport = Self {
+            query_rx,
+            query_response_tx: response_tx,
+            publish_rx,
+        };
+
+        let handle = InProcessClientHandle {
+            query_tx,
+            query_response_rx: Mutex::new(response_rx),
+            publish_tx,
+            client_id: ClientId::new(vec![0, 1, 2, 3]),
+        };
+
+        (transport, handle)
+    }
+}
+
+impl Default for InProcessHubTransport {
+    fn default() -> Self {
+        Self::new().0
+    }
+}
+
+impl InProcessClientHandle {
+    /// Send a query and wait for response.
+    pub async fn request(&self, data: &[u8]) -> Result<Vec<u8>> {
+        self.query_tx
+            .send((self.client_id.clone(), data.to_vec()))
+            .map_err(|_| anyhow!("Hub disconnected"))?;
+
+        let mut rx = self.query_response_rx.lock();
+        match rx.recv().await {
+            Some((_, response)) => Ok(response),
+            None => Err(anyhow!("Hub disconnected")),
+        }
+    }
+
+    /// Publish a message (fire-and-forget).
+    pub fn publish(&self, data: &[u8]) -> Result<()> {
+        self.publish_tx
+            .send(data.to_vec())
+            .map_err(|_| anyhow!("Hub disconnected"))
+    }
+}
+
+#[async_trait]
+impl HubTransport for InProcessHubTransport {
+    async fn recv(&mut self) -> Result<HubMessage> {
+        tokio::select! {
+            Some((client, data)) = self.query_rx.recv() => {
+                Ok(HubMessage::Query { client, data })
+            }
+            Some(data) = self.publish_rx.recv() => {
+                Ok(HubMessage::Publish { data })
+            }
+            else => Err(anyhow!("All clients disconnected"))
+        }
+    }
+
+    async fn respond(&mut self, client: &ClientId, data: &[u8]) -> Result<()> {
+        self.query_response_tx
+            .send((client.clone(), data.to_vec()))
+            .map_err(|_| anyhow!("Client disconnected"))
+    }
+
+    fn name(&self) -> &'static str {
+        "in_process"
+    }
+}
+
+/// ZMQ-based hub transport.
+///
+/// Uses ROUTER for queries and PULL for registrations.
+pub struct ZmqHubTransport {
+    router: router::Router,
+    puller: pull::Pull,
+}
+
+/// Default high-water mark for ZMQ hub sockets.
+pub const DEFAULT_HUB_HWM: i32 = 10_000;
+
+/// Configuration for ZMQ hub transport.
+#[derive(Clone, Debug)]
+pub struct ZmqHubConfig {
+    pub query_bind_addr: String,
+    pub subscribe_bind_addr: String,
+    /// High-water mark for the ROUTER (query) socket.
+    pub router_hwm: i32,
+    /// High-water mark for the PULL (registration) socket.
+    pub pull_hwm: i32,
+}
+
+impl ZmqHubConfig {
+    pub fn new(query_addr: impl Into<String>, subscribe_addr: impl Into<String>) -> Self {
+        Self {
+            query_bind_addr: query_addr.into(),
+            subscribe_bind_addr: subscribe_addr.into(),
+            router_hwm: DEFAULT_HUB_HWM,
+            pull_hwm: DEFAULT_HUB_HWM,
+        }
+    }
+
+    pub fn default_ports(port_base: u16) -> Self {
+        Self {
+            query_bind_addr: format!("tcp://*:{}", port_base),
+            subscribe_bind_addr: format!("tcp://*:{}", port_base + 1),
+            router_hwm: DEFAULT_HUB_HWM,
+            pull_hwm: DEFAULT_HUB_HWM,
+        }
+    }
+
+    /// Set high-water marks for both sockets.
+    pub fn with_hwm(mut self, hwm: i32) -> Self {
+        self.router_hwm = hwm;
+        self.pull_hwm = hwm;
+        self
+    }
+}
+
+impl Default for ZmqHubConfig {
+    fn default() -> Self {
+        Self::default_ports(5555)
+    }
+}
+
+impl ZmqHubTransport {
+    /// Bind and start listening.
+    pub fn bind(config: ZmqHubConfig) -> Result<Self> {
+        let context = Context::new();
+
+        let router = router::router(&context)
+            .set_sndhwm(config.router_hwm)
+            .set_rcvhwm(config.router_hwm)
+            .bind(&config.query_bind_addr)
+            .map_err(|e| anyhow!("Failed to bind ROUTER to {}: {}", config.query_bind_addr, e))?;
+
+        let puller = pull::pull(&context)
+            .set_rcvhwm(config.pull_hwm)
+            .bind(&config.subscribe_bind_addr)
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to bind PULL to {}: {}",
+                    config.subscribe_bind_addr,
+                    e
+                )
+            })?;
+
+        tracing::info!(
+            query_addr = %config.query_bind_addr,
+            pull_addr = %config.subscribe_bind_addr,
+            router_hwm = config.router_hwm,
+            pull_hwm = config.pull_hwm,
+            "ZMQ hub transport bound"
+        );
+
+        Ok(Self { router, puller })
+    }
+
+    /// Bind with default configuration.
+    pub fn bind_default() -> Result<Self> {
+        Self::bind(ZmqHubConfig::default())
+    }
+}
+
+#[async_trait]
+impl HubTransport for ZmqHubTransport {
+    async fn recv(&mut self) -> Result<HubMessage> {
+        tokio::select! {
+            result = self.router.next() => {
+                match result {
+                    Some(Ok(msg)) => {
+                        let frames: Vec<_> = msg.iter().collect();
+                        if frames.len() < 2 {
+                            return Err(anyhow!("Invalid ROUTER message: expected identity + data"));
+                        }
+                        let client = ClientId::new(frames[0].to_vec());
+                        let data = frames[frames.len() - 1].to_vec();
+                        Ok(HubMessage::Query { client, data })
+                    }
+                    Some(Err(e)) => Err(anyhow!("ROUTER receive error: {}", e)),
+                    None => Err(anyhow!("ROUTER socket closed")),
+                }
+            }
+            result = self.puller.next() => {
+                match result {
+                    Some(Ok(msg)) => {
+                        let frames: Vec<_> = msg.iter().collect();
+                        if frames.is_empty() {
+                            return Err(anyhow!("Empty PULL message"));
+                        }
+                        let data = frames[0].to_vec();
+                        Ok(HubMessage::Publish { data })
+                    }
+                    Some(Err(e)) => Err(anyhow!("PULL receive error: {}", e)),
+                    None => Err(anyhow!("PULL socket closed")),
+                }
+            }
+        }
+    }
+
+    async fn respond(&mut self, client: &ClientId, data: &[u8]) -> Result<()> {
+        let mut msg = VecDeque::new();
+        msg.push_back(Message::from(client.as_bytes().to_vec()));
+        msg.push_back(Message::from(data.to_vec()));
+
+        self.router
+            .send(Multipart(msg))
+            .await
+            .map_err(|e| anyhow!("Failed to send response: {}", e))
+    }
+
+    fn name(&self) -> &'static str {
+        "zmq"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_in_process_hub_transport() {
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        // Spawn hub handler
+        let hub_task = tokio::spawn(async move {
+            if let Ok(HubMessage::Query { client, data }) = transport.recv().await {
+                let mut response = data;
+                response.reverse();
+                transport.respond(&client, &response).await.unwrap();
+            }
+        });
+
+        // Client sends request
+        let response = handle.request(b"hello").await.unwrap();
+        assert_eq!(response, b"olleh");
+
+        hub_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_in_process_publish() {
+        let (mut transport, handle) = InProcessHubTransport::new();
+
+        // Spawn hub handler
+        let hub_task = tokio::spawn(async move {
+            if let Ok(HubMessage::Publish { data }) = transport.recv().await {
+                assert_eq!(data, b"registration");
+            }
+        });
+
+        // Client publishes
+        handle.publish(b"registration").unwrap();
+
+        hub_task.await.unwrap();
+    }
+}
+

--- a/lib/llm/src/block_manager/distributed/registry/core/hub_transport.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/hub_transport.rs
@@ -90,11 +90,6 @@ impl InProcessHubTransport {
     }
 }
 
-impl Default for InProcessHubTransport {
-    fn default() -> Self {
-        Self::new().0
-    }
-}
 
 impl InProcessClientHandle {
     /// Send a query and wait for response.

--- a/lib/llm/src/block_manager/distributed/registry/core/hub_transport.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/hub_transport.rs
@@ -5,11 +5,11 @@
 
 use std::collections::VecDeque;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
-use tmq::{pull, router, Context, Message, Multipart};
+use tmq::{Context, Message, Multipart, pull, router};
 use tokio::sync::mpsc;
 
 /// Opaque client identifier for routing responses.
@@ -330,4 +330,3 @@ mod tests {
         hub_task.await.unwrap();
     }
 }
-

--- a/lib/llm/src/block_manager/distributed/registry/core/hub_transport.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/hub_transport.rs
@@ -90,7 +90,6 @@ impl InProcessHubTransport {
     }
 }
 
-
 impl InProcessClientHandle {
     /// Send a query and wait for response.
     pub async fn request(&self, data: &[u8]) -> Result<Vec<u8>> {

--- a/lib/llm/src/block_manager/distributed/registry/core/hub_transport.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/hub_transport.rs
@@ -274,6 +274,7 @@ impl HubTransport for ZmqHubTransport {
     async fn respond(&mut self, client: &ClientId, data: &[u8]) -> Result<()> {
         let mut msg = VecDeque::new();
         msg.push_back(Message::from(client.as_bytes().to_vec()));
+        msg.push_back(Message::from(vec![])); // empty delimiter frame
         msg.push_back(Message::from(data.to_vec()));
 
         self.router

--- a/lib/llm/src/block_manager/distributed/registry/core/key.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/key.rs
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Registry key types and traits.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+/// Trait for registry keys.
+pub trait RegistryKey: Copy + Hash + Eq + Debug + Send + Sync + 'static {
+    fn to_bytes(&self) -> Vec<u8>;
+    fn from_bytes(bytes: &[u8]) -> Option<Self>;
+}
+
+impl RegistryKey for u64 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        bytes.try_into().ok().map(u64::from_le_bytes)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Key128(pub u128);
+
+impl RegistryKey for Key128 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_le_bytes().to_vec()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 16 {
+            return None;
+        }
+        Some(Self(u128::from_le_bytes(bytes[0..16].try_into().ok()?)))
+    }
+}
+
+/// Key combining bucket identifier and sequence hash.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CompositeKey {
+    pub bucket_id: u64,
+    pub sequence_hash: u64,
+}
+
+impl RegistryKey for CompositeKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(16);
+        buf.extend_from_slice(&self.bucket_id.to_le_bytes());
+        buf.extend_from_slice(&self.sequence_hash.to_le_bytes());
+        buf
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 16 {
+            return None;
+        }
+        Some(Self {
+            bucket_id: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
+            sequence_hash: u64::from_le_bytes(bytes[8..16].try_into().ok()?),
+        })
+    }
+}
+
+/// Key with bucket, sequence hash, and position in sequence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct PositionalKey {
+    pub bucket_id: u64,
+    pub sequence_hash: u64,
+    pub position: u32,
+}
+
+impl RegistryKey for PositionalKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(20);
+        buf.extend_from_slice(&self.bucket_id.to_le_bytes());
+        buf.extend_from_slice(&self.sequence_hash.to_le_bytes());
+        buf.extend_from_slice(&self.position.to_le_bytes());
+        buf
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 20 {
+            return None;
+        }
+        Some(Self {
+            bucket_id: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
+            sequence_hash: u64::from_le_bytes(bytes[8..16].try_into().ok()?),
+            position: u32::from_le_bytes(bytes[16..20].try_into().ok()?),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_u64_roundtrip() {
+        let key: u64 = 0x123456789ABCDEF0;
+        let bytes = key.to_bytes();
+        assert_eq!(u64::from_bytes(&bytes), Some(key));
+    }
+
+    #[test]
+    fn test_key128_roundtrip() {
+        let key = Key128(0x123456789ABCDEF0_FEDCBA9876543210);
+        let bytes = key.to_bytes();
+        assert_eq!(Key128::from_bytes(&bytes), Some(key));
+    }
+
+    #[test]
+    fn test_composite_key_roundtrip() {
+        let key = CompositeKey {
+            bucket_id: 123,
+            sequence_hash: 456,
+        };
+        let bytes = key.to_bytes();
+        assert_eq!(CompositeKey::from_bytes(&bytes), Some(key));
+    }
+
+    #[test]
+    fn test_positional_key_roundtrip() {
+        let key = PositionalKey {
+            bucket_id: 123,
+            sequence_hash: 456,
+            position: 789,
+        };
+        let bytes = key.to_bytes();
+        assert_eq!(PositionalKey::from_bytes(&bytes), Some(key));
+    }
+}
+

--- a/lib/llm/src/block_manager/distributed/registry/core/key.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/key.rs
@@ -132,4 +132,3 @@ mod tests {
         assert_eq!(PositionalKey::from_bytes(&bytes), Some(key));
     }
 }
-

--- a/lib/llm/src/block_manager/distributed/registry/core/key.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/key.rs
@@ -6,6 +6,8 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 
+use super::storage::PositionalStorageKey;
+
 /// Trait for registry keys.
 pub trait RegistryKey: Copy + Hash + Eq + Debug + Send + Sync + 'static {
     fn to_bytes(&self) -> Vec<u8>;
@@ -38,17 +40,17 @@ impl RegistryKey for Key128 {
     }
 }
 
-/// Key combining bucket identifier and sequence hash.
+/// Key combining worker identifier and sequence hash.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct CompositeKey {
-    pub bucket_id: u64,
+    pub worker_id: u64,
     pub sequence_hash: u64,
 }
 
 impl RegistryKey for CompositeKey {
     fn to_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(16);
-        buf.extend_from_slice(&self.bucket_id.to_le_bytes());
+        buf.extend_from_slice(&self.worker_id.to_le_bytes());
         buf.extend_from_slice(&self.sequence_hash.to_le_bytes());
         buf
     }
@@ -58,16 +60,16 @@ impl RegistryKey for CompositeKey {
             return None;
         }
         Some(Self {
-            bucket_id: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
+            worker_id: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
             sequence_hash: u64::from_le_bytes(bytes[8..16].try_into().ok()?),
         })
     }
 }
 
-/// Key with bucket, sequence hash, and position in sequence.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+/// Key with worker id, sequence hash, and position in sequence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PositionalKey {
-    pub bucket_id: u64,
+    pub worker_id: u64,
     pub sequence_hash: u64,
     pub position: u32,
 }
@@ -75,7 +77,7 @@ pub struct PositionalKey {
 impl RegistryKey for PositionalKey {
     fn to_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(20);
-        buf.extend_from_slice(&self.bucket_id.to_le_bytes());
+        buf.extend_from_slice(&self.worker_id.to_le_bytes());
         buf.extend_from_slice(&self.sequence_hash.to_le_bytes());
         buf.extend_from_slice(&self.position.to_le_bytes());
         buf
@@ -86,10 +88,16 @@ impl RegistryKey for PositionalKey {
             return None;
         }
         Some(Self {
-            bucket_id: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
+            worker_id: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
             sequence_hash: u64::from_le_bytes(bytes[8..16].try_into().ok()?),
             position: u32::from_le_bytes(bytes[16..20].try_into().ok()?),
         })
+    }
+}
+
+impl PositionalStorageKey for PositionalKey {
+    fn position(&self) -> u64 {
+        self.position as u64
     }
 }
 
@@ -114,7 +122,7 @@ mod tests {
     #[test]
     fn test_composite_key_roundtrip() {
         let key = CompositeKey {
-            bucket_id: 123,
+            worker_id: 123,
             sequence_hash: 456,
         };
         let bytes = key.to_bytes();
@@ -124,7 +132,7 @@ mod tests {
     #[test]
     fn test_positional_key_roundtrip() {
         let key = PositionalKey {
-            bucket_id: 123,
+            worker_id: 123,
             sequence_hash: 456,
             position: 789,
         };

--- a/lib/llm/src/block_manager/distributed/registry/core/lease.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/lease.rs
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lease management for preventing duplicate storage.
+//!
+//! When a client requests to offload keys, they receive leases that grant
+//! exclusive rights to store those keys. Other clients see `Leased` status
+//! until the lease expires or the key is registered.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+use tracing::debug;
+
+/// Information about an active lease.
+#[derive(Debug, Clone)]
+pub struct LeaseInfo {
+    /// Client that holds the lease.
+    pub client_id: u64,
+    /// When the lease was granted.
+    pub granted_at: Instant,
+    /// When the lease expires.
+    pub expires_at: Instant,
+}
+
+impl LeaseInfo {
+    /// Check if the lease has expired.
+    pub fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+
+    /// Get remaining time until expiration.
+    pub fn remaining(&self) -> Duration {
+        self.expires_at.saturating_duration_since(Instant::now())
+    }
+}
+
+/// Manages leases for registry keys.
+///
+/// Leases prevent race conditions where multiple workers try to store
+/// the same block simultaneously. When a client calls `can_offload`,
+/// they receive a lease granting exclusive rights to store the key.
+///
+/// # Lease Lifecycle
+///
+/// 1. Client calls `can_offload([k1, k2, k3])`
+/// 2. Hub grants leases for keys not already stored/leased
+/// 3. Client stores the blocks to object storage
+/// 4. Client calls `register([k1, k2, k3])` to convert leases to entries
+/// 5. If client crashes, leases expire after TTL
+///
+/// # Thread Safety
+///
+/// The lease manager uses `RwLock` for concurrent access from multiple
+/// hub tasks.
+pub struct LeaseManager<K>
+where
+    K: Eq + Hash + Clone,
+{
+    /// Active leases: key -> lease info
+    leases: RwLock<HashMap<K, LeaseInfo>>,
+    /// Default lease duration
+    lease_ttl: Duration,
+    /// Counter for generating unique client IDs
+    client_counter: AtomicU64,
+    /// Statistics
+    leases_granted: AtomicU64,
+    leases_expired: AtomicU64,
+    leases_converted: AtomicU64,
+}
+
+impl<K> LeaseManager<K>
+where
+    K: Eq + Hash + Clone,
+{
+    /// Create a new lease manager with the given TTL.
+    pub fn new(lease_ttl: Duration) -> Self {
+        Self {
+            leases: RwLock::new(HashMap::new()),
+            lease_ttl,
+            client_counter: AtomicU64::new(1),
+            leases_granted: AtomicU64::new(0),
+            leases_expired: AtomicU64::new(0),
+            leases_converted: AtomicU64::new(0),
+        }
+    }
+
+    /// Create with default TTL of 30 seconds.
+    pub fn with_default_ttl() -> Self {
+        Self::new(Duration::from_secs(30))
+    }
+
+    /// Generate a unique client ID.
+    pub fn next_client_id(&self) -> u64 {
+        self.client_counter.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Try to acquire a lease for a key.
+    ///
+    /// Returns `Some(lease_info)` if the lease was granted,
+    /// `None` if the key is already leased by another client.
+    pub fn try_acquire(&self, key: K, client_id: u64) -> Option<LeaseInfo> {
+        let now = Instant::now();
+        let mut leases = self.leases.write();
+
+        // Check if there's an existing lease
+        if let Some(existing) = leases.get(&key) {
+            if !existing.is_expired() && existing.client_id != client_id {
+                // Another client holds an active lease
+                return None;
+            }
+            // Lease expired or same client - we can take it
+        }
+
+        let info = LeaseInfo {
+            client_id,
+            granted_at: now,
+            expires_at: now + self.lease_ttl,
+        };
+
+        leases.insert(key, info.clone());
+        self.leases_granted.fetch_add(1, Ordering::Relaxed);
+        Some(info)
+    }
+
+    /// Check if a key is currently leased (and not expired).
+    pub fn is_leased(&self, key: &K) -> bool {
+        let leases = self.leases.read();
+        leases.get(key).map(|l| !l.is_expired()).unwrap_or(false)
+    }
+
+    /// Check if a key is leased by a specific client.
+    pub fn is_leased_by(&self, key: &K, client_id: u64) -> bool {
+        let leases = self.leases.read();
+        leases
+            .get(key)
+            .map(|l| !l.is_expired() && l.client_id == client_id)
+            .unwrap_or(false)
+    }
+
+    /// Get lease info for a key.
+    pub fn get_lease(&self, key: &K) -> Option<LeaseInfo> {
+        let leases = self.leases.read();
+        leases.get(key).filter(|l| !l.is_expired()).cloned()
+    }
+
+    /// Release a lease (called when registration completes).
+    ///
+    /// Returns true if the lease was released.
+    pub fn release(&self, key: &K) -> bool {
+        let mut leases = self.leases.write();
+        if leases.remove(key).is_some() {
+            self.leases_converted.fetch_add(1, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Release multiple leases.
+    pub fn release_many(&self, keys: &[K]) {
+        let mut leases = self.leases.write();
+        for key in keys {
+            if leases.remove(key).is_some() {
+                self.leases_converted.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Clean up expired leases.
+    ///
+    /// Returns the number of leases that were expired.
+    pub fn cleanup_expired(&self) -> usize {
+        let mut leases = self.leases.write();
+        let before = leases.len();
+        leases.retain(|_, info| !info.is_expired());
+        let expired = before - leases.len();
+        self.leases_expired
+            .fetch_add(expired as u64, Ordering::Relaxed);
+        expired
+    }
+
+    /// Get the number of active leases.
+    pub fn active_count(&self) -> usize {
+        let leases = self.leases.read();
+        leases.values().filter(|l| !l.is_expired()).count()
+    }
+
+    /// Get the total number of leases (including potentially expired).
+    pub fn total_count(&self) -> usize {
+        self.leases.read().len()
+    }
+
+    /// Get lease statistics.
+    pub fn stats(&self) -> LeaseStats {
+        LeaseStats {
+            active: self.active_count(),
+            granted: self.leases_granted.load(Ordering::Relaxed),
+            expired: self.leases_expired.load(Ordering::Relaxed),
+            converted: self.leases_converted.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Get the lease TTL.
+    pub fn ttl(&self) -> Duration {
+        self.lease_ttl
+    }
+}
+
+/// Statistics about lease activity.
+#[derive(Debug, Clone, Default)]
+pub struct LeaseStats {
+    /// Currently active leases.
+    pub active: usize,
+    /// Total leases granted.
+    pub granted: u64,
+    /// Leases that expired without registration.
+    pub expired: u64,
+    /// Leases converted to stored entries.
+    pub converted: u64,
+}
+
+/// Background task that periodically cleans up expired leases.
+pub async fn lease_cleanup_task<K>(
+    manager: std::sync::Arc<LeaseManager<K>>,
+    interval: Duration,
+    cancel: tokio_util::sync::CancellationToken,
+) where
+    K: Eq + Hash + Clone + Send + Sync + 'static,
+{
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                debug!("Lease cleanup task shutting down");
+                break;
+            }
+            _ = ticker.tick() => {
+                let expired = manager.cleanup_expired();
+                if expired > 0 {
+                    debug!(expired, active = manager.active_count(), "Cleaned up expired leases");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_acquire_lease() {
+        let manager = LeaseManager::<u64>::new(Duration::from_secs(30));
+
+        // First client can acquire
+        let lease = manager.try_acquire(1, 100);
+        assert!(lease.is_some());
+        assert!(manager.is_leased(&1));
+        assert!(manager.is_leased_by(&1, 100));
+
+        // Same client can re-acquire (refresh)
+        let lease2 = manager.try_acquire(1, 100);
+        assert!(lease2.is_some());
+
+        // Different client cannot acquire
+        let lease3 = manager.try_acquire(1, 200);
+        assert!(lease3.is_none());
+    }
+
+    #[test]
+    fn test_lease_expiration() {
+        let manager = LeaseManager::<u64>::new(Duration::from_millis(10));
+
+        // Acquire lease
+        let _lease = manager.try_acquire(1, 100);
+        assert!(manager.is_leased(&1));
+
+        // Wait for expiration
+        std::thread::sleep(Duration::from_millis(20));
+
+        // Lease should be expired
+        assert!(!manager.is_leased(&1));
+
+        // Another client can now acquire
+        let lease2 = manager.try_acquire(1, 200);
+        assert!(lease2.is_some());
+    }
+
+    #[test]
+    fn test_release_lease() {
+        let manager = LeaseManager::<u64>::new(Duration::from_secs(30));
+
+        manager.try_acquire(1, 100);
+        assert!(manager.is_leased(&1));
+
+        manager.release(&1);
+        assert!(!manager.is_leased(&1));
+    }
+
+    #[test]
+    fn test_cleanup_expired() {
+        let manager = LeaseManager::<u64>::new(Duration::from_millis(10));
+
+        manager.try_acquire(1, 100);
+        manager.try_acquire(2, 100);
+        manager.try_acquire(3, 100);
+
+        assert_eq!(manager.total_count(), 3);
+
+        std::thread::sleep(Duration::from_millis(20));
+
+        let expired = manager.cleanup_expired();
+        assert_eq!(expired, 3);
+        assert_eq!(manager.total_count(), 0);
+    }
+
+    #[test]
+    fn test_stats() {
+        let manager = LeaseManager::<u64>::new(Duration::from_secs(30));
+
+        manager.try_acquire(1, 100);
+        manager.try_acquire(2, 100);
+        manager.release(&1);
+
+        let stats = manager.stats();
+        assert_eq!(stats.granted, 2);
+        assert_eq!(stats.converted, 1);
+        assert_eq!(stats.active, 1);
+    }
+}
+

--- a/lib/llm/src/block_manager/distributed/registry/core/lease.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/lease.rs
@@ -334,4 +334,3 @@ mod tests {
         assert_eq!(stats.active, 1);
     }
 }
-

--- a/lib/llm/src/block_manager/distributed/registry/core/lease.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/lease.rs
@@ -107,12 +107,12 @@ where
         let mut leases = self.leases.write();
 
         // Check if there's an existing lease
-        if let Some(existing) = leases.get(&key) {
-            if !existing.is_expired() && existing.client_id != client_id {
-                // Another client holds an active lease
-                return None;
-            }
-            // Lease expired or same client - we can take it
+        if let Some(existing) = leases.get(&key)
+            && !existing.is_expired()
+            && existing.client_id != client_id
+        {
+            // Another client holds an active lease
+            return None;
         }
 
         let info = LeaseInfo {

--- a/lib/llm/src/block_manager/distributed/registry/core/metadata.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/metadata.rs
@@ -87,8 +87,16 @@ impl RegistryMetadata for PositionMetadata {
 
         Some(Self {
             position,
-            parent_hash: if parent_raw == 0 { None } else { Some(parent_raw) },
-            sequence_length: if seq_len_raw == 0 { None } else { Some(seq_len_raw) },
+            parent_hash: if parent_raw == 0 {
+                None
+            } else {
+                Some(parent_raw)
+            },
+            sequence_length: if seq_len_raw == 0 {
+                None
+            } else {
+                Some(seq_len_raw)
+            },
             created_at,
         })
     }
@@ -134,4 +142,3 @@ mod tests {
         assert_eq!(decoded.created_at, meta.created_at);
     }
 }
-

--- a/lib/llm/src/block_manager/distributed/registry/core/metadata.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/metadata.rs
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Registry metadata types and traits.
+
+use std::fmt::Debug;
+
+pub trait RegistryMetadata: Clone + Debug + Default + Send + Sync + 'static {
+    fn to_bytes(&self) -> Vec<u8>;
+    fn from_bytes(bytes: &[u8]) -> Option<Self>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NoMetadata;
+
+impl PartialEq for NoMetadata {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for NoMetadata {}
+
+impl RegistryMetadata for NoMetadata {
+    fn to_bytes(&self) -> Vec<u8> {
+        Vec::new()
+    }
+
+    fn from_bytes(_bytes: &[u8]) -> Option<Self> {
+        Some(Self)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TimestampMetadata {
+    pub created_at: u64,
+    pub ttl_secs: Option<u32>,
+}
+
+impl RegistryMetadata for TimestampMetadata {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(12);
+        buf.extend_from_slice(&self.created_at.to_le_bytes());
+        buf.extend_from_slice(&self.ttl_secs.unwrap_or(0).to_le_bytes());
+        buf
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 12 {
+            return None;
+        }
+        let created_at = u64::from_le_bytes(bytes[0..8].try_into().ok()?);
+        let ttl_raw = u32::from_le_bytes(bytes[8..12].try_into().ok()?);
+        Some(Self {
+            created_at,
+            ttl_secs: if ttl_raw == 0 { None } else { Some(ttl_raw) },
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PositionMetadata {
+    pub position: u32,
+    pub parent_hash: Option<u64>,
+    pub sequence_length: Option<u32>,
+    pub created_at: u64,
+}
+
+impl RegistryMetadata for PositionMetadata {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(24);
+        buf.extend_from_slice(&self.position.to_le_bytes());
+        buf.extend_from_slice(&self.parent_hash.unwrap_or(0).to_le_bytes());
+        buf.extend_from_slice(&self.sequence_length.unwrap_or(0).to_le_bytes());
+        buf.extend_from_slice(&self.created_at.to_le_bytes());
+        buf
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 24 {
+            return None;
+        }
+        let position = u32::from_le_bytes(bytes[0..4].try_into().ok()?);
+        let parent_raw = u64::from_le_bytes(bytes[4..12].try_into().ok()?);
+        let seq_len_raw = u32::from_le_bytes(bytes[12..16].try_into().ok()?);
+        let created_at = u64::from_le_bytes(bytes[16..24].try_into().ok()?);
+
+        Some(Self {
+            position,
+            parent_hash: if parent_raw == 0 { None } else { Some(parent_raw) },
+            sequence_length: if seq_len_raw == 0 { None } else { Some(seq_len_raw) },
+            created_at,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_metadata_roundtrip() {
+        let meta = NoMetadata;
+        let bytes = meta.to_bytes();
+        assert!(bytes.is_empty());
+        assert!(NoMetadata::from_bytes(&bytes).is_some());
+    }
+
+    #[test]
+    fn test_timestamp_metadata_roundtrip() {
+        let meta = TimestampMetadata {
+            created_at: 1234567890,
+            ttl_secs: Some(3600),
+        };
+        let bytes = meta.to_bytes();
+        let decoded = TimestampMetadata::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.created_at, meta.created_at);
+        assert_eq!(decoded.ttl_secs, meta.ttl_secs);
+    }
+
+    #[test]
+    fn test_position_metadata_roundtrip() {
+        let meta = PositionMetadata {
+            position: 5,
+            parent_hash: Some(0xDEADBEEF),
+            sequence_length: Some(10),
+            created_at: 9999999999,
+        };
+        let bytes = meta.to_bytes();
+        let decoded = PositionMetadata::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.position, meta.position);
+        assert_eq!(decoded.parent_hash, meta.parent_hash);
+        assert_eq!(decoded.sequence_length, meta.sequence_length);
+        assert_eq!(decoded.created_at, meta.created_at);
+    }
+}
+

--- a/lib/llm/src/block_manager/distributed/registry/core/mod.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/mod.rs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Core traits and types for the pluggable registry architecture.
+
+pub mod builder;
+pub mod codec;
+pub mod error;
+pub mod eviction;
+pub mod hub;
+pub mod hub_transport;
+pub mod key;
+pub mod lease;
+pub mod metadata;
+pub mod registry;
+pub mod storage;
+pub mod transport;
+pub mod value;
+pub mod zmq_hub;
+pub mod zmq_transport;
+
+#[cfg(test)]
+mod tests;
+
+// Codec
+pub use codec::{BinaryCodec, OffloadStatus, QueryType, RegistryCodec, ResponseType, PROTOCOL_VERSION};
+
+// Error types
+pub use error::{RegistryError, RegistryResult};
+
+// Lease management
+pub use lease::{LeaseManager, LeaseInfo};
+
+// Storage & Eviction
+pub use eviction::{Eviction, NoEviction, TailEviction};
+pub use storage::{HashMapStorage, Storage};
+
+// Key, Value, Metadata
+pub use key::{CompositeKey, Key128, PositionalKey, RegistryKey};
+pub use metadata::{NoMetadata, PositionMetadata, RegistryMetadata, TimestampMetadata};
+pub use value::{RegistryValue, StorageBackend, StorageLocation};
+
+// Client
+pub use registry::{OffloadResult, Registry, RegistryClient};
+pub use transport::{InProcessHub, InProcessTransport, RegistryTransport};
+pub use zmq_transport::{ZmqTransport, ZmqTransportConfig};
+
+// Hub (Server)
+pub use hub::{HubStats, RegistryHub};
+pub use hub_transport::{ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport, ZmqHubTransport, ZmqHubConfig};
+
+// Builder
+pub use builder::{ClientBuilder, HubBuilder, client, hub};
+
+// ZMQ Hub
+pub use zmq_hub::{ZmqHub, ZmqHubConfig as ZmqHubServerConfig};
+

--- a/lib/llm/src/block_manager/distributed/registry/core/mod.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/mod.rs
@@ -23,13 +23,15 @@ pub mod zmq_transport;
 mod tests;
 
 // Codec
-pub use codec::{BinaryCodec, OffloadStatus, QueryType, RegistryCodec, ResponseType, PROTOCOL_VERSION};
+pub use codec::{
+    BinaryCodec, OffloadStatus, PROTOCOL_VERSION, QueryType, RegistryCodec, ResponseType,
+};
 
 // Error types
 pub use error::{RegistryError, RegistryResult};
 
 // Lease management
-pub use lease::{LeaseManager, LeaseInfo};
+pub use lease::{LeaseInfo, LeaseManager};
 
 // Storage & Eviction
 pub use eviction::{Eviction, NoEviction, TailEviction};
@@ -47,11 +49,13 @@ pub use zmq_transport::{ZmqTransport, ZmqTransportConfig};
 
 // Hub (Server)
 pub use hub::{HubStats, RegistryHub};
-pub use hub_transport::{ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport, ZmqHubTransport, ZmqHubConfig};
+pub use hub_transport::{
+    ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport, ZmqHubConfig,
+    ZmqHubTransport,
+};
 
 // Builder
 pub use builder::{ClientBuilder, HubBuilder, client, hub};
 
 // ZMQ Hub
 pub use zmq_hub::{ZmqHub, ZmqHubConfig as ZmqHubServerConfig};
-

--- a/lib/llm/src/block_manager/distributed/registry/core/mod.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/mod.rs
@@ -70,6 +70,6 @@ pub use persistence::{
 
 // Event Bus
 pub use events::{
-    EventBus, EventBusConfig, EventHandler, EventReceiver, EventTopic, EvictionReason,
-    InProcessEventBus, RegistryEvent, StorageTier, StorageType,
+    EventBus, EventBusConfig, EventBusConfigError, EventHandler, EventReceiver, EventTopic,
+    EvictionReason, InProcessEventBus, RegistryEvent, StorageTier, StorageType,
 };

--- a/lib/llm/src/block_manager/distributed/registry/core/mod.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/mod.rs
@@ -6,12 +6,14 @@
 pub mod builder;
 pub mod codec;
 pub mod error;
+pub mod events;
 pub mod eviction;
 pub mod hub;
 pub mod hub_transport;
 pub mod key;
 pub mod lease;
 pub mod metadata;
+pub mod persistence;
 pub mod registry;
 pub mod storage;
 pub mod transport;
@@ -34,8 +36,8 @@ pub use error::{RegistryError, RegistryResult};
 pub use lease::{LeaseInfo, LeaseManager};
 
 // Storage & Eviction
-pub use eviction::{Eviction, NoEviction, TailEviction};
-pub use storage::{HashMapStorage, Storage};
+pub use eviction::{Eviction, NoEviction, PositionalEviction, TailEviction};
+pub use storage::{HashMapStorage, PositionalStorageKey, RadixStorage, Storage};
 
 // Key, Value, Metadata
 pub use key::{CompositeKey, Key128, PositionalKey, RegistryKey};
@@ -50,8 +52,8 @@ pub use zmq_transport::{ZmqTransport, ZmqTransportConfig};
 // Hub (Server)
 pub use hub::{HubStats, RegistryHub};
 pub use hub_transport::{
-    ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport, ZmqHubConfig,
-    ZmqHubTransport,
+    ClientId, HubMessage, HubTransport, InProcessClientHandle, InProcessHubTransport,
+    ZmqHubTransport, ZmqHubTransportConfig,
 };
 
 // Builder
@@ -59,3 +61,15 @@ pub use builder::{ClientBuilder, HubBuilder, client, hub};
 
 // ZMQ Hub
 pub use zmq_hub::{ZmqHub, ZmqHubConfig as ZmqHubServerConfig};
+
+// Persistence
+pub use persistence::{
+    AccessStats, HybridPersistence, LocalDiskBackend, PersistedEntry, PersistenceBackend,
+    PersistenceConfig, RegistrySnapshot, SnapshotPersistence, WalEntry, WalPersistence,
+};
+
+// Event Bus
+pub use events::{
+    EventBus, EventBusConfig, EventHandler, EventReceiver, EventTopic, EvictionReason,
+    InProcessEventBus, RegistryEvent, StorageTier, StorageType,
+};

--- a/lib/llm/src/block_manager/distributed/registry/core/persistence.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/persistence.rs
@@ -537,7 +537,9 @@ where
     ///
     /// - `Ok(None)` if no persisted state exists (empty snapshot and no WAL entries)
     /// - `Ok(Some((snapshot, wal_entries)))` with the snapshot and entries to replay
-    pub async fn recover(&self) -> Result<Option<(RegistrySnapshot<K, V, M>, Vec<WalEntry<K, V, M>>)>> {
+    pub async fn recover(
+        &self,
+    ) -> Result<Option<(RegistrySnapshot<K, V, M>, Vec<WalEntry<K, V, M>>)>> {
         // Load latest snapshot
         let snapshot = self.snapshot.load_latest().await?.unwrap_or_default();
 

--- a/lib/llm/src/block_manager/distributed/registry/core/persistence.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/persistence.rs
@@ -1,0 +1,743 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Persistence layer for the registry hub.
+//!
+//! Provides snapshot and WAL-based persistence for crash recovery.
+//!
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use bincode::config;
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+
+/// Persisted entry in the registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedEntry<K, V, M> {
+    pub key: K,
+    pub value: V,
+    pub metadata: Option<M>,
+}
+
+/// Access statistics for eviction tracking.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AccessStats {
+    /// Last access timestamp (milliseconds since epoch)
+    pub last_access_ms: u64,
+    /// Total access count
+    pub access_count: u64,
+}
+
+/// Full registry state for snapshots.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistrySnapshot<K, V, M> {
+    /// Protocol version for forward/backward compatibility
+    pub version: u32,
+    /// Snapshot sequence number
+    pub sequence: u64,
+    /// Timestamp when snapshot was taken
+    pub timestamp_ms: u64,
+    /// All entries in the registry
+    pub entries: Vec<PersistedEntry<K, V, M>>,
+    /// Access statistics for each key (for LRU/LFU)
+    pub access_stats: Vec<(K, AccessStats)>,
+}
+
+impl<K, V, M> Default for RegistrySnapshot<K, V, M> {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            sequence: 0,
+            timestamp_ms: 0,
+            entries: Vec::new(),
+            access_stats: Vec::new(),
+        }
+    }
+}
+
+/// WAL entry types for incremental persistence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum WalEntry<K, V, M> {
+    /// Register new entries
+    Register {
+        seq: u64,
+        entries: Vec<PersistedEntry<K, V, M>>,
+    },
+    /// Remove entries by key
+    Remove { seq: u64, keys: Vec<K> },
+    /// Touch entries (access notification)
+    Touch { seq: u64, keys: Vec<K> },
+    /// Checkpoint marker
+    Checkpoint { seq: u64, snapshot_seq: u64 },
+}
+
+/// Trait for persistence storage backends.
+#[async_trait]
+pub trait PersistenceBackend: Send + Sync {
+    /// Write data to a path (atomic if possible)
+    async fn write(&self, path: &str, data: &[u8]) -> Result<()>;
+
+    /// Read data from a path
+    async fn read(&self, path: &str) -> Result<Vec<u8>>;
+
+    /// Check if a path exists
+    async fn exists(&self, path: &str) -> Result<bool>;
+
+    /// Append data to a file (for WAL)
+    async fn append(&self, path: &str, data: &[u8]) -> Result<()>;
+
+    /// List files with prefix
+    async fn list(&self, prefix: &str) -> Result<Vec<String>>;
+
+    /// Delete a file
+    async fn delete(&self, path: &str) -> Result<()>;
+
+    /// Atomic rename (for safe snapshot writes)
+    async fn rename(&self, from: &str, to: &str) -> Result<()>;
+}
+
+/// Local disk persistence backend.
+pub struct LocalDiskBackend {
+    base_path: PathBuf,
+}
+
+impl LocalDiskBackend {
+    pub fn new(base_path: impl AsRef<Path>) -> Result<Self> {
+        let base_path = base_path.as_ref().to_path_buf();
+        std::fs::create_dir_all(&base_path)?;
+        Ok(Self { base_path })
+    }
+
+    fn full_path(&self, path: &str) -> PathBuf {
+        self.base_path.join(path)
+    }
+}
+
+#[async_trait]
+impl PersistenceBackend for LocalDiskBackend {
+    async fn write(&self, path: &str, data: &[u8]) -> Result<()> {
+        let full_path = self.full_path(path);
+
+        // Create parent directories if needed
+        if let Some(parent) = full_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        // Write to temp file first, then rename (atomic on most filesystems)
+        let temp_path = full_path.with_extension("tmp");
+        tokio::fs::write(&temp_path, data).await?;
+        tokio::fs::rename(&temp_path, &full_path).await?;
+
+        // Sync to ensure durability
+        if let Ok(file) = tokio::fs::File::open(&full_path).await {
+            let _ = file.sync_all().await;
+        }
+
+        Ok(())
+    }
+
+    async fn read(&self, path: &str) -> Result<Vec<u8>> {
+        let full_path = self.full_path(path);
+        Ok(tokio::fs::read(&full_path).await?)
+    }
+
+    async fn exists(&self, path: &str) -> Result<bool> {
+        let full_path = self.full_path(path);
+        Ok(full_path.exists())
+    }
+
+    async fn append(&self, path: &str, data: &[u8]) -> Result<()> {
+        let full_path = self.full_path(path);
+
+        // Create parent directories if needed
+        if let Some(parent) = full_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&full_path)
+            .await?;
+
+        file.write_all(data).await?;
+        file.sync_all().await?;
+
+        Ok(())
+    }
+
+    async fn list(&self, prefix: &str) -> Result<Vec<String>> {
+        let search_path = self.full_path(prefix);
+
+        let mut results = Vec::new();
+
+        // If prefix is a directory, list its contents
+        if search_path.is_dir() {
+            let mut entries = tokio::fs::read_dir(&search_path).await?;
+            while let Some(entry) = entries.next_entry().await? {
+                let path = entry.path();
+                if let Ok(relative) = path.strip_prefix(&self.base_path) {
+                    results.push(relative.to_string_lossy().to_string());
+                }
+            }
+        } else {
+            // Otherwise, list files in parent that start with the prefix
+            let search_dir = search_path
+                .parent()
+                .unwrap_or(&self.base_path)
+                .to_path_buf();
+
+            if search_dir.exists() {
+                let mut entries = tokio::fs::read_dir(&search_dir).await?;
+                while let Some(entry) = entries.next_entry().await? {
+                    let path = entry.path();
+                    if let Ok(relative) = path.strip_prefix(&self.base_path) {
+                        let path_str = relative.to_string_lossy().to_string();
+                        if path_str.starts_with(prefix) {
+                            results.push(path_str);
+                        }
+                    }
+                }
+            }
+        }
+
+        results.sort();
+        Ok(results)
+    }
+
+    async fn delete(&self, path: &str) -> Result<()> {
+        let full_path = self.full_path(path);
+        if full_path.exists() {
+            tokio::fs::remove_file(&full_path).await?;
+        }
+        Ok(())
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<()> {
+        let from_path = self.full_path(from);
+        let to_path = self.full_path(to);
+        tokio::fs::rename(&from_path, &to_path).await?;
+        Ok(())
+    }
+}
+
+/// Snapshot-based persistence.
+pub struct SnapshotPersistence<K, V, M> {
+    backend: Box<dyn PersistenceBackend>,
+    snapshot_prefix: String,
+    ops_since_snapshot: AtomicU64,
+    snapshot_interval: u64,
+    retention_count: usize,
+    _phantom: std::marker::PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M> SnapshotPersistence<K, V, M>
+where
+    K: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    V: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+    M: Serialize + for<'de> Deserialize<'de> + Send + Sync,
+{
+    pub fn new(
+        backend: Box<dyn PersistenceBackend>,
+        snapshot_prefix: String,
+        snapshot_interval: u64,
+        retention_count: usize,
+    ) -> Self {
+        Self {
+            backend,
+            snapshot_prefix,
+            ops_since_snapshot: AtomicU64::new(0),
+            snapshot_interval,
+            retention_count,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Take a snapshot of the registry state.
+    pub async fn take_snapshot(&self, snapshot: &RegistrySnapshot<K, V, M>) -> Result<()> {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        let filename = format!(
+            "{}/snapshot-{:08}-{}.bin",
+            self.snapshot_prefix, snapshot.sequence, timestamp
+        );
+
+        let data = bincode::serde::encode_to_vec(snapshot, config::standard())?;
+        self.backend.write(&filename, &data).await?;
+        self.ops_since_snapshot.store(0, Ordering::Release);
+
+        tracing::info!(
+            seq = snapshot.sequence,
+            entries = snapshot.entries.len(),
+            "Snapshot saved: {}",
+            filename
+        );
+
+        // Clean up old snapshots
+        self.cleanup_old_snapshots().await?;
+
+        Ok(())
+    }
+
+    /// Load the latest snapshot.
+    pub async fn load_latest(&self) -> Result<Option<RegistrySnapshot<K, V, M>>> {
+        let files = self.backend.list(&self.snapshot_prefix).await?;
+
+        let snapshot_files: Vec<_> = files
+            .iter()
+            .filter(|f| f.contains("snapshot-") && f.ends_with(".bin"))
+            .collect();
+
+        if snapshot_files.is_empty() {
+            return Ok(None);
+        }
+
+        // Get the latest snapshot (highest sequence number)
+        let latest = snapshot_files.iter().max().unwrap();
+        let data = self.backend.read(latest).await?;
+        let (snapshot, _): (RegistrySnapshot<K, V, M>, _) =
+            bincode::serde::decode_from_slice(&data, config::standard())?;
+
+        tracing::info!(
+            seq = snapshot.sequence,
+            entries = snapshot.entries.len(),
+            "Loaded snapshot: {}",
+            latest
+        );
+
+        Ok(Some(snapshot))
+    }
+
+    /// Record an operation (for snapshot interval tracking).
+    pub fn record_operation(&self) {
+        self.ops_since_snapshot.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Check if we should take a snapshot.
+    pub fn should_snapshot(&self) -> bool {
+        self.ops_since_snapshot.load(Ordering::Relaxed) >= self.snapshot_interval
+    }
+
+    /// Clean up old snapshots, keeping only the most recent ones.
+    async fn cleanup_old_snapshots(&self) -> Result<()> {
+        let files = self.backend.list(&self.snapshot_prefix).await?;
+
+        let mut snapshot_files: Vec<_> = files
+            .iter()
+            .filter(|f| f.contains("snapshot-") && f.ends_with(".bin"))
+            .cloned()
+            .collect();
+
+        if snapshot_files.len() <= self.retention_count {
+            return Ok(());
+        }
+
+        snapshot_files.sort();
+        let to_delete = snapshot_files.len() - self.retention_count;
+
+        for file in snapshot_files.iter().take(to_delete) {
+            tracing::debug!("Deleting old snapshot: {}", file);
+            self.backend.delete(file).await?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Write-Ahead Log persistence.
+pub struct WalPersistence<K, V, M> {
+    backend: Box<dyn PersistenceBackend>,
+    wal_path: String,
+    current_seq: AtomicU64,
+    _phantom: std::marker::PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M> WalPersistence<K, V, M>
+where
+    K: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+    V: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+    M: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+{
+    pub fn new(backend: Box<dyn PersistenceBackend>, wal_path: String) -> Self {
+        Self {
+            backend,
+            wal_path,
+            current_seq: AtomicU64::new(0),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Log a WAL entry.
+    pub async fn log(&self, entry: WalEntry<K, V, M>) -> Result<u64> {
+        let seq = self.current_seq.fetch_add(1, Ordering::SeqCst);
+
+        // Serialize with length prefix for safe recovery
+        let data = bincode::serde::encode_to_vec(&entry, config::standard())?;
+        let mut buf = Vec::with_capacity(4 + data.len());
+        buf.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&data);
+
+        self.backend.append(&self.wal_path, &buf).await?;
+
+        Ok(seq)
+    }
+
+    /// Replay WAL entries from disk.
+    pub async fn replay(&self) -> Result<Vec<WalEntry<K, V, M>>> {
+        if !self.backend.exists(&self.wal_path).await? {
+            return Ok(Vec::new());
+        }
+
+        let data = self.backend.read(&self.wal_path).await?;
+        let mut entries = Vec::new();
+        let mut pos = 0;
+
+        while pos + 4 <= data.len() {
+            let len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap_or([0; 4])) as usize;
+            pos += 4;
+
+            if pos + len > data.len() {
+                tracing::warn!("WAL truncated at position {} (expected {} bytes)", pos, len);
+                break;
+            }
+
+            match bincode::serde::decode_from_slice::<WalEntry<K, V, M>, _>(
+                &data[pos..pos + len],
+                config::standard(),
+            ) {
+                Ok((entry, _)) => entries.push(entry),
+                Err(e) => {
+                    tracing::warn!("Failed to deserialize WAL entry at position {}: {}", pos, e);
+                    break;
+                }
+            }
+            pos += len;
+        }
+
+        // Update sequence counter
+        if let Some(last_seq) = entries
+            .iter()
+            .map(|e| match e {
+                WalEntry::Register { seq, .. } => *seq,
+                WalEntry::Remove { seq, .. } => *seq,
+                WalEntry::Touch { seq, .. } => *seq,
+                WalEntry::Checkpoint { seq, .. } => *seq,
+            })
+            .max()
+        {
+            self.current_seq.store(last_seq + 1, Ordering::Release);
+        }
+
+        tracing::info!(entries = entries.len(), "Replayed WAL entries");
+        Ok(entries)
+    }
+
+    /// Truncate WAL after checkpoint.
+    pub async fn truncate(&self) -> Result<()> {
+        self.backend.delete(&self.wal_path).await?;
+        tracing::debug!("WAL truncated");
+        Ok(())
+    }
+
+    /// Get current sequence number.
+    pub fn current_seq(&self) -> u64 {
+        self.current_seq.load(Ordering::Relaxed)
+    }
+
+    /// Set sequence number (used during recovery).
+    pub fn set_seq(&self, seq: u64) {
+        self.current_seq.store(seq, Ordering::Release);
+    }
+}
+
+/// Hybrid persistence combining snapshots and WAL.
+pub struct HybridPersistence<K, V, M>
+where
+    K: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+    V: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+    M: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync,
+{
+    snapshot: SnapshotPersistence<K, V, M>,
+    wal: WalPersistence<K, V, M>,
+}
+
+impl<K, V, M> HybridPersistence<K, V, M>
+where
+    K: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+    V: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+    M: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+{
+    /// Create new hybrid persistence.
+    ///
+    /// # Arguments
+    /// * `backend` - Storage backend (must be cloneable or create two instances)
+    /// * `base_prefix` - Base path/prefix for all persistence files
+    /// * `snapshot_interval` - Number of operations before taking a snapshot
+    /// * `retention_count` - Number of snapshots to retain
+    pub fn new(
+        snapshot_backend: Box<dyn PersistenceBackend>,
+        wal_backend: Box<dyn PersistenceBackend>,
+        base_prefix: &str,
+        snapshot_interval: u64,
+        retention_count: usize,
+    ) -> Self {
+        let snapshot = SnapshotPersistence::new(
+            snapshot_backend,
+            format!("{}/snapshots", base_prefix),
+            snapshot_interval,
+            retention_count,
+        );
+
+        let wal = WalPersistence::new(wal_backend, format!("{}/wal.log", base_prefix));
+
+        Self { snapshot, wal }
+    }
+
+    /// Log an operation to WAL and maybe trigger snapshot.
+    pub async fn log_operation(&self, entry: WalEntry<K, V, M>) -> Result<u64> {
+        let seq = self.wal.log(entry).await?;
+        self.snapshot.record_operation();
+        Ok(seq)
+    }
+
+    /// Take a checkpoint (snapshot + truncate WAL).
+    pub async fn checkpoint(&self, snapshot: &RegistrySnapshot<K, V, M>) -> Result<()> {
+        // Take snapshot
+        self.snapshot.take_snapshot(snapshot).await?;
+
+        // Log checkpoint to WAL
+        self.wal
+            .log(WalEntry::Checkpoint {
+                seq: self.wal.current_seq(),
+                snapshot_seq: snapshot.sequence,
+            })
+            .await?;
+
+        // Truncate WAL
+        self.wal.truncate().await?;
+
+        Ok(())
+    }
+
+    /// Recover state from persistence.
+    ///
+    /// Returns both the recovered snapshot and any WAL entries that need to be
+    /// applied on top of it. The caller is responsible for applying the WAL
+    /// entries to rebuild the complete state.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(None)` if no persisted state exists (empty snapshot and no WAL entries)
+    /// - `Ok(Some((snapshot, wal_entries)))` with the snapshot and entries to replay
+    pub async fn recover(&self) -> Result<Option<(RegistrySnapshot<K, V, M>, Vec<WalEntry<K, V, M>>)>> {
+        // Load latest snapshot
+        let snapshot = self.snapshot.load_latest().await?.unwrap_or_default();
+
+        // Replay WAL entries after snapshot
+        let wal_entries = self.wal.replay().await?;
+
+        // Update sequence
+        self.wal.set_seq(snapshot.sequence + 1);
+
+        if !wal_entries.is_empty() {
+            tracing::info!(
+                snapshot_seq = snapshot.sequence,
+                wal_entries = wal_entries.len(),
+                "Recovery: loaded snapshot + {} WAL entries to apply",
+                wal_entries.len()
+            );
+        }
+
+        if snapshot.entries.is_empty() && wal_entries.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some((snapshot, wal_entries)))
+    }
+
+    /// Check if a snapshot should be taken.
+    pub fn should_snapshot(&self) -> bool {
+        self.snapshot.should_snapshot()
+    }
+
+    /// Get reference to snapshot persistence.
+    pub fn snapshot(&self) -> &SnapshotPersistence<K, V, M> {
+        &self.snapshot
+    }
+
+    /// Get reference to WAL persistence.
+    pub fn wal(&self) -> &WalPersistence<K, V, M> {
+        &self.wal
+    }
+}
+
+/// Configuration for persistence.
+#[derive(Debug, Clone)]
+pub struct PersistenceConfig {
+    /// Enable persistence
+    pub enabled: bool,
+    /// Base path/prefix for persistence files
+    pub base_path: String,
+    /// Snapshot interval (number of operations)
+    pub snapshot_interval: u64,
+    /// Number of snapshots to retain
+    pub snapshot_retention: usize,
+}
+
+impl Default for PersistenceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            base_path: "/tmp/registry".to_string(),
+            snapshot_interval: 10000,
+            snapshot_retention: 3,
+        }
+    }
+}
+
+impl PersistenceConfig {
+    /// Create from environment variables.
+    ///
+    /// Environment variables:
+    /// - `DYN_REGISTRY_PERSISTENCE_ENABLED`: "1" or "true" to enable
+    /// - `DYN_REGISTRY_PERSISTENCE_PATH`: Base path for persistence files
+    /// - `DYN_REGISTRY_PERSISTENCE_SNAPSHOT_INTERVAL`: Operations between snapshots
+    /// - `DYN_REGISTRY_PERSISTENCE_SNAPSHOT_RETENTION`: Number of snapshots to keep
+    pub fn from_env() -> Self {
+        let enabled = std::env::var("DYN_REGISTRY_PERSISTENCE_ENABLED")
+            .map(|v| v == "1" || v.to_lowercase() == "true")
+            .unwrap_or(false);
+
+        let base_path = std::env::var("DYN_REGISTRY_PERSISTENCE_PATH")
+            .unwrap_or_else(|_| "/tmp/registry".to_string());
+
+        let snapshot_interval = std::env::var("DYN_REGISTRY_PERSISTENCE_SNAPSHOT_INTERVAL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(10000);
+
+        let snapshot_retention = std::env::var("DYN_REGISTRY_PERSISTENCE_SNAPSHOT_RETENTION")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(3);
+
+        Self {
+            enabled,
+            base_path,
+            snapshot_interval,
+            snapshot_retention,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_local_disk_backend() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let backend = LocalDiskBackend::new(temp_dir.path()).unwrap();
+
+        // Test write and read
+        backend.write("test.bin", b"hello world").await.unwrap();
+        let data = backend.read("test.bin").await.unwrap();
+        assert_eq!(data, b"hello world");
+
+        // Test exists
+        assert!(backend.exists("test.bin").await.unwrap());
+        assert!(!backend.exists("nonexistent.bin").await.unwrap());
+
+        // Test append
+        backend.append("append.log", b"line1\n").await.unwrap();
+        backend.append("append.log", b"line2\n").await.unwrap();
+        let log = backend.read("append.log").await.unwrap();
+        assert_eq!(log, b"line1\nline2\n");
+
+        // Test list
+        backend.write("subdir/file1.bin", b"1").await.unwrap();
+        backend.write("subdir/file2.bin", b"2").await.unwrap();
+        let files = backend.list("subdir").await.unwrap();
+        assert_eq!(files.len(), 2);
+
+        // Test delete
+        backend.delete("test.bin").await.unwrap();
+        assert!(!backend.exists("test.bin").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_persistence() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let backend = Box::new(LocalDiskBackend::new(temp_dir.path()).unwrap());
+
+        let persistence: SnapshotPersistence<u64, String, ()> =
+            SnapshotPersistence::new(backend, "snapshots".to_string(), 100, 2);
+
+        // Create and save snapshot
+        let snapshot = RegistrySnapshot {
+            version: 1,
+            sequence: 1,
+            timestamp_ms: 12345,
+            entries: vec![
+                PersistedEntry {
+                    key: 1,
+                    value: "one".to_string(),
+                    metadata: None,
+                },
+                PersistedEntry {
+                    key: 2,
+                    value: "two".to_string(),
+                    metadata: None,
+                },
+            ],
+            access_stats: vec![],
+        };
+
+        persistence.take_snapshot(&snapshot).await.unwrap();
+
+        // Load snapshot
+        let loaded = persistence.load_latest().await.unwrap().unwrap();
+        assert_eq!(loaded.sequence, 1);
+        assert_eq!(loaded.entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_wal_persistence() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let backend = Box::new(LocalDiskBackend::new(temp_dir.path()).unwrap());
+
+        let wal: WalPersistence<u64, String, ()> =
+            WalPersistence::new(backend, "wal.log".to_string());
+
+        // Log entries
+        wal.log(WalEntry::Register {
+            seq: 1,
+            entries: vec![PersistedEntry {
+                key: 1,
+                value: "one".to_string(),
+                metadata: None,
+            }],
+        })
+        .await
+        .unwrap();
+
+        wal.log(WalEntry::Remove {
+            seq: 2,
+            keys: vec![1],
+        })
+        .await
+        .unwrap();
+
+        // Replay
+        let entries = wal.replay().await.unwrap();
+        assert_eq!(entries.len(), 2);
+    }
+}

--- a/lib/llm/src/block_manager/distributed/registry/core/registry.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/registry.rs
@@ -1,0 +1,452 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generic registry client.
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use super::codec::{BinaryCodec, OffloadStatus, QueryType, RegistryCodec, ResponseType};
+use super::key::RegistryKey;
+use super::metadata::RegistryMetadata;
+use super::transport::RegistryTransport;
+use super::value::RegistryValue;
+
+#[derive(Debug, Clone)]
+pub struct OffloadResult<K> {
+    pub can_offload: Vec<K>,
+    pub already_stored: Vec<K>,
+    pub leased: Vec<K>,
+}
+
+impl<K> Default for OffloadResult<K> {
+    fn default() -> Self {
+        Self {
+            can_offload: Vec::new(),
+            already_stored: Vec::new(),
+            leased: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+pub trait Registry<K, V, M>: Send + Sync
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+{
+    async fn register(&self, entries: &[(K, V, M)]) -> Result<()>;
+    async fn can_offload(&self, keys: &[K]) -> Result<OffloadResult<K>>;
+    async fn match_prefix(&self, keys: &[K]) -> Result<Vec<(K, V, M)>>;
+    async fn flush(&self) -> Result<()>;
+}
+
+/// Pending batch state.
+struct PendingBatch<K, V, M> {
+    entries: Vec<(K, V, M)>,
+    /// When the first entry was added to this batch.
+    first_entry_time: Option<tokio::time::Instant>,
+}
+
+impl<K, V, M> Default for PendingBatch<K, V, M> {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            first_entry_time: None,
+        }
+    }
+}
+
+impl<K: Clone, V: Clone, M: Clone> PendingBatch<K, V, M> {
+    fn add(&mut self, entries: &[(K, V, M)]) {
+        if self.first_entry_time.is_none() && !entries.is_empty() {
+            self.first_entry_time = Some(tokio::time::Instant::now());
+        }
+        self.entries.extend(entries.iter().cloned());
+    }
+
+    fn take(&mut self) -> Vec<(K, V, M)> {
+        self.first_entry_time = None;
+        std::mem::take(&mut self.entries)
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Check if the batch has exceeded the timeout.
+    fn is_timed_out(&self, timeout: Duration) -> bool {
+        self.first_entry_time
+            .map(|t| t.elapsed() >= timeout)
+            .unwrap_or(false)
+    }
+}
+
+pub struct RegistryClient<K, V, M, T, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+    C: RegistryCodec<K, V, M>,
+{
+    transport: T,
+    codec: C,
+    pending: Arc<Mutex<PendingBatch<K, V, M>>>,
+    batch_size: usize,
+    batch_timeout: Duration,
+    _phantom: PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M, T, C> RegistryClient<K, V, M, T, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+    C: RegistryCodec<K, V, M>,
+{
+    pub fn new(transport: T, codec: C) -> Self {
+        Self {
+            transport,
+            codec,
+            pending: Arc::new(Mutex::new(PendingBatch::default())),
+            batch_size: 100,
+            batch_timeout: Duration::from_millis(10),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn with_batch_size(mut self, size: usize) -> Self {
+        self.batch_size = size;
+        self
+    }
+
+    pub fn with_batch_timeout(mut self, timeout: Duration) -> Self {
+        self.batch_timeout = timeout;
+        self
+    }
+
+    /// Start a background task that flushes pending entries on timeout.
+    ///
+    /// Returns a handle that can be used to stop the task.
+    pub fn start_batch_flush_task(
+        self: &Arc<Self>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> tokio::task::JoinHandle<()>
+    where
+        K: 'static,
+        V: 'static,
+        M: 'static,
+        T: 'static,
+        C: 'static,
+    {
+        let client = Arc::clone(self);
+        let timeout = self.batch_timeout;
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(timeout / 2);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => {
+                        tracing::debug!("Batch flush task shutting down");
+                        // Final flush on shutdown
+                        let _ = client.flush().await;
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        // Check if batch has timed out
+                        let should_flush = {
+                            let pending = client.pending.lock().await;
+                            !pending.is_empty() && pending.is_timed_out(timeout)
+                        };
+
+                        if should_flush {
+                            if let Err(e) = client.flush().await {
+                                tracing::warn!(error = %e, "Batch flush failed");
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[async_trait]
+impl<K, V, M, T, C> Registry<K, V, M> for RegistryClient<K, V, M, T, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+    C: RegistryCodec<K, V, M>,
+{
+    async fn register(&self, entries: &[(K, V, M)]) -> Result<()> {
+        let should_flush = {
+            let mut pending = self.pending.lock().await;
+            pending.add(entries);
+            pending.len() >= self.batch_size
+        };
+
+        if should_flush {
+            self.flush().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn can_offload(&self, keys: &[K]) -> Result<OffloadResult<K>> {
+        if keys.is_empty() {
+            return Ok(OffloadResult::default());
+        }
+
+        let mut buf = Vec::new();
+        self.codec.encode_query(&QueryType::CanOffload(keys.to_vec()), &mut buf);
+
+        let response = self.transport.request(&buf).await?;
+        let decoded = self.codec.decode_response(&response)
+            .ok_or_else(|| anyhow::anyhow!("invalid response"))?;
+
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                let mut result = OffloadResult::default();
+                for (key, status) in keys.iter().zip(statuses.iter()) {
+                    match status {
+                        OffloadStatus::Granted => result.can_offload.push(*key),
+                        OffloadStatus::AlreadyStored => result.already_stored.push(*key),
+                        OffloadStatus::Leased => result.leased.push(*key),
+                    }
+                }
+                Ok(result)
+            }
+            _ => Err(anyhow::anyhow!("unexpected response type")),
+        }
+    }
+
+    async fn match_prefix(&self, keys: &[K]) -> Result<Vec<(K, V, M)>> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut buf = Vec::new();
+        self.codec.encode_query(&QueryType::Match(keys.to_vec()), &mut buf);
+
+        let response = self.transport.request(&buf).await?;
+        let decoded = self.codec.decode_response(&response)
+            .ok_or_else(|| anyhow::anyhow!("invalid response"))?;
+
+        match decoded {
+            ResponseType::Match(entries) => Ok(entries),
+            _ => Err(anyhow::anyhow!("unexpected response type")),
+        }
+    }
+
+    async fn flush(&self) -> Result<()> {
+        let entries = {
+            let mut pending = self.pending.lock().await;
+            pending.take()
+        };
+
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        let mut buf = Vec::new();
+        self.codec.encode_register(&entries, &mut buf);
+        self.transport.publish(&buf).await
+    }
+}
+
+/// Create a simple registry client with binary codec.
+pub fn simple_client<K, V, M, T>(transport: T) -> RegistryClient<K, V, M, T, BinaryCodec<K, V, M>>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    T: RegistryTransport,
+{
+    RegistryClient::new(transport, BinaryCodec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_manager::distributed::registry::core::metadata::NoMetadata;
+    use crate::block_manager::distributed::registry::core::transport::InProcessTransport;
+    use crate::block_manager::distributed::registry::core::codec::BinaryCodec;
+
+    #[tokio::test]
+    async fn test_registry_client_can_offload() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let (transport, _rx) = InProcessTransport::new(move |data| {
+            let query = codec.decode_query(data);
+            match query {
+                Some(QueryType::CanOffload(keys)) => {
+                    let statuses: Vec<_> = keys.iter().map(|k| {
+                        if *k % 2 == 0 {
+                            OffloadStatus::AlreadyStored
+                        } else {
+                            OffloadStatus::Granted
+                        }
+                    }).collect();
+                    let mut buf = Vec::new();
+                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf);
+                    buf
+                }
+                _ => Vec::new(),
+            }
+        });
+
+        let client: RegistryClient<u64, u64, NoMetadata, _, _> =
+            RegistryClient::new(transport, BinaryCodec::new());
+
+        let result = client.can_offload(&[1, 2, 3, 4]).await.unwrap();
+
+        assert_eq!(result.can_offload, vec![1, 3]);
+        assert_eq!(result.already_stored, vec![2, 4]);
+    }
+
+    #[tokio::test]
+    async fn test_registry_client_leased_status() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let (transport, _rx) = InProcessTransport::new(move |data| {
+            let query = codec.decode_query(data);
+            match query {
+                Some(QueryType::CanOffload(keys)) => {
+                    let statuses: Vec<_> = keys.iter().map(|k| {
+                        if *k == 1 {
+                            OffloadStatus::Leased
+                        } else {
+                            OffloadStatus::Granted
+                        }
+                    }).collect();
+                    let mut buf = Vec::new();
+                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf);
+                    buf
+                }
+                _ => Vec::new(),
+            }
+        });
+
+        let client: RegistryClient<u64, u64, NoMetadata, _, _> =
+            RegistryClient::new(transport, BinaryCodec::new());
+
+        let result = client.can_offload(&[1, 2, 3]).await.unwrap();
+
+        assert_eq!(result.leased, vec![1]);
+        assert_eq!(result.can_offload, vec![2, 3]);
+    }
+
+    #[tokio::test]
+    async fn test_registry_client_match() {
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        let (transport, _rx) = InProcessTransport::new(move |data| {
+            let query = codec.decode_query(data);
+            match query {
+                Some(QueryType::Match(keys)) => {
+                    let entries: Vec<_> = keys.into_iter()
+                        .take(2)
+                        .map(|k| (k, k * 100, NoMetadata))
+                        .collect();
+                    let mut buf = Vec::new();
+                    codec.encode_response(&ResponseType::Match(entries), &mut buf);
+                    buf
+                }
+                _ => Vec::new(),
+            }
+        });
+
+        let client: RegistryClient<u64, u64, NoMetadata, _, _> =
+            RegistryClient::new(transport, BinaryCodec::new());
+
+        let result = client.match_prefix(&[1, 2, 3, 4]).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], (1, 100, NoMetadata));
+        assert_eq!(result[1], (2, 200, NoMetadata));
+    }
+
+    #[tokio::test]
+    async fn test_batch_size_flush() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let flush_count = Arc::new(AtomicUsize::new(0));
+        let flush_count_clone = Arc::clone(&flush_count);
+
+        let (transport, mut rx) = InProcessTransport::new(move |_| Vec::new());
+
+        // Count publishes in background
+        let flush_counter = flush_count_clone;
+        tokio::spawn(async move {
+            while let Some(_) = rx.recv().await {
+                flush_counter.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        let client: RegistryClient<u64, u64, NoMetadata, _, _> =
+            RegistryClient::new(transport, BinaryCodec::new()).with_batch_size(3);
+
+        // Add 2 entries (below threshold)
+        client.register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)]).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        assert_eq!(flush_count.load(Ordering::SeqCst), 0);
+
+        // Add 1 more (reaches threshold of 3)
+        client.register(&[(3, 300, NoMetadata)]).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        assert_eq!(flush_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_batch_timeout_flush() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let flush_count = Arc::new(AtomicUsize::new(0));
+        let flush_count_clone = Arc::clone(&flush_count);
+
+        let (transport, mut rx) = InProcessTransport::new(move |_| Vec::new());
+
+        // Count publishes in background
+        let flush_counter = flush_count_clone;
+        tokio::spawn(async move {
+            while let Some(_) = rx.recv().await {
+                flush_counter.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        let client = Arc::new(
+            RegistryClient::<u64, u64, NoMetadata, _, _>::new(transport, BinaryCodec::new())
+                .with_batch_size(100) // High batch size
+                .with_batch_timeout(Duration::from_millis(50)) // Short timeout
+        );
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let _task = client.start_batch_flush_task(cancel.clone());
+
+        // Add entries (below batch size threshold)
+        client.register(&[(1, 100, NoMetadata)]).await.unwrap();
+
+        // Wait for timeout to trigger flush
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(flush_count.load(Ordering::SeqCst) >= 1);
+
+        cancel.cancel();
+    }
+}

--- a/lib/llm/src/block_manager/distributed/registry/core/registry.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/registry.rs
@@ -214,10 +214,13 @@ where
         }
 
         let mut buf = Vec::new();
-        self.codec.encode_query(&QueryType::CanOffload(keys.to_vec()), &mut buf);
+        self.codec
+            .encode_query(&QueryType::CanOffload(keys.to_vec()), &mut buf);
 
         let response = self.transport.request(&buf).await?;
-        let decoded = self.codec.decode_response(&response)
+        let decoded = self
+            .codec
+            .decode_response(&response)
             .ok_or_else(|| anyhow::anyhow!("invalid response"))?;
 
         match decoded {
@@ -242,10 +245,13 @@ where
         }
 
         let mut buf = Vec::new();
-        self.codec.encode_query(&QueryType::Match(keys.to_vec()), &mut buf);
+        self.codec
+            .encode_query(&QueryType::Match(keys.to_vec()), &mut buf);
 
         let response = self.transport.request(&buf).await?;
-        let decoded = self.codec.decode_response(&response)
+        let decoded = self
+            .codec
+            .decode_response(&response)
             .ok_or_else(|| anyhow::anyhow!("invalid response"))?;
 
         match decoded {
@@ -284,9 +290,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::block_manager::distributed::registry::core::codec::BinaryCodec;
     use crate::block_manager::distributed::registry::core::metadata::NoMetadata;
     use crate::block_manager::distributed::registry::core::transport::InProcessTransport;
-    use crate::block_manager::distributed::registry::core::codec::BinaryCodec;
 
     #[tokio::test]
     async fn test_registry_client_can_offload() {
@@ -296,13 +302,16 @@ mod tests {
             let query = codec.decode_query(data);
             match query {
                 Some(QueryType::CanOffload(keys)) => {
-                    let statuses: Vec<_> = keys.iter().map(|k| {
-                        if *k % 2 == 0 {
-                            OffloadStatus::AlreadyStored
-                        } else {
-                            OffloadStatus::Granted
-                        }
-                    }).collect();
+                    let statuses: Vec<_> = keys
+                        .iter()
+                        .map(|k| {
+                            if *k % 2 == 0 {
+                                OffloadStatus::AlreadyStored
+                            } else {
+                                OffloadStatus::Granted
+                            }
+                        })
+                        .collect();
                     let mut buf = Vec::new();
                     codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf);
                     buf
@@ -328,13 +337,16 @@ mod tests {
             let query = codec.decode_query(data);
             match query {
                 Some(QueryType::CanOffload(keys)) => {
-                    let statuses: Vec<_> = keys.iter().map(|k| {
-                        if *k == 1 {
-                            OffloadStatus::Leased
-                        } else {
-                            OffloadStatus::Granted
-                        }
-                    }).collect();
+                    let statuses: Vec<_> = keys
+                        .iter()
+                        .map(|k| {
+                            if *k == 1 {
+                                OffloadStatus::Leased
+                            } else {
+                                OffloadStatus::Granted
+                            }
+                        })
+                        .collect();
                     let mut buf = Vec::new();
                     codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf);
                     buf
@@ -360,7 +372,8 @@ mod tests {
             let query = codec.decode_query(data);
             match query {
                 Some(QueryType::Match(keys)) => {
-                    let entries: Vec<_> = keys.into_iter()
+                    let entries: Vec<_> = keys
+                        .into_iter()
                         .take(2)
                         .map(|k| (k, k * 100, NoMetadata))
                         .collect();
@@ -403,7 +416,10 @@ mod tests {
             RegistryClient::new(transport, BinaryCodec::new()).with_batch_size(3);
 
         // Add 2 entries (below threshold)
-        client.register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)]).await.unwrap();
+        client
+            .register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)])
+            .await
+            .unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
         assert_eq!(flush_count.load(Ordering::SeqCst), 0);
 
@@ -433,7 +449,7 @@ mod tests {
         let client = Arc::new(
             RegistryClient::<u64, u64, NoMetadata, _, _>::new(transport, BinaryCodec::new())
                 .with_batch_size(100) // High batch size
-                .with_batch_timeout(Duration::from_millis(50)) // Short timeout
+                .with_batch_timeout(Duration::from_millis(50)), // Short timeout
         );
 
         let cancel = tokio_util::sync::CancellationToken::new();

--- a/lib/llm/src/block_manager/distributed/registry/core/registry.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/registry.rs
@@ -215,7 +215,7 @@ where
 
         let mut buf = Vec::new();
         self.codec
-            .encode_query(&QueryType::CanOffload(keys.to_vec()), &mut buf);
+            .encode_query(&QueryType::CanOffload(keys.to_vec()), &mut buf)?;
 
         let response = self.transport.request(&buf).await?;
         let decoded = self
@@ -246,7 +246,7 @@ where
 
         let mut buf = Vec::new();
         self.codec
-            .encode_query(&QueryType::Match(keys.to_vec()), &mut buf);
+            .encode_query(&QueryType::Match(keys.to_vec()), &mut buf)?;
 
         let response = self.transport.request(&buf).await?;
         let decoded = self
@@ -271,7 +271,7 @@ where
         }
 
         let mut buf = Vec::new();
-        self.codec.encode_register(&entries, &mut buf);
+        self.codec.encode_register(&entries, &mut buf)?;
         self.transport.publish(&buf).await
     }
 }
@@ -313,7 +313,7 @@ mod tests {
                         })
                         .collect();
                     let mut buf = Vec::new();
-                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf);
+                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf).unwrap();
                     buf
                 }
                 _ => Vec::new(),
@@ -348,7 +348,7 @@ mod tests {
                         })
                         .collect();
                     let mut buf = Vec::new();
-                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf);
+                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf).unwrap();
                     buf
                 }
                 _ => Vec::new(),
@@ -378,7 +378,7 @@ mod tests {
                         .map(|k| (k, k * 100, NoMetadata))
                         .collect();
                     let mut buf = Vec::new();
-                    codec.encode_response(&ResponseType::Match(entries), &mut buf);
+                    codec.encode_response(&ResponseType::Match(entries), &mut buf).unwrap();
                     buf
                 }
                 _ => Vec::new(),

--- a/lib/llm/src/block_manager/distributed/registry/core/registry.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/registry.rs
@@ -313,7 +313,9 @@ mod tests {
                         })
                         .collect();
                     let mut buf = Vec::new();
-                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf).unwrap();
+                    codec
+                        .encode_response(&ResponseType::CanOffload(statuses), &mut buf)
+                        .unwrap();
                     buf
                 }
                 _ => Vec::new(),
@@ -348,7 +350,9 @@ mod tests {
                         })
                         .collect();
                     let mut buf = Vec::new();
-                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf).unwrap();
+                    codec
+                        .encode_response(&ResponseType::CanOffload(statuses), &mut buf)
+                        .unwrap();
                     buf
                 }
                 _ => Vec::new(),
@@ -378,7 +382,9 @@ mod tests {
                         .map(|k| (k, k * 100, NoMetadata))
                         .collect();
                     let mut buf = Vec::new();
-                    codec.encode_response(&ResponseType::Match(entries), &mut buf).unwrap();
+                    codec
+                        .encode_response(&ResponseType::Match(entries), &mut buf)
+                        .unwrap();
                     buf
                 }
                 _ => Vec::new(),

--- a/lib/llm/src/block_manager/distributed/registry/core/storage.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/storage.rs
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Storage trait and implementations.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use parking_lot::RwLock;
+
+/// Storage for key-value pairs.
+pub trait Storage<K, V>: Send + Sync {
+    fn insert(&self, key: K, value: V);
+    fn get(&self, key: &K) -> Option<V>;
+    fn contains(&self, key: &K) -> bool;
+    fn remove(&self, key: &K) -> Option<V>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    fn clear(&self);
+}
+
+/// HashMap-based storage.
+pub struct HashMapStorage<K, V> {
+    map: RwLock<HashMap<K, V>>,
+}
+
+impl<K, V> HashMapStorage<K, V>
+where
+    K: Eq + Hash,
+{
+    pub fn new() -> Self {
+        Self {
+            map: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            map: RwLock::new(HashMap::with_capacity(capacity)),
+        }
+    }
+}
+
+impl<K, V> Default for HashMapStorage<K, V>
+where
+    K: Eq + Hash,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> Storage<K, V> for HashMapStorage<K, V>
+where
+    K: Eq + Hash + Clone + Send + Sync,
+    V: Clone + Send + Sync,
+{
+    fn insert(&self, key: K, value: V) {
+        self.map.write().insert(key, value);
+    }
+
+    fn get(&self, key: &K) -> Option<V> {
+        self.map.read().get(key).cloned()
+    }
+
+    fn contains(&self, key: &K) -> bool {
+        self.map.read().contains_key(key)
+    }
+
+    fn remove(&self, key: &K) -> Option<V> {
+        self.map.write().remove(key)
+    }
+
+    fn len(&self) -> usize {
+        self.map.read().len()
+    }
+
+    fn clear(&self) {
+        self.map.write().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hashmap_storage() {
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+
+        assert_eq!(storage.get(&1), Some(100));
+        assert_eq!(storage.get(&3), None);
+        assert!(storage.contains(&1));
+        assert!(!storage.contains(&3));
+        assert_eq!(storage.len(), 2);
+
+        storage.remove(&1);
+        assert_eq!(storage.len(), 1);
+        assert!(!storage.contains(&1));
+
+        storage.clear();
+        assert!(storage.is_empty());
+    }
+}

--- a/lib/llm/src/block_manager/distributed/registry/core/storage.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/storage.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
+use dashmap::DashMap;
 use parking_lot::RwLock;
 
 /// Storage for key-value pairs.
@@ -82,6 +83,126 @@ where
     }
 }
 
+/// Trait for keys that have an extractable position for radix organization.
+pub trait PositionalStorageKey: Eq + Hash + Clone + Send + Sync {
+    /// Extract the position/prefix used for first-level partitioning.
+    fn position(&self) -> u64;
+}
+
+/// Radix-style storage using a two-level DashMap for concurrent access.
+///
+/// Organizes entries by position first, then by full key within each position.
+/// This provides:
+/// - Efficient prefix/position-based lookups
+/// - High concurrency via sharded DashMap structure
+/// - Natural grouping for positional data (e.g., sequence positions)
+///
+/// # Example
+/// ```text
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+/// struct MyKey { position: u64, hash: u64 }
+///
+/// impl PositionalStorageKey for MyKey {
+///     fn position(&self) -> u64 { self.position }
+/// }
+///
+/// let storage: RadixStorage<MyKey, String> = RadixStorage::new();
+/// storage.insert(MyKey { position: 0, hash: 123 }, "value".to_string());
+/// ```
+pub struct RadixStorage<K, V> {
+    /// Two-level map: position -> (key -> value)
+    map: DashMap<u64, DashMap<K, V>>,
+}
+
+impl<K, V> RadixStorage<K, V>
+where
+    K: PositionalStorageKey,
+{
+    pub fn new() -> Self {
+        Self {
+            map: DashMap::new(),
+        }
+    }
+
+    /// Get the sub-map for a specific position.
+    pub fn position(
+        &self,
+        position: u64,
+    ) -> Option<dashmap::mapref::one::Ref<'_, u64, DashMap<K, V>>> {
+        self.map.get(&position)
+    }
+
+    /// Get or create the sub-map for a key's position.
+    pub fn prefix(&self, key: &K) -> dashmap::mapref::one::RefMut<'_, u64, DashMap<K, V>> {
+        self.map.entry(key.position()).or_default()
+    }
+
+    /// Iterate over all positions that have entries.
+    pub fn positions(&self) -> Vec<u64> {
+        self.map.iter().map(|entry| *entry.key()).collect()
+    }
+
+    /// Get the count of entries at a specific position.
+    pub fn position_len(&self, position: u64) -> usize {
+        self.map.get(&position).map(|m| m.len()).unwrap_or(0)
+    }
+}
+
+impl<K, V> Default for RadixStorage<K, V>
+where
+    K: PositionalStorageKey,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> Storage<K, V> for RadixStorage<K, V>
+where
+    K: PositionalStorageKey + 'static,
+    V: Clone + Send + Sync + 'static,
+{
+    fn insert(&self, key: K, value: V) {
+        let position = key.position();
+        self.map.entry(position).or_default().insert(key, value);
+    }
+
+    fn get(&self, key: &K) -> Option<V> {
+        let position = key.position();
+        self.map.get(&position)?.get(key).map(|v| v.clone())
+    }
+
+    fn contains(&self, key: &K) -> bool {
+        let position = key.position();
+        self.map
+            .get(&position)
+            .map(|m| m.contains_key(key))
+            .unwrap_or(false)
+    }
+
+    fn remove(&self, key: &K) -> Option<V> {
+        let position = key.position();
+        let inner = self.map.get(&position)?;
+        let removed = inner.remove(key).map(|(_, v)| v);
+
+        // Clean up empty position maps atomically to avoid TOCTOU race
+        // Use remove_if to atomically check emptiness and remove in one operation
+        drop(inner);
+        self.map
+            .remove_if(&position, |_, inner_map| inner_map.is_empty());
+
+        removed
+    }
+
+    fn len(&self) -> usize {
+        self.map.iter().map(|entry| entry.len()).sum()
+    }
+
+    fn clear(&self) {
+        self.map.clear();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -105,5 +226,119 @@ mod tests {
 
         storage.clear();
         assert!(storage.is_empty());
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    struct TestPositionalKey {
+        position: u64,
+        hash: u64,
+    }
+
+    impl PositionalStorageKey for TestPositionalKey {
+        fn position(&self) -> u64 {
+            self.position
+        }
+    }
+
+    #[test]
+    fn test_radix_storage_basic() {
+        let storage: RadixStorage<TestPositionalKey, u64> = RadixStorage::new();
+
+        let key1 = TestPositionalKey {
+            position: 0,
+            hash: 100,
+        };
+        let key2 = TestPositionalKey {
+            position: 0,
+            hash: 200,
+        };
+        let key3 = TestPositionalKey {
+            position: 1,
+            hash: 100,
+        };
+
+        storage.insert(key1, 1);
+        storage.insert(key2, 2);
+        storage.insert(key3, 3);
+
+        assert_eq!(storage.get(&key1), Some(1));
+        assert_eq!(storage.get(&key2), Some(2));
+        assert_eq!(storage.get(&key3), Some(3));
+        assert_eq!(storage.len(), 3);
+    }
+
+    #[test]
+    fn test_radix_storage_position_grouping() {
+        let storage: RadixStorage<TestPositionalKey, u64> = RadixStorage::new();
+
+        // Insert keys at different positions
+        for pos in 0..3 {
+            for hash in 0..5 {
+                storage.insert(
+                    TestPositionalKey {
+                        position: pos,
+                        hash,
+                    },
+                    pos * 10 + hash,
+                );
+            }
+        }
+
+        assert_eq!(storage.len(), 15);
+        assert_eq!(storage.position_len(0), 5);
+        assert_eq!(storage.position_len(1), 5);
+        assert_eq!(storage.position_len(2), 5);
+        assert_eq!(storage.position_len(99), 0);
+
+        let mut positions = storage.positions();
+        positions.sort();
+        assert_eq!(positions, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_radix_storage_remove() {
+        let storage: RadixStorage<TestPositionalKey, u64> = RadixStorage::new();
+
+        let key1 = TestPositionalKey {
+            position: 0,
+            hash: 100,
+        };
+        let key2 = TestPositionalKey {
+            position: 0,
+            hash: 200,
+        };
+
+        storage.insert(key1, 1);
+        storage.insert(key2, 2);
+
+        assert_eq!(storage.remove(&key1), Some(1));
+        assert_eq!(storage.len(), 1);
+        assert!(!storage.contains(&key1));
+        assert!(storage.contains(&key2));
+
+        // Remove last key at position 0, should clean up the position map
+        assert_eq!(storage.remove(&key2), Some(2));
+        assert_eq!(storage.len(), 0);
+        assert!(storage.position(0).is_none());
+    }
+
+    #[test]
+    fn test_radix_storage_clear() {
+        let storage: RadixStorage<TestPositionalKey, u64> = RadixStorage::new();
+
+        for pos in 0..10 {
+            storage.insert(
+                TestPositionalKey {
+                    position: pos,
+                    hash: 0,
+                },
+                pos,
+            );
+        }
+
+        assert_eq!(storage.len(), 10);
+        storage.clear();
+        assert!(storage.is_empty());
+        assert!(storage.positions().is_empty());
     }
 }

--- a/lib/llm/src/block_manager/distributed/registry/core/tests.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/tests.rs
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the registry.
+
+#[cfg(test)]
+mod integration {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use crate::block_manager::distributed::registry::core::{
+        BinaryCodec, HashMapStorage, InProcessHubTransport, InProcessTransport,
+        NoMetadata, OffloadStatus, QueryType, Registry, RegistryCodec,
+        RegistryTransport, ResponseType, Storage,
+        client, hub,
+    };
+
+    /// Full end-to-end test: Client <-> Hub using in-process transport.
+    #[tokio::test]
+    async fn test_client_hub_integration() {
+        // Create hub with storage using the builder
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+
+        let registry_hub = hub::<u64, u64, NoMetadata, _>(storage)
+            .lease_ttl(Duration::from_secs(30))
+            .build();
+
+        // Create in-process transport pair
+        let (mut hub_transport, client_handle) = InProcessHubTransport::new();
+
+        // Spawn hub server
+        let hub_task = tokio::spawn(async move {
+            for _ in 0..3 {
+                registry_hub.process_one(&mut hub_transport).await.ok();
+            }
+        });
+
+        let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+        // Test can_offload
+        let mut buf = Vec::new();
+        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf);
+        let response = client_handle.request(&buf).await.unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                assert_eq!(statuses[0], OffloadStatus::AlreadyStored);
+                assert_eq!(statuses[1], OffloadStatus::Granted);
+            }
+            _ => panic!("Wrong response"),
+        }
+
+        // Test match
+        buf.clear();
+        codec.encode_query(&QueryType::Match(vec![1, 2]), &mut buf);
+        let response = client_handle.request(&buf).await.unwrap();
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
+        match decoded {
+            ResponseType::Match(entries) => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0], (1, 100, NoMetadata));
+                assert_eq!(entries[1], (2, 200, NoMetadata));
+            }
+            _ => panic!("Wrong response"),
+        }
+
+        // One more query to complete hub_task
+        buf.clear();
+        codec.encode_query(&QueryType::CanOffload(vec![1]), &mut buf);
+        let _ = client_handle.request(&buf).await;
+
+        hub_task.await.unwrap();
+    }
+
+    /// Test with mock hub (simpler, no spawning).
+    #[tokio::test]
+    async fn test_full_registry_flow() {
+        let hub_storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        hub_storage.insert(1, 100);
+        hub_storage.insert(2, 200);
+        hub_storage.insert(3, 300);
+
+        let (transport, _rx) = InProcessTransport::new(move |data| {
+            let codec: BinaryCodec<u64, u64, NoMetadata> = BinaryCodec::new();
+
+            if let Some(query) = codec.decode_query(data) {
+                let mut buf = Vec::new();
+                match query {
+                    QueryType::CanOffload(keys) => {
+                        let statuses: Vec<_> = keys
+                            .iter()
+                            .map(|k| {
+                                if hub_storage.contains(k) {
+                                    OffloadStatus::AlreadyStored
+                                } else {
+                                    OffloadStatus::Granted
+                                }
+                            })
+                            .collect();
+                        codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf);
+                    }
+                    QueryType::Match(keys) => {
+                        let entries: Vec<_> = keys
+                            .iter()
+                            .filter_map(|k| hub_storage.get(k).map(|v| (*k, v, NoMetadata)))
+                            .collect();
+                        codec.encode_response(&ResponseType::Match(entries), &mut buf);
+                    }
+                }
+                buf
+            } else {
+                Vec::new()
+            }
+        });
+
+        // Build client using the builder
+        let registry_client = client::<u64, u64, NoMetadata, _>(transport)
+            .batch_size(100)
+            .build();
+
+        // Test can_offload
+        let result = registry_client.can_offload(&[1, 2, 5, 6]).await.unwrap();
+        assert_eq!(result.already_stored, vec![1, 2]);
+        assert_eq!(result.can_offload, vec![5, 6]);
+
+        // Test match_prefix
+        let matched = registry_client.match_prefix(&[1, 2, 3]).await.unwrap();
+        assert_eq!(matched.len(), 3);
+        assert_eq!(matched[0].1, 100);
+        assert_eq!(matched[1].1, 200);
+        assert_eq!(matched[2].1, 300);
+    }
+
+    /// Test batched registration and flush.
+    #[tokio::test]
+    async fn test_register_and_flush() {
+        use std::sync::Mutex;
+
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let received_clone = received.clone();
+
+        let (transport, mut rx) = InProcessTransport::new(move |_data| Vec::new());
+
+        let received_for_task = received_clone.clone();
+        tokio::spawn(async move {
+            while let Some(data) = rx.recv().await {
+                received_for_task.lock().unwrap().push(data);
+            }
+        });
+
+        // Build client with custom batch size using the builder
+        let registry_client = client::<u64, u64, NoMetadata, _>(transport)
+            .batch_size(10)
+            .build();
+
+        registry_client
+            .register(&[(1, 100, NoMetadata), (2, 200, NoMetadata)])
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        assert!(received.lock().unwrap().is_empty());
+
+        registry_client.flush().await.unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        assert_eq!(received.lock().unwrap().len(), 1);
+    }
+
+    /// ZMQ end-to-end test.
+    ///
+    /// Run manually: `cargo test -- --ignored test_zmq_e2e`
+    #[tokio::test]
+    #[ignore]
+    async fn test_zmq_e2e() {
+        use crate::block_manager::distributed::registry::core::{
+            ZmqHub, ZmqHubServerConfig, ZmqTransport,
+        };
+        use tokio_util::sync::CancellationToken;
+
+        let port_base = 17555;
+        let config = ZmqHubServerConfig::bind_all(port_base, port_base + 1);
+
+        // Create hub with pre-populated storage
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+
+        let hub = ZmqHub::new(config, storage, BinaryCodec::<u64, u64, NoMetadata>::new());
+        let cancel = CancellationToken::new();
+
+        // Start hub
+        let hub_cancel = cancel.clone();
+        let hub_handle = tokio::spawn(async move {
+            hub.serve(hub_cancel).await
+        });
+
+        // Wait for hub to bind
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Connect client
+        let transport = ZmqTransport::connect_to("localhost", port_base, port_base + 1)
+            .expect("Failed to connect");
+
+        // Test query directly with transport
+        let codec = BinaryCodec::<u64, u64, NoMetadata>::new();
+
+        // Test can_offload
+        let mut buf = Vec::new();
+        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf);
+        let response = transport.request(&buf).await.expect("Request failed");
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                assert_eq!(statuses[0], OffloadStatus::AlreadyStored);
+                assert_eq!(statuses[1], OffloadStatus::Granted);
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        // Test match
+        buf.clear();
+        codec.encode_query(&QueryType::Match(vec![1, 2]), &mut buf);
+        let response = transport.request(&buf).await.expect("Match request failed");
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::Match(entries) => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0], (1, 100, NoMetadata));
+                assert_eq!(entries[1], (2, 200, NoMetadata));
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        // Shutdown
+        cancel.cancel();
+        let _ = tokio::time::timeout(Duration::from_secs(1), hub_handle).await;
+    }
+}
+

--- a/lib/llm/src/block_manager/distributed/registry/core/tests.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/tests.rs
@@ -40,7 +40,7 @@ mod integration {
 
         // Test can_offload
         let mut buf = Vec::new();
-        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf);
+        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf).unwrap();
         let response = client_handle.request(&buf).await.unwrap();
         let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
         match decoded {
@@ -53,7 +53,7 @@ mod integration {
 
         // Test match
         buf.clear();
-        codec.encode_query(&QueryType::Match(vec![1, 2]), &mut buf);
+        codec.encode_query(&QueryType::Match(vec![1, 2]), &mut buf).unwrap();
         let response = client_handle.request(&buf).await.unwrap();
         let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
         match decoded {
@@ -67,7 +67,7 @@ mod integration {
 
         // One more query to complete hub_task
         buf.clear();
-        codec.encode_query(&QueryType::CanOffload(vec![1]), &mut buf);
+        codec.encode_query(&QueryType::CanOffload(vec![1]), &mut buf).unwrap();
         let _ = client_handle.request(&buf).await;
 
         hub_task.await.unwrap();
@@ -98,14 +98,14 @@ mod integration {
                                 }
                             })
                             .collect();
-                        codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf);
+                        codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf).unwrap();
                     }
                     QueryType::Match(keys) => {
                         let entries: Vec<_> = keys
                             .iter()
                             .filter_map(|k| hub_storage.get(k).map(|v| (*k, v, NoMetadata)))
                             .collect();
-                        codec.encode_response(&ResponseType::Match(entries), &mut buf);
+                        codec.encode_response(&ResponseType::Match(entries), &mut buf).unwrap();
                     }
                 }
                 buf
@@ -206,7 +206,7 @@ mod integration {
 
         // Test can_offload
         let mut buf = Vec::new();
-        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf);
+        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf).unwrap();
         let response = transport.request(&buf).await.expect("Request failed");
         let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
 
@@ -220,7 +220,7 @@ mod integration {
 
         // Test match
         buf.clear();
-        codec.encode_query(&QueryType::Match(vec![1, 2]), &mut buf);
+        codec.encode_query(&QueryType::Match(vec![1, 2]), &mut buf).unwrap();
         let response = transport.request(&buf).await.expect("Match request failed");
         let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
 

--- a/lib/llm/src/block_manager/distributed/registry/core/tests.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/tests.rs
@@ -40,7 +40,9 @@ mod integration {
 
         // Test can_offload
         let mut buf = Vec::new();
-        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf).unwrap();
+        codec
+            .encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf)
+            .unwrap();
         let response = client_handle.request(&buf).await.unwrap();
         let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
         match decoded {
@@ -53,7 +55,9 @@ mod integration {
 
         // Test match
         buf.clear();
-        codec.encode_query(&QueryType::Match(vec![1, 2]), &mut buf).unwrap();
+        codec
+            .encode_query(&QueryType::Match(vec![1, 2]), &mut buf)
+            .unwrap();
         let response = client_handle.request(&buf).await.unwrap();
         let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
         match decoded {
@@ -67,7 +71,9 @@ mod integration {
 
         // One more query to complete hub_task
         buf.clear();
-        codec.encode_query(&QueryType::CanOffload(vec![1]), &mut buf).unwrap();
+        codec
+            .encode_query(&QueryType::CanOffload(vec![1]), &mut buf)
+            .unwrap();
         let _ = client_handle.request(&buf).await;
 
         hub_task.await.unwrap();
@@ -98,14 +104,18 @@ mod integration {
                                 }
                             })
                             .collect();
-                        codec.encode_response(&ResponseType::CanOffload(statuses), &mut buf).unwrap();
+                        codec
+                            .encode_response(&ResponseType::CanOffload(statuses), &mut buf)
+                            .unwrap();
                     }
                     QueryType::Match(keys) => {
                         let entries: Vec<_> = keys
                             .iter()
                             .filter_map(|k| hub_storage.get(k).map(|v| (*k, v, NoMetadata)))
                             .collect();
-                        codec.encode_response(&ResponseType::Match(entries), &mut buf).unwrap();
+                        codec
+                            .encode_response(&ResponseType::Match(entries), &mut buf)
+                            .unwrap();
                     }
                 }
                 buf
@@ -206,7 +216,9 @@ mod integration {
 
         // Test can_offload
         let mut buf = Vec::new();
-        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf).unwrap();
+        codec
+            .encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf)
+            .unwrap();
         let response = transport.request(&buf).await.expect("Request failed");
         let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
 
@@ -220,7 +232,9 @@ mod integration {
 
         // Test match
         buf.clear();
-        codec.encode_query(&QueryType::Match(vec![1, 2]), &mut buf).unwrap();
+        codec
+            .encode_query(&QueryType::Match(vec![1, 2]), &mut buf)
+            .unwrap();
         let response = transport.request(&buf).await.expect("Match request failed");
         let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
 

--- a/lib/llm/src/block_manager/distributed/registry/core/tests.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/tests.rs
@@ -9,10 +9,9 @@ mod integration {
     use std::time::Duration;
 
     use crate::block_manager::distributed::registry::core::{
-        BinaryCodec, HashMapStorage, InProcessHubTransport, InProcessTransport,
-        NoMetadata, OffloadStatus, QueryType, Registry, RegistryCodec,
-        RegistryTransport, ResponseType, Storage,
-        client, hub,
+        BinaryCodec, HashMapStorage, InProcessHubTransport, InProcessTransport, NoMetadata,
+        OffloadStatus, QueryType, Registry, RegistryCodec, RegistryTransport, ResponseType,
+        Storage, client, hub,
     };
 
     /// Full end-to-end test: Client <-> Hub using in-process transport.
@@ -193,9 +192,7 @@ mod integration {
 
         // Start hub
         let hub_cancel = cancel.clone();
-        let hub_handle = tokio::spawn(async move {
-            hub.serve(hub_cancel).await
-        });
+        let hub_handle = tokio::spawn(async move { hub.serve(hub_cancel).await });
 
         // Wait for hub to bind
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -241,4 +238,3 @@ mod integration {
         let _ = tokio::time::timeout(Duration::from_secs(1), hub_handle).await;
     }
 }
-

--- a/lib/llm/src/block_manager/distributed/registry/core/transport.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/transport.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transport trait and implementations.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+
+#[async_trait]
+pub trait RegistryTransport: Send + Sync {
+    async fn request(&self, data: &[u8]) -> Result<Vec<u8>>;
+    async fn publish(&self, data: &[u8]) -> Result<()>;
+    fn name(&self) -> &'static str;
+}
+
+/// In-process transport for testing.
+pub struct InProcessTransport {
+    handler: Arc<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>,
+    publish_tx: mpsc::UnboundedSender<Vec<u8>>,
+}
+
+impl InProcessTransport {
+    pub fn new<F>(handler: F) -> (Self, mpsc::UnboundedReceiver<Vec<u8>>)
+    where
+        F: Fn(&[u8]) -> Vec<u8> + Send + Sync + 'static,
+    {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                handler: Arc::new(handler),
+                publish_tx: tx,
+            },
+            rx,
+        )
+    }
+
+    pub fn pair() -> (Self, InProcessHub) {
+        let hub = InProcessHub::new();
+        let hub_clone = hub.clone();
+        let (transport, rx) = Self::new(move |data| hub_clone.handle(data));
+
+        let hub_for_publish = hub.clone();
+        tokio::spawn(async move {
+            let mut rx = rx;
+            while let Some(data) = rx.recv().await {
+                hub_for_publish.handle(&data);
+            }
+        });
+
+        (transport, hub)
+    }
+}
+
+#[async_trait]
+impl RegistryTransport for InProcessTransport {
+    async fn request(&self, data: &[u8]) -> Result<Vec<u8>> {
+        Ok((self.handler)(data))
+    }
+
+    async fn publish(&self, data: &[u8]) -> Result<()> {
+        self.publish_tx.send(data.to_vec())?;
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "in_process"
+    }
+}
+
+/// In-process hub for testing.
+#[derive(Clone)]
+pub struct InProcessHub {
+    request_handler: Arc<Mutex<Option<Box<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>>>>,
+}
+
+impl InProcessHub {
+    pub fn new() -> Self {
+        Self {
+            request_handler: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn set_handler<F>(&self, handler: F)
+    where
+        F: Fn(&[u8]) -> Vec<u8> + Send + Sync + 'static,
+    {
+        *self.request_handler.lock() = Some(Box::new(handler));
+    }
+
+    pub fn handle(&self, data: &[u8]) -> Vec<u8> {
+        if let Some(handler) = self.request_handler.lock().as_ref() {
+            handler(data)
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+impl Default for InProcessHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_in_process_transport() {
+        let (transport, _rx) = InProcessTransport::new(|data| {
+            let mut response = data.to_vec();
+            response.reverse();
+            response
+        });
+
+        let result = transport.request(b"hello").await.unwrap();
+        assert_eq!(result, b"olleh");
+    }
+
+    #[tokio::test]
+    async fn test_in_process_publish() {
+        let (transport, mut rx) = InProcessTransport::new(|_| Vec::new());
+
+        transport.publish(b"test message").await.unwrap();
+
+        let received = rx.recv().await.unwrap();
+        assert_eq!(received, b"test message");
+    }
+}

--- a/lib/llm/src/block_manager/distributed/registry/core/transport.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/transport.rs
@@ -17,9 +17,12 @@ pub trait RegistryTransport: Send + Sync {
     fn name(&self) -> &'static str;
 }
 
+/// Handler function type for in-process transport.
+type RequestHandler = Arc<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>;
+
 /// In-process transport for testing.
 pub struct InProcessTransport {
-    handler: Arc<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>,
+    handler: RequestHandler,
     publish_tx: mpsc::UnboundedSender<Vec<u8>>,
 }
 
@@ -71,10 +74,13 @@ impl RegistryTransport for InProcessTransport {
     }
 }
 
+/// Handler option type for in-process hub.
+type HubHandler = Option<Box<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>>;
+
 /// In-process hub for testing.
 #[derive(Clone)]
 pub struct InProcessHub {
-    request_handler: Arc<Mutex<Option<Box<dyn Fn(&[u8]) -> Vec<u8> + Send + Sync>>>>,
+    request_handler: Arc<Mutex<HubHandler>>,
 }
 
 impl InProcessHub {

--- a/lib/llm/src/block_manager/distributed/registry/core/value.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/value.rs
@@ -107,4 +107,3 @@ mod tests {
         assert_eq!(decoded.size_bytes, loc.size_bytes);
     }
 }
-

--- a/lib/llm/src/block_manager/distributed/registry/core/value.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/value.rs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Registry value types and traits.
+
+use std::fmt::Debug;
+
+pub trait RegistryValue: Clone + Debug + Send + Sync + 'static {
+    fn to_bytes(&self) -> Vec<u8>;
+    fn from_bytes(bytes: &[u8]) -> Option<Self>;
+}
+
+impl RegistryValue for u64 {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_le_bytes().to_vec()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        bytes.try_into().ok().map(u64::from_le_bytes)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum StorageBackend {
+    S3 = 0,
+    Gcs = 1,
+    Azure = 2,
+    Local = 3,
+    Rdma = 4,
+}
+
+impl TryFrom<u8> for StorageBackend {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::S3),
+            1 => Ok(Self::Gcs),
+            2 => Ok(Self::Azure),
+            3 => Ok(Self::Local),
+            4 => Ok(Self::Rdma),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct StorageLocation {
+    pub backend: StorageBackend,
+    pub path: String,
+    pub size_bytes: u64,
+}
+
+impl RegistryValue for StorageLocation {
+    fn to_bytes(&self) -> Vec<u8> {
+        let path_bytes = self.path.as_bytes();
+        let mut buf = Vec::with_capacity(1 + 2 + path_bytes.len() + 8);
+        buf.push(self.backend as u8);
+        buf.extend_from_slice(&(path_bytes.len() as u16).to_le_bytes());
+        buf.extend_from_slice(path_bytes);
+        buf.extend_from_slice(&self.size_bytes.to_le_bytes());
+        buf
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 11 {
+            return None;
+        }
+        let backend = StorageBackend::try_from(bytes[0]).ok()?;
+        let path_len = u16::from_le_bytes(bytes[1..3].try_into().ok()?) as usize;
+        if bytes.len() < 3 + path_len + 8 {
+            return None;
+        }
+        let path = String::from_utf8(bytes[3..3 + path_len].to_vec()).ok()?;
+        let size_bytes = u64::from_le_bytes(bytes[3 + path_len..3 + path_len + 8].try_into().ok()?);
+        Some(Self {
+            backend,
+            path,
+            size_bytes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_u64_roundtrip() {
+        let val: u64 = 0x123456789ABCDEF0;
+        let bytes = val.to_bytes();
+        assert_eq!(u64::from_bytes(&bytes), Some(val));
+    }
+
+    #[test]
+    fn test_storage_location_roundtrip() {
+        let loc = StorageLocation {
+            backend: StorageBackend::S3,
+            path: "bucket/key/object.bin".to_string(),
+            size_bytes: 1024 * 1024,
+        };
+        let bytes = loc.to_bytes();
+        let decoded = StorageLocation::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.backend, loc.backend);
+        assert_eq!(decoded.path, loc.path);
+        assert_eq!(decoded.size_bytes, loc.size_bytes);
+    }
+}
+

--- a/lib/llm/src/block_manager/distributed/registry/core/value.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/value.rs
@@ -23,11 +23,8 @@ impl RegistryValue for u64 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum StorageBackend {
-    S3 = 0,
-    Gcs = 1,
-    Azure = 2,
-    Local = 3,
-    Rdma = 4,
+    Object = 0,
+    Disk = 1,
 }
 
 impl TryFrom<u8> for StorageBackend {
@@ -35,11 +32,8 @@ impl TryFrom<u8> for StorageBackend {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(Self::S3),
-            1 => Ok(Self::Gcs),
-            2 => Ok(Self::Azure),
-            3 => Ok(Self::Local),
-            4 => Ok(Self::Rdma),
+            0 => Ok(Self::Object),
+            1 => Ok(Self::Disk),
             _ => Err(()),
         }
     }
@@ -96,7 +90,7 @@ mod tests {
     #[test]
     fn test_storage_location_roundtrip() {
         let loc = StorageLocation {
-            backend: StorageBackend::S3,
+            backend: StorageBackend::Object,
             path: "bucket/key/object.bin".to_string(),
             size_bytes: 1024 * 1024,
         };

--- a/lib/llm/src/block_manager/distributed/registry/core/zmq_hub.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/zmq_hub.rs
@@ -1,0 +1,400 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! ZMQ-based registry hub with proper async handling.
+//!
+//! Uses separate tasks for queries and registrations to avoid
+//! issues with tokio::select! and ZMQ streams.
+
+use std::collections::VecDeque;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use futures_util::{SinkExt, StreamExt};
+use tmq::{pull, router, Context, Message, Multipart};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+
+use super::codec::{OffloadStatus, QueryType, RegistryCodec, ResponseType};
+use super::key::RegistryKey;
+use super::metadata::RegistryMetadata;
+use super::storage::Storage;
+use super::value::RegistryValue;
+
+/// Configuration for ZMQ hub.
+#[derive(Clone, Debug)]
+pub struct ZmqHubConfig {
+    pub query_addr: String,
+    pub pull_addr: String,
+    pub capacity: u64,
+}
+
+impl ZmqHubConfig {
+    pub fn new(query_addr: impl Into<String>, pull_addr: impl Into<String>) -> Self {
+        Self {
+            query_addr: query_addr.into(),
+            pull_addr: pull_addr.into(),
+            capacity: 100_000,
+        }
+    }
+
+    pub fn with_ports(host: &str, query_port: u16, pull_port: u16) -> Self {
+        Self::new(
+            format!("tcp://{}:{}", host, query_port),
+            format!("tcp://{}:{}", host, pull_port),
+        )
+    }
+
+    pub fn bind_all(query_port: u16, pull_port: u16) -> Self {
+        Self::with_ports("*", query_port, pull_port)
+    }
+}
+
+impl Default for ZmqHubConfig {
+    fn default() -> Self {
+        Self::bind_all(5555, 5556)
+    }
+}
+
+/// ZMQ-based registry hub.
+pub struct ZmqHub<K, V, M, S, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V> + Send + Sync + 'static,
+    C: RegistryCodec<K, V, M> + Send + Sync + 'static,
+{
+    config: ZmqHubConfig,
+    storage: Arc<S>,
+    codec: Arc<C>,
+    _phantom: PhantomData<(K, V, M)>,
+}
+
+impl<K, V, M, S, C> ZmqHub<K, V, M, S, C>
+where
+    K: RegistryKey,
+    V: RegistryValue,
+    M: RegistryMetadata,
+    S: Storage<K, V> + Send + Sync + 'static,
+    C: RegistryCodec<K, V, M> + Send + Sync + 'static,
+{
+    pub fn new(config: ZmqHubConfig, storage: S, codec: C) -> Self {
+        Self {
+            config,
+            storage: Arc::new(storage),
+            codec: Arc::new(codec),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Get reference to storage for seeding data.
+    pub fn storage(&self) -> &S {
+        &self.storage
+    }
+
+    /// Run the hub until cancelled.
+    pub async fn serve(&self, cancel: CancellationToken) -> Result<()> {
+        info!(
+            query_addr = %self.config.query_addr,
+            pull_addr = %self.config.pull_addr,
+            "ZMQ hub starting"
+        );
+
+        // Spawn query handler
+        let query_cancel = cancel.clone();
+        let query_storage = self.storage.clone();
+        let query_codec = self.codec.clone();
+        let query_addr = self.config.query_addr.clone();
+
+        let query_handle = tokio::spawn(async move {
+            Self::run_query_handler(query_storage, query_codec, query_addr, query_cancel).await
+        });
+
+        // Spawn registration handler
+        let pull_cancel = cancel.clone();
+        let pull_storage = self.storage.clone();
+        let pull_codec = self.codec.clone();
+        let pull_addr = self.config.pull_addr.clone();
+
+        let pull_handle = tokio::spawn(async move {
+            Self::run_pull_handler(pull_storage, pull_codec, pull_addr, pull_cancel).await
+        });
+
+        // Wait for either to finish or cancellation
+        tokio::select! {
+            result = query_handle => {
+                if let Err(e) = result {
+                    error!(error = %e, "Query handler panicked");
+                }
+            }
+            result = pull_handle => {
+                if let Err(e) = result {
+                    error!(error = %e, "Pull handler panicked");
+                }
+            }
+            _ = cancel.cancelled() => {
+                info!("Hub received shutdown signal");
+            }
+        }
+
+        info!(entries = self.storage.len(), "ZMQ hub stopped");
+        Ok(())
+    }
+
+    /// Run the query handler (ROUTER socket).
+    async fn run_query_handler(
+        storage: Arc<S>,
+        codec: Arc<C>,
+        addr: String,
+        cancel: CancellationToken,
+    ) -> Result<()> {
+        let context = Context::new();
+        let router = router::router(&context)
+            .bind(&addr)
+            .map_err(|e| anyhow!("Failed to bind ROUTER to {}: {}", addr, e))?;
+
+        let (mut send_half, mut recv_half) = router.split();
+
+        info!(addr = %addr, "Query handler started (ROUTER)");
+
+        // Response channel for pipelining
+        let (tx, mut rx) = mpsc::channel::<(Vec<u8>, Vec<u8>)>(1024);
+
+        // Sender task
+        let send_cancel = cancel.clone();
+        let sender_handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = send_cancel.cancelled() => break,
+                    Some((identity, response)) = rx.recv() => {
+                        let mut frames = VecDeque::new();
+                        frames.push_back(Message::from(identity));
+                        frames.push_back(Message::from(response));
+
+                        if let Err(e) = send_half.send(Multipart(frames)).await {
+                            error!(error = %e, "Failed to send response");
+                        }
+                    }
+                    else => break,
+                }
+            }
+        });
+
+        // Receive loop
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    debug!("Query handler shutting down");
+                    break;
+                }
+                result = recv_half.next() => {
+                    match result {
+                        Some(Ok(msg)) => {
+                            let frames: Vec<_> = msg.iter().collect();
+                            if frames.len() < 2 {
+                                warn!(frames = frames.len(), "Invalid ROUTER message");
+                                continue;
+                            }
+
+                            let identity = frames[0].to_vec();
+                            let data = frames[frames.len() - 1].to_vec();
+
+                            let response = Self::handle_query(&storage, &codec, &data);
+
+                            if tx.send((identity, response)).await.is_err() {
+                                error!("Response channel closed");
+                                break;
+                            }
+                        }
+                        Some(Err(e)) => {
+                            error!(error = %e, "ROUTER receive error");
+                        }
+                        None => {
+                            warn!("ROUTER socket closed");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        drop(tx);
+        let _ = sender_handle.await;
+        Ok(())
+    }
+
+    /// Run the registration handler (PULL socket).
+    async fn run_pull_handler(
+        storage: Arc<S>,
+        codec: Arc<C>,
+        addr: String,
+        cancel: CancellationToken,
+    ) -> Result<()> {
+        let context = Context::new();
+        let mut puller = pull::pull(&context)
+            .bind(&addr)
+            .map_err(|e| anyhow!("Failed to bind PULL to {}: {}", addr, e))?;
+
+        info!(addr = %addr, "Pull handler started (PULL)");
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    debug!("Pull handler shutting down");
+                    break;
+                }
+                result = puller.next() => {
+                    match result {
+                        Some(Ok(msg)) => {
+                            for frame in msg.iter() {
+                                Self::handle_registration(&storage, &codec, frame.as_ref());
+                            }
+                        }
+                        Some(Err(e)) => {
+                            error!(error = %e, "PULL receive error");
+                        }
+                        None => {
+                            warn!("PULL socket closed");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handle a query and return response bytes.
+    fn handle_query(storage: &S, codec: &C, data: &[u8]) -> Vec<u8> {
+        let mut response = Vec::new();
+
+        let Some(query) = codec.decode_query(data) else {
+            warn!("Failed to decode query");
+            return response;
+        };
+
+        match query {
+            QueryType::CanOffload(keys) => {
+                let statuses: Vec<_> = keys
+                    .iter()
+                    .map(|k| {
+                        if storage.contains(k) {
+                            OffloadStatus::AlreadyStored
+                        } else {
+                            OffloadStatus::Granted
+                        }
+                    })
+                    .collect();
+
+                debug!(
+                    keys = keys.len(),
+                    granted = statuses.iter().filter(|s| **s == OffloadStatus::Granted).count(),
+                    "can_offload query"
+                );
+
+                codec.encode_response(&ResponseType::CanOffload(statuses), &mut response);
+            }
+            QueryType::Match(keys) => {
+                let entries: Vec<_> = keys
+                    .iter()
+                    .filter_map(|k| storage.get(k).map(|v| (*k, v, M::default())))
+                    .collect();
+
+                debug!(
+                    requested = keys.len(),
+                    matched = entries.len(),
+                    "match query"
+                );
+
+                codec.encode_response(&ResponseType::Match(entries), &mut response);
+            }
+        }
+
+        response
+    }
+
+    /// Handle a registration message.
+    fn handle_registration(storage: &S, codec: &C, data: &[u8]) {
+        let Some(entries) = codec.decode_register(data) else {
+            warn!("Failed to decode registration");
+            return;
+        };
+
+        let count = entries.len();
+        for (key, value, _metadata) in entries {
+            storage.insert(key, value);
+        }
+
+        debug!(count, total = storage.len(), "registration processed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_manager::distributed::registry::core::{
+        BinaryCodec, HashMapStorage, NoMetadata,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn test_config_builder() {
+        let config = ZmqHubConfig::bind_all(6000, 6001);
+        assert_eq!(config.query_addr, "tcp://*:6000");
+        assert_eq!(config.pull_addr, "tcp://*:6001");
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires ZMQ, run with: cargo test -- --ignored
+    async fn test_zmq_hub_e2e() {
+        use crate::block_manager::distributed::registry::core::{RegistryTransport, ZmqTransport};
+
+        let port_base = 16555;
+        let config = ZmqHubConfig::bind_all(port_base, port_base + 1);
+
+        let storage: HashMapStorage<u64, u64> = HashMapStorage::new();
+        storage.insert(1, 100);
+        storage.insert(2, 200);
+
+        let hub = ZmqHub::new(config, storage, BinaryCodec::<u64, u64, NoMetadata>::new());
+        let cancel = CancellationToken::new();
+
+        // Start hub
+        let hub_cancel = cancel.clone();
+        let hub_handle = tokio::spawn(async move {
+            hub.serve(hub_cancel).await
+        });
+
+        // Wait for hub to bind
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Connect client
+        let transport = ZmqTransport::connect_to("localhost", port_base, port_base + 1)
+            .expect("Failed to connect");
+
+        // Test query
+        let codec = BinaryCodec::<u64, u64, NoMetadata>::new();
+        let mut buf = Vec::new();
+        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf);
+
+        let response = transport.request(&buf).await.expect("Request failed");
+        let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();
+
+        match decoded {
+            ResponseType::CanOffload(statuses) => {
+                assert_eq!(statuses[0], OffloadStatus::AlreadyStored);
+                assert_eq!(statuses[1], OffloadStatus::Granted);
+            }
+            _ => panic!("Wrong response type"),
+        }
+
+        // Shutdown
+        cancel.cancel();
+        let _ = tokio::time::timeout(Duration::from_secs(1), hub_handle).await;
+    }
+}
+

--- a/lib/llm/src/block_manager/distributed/registry/core/zmq_hub.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/zmq_hub.rs
@@ -299,7 +299,9 @@ where
                     "can_offload query"
                 );
 
-                if let Err(e) = codec.encode_response(&ResponseType::CanOffload(statuses), &mut response) {
+                if let Err(e) =
+                    codec.encode_response(&ResponseType::CanOffload(statuses), &mut response)
+                {
                     warn!("Failed to encode response: {}", e);
                 }
             }
@@ -315,7 +317,8 @@ where
                     "match query"
                 );
 
-                if let Err(e) = codec.encode_response(&ResponseType::Match(entries), &mut response) {
+                if let Err(e) = codec.encode_response(&ResponseType::Match(entries), &mut response)
+                {
                     warn!("Failed to encode response: {}", e);
                 }
             }
@@ -384,7 +387,9 @@ mod tests {
         // Test query
         let codec = BinaryCodec::<u64, u64, NoMetadata>::new();
         let mut buf = Vec::new();
-        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf).unwrap();
+        codec
+            .encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf)
+            .unwrap();
 
         let response = transport.request(&buf).await.expect("Request failed");
         let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();

--- a/lib/llm/src/block_manager/distributed/registry/core/zmq_hub.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/zmq_hub.rs
@@ -299,7 +299,9 @@ where
                     "can_offload query"
                 );
 
-                codec.encode_response(&ResponseType::CanOffload(statuses), &mut response);
+                if let Err(e) = codec.encode_response(&ResponseType::CanOffload(statuses), &mut response) {
+                    warn!("Failed to encode response: {}", e);
+                }
             }
             QueryType::Match(keys) => {
                 let entries: Vec<_> = keys
@@ -313,7 +315,9 @@ where
                     "match query"
                 );
 
-                codec.encode_response(&ResponseType::Match(entries), &mut response);
+                if let Err(e) = codec.encode_response(&ResponseType::Match(entries), &mut response) {
+                    warn!("Failed to encode response: {}", e);
+                }
             }
         }
 
@@ -380,7 +384,7 @@ mod tests {
         // Test query
         let codec = BinaryCodec::<u64, u64, NoMetadata>::new();
         let mut buf = Vec::new();
-        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf);
+        codec.encode_query(&QueryType::CanOffload(vec![1, 3]), &mut buf).unwrap();
 
         let response = transport.request(&buf).await.expect("Request failed");
         let decoded: ResponseType<u64, u64, NoMetadata> = codec.decode_response(&response).unwrap();

--- a/lib/llm/src/block_manager/distributed/registry/core/zmq_hub.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/zmq_hub.rs
@@ -10,9 +10,9 @@ use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use futures_util::{SinkExt, StreamExt};
-use tmq::{pull, router, Context, Message, Multipart};
+use tmq::{Context, Message, Multipart, pull, router};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -292,7 +292,10 @@ where
 
                 debug!(
                     keys = keys.len(),
-                    granted = statuses.iter().filter(|s| **s == OffloadStatus::Granted).count(),
+                    granted = statuses
+                        .iter()
+                        .filter(|s| **s == OffloadStatus::Granted)
+                        .count(),
                     "can_offload query"
                 );
 
@@ -365,9 +368,7 @@ mod tests {
 
         // Start hub
         let hub_cancel = cancel.clone();
-        let hub_handle = tokio::spawn(async move {
-            hub.serve(hub_cancel).await
-        });
+        let hub_handle = tokio::spawn(async move { hub.serve(hub_cancel).await });
 
         // Wait for hub to bind
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -397,4 +398,3 @@ mod tests {
         let _ = tokio::time::timeout(Duration::from_secs(1), hub_handle).await;
     }
 }
-

--- a/lib/llm/src/block_manager/distributed/registry/core/zmq_transport.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/zmq_transport.rs
@@ -1,0 +1,239 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! ZMQ transport implementation.
+//!
+//! Uses DEALER/ROUTER for queries and PUSH/PULL for registrations.
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use tmq::{dealer, push, Context, Message, Multipart};
+use tokio::sync::Mutex;
+
+use super::transport::RegistryTransport;
+
+/// Default high-water mark for ZMQ sockets.
+///
+/// This limits the number of messages that can be queued before
+/// sends start blocking or dropping messages.
+pub const DEFAULT_HWM: i32 = 10_000;
+
+/// Configuration for ZMQ transport.
+#[derive(Clone, Debug)]
+pub struct ZmqTransportConfig {
+    pub query_addr: String,
+    pub publish_addr: String,
+    pub request_timeout: Duration,
+    /// High-water mark for the DEALER (query) socket.
+    /// Limits queued outbound queries.
+    pub dealer_hwm: i32,
+    /// High-water mark for the PUSH (publish) socket.
+    /// Limits queued registrations - prevents unbounded memory growth.
+    pub push_hwm: i32,
+}
+
+impl ZmqTransportConfig {
+    pub fn new(query_addr: impl Into<String>, publish_addr: impl Into<String>) -> Self {
+        Self {
+            query_addr: query_addr.into(),
+            publish_addr: publish_addr.into(),
+            request_timeout: Duration::from_secs(5),
+            dealer_hwm: DEFAULT_HWM,
+            push_hwm: DEFAULT_HWM,
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
+    /// Set high-water marks for both sockets.
+    ///
+    /// Lower values reduce memory usage but may drop messages under load.
+    /// Higher values buffer more but use more memory.
+    pub fn with_hwm(mut self, hwm: i32) -> Self {
+        self.dealer_hwm = hwm;
+        self.push_hwm = hwm;
+        self
+    }
+
+    /// Set high-water mark for the DEALER (query) socket.
+    pub fn with_dealer_hwm(mut self, hwm: i32) -> Self {
+        self.dealer_hwm = hwm;
+        self
+    }
+
+    /// Set high-water mark for the PUSH (registration) socket.
+    pub fn with_push_hwm(mut self, hwm: i32) -> Self {
+        self.push_hwm = hwm;
+        self
+    }
+}
+
+impl Default for ZmqTransportConfig {
+    fn default() -> Self {
+        Self {
+            query_addr: "tcp://localhost:5555".to_string(),
+            publish_addr: "tcp://localhost:5556".to_string(),
+            request_timeout: Duration::from_secs(5),
+            dealer_hwm: DEFAULT_HWM,
+            push_hwm: DEFAULT_HWM,
+        }
+    }
+}
+
+/// ZMQ-based transport for distributed registry.
+///
+/// Uses two sockets:
+/// - DEALER for request/response queries
+/// - PUSH for fire-and-forget registrations
+///
+/// Both sockets have configurable high-water marks to prevent
+/// unbounded memory growth under load.
+pub struct ZmqTransport {
+    config: ZmqTransportConfig,
+    dealer: Mutex<dealer::Dealer>,
+    pusher: Mutex<push::Push>,
+}
+
+impl ZmqTransport {
+    /// Connect to a registry hub.
+    pub fn connect(config: ZmqTransportConfig) -> Result<Self> {
+        let context = Context::new();
+
+        // Create DEALER socket with HWM
+        let dealer = dealer::dealer(&context)
+            .set_sndhwm(config.dealer_hwm)
+            .set_rcvhwm(config.dealer_hwm)
+            .connect(&config.query_addr)
+            .map_err(|e| anyhow!("Failed to connect DEALER to {}: {}", config.query_addr, e))?;
+
+        // Create PUSH socket with HWM
+        let pusher = push::push(&context)
+            .set_sndhwm(config.push_hwm)
+            .connect(&config.publish_addr)
+            .map_err(|e| anyhow!("Failed to connect PUSH to {}: {}", config.publish_addr, e))?;
+
+        tracing::debug!(
+            query_addr = %config.query_addr,
+            push_addr = %config.publish_addr,
+            dealer_hwm = config.dealer_hwm,
+            push_hwm = config.push_hwm,
+            "ZMQ transport connected"
+        );
+
+        Ok(Self {
+            config,
+            dealer: Mutex::new(dealer),
+            pusher: Mutex::new(pusher),
+        })
+    }
+
+    /// Connect with default configuration.
+    pub fn connect_default() -> Result<Self> {
+        Self::connect(ZmqTransportConfig::default())
+    }
+
+    /// Connect to specific host and ports.
+    pub fn connect_to(host: &str, query_port: u16, publish_port: u16) -> Result<Self> {
+        let config = ZmqTransportConfig::new(
+            format!("tcp://{}:{}", host, query_port),
+            format!("tcp://{}:{}", host, publish_port),
+        );
+        Self::connect(config)
+    }
+
+    /// Connect to specific host and ports with custom HWM.
+    pub fn connect_to_with_hwm(host: &str, query_port: u16, publish_port: u16, hwm: i32) -> Result<Self> {
+        let config = ZmqTransportConfig::new(
+            format!("tcp://{}:{}", host, query_port),
+            format!("tcp://{}:{}", host, publish_port),
+        ).with_hwm(hwm);
+        Self::connect(config)
+    }
+}
+
+#[async_trait]
+impl RegistryTransport for ZmqTransport {
+    async fn request(&self, data: &[u8]) -> Result<Vec<u8>> {
+        let mut socket = self.dealer.lock().await;
+
+        let mut msg = VecDeque::new();
+        msg.push_back(Message::from(data.to_vec()));
+        socket.send(Multipart(msg)).await
+            .map_err(|e| anyhow!("Failed to send request: {}", e))?;
+
+        let response = tokio::time::timeout(self.config.request_timeout, async {
+            match socket.next().await {
+                Some(Ok(msg)) => {
+                    let frames: Vec<_> = msg.iter().collect();
+                    if frames.is_empty() {
+                        return Err(anyhow!("Empty response"));
+                    }
+                    Ok(frames[0].to_vec())
+                }
+                Some(Err(e)) => Err(anyhow!("Receive error: {}", e)),
+                None => Err(anyhow!("Socket closed")),
+            }
+        })
+        .await
+        .map_err(|_| anyhow!("Request timed out after {:?}", self.config.request_timeout))??;
+
+        Ok(response)
+    }
+
+    async fn publish(&self, data: &[u8]) -> Result<()> {
+        let mut socket = self.pusher.lock().await;
+
+        let mut msg = VecDeque::new();
+        msg.push_back(Message::from(data.to_vec()));
+        socket.send(Multipart(msg)).await
+            .map_err(|e| anyhow!("Failed to push: {}", e))?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "zmq"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_builder() {
+        let config = ZmqTransportConfig::new("tcp://host:1234", "tcp://host:5678")
+            .with_timeout(Duration::from_secs(10))
+            .with_hwm(5000);
+
+        assert_eq!(config.query_addr, "tcp://host:1234");
+        assert_eq!(config.publish_addr, "tcp://host:5678");
+        assert_eq!(config.request_timeout, Duration::from_secs(10));
+        assert_eq!(config.dealer_hwm, 5000);
+        assert_eq!(config.push_hwm, 5000);
+    }
+
+    #[test]
+    fn test_separate_hwm() {
+        let config = ZmqTransportConfig::new("tcp://host:1234", "tcp://host:5678")
+            .with_dealer_hwm(1000)
+            .with_push_hwm(2000);
+
+        assert_eq!(config.dealer_hwm, 1000);
+        assert_eq!(config.push_hwm, 2000);
+    }
+
+    #[test]
+    fn test_default_hwm() {
+        let config = ZmqTransportConfig::default();
+        assert_eq!(config.dealer_hwm, DEFAULT_HWM);
+        assert_eq!(config.push_hwm, DEFAULT_HWM);
+    }
+}

--- a/lib/llm/src/block_manager/distributed/registry/core/zmq_transport.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/zmq_transport.rs
@@ -8,10 +8,10 @@
 use std::collections::VecDeque;
 use std::time::Duration;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
-use tmq::{dealer, push, Context, Message, Multipart};
+use tmq::{Context, Message, Multipart, dealer, push};
 use tokio::sync::Mutex;
 
 use super::transport::RegistryTransport;
@@ -149,11 +149,17 @@ impl ZmqTransport {
     }
 
     /// Connect to specific host and ports with custom HWM.
-    pub fn connect_to_with_hwm(host: &str, query_port: u16, publish_port: u16, hwm: i32) -> Result<Self> {
+    pub fn connect_to_with_hwm(
+        host: &str,
+        query_port: u16,
+        publish_port: u16,
+        hwm: i32,
+    ) -> Result<Self> {
         let config = ZmqTransportConfig::new(
             format!("tcp://{}:{}", host, query_port),
             format!("tcp://{}:{}", host, publish_port),
-        ).with_hwm(hwm);
+        )
+        .with_hwm(hwm);
         Self::connect(config)
     }
 }
@@ -165,7 +171,9 @@ impl RegistryTransport for ZmqTransport {
 
         let mut msg = VecDeque::new();
         msg.push_back(Message::from(data.to_vec()));
-        socket.send(Multipart(msg)).await
+        socket
+            .send(Multipart(msg))
+            .await
             .map_err(|e| anyhow!("Failed to send request: {}", e))?;
 
         let response = tokio::time::timeout(self.config.request_timeout, async {
@@ -192,7 +200,9 @@ impl RegistryTransport for ZmqTransport {
 
         let mut msg = VecDeque::new();
         msg.push_back(Message::from(data.to_vec()));
-        socket.send(Multipart(msg)).await
+        socket
+            .send(Multipart(msg))
+            .await
             .map_err(|e| anyhow!("Failed to push: {}", e))?;
 
         Ok(())

--- a/lib/llm/src/block_manager/distributed/registry/core/zmq_transport.rs
+++ b/lib/llm/src/block_manager/distributed/registry/core/zmq_transport.rs
@@ -183,7 +183,8 @@ impl RegistryTransport for ZmqTransport {
                     if frames.is_empty() {
                         return Err(anyhow!("Empty response"));
                     }
-                    Ok(frames[0].to_vec())
+                    // Use the last frame as the data frame (DEALER socket may have identity frames first)
+                    Ok(frames[frames.len() - 1].to_vec())
                 }
                 Some(Err(e)) => Err(anyhow!("Receive error: {}", e)),
                 None => Err(anyhow!("Socket closed")),

--- a/lib/llm/src/block_manager/distributed/registry/mod.rs
+++ b/lib/llm/src/block_manager/distributed/registry/mod.rs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Distributed registry for KV cache block deduplication.
+//!
+//! Provides a pluggable architecture for tracking KV blocks across workers.
+
+pub mod config;
+pub mod core;
+
+pub use config::{RegistryClientConfig, RegistryHubConfig};
+pub use core::*;


### PR DESCRIPTION
#### Overview:

When multiple instances/workers write to shared storage (S3, GCS, filesystem), they risk storing duplicate blocks. The registry solves this by providing a centralized catalog that tracks what's already stored, enabling cross-worker deduplication and distributed sharing of blocks via G4 access.

#### Where should the reviewer start?

README.md

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: #4887


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full distributed registry: client + hub with lease-based ownership, deduplication, builders, configurable hub/client, eviction policies (tail/positional), in-memory & radix storage, in-process and ZMQ transports, versioned binary protocol, metadata/value abstractions, and persistence (WAL + snapshots).

* **Documentation**
  * Added comprehensive README covering architecture, workflows, configuration, protocol, error handling, and usage examples.

* **Tests**
  * Extensive unit and integration tests including in-process and optional ZMQ end-to-end flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->