### PR TITLE
chore: Update command to build Dynamo + SGLang container

### DIFF
--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -137,7 +137,7 @@ We are in the process of shipping pre-built docker containers that contain insta
 cd $DYNAMO_ROOT
 ./container/build.sh \
   --framework SGLANG \
-  --tag dynamo-sglang:latest \
+  --tag dynamo-sglang:latest
 ```
 
 And then run it using


### PR DESCRIPTION
There is an unnecessary backlash in the end of the command for building the docker container:

```
./container/build.sh \
  --framework SGLANG \
  --tag dynamo-sglang:latest \
```

Because of which, the shell ignores the newline and treats the next line as a continuation of the same command, which is incorrect.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed Docker build command formatting in the SGLang documentation for improved readability and correct execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->