### PR TITLE
chore: Bump cuda to 12.9.1 for vllm container

### DIFF
--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -70,7 +70,7 @@ ARG NIXL_GDRCOPY_REF
 ARG NIXL_LIBFABRIC_REF
 
 ARG RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
-ARG RUNTIME_IMAGE_TAG="12.9.0-runtime-ubuntu24.04"
+ARG RUNTIME_IMAGE_TAG="12.9.1-runtime-ubuntu24.04"
 ARG CUDA_VERSION="12.9"
 
 # Make sure to update the dependency version in pyproject.toml when updating this

--- a/container/build.sh
+++ b/container/build.sh
@@ -106,10 +106,10 @@ VLLM_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 # Please check https://github.com/ai-dynamo/dynamo/pull/1065
 # for details and reproducer to manually test if the image
 # can be updated to later versions.
-VLLM_BASE_IMAGE_TAG="25.04-cuda12.9-devel-ubuntu24.04"
+VLLM_BASE_IMAGE_TAG="25.06-cuda12.9-devel-ubuntu24.04"
 VLLM_BASE_IMAGE_TAG_CU13="25.11-cuda13.0-devel-ubuntu24.04"
 VLLM_RUNTIME_IMAGE="nvcr.io/nvidia/cuda"
-VLLM_RUNTIME_IMAGE_TAG="12.9.0-runtime-ubuntu24.04"
+VLLM_RUNTIME_IMAGE_TAG="12.9.1-runtime-ubuntu24.04"
 VLLM_RUNTIME_IMAGE_TAG_CU13="13.0.2-runtime-ubuntu24.04"
 
 NONE_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
@@ -564,21 +564,6 @@ fi
 # Set the commit sha in the container so we can inspect what build this relates to
 DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA:-$(git rev-parse HEAD)}
 BUILD_ARGS+=" --build-arg DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA "
-
-# Special handling for vLLM on ARM64 - set required defaults if not already specified by user
-if [[ $FRAMEWORK == "VLLM" ]] && [[ "$PLATFORM" == *"linux/arm64"* ]]; then
-    # Set base image tag to CUDA 12.9 if using the default value (user didn't override)
-    if [ "$BASE_IMAGE_TAG" == "$VLLM_BASE_IMAGE_TAG" ]; then
-        BASE_IMAGE_TAG="25.06-cuda12.9-devel-ubuntu24.04"
-        echo "INFO: Automatically setting base-image-tag to $BASE_IMAGE_TAG for vLLM ARM64"
-    fi
-
-    # Add required build args if not already present
-    if [[ "$BUILD_ARGS" != *"RUNTIME_IMAGE_TAG"* ]]; then
-        BUILD_ARGS+=" --build-arg RUNTIME_IMAGE_TAG=12.9.0-runtime-ubuntu24.04 "
-        echo "INFO: Automatically setting RUNTIME_IMAGE_TAG=12.9.0-runtime-ubuntu24.04 for vLLM ARM64"
-    fi
-fi
 
 # Update DOCKERFILE if framework is VLLM
 if [[ $FRAMEWORK == "VLLM" ]]; then


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vLLM container base image (25.04 → 25.06) and runtime (12.9.0 → 12.9.1).
  * Simplified container build configuration by removing ARM64 platform-specific logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->