### PR TITLE
docs: Update TensorRT-LLM install prerequisites for 1.2.0rc5 (cherry-pick)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/
 
 > [!Note]
 > Ensure that you select a PyTorch container image version that matches the version of TensorRT-LLM you are using.
-> For example, if you are using `tensorrt-llm==1.1.0rc5`, use the PyTorch container image version `25.06`.
+> For example, if you are using `tensorrt-llm==1.2.0rc5`, use the PyTorch container image version `25.10`.
 > To find the correct PyTorch container version for your desired `tensorrt-llm` release, visit the [TensorRT-LLM Dockerfile.multi](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/Dockerfile.multi) on GitHub. Switch to the branch that matches your `tensorrt-llm` version, and look for the `BASE_TAG` line to identify the recommended PyTorch container tag.
 
 > [!Important]
@@ -233,13 +233,13 @@ It is recommended to use [NGC PyTorch Container](https://catalog.ngc.nvidia.com/
 ### Install prerequisites
 
 ```
-# Optional step: Only required for Blackwell and Grace Hopper
-uv pip install torch==2.7.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
-
-# Required until the trtllm version is bumped to include this pinned dependency itself
-uv pip install "cuda-python>=12,<13"
+# Optional step: Only required for non-container installations. The PyTorch 25.10 container already includes PyTorch 2.9.0 with CUDA 13.0.
+uv pip install torch==2.9.0 torchvision --index-url https://download.pytorch.org/whl/cu130
 
 sudo apt-get -y install libopenmpi-dev
+
+# Optional step: Only required for disaggregated serving
+sudo apt-get -y install libzmq3-dev
 ```
 
 > [!Tip]


### PR DESCRIPTION
Cherry-pick of #5194 to release/0.8.0

## Summary
Updates the TensorRT-LLM installation prerequisites section in the README to match the official TensorRT-LLM 1.2.0rc5 documentation.

## Changes
- Update PyTorch version from 2.7.1/cu128 to 2.9.0/cu130
- Remove unnecessary cuda-python pin
- Add libzmq3-dev requirement for disaggregated serving

## Related Issues
- Fixes: https://nvbugspro.nvidia.com/bug/5769734
- Linear: DYN-1682