### PR TITLE
fix: Optimize TRTLLM multimodal request processing by reusing the tokenizer

### DIFF
--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -43,12 +43,7 @@ class TokenizerProtocol(Protocol):
 
 
 class MultimodalRequestProcessor:
-    """Simple processor for OpenAI format multimodal requests.
-
-    This class initializes the tokenizer and processor ONCE at construction time
-    to avoid the ~900ms per-request overhead of reinitializing them in
-    default_multimodal_input_loader.
-    """
+    """Simple processor for OpenAI format multimodal requests."""
 
     def __init__(
         self,

--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -23,6 +23,7 @@ from urllib.request import urlopen
 
 import torch
 from tensorrt_llm.inputs import default_multimodal_input_loader
+from tensorrt_llm.llmapi.tokenizer import tokenizer_factory
 
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -42,7 +43,12 @@ class TokenizerProtocol(Protocol):
 
 
 class MultimodalRequestProcessor:
-    """Simple processor for OpenAI format multimodal requests."""
+    """Simple processor for OpenAI format multimodal requests.
+
+    This class initializes the tokenizer and processor ONCE at construction time
+    to avoid the ~900ms per-request overhead of reinitializing them in
+    default_multimodal_input_loader.
+    """
 
     def __init__(
         self,
@@ -54,11 +60,16 @@ class MultimodalRequestProcessor:
     ):
         self.model_type = model_type
         self.model_dir = model_dir
-        self.tokenizer = tokenizer
         self.modality = ""
         self.allowed_local_media_path = allowed_local_media_path
         self.max_file_size_mb = max_file_size_mb
         self.max_file_size_bytes = max_file_size_mb * 1024 * 1024
+
+        # Initialize tokenizer ONCE at startup to avoid per-request overhead
+        if tokenizer is not None:
+            self.tokenizer = tokenizer
+        else:
+            self.tokenizer = tokenizer_factory(model_dir)
 
     def is_url(self, path: str) -> bool:
         """Check if a path is a URL."""
@@ -189,8 +200,10 @@ class MultimodalRequestProcessor:
             logging.debug(f"Using embedding paths in prefill worker: {embedding_paths}")
 
         # Process with default_multimodal_input_loader
+        # Pass self.tokenizer to reuse the pre-initialized tokenizer instead of
+        # creating a new one per request
         processed_inputs = default_multimodal_input_loader(
-            tokenizer=None,
+            tokenizer=self.tokenizer,
             model_dir=self.model_dir,
             model_type=self.model_type,
             modality=self.modality,


### PR DESCRIPTION
#### Overview:

Optimize multimodal request processing by reusing the tokenizer instead of reinitializing it on every request inside `default_multimodal_input_loader`

#### Details:

Initialize tokenizer once in MultimodalRequestProcessor.__init__ using tokenizer_factory if not provided

#### Where should the reviewer start?

components/src/dynamo/trtllm/multimodal_processor.py - the only file changed

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- relates to GitHub issue: #5086


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Tokenizer is now pre-initialized at startup and reused across multiple requests, eliminating per-request creation overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->