### PR TITLE
fix: repro memory leak and deadlock under high payloads and high concurrency

### DIFF
--- a/lib/bindings/python/examples/pipeline_openai/README.md
+++ b/lib/bindings/python/examples/pipeline_openai/README.md
@@ -1,0 +1,22 @@
+# Memory Profiling Pipeline
+This OpenAI Compatible pipeline is profiling memory allocations of dynamo itself in a high-thoughput for large payloads.
+
+files:
+```
+frontend.py -> HTTP Frontend, implemented in Python with the Rust bindings
+backend.py  -> proxy and backend implementation
+load_test.py -> Sends http requests to frontend
+memory_monitor.py -> Monitors pid memory usage
+```
+
+Startup, best run from three different terminals in this order:
+```
+python ./backend.py &
+python ./backend.py --proxy-mode &
+python ./frontend.py
+```
+
+Then
+```
+python load_test.py
+```

--- a/lib/bindings/python/examples/pipeline_openai/backend.py
+++ b/lib/bindings/python/examples/pipeline_openai/backend.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import os
+
+# Import shared memory monitoring
+import sys
+
+import uvloop
+
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "."))
+from memory_monitor import create_monitor, setup_background_monitor
+
+# Create monitor if profiling is enabled
+monitor = create_monitor("BACKEND")
+
+uvloop.install()
+
+
+class RequestHandler:
+    def __init__(self, proxy_client=None):
+        print(
+            f"Initialized backend request handler {'proxy' if proxy_client else 'worker'} with memory monitoring"
+        )
+        if monitor:
+            monitor.log_memory("Initial:")
+        self.proxy_client = proxy_client
+
+    async def generate(self, request, context):
+        if monitor:
+            monitor.increment_request()
+
+        max_tokens = request.get("max_tokens", 10)
+        if self.proxy_client:
+            print(f"Proxying request {context.id()}")
+            stream = await self.proxy_client.random(request)
+            i = 0
+            async for chunk in stream:
+                i += 1
+                yield f"chunk{i}"
+        else:
+            print(f"Generating mock response {context.id()}")
+            for i in range(max_tokens):
+                await asyncio.sleep(1e-5)  # yield / switch context
+                yield f"chunk{i}"
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime, proxy_mode: bool = False):
+    name = "worker" if not proxy_mode else "proxy_worker"
+    component = runtime.namespace("openai/pipeline").component(name)
+    # await component.create_service()
+
+    endpoint = component.endpoint("generate")
+
+    # Setup background memory monitoring
+    monitor_task = setup_background_monitor(monitor)
+    # Create pipeline client if in proxy mode
+    if proxy_mode:
+        proxy_client = (
+            await runtime.namespace("openai/pipeline")
+            .component("worker")
+            .endpoint("generate")
+            .client()
+        )
+    else:
+        proxy_client = None
+
+    try:
+        await endpoint.serve_endpoint(RequestHandler(proxy_client).generate)
+    finally:
+        if monitor:
+            print("\nShutdown - Final memory state:")
+            monitor.log_memory("Final:")
+        if monitor_task:
+            monitor_task.cancel()
+        raise
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--proxy-mode", action="store_true", help="Run in proxy mode")
+    args = parser.parse_args()
+    asyncio.run(worker(proxy_mode=args.proxy_mode))

--- a/lib/bindings/python/examples/pipeline_openai/frontend.py
+++ b/lib/bindings/python/examples/pipeline_openai/frontend.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+import sys
+import time
+import uuid
+
+import uvloop
+
+from dynamo.llm import HttpAsyncEngine, HttpError, HttpService
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+
+# Import shared memory monitoring
+sys.path.append(os.path.join(os.path.dirname(__file__), "."))
+from memory_monitor import create_monitor, setup_background_monitor
+
+# Create monitor if profiling is enabled
+monitor = create_monitor("FRONTEND")
+
+
+class MockEngine:
+    def __init__(self, model_name, pipeline_client):
+        self.model_name = model_name
+        self.pipeline_client = pipeline_client
+        if monitor:
+            print("Initialized frontend engine with memory monitoring")
+            monitor.log_memory("Initial:")
+
+    def generate(self, request):
+        if monitor:
+            monitor.increment_request()
+
+        id = f"chat-{uuid.uuid4()}"
+        created = int(time.time())
+        model = self.model_name
+        # print(f"{created} | Received request: {request}")
+
+        async def generator():
+            num_chunks = 10
+            i = 0
+            for _ in range(5):
+                try:
+                    stream = await self.pipeline_client.random(request)
+                    break
+                except Exception as e:
+                    print(f"Error contacting pipeline: {e}")
+                    await asyncio.sleep(0.1)
+            else:
+                print(f"Failed to contact pipeline after retries for request {id}")
+                raise HttpError(401, "Failed to contact pipeline after retries")
+
+            async for output in stream:
+                mock_content = f"chunk{i}"
+                finish_reason = "stop" if (i == num_chunks - 1) else None
+                chunk = {
+                    "id": id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": i,
+                            "delta": {"role": "assistant", "content": mock_content},
+                            "logprobs": None,
+                            "finish_reason": finish_reason,
+                        }
+                    ],
+                }
+                i += 1
+                yield chunk
+
+        return generator()
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime):
+    model: str = "mock_model"
+    served_model_name: str = "mock_model"
+
+    pipeline = (
+        await runtime.namespace("openai/pipeline")
+        .component("proxy_worker")
+        .endpoint("generate")
+        .client()
+    )
+
+    loop = asyncio.get_running_loop()
+    python_engine = MockEngine(model, pipeline)
+    engine = HttpAsyncEngine(python_engine.generate, loop)
+    # test the engine with a dummy request
+    async for _ in python_engine.generate(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 2,
+        }
+    ):
+        pass
+
+    host: str = "localhost"
+    port: int = 8000
+    service: HttpService = HttpService(port=port)
+    service.add_chat_completions_model(served_model_name, "mdcsum", engine)
+    service.enable_endpoint("chat", True)
+
+    print("Starting service")
+    shutdown_signal = service.run(runtime.child_token())
+
+    # Setup background memory monitoring
+    monitor_task = setup_background_monitor(monitor)
+
+    try:
+        print(f"Serving endpoint: {host}:{port}/v1/models")
+        print(f"Serving endpoint: {host}:{port}/v1/chat/completions")
+        print(f"Serving the following models: {service.list_chat_completions_models()}")
+        # Block until shutdown signal received
+        await shutdown_signal
+    except asyncio.CancelledError:
+        # Handle cancellation during shutdown gracefully
+        print("Service shutdown requested...")
+    except KeyboardInterrupt:
+        # Handle Ctrl+C gracefully
+        print("Keyboard interrupt received, shutting down...")
+    except Exception as e:
+        print(f"Unexpected error occurred: {e}")
+    finally:
+        if monitor:
+            print("\nShutdown - Final memory state:")
+            monitor.log_memory("Final:")
+        if monitor_task:
+            monitor_task.cancel()
+        print("Shutting down worker...")
+
+
+if __name__ == "__main__":
+    uvloop.install()
+    asyncio.run(worker())

--- a/lib/bindings/python/examples/pipeline_openai/load_test.py
+++ b/lib/bindings/python/examples/pipeline_openai/load_test.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+Simple load test for testing remote servers.
+Focuses on generating load without memory profiling on client side.
+"""
+
+import asyncio
+import time
+import traceback
+
+import aiohttp
+import orjson
+
+PAYLOAD = "Hello from request. " * 1  # Adjust payload size as needed
+
+
+class LoadTestDebugger:
+    def __init__(self, base_url: str = "http://localhost:8000"):
+        self.base_url = base_url
+        self.session = None
+        # Use collections.deque with maxlen to prevent unbounded memory growth
+        from collections import deque
+
+        self.request_times = deque(maxlen=10000)  # Keep only last 10k request times
+        self.errors = deque(maxlen=1000)  # Keep only last 1k errors
+        self.total_requests = 0
+        self.total_errors = 0
+
+    async def start_session(self):
+        """Start HTTP session with optimizations for high concurrency"""
+        connector = aiohttp.TCPConnector(
+            limit=0,  # No limit on total connections
+            limit_per_host=2000,  # Allow up to 2000 connections per host
+            ttl_dns_cache=300,  # DNS cache TTL
+            use_dns_cache=True,
+            keepalive_timeout=30,
+            enable_cleanup_closed=True,
+            force_close=False,  # Keep connections alive
+            ssl=False,  # Disable SSL verification for load testing
+        )
+
+        timeout = aiohttp.ClientTimeout(
+            total=120,  # Total request timeout
+            connect=10,  # Connection timeout
+            sock_read=30,  # Socket read timeout
+        )
+
+        self.session = aiohttp.ClientSession(
+            connector=connector, timeout=timeout, headers={"Connection": "keep-alive"}
+        )
+
+    async def stop_session(self):
+        """Stop HTTP session"""
+        if self.session:
+            await self.session.close()
+
+    async def test_connection(self):
+        """Test if the backend is accessible"""
+        try:
+            async with self.session.get(
+                f"{self.base_url}/v1/models", timeout=aiohttp.ClientTimeout(total=5)
+            ) as response:
+                if response.status == 200:
+                    print(f"✓ Backend is accessible at {self.base_url}")
+                    return True
+                else:
+                    print(f"✗ Backend returned status {response.status}")
+                    return False
+        except Exception as e:
+            print(f"✗ Cannot connect to backend at {self.base_url}: {e}")
+            return False
+
+    async def send_request(self, request_id: int):
+        """Send a single request and measure performance"""
+        start_time = time.time()
+
+        payload = {
+            "model": "mock_model",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": f"{PAYLOAD} (Request ID: {request_id})",
+                }
+            ],
+            "max_tokens": 2,
+        }
+        json = orjson.dumps(payload).decode()
+
+        try:
+            async with self.session.post(
+                f"{self.base_url}/v1/chat/completions",
+                data=json,
+                headers={"Content-Type": "application/json"},
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as response:
+                if response.status == 200:
+                    # Consume the streaming response without storing all chunks
+                    chunk_count = 0
+                    async for line in response.content:
+                        if line.strip():
+                            chunk_count += 1
+                            # Don't store chunks to save memory - just count them
+                            pass
+
+                    end_time = time.time()
+                    self.request_times.append(end_time - start_time)
+                    self.total_requests += 1
+
+                    if request_id % 1000 == 0:
+                        print(
+                            f"Request {request_id} completed in {end_time - start_time:.3f}s"
+                        )
+                        if self.request_times:
+                            recent_times = (
+                                list(self.request_times)[-100:]
+                                if len(self.request_times) >= 100
+                                else list(self.request_times)
+                            )
+                            print(
+                                f"Average response time: {sum(recent_times) / len(recent_times):.3f}s"
+                            )
+
+                else:
+                    self.errors.append(
+                        f"Request {request_id}: HTTP {response.status} description {await response.text()}"
+                    )
+                    self.total_errors += 1
+
+        except Exception as e:
+            self.errors.append(f"Request {request_id}: {str(e)}")
+            self.total_errors += 1
+            if self.total_errors % 100 == 0:
+                print(f"Total error count: {self.total_errors}")
+
+    async def run_load_test(self, total_requests: int = 100000, concurrent: int = 10):
+        """Run load test"""
+        print(
+            f"Starting load test: {total_requests} requests with {concurrent} concurrent"
+        )
+
+        test_start_time = time.time()
+        semaphore = asyncio.Semaphore(concurrent)
+
+        async def bounded_request(request_id):
+            async with semaphore:
+                await self.send_request(request_id)
+
+        # Use smaller batches and process more efficiently
+        batch_size = 500  # Reduced batch size
+        completed_requests = 0
+
+        for batch_start in range(0, total_requests, batch_size):
+            batch_end = min(batch_start + batch_size, total_requests)
+
+            # Create and execute tasks for this batch
+            tasks = [
+                asyncio.create_task(bounded_request(i))
+                for i in range(batch_start, batch_end)
+            ]
+
+            # Wait for this batch to complete
+            try:
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                completed_requests += len(
+                    [r for r in results if not isinstance(r, Exception)]
+                )
+            except Exception as e:
+                print(f"Batch {batch_start}-{batch_end} error: {e}")
+
+            # Explicitly clean up task references
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+                # Help GC by removing references
+                del task
+            del tasks
+
+            # Progress update every few batches
+            if batch_end % 5000 == 0:
+                elapsed = time.time() - test_start_time
+                rate = batch_end / elapsed if elapsed > 0 else 0
+                print(
+                    f"Progress: {batch_end}/{total_requests} requests, rate: {rate:.1f} req/s"
+                )
+                print(f"  Completed: {completed_requests}, Errors: {self.total_errors}")
+
+        # Final analysis
+        print("\nLoad test completed!")
+        print(f"Total requests sent: {total_requests}")
+        print(f"Successful requests: {self.total_requests}")
+        print(f"Total errors: {self.total_errors}")
+        if self.request_times:
+            print(
+                f"Average response time: {sum(self.request_times) / len(self.request_times):.3f}s"
+            )
+        else:
+            print("No successful requests - all requests failed!")
+            print("Check backend server is running and accessible")
+
+        if self.errors:
+            print(f"\nLast 10 errors (of {self.total_errors} total):")
+            for error in list(self.errors)[-10:]:
+                print(f"  {error}")
+
+            # Show error summary
+            error_types = {}
+            for error in self.errors:
+                error_type = error.split(":")[1].strip() if ":" in error else "unknown"
+                error_types[error_type] = error_types.get(error_type, 0) + 1
+
+            print(f"\nError summary (from last {len(self.errors)} errors):")
+            for error_type, count in error_types.items():
+                print(f"  {error_type}: {count} occurrences")
+
+
+async def main():
+    debugger = LoadTestDebugger()
+
+    try:
+        await debugger.start_session()
+
+        # Test connection first
+        if not await debugger.test_connection():
+            print(
+                "Cannot connect to backend. Make sure it's running at http://localhost:8000"
+            )
+            return
+
+        # Run a smaller test first
+        print("Running initial test...")
+        start_time = time.time()
+        await debugger.run_load_test(total_requests=100, concurrent=10)
+
+        # If that works, run the full test
+        print("\nRunning full load test...")
+        start_time = time.time()
+        await debugger.run_load_test(total_requests=20000, concurrent=10)
+        total_time = time.time() - start_time
+        print(f"Total test time: {total_time:.2f}s")
+
+    except KeyboardInterrupt:
+        print("Load test interrupted")
+    except Exception as e:
+        print(f"Load test failed: {e}")
+        traceback.print_exc()
+    finally:
+        await debugger.stop_session()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lib/bindings/python/examples/pipeline_openai/memory_monitor.py
+++ b/lib/bindings/python/examples/pipeline_openai/memory_monitor.py
@@ -1,0 +1,85 @@
+"""
+Shared memory monitoring utilities for Dynamo components.
+Enable with environment variable DYNAMO_MEMORY_PROFILE=1
+"""
+import asyncio
+import gc
+import os
+import threading
+import time
+
+import psutil
+
+
+class MemoryMonitor:
+    """Memory monitor that can be shared across components"""
+
+    def __init__(self, component_name):
+        self.process = psutil.Process(os.getpid())
+        self.request_count = 0
+        self.start_time = time.time()
+        self.component_name = component_name
+        self.freed_last = 0
+
+    @property
+    def initial_memory(self):
+        if not hasattr(self, "_initial_memory"):
+            self._initial_memory = self.process.memory_info().rss
+        return self._initial_memory
+
+    def log_memory(self, label=""):
+        """Log current memory usage"""
+        memory_info = self.process.memory_info()
+        rss_mb = memory_info.rss / 1024 / 1024
+        vms_mb = memory_info.vms / 1024 / 1024
+        rss_growth = (memory_info.rss - self.initial_memory) / 1024 / 1024
+        uptime = time.time() - self.start_time
+
+        print(
+            f"[{self.component_name}] [{uptime:.1f}s] {label} Memory: RSS={rss_mb:.2f}MB (+{rss_growth:.2f}MB), VMS={vms_mb:.2f}MB, Requests={self.request_count}, Last GC freed={self.freed_last:.2f}MB"
+        )
+
+    def increment_request(self):
+        """Increment request counter and log if needed"""
+        self.request_count += 1
+        self.initial_memory
+
+        # Log every 5000 requests
+        if self.request_count % 5000 == 0:
+            threading.Thread(
+                target=self.log_memory,
+                args=(f"After {self.request_count} requests:",),
+                daemon=True,
+            ).start()
+
+        # Force GC and log every 20000 requests
+        if self.request_count % 20000 == 0:
+            before_gc = self.process.memory_info().rss
+            collected = gc.collect()
+            after_gc = self.process.memory_info().rss
+            freed_mb = (before_gc - after_gc) / 1024 / 1024
+            self.freed_last = freed_mb
+            print(
+                f"[{self.component_name}]   GC collected {collected} objects, freed {self.freed_last:.2f}MB"
+            )
+
+
+def create_monitor(component_name):
+    """Create a memory monitor if profiling is enabled, otherwise return None"""
+    if os.getenv("DYNAMO_MEMORY_PROFILE", "1") == "1":
+        return MemoryMonitor(component_name)
+    return None
+
+
+def setup_background_monitor(monitor):
+    """Create background monitoring task if monitor exists"""
+    if not monitor:
+        print("Memory monitoring not enabled.")
+        return None
+
+    async def background_monitor():
+        while True:
+            await asyncio.sleep(15)  # Log every 15 seconds
+            monitor.log_memory("Background check:")
+
+    return asyncio.create_task(background_monitor())


### PR DESCRIPTION
Signed-off-by: michaelfeil <me@michaelfeil.eu>

#### Overview:

Motivation: I noticed that the Frontend Pod is suspect of some unlimited memory growth issue. Here a picture from ~200 prod pods. 
I wrote a minimal repo to prove this is also happening in Dynamo upstream, not just on my private fork. Typically, the memory can grow by ~10-40GB/day, maybe after processing 200k-1M requests. The resolution was/is a un-graceful termination by k8s, dropping ALL streams and init. 
<img width="1650" height="488" alt="image" src="https://github.com/user-attachments/assets/5dfc9e86-c4a5-446a-a4b1-658d85b1ca7a" />

### Critical Observations RUN 1:
- Sending long context request causes memory leak, short context messages
- The backend.py is super super simple. The proxy configuration it still gathers 1.4B of RAM after the requests are done. The non-proxy configuration is better of. Pods that are in the middle of the DAG seem to suffer the most. 

### Critical Observations RUN 2:
- Its very easy to "stall"/"deadlock" the entire pipeline. This is actually a easteregg that was unexpected. My fork is off of 0.6.0 and does not have this behavior. 


#### Details:

To repro, I wrote the following minimal DAG:

```
frontend -> backend-proxy (proxy's to prefil/decoder worker) -> backend (similar to prefill worker)
```

I am then sending short or long context requests:

## Run 1:
1. Spawning the there components: frontend -> backend-proxy  -> backend
2. `./load_test.py --payload-size 10 --concurrency 48` running 30 token requests
Results:
Progress: 10000/10000 requests, rate: 1863.8 req/s
  Completed: 10000, Errors: 0
```
Load test completed!
Total requests sent: 10000
Successful requests: 10100
Total errors: 0
Average response time: 0.025s
Total test time: 5.37s
```
<img width="727" height="97" alt="image" src="https://github.com/user-attachments/assets/10c119e4-d1c8-4fe3-ae45-4f9e05c373fc" />

## Run 1- continued with larger requests
After small requests work fine, lets run some approx 200k context requests. Very typical for agentic workflows, assuming large kv-cache, but payload is transmitted every turn. 
```
./load_test.py --payload-size 20000 --concurrency 48
```

<img width="740" height="77" alt="image" src="https://github.com/user-attachments/assets/16ca4dc2-4824-45ae-a896-673394ca9aeb" />

Memory grew a bit! Lets re-run `20000` sized request the same server again.

<img width="735" height="100" alt="image" src="https://github.com/user-attachments/assets/5a6a8d88-62cd-41cf-9b09-fea6ecee1f49" />

Lets increase to `./load_test.py --payload-size 200000 --concurrency 48`

<img width="776" height="120" alt="image" src="https://github.com/user-attachments/assets/2b49a135-aaf8-4180-8181-4d1ed263f17a" />

Lets increase to `./load_test.py --payload-size 200000 --concurrency 96`

<img width="732" height="95" alt="image" src="https://github.com/user-attachments/assets/ffb34505-a65e-4151-bd99-b84c109b1ae5" />


```
# RUNNING ./load_test.py --payload-size 20000 --concurrency 48 now 
[FRONTEND] [495.6s] Background check: Memory: RSS=233.79MB (+183.42MB), VMS=30935.37MB, Requests=30301, Last GC freed=0.00MB
[FRONTEND] [510.6s] Background check: Memory: RSS=233.79MB (+183.42MB), VMS=30935.37MB, Requests=30301, Last GC freed=0.00MB
[FRONTEND] [525.6s] Background check: Memory: RSS=233.79MB (+183.42MB), VMS=30935.37MB, Requests=30301, Last GC freed=0.00MB
[FRONTEND] [540.6s] Background check: Memory: RSS=233.79MB (+183.42MB), VMS=30935.37MB, Requests=30301, Last GC freed=0.00MB
# RUNNING ./load_test.py --payload-size 200000 --concurrency 48 now 
[FRONTEND] [555.6s] Background check: Memory: RSS=960.87MB (+910.50MB), VMS=30957.11MB, Requests=31666, Last GC freed=0.00MB
[FRONTEND] [570.2s] After 35000 requests: Memory: RSS=980.10MB (+929.72MB), VMS=31056.72MB, Requests=35001, Last GC freed=0.00MB
[FRONTEND] [570.6s] Background check: Memory: RSS=1180.07MB (+1129.70MB), VMS=31132.97MB, Requests=35079, Last GC freed=0.00MB
[FRONTEND] [585.6s] Background check: Memory: RSS=1127.55MB (+1077.18MB), VMS=31037.60MB, Requests=38563, Last GC freed=0.00MB
[FRONTEND] [592.1s] After 40000 requests: Memory: RSS=1089.83MB (+1039.45MB), VMS=31037.63MB, Requests=40000, Last GC freed=0.00MB
[FRONTEND]   GC collected 33 objects, freed 0.00MB
[FRONTEND] [600.6s] Background check: Memory: RSS=1065.80MB (+1015.43MB), VMS=31129.16MB, Requests=40401, Last GC freed=0.00MB
[FRONTEND] [615.6s] Background check: Memory: RSS=1065.80MB (+1015.43MB), VMS=31121.15MB, Requests=40401, Last GC freed=0.00MB
# RUNNING ./load_test.py --payload-size 200000 --concurrency 96 now 
[FRONTEND] [630.6s] Background check: Memory: RSS=1654.90MB (+1604.52MB), VMS=31106.66MB, Requests=40930, Last GC freed=0.00MB
[FRONTEND] [645.6s] Background check: Memory: RSS=1861.16MB (+1810.78MB), VMS=31301.21MB, Requests=44029, Last GC freed=0.00MB
[FRONTEND] [650.3s] After 45000 requests: Memory: RSS=2192.25MB (+2141.88MB), VMS=31347.40MB, Requests=45000, Last GC freed=0.00MB
[FRONTEND] [660.6s] Background check: Memory: RSS=1986.45MB (+1936.07MB), VMS=31309.22MB, Requests=47192, Last GC freed=0.00MB
[FRONTEND] [673.6s] After 50000 requests: Memory: RSS=2333.06MB (+2282.69MB), VMS=31328.31MB, Requests=50000, Last GC freed=0.00MB
[FRONTEND] [675.6s] Background check: Memory: RSS=2015.35MB (+1964.97MB), VMS=31316.85MB, Requests=50446, Last GC freed=0.00MB
````

A lot of growth. And thats just after 50k requests. Lets move on an run the benchmark over night. If it was just small buffers, it would disappear/saturate. For this, I increase to 10000k requests, and run the bench again. 

<img width="749" height="140" alt="image" src="https://github.com/user-attachments/assets/e5ed1703-529c-44ad-b1e1-4ab5618436ba" />

# RUN 2 super small payloads but high concurrency -- deadlock

On my 0.6.0 branch where i wrote this script originally for, my testing concurrency was maxed at 1000. 
Somehow 1000 deadlocks on the current main branch, while it works just fine on 0.6.0. 
Running the benchmark with concurrency 400, everything is snappy. 

```
pipeline_openai  $ ./load_test.py --payload-size 2 --concurrency 400
✓ Backend is accessible at http://localhost:8000
Running initial test...
Starting load test: 100 requests with 10 concurrent
Request 0 completed in 0.006s
Average response time: 0.006s

Load test completed!
Total requests sent: 100
Successful requests: 100
Total errors: 0
Average response time: 0.006s

Running full load test...
Starting load test: 10000 requests with 400 concurrent
Request 0 completed in 0.092s
Average response time: 0.007s
....
Request 9000 completed in 0.093s
Average response time: 0.158s
Progress: 10000/10000 requests, rate: 1639.8 req/s
  Completed: 10000, Errors: 0

Load test completed!
Total requests sent: 10000
Successful requests: 10100
Total errors: 0
Average response time: 0.210s
Total test time: 6.10s
```

Running at concurrency 1000
```
./load_test.py --payload-size 2 --concurrency 1000
✓ Backend is accessible at http://localhost:8000
Running initial test...
Starting load test: 100 requests with 10 concurrent
Request 0 completed in 0.006s
Average response time: 0.006s

Load test completed!
Total requests sent: 100
Successful requests: 100
Total errors: 0
Average response time: 0.006s

Running full load test...
Starting load test: 10000 requests with 1000 concurrent
Request 0 completed in 0.299s
Average response time: 0.009s
Request 1000 completed in 0.133s
Average response time: 0.277s
Request 2000 completed in 0.118s
Average response time: 0.270s
Request 3000 completed in 0.155s
Average response time: 0.185s
Request 4000 completed in 0.095s
Average response time: 0.225s
Progress: 5000/10000 requests, rate: 1480.8 req/s
  Completed: 5000, Errors: 0
Request 5000 completed in 0.108s
Average response time: 0.272s
Request 6000 completed in 0.124s
Average response time: 0.243s
Request 7000 completed in 0.110s
Average response time: 0.231s # STALLS FOR 100s of seconds here, after 7k processed requests. Are we starving the runtime here??
Total error count: 100
Total error count: 200
Total error count: 300
Total error count: 400
Total error count: 500
Total error count: 600
Total error count: 700
Total error count: 800
Total error count: 900
Total error count: 1000
Total error count: 1100
Total error count: 1200
Total error count: 1300
Total error count: 1400
Total error count: 1500
Total error count: 1600
Total error count: 1700
Total error count: 1800
```

After this, even curl http://localhost:8000/v1/models is broken. The python memory stats keep printing (not a GIL deadlock, otherwise no more async prints from the memory reporter). Feels like a tokio deadlock.

```
pipeline_openai  $ ./load_test.py --payload-size 2 --concurrency 1000
✗ Cannot connect to backend at http://localhost:8000: 
```

# Attempts to fix it:
Tried:
- memray, starting the application. Says a lot of python String allocations + NvChatCompletion types are responsible for memory usage. 
-  Attach all kind of timeouts on the python engine.rs so that e.g. operations time out / queues get drained. 


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide for Memory Profiling Pipeline example with detailed setup and startup instructions.

* **New Features**
  * Added complete example pipeline demonstrating an OpenAI-like chat service with integrated memory monitoring.
  * Introduced load testing utility for evaluating performance and stability under high-concurrency, high-payload scenarios.
  * Added memory profiling and monitoring capabilities for tracking resource usage across pipeline components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->