### PR TITLE
chore: use python apt for frontend container instead of uv

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -570,6 +570,11 @@ RUN apt-get update -y \
         libstdc++6 \
         # required for verification of GPG keys
         gnupg2 \
+        # required for installing dependencies from git repositories
+        git \
+        git-lfs \
+        # Python runtime - required for virtual environment to work
+        python${PYTHON_VERSION}-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -604,12 +609,38 @@ COPY --chown=dynamo: ATTRIBUTION* LICENSE /workspace/
 
 ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="/opt/dynamo/venv/bin:$PATH"
-# Copy virtual environment directly from dynamo_base (dev image)
-# This includes all installed packages: dynamo, nixl, requirements.txt, requirements.test.txt
-# Copy uv to system /bin
-COPY --chown=dynamo: --from=dev /bin/uv /bin/uvx /bin/
-RUN uv python install $PYTHON_VERSION
-COPY --chown=dynamo: --from=dev /opt/dynamo/venv/ /opt/dynamo/venv/
+
+# Copy uv and wheelhouse from runtime stage
+COPY --chown=dynamo: --from=runtime /bin/uv /bin/uvx /bin/
+COPY --chown=dynamo: --from=runtime /opt/dynamo/wheelhouse/ /opt/dynamo/wheelhouse/
+
+# Create virtual environment
+RUN mkdir -p /opt/dynamo/venv && \
+    uv venv /opt/dynamo/venv --python $PYTHON_VERSION
+
+# Install common and test dependencies
+RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
+    --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.test.txt \
+    UV_GIT_LFS=1 uv pip install \
+        --no-cache \
+        --requirement /tmp/requirements.txt \
+        --requirement /tmp/requirements.test.txt
+
+ARG ENABLE_KVBM
+RUN uv pip install \
+    /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
+    /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
+    /opt/dynamo/wheelhouse/nixl/nixl*.whl && \
+    if [ "$ENABLE_KVBM" = "true" ]; then \
+        KVBM_WHEEL=$(ls /opt/dynamo/wheelhouse/kvbm*.whl 2>/dev/null | head -1); \
+        if [ -z "$KVBM_WHEEL" ]; then \
+            echo "ERROR: ENABLE_KVBM is true but no KVBM wheel found in wheelhouse" >&2; \
+            exit 1; \
+        fi; \
+        uv pip install "$KVBM_WHEEL"; \
+    fi && \
+    cd /workspace/benchmarks && \
+    UV_GIT_LFS=1 uv pip install --no-cache .
 
 # Setup environment for all users
 USER root


### PR DESCRIPTION
#### Overview:

For the frontend container, use the python apt distribution instead of uv python to match the process followed by other runtime containers. This requires us to install the built packages into the venv instead of copying the venv. As a result, we are added the following ubuntu packages into the frontend container:

````
git
git-lfs
python3.{PYTHON_VERSION}-dev
````

With these additional packages, we are seeing a slight increase in frontend container image size (9.17 -> 9.51 GB). 
#### Details:

- use python apt instead of uv python
- Install pre-built artifacts into frontend container (instead of copying) and remove dependency on dev stage


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build configuration with enhanced Git and Python development tool support
  * Improved dependency installation process with validation checks for optional components
  * Refined virtual environment creation and package management workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->