### PR TITLE
fix: resolve sgl be E/P/D multimodal routing issues

### DIFF
--- a/components/src/dynamo/sglang/multimodal_utils/multimodal_encode_utils.py
+++ b/components/src/dynamo/sglang/multimodal_utils/multimodal_encode_utils.py
@@ -82,7 +82,18 @@ def is_model_supported(model_name: str, supported_model: str) -> bool:
     normalized_name = normalize_model_name(model_name).lower()
     normalized_supported = normalize_model_name(supported_model).lower()
 
-    return normalized_name == normalized_supported
+    # Exact match
+    if normalized_name == normalized_supported:
+        return True
+
+    # Handle local path case: compare only the model name part (without organization)
+    # e.g., "qwen2.5-vl-7b-instruct" matches "qwen/qwen2.5-vl-7b-instruct"
+    if "/" in normalized_supported:
+        model_part = normalized_supported.split("/")[-1]
+        if normalized_name == model_part:
+            return True
+
+    return False
 
 
 def get_qwen_image_features(

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -237,7 +237,7 @@ class MultimodalWorkerHandler(BaseWorkerHandler):
         config: Config,
         prefill_client: Client = None,
     ):
-        super().__init__(component, engine, config, None, prefill_client)
+        super().__init__(component, engine, config, None)
 
         # Initialize processors
         self.embeddings_processor = EmbeddingsProcessor()


### PR DESCRIPTION
#### Overview:

a drafted fix to address following failed test case:
Encountered `TypeError: BaseWorkerHandler.__init__() takes from 4 to 5 positional arguments but 6 were given ` while running `dynamo/examples/backends/sglang/launch/multimodal_epd.sh` script. 

#### Details:

Encode/prefill/decode worker is an internal component, should not register with Frontend, only needs to provide internal service endpoint for Processor to call

modify worker_handler to fix argument number mismatch 

support model name = local dir

#### Where should the reviewer start?

components/src/dynamo/sglang/main.py
components/src/dynamo/sglang/multimodal_utils/multimodal_encode_utils.py
components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py

<img width="2304" height="1296" alt="correct_curl_epd_result" src="https://github.com/user-attachments/assets/1bf87057-013f-4b43-9cb6-1984a608b5fc" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced model name matching to better support local file path configurations.

* **Refactor**
  * Updated internal worker initialization and endpoint registration architecture.
  * Modified how workers establish and manage service endpoints internally.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->