### PR TITLE
docs: update readme for pip install ai-dynamo[trtllm]

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,11 @@ sudo apt-get -y install libzmq3-dev
 ### After installing the pre-requisites above, install Dynamo
 
 ```
-uv pip install ai-dynamo[trtllm]
+pip install --pre --extra-index-url https://pypi.nvidia.com ai-dynamo[trtllm]
 ```
+
+> [!Note]
+> We use `pip` instead of `uv` here because `tensorrt-llm` has a URL-based git dependency (`etcd3`) that `uv` does not currently support.
 
 Run the backend/worker like this:
 


### PR DESCRIPTION
#### Overview:

use pip install for trtllm backend, add uv issue with url dependency


closes: DYN-1680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TRT-LLM engine installation instructions to use pip with NVIDIA PyPI index and pre-release support. Added explanatory note in documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->