### PR TITLE
fix(sglang): use external_trace_header API for distributed tracing

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -113,9 +113,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
         input_param = self._get_input_param(inner_request)
 
-        # Propagate trace context to SGLang
-        if self.enable_trace:
-            self._propagate_trace_context_to_sglang(context, bootstrap_room)
+        trace_header = self._get_trace_header(context) if self.enable_trace else None
 
         results = await self.engine.async_generate(
             **input_param,
@@ -124,6 +122,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             bootstrap_host=self.bootstrap_host,
             bootstrap_port=self.bootstrap_port,
             bootstrap_room=bootstrap_room,
+            external_trace_header=trace_header,
             rid=trace_id,
         )
 


### PR DESCRIPTION
## Summary
- Replace internal SGLang trace propagation (`trace_set_remote_propagate_context`) with the public `external_trace_header` parameter
- Remove dependency on internal `sglang.srt.tracing` module
- Simplify trace context by using W3C traceparent header directly

## Background
This PR extracts the still-needed portions from #5122 after #5283 merged the Rust TCP tracing support. The Python SGLang changes use SGLang's official `external_trace_header` API instead of the internal tracing module, which is cleaner and more maintainable.

## Changes
- `handler_base.py`: Replace `_propagate_trace_context_to_sglang()` with `_get_trace_header()` 
- `decode_handler.py`: Pass `external_trace_header` to `async_generate()` calls
- `prefill_handler.py`: Pass `external_trace_header` to `async_generate()` calls

<img width="947" height="487" alt="Screenshot 2026-01-13 at 12 05 52 AM" src="https://github.com/user-attachments/assets/d20fcd4f-51d9-4ba5-83c5-b977c15ac069" />