### PR TITLE
ci: remove deprecated  parameters

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -43,9 +43,6 @@ inputs:
   cuda_version:
     description: 'Optional override for CUDA_VERSION build-arg'
     required: true
-  torch_backend:
-    description: 'Optional override for TORCH_BACKEND build-arg (e.g., cu129)'
-    required: false
   enable_kvbm:
     description: 'Enable KVBM support (optional)'
     required: false
@@ -129,9 +126,6 @@ runs:
         fi
         if [ -n "${{ inputs.cuda_version }}" ]; then
           EXTRA_ARGS+="--build-arg CUDA_VERSION=${{ inputs.cuda_version }} "
-        fi
-        if [ -n "${{ inputs.torch_backend }}" ]; then
-          EXTRA_ARGS+="--build-arg TORCH_BACKEND=${{ inputs.torch_backend }} "
         fi
         if [ -n "${{ inputs.dynamo_base_image }}" ]; then
           EXTRA_ARGS+=" --dynamo-base-image ${{ inputs.dynamo_base_image }}"

--- a/.github/workflows/ci-test-suite.yml
+++ b/.github/workflows/ci-test-suite.yml
@@ -111,7 +111,6 @@ jobs:
           base_image_tag: ''
           runtime_image_tag: ''
           cuda_version: ''
-          torch_backend: ''
           ci_token: ${{ secrets.CI_TOKEN }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           sccache_s3_bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
@@ -146,17 +145,14 @@ jobs:
             base_image_tag: '25.06-cuda12.9-devel-ubuntu24.04'
             runtime_image_tag: '12.9.0-runtime-ubuntu24.04'
             cuda_version: '12.9'
-            torch_backend: 'cu129'
           - framework: trtllm
             base_image_tag: '25.06-py3'
             runtime_image_tag: ''
             cuda_version: '12.9'
-            torch_backend: 'cu129'
           - framework: sglang
             base_image_tag: ''
             runtime_image_tag: ''
             cuda_version: ''
-            torch_backend: ''
     env:
       ECR_HOSTNAME: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
     steps:
@@ -187,7 +183,6 @@ jobs:
           base_image_tag: ${{ matrix.base_image_tag }}
           runtime_image_tag: ${{ matrix.runtime_image_tag }}
           cuda_version: ${{ matrix.cuda_version }}
-          torch_backend: ${{ matrix.torch_backend }}
           ci_token: ${{ secrets.CI_TOKEN }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           sccache_s3_bucket: ${{ secrets.SCCACHE_S3_BUCKET }}

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -232,8 +232,6 @@ jobs:
           framework: vllm
           target: runtime
           platform: 'linux/${{ matrix.platform.arch }}'
-          base_image_tag: ${{ matrix.platform.arch == 'arm64' && '25.06-cuda12.9-devel-ubuntu24.04' || '' }}
-          runtime_image_tag: ${{ matrix.platform.arch == 'arm64' && '12.9.0-runtime-ubuntu24.04' || '' }}
           cuda_version: '12.9'
           ci_token: ${{ secrets.CI_TOKEN }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -171,7 +171,6 @@ jobs:
           base_image_tag: '25.11-cuda13.0-devel-ubuntu24.04'
           runtime_image_tag: '13.0.2-runtime-ubuntu24.04'
           cuda_version: '13.0'
-          torch_backend: 'cu130'
           ci_token: ${{ secrets.CI_TOKEN }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           sccache_s3_bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
@@ -238,7 +237,6 @@ jobs:
           base_image_tag: ${{ matrix.platform.arch == 'arm64' && '25.06-cuda12.9-devel-ubuntu24.04' || '' }}
           runtime_image_tag: ${{ matrix.platform.arch == 'arm64' && '12.9.0-runtime-ubuntu24.04' || '' }}
           cuda_version: '12.9'
-          torch_backend: ${{ matrix.platform.arch == 'arm64' && 'cu129' || '' }}
           ci_token: ${{ secrets.CI_TOKEN }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           sccache_s3_bucket: ${{ secrets.SCCACHE_S3_BUCKET }}
@@ -305,7 +303,6 @@ jobs:
           target: runtime
           platform: 'linux/${{ matrix.platform.arch }}'
           cuda_version: '13.0'
-          torch_backend: 'cu130'
           ci_token: ${{ secrets.CI_TOKEN }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
           sccache_s3_bucket: ${{ secrets.SCCACHE_S3_BUCKET }}

--- a/.github/workflows/container-validation-backends.yml
+++ b/.github/workflows/container-validation-backends.yml
@@ -168,8 +168,6 @@ jobs:
           framework: vllm
           target: runtime
           platform: 'linux/${{ matrix.platform.arch }}'
-          base_image_tag: '25.11-cuda13.0-devel-ubuntu24.04'
-          runtime_image_tag: '13.0.2-runtime-ubuntu24.04'
           cuda_version: '13.0'
           ci_token: ${{ secrets.CI_TOKEN }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
#### Overview:

Removing noise from CI code

#### Details:

1. Removed all appearances of `torch_backend`/`TORCH_BACKEND`:  

`TORCH_BACKEND` became obsolete by #4997 changes, introduced by  @dmitry-tokarev-nv  

2. Removed redundant runtime/base_image_tag override for vllm-cuda-13:  
VLLM's default CUDA 13 image tags are set in [build.sh](https://github.com/ai-dynamo/dynamo/blob/main/container/build.sh#L110) and [passed](https://github.com/ai-dynamo/dynamo/blob/main/container/build.sh#L425) as build arguments, overriding is unnecessary and add complexity. 

3. Removed redundant runtime/base_image_tag override for vllm arm cuda 12.9 
[Already handled by build.sh L569) ](https://github.com/ai-dynamo/dynamo/blob/main/container/build.sh#L569)

#### Where should the reviewer start?
1. #4997
2.  [build.sh](https://github.com/ai-dynamo/dynamo/blob/main/container/build.sh)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Docker build and CI/CD workflows by removing unused backend configuration parameters from build matrices and validation jobs. Image selection and runtime configuration now rely on default values instead of explicit hard-coded specifiers, reducing configuration complexity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->