### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/docs/backends/trtllm/kv-cache-transfer.md
+++ b/docs/backends/trtllm/kv-cache-transfer.md
@@ -21,6 +21,10 @@ limitations under the License.
 
 In disaggregated serving architectures, KV cache must be transferred between prefill and decode workers. TensorRT-LLM supports two methods for this transfer:
 
+## Using NIXL for KV Cache Transfer
+
+Start the disaggregated service: See [Disaggregated Serving](./README.md#disaggregated) to learn how to start the deployment.
+
 ## Default Method: NIXL
 By default, TensorRT-LLM uses **NIXL** (NVIDIA Inference Xfer Library) with UCX (Unified Communication X) as backend for KV cache transfer between prefill and decode workers. [NIXL](https://github.com/ai-dynamo/nixl) is NVIDIA's high-performance communication library designed for efficient data transfer in distributed GPU environments.
 

--- a/docs/router/kv_cache_routing.md
+++ b/docs/router/kv_cache_routing.md
@@ -79,7 +79,7 @@ For basic model registration without KV routing, you can use `--router-mode roun
 
 ## Disaggregated Serving (Prefill and Decode)
 
-Dynamo supports disaggregated serving where prefill (prompt processing) and decode (token generation) are handled by separate worker pools. When you register workers with `ModelType.Prefill` (see [Backend Guide](../development/backend-guide.md#model-types)), the frontend automatically detects them and activates an internal prefill router.
+Dynamo supports disaggregated serving where prefill (prompt processing) and decode (token generation) are handled by separate worker pools. When you register workers with `ModelType.Prefill` (see [Backend Guide](../development/backend-guide.md)), the frontend automatically detects them and activates an internal prefill router.
 
 ### Automatic Prefill Router Activation
 


### PR DESCRIPTION
## Summary

Fixes broken documentation links identified by Decimal automated link checker (January 7, 2026).

## Changes

1. **`docs/router/kv_cache_routing.md`**: Removed non-existent `#model-types` anchor from backend-guide.md link

2. **`docs/backends/trtllm/kv-cache-transfer.md`**: Added cross-reference section with correct `#disaggregated` anchor for users looking to start disaggregated serving

## Verification

All broken patterns verified as resolved:
```bash
grep -r "backend-guide.md#model-types" docs/    # No matches
grep -r "#disaggregated-serving" docs/          # No matches
```

## Additional Context

- 9 other broken links (deploy/cloud/operator paths) were already fixed in main
- Mooncake link was already using the stable documentation site URL
- Full report available in `dag_local_files/reports/decimal-broken-links-2026-01-09.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation section for KV cache transfer using NIXL, including setup instructions for the disaggregated service.
  * Updated backend guide references in KV cache routing documentation for improved link consistency across the documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->