### PR TITLE
fix(llm): Send HF URLs to frontend not full paths

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -360,7 +360,12 @@ fn register_llm<'p>(
 
         let mut builder = dynamo_llm::local_model::LocalModelBuilder::default();
         builder
+            // model path is the physical path on disk of the downloaded model
             .model_path(model_path)
+            // source path is what the user gave as `--model-path`, either a real path (in which
+            // case it matches model_path above), or an HF repo.
+            .source_path(source_path.clone().into())
+            // --served_model_name
             .model_name(model_name.clone())
             .context_length(context_length)
             .kv_cache_block_size(kv_cache_block_size)
@@ -386,7 +391,10 @@ fn register_llm<'p>(
         if let Some(lora_name) = lora_identifier {
             tracing::info!("Registered LoRA '{}' MDC", lora_name);
         } else {
-            tracing::info!("Registered base model '{:?}' MDC", model_name);
+            tracing::info!(
+                "Registered base model '{}' MDC",
+                model_name.unwrap_or(source_path)
+            );
         }
 
         Ok(())

--- a/lib/llm/src/common/checked_file.rs
+++ b/lib/llm/src/common/checked_file.rs
@@ -116,7 +116,15 @@ impl CheckedFile {
                     *path = new_path;
                 }
             }
-            Either::Right(_) => tracing::warn!("Cannot update directory on URL"),
+            Either::Right(url) => {
+                let Some(filename) = url.path().split('/').next_back().filter(|s| !s.is_empty())
+                else {
+                    tracing::warn!(%url, "Cannot update directory on invalid URL");
+                    return;
+                };
+                let p = dir.join(filename);
+                self.path = Either::Left(p);
+            }
         }
     }
 }

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -24,6 +24,7 @@ use crate::{
     },
 };
 
+use anyhow::Context as _;
 use dynamo_runtime::{
     DistributedRuntime,
     component::Client,
@@ -191,9 +192,11 @@ where
             Pin<Box<dyn AsyncEngineStream<Annotated<BackendOutput>>>>,
         >,
 {
-    let PromptFormatter::OAI(formatter) = PromptFormatter::from_mdc(card)?;
+    let PromptFormatter::OAI(formatter) =
+        PromptFormatter::from_mdc(card).context("PromptFormatter.from_mdc")?;
     let preprocessor =
-        OpenAIPreprocessor::new_with_parts(card.clone(), formatter, hf_tokenizer.clone())?;
+        OpenAIPreprocessor::new_with_parts(card.clone(), formatter, hf_tokenizer.clone())
+            .context("OpenAIPreprocessor.new_with_parts")?;
     build_routed_pipeline_with_preprocessor(
         card,
         client,

--- a/lib/llm/src/preprocessor/prompt/template.rs
+++ b/lib/llm/src/preprocessor/prompt/template.rs
@@ -42,8 +42,12 @@ impl PromptFormatter {
                         mdc.display_name
                     );
                 };
-                let contents = std::fs::read_to_string(file)
-                    .with_context(|| format!("fs:read_to_string '{}'", file.display()))?;
+                let contents = std::fs::read_to_string(file).with_context(|| {
+                    format!(
+                        "PromptFormatter.from_mdc fs:read_to_string '{}'",
+                        file.display()
+                    )
+                })?;
                 let mut config: ChatTemplate =
                     serde_json::from_str(&contents).inspect_err(|err| {
                         crate::log_json_err(&file.display().to_string(), &contents, err)
@@ -53,8 +57,9 @@ impl PromptFormatter {
                 // stores the chat template in a separate file, we check if the file exists and
                 // put the chat template into config as normalization.
                 // This may also be a custom template provided via CLI flag.
-                if let Some(PromptFormatterArtifact::HfChatTemplate(checked_file)) =
-                    mdc.chat_template_file.as_ref()
+                if let Some(PromptFormatterArtifact::HfChatTemplate {
+                    file: checked_file, ..
+                }) = mdc.chat_template_file.as_ref()
                 {
                     let Some(chat_template_file) = checked_file.path() else {
                         anyhow::bail!(
@@ -77,7 +82,7 @@ impl PromptFormatter {
                         .map_or(ContextMixins::default(), |x| ContextMixins::new(&x)),
                 )
             }
-            PromptFormatterArtifact::HfChatTemplate(_) => Err(anyhow::anyhow!(
+            PromptFormatterArtifact::HfChatTemplate { .. } => Err(anyhow::anyhow!(
                 "prompt_formatter should not have type HfChatTemplate"
             )),
         }


### PR DESCRIPTION
Previously the backend would download the model from Modelexpress (MX), and publish a Model Deployment Card with full local paths. The expectation was that these paths are on a shared folder that all machines can access, so we download the model only once. Turns out not everyone has a shared folder. In those cases frontend was unable to access the model.

Now we re-rewrite the local path into a custom URL (e.g. `hf://Qwen/Qwen3-0.6B/config.json`). Frontend will ask MX for the model, and replace these URLs with it's own local path. This is quite similar to how it worked when we published `config.json` et al in NATS.

Follow-on from https://github.com/ai-dynamo/dynamo/pull/5274
Fixes for: https://github.com/ai-dynamo/dynamo/issues/4748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models now preserve and display the original source path (local or repo) which is used for naming and metadata.
  * When publishing, local model files can be rewritten into URL-backed references so deployments reference remote locations.

* **Bug Fixes**
  * Improved handling of remote URLs by extracting filenames when downloading and creating local copies.
  * Logging now prefers a human-friendly source path when model name is unavailable.

* **Stability**
  * Improved error context for prompt/template loading operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->