### PR TITLE
refactor: extract changed-files logic into reusable composite action

### DIFF
--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -1,0 +1,114 @@
+name: 'Changed Files Check'
+description: 'Detect changed files using filters.yaml and check for uncovered files'
+
+inputs:
+  gh_token:
+    description: 'GitHub token for PR API calls'
+    required: true
+
+outputs:
+  core:
+    description: 'Whether core files changed'
+    value: ${{ steps.filter.outputs.core_any_modified }}
+  operator:
+    description: 'Whether operator files changed'
+    value: ${{ steps.filter.outputs.operator_any_modified }}
+  deploy:
+    description: 'Whether deploy files changed'
+    value: ${{ steps.filter.outputs.deploy_any_modified }}
+  vllm:
+    description: 'Whether vllm files changed'
+    value: ${{ steps.filter.outputs.vllm_any_modified }}
+  sglang:
+    description: 'Whether sglang files changed'
+    value: ${{ steps.filter.outputs.sglang_any_modified }}
+  trtllm:
+    description: 'Whether trtllm files changed'
+    value: ${{ steps.filter.outputs.trtllm_any_modified }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get merge base
+      id: merge-base
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+      run: |
+        # For PR branches, compare against merge-base with PR's target branch
+        # For main/release branches, use default behavior (previous commit)
+        if [[ "${{ github.ref_name }}" =~ ^pull-request/([0-9]+)$ ]]; then
+          PR_NUMBER="${BASH_REMATCH[1]}"
+          BASE_BRANCH=$(gh pr view "$PR_NUMBER" --json baseRefName -q '.baseRefName')
+          echo "PR #$PR_NUMBER targets branch: $BASE_BRANCH"
+          BASE_SHA=$(git merge-base "origin/$BASE_BRANCH" HEAD)
+          echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
+          echo "Using merge-base with $BASE_BRANCH: $BASE_SHA"
+        else
+          echo "base_sha=" >> $GITHUB_OUTPUT
+          echo "Using default comparison (previous commit)"
+        fi
+
+    - name: Check for changes
+      uses: tj-actions/changed-files@aa08304bd477b800d468db44fe10f6c61f7f7b11  # v42.1.0
+      id: filter
+      with:
+        files_yaml_from_source_file: .github/filters.yaml
+        base_sha: ${{ steps.merge-base.outputs.base_sha }}
+
+    - name: Debug changed files
+      shell: bash
+      run: |
+        echo "=== Base SHA Used ==="
+        echo "base_sha: ${{ steps.merge-base.outputs.base_sha || 'default (previous commit)' }}"
+        echo ""
+        echo "=== All Modified Files (${{ steps.filter.outputs.all_all_modified_files_count }} total) ==="
+        echo "${{ steps.filter.outputs.all_all_modified_files }}"
+        echo ""
+        echo "=== Filters That Matched ==="
+        echo "changed_keys: ${{ steps.filter.outputs.changed_keys }}"
+        echo ""
+        echo "=== Filter Results ==="
+        echo "docs: ${{ steps.filter.outputs.docs_any_modified }}"
+        echo "ci: ${{ steps.filter.outputs.ci_any_modified }}"
+        echo "core: ${{ steps.filter.outputs.core_any_modified }}"
+        echo "operator: ${{ steps.filter.outputs.operator_any_modified }}"
+        echo "deploy: ${{ steps.filter.outputs.deploy_any_modified }}"
+        echo "planner: ${{ steps.filter.outputs.planner_any_modified }}"
+        echo "vllm: ${{ steps.filter.outputs.vllm_any_modified }}"
+        echo "sglang: ${{ steps.filter.outputs.sglang_any_modified }}"
+        echo "trtllm: ${{ steps.filter.outputs.trtllm_any_modified }}"
+        echo ""
+        echo "=== Files Matching Each Filter ==="
+        echo "docs: ${{ steps.filter.outputs.docs_all_modified_files }}"
+        echo "ci: ${{ steps.filter.outputs.ci_all_modified_files }}"
+        echo "core: ${{ steps.filter.outputs.core_all_modified_files }}"
+        echo "operator: ${{ steps.filter.outputs.operator_all_modified_files }}"
+        echo "deploy: ${{ steps.filter.outputs.deploy_all_modified_files }}"
+        echo "planner: ${{ steps.filter.outputs.planner_all_modified_files }}"
+        echo "vllm: ${{ steps.filter.outputs.vllm_all_modified_files }}"
+        echo "sglang: ${{ steps.filter.outputs.sglang_all_modified_files }}"
+        echo "trtllm: ${{ steps.filter.outputs.trtllm_all_modified_files }}"
+
+    - name: Check for uncovered files
+      shell: bash
+      run: |
+        # Combine all filter-specific files into one list
+        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
+
+        # Get all modified files
+        ALL_FILES=$(echo "${{ steps.filter.outputs.all_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
+
+        # Find files in ALL but not in COVERED
+        UNCOVERED=$(comm -23 <(echo "$ALL_FILES") <(echo "$COVERED_FILES"))
+
+        if [ -n "$UNCOVERED" ]; then
+          echo "::error::The following files are not covered by any CI filter:"
+          echo "$UNCOVERED"
+          echo ""
+          echo "Please add these paths to .github/filters.yaml"
+          echo "See .github/FILTERS.md for documentation"
+          exit 1
+        fi
+        echo "All modified files are covered by CI filters."
+

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -30,93 +30,22 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'workflow_dispatch' && 'protected-deploy' || '' }}
     outputs:
-      core: ${{ steps.filter.outputs.core_any_modified }}
-      operator: ${{ steps.filter.outputs.operator_any_modified }}
-      deploy: ${{ steps.filter.outputs.deploy_any_modified }}
-      vllm: ${{ steps.filter.outputs.vllm_any_modified }}
-      sglang: ${{ steps.filter.outputs.sglang_any_modified }}
-      trtllm: ${{ steps.filter.outputs.trtllm_any_modified }}
+      core: ${{ steps.changes.outputs.core }}
+      operator: ${{ steps.changes.outputs.operator }}
+      deploy: ${{ steps.changes.outputs.deploy }}
+      vllm: ${{ steps.changes.outputs.vllm }}
+      sglang: ${{ steps.changes.outputs.sglang }}
+      trtllm: ${{ steps.changes.outputs.trtllm }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
         with:
           fetch-depth: 0
-      - name: Get merge base
-        id: merge-base
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # For PR branches, compare against merge-base with PR's target branch
-          # For main/release branches, use default behavior (previous commit)
-          if [[ "${{ github.ref_name }}" =~ ^pull-request/([0-9]+)$ ]]; then
-            PR_NUMBER="${BASH_REMATCH[1]}"
-            BASE_BRANCH=$(gh pr view "$PR_NUMBER" --json baseRefName -q '.baseRefName')
-            echo "PR #$PR_NUMBER targets branch: $BASE_BRANCH"
-            BASE_SHA=$(git merge-base "origin/$BASE_BRANCH" HEAD)
-            echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
-            echo "Using merge-base with $BASE_BRANCH: $BASE_SHA"
-          else
-            echo "base_sha=" >> $GITHUB_OUTPUT
-            echo "Using default comparison (previous commit)"
-          fi
       - name: Check for changes
-        uses: tj-actions/changed-files@aa08304bd477b800d468db44fe10f6c61f7f7b11  # v42.1.0
-        id: filter
+        id: changes
+        uses: ./.github/actions/changed-files
         with:
-          files_yaml_from_source_file: .github/filters.yaml
-          base_sha: ${{ steps.merge-base.outputs.base_sha }}
-      - name: Debug changed files
-        run: |
-          echo "=== Base SHA Used ==="
-          echo "base_sha: ${{ steps.merge-base.outputs.base_sha || 'default (previous commit)' }}"
-          echo ""
-          echo "=== All Modified Files (${{ steps.filter.outputs.all_all_modified_files_count }} total) ==="
-          echo "${{ steps.filter.outputs.all_all_modified_files }}"
-          echo ""
-          echo "=== Filters That Matched ==="
-          echo "changed_keys: ${{ steps.filter.outputs.changed_keys }}"
-          echo ""
-          echo "=== Filter Results ==="
-          echo "docs: ${{ steps.filter.outputs.docs_any_modified }}"
-          echo "ci: ${{ steps.filter.outputs.ci_any_modified }}"
-          echo "core: ${{ steps.filter.outputs.core_any_modified }}"
-          echo "operator: ${{ steps.filter.outputs.operator_any_modified }}"
-          echo "deploy: ${{ steps.filter.outputs.deploy_any_modified }}"
-          echo "planner: ${{ steps.filter.outputs.planner_any_modified }}"
-          echo "vllm: ${{ steps.filter.outputs.vllm_any_modified }}"
-          echo "sglang: ${{ steps.filter.outputs.sglang_any_modified }}"
-          echo "trtllm: ${{ steps.filter.outputs.trtllm_any_modified }}"
-          echo ""
-          echo "=== Files Matching Each Filter ==="
-          echo "docs: ${{ steps.filter.outputs.docs_all_modified_files }}"
-          echo "ci: ${{ steps.filter.outputs.ci_all_modified_files }}"
-          echo "core: ${{ steps.filter.outputs.core_all_modified_files }}"
-          echo "operator: ${{ steps.filter.outputs.operator_all_modified_files }}"
-          echo "deploy: ${{ steps.filter.outputs.deploy_all_modified_files }}"
-          echo "planner: ${{ steps.filter.outputs.planner_all_modified_files }}"
-          echo "vllm: ${{ steps.filter.outputs.vllm_all_modified_files }}"
-          echo "sglang: ${{ steps.filter.outputs.sglang_all_modified_files }}"
-          echo "trtllm: ${{ steps.filter.outputs.trtllm_all_modified_files }}"
-      - name: Check for uncovered files
-        run: |
-          # Combine all filter-specific files into one list
-          COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
-
-          # Get all modified files
-          ALL_FILES=$(echo "${{ steps.filter.outputs.all_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
-
-          # Find files in ALL but not in COVERED
-          UNCOVERED=$(comm -23 <(echo "$ALL_FILES") <(echo "$COVERED_FILES"))
-
-          if [ -n "$UNCOVERED" ]; then
-            echo "::error::The following files are not covered by any CI filter:"
-            echo "$UNCOVERED"
-            echo ""
-            echo "Please add these paths to .github/filters.yaml"
-            echo "See .github/FILTERS.md for documentation"
-            exit 1
-          fi
-          echo "All modified files are covered by CI filters."
+          gh_token: ${{ github.token }}
 
   backend-status-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -19,45 +19,17 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     outputs:
-      core: ${{ steps.filter.outputs.core_any_modified }}
+      core: ${{ steps.changes.outputs.core }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
         with:
           fetch-depth: 0
       - name: Check for changes
-        uses: tj-actions/changed-files@aa08304bd477b800d468db44fe10f6c61f7f7b11  # v42.1.0
-        id: filter
+        id: changes
+        uses: ./.github/actions/changed-files
         with:
-          files_yaml_from_source_file: .github/filters.yaml
-      - name: Debug changed files
-        run: |
-          echo "=== All Modified Files (${{ steps.filter.outputs.all_all_modified_files_count }} total) ==="
-          echo "${{ steps.filter.outputs.all_all_modified_files }}"
-          echo ""
-          echo "=== Filter Results ==="
-          echo "core_any_modified: ${{ steps.filter.outputs.core_any_modified }}"
-          echo "core files: ${{ steps.filter.outputs.core_all_modified_files }}"
-      - name: Check for uncovered files
-        run: |
-          # Combine all filter-specific files into one list
-          COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
-
-          # Get all modified files
-          ALL_FILES=$(echo "${{ steps.filter.outputs.all_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
-
-          # Find files in ALL but not in COVERED
-          UNCOVERED=$(comm -23 <(echo "$ALL_FILES") <(echo "$COVERED_FILES"))
-
-          if [ -n "$UNCOVERED" ]; then
-            echo "::error::The following files are not covered by any CI filter:"
-            echo "$UNCOVERED"
-            echo ""
-            echo "Please add these paths to .github/filters.yaml"
-            echo "See .github/FILTERS.md for documentation"
-            exit 1
-          fi
-          echo "All modified files are covered by CI filters."
+          gh_token: ${{ github.token }}
 
   dynamo-status-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Extract duplicated changed-files detection logic into a reusable composite action.

## Motivation
Follow-up from #5214 - keeping the workflow files cleaner by moving common logic to `.github/actions/`.

## Changes
- Create `.github/actions/changed-files/action.yml` composite action containing:
  - Merge-base detection for PR branches
  - tj-actions/changed-files with filters.yaml
  - Debug output of all filters
  - Uncovered files check
- Update `container-validation-backends.yml` to use new action
- Update `container-validation-dynamo.yml` to use new action

## Test Plan
- [ ] CI passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a new GitHub Actions composite workflow for detecting changed files with built-in coverage validation, ensuring all modifications are properly tracked by CI filters.
  * Refactored container validation workflows to use the new local change detection system instead of external dependencies, improving reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->