### PR TITLE
fix: Update TRT-LLM Wide-EP Disagg GB200 Recipe to be compatible with TRT-LLM Version

### DIFF
--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
@@ -20,10 +20,9 @@ metadata:
   name: prefill-config
 data:
   prefill_config.yaml: |
-    build_config:
-        max_batch_size: 4
-        max_num_tokens: 4608
-        max_seq_len: 1227
+    max_batch_size: 4
+    max_num_tokens: 4608
+    max_seq_len: 1227
     tensor_parallel_size: 4
     moe_expert_parallel_size: 4
     enable_attention_dp: true
@@ -52,10 +51,9 @@ data:
     moe_expert_parallel_size: 32
     enable_attention_dp: true
     pipeline_parallel_size: 1
-    build_config:
-        max_batch_size: 32
-        max_num_tokens: 32
-        max_seq_len: 2251
+    max_batch_size: 32
+    max_num_tokens: 32
+    max_seq_len: 2251
     cuda_graph_config:
       enable_padding: true
       batch_sizes:


### PR DESCRIPTION
Latest TRT-LLM doesn't require `build_config` being set in the ConfigMaps. This PR removes it from the GB200 TRT-LLM Wide-EP Disagg recipe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured deployment configuration settings for improved clarity and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->