### PR TITLE
fix: pass model_name to load_from_disk() for correct source_model

### DIFF
--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -1452,9 +1452,12 @@ pub async fn create_worker_selection_pipeline_chat(
         })?;
 
     // Load a fresh card from local files, then copy runtime config from original card
+    // Use source_model (HF repo ID) or display_name for proper frontend config downloads
     tracing::debug!("Loading ModelDeploymentCard from local path...");
-    let mut card_with_local_files = ModelDeploymentCard::load_from_disk(&local_path, None)
-        .with_context(|| format!("Failed to load card from disk: {:?}", local_path))?;
+    let model_name = card.source_model.as_ref().unwrap_or(&card.display_name);
+    let mut card_with_local_files =
+        ModelDeploymentCard::load_from_disk(&local_path, None, Some(model_name))
+            .with_context(|| format!("Failed to load card from disk: {:?}", local_path))?;
 
     // Copy runtime settings from the backend's card
     tracing::debug!("Copying runtime config from backend card...");

--- a/lib/bindings/python/rust/llm/model_card.rs
+++ b/lib/bindings/python/rust/llm/model_card.rs
@@ -17,8 +17,8 @@ impl ModelDeploymentCard {
     // Previously called "from_local_path"
     #[staticmethod]
     fn load(path: String, model_name: String) -> PyResult<ModelDeploymentCard> {
-        let mut card = RsModelDeploymentCard::load_from_disk(&path, None).map_err(to_pyerr)?;
-        card.set_name(&model_name);
+        let card =
+            RsModelDeploymentCard::load_from_disk(&path, None, Some(&model_name)).map_err(to_pyerr)?;
         Ok(ModelDeploymentCard { inner: card })
     }
 

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -309,16 +309,20 @@ impl LocalModelBuilder {
         }
         let model_path = fs::canonicalize(model_path)?;
 
-        let mut card =
-            ModelDeploymentCard::load_from_disk(&model_path, self.custom_template_path.as_deref())?;
-        // The served model name defaults to the full model path.
-        // This matches what vllm and sglang do.
-        card.set_name(
-            &self
-                .model_name
-                .clone()
-                .unwrap_or_else(|| model_path.display().to_string()),
-        );
+        // The model_name is used for:
+        // 1. display_name: what the model is registered as (served-model-name)
+        // 2. source_model: the HuggingFace repo ID for frontend config downloads
+        // Defaults to the full model path if not specified (matches vllm/sglang behavior).
+        let model_name = self
+            .model_name
+            .clone()
+            .unwrap_or_else(|| model_path.display().to_string());
+
+        let mut card = ModelDeploymentCard::load_from_disk(
+            &model_path,
+            self.custom_template_path.as_deref(),
+            Some(&model_name),
+        )?;
 
         card.kv_cache_block_size = self.kv_cache_block_size;
 

--- a/lib/llm/tests/backend.rs
+++ b/lib/llm/tests/backend.rs
@@ -6,8 +6,9 @@ use dynamo_llm::model_card::ModelDeploymentCard;
 
 #[test]
 fn test_sequence_factory() {
-    let mdc = ModelDeploymentCard::load_from_disk("tests/data/sample-models/TinyLlama_v1.1", None)
-        .unwrap();
+    let mdc =
+        ModelDeploymentCard::load_from_disk("tests/data/sample-models/TinyLlama_v1.1", None, None)
+            .unwrap();
 
     let operator = Backend::from_mdc(&mdc);
 

--- a/lib/llm/tests/model_card.rs
+++ b/lib/llm/tests/model_card.rs
@@ -8,7 +8,7 @@ const HF_PATH: &str = "tests/data/sample-models/TinyLlama_v1.1";
 
 #[tokio::test]
 async fn test_model_info_from_hf_like_local_repo() {
-    let mdc = ModelDeploymentCard::load_from_disk(HF_PATH, None).unwrap();
+    let mdc = ModelDeploymentCard::load_from_disk(HF_PATH, None, None).unwrap();
     let info = mdc.model_info.unwrap().get_model_info().unwrap();
     assert_eq!(info.model_type(), "llama");
     assert_eq!(info.bos_token_id(), 1);
@@ -20,13 +20,13 @@ async fn test_model_info_from_hf_like_local_repo() {
 #[tokio::test]
 async fn test_model_info_from_non_existent_local_repo() {
     let path = "tests/data/sample-models/this-model-does-not-exist";
-    let result = ModelDeploymentCard::load_from_disk(path, None);
+    let result = ModelDeploymentCard::load_from_disk(path, None, None);
     assert!(result.is_err());
 }
 
 #[tokio::test]
 async fn test_tokenizer_from_hf_like_local_repo() {
-    let mdc = ModelDeploymentCard::load_from_disk(HF_PATH, None).unwrap();
+    let mdc = ModelDeploymentCard::load_from_disk(HF_PATH, None, None).unwrap();
     // Verify tokenizer file was found
     match mdc.tokenizer.unwrap() {
         TokenizerKind::HfTokenizerJson(_) => (),
@@ -35,7 +35,7 @@ async fn test_tokenizer_from_hf_like_local_repo() {
 
 #[tokio::test]
 async fn test_prompt_formatter_from_hf_like_local_repo() {
-    let mdc = ModelDeploymentCard::load_from_disk(HF_PATH, None).unwrap();
+    let mdc = ModelDeploymentCard::load_from_disk(HF_PATH, None, None).unwrap();
     // Verify prompt formatter was found
     match mdc.prompt_formatter {
         Some(PromptFormatterArtifact::HfTokenizerConfigJson(_)) => (),
@@ -47,7 +47,7 @@ async fn test_prompt_formatter_from_hf_like_local_repo() {
 async fn test_missing_required_files() {
     // Create empty temp directory
     let temp_dir = tempdir().unwrap();
-    let result = ModelDeploymentCard::load_from_disk(temp_dir.path(), None);
+    let result = ModelDeploymentCard::load_from_disk(temp_dir.path(), None, None);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     // Should fail because config.json is missing

--- a/lib/llm/tests/preprocessor.rs
+++ b/lib/llm/tests/preprocessor.rs
@@ -60,8 +60,8 @@ async fn make_mdc_from_repo(
     //TODO: remove this once we have nim-hub support. See the NOTE above.
     let downloaded_path = maybe_download_model(local_path, hf_repo, hf_revision).await;
     let display_name = format!("{}--{}", hf_repo, hf_revision);
-    let mut mdc = ModelDeploymentCard::load_from_disk(downloaded_path, None).unwrap();
-    mdc.set_name(&display_name);
+    let mut mdc =
+        ModelDeploymentCard::load_from_disk(downloaded_path, None, Some(&display_name)).unwrap();
     mdc.prompt_context = mixins;
     mdc
 }


### PR DESCRIPTION
## Summary

- Fixes frontend failing to download model configs from HuggingFace in Kubernetes deployments
- The `source_model` field was incorrectly set to the local cache path instead of the HF model ID

## Problem

The frontend was seeing errors like:
```
WARN model_express > ModelExpress download from /home/dynamo/.cache/huggingface/hub/models--Qwen--Qwen3-0.6B/snapshots/... failed
```

**Root cause:** `set_name()` was storing `display_name` (the local path from `from_repo_checkout()`) into `source_model` before updating it with the actual model name.

**Why this worked with file kv store but failed in Kubernetes:**
- **File kv store:** Frontend and worker share the same filesystem, so `download_config()` finds local files and skips the HF download
- **Kubernetes/NATS:** Frontend is on a different pod and must download configs from HuggingFace. With the bug, `source_model` was the worker's local cache path which is neither a valid HF repo ID nor accessible from the frontend

## Fix

- Add `model_name: Option<&str>` parameter to `load_from_disk()` so `display_name` and `source_model` are set correctly at construction time
- Simplify `set_name()` to only update display fields (no longer touches `source_model`)

## Test plan

- [ ] Deploy to Kubernetes with disaggregated workers
- [ ] Verify frontend logs show successful ModelExpress download
- [ ] Verify `/health` endpoint shows model ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)