### PR TITLE
fix: test_consolidator_router_e2e trtllm import failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,14 @@ filterwarnings = [
     'ignore:Field name "schema" in "ResponseFormat" shadows an attribute in parent:UserWarning',
     # pytest-benchmark automatically disables when xdist is active, ignore the warning
     "ignore:.*Benchmarks are automatically disabled.*:pytest_benchmark.logger.PytestBenchmarkWarning",
+
+    ################################################################################################
+    # TRT-LLM
+    ################################################################################################
+    # torchao deprecation warnings for import path changes (see https://github.com/pytorch/ao/issues/2752)
+    "ignore:Importing.*torchao\\.dtypes.*:DeprecationWarning",
+    # nvidia-modelopt warning about transformers version incompatibility
+    "ignore:transformers version .* is incompatible with nvidia-modelopt.*:UserWarning",
 ]
 
 


### PR DESCRIPTION
there is a TRT-LLM version change between dynamo-0.8.0/rc6 and dynamo-0.8.0/rc7, such that TRT-LLM dependency generates different warnings. 

```
dynamo@68c4a91566d9:/workspace$   pip list | grep llm
tensorrt_llm                             1.2.0rc6
 
dynamo@56b2456d5577:/workspace$ pip list | grep llm
tensorrt_llm                             1.2.0rc6.post1
```

because `pyproject.toml` generally treats warnings as failure, we're getting failures when kicking off `test_consolidator_router_e2e` 

This PR filters out these warnings so that tests could succeeds.

# Test Plan

Reproduced failure on GB200 with

```
pytest -v -s -rA -m kvbm   tests/kvbm_integration/test_consolidator_router_e2e.py

...

ERROR tests/kvbm_integration/test_consolidator_router_e2e.py - DeprecationWarning: Importing from torchao.dtypes.floatx.floatx_tensor_core_layout is deprecated. Please use 'from torchao.prototype.dtypes.floatx.floatx_tensor_core_layout import ...' instead. This import path will be removed in a future torchao release. Please check issue: 
```

made the change and reran tests and got

```
=============== short test summary info ================
PASSED tests/kvbm_integration/test_consolidator_router_e2e.py::TestConsolidatorRouterE2E::test_basic_consolidator_flow[trtllm]
PASSED tests/kvbm_integration/test_consolidator_router_e2e.py::TestConsolidatorRouterE2E::test_consolidator_handles_concurrent_requests[trtllm]
PASSED tests/kvbm_integration/test_consolidator_router_e2e.py::TestConsolidatorRouterE2E::test_store_deduplication_across_sources[trtllm]
PASSED tests/kvbm_integration/test_consolidator_router_e2e.py::TestConsolidatorRouterE2E::test_remove_deduplication_across_sources[trtllm]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to suppress specific deprecation and compatibility warnings, enhancing the development and testing environment experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->