### PR TITLE
fix: Support plain text input and reuse the processor in trtllm multimodal mode

### DIFF
--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -17,13 +17,20 @@ import logging
 import time
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Protocol, Tuple
+from typing import Any, Dict, List, Optional, Protocol, Tuple, Union, Coroutine
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
 import torch
-from tensorrt_llm.inputs import default_multimodal_input_loader
-from tensorrt_llm.llmapi.tokenizer import tokenizer_factory
+
+from transformers import AutoProcessor, ProcessorMixin
+from tensorrt_llm.inputs import (ConversationMessage, MultimodalData, load_image, 
+                                 load_video, MultimodalDataTracker,
+                                 add_multimodal_placeholders, apply_chat_template)
+from tensorrt_llm.inputs.utils import load_audio, HF_CHAT_TEMPLATE_EXCEPTIONS
+from tensorrt_llm.llmapi.llm_utils import ModelLoader
+from tensorrt_llm.llmapi.tokenizer import tokenizer_factory, TokenizerBase, TransformersTokenizer
+from tensorrt_llm.serve.chat_utils import parse_chat_message_content
 
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -65,6 +72,12 @@ class MultimodalRequestProcessor:
             self.tokenizer = tokenizer
         else:
             self.tokenizer = tokenizer_factory(model_dir)
+        
+        self.processor = None
+        if model_type not in HF_CHAT_TEMPLATE_EXCEPTIONS:
+            self.processor = AutoProcessor.from_pretrained(model_dir,
+                                use_fast=True,
+                                trust_remote_code=True)
 
     def is_url(self, path: str) -> bool:
         """Check if a path is a URL."""
@@ -176,37 +189,43 @@ class MultimodalRequestProcessor:
         )
 
         if not image_urls and not embedding_paths:
-            logging.warning("No multimodal content, returning None")
-            return None
+            logging.warning("No multimodal content, pure text request detected.")
+            processed_inputs = await get_multimodal_inputs(
+                messages=messages,
+                model_type=self.model_type,
+                tokenizer=self.tokenizer,
+                processor=self.processor,
+            )
+        else:
+            loader_kwargs = {}
+            if embeddings is not None:
+                # EPD flow
+                loader_kwargs["mm_embeddings"] = [embeddings]
+                logging.debug(f"Using NIXL embeddings in prefill worker: {embeddings}")
+            elif image_urls:
+                # Image-only flow
+                loader_kwargs["media"] = [image_urls]
+            elif embedding_paths:
+                # PD flow with no NIXL and no encoder
+                loader_kwargs["mm_embeddings"] = [
+                    self.load_tensor_from_path_or_url(path) for path in embedding_paths
+                ]
+                logging.debug(f"Using embedding paths in prefill worker: {embedding_paths}")
 
-        loader_kwargs = {}
-        if embeddings is not None:
-            # EPD flow
-            loader_kwargs["mm_embeddings"] = [embeddings]
-            logging.debug(f"Using NIXL embeddings in prefill worker: {embeddings}")
-        elif image_urls:
-            # Image-only flow
-            loader_kwargs["media"] = [image_urls]
-        elif embedding_paths:
-            # PD flow with no NIXL and no encoder
-            loader_kwargs["mm_embeddings"] = [
-                self.load_tensor_from_path_or_url(path) for path in embedding_paths
-            ]
-            logging.debug(f"Using embedding paths in prefill worker: {embedding_paths}")
-
-        # Process with default_multimodal_input_loader
-        # Pass self.tokenizer to reuse the pre-initialized tokenizer instead of
-        # creating a new one per request
-        processed_inputs = default_multimodal_input_loader(
-            tokenizer=self.tokenizer,
-            model_dir=self.model_dir,
-            model_type=self.model_type,
-            modality=self.modality,
-            prompts=[text_prompt],
-            image_data_format="pt",
-            device="cuda",
-            **loader_kwargs,
-        )
+            # Process with default_multimodal_input_loader
+            # Pass self.tokenizer to reuse the pre-initialized tokenizer instead of
+            # creating a new one per request
+            processed_inputs = default_multimodal_input_loader(
+                tokenizer=self.tokenizer,
+                processor=self.processor,
+                model_dir=self.model_dir,
+                model_type=self.model_type,
+                modality=self.modality,
+                prompts=[text_prompt],
+                image_data_format="pt",
+                device="cuda",
+                **loader_kwargs,
+            )
 
         # Return the first processed input if available
         if processed_inputs:
@@ -248,3 +267,224 @@ class MultimodalRequestProcessor:
             "object": "chat.completion.chunk",
             "choices": [choice],
         }
+
+def default_multimodal_input_loader(
+        *,
+        tokenizer: Optional[Union[TransformersTokenizer, TokenizerBase]],
+        processor: ProcessorMixin,
+        model_dir: str,
+        model_type: str,
+        modality: str,
+        prompts: List[str],
+        media: Optional[Union[List[str], List[List[str]]]] = None,
+        image_data_format: str = "pt",
+        num_frames: int = 8,
+        mm_embeddings: Optional[Union[List[torch.Tensor],
+                                      List[List[torch.Tensor]]]] = None,
+        device: str = "cpu") -> List[dict[str, Union[str, torch.Tensor]]]:
+
+    def convert_to_conversation_message(
+        prompt: str,
+        media: Union[Any, List[Any]],
+        modality: str,
+        is_embedding: bool = False,
+    ) -> ConversationMessage:
+        if isinstance(media, str):
+            media = [media]
+        if modality in ["image", "multiple_image"]:
+            if is_embedding:
+                # each mm_embedding corresponds to each image placeholder
+                if not isinstance(media, list):
+                    media = [media]
+
+                mm_data = [{
+                    'modality': modality,
+                    'mm_embedding_info': mm
+                } for mm in media]
+            else:
+                mm_data = [
+                    MultimodalData(modality=modality,
+                                   data=load_image(i,
+                                                   format=image_data_format,
+                                                   device=device))
+                    for i in media
+                ]
+        elif modality == "video":
+            if is_embedding:
+                raise ValueError(
+                    "External embedding is not supported for video modality yet."
+                )
+            mm_data = [
+                MultimodalData(modality=modality,
+                               data=load_video(i,
+                                               num_frames,
+                                               format=image_data_format,
+                                               device=device)) for i in media
+            ]
+        elif modality == "audio":
+            if is_embedding:
+                raise ValueError(
+                    "External embedding is not supported for audio modality yet."
+                )
+            mm_data = [
+                MultimodalData(modality=modality,
+                               data=load_audio(i, device=device)) for i in media
+            ]
+        elif modality == "image_audio":
+            if is_embedding:
+                raise ValueError(
+                    "External embedding is not supported for image_audio modality yet."
+                )
+            # Use different load_xxx functions to match the modality.
+            mm_data = []
+            for m in media:
+                data = None
+                _modal = None
+                if _modal is None:
+                    try:
+                        data = load_image(m,
+                                          format=image_data_format,
+                                          device=device)
+                        _modal = "image"
+                    except Exception:
+                        pass
+                if _modal is None:
+                    try:
+                        data = load_audio(m, device=device)
+                        _modal = "audio"
+                    except Exception:
+                        pass
+                if _modal is None:
+                    raise ValueError(f"Unknown matching modality: {modality}")
+                mm_data.append(MultimodalData(modality=_modal, data=data))
+        elif modality == "mixture_text_image":
+            mm_data = []
+            for m in media:
+                if m:
+                    mm_data.append(
+                        MultimodalData(modality="image",
+                                       data=load_image(m,
+                                                       format=image_data_format,
+                                                       device=device)))
+        else:
+            raise ValueError(f"Unknown modality: {modality}")
+        return ConversationMessage(role="user", content=prompt, media=mm_data)
+
+    assert media is not None or mm_embeddings is not None, "Either media or mm_embeddings must be provided."
+    assert media is None or mm_embeddings is None, "Either media or mm_embeddings must be provided, not both."
+    media_or_embeddings = media if media is not None else mm_embeddings
+    is_embedding = mm_embeddings is not None
+
+    if len(media_or_embeddings) > len(prompts) and len(prompts) == 1:
+        # 1 prompt + N media
+        assert not isinstance(
+            media_or_embeddings[0],
+            list)  # media cannot be a list of lists in this case
+        media_or_embeddings = [media_or_embeddings]
+    assert len(media_or_embeddings) == len(prompts)
+
+    if tokenizer is None and model_type not in HF_CHAT_TEMPLATE_EXCEPTIONS:
+        tokenizer = ModelLoader.load_hf_tokenizer(model_dir, use_fast=True)
+
+    if processor is None:
+        if model_type not in HF_CHAT_TEMPLATE_EXCEPTIONS:
+            processor = AutoProcessor.from_pretrained(model_dir,
+                                                    use_fast=True,
+                                                    trust_remote_code=True)
+
+    inputs = []
+    for prompt_idx, (prompt,
+                     media) in enumerate(zip(prompts, media_or_embeddings)):
+        conv = convert_to_conversation_message(prompt, media, modality,
+                                               is_embedding)
+
+        mm_data_tracker = MultimodalDataTracker(model_type)
+        for mdata in conv["media"]:
+            # Check if mdata is a MultimodalData
+            if isinstance(mdata,
+                          dict) and "modality" in mdata and "data" in mdata:
+                mdata_modality = mdata["modality"]
+                if modality == "multiple_image":
+                    mdata_modality = "image"
+                mm_data_tracker.add_data(mdata_modality, mdata["data"])
+            else:
+                # Add embeddings to the tracker for placeholder handling
+                mm_data_tracker.add_data(mdata["modality"],
+                                         mdata["mm_embedding_info"])
+        mm_placeholder_counts = mm_data_tracker.placeholder_counts()
+        prompt = conv["content"]
+        if mm_placeholder_counts:
+            conv["content"] = add_multimodal_placeholders(
+                model_type, conv["content"], mm_placeholder_counts)
+        prompt = apply_chat_template(
+            model_type=model_type,
+            tokenizer=tokenizer,
+            processor=processor,
+            conversation=[conv],
+            add_generation_prompt=True,
+            mm_placeholder_counts=[mm_placeholder_counts])
+        input = {"prompt": prompt}
+        if mm_placeholder_counts:
+            if mm_embeddings is not None:
+                input[
+                    "multi_modal_embeddings"] = mm_data_tracker.retrieve_all_sync(
+                    )
+            else:
+                input["multi_modal_data"] = mm_data_tracker.retrieve_all_sync()
+        inputs.append(input)
+
+    return inputs
+
+
+async def get_multimodal_inputs(
+    messages: List[Dict],
+    model_type: str,
+    tokenizer: Optional[Union[TransformersTokenizer, TokenizerBase]],
+    processor: ProcessorMixin,
+) -> List[Any]:
+    conversation: List[ConversationMessage] = []
+
+    conversation, mm_coroutines, mm_placeholder_counts = parse_chat_messages_coroutines(messages, model_type)
+    
+    prompt: str = apply_chat_template(
+            model_type=model_type,
+            tokenizer=tokenizer,
+            processor=processor,
+            conversation=conversation,
+            mm_placeholder_counts=mm_placeholder_counts,
+            add_generation_prompt=True,
+        )
+    input = {"prompt": prompt}
+
+    mm_data = await mm_coroutines
+    if mm_data is not None:
+        input["multi_modal_data"] = mm_data
+    return [input]
+
+def parse_chat_messages_coroutines(
+    messages: List[Any],
+    model_type: str,
+) -> Tuple[List[ConversationMessage], Optional[Coroutine[
+        Any, Any, Optional[Dict[str, List[Any]]]]]]:
+    """Parse multiple chat messages and return conversation and coroutine."""
+    conversation = []
+    mm_placeholder_counts = []
+    mm_data_tracker = MultimodalDataTracker(model_type)
+
+    for msg in messages:
+        parsed_msg = parse_chat_message_content(msg, mm_data_tracker)
+        conversation.append(parsed_msg)
+        tmp_tracker = MultimodalDataTracker(model_type)
+        if parsed_msg["media"]:
+            for mdata in parsed_msg["media"]:
+                mm_data_tracker.add_data(mdata["modality"], mdata["data"])
+                tmp_tracker.add_data(mdata["modality"], mdata["data"])
+        mm_placeholder_count = tmp_tracker.placeholder_counts()
+        if mm_placeholder_count:
+            parsed_msg["content"] = add_multimodal_placeholders(
+                model_type, parsed_msg["content"],
+                mm_placeholder_count)
+        mm_placeholder_counts.append(mm_placeholder_count)
+
+    return conversation, mm_data_tracker.retrieve_all_async(
+    ), mm_placeholder_counts

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -368,15 +368,15 @@ impl OpenAIPreprocessor {
 
         if !media_map.is_empty() {
             builder.multi_modal_data(Some(media_map));
-
-            // Preserve original messages in extra_args for multimodal workers that need them
-            // (e.g., TRT-LLM multimodal processor needs raw messages for proper tokenization)
-            let messages_json = serde_json::to_value(&messages)?;
-            let extra_args = serde_json::json!({
-                "messages": messages_json
-            });
-            builder.extra_args(Some(extra_args));
         }
+
+        // Preserve original messages in extra_args for multimodal workers that need them
+        // (e.g., TRT-LLM multimodal processor needs raw messages for proper tokenization)
+        let messages_json = serde_json::to_value(&messages)?;
+        let extra_args = serde_json::json!({
+            "messages": messages_json,
+        });
+        builder.extra_args(Some(extra_args));
 
         Ok(())
     }


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
The fix modifies the initialization logic to create and reuse a single processor across multiple requests. This eliminates the repeated initialization cost.
The fix also enables the router to handle plain text inputs in multi-modal scenarios.

#### Details:

<!-- Describe the changes made in this PR. -->
Created a new default_multimodal_input_loader function in Dynamo that mirrors the necessary steps originally handled by the external trtllm module. Modified the function signature to accept a pre-initialized processor object as a parameter. This allows the caller to instantiate the processor once and pass the same processor for all subsequent requests.
The handling of plain text inputs is aligned with the method used in the tensorrt_llm.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
components/src/dynamo/trtllm/multimodal_processor.py
lib/llm/src/preprocessor.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #5267 
- relates to GitHub issue: #5086 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive multimodal input support, enabling processing of images, videos, audio, and mixed content types in conversations.
  * Enhanced chat message handling with improved placeholder management for media content.
  * Refined request processing pipeline for seamless multimodal content assembly and streaming response generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->