### PR TITLE
fix: avoid example TRT-LLM worker OOM by tuning params

### DIFF
--- a/examples/deployments/router_standalone_trtllm/README.md
+++ b/examples/deployments/router_standalone_trtllm/README.md
@@ -176,6 +176,7 @@ python test_router.py -v
 - `DYNAMO_DEBUG=1`: Enable debug file dumps to `/tmp/debug_*.txt`
 - `LOGLEVEL=DEBUG`: Set logging level (DEBUG, INFO, WARNING, ERROR)
 - `TRANSFORMERS_ATTN_IMPLEMENTATION=eager`: Disable FlashAttention (set automatically)
+- `TRTLLM_MAX_NUM_TOKENS`: Set max token length
 
 ### Port Assignment
 


### PR DESCRIPTION
This PR is a quick fix with hardcoded gpu_mem_fraction so that the example can run without OOM in the default mode in H100 -- 2 workers, each of them gets 40% GPU memory.

`nvidia-smi` confirms memory is spread out (though they aren't even). Prior to this PR, 90% memory will go to the 1st worker. A request on the 2nd worker can cause it OOM.

```
Wed Jan  7 13:01:43 2026       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.216.03             Driver Version: 535.216.03   CUDA Version: 13.0     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA H100 80GB HBM3          On  | 00000000:3F:00.0 Off |                    0 |
| N/A   39C    P0             121W / 700W |  57860MiB / 81559MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   1368555      C   python                                      588MiB |
|    0   N/A  N/A   1368788      C   /opt/dynamo/venv/bin/python               35782MiB |
|    0   N/A  N/A   1369449      C   /opt/dynamo/venv/bin/python               21466MiB |
+---------------------------------------------------------------------------------------+

```

sends 2 identical requests to router

```
curl -s -X POST http://localhost:7777/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen/Qwen2-VL-2B-Instruct",
    "messages": [{
      "role": "user",
      "content": [
        {"type": "text", "text": "Describe both images in detail."},
        {"type": "image_url", "image_url": {"url": "https://huggingface.co/datasets/Sayali9141/traffic_signal_images/resolve/main/61.jpg"}},
        {"type": "image_url", "image_url": {"url": "http://images.cocodataset.org/test2017/000000000001.jpg"}}
      ]
    }],
    "max_tokens": 500,
    "stream": false
  }' | jq
```

the below logs confirm 1st request went to worker 0 and 2nd went to worker 1. both were working fine.

```
[2026-01-07 13:02:15] INFO router.py:212: Router: raw_scores={}
[2026-01-07 13:02:15] INFO router.py:228: worker_id: 0, logit = 2 * 0.000 - 0.000 - 0.000 = 0.000
[2026-01-07 13:02:15] INFO router.py:228: worker_id: 1, logit = 2 * 0.000 - 0.000 - 0.000 = 0.000
INFO:     127.0.0.1:45514 - "POST /find_best_worker HTTP/1.1" 200 OK
[2026-01-07 13:02:15] INFO _client.py:1740: HTTP Request: POST http://localhost:7778/find_best_worker "HTTP/1.1 200 OK"
[2026-01-07 13:02:15] INFO worker.py:375: Worker 0: Starting KV events monitoring
/opt/dynamo/venv/lib/python3.12/site-packages/torch/multiprocessing/reductions.py:598: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  if storage.is_cuda:
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
	- Avoid using `tokenizers` before the fork if possible
	- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
INFO:     127.0.0.1:45508 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-01-07 13:02:17] INFO worker.py:411: Worker 0: KV events iterator obtained

Fetching 1 files:   0%|          | 0/1 [00:00<?, ?it/s]
Fetching 1 files: 100%|██████████| 1/1 [00:00<00:00, 17924.38it/s]

Fetching 1 files:   0%|          | 0/1 [00:00<?, ?it/s]
Fetching 1 files: 100%|██████████| 1/1 [00:00<00:00, 4928.68it/s]

Fetching 1 files:   0%|          | 0/1 [00:00<?, ?it/s]
Fetching 1 files: 100%|██████████| 1/1 [00:00<00:00, 9320.68it/s]
[2026-01-07 13:02:28] INFO router.py:212: Router: raw_scores={}
[2026-01-07 13:02:28] INFO router.py:228: worker_id: 0, logit = 2 * 0.000 - 0.000 - 1.000 = -1.000
[2026-01-07 13:02:28] INFO router.py:228: worker_id: 1, logit = 2 * 0.000 - 0.000 - 0.000 = 0.000
INFO:     127.0.0.1:22668 - "POST /find_best_worker HTTP/1.1" 200 OK
[2026-01-07 13:02:28] INFO _client.py:1740: HTTP Request: POST http://localhost:7778/find_best_worker "HTTP/1.1 200 OK"
[2026-01-07 13:02:28] INFO worker.py:375: Worker 1: Starting KV events monitoring
INFO:     127.0.0.1:14758 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2026-01-07 13:02:30] INFO worker.py:411: Worker 1: KV events iterator obtained

```