### PR TITLE
ci: exclude dev container from CI triggers

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -57,6 +57,7 @@ ignore:
   - 'container/Dockerfile.local_dev'
   - 'container/run.sh'
   - 'container/use-sccache.sh'
+  - 'container/dev/**'
 
 ci: &ci
   - '.github/workflows/**'
@@ -69,7 +70,6 @@ core:
   - 'container/build.sh'
   - 'container/Dockerfile'
   - '.dockerignore'
-  - 'container/dev/**'
   - 'container/deps/*'
   - '.cargo/config.toml'
   - 'lib/**'


### PR DESCRIPTION
## Summary
Exclude dev container changes from triggering full CI builds.

## Changes
Move `container/dev/**` from `core` to `ignore` section in `.github/filters.yaml`.

## Motivation
Dev container changes are development-only and don't need to trigger the full CI pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated filter patterns to exclude container development files from core processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->