### PR TITLE
fix: Replace NixlAgentMetadata with NixlHandshakePayload for vllm 0.13.0

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
@@ -13,8 +13,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
     MultiKVConnectorMetadata,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
-    NixlAgentMetadata,
     NixlConnector,
+    NixlHandshakePayload,
 )
 from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -111,14 +111,14 @@ class PdConnector(MultiConnector):
         metadata so decode workers can connect for KV transfer coordination.
 
         Returns:
-            NixlAgentMetadata from the NIXL connector, or None if not available.
+            NixlHandshakePayload from the NIXL connector, or None if not available.
         """
         # Get handshake metadata from the NIXL connector (second connector)
         nixl_connector = self._connectors[1]
         metadata = nixl_connector.get_handshake_metadata()
-        if metadata is not None and not isinstance(metadata, NixlAgentMetadata):
+        if metadata is not None and not isinstance(metadata, NixlHandshakePayload):
             raise TypeError(
-                f"Expected NixlAgentMetadata from NIXL connector, "
+                f"Expected NixlHandshakePayload from NIXL connector, "
                 f"got {type(metadata).__name__}"
             )
         return metadata


### PR DESCRIPTION
#### Overview:

In vllm v0.13.0, there's a new wrapper [NixlHandshakePayload](https://github.com/vllm-project/vllm/blob/releases/v0.13.0/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py#L128) introduced which implements `KVConnectorHandshakeMetadata`. The original `NixlAgentMetadata` no longer implements `KVConnectorHandshakeMetadata`.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the connector integration to properly validate handshake metadata during initialization. This change ensures more reliable communication between components in the vLLM integration layer, improving stability and error handling for connection establishment processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->