### PR TITLE
fix: ignore torchao SyntaxWarning in pytest filterwarnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,11 @@ filterwarnings = [
     ################################################################################################
     # TRT-LLM
     ################################################################################################
+    # torchao sometimes emits SyntaxWarning from docstrings (e.g. invalid escape sequences) at import
+    # time; our global `error` policy would otherwise fail test collection. Do not rely on module=
+    # matching here because these can be raised during compilation where the module field may not
+    # match as expected.
+    "ignore:.*invalid escape sequence.*:SyntaxWarning",
     # torchao deprecation warnings for import path changes (see https://github.com/pytorch/ao/issues/2752)
     "ignore:Importing.*torchao\\.dtypes.*:DeprecationWarning",
     # nvidia-modelopt warning about transformers version incompatibility


### PR DESCRIPTION
Cherry-pick of #5429 to release/0.8.0

## Summary

Adds a pytest warning filter to ignore `SyntaxWarning` for invalid escape sequences emitted by `torchao` at import time. This prevents test collection failures when running KVBM integration tests in TRT-LLM containers with newer `torchao` versions.

## Original PR

- Main PR: https://github.com/ai-dynamo/dynamo/pull/5429
- NVBugs: https://nvbugs/5764977

(cherry picked from commit 6fe88553c582e0dcffea5fce17a099439bccec4c)