### PR TITLE
fix: remove unused prometheus port args in trtllm planner DGD

### DIFF
--- a/examples/backends/trtllm/deploy/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/disagg_planner.yaml
@@ -52,7 +52,6 @@ spec:
             - --backend=trtllm
             - --adjustment-interval=60
             - --profile-results-dir=/workspace/profiling_results
-            - --prometheus-port=9085
           volumeMounts:
             - name: planner-profile-data
               mountPath: /workspace/profiling_results


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed explicit Prometheus port configuration from container settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->