### PR TITLE
feat: Sleep/wake endpoints for vLLM runtime

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -447,6 +447,11 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
 
     setup_metrics_collection(config, generate_endpoint, logger)
 
+    # Register sleep/wake engine routes
+    runtime.register_engine_route("sleep", handler.sleep)
+    runtime.register_engine_route("wake", handler.wake)
+    logger.info("Registered engine routes: /engine/sleep, /engine/wake")
+
     # Register prefill model with ModelType.Prefill
     if not config.engine_args.data_parallel_rank:  # if rank is 0 or None then register
         model_input = (
@@ -565,6 +570,11 @@ async def init(runtime: DistributedRuntime, config: Config):
         handler.kv_publishers = kv_publishers
 
     setup_metrics_collection(config, generate_endpoint, logger)
+
+    # Register sleep/wake engine routes
+    runtime.register_engine_route("sleep", handler.sleep)
+    runtime.register_engine_route("wake", handler.wake)
+    logger.info("Registered engine routes: /engine/sleep, /engine/wake")
 
     if not config.engine_args.data_parallel_rank:  # if rank is 0 or None then register
         # Parse endpoint types from --dyn-endpoint-types flag


### PR DESCRIPTION
Added endpoints for worker sleep/wake in vLLM runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sleep/wake functionality to reduce memory usage of idle engine instances; endpoints can be unregistered during sleep and re-registered when active.
  * New HTTP endpoints expose memory-management actions for engine lifecycle control.
  * Sleep/wake support for vLLM and SGLang backends with automatic memory optimization.

* **Tests**
  * Added comprehensive test suite validating sleep/wake operations and memory reduction across backends.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->