### PR TITLE
fix: add subcomponenttype to recipes missing this field

### DIFF
--- a/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
@@ -26,6 +26,7 @@ spec:
     decode:
       dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
+      subComponentType: decode
       replicas: 1
       multinode:
         nodeCount: 2
@@ -71,6 +72,7 @@ spec:
     prefill:
       dynamoNamespace: sgl-dsr1-16gpu
       componentType: worker
+      subComponentType: prefill
       replicas: 1
       multinode:
         nodeCount: 2

--- a/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
@@ -26,6 +26,7 @@ spec:
     decode:
       dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
+      subComponentType: decode
       replicas: 1
       resources:
         limits:
@@ -68,6 +69,7 @@ spec:
     prefill:
       dynamoNamespace: sgl-dsr1-8gpu
       componentType: worker
+      subComponentType: prefill
       replicas: 1
       resources:
         limits:

--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
@@ -139,6 +139,7 @@ spec:
     prefill:
       dynamoNamespace: trtllm-disagg-multinode
       componentType: worker
+      subComponentType: prefill
       replicas: 1
       # NOTE: Prefill uses 1 node (no multinode section = single node)
       #       and contributes to ComputeDomain.numNodes (see above)
@@ -196,6 +197,7 @@ spec:
     decode:
       dynamoNamespace: trtllm-disagg-multinode
       componentType: worker
+      subComponentType: decode
       replicas: 1
       volumeMounts:
         - name: model-cache

--- a/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
+++ b/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
@@ -28,6 +28,7 @@ spec:
     decode:
       dynamoNamespace: vllm-dsr1
       componentType: worker
+      subComponentType: decode
       replicas: 1
       multinode:
         nodeCount: 2
@@ -95,6 +96,7 @@ spec:
     prefill:
       dynamoNamespace: vllm-dsr1
       componentType: worker
+      subComponentType: prefill
       replicas: 1
       multinode:
         nodeCount: 2

--- a/recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml
@@ -26,6 +26,7 @@ spec:
       replicas: 1
     VllmPrefillWorker:
       componentType: worker
+      subComponentType: prefill
       dynamoNamespace: llama3-70b-disagg-mn
       envFromSecret: hf-token-secret
       volumeMounts:
@@ -57,6 +58,7 @@ spec:
           gpu: "8"
     VllmDecodeWorker:
       componentType: worker
+      subComponentType: decode
       dynamoNamespace: llama3-70b-disagg-mn
       envFromSecret: hf-token-secret
       volumeMounts:

--- a/recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml
@@ -26,6 +26,7 @@ spec:
       replicas: 1
     VllmPrefillWorker:
       componentType: worker
+      subComponentType: prefill
       dynamoNamespace: llama3-70b-disagg-sn
       envFromSecret: hf-token-secret
       volumeMounts:
@@ -69,6 +70,7 @@ spec:
           gpu: "2"
     VllmDecodeWorker:
       componentType: worker
+      subComponentType: decode
       dynamoNamespace: llama3-70b-disagg-sn
       envFromSecret: hf-token-secret
       volumeMounts:


### PR DESCRIPTION
so that they work with planner...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations for DeepSeek-R1 and Llama-3-70B model recipes to include explicit sub-component type specifications for disaggregated worker components. Changes have been applied across vLLM, SGLang, and TensorRT-LLM serving frameworks, with decode and prefill worker roles now explicitly identified in the deployment manifests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->