### PR TITLE
fix: ignore torchao SyntaxWarning in pytest filterwarnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,11 @@ filterwarnings = [
     ################################################################################################
     # TRT-LLM
     ################################################################################################
+    # torchao sometimes emits SyntaxWarning from docstrings (e.g. invalid escape sequences) at import
+    # time; our global `error` policy would otherwise fail test collection. Do not rely on module=
+    # matching here because these can be raised during compilation where the module field may not
+    # match as expected.
+    "ignore:.*invalid escape sequence.*:SyntaxWarning",
     # torchao deprecation warnings for import path changes (see https://github.com/pytorch/ao/issues/2752)
     "ignore:Importing.*torchao\\.dtypes.*:DeprecationWarning",
     # nvidia-modelopt warning about transformers version incompatibility


### PR DESCRIPTION
## Summary

Adds a pytest warning filter to ignore `SyntaxWarning` for invalid escape sequences emitted by `torchao` at import time. This prevents test collection failures when running KVBM integration tests in TRT-LLM containers with newer `torchao` versions (e.g., 0.15.0 bundled with TRT-LLM 1.2.0rc6.post1).

## Problem

When running pytest with `filterwarnings = ["error"]` (our default strict mode), test collection fails during `import tensorrt_llm` because `torchao` emits a `SyntaxWarning` from a docstring containing an invalid escape sequence:

```
/opt/dynamo/venv/lib/python3.12/site-packages/torchao/quantization/quant_api.py:2511: SyntaxWarning: invalid escape sequence '\\.'  """Configuration class for applying different quantization configs...
```

This causes all TRT-LLM KVBM tests to error during collection rather than run.

## Solution

Add the following filter to `pyproject.toml`:

```toml
"ignore:.*invalid escape sequence.*:SyntaxWarning",
```
 
This filter is placed in the existing TRT-LLM warning filters section alongside related `torchao` and `nvidia-modelopt` filters.

## Testing

- Verified filter syntax is valid (no linter errors)
- Filter follows the same pattern as existing upstream library warning suppressions

## Related

- NVBugs: https://nvbugs/5764977
- Upstream issue: https://github.com/pytorch/ao/issues/2752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to suppress SyntaxWarning related to invalid escape sequences, resolving test collection failures during builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->