### PR TITLE
docs(recipes): Add README documentation for all model recipes

### DIFF
--- a/recipes/deepseek-r1/README.md
+++ b/recipes/deepseek-r1/README.md
@@ -1,0 +1,159 @@
+# DeepSeek-R1
+
+Production-ready recipes for DeepSeek-R1, a 671B parameter Mixture-of-Experts model, across multiple backends.
+
+## Available Configurations
+
+| Backend | Mode | GPUs | Hardware | Description |
+|---------|------|------|----------|-------------|
+| [SGLang](sglang/disagg-8gpu/) | Disagg WideEP | 8x H200 | Hopper | Single-node disaggregated |
+| [SGLang](sglang/disagg-16gpu/) | Disagg WideEP | 16x H200 | Hopper | Multi-node disaggregated |
+| [vLLM](vllm/disagg/) | Disaggregated | 16x H200 | Hopper | vLLM backend |
+| [TRT-LLM](trtllm/disagg/wide_ep/gb200/) | Disagg WideEP | 36x GB200 | Blackwell | 8 decode + 1 prefill nodes |
+
+## Model Characteristics
+
+- **Architecture**: Mixture-of-Experts (MoE)
+- **Total parameters**: 671B
+- **Active parameters**: ~37B per token
+- **Memory requirement**: Requires multi-GPU/multi-node deployment
+
+## Prerequisites
+
+- **Model**: `deepseek-ai/DeepSeek-R1`
+- **Storage**: ~1.5TB for model weights
+- **HuggingFace token**: Required
+- **Networking**: High-bandwidth interconnect (IB/RoCE) recommended
+
+## Model Download
+
+Different backends may require different download configurations:
+
+```bash
+export NAMESPACE=deepseek-demo
+kubectl create namespace ${NAMESPACE}
+
+# Create HF token secret
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="your-token" -n ${NAMESPACE}
+
+# For SGLang backend:
+kubectl apply -f model-cache/model-download-sglang.yaml -n ${NAMESPACE}
+
+# For vLLM/TRT-LLM backends:
+kubectl apply -f model-cache/model-download.yaml -n ${NAMESPACE}
+
+# Monitor progress (this will take a while for 1.5TB)
+kubectl logs -f job/model-download -n ${NAMESPACE}
+```
+
+## Backend Selection Guide
+
+### SGLang (Recommended for Hopper)
+Best for H100/H200 deployments with WideEP support.
+
+**Pros**:
+- Native WideEP support
+- Optimized for DeepSeek architecture
+- DP-attention support
+
+**See**: [sglang/README.md](sglang/README.md) for detailed instructions.
+
+### vLLM
+General-purpose backend with broad compatibility.
+
+**Pros**:
+- Familiar API
+- Good community support
+
+**See**: [vllm/disagg/README.md](vllm/disagg/README.md) for detailed instructions.
+
+### TensorRT-LLM (GB200/Blackwell)
+Optimized for NVIDIA Blackwell architecture.
+
+**Pros**:
+- Maximum performance on GB200
+- WideEP with NIXL support
+
+**See**: [trtllm/disagg/wide_ep/gb200/](trtllm/disagg/wide_ep/gb200/) for configuration.
+
+## SGLang Quick Start (8x H200)
+
+```bash
+# 1. Download model (use SGLang-specific download)
+kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
+kubectl apply -f model-cache/model-download-sglang.yaml -n ${NAMESPACE}
+
+# 2. Wait for download
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=36000s
+
+# 3. Update image in deploy.yaml, then:
+kubectl apply -f sglang/disagg-8gpu/deploy.yaml -n ${NAMESPACE}
+
+# 4. Test
+kubectl port-forward svc/sgl-dsr1-8gpu-frontend 8000:8000 -n ${NAMESPACE}
+curl http://localhost:8000/v1/models
+```
+
+## Key Configuration
+
+### Image Tags
+Replace `my-registry/sglang-runtime:my-tag` with your actual registry and tag:
+```yaml
+image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.0
+```
+
+### WideEP Settings (SGLang)
+
+```yaml
+args:
+  - --tp
+  - "16"
+  - --dp
+  - "16"
+  - --enable-dp-attention
+  - --ep-size
+  - "16"
+```
+
+### Memory Configuration
+
+```yaml
+--mem-fraction-static 0.75  # Reduce if you see NCCL/OOM errors
+```
+
+> **Warning**: If you see NCCL errors when sending requests, it's usually caused by OOM. Reduce `--mem-fraction-static`.
+
+## Multi-Node Networking
+
+DeepSeek-R1 deployments require high-bandwidth interconnect:
+
+- **Minimum**: 100Gbps Ethernet
+- **Recommended**: InfiniBand or RoCE
+- **NVSHMEM**: Required for WideEP configurations
+
+Ensure your Kubernetes cluster has proper RDMA/IB configuration.
+
+## Troubleshooting
+
+**NCCL errors during inference**:
+```bash
+# Usually OOM - reduce memory fraction
+--mem-fraction-static 0.70
+```
+
+**Model download timeout**:
+- 671B model requires 1.5TB+ transfer
+- Use a dedicated download pod with extended timeout
+- Consider pre-downloading to shared storage
+
+**Pods stuck in Init**:
+- Check network connectivity between nodes
+- Verify NVSHMEM/IB drivers are installed
+- Check GPU operator status
+
+**Tokenization mismatches (SGLang)**:
+```yaml
+# Use SGLang's tokenizer to avoid issues:
+--skip-tokenizer-init  # Let SGLang handle tokenization
+```

--- a/recipes/gpt-oss-120b/README.md
+++ b/recipes/gpt-oss-120b/README.md
@@ -1,52 +1,137 @@
-# GPT-OSS-120B Recipe Guide
+# GPT-OSS-120B with TensorRT-LLM
 
-This guide will help you run the GPT-OSS-120B language model using Dynamo's optimized setup.
+Production-ready recipes for GPT-OSS-120B using the TensorRT-LLM backend, optimized for NVIDIA GB200 (Blackwell) hardware.
+
+## Available Configurations
+
+| Mode | GPUs | Hardware | Description |
+|------|------|----------|-------------|
+| [Aggregated](trtllm/agg/) | 4x GB200 | Blackwell | WideEP deployment |
+| [Disaggregated](trtllm/disagg/) | TBD | Blackwell | Engine configs only (no K8s manifest) |
+
+## Hardware Requirements
+
+> **Note**: This recipe is specifically designed for **GB200 (Blackwell)** GPUs with ARM64 architecture.
+
+- **GPUs**: 4x NVIDIA GB200
+- **Architecture**: ARM64
+- **Interconnect**: NVLink/NVSwitch recommended
 
 ## Prerequisites
 
-Follow the instructions in recipe [README.md](../README.md) to create a namespace and kubernetes secret for huggingface token.
+- **Model**: GPT-OSS-120B
+- **Storage**: ~250GB for model weights
+- **HuggingFace token**: Required for model download
+- **GB200 cluster**: ARM64 Blackwell GPUs
 
 ## Quick Start
 
-To run the model, simply execute this command in your terminal:
+### Option A: Using run.sh Script
 
 ```bash
-cd recipe
+cd recipes
 ./run.sh --model gpt-oss-120b --framework trtllm agg
 ```
 
-## (Alternative) Step by Step Guide
-
-### 1. Download the Model
+### Option B: Step-by-Step
 
 ```bash
-cd recipes/gpt-oss-120b
-kubectl apply -n $NAMESPACE -f ./model-cache
+export NAMESPACE=gpt-oss-demo
+kubectl create namespace ${NAMESPACE}
+
+# 1. Create HF token secret
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="your-token" -n ${NAMESPACE}
+
+# 2. Update storageClassName in model-cache/model-cache.yaml, then:
+kubectl apply -f model-cache/ -n ${NAMESPACE}
+
+# 3. Wait for model download
+kubectl logs -f job/model-download -n ${NAMESPACE}
+
+# 4. Update image tag in deploy.yaml, then deploy:
+kubectl apply -f trtllm/agg/deploy.yaml -n ${NAMESPACE}
+
+# 5. Test
+kubectl port-forward svc/gpt-oss-120b-agg-frontend 8000:8000 -n ${NAMESPACE}
+curl http://localhost:8000/v1/models
 ```
 
-### 2. Deploy and Benchmark the Model
+## Key Configuration
+
+### Image Tag
+
+This recipe requires the ARM64 TensorRT-LLM runtime container:
+
+```yaml
+# For Dynamo 0.5.1+:
+image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.5.1
+
+# Pre-release (before 0.5.1):
+image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.5.1-rc0.pre3
+```
+
+### Storage Class
+
+The recipe does not specify a storage class by default. Update `model-cache/model-cache.yaml`:
+
+```yaml
+spec:
+  storageClassName: "your-storage-class-name"
+```
+
+Find available storage classes:
+```bash
+kubectl get storageclass
+```
+
+## Deployment Mode
+
+### Aggregated (4x GB200)
 
 ```bash
-cd recipes/gpt-oss-120b
-kubectl apply -n $NAMESPACE -f ./trtllm/agg
+kubectl apply -f trtllm/agg/deploy.yaml -n ${NAMESPACE}
 ```
 
-### Container Image
-This recipe was tested with dynamo trtllm runtime container for ARM64 processors.
+**Features**:
+- WideEP (Wide Expert Parallelism) for efficient MoE inference
+- Optimized for Blackwell architecture
+- Single-command deployment
 
-**Important Note:**
+### Disaggregated
 
-Before dynamo v0.5.1 release, following container image is supported:
-```
-nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.5.1-rc0.pre3
+The disaggregated mode currently provides engine configuration files only. Full Kubernetes manifests are pending.
+
+See [trtllm/disagg/](trtllm/disagg/) for available engine configurations.
+
+## Benchmarking
+
+```bash
+kubectl apply -f trtllm/agg/perf.yaml -n ${NAMESPACE}
+kubectl logs -f job/gpt-oss-120b-agg-perf -n ${NAMESPACE}
 ```
 
-After dynamo v0.5.1 release, following container image will be supported:
+The benchmark uses a pinned version of aiperf for reproducible results.
+
+## Troubleshooting
+
+**Image pull errors**:
+- Ensure you're using ARM64-compatible images
+- Verify NGC credentials are configured
+
+**Storage class not found**:
+```bash
+# List available storage classes
+kubectl get storageclass
+# Update model-cache.yaml with a valid class
 ```
-nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.5.1
-```
+
+**GPU scheduling issues**:
+- Verify GB200 GPUs are available: `kubectl describe nodes | grep -i gpu`
+- Check GPU operator status
 
 ## Notes
-1. The benchmark container image uses a specific commit of aiperf to ensure reproducible results and compatibility with the benchmarking setup.
 
-2. storage class is not specified in the recipe, you need to specify it in the `deploy.yaml` file.
+1. This recipe is optimized for GB200 hardware and may not work on other GPU architectures.
+2. The benchmarking container uses a specific aiperf commit to ensure reproducibility.
+3. WideEP requires proper NVLink/NVSwitch configuration for optimal performance.

--- a/recipes/llama-3-70b/README.md
+++ b/recipes/llama-3-70b/README.md
@@ -1,0 +1,142 @@
+# Llama-3.3-70B with vLLM
+
+Production-ready recipes for Llama-3.3-70B-Instruct using the vLLM backend with FP8 dynamic quantization.
+
+## Available Configurations
+
+| Mode | GPUs | Description | Best For |
+|------|------|-------------|----------|
+| [Aggregated](vllm/agg/) | 4x H100/H200 | Single TP4 worker | Low-latency, simple setup |
+| [Disagg Single-Node](vllm/disagg-single-node/) | 8x H100/H200 | 2x prefill (TP2) + 1x decode (TP4) | High throughput, single node |
+| [Disagg Multi-Node](vllm/disagg-multi-node/) | 16x H100/H200 | Multi-node prefill/decode separation | Maximum throughput |
+
+## Prerequisites
+
+- **Model**: `RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic`
+- **Storage**: ~150GB for model weights
+- **HuggingFace token**: Required for model download
+
+## Quick Start
+
+```bash
+export NAMESPACE=llama-demo
+kubectl create namespace ${NAMESPACE}
+
+# 1. Create HF token secret
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="your-token" -n ${NAMESPACE}
+
+# 2. Update storageClassName in model-cache/model-cache.yaml, then:
+kubectl apply -f model-cache/ -n ${NAMESPACE}
+
+# 3. Wait for model download (~15-30 min for 70B)
+kubectl logs -f job/model-download -n ${NAMESPACE}
+
+# 4. Update image tag in deploy.yaml, then deploy:
+kubectl apply -f vllm/agg/deploy.yaml -n ${NAMESPACE}
+
+# 5. Test
+kubectl port-forward svc/llama3-70b-agg-frontend 8000:8000 -n ${NAMESPACE}
+curl http://localhost:8000/v1/models
+```
+
+## Key Configuration
+
+### Image Tag
+All `deploy.yaml` files use `image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag`. Replace `my-tag` with your Dynamo version (e.g., `0.7.0`).
+
+### GPU Memory Utilization
+
+```yaml
+# In deploy.yaml args:
+--gpu-memory-utilization 0.90  # Default for most configs
+```
+
+> **Warning**: The UX review found that `0.95` can cause OOM on Llama-3.3-70B. Use `0.90` or lower if you see CUDA OOM errors during warmup.
+
+### Tensor Parallelism
+
+| Mode | Prefill TP | Decode TP | Total GPUs |
+|------|-----------|-----------|------------|
+| Aggregated | - | TP4 | 4 |
+| Disagg Single-Node | TP2 (x2 replicas) | TP4 | 8 |
+| Disagg Multi-Node | TP4 (x2 replicas) | TP8 | 16 |
+
+## Deployment Modes
+
+### Aggregated (4 GPUs)
+Simplest deployment - single worker handles both prefill and decode.
+
+```bash
+kubectl apply -f vllm/agg/deploy.yaml -n ${NAMESPACE}
+```
+
+**When to use**: Development, low-traffic production, latency-sensitive workloads.
+
+### Disaggregated Single-Node (8 GPUs)
+Separates prefill and decode workers on a single node.
+
+```bash
+kubectl apply -f vllm/disagg-single-node/deploy.yaml -n ${NAMESPACE}
+```
+
+**When to use**: High throughput on single node, workloads with long input sequences.
+
+**Key benefit**: Decode workers are isolated from prefill latency spikes.
+
+### Disaggregated Multi-Node (16 GPUs)
+Scales prefill and decode across multiple nodes.
+
+```bash
+kubectl apply -f vllm/disagg-multi-node/deploy.yaml -n ${NAMESPACE}
+```
+
+**When to use**: Maximum throughput, production workloads at scale.
+
+## Inference Gateway (GAIE) Integration
+
+The aggregated deployment includes optional GAIE integration for advanced routing:
+
+```bash
+# After deploying the base recipe:
+kubectl apply -R -f vllm/agg/gaie/k8s-manifests -n ${NAMESPACE}
+```
+
+See [gaie/k8s-manifests/](vllm/agg/gaie/k8s-manifests/) for the full configuration.
+
+## Benchmarking
+
+Each deployment mode includes a `perf.yaml` for standardized benchmarking:
+
+```bash
+# Run after deployment is ready
+kubectl apply -f vllm/agg/perf.yaml -n ${NAMESPACE}
+
+# Monitor progress
+kubectl logs -f job/llama3-70b-agg-perf -n ${NAMESPACE}
+```
+
+**Default benchmark config**:
+- Input sequence length: 8192 tokens
+- Output sequence length: 1024 tokens
+- Concurrency: 16 per GPU
+
+## Troubleshooting
+
+**OOM during warmup**:
+```yaml
+# Reduce gpu-memory-utilization:
+--gpu-memory-utilization 0.85
+```
+
+**Pods stuck in Pending**:
+```bash
+kubectl describe pod <pod-name> -n ${NAMESPACE}
+# Check for GPU availability and resource constraints
+```
+
+**Model download timeout**:
+```bash
+# Increase job timeout or check HF token permissions
+kubectl logs job/model-download -n ${NAMESPACE}
+```

--- a/recipes/qwen3-235b-a22b-fp8/README.md
+++ b/recipes/qwen3-235b-a22b-fp8/README.md
@@ -1,0 +1,166 @@
+# Qwen3-235B-A22B-FP8 with TensorRT-LLM
+
+Production-ready recipes for Qwen3-235B-A22B, a Mixture-of-Experts (MoE) model with FP8 quantization, using the TensorRT-LLM backend.
+
+## Available Configurations
+
+| Mode | GPUs | Workers | Description |
+|------|------|---------|-------------|
+| [Aggregated](trtllm/agg/) | 16x (4x TP4) | 4 replicas | Expert parallel across 4 GPUs per worker |
+| [Disaggregated](trtllm/disagg/) | 20x | 4x prefill + 2x decode | Prefill/decode separation |
+
+## Model Characteristics
+
+- **Architecture**: Mixture-of-Experts (MoE)
+- **Active parameters**: 22B per token (out of 235B total)
+- **Expert parallelism**: Required for efficient inference
+- **Memory**: ~500GB total weights, distributed across GPUs
+
+## Prerequisites
+
+- **Model**: `Qwen/Qwen3-235B-A22B-FP8`
+- **Storage**: ~500GB for model weights
+- **HuggingFace token**: Required for model download
+- **Multi-node cluster**: Recommended for production
+
+## Quick Start
+
+```bash
+export NAMESPACE=qwen-moe-demo
+kubectl create namespace ${NAMESPACE}
+
+# 1. Create HF token secret
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="your-token" -n ${NAMESPACE}
+
+# 2. Update storageClassName in model-cache/model-cache.yaml
+# NOTE: Ensure you have ~500GB available
+kubectl apply -f model-cache/ -n ${NAMESPACE}
+
+# 3. Wait for model download (can take 1-2 hours for 235B)
+kubectl logs -f job/model-download -n ${NAMESPACE}
+
+# 4. Update image tag in deploy.yaml, then deploy:
+kubectl apply -f trtllm/agg/deploy.yaml -n ${NAMESPACE}
+
+# 5. Test
+kubectl port-forward svc/qwen3-235b-a22b-agg-frontend 8000:8000 -n ${NAMESPACE}
+curl http://localhost:8000/v1/models
+```
+
+## Key Configuration
+
+### Image Tag
+Replace `my-tag` with your Dynamo version:
+```yaml
+image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+```
+
+### MoE-Specific Settings
+
+```yaml
+# In the ConfigMap:
+tensor_parallel_size: 4
+moe_expert_parallel_size: 4  # Distribute experts across GPUs
+moe_tensor_parallel_size: 1
+```
+
+### Memory Requirements
+
+```yaml
+sharedMemory:
+  size: 256Gi  # Required for MoE expert communication
+```
+
+This model requires significant shared memory for cross-GPU expert communication.
+
+## Engine Configuration
+
+The recipes include optimized TRT-LLM settings for MoE:
+
+```yaml
+backend: pytorch
+trust_remote_code: true
+enable_chunked_prefill: true
+build_config:
+  max_batch_size: 128
+  max_num_tokens: 8192
+  max_seq_len: 8192
+kv_cache_config:
+  enable_block_reuse: true
+  free_gpu_memory_fraction: 0.8
+```
+
+## Deployment Modes
+
+### Aggregated (16 GPUs)
+
+```bash
+kubectl apply -f trtllm/agg/deploy.yaml -n ${NAMESPACE}
+```
+
+**Architecture**: 4x TP4 workers with expert parallelism.
+
+**Resource per worker**:
+- 4 GPUs
+- 256Gi shared memory
+
+### Disaggregated (20 GPUs)
+
+```bash
+kubectl apply -f trtllm/disagg/deploy.yaml -n ${NAMESPACE}
+```
+
+**Architecture**:
+- **Prefill**: Optimized for long context processing
+- **Decode**: Optimized for token generation latency
+
+## Performance Considerations
+
+### Expert Parallelism
+MoE models benefit significantly from expert parallelism. The default configuration distributes experts across 4 GPUs:
+
+```yaml
+moe_expert_parallel_size: 4
+```
+
+### Chunked Prefill
+Enabled by default to handle long sequences efficiently:
+
+```yaml
+enable_chunked_prefill: true
+```
+
+### KV Cache
+Block reuse is enabled for better memory efficiency:
+
+```yaml
+kv_cache_config:
+  enable_block_reuse: true
+```
+
+## Benchmarking
+
+```bash
+kubectl apply -f trtllm/agg/perf.yaml -n ${NAMESPACE}
+kubectl logs -f job/qwen3-235b-a22b-agg-perf -n ${NAMESPACE}
+```
+
+## Troubleshooting
+
+**Model download fails or times out**:
+- Ensure sufficient storage (~500GB)
+- Check network bandwidth to HuggingFace
+- Consider using a separate download pod with higher timeout
+
+**OOM during expert routing**:
+- Increase shared memory allocation
+- Reduce `free_gpu_memory_fraction` in the ConfigMap
+
+**Slow startup**:
+- MoE models take longer to initialize due to expert weight distribution
+- First startup includes engine compilation (30-60 minutes typical)
+
+**NCCL timeout errors**:
+- Check inter-node networking
+- Ensure IB/RoCE is configured correctly for multi-node setups

--- a/recipes/qwen3-32b-fp8/README.md
+++ b/recipes/qwen3-32b-fp8/README.md
@@ -1,0 +1,136 @@
+# Qwen3-32B-FP8 with TensorRT-LLM
+
+Production-ready recipes for Qwen3-32B with FP8 quantization using the TensorRT-LLM backend.
+
+## Available Configurations
+
+| Mode | GPUs | Prefill | Decode | Description |
+|------|------|---------|--------|-------------|
+| [Aggregated](trtllm/agg/) | 4x | - | 2x TP2 workers | Simple deployment |
+| [Disaggregated](trtllm/disagg/) | 8x | 4x TP1 | 2x TP2 | Prefill/decode separation |
+
+## Prerequisites
+
+- **Model**: `Qwen/Qwen3-32B-FP8`
+- **Storage**: ~70GB for model weights
+- **HuggingFace token**: Required for model download
+
+## Quick Start
+
+```bash
+export NAMESPACE=qwen-demo
+kubectl create namespace ${NAMESPACE}
+
+# 1. Create HF token secret
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="your-token" -n ${NAMESPACE}
+
+# 2. Update storageClassName in model-cache/model-cache.yaml, then:
+kubectl apply -f model-cache/ -n ${NAMESPACE}
+
+# 3. Wait for model download
+kubectl logs -f job/model-download -n ${NAMESPACE}
+
+# 4. Update image tag in deploy.yaml, then deploy:
+kubectl apply -f trtllm/agg/deploy.yaml -n ${NAMESPACE}
+
+# 5. Test
+kubectl port-forward svc/qwen3-32b-fp8-agg-frontend 8000:8000 -n ${NAMESPACE}
+curl http://localhost:8000/v1/models
+```
+
+## Key Configuration
+
+### Image Tag
+Replace `my-tag` with your Dynamo version:
+```yaml
+image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0
+```
+
+### Engine Configuration
+
+The recipes include embedded ConfigMaps with TRT-LLM engine settings:
+
+```yaml
+# Key settings in the ConfigMap:
+tensor_parallel_size: 2
+max_batch_size: 128
+max_num_tokens: 7800
+max_seq_len: 7800
+kv_cache_config:
+  free_gpu_memory_fraction: 0.7
+  dtype: fp8
+```
+
+### GPU Memory
+
+```yaml
+--free-gpu-memory-fraction 0.9  # In worker args
+```
+
+Reduce to `0.7-0.8` if you encounter OOM errors.
+
+## Deployment Modes
+
+### Aggregated (4 GPUs)
+
+```bash
+kubectl apply -f trtllm/agg/deploy.yaml -n ${NAMESPACE}
+```
+
+**Architecture**: 2x TP2 workers with round-robin routing.
+
+### Disaggregated (8 GPUs)
+
+```bash
+kubectl apply -f trtllm/disagg/deploy.yaml -n ${NAMESPACE}
+```
+
+**Architecture**:
+- **Prefill**: 4x TP1 workers (optimized for throughput)
+- **Decode**: 2x TP2 workers (optimized for latency)
+
+**When to use**: Workloads with long input sequences where you want to isolate decode latency from prefill bursts.
+
+## TensorRT-LLM Specific Settings
+
+### Environment Variables
+
+```yaml
+env:
+  - name: TRTLLM_ENABLE_PDL
+    value: "1"  # Enable PDL for better performance
+  - name: TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL
+    value: "True"  # Required for some model configurations
+```
+
+### CUDA Graph Configuration
+
+The ConfigMap includes CUDA graph batch sizes for optimal performance:
+
+```yaml
+cuda_graph_config:
+  enable_padding: true
+  batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128]
+```
+
+## Benchmarking
+
+```bash
+kubectl apply -f trtllm/agg/perf.yaml -n ${NAMESPACE}
+kubectl logs -f job/qwen3-32b-fp8-agg-perf -n ${NAMESPACE}
+```
+
+## Troubleshooting
+
+**Engine compilation takes too long**:
+TRT-LLM compiles engines on first startup. This can take 10-30 minutes. Check logs:
+```bash
+kubectl logs -f <worker-pod> -n ${NAMESPACE}
+```
+
+**NCCL errors**:
+Usually indicates OOM. Reduce `free_gpu_memory_fraction` in the ConfigMap.
+
+**Pods crash during warmup**:
+Increase liveness/readiness probe timeouts or check resource limits.


### PR DESCRIPTION
Add lightweight but useful documentation to help customers who use recipes as their entry point to Dynamo:

- llama-3-70b: vLLM configs (agg, disagg), GAIE integration, OOM guidance
- qwen3-32b-fp8: TRT-LLM configs, engine ConfigMap docs
- qwen3-235b-a22b-fp8: MoE settings, expert parallelism, memory requirements
- deepseek-r1: Top-level guide covering SGLang/vLLM/TRT-LLM backends
- gpt-oss-120b: Updated with GB200 requirements, ARM64 image tags

Each README includes:
- Available configurations table with GPU requirements
- Prerequisites and quick start commands
- Key configuration values (image tags, memory, TP settings)
- Troubleshooting for common issues (OOM, probe timeouts, NCCL errors)

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
