### PR TITLE
fix: reduce VLLM_MOE_DP_CHUNK_SIZE to 384

### DIFF
--- a/recipes/deepseek-r1/vllm/disagg/README.md
+++ b/recipes/deepseek-r1/vllm/disagg/README.md
@@ -92,5 +92,6 @@ curl -sS http://localhost:8000/v1/chat/completions \
 - If your cluster/network requires specific interfaces, adjust environment variables (e.g., `NCCL_SOCKET_IFNAME`) in the manifest accordingly.
 - If your storage class differs, update `storageClassName` before applying the PVC.
 - **If you want to run multinode deployments, IBGDA (InfiniBand GPU Direct Async) must be enabled on your nodes.** To enable IBGDA, you can follow this configuration script: [configure_system_drivers.sh](https://github.com/vllm-project/vllm/blob/v0.11.2/tools/ep_kernels/configure_system_drivers.sh). The script configures NVIDIA driver parameters and requires a system reboot to take effect.
+- `VLLM_MOE_DP_CHUNK_SIZE` can be tuned further. The value 384 was chosen to be largest possible that still can be deployed on 16 H200s. This value should be greater than per rank concurrency.
 
 

--- a/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
+++ b/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
@@ -58,7 +58,7 @@ spec:
             - name: VLLM_ALL2ALL_BACKEND
               value: deepep_low_latency
             - name: VLLM_MOE_DP_CHUNK_SIZE
-              value: "512"
+              value: "384"
             - name: VLLM_SKIP_P2P_CHECK
               value: "1"
             - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
@@ -67,8 +67,6 @@ spec:
               value: enabled
             - name: VLLM_MOE_ROUTING_SIMULATION_STRATEGY
               value: "uniform_random"
-            - name: NVSHMEM_QP_DEPTH
-              value: "1512"
             - name: GLOO_SOCKET_IFNAME
               value: eth0
           command:
@@ -125,7 +123,7 @@ spec:
             - name: VLLM_ALL2ALL_BACKEND
               value: deepep_high_throughput
             - name: VLLM_MOE_DP_CHUNK_SIZE
-              value: "512"
+              value: "384"
             - name: VLLM_SKIP_P2P_CHECK
               value: "1"
             - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
@@ -134,8 +132,6 @@ spec:
               value: enabled
             - name: VLLM_MOE_ROUTING_SIMULATION_STRATEGY
               value: "uniform_random"
-            - name: NVSHMEM_QP_DEPTH
-              value: "1512"
             - name: GLOO_SOCKET_IFNAME
               value: eth0
           command:


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Decrease `VLLM_MOE_DP_CHUNK_SIZE` to 384 to recede memory footprint and enable inference on 16xH200.

#### Details:

Since vLLM 0.12.0 DeepGEMM version is bumped to 0.2.1. It introduced additional features (e.g. E8M0) that increased the memory footprint and resulted in current configuration to OOM on 16xH200.

This PR reduces `VLLM_MOE_DP_CHUNK_SIZE` to 384 which in turn reduces memory used by the MoE layers. This is a tunable parameter and should be larger than expected concurrency per rank. 

With reduced MoE chunk size we no longer need to increase the default `NVSHMEM_QP_DEPTH`.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized DeepSeek-R1 deployment configuration for 16-GPU Hopper GPU systems. Refined critical memory allocation and GPU resource management parameters to enhance inference throughput, reduce memory consumption, and improve overall system stability. These targeted adjustments significantly boost performance and resource efficiency for distributed model serving in enterprise-scale deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->