### PR TITLE
fix. filter out syntax warning to prevent TRTLLM import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,10 +205,8 @@ filterwarnings = [
     # TRT-LLM
     ################################################################################################
     # torchao sometimes emits SyntaxWarning from docstrings (e.g. invalid escape sequences) at import
-    # time; our global `error` policy would otherwise fail test collection. Do not rely on module=
-    # matching here because these can be raised during compilation where the module field may not
-    # match as expected.
-    "ignore:.*invalid escape sequence.*:SyntaxWarning",
+    # time; scope suppression to torchao to avoid masking unrelated SyntaxWarnings.
+    "ignore:.*invalid escape sequence.*:SyntaxWarning:torchao.*",
     # torchao deprecation warnings for import path changes (see https://github.com/pytorch/ao/issues/2752)
     "ignore:Importing.*torchao\\.dtypes.*:DeprecationWarning",
     # nvidia-modelopt warning about transformers version incompatibility


### PR DESCRIPTION
This PR is a follow-up of Neelay's comment in https://github.com/ai-dynamo/dynamo/pull/5429

Specifically, it narrows down the filter on "torchao" instead of acting as an uber umbrella.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Refined test warning filters to target specific modules, improving test output clarity and reducing noise during development and testing cycles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->