### PR TITLE
fix: [vLLM multimodel] launch image loading in parallel

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -757,6 +757,48 @@ class BaseWorkerHandler(ABC):
 
         return prompt, sequence_length, embeddings_tensor
 
+    async def _load_image_batch(
+        self, image_mm_items: list[Dict[str, Any]]
+    ) -> list[Any]:
+        """
+        Load a batch of images from multimodal data items.
+
+        Args:
+            image_mm_items: List of multimodal data items for images
+        Returns:
+            List of loaded image data
+        Raises:
+            Exception: If any image fails to load
+        """
+        image_futures = []
+        for item in image_mm_items:
+            if isinstance(item, dict) and URL_VARIANT_KEY in item:
+                url = item[URL_VARIANT_KEY]
+                image_futures.append(self.image_loader.load_image(url))
+                logger.debug(f"Preparing to load image from URL: {url[:80]}...")
+            elif isinstance(item, dict) and DECODED_VARIANT_KEY in item:
+                logger.warning(
+                    "Decoded multimodal data not yet supported in standard worker"
+                )
+
+        results = await asyncio.gather(*image_futures, return_exceptions=True)
+        loaded_images = []
+        collective_exceptions = ""
+        for i, result in enumerate(results):
+            if isinstance(result, Exception):
+                url = image_mm_items[i].get(URL_VARIANT_KEY, "unknown")
+                logger.error(f"Failed to load image from {url[:80]}...: {result}")
+                collective_exceptions += (
+                    f"Failed to load image from {url[:80]}...: {result}\n"
+                )
+                continue
+            loaded_images.append(result)
+
+        if collective_exceptions:
+            raise Exception(collective_exceptions)
+
+        return loaded_images
+
     async def _extract_multimodal_data(
         self, request: Dict[str, Any]
     ) -> Dict[str, Any] | None:
@@ -777,28 +819,7 @@ class BaseWorkerHandler(ABC):
         vllm_mm_data = {}
 
         # Process image_url entries
-        images = []
-        image_futures = []
-        for item in mm_map.get(IMAGE_URL_KEY, []):
-            if isinstance(item, dict) and URL_VARIANT_KEY in item:
-                url = item[URL_VARIANT_KEY]
-                # Gather image fetch work
-                image_futures.append(self.image_loader.load_image(url))
-                logger.debug(f"Preparing to load image from URL: {url[:80]}...")
-            elif isinstance(item, dict) and DECODED_VARIANT_KEY in item:
-                # Decoded support from PRs #3971/#3988 (frontend decoding + NIXL transfer)
-                # Will contain NIXL metadata for direct memory access
-                # TODO: Implement NIXL read when PRs merge
-                logger.warning(
-                    "Decoded multimodal data not yet supported in standard worker"
-                )
-
-        try:
-            images = await asyncio.gather(*image_futures)
-            logger.debug(f"Loaded {len(images)} image(s) from URLs")
-        except Exception:
-            logger.exception(f"Failed to load image from {url[:80]}...")
-            raise
+        images = await self._load_image_batch(mm_map.get(IMAGE_URL_KEY, []))
 
         if images:
             # vLLM expects single image or list


### PR DESCRIPTION
Signed-off-by: Guan Luo <41310872+GuanLuo@users.noreply.github.com>

#### Overview:

Improve TTFT of multi-image MM request:

Before TTFT 1,688.90 ms

After TTFT 656.77

Bench command:
`aiperf profile -m Qwen/Qwen2.5-VL-7B-Instruct --endpoint-type chat --synthetic-input-tokens-mean 1 --synthetic-input-tokens-stddev 0 --streaming --request-count 100 --warmup-request-count 2 --concurrency 1 --osl 1 --input-file data_small.jsonl --custom-dataset-type single_turn --ui none`

Bench data (data_small.jsonl):
`{"images": ["http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg","http://images.cocodataset.org/test2017/000000155781.jpg"]}`


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Image loading in multimodal data extraction now uses concurrent processing instead of sequential operations.
  * Error handling updated with aggregated failure reporting for image operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->