### PR TITLE
fix: Remove asymmetric --request-plane nats from run_engines.sh script

### DIFF
--- a/benchmarks/router/README.md
+++ b/benchmarks/router/README.md
@@ -107,6 +107,9 @@ We also supports running lightweight mock engines that simulate vLLM behavior wi
 In a **new terminal**, launch the Dynamo router using the Python CLI:
 
 ```bash
+# Explicitly set NATS server for KV event publishing
+export NATS_SERVER="${NATS_SERVER:-nats://localhost:4222}"
+
 python -m dynamo.frontend \
     --router-mode kv \
     --router-reset-states \

--- a/benchmarks/router/run_engines.sh
+++ b/benchmarks/router/run_engines.sh
@@ -251,7 +251,6 @@ else
                     VLLM_ARGS+=("--is-decode-worker")
                 fi
                 VLLM_ARGS+=("${EXTRA_ARGS[@]}")
-                VLLM_ARGS+=("--request-plane" "nats")
 
                 exec env PYTHONHASHSEED=0 CUDA_VISIBLE_DEVICES=$GPU_DEVICES DYN_VLLM_KV_EVENT_PORT=$((20080 + i)) VLLM_NIXL_SIDE_CHANNEL_PORT=$((20096 + i)) python3 -m dynamo.vllm \
                     "${VLLM_ARGS[@]}"


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Problem: 
- `run_engines.sh` sets `--request-plane nats`, but frontend steps in README are using default TCP request plane, leading to mismatch and ultimately a TCP error:
```
{
  "message": "Failed to generate completions: Invalid TCP address 'dynamo_backend.generate-694d9b96e24ab707': invalid socket address syntax",
  "type": "Internal Server Error",
  "code": 500
}
```

Solution: 
- this PR removes the unnecessary `--request-plane nats` from the engine script so both frontend/backend are using TCP request plane, and then it also updates the README to mention setting the NATS_SERVER env var to make sure the kv events work as expected. 
- This behavior of initializing nats client based on NATS_SERVER env var or something else may change in future (ex: https://github.com/ai-dynamo/dynamo/pull/5237), but this should fix the bug with the code as-is until that PR is merged.
- Fixes https://nvbugspro.nvidia.com/bug/5788225


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated router benchmark NATS server configuration to include a default fallback value when the environment variable is not explicitly set by the user.
  * Removed NATS request plane argument from vLLM engine configuration parameters in benchmark launcher scripts.
  * Applied minor formatting improvements to benchmark documentation and shell scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->