### PR TITLE
test: Expand time range for flaky recorder test to improve stability

### DIFF
--- a/lib/llm/src/recorder.rs
+++ b/lib/llm/src/recorder.rs
@@ -464,11 +464,11 @@ mod tests {
         // Check that both events were recorded
         assert_eq!(recorder.event_count().await, 2);
 
-        // Check that the elapsed time is between 7 and 13 milliseconds
+        // Check that the elapsed time is between 5 and 15 milliseconds
         let elapsed_ms = recorder.elapsed_time().await.unwrap().as_millis();
-        if !(7..=13).contains(&elapsed_ms) {
+        if !(5..=15).contains(&elapsed_ms) {
             println!("Actual elapsed time: {} ms", elapsed_ms);
-            assert!((7..=13).contains(&elapsed_ms));
+            assert!((5..=15).contains(&elapsed_ms));
         }
 
         // Force shutdown to flush file


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

- This test looks for time range between 7-13ms, but has failed a few times recently with 14ms.
- This PR relaxes the constraint slightly based on feedback from @PeaBrane who initially wrote the test

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted timing tolerance in recorder tests for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->