### PR TITLE
ci: Marking test_indexers_sync as flaky

### DIFF
--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -522,6 +522,7 @@ def test_kv_push_router_bindings(
     ],
 )
 @pytest.mark.timeout(90)  # TODO: figure out a timeout
+@pytest.mark.xfail(strict=False, reason="Flaky test")
 def test_indexers_sync(
     request,
     runtime_services_dynamic_ports,

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -475,6 +475,7 @@ def test_router_decisions_sglang_dp(
     ids=["jetstream"],  # "nats_core" and "file" commented out
 )
 @pytest.mark.timeout(150)  # ~3x average (~46s/test), rounded up
+@pytest.mark.xfail(strict=False, reason="Flaky test")
 def test_sglang_indexers_sync(
     request,
     runtime_services_dynamic_ports,

--- a/tests/router/test_router_e2e_with_trtllm.py
+++ b/tests/router/test_router_e2e_with_trtllm.py
@@ -403,6 +403,7 @@ def test_router_decisions_trtllm_multiple_workers(
     ],
     ids=["jetstream"],  # "nats_core" and "file" commented out
 )
+@pytest.mark.xfail(strict=False, reason="Flaky test")
 def test_trtllm_indexers_sync(
     request,
     runtime_services_dynamic_ports,

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -489,6 +489,7 @@ def test_router_decisions_vllm_dp(
     ],
     ids=["jetstream", "tcp_nats_core"],
 )
+@pytest.mark.xfail(strict=False, reason="Flaky test")
 def test_vllm_indexers_sync(
     request,
     runtime_services_dynamic_ports,


### PR DESCRIPTION
#### Overview:

  - Mark router indexer sync tests as expected failures with strict=False to allow flaky behavior without blocking CI
  - Affected tests:
    - `test_trtllm_indexers_sync`
    - `test_indexers_sync` (mockers)
    - `test_sglang_indexers_sync`
    - `test_vllm_indexers_sync`

  With xfail(strict=False), these tests will:
  - Report XFAIL if they fail (CI passes)
  - Report XPASS if they pass (CI passes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Marked multiple test suites as flaky to document known intermittent failures. This improves test reliability tracking and allows non-critical test failures to be properly flagged without blocking CI/CD pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->