### PR TITLE
fix: Limit max response middleware body size with get_body_limit() instead of usize::MAX

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -224,7 +224,7 @@ pub async fn smart_json_error_middleware(request: Request<Body>, next: Next) -> 
 
     if response.status() == StatusCode::UNPROCESSABLE_ENTITY {
         let (_parts, body) = response.into_parts();
-        let body_bytes = axum::body::to_bytes(body, usize::MAX)
+        let body_bytes = axum::body::to_bytes(body, get_body_limit())
             .await
             .unwrap_or_default();
         let error_message = String::from_utf8_lossy(&body_bytes).to_string();


### PR DESCRIPTION
Signed-off-by: michaelfeil <me@michaelfeil.eu>

#### Overview:

I am hunting down a memory bug. This is super uncritical, but using usize::max here is not appropriate for error messages.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error response handling by implementing configurable limits on HTTP response body sizes, enhancing system stability and performance when processing error responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->