### PR TITLE
fix: remove duplicate docker buildx setup in frontend container build

### DIFF
--- a/.github/workflows/build-frontend-image.yaml
+++ b/.github/workflows/build-frontend-image.yaml
@@ -10,7 +10,7 @@ on:
     - release/*.*.*
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
@@ -26,10 +26,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build-frontend-image.yaml
+++ b/.github/workflows/build-frontend-image.yaml
@@ -8,7 +8,6 @@ on:
     branches:
     - main
     - release/*.*.*
-    - tusharma/fix-frontend-image-build-ci
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}

--- a/.github/workflows/build-frontend-image.yaml
+++ b/.github/workflows/build-frontend-image.yaml
@@ -8,6 +8,7 @@ on:
     branches:
     - main
     - release/*.*.*
+    - tusharma/fix-frontend-image-build-ci
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.run_id || github.ref_name }}


### PR DESCRIPTION
#### Overview:

There was an intermittent failure in the frontend build job where the build would fail with the following error: 
````
ERROR: failed to build: Cache export is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again
````
This happens because  In build-frontend-image.yaml, Docker Buildx is setup with the docker driver. But then the docker-build action also sets up Docker Buildx with the docker-container driver. The docker-build action uses cache export options that require the docker-container driver. The intermittent failure happens because sometimes the second Buildx setup (in the action) properly overrides the first one, and sometimes it doesn't — leaving the docker driver active when the build runs.

#### Details:

- remove duplicate docker buildx setup action with driver

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal CI/CD pipeline configuration to improve workflow efficiency and reliability.

**Note:** This release contains only internal infrastructure updates with no user-visible changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->