### PR TITLE
fix: assign unique ports per vLLM worker to avoid ZMQ bind conflicts

### DIFF
--- a/benchmarks/router/run_engines.sh
+++ b/benchmarks/router/run_engines.sh
@@ -251,8 +251,9 @@ else
                     VLLM_ARGS+=("--is-decode-worker")
                 fi
                 VLLM_ARGS+=("${EXTRA_ARGS[@]}")
+                VLLM_ARGS+=("--request-plane" "nats")
 
-                exec env PYTHONHASHSEED=0 CUDA_VISIBLE_DEVICES=$GPU_DEVICES python3 -m dynamo.vllm \
+                exec env PYTHONHASHSEED=0 CUDA_VISIBLE_DEVICES=$GPU_DEVICES DYN_VLLM_KV_EVENT_PORT=$((20080 + i)) VLLM_NIXL_SIDE_CHANNEL_PORT=$((20096 + i)) python3 -m dynamo.vllm \
                     "${VLLM_ARGS[@]}"
             fi
         } &


### PR DESCRIPTION
## Summary
Fix ZMQ port conflicts when running multiple vLLM workers via run_engines.sh

## Problem
When launching multiple vLLM workers, all instances attempted to bind to the same ZMQ port (20080) for KV events, causing `zmq.error.ZMQError: Address already in use`.

## Solution
- Add unique port environment variables per worker:
  - `DYN_VLLM_KV_EVENT_PORT=$((20080 + i))`
  - `VLLM_NIXL_SIDE_CHANNEL_PORT=$((20096 + i))`
- Add `--request-plane nats` to fix "failed to publish" warnings

## Test Plan
- [ ] Run `run_engines.sh --num-workers 4 --tensor-parallel-size 2` and verify all workers start without port conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark configuration and environment variables for worker process management to improve testing infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->