### PR TITLE
fix: honor TRTLLM_USE_UCX_KV_CACHE=1 with DEFAULT backend

### DIFF
--- a/docs/backends/trtllm/kv-cache-transfer.md
+++ b/docs/backends/trtllm/kv-cache-transfer.md
@@ -34,9 +34,10 @@ TODO: Add instructions for how to specify different backends for NIXL.
 
 ## Alternative Method: UCX
 
-TensorRT-LLM can also leverage **UCX** (Unified Communication X) directly for KV cache transfer between prefill and decode workers. There are two ways to enable UCX as the KV cache transfer backend:
+TensorRT-LLM can also leverage **UCX** (Unified Communication X) directly for KV cache transfer between prefill and decode workers. To enable UCX as the KV cache transfer backend:
 
 1. **Recommended:** Set `cache_transceiver_config.backend: UCX` in your engine configuration YAML file.
-2. Alternatively, set the environment variable `TRTLLM_USE_UCX_KV_CACHE=1` and configure `cache_transceiver_config.backend: DEFAULT` in the engine configuration YAML.
 
-This flexibility allows users to choose the most suitable method for their deployment and compatibility requirements.
+> Notes:
+> - UCX remains opt-in. The `DEFAULT` backend continues to use the existing NIXL path.
+> - If you set `TRTLLM_USE_UCX_KV_CACHE=1` while leaving `cache_transceiver_config.backend` as `DEFAULT` (or empty), Dynamo will auto-switch it to `UCX` at runtime. If you explicitly set a different backend, Dynamo will not override it.


### PR DESCRIPTION
## Summary
When `TRTLLM_USE_UCX_KV_CACHE=1` is set and `cache_transceiver_config.backend` is `DEFAULT` or empty, auto-switch to `UCX` at runtime. Previously, this env-var had no effect when backend was set to `DEFAULT`.

## Changes
- **`components/src/dynamo/trtllm/main.py`**: Check for the env var and force backend to UCX when applicable
- **`docs/backends/trtllm/kv-cache-transfer.md`**: Clarify that UCX is opt-in and document the env-var fallback behavior

## Testing
Manual verification with TRT-LLM disaggregated serving using:
- `TRTLLM_USE_UCX_KV_CACHE=1` + `cache_transceiver_config.backend: DEFAULT`

## Fixes
NVBugs 5769531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for UCX KV cache mode with environment variable control for KV cache configuration.

* **Documentation**
  * Updated KV cache backend configuration guidance with clarity on opt-in behavior and runtime auto-switch settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->