### PR TITLE
fix: return None for hidden stop tokens to prevent EOS in output

### DIFF
--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -456,7 +456,7 @@ impl Decoder {
         // check for hidden stop tokens - eos takes precedence
         if self.hidden_stop_ids.contains(&token_id) {
             return Ok(StepResult::with_stop_trigger(
-                token,
+                None,
                 StopTrigger::HiddenStopTokenDetected(token_id),
             ));
         }


### PR DESCRIPTION
Fixes the issue of eos_token appearing in output

#### Overview:

This PR fixes a bug where EOS (end-of-string) tokens were appearing in the generated output text. When hidden stop tokens are detected, the decoder now returns `None` instead of the decoded token text, preventing tokens like `</s>` from leaking into user-facing content.

#### Details:

- **Modified `Decoder::step()` function**: When a token ID is found in `hidden_stop_ids`, return `None` instead of the decoded token text
- **Rationale**: Hidden stop tokens (like EOS) should signal generation termination without their decoded text appearing in output
- **Behavior change**: 
  - **Before**: `StepResult::with_stop_trigger(token, ...)` - returned decoded EOS token (e.g., `"</s>"`)
  - **After**: `StepResult::with_stop_trigger(None, ...)` - returns `None` to exclude from output
- The `process_token_ids()` function already handles `None` tokens correctly by skipping them during text accumulation
- This simplifies the logic and ensures hidden stop tokens are never visible to users

#### Where should the reviewer start?

Check this file: `lib/llm/src/backend.rs`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #5156 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of hidden stop tokens to return only the stop signal without including the associated token text, ensuring cleaner output while preserving all stop-sequence logic and safety mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->