### PR TITLE
fix: prevent services adding/removal in dgd

### DIFF
--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -119,6 +119,10 @@ func (v *DynamoGraphDeploymentValidator) validateServiceTopology(old *nvidiacomv
 		return nil
 	}
 
+	// Sort for deterministic error messages
+	sort.Strings(added)
+	sort.Strings(removed)
+
 	// Build descriptive error message
 	var errMsg string
 	switch {
@@ -126,17 +130,17 @@ func (v *DynamoGraphDeploymentValidator) validateServiceTopology(old *nvidiacomv
 		errMsg = fmt.Sprintf(
 			"service topology is immutable and cannot be modified after creation: "+
 				"services added: %v, services removed: %v",
-			sortedSlice(added), sortedSlice(removed))
+			added, removed)
 	case len(added) > 0:
 		errMsg = fmt.Sprintf(
 			"service topology is immutable and cannot be modified after creation: "+
 				"services added: %v",
-			sortedSlice(added))
+			added)
 	case len(removed) > 0:
 		errMsg = fmt.Sprintf(
 			"service topology is immutable and cannot be modified after creation: "+
 				"services removed: %v",
-			sortedSlice(removed))
+			removed)
 	}
 
 	return errors.New(errMsg)
@@ -258,16 +262,4 @@ func difference(a, b map[string]struct{}) []string {
 		}
 	}
 	return result
-}
-
-// sortedSlice returns a sorted copy of the input slice for consistent error messages.
-// Ensures deterministic output for testing and better user experience.
-func sortedSlice(slice []string) []string {
-	if len(slice) == 0 {
-		return slice
-	}
-	sorted := make([]string, len(slice))
-	copy(sorted, slice)
-	sort.Strings(sorted)
-	return sorted
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -20,6 +20,7 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
@@ -79,6 +80,11 @@ func (v *DynamoGraphDeploymentValidator) ValidateUpdate(old *nvidiacomv1alpha1.D
 		return warnings, err
 	}
 
+	// Validate service topology is unchanged (service names must remain the same)
+	if err := v.validateServiceTopology(old); err != nil {
+		return warnings, err
+	}
+
 	// Validate replicas changes for services with scaling adapter enabled
 	// Pass userInfo (may be nil - will fail closed for DGDSA-enabled services)
 	if err := v.validateReplicasChanges(old, userInfo); err != nil {
@@ -96,6 +102,44 @@ func (v *DynamoGraphDeploymentValidator) validateImmutableFields(old *nvidiacomv
 		return fmt.Errorf("spec.backendFramework is immutable and cannot be changed after creation")
 	}
 	return nil
+}
+
+// validateServiceTopology ensures the set of service names remains unchanged.
+// Users can modify service specifications, but cannot add or remove services.
+// This maintains graph topology immutability while allowing configuration updates.
+func (v *DynamoGraphDeploymentValidator) validateServiceTopology(old *nvidiacomv1alpha1.DynamoGraphDeployment) error {
+	oldServices := getServiceNames(old.Spec.Services)
+	newServices := getServiceNames(v.deployment.Spec.Services)
+
+	added := difference(newServices, oldServices)
+	removed := difference(oldServices, newServices)
+
+	// Fast path: no changes
+	if len(added) == 0 && len(removed) == 0 {
+		return nil
+	}
+
+	// Build descriptive error message
+	var errMsg string
+	switch {
+	case len(added) > 0 && len(removed) > 0:
+		errMsg = fmt.Sprintf(
+			"service topology is immutable and cannot be modified after creation: "+
+				"services added: %v, services removed: %v",
+			sortedSlice(added), sortedSlice(removed))
+	case len(added) > 0:
+		errMsg = fmt.Sprintf(
+			"service topology is immutable and cannot be modified after creation: "+
+				"services added: %v",
+			sortedSlice(added))
+	case len(removed) > 0:
+		errMsg = fmt.Sprintf(
+			"service topology is immutable and cannot be modified after creation: "+
+				"services removed: %v",
+			sortedSlice(removed))
+	}
+
+	return errors.New(errMsg)
 }
 
 // validateReplicasChanges checks if replicas were changed for services with scaling adapter enabled.
@@ -192,4 +236,38 @@ func (v *DynamoGraphDeploymentValidator) validatePVC(index int, pvc *nvidiacomv1
 	}
 
 	return err
+}
+
+// getServiceNames extracts service names from a services map.
+// Returns a set-like map for efficient lookup and comparison.
+func getServiceNames(services map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec) map[string]struct{} {
+	names := make(map[string]struct{}, len(services))
+	for name := range services {
+		names[name] = struct{}{}
+	}
+	return names
+}
+
+// difference returns elements in set a that are not in set b (a - b).
+// This is used to find added or removed services.
+func difference(a, b map[string]struct{}) []string {
+	var result []string
+	for name := range a {
+		if _, exists := b[name]; !exists {
+			result = append(result, name)
+		}
+	}
+	return result
+}
+
+// sortedSlice returns a sorted copy of the input slice for consistent error messages.
+// Ensures deterministic output for testing and better user experience.
+func sortedSlice(slice []string) []string {
+	if len(slice) == 0 {
+		return slice
+	}
+	sorted := make([]string, len(slice))
+	copy(sorted, slice)
+	sort.Strings(sorted)
+	return sorted
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -18,6 +18,7 @@
 package validation
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
@@ -715,95 +716,20 @@ func TestDifference(t *testing.T) {
 			got := difference(tt.a, tt.b)
 
 			// Sort both slices for comparison (since map iteration order is undefined)
-			sortedGot := sortedSlice(got)
-			sortedWant := sortedSlice(tt.want)
+			sort.Strings(got)
+			want := make([]string, len(tt.want))
+			copy(want, tt.want)
+			sort.Strings(want)
 
-			if len(sortedGot) != len(sortedWant) {
-				t.Errorf("difference() length = %v, want %v", len(sortedGot), len(sortedWant))
-				return
-			}
-
-			for i := range sortedGot {
-				if sortedGot[i] != sortedWant[i] {
-					t.Errorf("difference() = %v, want %v", sortedGot, sortedWant)
-					return
-				}
-			}
-		})
-	}
-}
-
-func TestSortedSlice(t *testing.T) {
-	tests := []struct {
-		name  string
-		input []string
-		want  []string
-	}{
-		{
-			name:  "empty slice",
-			input: []string{},
-			want:  []string{},
-		},
-		{
-			name:  "nil slice",
-			input: nil,
-			want:  nil,
-		},
-		{
-			name:  "single element",
-			input: []string{"backend"},
-			want:  []string{"backend"},
-		},
-		{
-			name:  "already sorted",
-			input: []string{"backend", "cache", "frontend"},
-			want:  []string{"backend", "cache", "frontend"},
-		},
-		{
-			name:  "reverse sorted",
-			input: []string{"frontend", "cache", "backend"},
-			want:  []string{"backend", "cache", "frontend"},
-		},
-		{
-			name:  "unsorted",
-			input: []string{"cache", "backend", "frontend"},
-			want:  []string{"backend", "cache", "frontend"},
-		},
-		{
-			name:  "does not modify original",
-			input: []string{"z", "a", "m"},
-			want:  []string{"a", "m", "z"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Save original for mutation test
-			original := make([]string, len(tt.input))
-			copy(original, tt.input)
-
-			got := sortedSlice(tt.input)
-
-			// Verify result
-			if len(got) != len(tt.want) {
-				t.Errorf("sortedSlice() length = %v, want %v", len(got), len(tt.want))
+			if len(got) != len(want) {
+				t.Errorf("difference() length = %v, want %v", len(got), len(want))
 				return
 			}
 
 			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Errorf("sortedSlice() = %v, want %v", got, tt.want)
+				if got[i] != want[i] {
+					t.Errorf("difference() = %v, want %v", got, want)
 					return
-				}
-			}
-
-			// Verify original wasn't modified (except for empty/nil cases)
-			if len(original) > 0 {
-				for i := range original {
-					if original[i] != tt.input[i] {
-						t.Errorf("sortedSlice() modified original slice: got %v, want %v", tt.input, original)
-						return
-					}
 				}
 			}
 		})


### PR DESCRIPTION
#### Overview:

prevent services adding/removal in dgd.

This was already prevented by grove but this adds a additional validation that informs users even sooner


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service topology is now immutable—deployments cannot add or remove services after initial creation. Attempting to modify services will result in a validation error with details about added or removed services.

* **Tests**
  * Added comprehensive test coverage for service topology validation and helper functions to ensure immutability constraints are properly enforced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->