### PR TITLE
fix: vllm default behaviour for generation prompt

### DIFF
--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -233,17 +233,19 @@ impl OAIChatLikeRequest for NvCreateChatCompletionRequest {
     }
 
     fn should_add_generation_prompt(&self) -> bool {
-        // Only add generation prompt if the last message was not assistant (default to true when no last message)
-        self.inner
-            .messages
-            .last()
-            .map(|last| {
-                !matches!(
-                    last,
-                    dynamo_async_openai::types::ChatCompletionRequestMessage::Assistant(_)
-                )
-            })
-            .unwrap_or(true)
+        // Using vLLM default behavior
+        true
+        // // Only add generation prompt if the last message was not assistant (default to true when no last message)
+        // self.inner
+        //     .messages
+        //     .last()
+        //     .map(|last| {
+        //         !matches!(
+        //             last,
+        //             dynamo_async_openai::types::ChatCompletionRequestMessage::Assistant(_)
+        //         )
+        //     })
+        //     .unwrap_or(true)
     }
 
     fn extract_text(&self) -> Option<TextInput> {
@@ -1181,9 +1183,6 @@ NORMAL MODE
     fn user() -> Msg {
         Msg::User(Default::default())
     }
-    fn asst() -> Msg {
-        Msg::Assistant(Default::default())
-    }
     fn tool() -> Msg {
         Msg::Tool(Default::default())
     }
@@ -1206,12 +1205,6 @@ NORMAL MODE
     fn add_after_tool() {
         let s = dummy_state(vec![tool()]);
         assert!(s.should_add_generation_prompt());
-    }
-
-    #[test]
-    fn no_after_assistant() {
-        let s = dummy_state(vec![asst()]);
-        assert!(!s.should_add_generation_prompt());
     }
 
     #[test]


### PR DESCRIPTION
#### Overview:

Current Logic in Dynamo for adding generation prompt:

true if the last message is not of Assistant role otherwise False

This does not match with vLLM behaviour for following case

**Request**
```
curl -sS "http://localhost:8000/v1/chat/completions" \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "Qwen/Qwen3-0.6B",
    "stream": false,
    "max_tokens" : 1000,
    "messages": [
      {
        "role": "user",
        "content": "test"
      },
      {
        "role": "assistant",
        "content": null,
        "tool_calls": [
          {
            "id": "call-1",
            "type": "function",
            "function": {
              "name": "ark_ai_mcp_client_server1_query_zone_target",
              "arguments": "{\"serviceName\":\"a\",\"zoneId\":1}"
            }
          }
        ]
      }
    ]
  }' | jq
```

**vLLM Rendered Prompt**
```
<|im_start|>user
test<|im_end|>
<|im_start|>assistant
<think>

</think>

<tool_call>
{"name": "ark_ai_mcp_client_server1_query_zone_target", "arguments": {"serviceName": "a", "zoneId": 1}}
</tool_call><|im_end|>
<|im_start|>assistant
```

**Dynamo Rendered Prompt**
```
<|im_start|>user
test<|im_end|>
<|im_start|>assistant
<think>

</think>

<tool_call>
{"name": "ark_ai_mcp_client_server1_query_zone_target", "arguments": {"serviceName":"a","zoneId":1}}
</tool_call><|im_end|>
```


The Fix: Adopting vLLM default behavior for adding generation prompt which is always True

Related Previous PRs: https://github.com/ai-dynamo/dynamo/pull/4168/

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chat completion to consistently generate prompts for all conversation requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->