### PR TITLE
fix: pass back `usage` when using text mode with VLLM

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1300,6 +1300,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         "choices": [choice_data],
                     }
 
+                    if output.finish_reason:
+                        chunk["usage"] = BaseWorkerHandler._build_completion_usage(
+                            request_output=res,
+                        )
+
                     yield chunk
 
             except EngineDeadError as e:


### PR DESCRIPTION
#### Overview:

Now the Dynamo frontend returns `usage` as `None` when using text mode with VLLM (`--use-vllm-tokenizer`). It is necessary to obtain the usage information in some use cases. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token usage statistics are now included in completion responses when available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->