### PR TITLE
fix: Move NATS max_payload from invalid CLI flag to config file

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,12 +11,11 @@ networks:
 services:
   nats-server:
     image: nats:2.11.4
-    # max_payload set to 15MB to accommodate 10MB decoded embeddings
-    # Base64 encoding: 10MB → ~13.3MB, 15MB provides ~1.7MB buffer for metadata
-    # NOTE: --max_payload is NOT a valid command-line flag in any NATS version
-    # max_payload must be configured via configuration file
     command: [ "-c", "/etc/nats/nats-server.conf" ]
     volumes:
+      # max_payload set to 15MB to accommodate 10MB decoded embeddings
+      # Base64 encoding: 10MB → ~13.3MB, 15MB provides ~1.7MB buffer for metadata
+      # max_payload must be configured via configuration file (does not exist as a CLI flag)
       - ./nats-server.conf:/etc/nats/nats-server.conf:ro
     ports:
       - 4222:4222

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -13,7 +13,11 @@ services:
     image: nats:2.11.4
     # max_payload set to 15MB to accommodate 10MB decoded embeddings
     # Base64 encoding: 10MB → ~13.3MB, 15MB provides ~1.7MB buffer for metadata
-    command: [ "-js", "--trace", "-m", "8222", "--max_payload", "15728640" ]
+    # NOTE: --max_payload is NOT a valid command-line flag in any NATS version
+    # max_payload must be configured via configuration file
+    command: [ "-c", "/etc/nats/nats-server.conf" ]
+    volumes:
+      - ./nats-server.conf:/etc/nats/nats-server.conf:ro
     ports:
       - 4222:4222
       - 6222:6222

--- a/deploy/nats-server.conf
+++ b/deploy/nats-server.conf
@@ -1,0 +1,13 @@
+# NATS Server Configuration
+# max_payload set to 15MB to accommodate 10MB decoded embeddings
+# Base64 encoding: 10MB → ~13.3MB, 15MB provides ~1.7MB buffer for metadata
+max_payload: 15728640
+
+# Enable JetStream
+jetstream: {}
+
+# Monitoring
+http_port: 8222
+
+# Enable trace logging
+trace: true


### PR DESCRIPTION
## Summary
Fixes NATS container startup failure caused by using invalid `--max_payload` CLI flag.

## Problem
NATS container was failing immediately on startup with error:
```
flag provided but not defined: --max_payload
```

The `--max_payload` flag has never been a valid command-line parameter in any NATS version. It can only be configured via configuration file.

## Solution
- Created `deploy/nats-server.conf` with proper `max_payload` configuration
- Maintained 15MB payload limit for embedding support

## Changes
- **New file**: `deploy/nats-server.conf` - NATS server configuration with max_payload, JetStream, trace logging, and monitoring settings
- **Modified**: `deploy/docker-compose.yml` - Changed command from CLI flags to config file approach

## Testing
**Before (reproduces the issue):**
```bash
docker run --rm nats:2.11.4 -js --max_payload 15728640
# Error: flag provided but not defined: -max_payload
```

**After:**
```bash
cd dynamo2
docker compose -f deploy/docker-compose.yml up -d
docker compose -f deploy/docker-compose.yml ps
# NATS container now runs successfully
```

## Related
- Fixes issue introduced in commit 6f9619a2 by @wenqiglantz
- NATS documentation: https://docs.nats.io/running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NATS server configuration to use a dedicated configuration file instead of command-line flags, improving deployment maintainability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->