### PR TITLE
ci: use pull_request_target for labeler workflow

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -16,7 +16,7 @@
 name: Label PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
#### Overview:

Change trigger from pull_request to pull_request_target to fix
'Resource not accessible by integration' error when PRs come from forks.

This is safe because:
- Checkout targets the base branch (default behavior)
- Labeler only reads file paths via GitHub API
- No PR code is executed"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for internal processes.

**Note:** This release contains no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->