### PR TITLE
feat(model_card): Make bos_token_id optional

### DIFF
--- a/lib/llm/tests/model_card.rs
+++ b/lib/llm/tests/model_card.rs
@@ -11,7 +11,7 @@ async fn test_model_info_from_hf_like_local_repo() {
     let mdc = ModelDeploymentCard::load_from_disk(HF_PATH, None).unwrap();
     let info = mdc.model_info.unwrap().get_model_info().unwrap();
     assert_eq!(info.model_type(), "llama");
-    assert_eq!(info.bos_token_id(), 1);
+    assert_eq!(info.bos_token_id(), Some(1));
     assert_eq!(info.eos_token_ids(), vec![2]);
     assert_eq!(info.max_position_embeddings(), Some(2048));
     assert_eq!(info.vocab_size(), Some(32000));


### PR DESCRIPTION
GLM 4.7 does not have it.

Fixes: https://github.com/ai-dynamo/dynamo/issues/5392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Beginning-of-Sequence token ID requirement relaxed; now optional in model configurations, expanding compatibility with diverse model definitions.
  * Loading logic enhanced to gracefully retrieve token IDs from fallback configuration sources when primary sources are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->