### PR TITLE
fix: enable K8s discovery in GAIE

### DIFF
--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -354,7 +354,9 @@ use std::pin::Pin;
 const GENERATE_ENDPOINT: &str = "generate";
 
 use anyhow::Context;
-use dynamo_runtime::{Runtime, distributed::DistributedConfig, traits::DistributedRuntimeProvider};
+use dynamo_runtime::{
+    Runtime, distributed::DistributedConfig, storage::kv, traits::DistributedRuntimeProvider,
+};
 
 use dynamo_llm::discovery::ModelManager;
 use dynamo_llm::entrypoint::build_routed_pipeline;
@@ -1354,7 +1356,32 @@ pub async fn create_worker_selection_pipeline_chat(
     use dynamo_llm::kv_router::PrefillRouter;
 
     let runtime = Runtime::from_settings()?;
-    let dst_config = DistributedConfig::from_settings();
+
+    // Check discovery backend to determine the appropriate configuration
+    // When using kubernetes discovery, etcd is not required - use in-memory KV store
+    // When using kv_store (etcd) discovery, etcd is required for both discovery and KV store
+    let discovery_backend =
+        std::env::var("DYN_DISCOVERY_BACKEND").unwrap_or_else(|_| "kv_store".to_string());
+
+    let dst_config = if discovery_backend == "kubernetes" {
+        tracing::info!(
+            "Using Kubernetes discovery backend - etcd not required for worker selection pipeline"
+        );
+        // Kubernetes discovery doesn't need etcd - use in-memory KV store
+        // Discovery happens via Kubernetes API (EndpointSlices)
+        DistributedConfig {
+            store_backend: kv::Selector::Memory,
+            nats_config: None,
+            request_plane: dynamo_runtime::distributed::RequestPlaneMode::default(),
+        }
+    } else {
+        tracing::info!(
+            "Using KV store (etcd) discovery backend for worker selection pipeline"
+        );
+        // Use default settings which connect to etcd
+        DistributedConfig::from_settings()
+    };
+
     let drt_owned = DistributedRuntime::new(runtime, dst_config).await?;
     let distributed_runtime: &'static DistributedRuntime = Box::leak(Box::new(drt_owned));
 

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -539,8 +539,24 @@ impl DistributedConfig {
         // If a NATS server is configured via env, enable the client regardless of request plane.
         let nats_enabled = request_plane.is_nats()
             || std::env::var(crate::config::environment_names::nats::NATS_SERVER).is_ok();
+
+        // Check discovery backend to determine the appropriate KV store backend.
+        // When using kubernetes discovery, etcd is not required - use in-memory KV store.
+        // When using kv_store (etcd) discovery, etcd is required for both discovery and KV store.
+        let discovery_backend =
+            std::env::var("DYN_DISCOVERY_BACKEND").unwrap_or_else(|_| "kv_store".to_string());
+
+        let store_backend = if discovery_backend == "kubernetes" {
+            tracing::info!(
+                "Using Kubernetes discovery backend - using in-memory KV store (etcd not required)"
+            );
+            kv::Selector::Memory
+        } else {
+            kv::Selector::Etcd(Box::default())
+        };
+
         DistributedConfig {
-            store_backend: kv::Selector::Etcd(Box::default()),
+            store_backend,
             nats_config: if nats_enabled {
                 Some(nats::ClientOptions::default())
             } else {

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -540,16 +540,13 @@ impl DistributedConfig {
         let nats_enabled = request_plane.is_nats()
             || std::env::var(crate::config::environment_names::nats::NATS_SERVER).is_ok();
 
-        // Check discovery backend to determine the appropriate KV store backend.
-        // When using kubernetes discovery, etcd is not required - use in-memory KV store.
-        // When using kv_store (etcd) discovery, etcd is required for both discovery and KV store.
+        // Check discovery backend to determine the appropriate KV store backend -
+        // kubernetes discovery, or etcd.
         let discovery_backend =
             std::env::var("DYN_DISCOVERY_BACKEND").unwrap_or_else(|_| "kv_store".to_string());
 
         let store_backend = if discovery_backend == "kubernetes" {
-            tracing::info!(
-                "Using Kubernetes discovery backend - using in-memory KV store (etcd not required)"
-            );
+            tracing::info!("Using Kubernetes discovery backend");
             kv::Selector::Memory
         } else {
             kv::Selector::Etcd(Box::default())

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -189,6 +189,11 @@ First, deploy the Dynamo Graph per instructions above.
 Then follow [Deploy Inference Gateway Section 2](../deploy/inference-gateway/README.md#2-deploy-inference-gateway) to install GAIE.
 
 Update the containers.epp.image in the deployment file, i.e. llama-3-70b/vllm/agg/gaie/k8s-manifests/epp/deployment.yaml. It should match the release tag and be in the format `nvcr.io/nvidia/ai-dynamo/frontend:<my-tag>` i.e. `nvcr.io/nvstaging/ai-dynamo/dynamo-frontend:0.7.0rc2-amd64`
+The recipe assumes you are using Kubernetes discovery backend and sets the `DYN_DISCOVERY_BACKEND` env variable in the epp deployment. If you want to use etcd enable the lines below and remove the DYN_DISCOVERY_BACKEND env var.
+```bash
+- name: ETCD_ENDPOINTS
+  value: "dynamo-platform-etcd.$(PLATFORM_NAMESPACE):2379" #  update dynamo-platform to appropriate namespace
+```
 
 ```bash
 export DEPLOY_PATH=llama-3-70b/vllm/agg/

--- a/recipes/llama-3-70b/vllm/agg/gaie/k8s-manifests/epp/deployment.yaml
+++ b/recipes/llama-3-70b/vllm/agg/gaie/k8s-manifests/epp/deployment.yaml
@@ -69,8 +69,9 @@ spec:
                   fieldPath: metadata.namespace
             - name: PLATFORM_NAMESPACE
               value: "$(POD_NAMESPACE)" # set to your dynamo platform namespace if different
-            - name: ETCD_ENDPOINTS
-              value: "dynamo-platform-etcd.$(PLATFORM_NAMESPACE):2379" #  update dynamo-platform to appropriate namespace
+            # if you want to use etcd enable this and remove the DYN_DISCOVERY_BACKEND env var
+            # - name: ETCD_ENDPOINTS
+            #   value: "dynamo-platform-etcd.$(PLATFORM_NAMESPACE):2379" #  update dynamo-platform to appropriate namespace
             - name: NATS_SERVER
               value: "nats://dynamo-platform-nats.$(PLATFORM_NAMESPACE):4222" #  update dynamo-platform to appropriate namespace
             - name: DYNAMO_NAMESPACE
@@ -83,6 +84,8 @@ spec:
               value: "true"
             - name: DYNAMO_ENFORCE_DISAGG
               value: "false"
+            - name: DYN_DISCOVERY_BACKEND
+              value: "kubernetes"
 
           ports:
             - containerPort: 9002


### PR DESCRIPTION
#### Overview:

https://nvbugspro.nvidia.com/bug/5792966

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discovery backend selection is now environment-driven. Set `DYN_DISCOVERY_BACKEND` to "kubernetes" to use in-memory KV store discovery; otherwise defaults to etcd-based discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->