### PR TITLE
fix: support trtllm decode-only

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -299,7 +299,9 @@ class HandlerBase:
             self.disaggregation_mode == DisaggregationMode.DECODE
             and disaggregated_params is None
         ):
-            disaggregated_params = LlmDisaggregatedParams(request_type="context_and_generation")
+            disaggregated_params = LlmDisaggregatedParams(
+                request_type="context_and_generation"
+            )
 
         num_output_tokens_so_far = 0
 

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -299,7 +299,7 @@ class HandlerBase:
             self.disaggregation_mode == DisaggregationMode.DECODE
             and disaggregated_params is None
         ):
-            raise ValueError("Disaggregated params are required for decode mode")
+            disaggregated_params = LlmDisaggregatedParams(request_type="context_and_generation")
 
         num_output_tokens_so_far = 0
 


### PR DESCRIPTION
#### Overview:
Previously, when falling back to decode-only logic in the prefill_router during the trtllm backend flow, the request would be intercepted by the following condition in handler_base and directly return an error, causing the request to fail:
`if (
            self.disaggregation_mode == DisaggregationMode.DECODE
            and disaggregated_params is None
        ):
            raise ValueError("Disaggregated params are required for decode mode")`

Now, instead of returning an error, we manually create a disaggregated_params with request_type set to context_and_generation, allowing the decode node to handle the request independently.
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
Create a disaggregated_params with request_type set to context_and_generation
<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?
/components/src/dynamo/trtllm/request_handlers/handler_base.py
<!-- call out specific files that should be looked at closely -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of decode mode operations by automatically generating default configuration parameters when explicit parameters are not provided, eliminating potential operation failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->