### PR TITLE
docs: update LoRA model name in docs

### DIFF
--- a/examples/backends/vllm/launch/lora/README.md
+++ b/examples/backends/vllm/launch/lora/README.md
@@ -39,8 +39,8 @@ Run the setup script to start MinIO and download/upload a LoRA adapter from Hugg
 
 This script will:
 - Start MinIO in a Docker container
-- Download a LoRA adapter from Hugging Face Hub (default: `Neural-Hacker/Qwen3-Math-Reasoning-LoRA`)
-- Upload the LoRA to MinIO at `s3://my-loras/Neural-Hacker/Qwen3-Math-Reasoning-LoRA`
+- Download a LoRA adapter from Hugging Face Hub (default: `codelion/Qwen3-0.6B-accuracy-recovery-lora`)
+- Upload the LoRA to MinIO at `s3://my-loras/codelion/Qwen3-0.6B-accuracy-recovery-lora`
 
 #### Script Options
 
@@ -103,9 +103,9 @@ Load a LoRA from S3-compatible storage backend (e.g. MinIO):
 curl -X POST http://localhost:8081/v1/loras \
   -H "Content-Type: application/json" \
   -d '{
-    "lora_name": "Neural-Hacker/Qwen3-Math-Reasoning-LoRA",
+    "lora_name": "codelion/Qwen3-0.6B-accuracy-recovery-lora",
     "source": {
-      "uri": "s3://my-loras/Neural-Hacker/Qwen3-Math-Reasoning-LoRA"
+      "uri": "s3://my-loras/codelion/Qwen3-0.6B-accuracy-recovery-lora"
     }
   }' | jq .
 ```
@@ -114,8 +114,8 @@ Expected response:
 ```json
 {
   "status": "success",
-  "message": "LoRA adapter 'Neural-Hacker/Qwen3-Math-Reasoning-LoRA' loaded successfully",
-  "lora_name": "Neural-Hacker/Qwen3-Math-Reasoning-LoRA",
+  "message": "LoRA adapter 'codelion/Qwen3-0.6B-accuracy-recovery-lora' loaded successfully",
+  "lora_name": "codelion/Qwen3-0.6B-accuracy-recovery-lora",
   "lora_id": 1207343256
 }
 ```
@@ -146,7 +146,7 @@ You should see both the base model and the LoRA adapter listed.
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "Neural-Hacker/Qwen3-Math-Reasoning-LoRA",
+    "model": "codelion/Qwen3-0.6B-accuracy-recovery-lora",
     "messages": [{
       "role": "user",
       "content": "What is good low risk investment strategy?"
@@ -176,7 +176,7 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 When you no longer need a LoRA, unload it to free up resources:
 
 ```bash
-curl -X DELETE http://localhost:8081/v1/loras/Neural-Hacker/Qwen3-Math-Reasoning-LoRA | jq .
+curl -X DELETE http://localhost:8081/v1/loras/codelion/Qwen3-0.6B-accuracy-recovery-lora | jq .
 ```
 
 Expected response:


### PR DESCRIPTION
#### Overview:

Update doc's  LoRA model name from `Neural-Hacker/Qwen3-Math-Reasoning-LoRA` to `codelion/Qwen3-0.6B-accuracy-recovery-lora`

Code change was already done in https://github.com/ai-dynamo/dynamo/pull/4807

#### Details:

Updated `examples/backends/vllm/launch/lora/README.md`

old lora model: [Neural-Hacker/Qwen3-Math-Reasoning-LoRA](https://huggingface.co/Neural-Hacker/Qwen3-Math-Reasoning-LoRA)
new lora model: [codelion/Qwen3-0.6B-accuracy-recovery-lora](https://huggingface.co/codelion/Qwen3-0.6B-accuracy-recovery-lora)


this PR
closes: DYN-1663
fixes: https://nvbugspro.nvidia.com/bug/5767516

## Summary by CodeRabbit

* **Documentation**
  * Updated example payloads and README documentation to reference new LoRA adapter and storage path configurations.
  * Updated API request examples including curl commands and JSON payloads with new adapter identifiers.
  * Updated expected response messages to reflect new adapter naming conventions across all examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->