### PR TITLE
docs: Fix KV cache transfer UCX configuration instructions

### DIFF
--- a/docs/backends/trtllm/kv-cache-transfer.md
+++ b/docs/backends/trtllm/kv-cache-transfer.md
@@ -30,9 +30,7 @@ TODO: Add instructions for how to specify different backends for NIXL.
 
 ## Alternative Method: UCX
 
-TensorRT-LLM can also leverage **UCX** (Unified Communication X) directly for KV cache transfer between prefill and decode workers. There are two ways to enable UCX as the KV cache transfer backend:
+TensorRT-LLM can also leverage **UCX** (Unified Communication X) directly for KV cache transfer between prefill and decode workers. To enable UCX as the KV cache transfer backend, set `cache_transceiver_config.backend: UCX` in your engine configuration YAML file.
 
-1. **Recommended:** Set `cache_transceiver_config.backend: UCX` in your engine configuration YAML file.
-2. Alternatively, set the environment variable `TRTLLM_USE_UCX_KV_CACHE=1` and configure `cache_transceiver_config.backend: DEFAULT` in the engine configuration YAML.
-
-This flexibility allows users to choose the most suitable method for their deployment and compatibility requirements.
+> [!Note]
+> The environment variable `TRTLLM_USE_UCX_KV_CACHE=1` with `cache_transceiver_config.backend: DEFAULT` does not enable UCX. You must explicitly set `backend: UCX` in the configuration.


### PR DESCRIPTION
## Summary
- Fix incorrect documentation stating that `TRTLLM_USE_UCX_KV_CACHE=1` with `backend: DEFAULT` enables UCX
- This combination does not work - users must explicitly set `backend: UCX`
- Added clarifying note to prevent user confusion

## Reference
- Linear: [DYN-1678](https://linear.app/nvidia/issue/DYN-1678)

## Test plan
- [ ] Verify documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified KV cache transfer enablement requirements: explicitly requires setting backend: UCX in the engine configuration YAML.
  * Removed guidance about alternative configuration methods.
  * Added prominent notes emphasizing that environment variables alone do not enable UCX and explicit backend configuration is mandatory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->