### PR TITLE
fix: Revert to mooncake for in example for release

### DIFF
--- a/examples/backends/sglang/deploy/disagg-multinode.yaml
+++ b/examples/backends/sglang/deploy/disagg-multinode.yaml
@@ -52,8 +52,6 @@ spec:
             - --skip-tokenizer-init
             - --disaggregation-mode
             - decode
-            - --disaggregation-transfer-backend
-            - nixl
             - --disaggregation-bootstrap-port
             - "30001"
             - --host
@@ -89,8 +87,6 @@ spec:
             - --skip-tokenizer-init
             - --disaggregation-mode
             - prefill
-            - --disaggregation-transfer-backend
-            - nixl
             - --disaggregation-bootstrap-port
             - "30001"
             - --mem-fraction-static

--- a/examples/backends/sglang/deploy/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/disagg_planner.yaml
@@ -72,8 +72,6 @@ spec:
             - --skip-tokenizer-init
             - --disaggregation-mode
             - decode
-            - --disaggregation-transfer-backend
-            - nixl
             - --disaggregation-bootstrap-port
             - "12345"
             - --host
@@ -108,8 +106,6 @@ spec:
             - --skip-tokenizer-init
             - --disaggregation-mode
             - prefill
-            - --disaggregation-transfer-backend
-            - nixl
             - --disaggregation-bootstrap-port
             - "12345"
             - --host


### PR DESCRIPTION
#### Overview:

Removes nixl flag reverting to mooncake for some examples due to broken nixl in docker.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SGLang backend deployment examples to remove disaggregation transfer backend specifications from decode and prefill configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->