### PR TITLE
fix: add sweep range for moe dgdr example

### DIFF
--- a/benchmarks/profiler/deploy/profile_sla_moe_dgdr.yaml
+++ b/benchmarks/profiler/deploy/profile_sla_moe_dgdr.yaml
@@ -20,6 +20,12 @@ spec:
         # Standard online profiling (not using AI Configurator)
         use_ai_configurator: false
 
+      hardware:
+        # for h200, sweep over 8-16 GPUs per engine
+        min_num_gpus_per_engine: 8
+        max_num_gpus_per_engine: 16
+        num_gpus_per_node: 8
+
       # SLA targets for profiling
       sla:
         isl: 3000   # Input sequence length


### PR DESCRIPTION
because auto-hardware identification is flaky and not enabled by default...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated profiling and benchmarking configuration with GPU resource specifications to enhance performance testing capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->