### PR TITLE
fix: Updating the GPU footprint mentioned in the DS R1 disagg recipe

### DIFF
--- a/recipes/deepseek-r1/sglang/README.md
+++ b/recipes/deepseek-r1/sglang/README.md
@@ -14,7 +14,7 @@ Dynamo commits after `1b3eed4b6a0e735d4ecec6681f4c0b89f2112167` (Sep 18, 2025) a
 
 ## Hardware
 
-The two deployment recipes are for 8xH200 and 16xH200. It should also work for other GPU SKUs. Change the TDP and DEP size accordingly to match the GPU capacity.
+The two deployment recipes are for 16xH200 (8 for prefill and 8 for decode) and 32xH200 (16 for prefill and 16 for decode). It should also work for other GPU SKUs. Change the TDP and DEP size accordingly to match the GPU capacity.
 
 If you see NCCL errors when sending requests to the engines, it is usually caused by OOM error. Try to reduce `--mem-fraction-static` in both prefill and decode engines.
 

--- a/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
@@ -26,8 +26,6 @@ spec:
       componentType: worker
       subComponentType: decode
       replicas: 1
-      multinode:
-        nodeCount: 2
       resources:
         limits:
           gpu: "8"
@@ -39,7 +37,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
-          workingDir: /sgl-workspace/dynamo
+          workingDir: /workspace
           command:
             - python3
             - -m
@@ -50,14 +48,13 @@ spec:
             - --served-model-name
             - deepseek-ai/DeepSeek-R1
             - --tp
-            - "16"
+            - "8"
             - --dp
-            - "16"
+            - "8"
             - --enable-dp-attention
             - --ep-size
-            - "16"
+            - "8"
             - --trust-remote-code
-            - --skip-tokenizer-init
             - --disaggregation-mode
             - decode
             - --disaggregation-bootstrap-port
@@ -71,8 +68,6 @@ spec:
       componentType: worker
       subComponentType: prefill
       replicas: 1
-      multinode:
-        nodeCount: 2
       resources:
         limits:
           gpu: "8"
@@ -84,7 +79,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
-          workingDir: /sgl-workspace/dynamo
+          workingDir: /workspace
           command:
             - python3
             - -m
@@ -95,11 +90,10 @@ spec:
             - --served-model-name
             - deepseek-ai/DeepSeek-R1
             - --tp
-            - "16"
+            - "8"
             - --ep-size
-            - "16"
+            - "8"
             - --trust-remote-code
-            - --skip-tokenizer-init
             - --disaggregation-mode
             - prefill
             - --disaggregation-bootstrap-port

--- a/recipes/deepseek-r1/sglang/disagg-32gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-32gpu/deploy.yaml
@@ -4,7 +4,7 @@
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
-  name: sgl-dsr1-8gpu
+  name: sgl-dsr1-32gpu
 spec:
   envs:
     - name: HF_HOME
@@ -26,6 +26,8 @@ spec:
       componentType: worker
       subComponentType: decode
       replicas: 1
+      multinode:
+        nodeCount: 2
       resources:
         limits:
           gpu: "8"
@@ -37,7 +39,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
-          workingDir: /workspace
+          workingDir: /sgl-workspace/dynamo
           command:
             - python3
             - -m
@@ -48,13 +50,14 @@ spec:
             - --served-model-name
             - deepseek-ai/DeepSeek-R1
             - --tp
-            - "8"
+            - "16"
             - --dp
-            - "8"
+            - "16"
             - --enable-dp-attention
             - --ep-size
-            - "8"
+            - "16"
             - --trust-remote-code
+            - --skip-tokenizer-init
             - --disaggregation-mode
             - decode
             - --disaggregation-bootstrap-port
@@ -68,6 +71,8 @@ spec:
       componentType: worker
       subComponentType: prefill
       replicas: 1
+      multinode:
+        nodeCount: 2
       resources:
         limits:
           gpu: "8"
@@ -79,7 +84,7 @@ spec:
       extraPodSpec:
         mainContainer:
           image: my-registry/sglang-runtime:my-tag
-          workingDir: /workspace
+          workingDir: /sgl-workspace/dynamo
           command:
             - python3
             - -m
@@ -90,10 +95,11 @@ spec:
             - --served-model-name
             - deepseek-ai/DeepSeek-R1
             - --tp
-            - "8"
+            - "16"
             - --ep-size
-            - "8"
+            - "16"
             - --trust-remote-code
+            - --skip-tokenizer-init
             - --disaggregation-mode
             - prefill
             - --disaggregation-bootstrap-port


### PR DESCRIPTION
The commits look dense, but all I've done is change the folder names from "disagg-16gpu" -> "disagg-32gpu" and "disagg-8gpu" -> "disagg-16gpu".

Since ther already was a folder names disagg-16gpu with a different yaml file, the git diff looks dense.

Also updated the readme file to reflect these changes.

This was brought to notice when MSFT was trying out the 8gpu recipe on a H200 node, and figured out that they needed a total of 16gpus for this (with 8 for prefill and 8 for decode)

Creating new RP to accomodate: https://github.com/ai-dynamo/dynamo/pull/4086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hardware requirements documentation with current GPU deployment specifications.

* **Chores**
  * Adjusted deployment configurations for different scaling scenarios: 16-GPU single-node and 32-GPU multi-node setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->