### PR TITLE
fix: read store_kv arg from env when using decorator

### DIFF
--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -36,7 +36,8 @@ def dynamo_worker(enable_nats: bool = True):
         async def wrapper(*args, **kwargs):
             loop = asyncio.get_running_loop()
             request_plane = os.environ.get("DYN_REQUEST_PLANE", "tcp")
-            runtime = DistributedRuntime(loop, "etcd", request_plane, enable_nats)
+            store_kv = os.environ.get("DYN_STORE_KV", "etcd")
+            runtime = DistributedRuntime(loop, store_kv, request_plane, enable_nats)
 
             await func(runtime, *args, **kwargs)
 


### PR DESCRIPTION
#### Overview:

matches the pattern used everywhere else 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the KV store backend via environment variable, with etcd as the default option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->