### PR TITLE
feat: Implement priority-based KV cache offload filtering

### DIFF
--- a/lib/bindings/kvbm/README.md
+++ b/lib/bindings/kvbm/README.md
@@ -86,6 +86,7 @@ Note that the default pip wheel built is not compatible with CUDA 13 at the mome
 | `DYN_KVBM_METRICS` | Enable metrics endpoint | `false` |
 | `DYN_KVBM_METRICS_PORT` | Metrics port | `6880` |
 | `DYN_KVBM_DISABLE_DISK_OFFLOAD_FILTER` | Disable disk offload filtering to remove SSD lifespan protection | `false` |
+| `DYN_KVBM_HOST_OFFLOAD_PREFIX_MIN_PRIORITY` | Minimum priority (0-100) for CPU offload with contiguous (prefix) semantics: offloading stops at the first block below threshold, and all subsequent blocks are also skipped. Used for EPC priority-based filtering. | `0` (no filtering) |
 
 #### Disk Storage Configuration
 

--- a/lib/bindings/kvbm/python/kvbm/trtllm_integration/connector/kvbm_connector_leader.py
+++ b/lib/bindings/kvbm/python/kvbm/trtllm_integration/connector/kvbm_connector_leader.py
@@ -123,6 +123,7 @@ class DynamoKVBMConnectorLeader(KvCacheConnectorScheduler):
                 req.new_tokens,
                 req.new_block_ids,
                 req.computed_position,
+                req.priorities,  # Pass retention priorities for offload filtering
             )
 
         resumed_from_preemption = False
@@ -133,6 +134,7 @@ class DynamoKVBMConnectorLeader(KvCacheConnectorScheduler):
                 req.new_tokens,
                 req.new_block_ids,
                 req.computed_position,
+                req.priorities,  # Pass retention priorities for offload filtering
             )
 
         return self._connector.build_connector_metadata(output)

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/trtllm_leader.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/trtllm_leader.rs
@@ -356,6 +356,7 @@ impl Leader for KvConnectorLeader {
                 &new_req.block_ids,
                 new_req.num_computed_tokens,
                 true,
+                new_req.priorities.as_deref(),
             )?;
 
             if let Some(pending_ops) = slot.take_pending_operations() {
@@ -387,6 +388,7 @@ impl Leader for KvConnectorLeader {
                 &cached_req.new_block_ids,
                 cached_req.num_computed_tokens,
                 false,
+                cached_req.priorities.as_deref(),
             )?;
 
             if let Some(pending_ops) = slot.take_pending_operations() {

--- a/lib/llm/src/block_manager.rs
+++ b/lib/llm/src/block_manager.rs
@@ -35,7 +35,10 @@ pub use block::{
 pub use config::*;
 
 pub use layout::{LayoutConfig, LayoutConfigBuilder, LayoutError, LayoutType, nixl::NixlLayout};
-pub use offload::{filter::OffloadFilter, request::BlockResult};
+pub use offload::{
+    filter::{FrequencyFilter, OffloadFilter, PriorityFilter},
+    request::BlockResult,
+};
 pub use pool::{BlockPool, ManagedBlockPool};
 pub use storage::{
     DeviceStorage, DiskStorage, PinnedStorage, Storage, StorageAllocator,

--- a/lib/llm/src/block_manager/offload.rs
+++ b/lib/llm/src/block_manager/offload.rs
@@ -382,7 +382,10 @@ impl<Locality: LocalityProvider + 'static, Metadata: BlockMetadata>
                     }
 
                     if let Some(offload_filter) = offload_filter.as_ref()
-                        && !offload_filter.should_offload(request.sequence_hash)
+                        && !offload_filter.should_offload_with_priority(
+                            request.sequence_hash,
+                            request.key.priority,
+                        )
                     {
                         continue;
                     }


### PR DESCRIPTION
Add PriorityFilter that filters blocks based on retention priority. Only blocks with priority >= threshold are offloaded to host/disk.

Changes:
- Add PriorityFilter struct with should_offload_with_priority method
- Extend OffloadFilter trait with priority-aware filtering
- Update connector structs to receive priorities from TRT-LLM
- Implement contiguous filtering in VllmConnectorSlot

Configuration: Set DYN_KVBM_HOST_OFFLOAD_PREFIX_MIN_PRIORITY env var to enable filtering (0 = no filtering, default).

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
