### PR TITLE
feat: bump up golang version to 1.25

### DIFF
--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - name: Check for uncommitted changes
         shell: bash
         env:

--- a/deploy/operator/Dockerfile
+++ b/deploy/operator/Dockerfile
@@ -4,7 +4,7 @@
 # Base stage - Common setup for all stages
 ARG DOCKER_PROXY
 ARG BASE_IMAGE="golang"
-ARG BASE_IMAGE_TAG="1.24"
+ARG BASE_IMAGE_TAG="1.25"
 FROM ${DOCKER_PROXY}${BASE_IMAGE}:${BASE_IMAGE_TAG} AS base
 
 # Docker buildx automatically provides these

--- a/deploy/operator/README.md
+++ b/deploy/operator/README.md
@@ -22,7 +22,7 @@ Built with [Kubebuilder](https://book.kubebuilder.io/), it follows Kubernetes be
 
 ### Pre-requisites
 
-- [Go](https://go.dev/doc/install) >= 1.24
+- [Go](https://go.dev/doc/install) >= 1.25
 - [Kubebuilder](https://book.kubebuilder.io/quick-start.html)
 
 ### Build

--- a/deploy/operator/go.mod
+++ b/deploy/operator/go.mod
@@ -1,8 +1,6 @@
 module github.com/ai-dynamo/dynamo/deploy/operator
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.25.0
 
 require (
 	emperror.dev/errors v0.8.1


### PR DESCRIPTION
#### Overview:

bump up golang version to 1.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.25.0
  * Updated base image version to 1.25 across all build stages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->