### PR TITLE
build: Install NVIDIA packages based on CUDA version

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -531,7 +531,7 @@ RUN --mount=type=bind,source=.,target=/mnt/local_src \
     elif [ "$CUDA_MAJOR" = "13" ]; then \
         # CUDA 13: Install CuDNN for PyTorch 2.9.1 compatibility
         pip install --no-cache-dir --break-system-packages --force-reinstall --no-deps \
-            nvidia-cudnn-cu12==9.16.0.29; \
+            nvidia-cudnn-cu13==9.16.0.29; \
     fi
 
 # Switch back to dynamo user after package installations

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -519,14 +519,20 @@ RUN --mount=type=bind,source=.,target=/mnt/local_src \
     pip install --no-cache-dir --break-system-packages "urllib3>=2.6.3" && \
     # pip/uv bypasses umask when creating .egg-info files, but chmod -R is fast here (small directory)
     chmod -R g+w /workspace/benchmarks && \
+    # Install NVIDIA packages based on CUDA version
+    # CuDNN 9.16+ required for PyTorch 2.9.1 compatibility (multimodal/Conv3d)
+    # See: https://github.com/pytorch/pytorch/issues/168167
     CUDA_MAJOR=$(nvcc --version | egrep -o 'cuda_[0-9]+' | cut -d_ -f2) && \
     if [ "$CUDA_MAJOR" = "12" ]; then \
-        # Install NVIDIA packages that are needed for DeepEP to work properly
-        # This is done in the upstream runtime image too, but these packages are overridden in earlier commands
+        # CUDA 12: Install NCCL, CuDNN, and CUTLASS for DeepEP
         pip install --no-cache-dir --break-system-packages --force-reinstall --no-deps \
             nvidia-nccl-cu12==2.28.3 \
             nvidia-cudnn-cu12==9.16.0.29 \
             nvidia-cutlass-dsl==4.3.0; \
+    elif [ "$CUDA_MAJOR" = "13" ]; then \
+        # CUDA 13: Install CuDNN for PyTorch 2.9.1 compatibility
+        pip install --no-cache-dir --break-system-packages --force-reinstall --no-deps \
+            nvidia-cudnn-cu12==9.16.0.29; \
     fi
 
 # Switch back to dynamo user after package installations

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -531,6 +531,9 @@ RUN --mount=type=bind,source=.,target=/mnt/local_src \
     elif [ "$CUDA_MAJOR" = "13" ]; then \
         # CUDA 13: Install CuDNN for PyTorch 2.9.1 compatibility
         pip install --no-cache-dir --break-system-packages --force-reinstall --no-deps \
+            nvidia-nccl-cu13==2.28.3 \
+            nvidia-cublas==13.1.0.3 \
+            nvidia-cutlass-dsl==4.3.1 \
             nvidia-cudnn-cu13==9.16.0.29; \
     fi
 

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -520,11 +520,10 @@ RUN --mount=type=bind,source=.,target=/mnt/local_src \
     # pip/uv bypasses umask when creating .egg-info files, but chmod -R is fast here (small directory)
     chmod -R g+w /workspace/benchmarks && \
     # Install NVIDIA packages based on CUDA version
-    # CuDNN 9.16+ required for PyTorch 2.9.1 compatibility (multimodal/Conv3d)
-    # See: https://github.com/pytorch/pytorch/issues/168167
     CUDA_MAJOR=$(nvcc --version | egrep -o 'cuda_[0-9]+' | cut -d_ -f2) && \
     if [ "$CUDA_MAJOR" = "12" ]; then \
-        # CUDA 12: Install NCCL, CuDNN, and CUTLASS for DeepEP
+        # Install NVIDIA packages that are needed for DeepEP to work properly
+        # This is done in the upstream runtime image too, but these packages are overridden in earlier commands
         pip install --no-cache-dir --break-system-packages --force-reinstall --no-deps \
             nvidia-nccl-cu12==2.28.3 \
             nvidia-cudnn-cu12==9.16.0.29 \


### PR DESCRIPTION
#### Overview:

Install NVIDIA packages based on CUDA version. CuDNN 9.16+ required for PyTorch 2.9.1 compatibility (multimodal/Conv3d). See: https://github.com/pytorch/pytorch/issues/168167

 
Related issue : sglang-build-test (cuda13.0, amd64) Failure: [Link](https://github.com/ai-dynamo/dynamo/actions/runs/21042830117/job/60509036060?pr=5450#step:8:1133)

```

[BASH] Traceback (most recent call last):
[BASH]   File "<frozen runpy>", line 198, in _run_module_as_main
[BASH]   File "<frozen runpy>", line 88, in _run_code
[BASH]   File "/usr/local/lib/python3.12/dist-packages/dynamo/sglang/__main__.py", line 7, in <module>
[BASH]     main()
...
...
...
[BASH]   File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/engine.py", line 160, in __init__
[BASH]     _launch_subprocesses(
[BASH]   File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/engine.py", line 913, in _launch_subprocesses
[BASH]     server_args.check_server_args()
[BASH]   File "/sgl-workspace/sglang/python/sglang/srt/server_args.py", line 4572, in check_server_args
[BASH]     self.check_torch_2_9_1_cudnn_compatibility()
[BASH]   File "/sgl-workspace/sglang/python/sglang/srt/server_args.py", line 4706, in check_torch_2_9_1_cudnn_compatibility
[BASH]     raise RuntimeError(msg)
[BASH] RuntimeError: CRITICAL WARNING: PyTorch 2.9.1 & CuDNN Compatibility Issue Detected
[BASH] --------------------------------------------------------------------------------
[BASH] Current Environment: PyTorch 2.9.1+cu130 | CuDNN 9.13
[BASH] 
[BASH] Issue:     There is a KNOWN BUG in PyTorch 2.9.1's `nn.Conv3d` implementation
[BASH]            when used with CuDNN versions older than 9.15. This can cause
[BASH]            SEVERE PERFORMANCE DEGRADATION and EXCESSIVE MEMORY USAGE.
[BASH] 
[BASH] Reference: https://github.com/pytorch/pytorch/issues/168167
[BASH] 
[BASH] Solution:  You MUST upgrade CuDNN to version 9.15+ to ensure correctness.
[BASH] 
[BASH] Run the following command immediately to fix:
[BASH]     pip install nvidia-cudnn-cu12==9.16.0.29
[BASH] 
[BASH] Or you can disable this check by setting env var SGLANG_DISABLE_CUDNN_CHECK=1

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended container support to include CUDA 13 in addition to CUDA 12 for broader deployment flexibility.

* **Chores**
  * Updated NVIDIA package installation logic to properly configure dependencies based on CUDA version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->