### PR TITLE
feat: remove ser/deser in gather_multi_model_data

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -294,31 +294,24 @@ impl OpenAIPreprocessor {
         request: &R,
         builder: &mut PreprocessedRequestBuilder,
     ) -> Result<()> {
-        let messages = request.messages();
-        let message_count = messages.len().unwrap_or(0);
         let mut media_map: MultimodalDataMap = HashMap::new();
         #[cfg(feature = "media-nixl")]
         let mut fetch_tasks: Vec<(String, ChatCompletionRequestUserMessageContentPart)> =
             Vec::new();
 
-        for idx in 0..message_count {
-            let msg = messages
-                .get_item_by_index(idx)
-                .map_err(|_| anyhow::Error::msg(format!("Cannot get message at index {idx}")))?;
-
-            let msg_json: serde_json::Value = serde_json::to_value(&msg)?;
-            let message: ChatCompletionRequestMessage = serde_json::from_value(msg_json)?;
-
-            let content_parts = match &message {
+        let Some(messages) = request.typed_messages() else {
+            return Ok(());
+        };
+        for message in messages.iter() {
+            let content_parts = match message {
                 ChatCompletionRequestMessage::User(u) => match &u.content {
                     ChatCompletionRequestUserMessageContent::Array(parts) => parts,
                     _ => continue,
                 },
                 _ => continue,
             };
-
             // Iterate over content parts
-            for content_part in content_parts {
+            for content_part in content_parts.iter() {
                 let (type_str, url) = match content_part {
                     ChatCompletionRequestUserMessageContentPart::ImageUrl(image_part) => {
                         ("image_url".to_string(), image_part.image_url.url.clone())
@@ -371,7 +364,7 @@ impl OpenAIPreprocessor {
 
             // Preserve original messages in extra_args for multimodal workers that need them
             // (e.g., TRT-LLM multimodal processor needs raw messages for proper tokenization)
-            let messages_json = serde_json::to_value(&messages)?;
+            let messages_json = serde_json::to_value(request.messages())?;
             let extra_args = serde_json::json!({
                 "messages": messages_json
             });

--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -52,6 +52,11 @@ pub enum PromptInput {
 pub trait OAIChatLikeRequest {
     fn model(&self) -> String;
     fn messages(&self) -> Value;
+    fn typed_messages(
+        &self,
+    ) -> Option<&[dynamo_async_openai::types::ChatCompletionRequestMessage]> {
+        None
+    }
     fn tools(&self) -> Option<Value> {
         None
     }

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -213,6 +213,12 @@ impl OAIChatLikeRequest for NvCreateChatCompletionRequest {
         Value::from_serialize(&messages_json)
     }
 
+    fn typed_messages(
+        &self,
+    ) -> Option<&[dynamo_async_openai::types::ChatCompletionRequestMessage]> {
+        Some(self.inner.messages.as_slice())
+    }
+
     fn tools(&self) -> Option<Value> {
         if self.inner.tools.is_none() {
             None


### PR DESCRIPTION
#### Overview:

Removes serde (de)serialization when handling mm data in the processor. Introduces an interface `typed_messages` to directly access the structured OAI messages. With large payloads (b64), this can be slow.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Handles part of this issue: https://github.com/ai-dynamo/dynamo/issues/5086#issuecomment-3743617961

> This preparation involves a complex serialization logic, which our measurements show introduces an overhead of approximately 100ms per request.

On the sample shared in the issue:
Before MR: 239ms
After MR: 1.4ms


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal message processing with improved type safety and iteration patterns for better reliability in LLM message handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->