### PR TITLE
fix: switch from nixl to mooncake in examples

### DIFF
--- a/examples/backends/sglang/deploy/disagg-multinode.yaml
+++ b/examples/backends/sglang/deploy/disagg-multinode.yaml
@@ -52,8 +52,6 @@ spec:
             - --skip-tokenizer-init
             - --disaggregation-mode
             - decode
-            - --disaggregation-transfer-backend
-            - nixl
             - --disaggregation-bootstrap-port
             - "30001"
             - --host
@@ -89,8 +87,6 @@ spec:
             - --skip-tokenizer-init
             - --disaggregation-mode
             - prefill
-            - --disaggregation-transfer-backend
-            - nixl
             - --disaggregation-bootstrap-port
             - "30001"
             - --mem-fraction-static

--- a/examples/backends/sglang/deploy/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/disagg_planner.yaml
@@ -72,8 +72,6 @@ spec:
             - --skip-tokenizer-init
             - --disaggregation-mode
             - decode
-            - --disaggregation-transfer-backend
-            - nixl
             - --disaggregation-bootstrap-port
             - "12345"
             - --host
@@ -108,8 +106,6 @@ spec:
             - --skip-tokenizer-init
             - --disaggregation-mode
             - prefill
-            - --disaggregation-transfer-backend
-            - nixl
             - --disaggregation-bootstrap-port
             - "12345"
             - --host


### PR DESCRIPTION
#### Overview:

Something about the new sglang container's NIXL seems to be broken. Reverting the example to use mooncake.

