### PR TITLE
feat: SGLang release/resume_memory_occupation endpoints

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -153,7 +153,21 @@ async def init(runtime: DistributedRuntime, config: Config):
     # Readiness gate: requests wait until model is registered
     ready_event = asyncio.Event()
 
-    handler = DecodeWorkerHandler(component, engine, config, publisher)
+    handler = DecodeWorkerHandler(
+        component, engine, config, publisher, generate_endpoint
+    )
+
+    # Register memory management routes using handler methods
+    runtime.register_engine_route(
+        "release_memory_occupation", handler.release_memory_occupation
+    )
+    runtime.register_engine_route(
+        "resume_memory_occupation", handler.resume_memory_occupation
+    )
+    logging.info(
+        "Registered engine routes: /engine/release_memory_occupation, /engine/resume_memory_occupation"
+    )
+
     print(f"Config: {config}")
     health_check_payload = SglangHealthCheckPayload(
         engine, use_text_input=dynamo_args.use_sglang_tokenizer
@@ -254,7 +268,20 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
     if engine.server_args.enable_metrics:
         setup_prometheus_registry(engine, generate_endpoint)
 
-    handler = PrefillWorkerHandler(component, engine, config, publisher)
+    handler = PrefillWorkerHandler(
+        component, engine, config, publisher, generate_endpoint
+    )
+
+    # Register memory management routes using handler methods
+    runtime.register_engine_route(
+        "release_memory_occupation", handler.release_memory_occupation
+    )
+    runtime.register_engine_route(
+        "resume_memory_occupation", handler.resume_memory_occupation
+    )
+    logging.info(
+        "Registered engine routes: /engine/release_memory_occupation, /engine/resume_memory_occupation"
+    )
 
     health_check_payload = SglangPrefillHealthCheckPayload(engine).to_dict()
 

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -23,6 +23,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         engine: sgl.Engine,
         config: Config,
         publisher: DynamoSglangPublisher,
+        generate_endpoint=None,
     ) -> None:
         """Initialize decode worker handler.
 
@@ -31,12 +32,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             engine: The SGLang engine instance.
             config: SGLang and Dynamo configuration.
             publisher: Metrics publisher for the worker.
+            generate_endpoint: The endpoint handle for discovery registration.
         """
         super().__init__(
             component,
             engine,
             config,
             publisher,
+            generate_endpoint,
         )
         if self.serving_mode == DisaggregationMode.DECODE:
             logging.info(

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -22,6 +22,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         engine: sgl.Engine,
         config: Config,
         publisher: DynamoSglangPublisher,
+        generate_endpoint=None,
     ) -> None:
         """Initialize prefill worker handler.
 
@@ -30,10 +31,11 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             engine: The SGLang engine instance.
             config: SGLang and Dynamo configuration.
             publisher: The SGLang publisher instance.
+            generate_endpoint: The endpoint handle for discovery registration.
         """
         self.engine = engine
         self.bootstrap_host, self.bootstrap_port = self._get_bootstrap_info(self.engine)
-        super().__init__(component, engine, config, publisher)
+        super().__init__(component, engine, config, publisher, generate_endpoint)
         self._consume_tasks = set()
         logging.info(
             f"Prefill worker handler initialized - bootstrap host: {self.bootstrap_host}, bootstrap port: {self.bootstrap_port}"


### PR DESCRIPTION
Add endpoints for releasing/remapping weights/KV cache in SGLang via torch_memory_saver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced memory management endpoints for dynamic release and restoration of GPU memory occupation, improving resource utilization during periods of low demand
  * Added sleep/wake worker functionality with automatic GPU memory management, allowing workers to transition to low-power states and resume operation with memory restored
  * Extended endpoint lifecycle management across vLLM and SGLang backends

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->