### PR TITLE
feat: Support the reading of routing hints from the headers 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ profiling_results*
 # Node.js
 node_modules/
 package-lock.json
+
+# Compiled static libraries
+*.a

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -41,6 +41,7 @@ use super::{
 };
 use crate::engines::ValidateRequest;
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
+use crate::protocols::openai::nvext::resolve_and_apply_routing_hints;
 use crate::protocols::openai::{
     chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
@@ -287,10 +288,12 @@ fn get_or_create_request_id(primary: Option<&str>, headers: &HeaderMap) -> Strin
 async fn handler_completions(
     State(state): State<Arc<service_v2::State>>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateCompletionRequest>,
+    Json(mut request): Json<NvCreateCompletionRequest>,
 ) -> Result<Response, ErrorResponse> {
     // return a 503 if the service is not ready
     check_ready(&state)?;
+
+    request.nvext = resolve_and_apply_routing_hints(request.nvext.take(), &headers);
 
     // create the context for the request
     let request_id = get_or_create_request_id(request.inner.user.as_deref(), &headers);
@@ -707,10 +710,12 @@ async fn embeddings(
 async fn handler_chat_completions(
     State((state, template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateChatCompletionRequest>,
+    Json(mut request): Json<NvCreateChatCompletionRequest>,
 ) -> Result<Response, ErrorResponse> {
     // return a 503 if the service is not ready
     check_ready(&state)?;
+
+    request.nvext = resolve_and_apply_routing_hints(request.nvext.take(), &headers);
 
     // create the context for the request
     let request_id = get_or_create_request_id(request.inner.user.as_deref(), &headers);
@@ -1137,10 +1142,12 @@ pub fn validate_completion_fields_generic(
 async fn handler_responses(
     State((state, template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
     headers: HeaderMap,
-    Json(request): Json<NvCreateResponse>,
+    Json(mut request): Json<NvCreateResponse>,
 ) -> Result<Response, ErrorResponse> {
     // return a 503 if the service is not ready
     check_ready(&state)?;
+
+    request.nvext = resolve_and_apply_routing_hints(request.nvext.take(), &headers);
 
     // create the context for the request
     let request_id = get_or_create_request_id(request.inner.user.as_deref(), &headers);

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -41,7 +41,7 @@ use super::{
 };
 use crate::engines::ValidateRequest;
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
-use crate::protocols::openai::nvext::resolve_and_apply_routing_hints;
+use crate::protocols::openai::nvext::apply_header_routing_overrides;
 use crate::protocols::openai::{
     chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
@@ -293,7 +293,7 @@ async fn handler_completions(
     // return a 503 if the service is not ready
     check_ready(&state)?;
 
-    request.nvext = resolve_and_apply_routing_hints(request.nvext.take(), &headers);
+    request.nvext = apply_header_routing_overrides(request.nvext.take(), &headers);
 
     // create the context for the request
     let request_id = get_or_create_request_id(request.inner.user.as_deref(), &headers);
@@ -715,7 +715,7 @@ async fn handler_chat_completions(
     // return a 503 if the service is not ready
     check_ready(&state)?;
 
-    request.nvext = resolve_and_apply_routing_hints(request.nvext.take(), &headers);
+    request.nvext = apply_header_routing_overrides(request.nvext.take(), &headers);
 
     // create the context for the request
     let request_id = get_or_create_request_id(request.inner.user.as_deref(), &headers);
@@ -1147,7 +1147,7 @@ async fn handler_responses(
     // return a 503 if the service is not ready
     check_ready(&state)?;
 
-    request.nvext = resolve_and_apply_routing_hints(request.nvext.take(), &headers);
+    request.nvext = apply_header_routing_overrides(request.nvext.take(), &headers);
 
     // create the context for the request
     let request_id = get_or_create_request_id(request.inner.user.as_deref(), &headers);

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -1,12 +1,107 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use axum::http::HeaderMap;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::{Validate, ValidationError};
 
 pub use crate::protocols::common::timing::TimingInfo;
+
+pub const HEADER_WORKER_INSTANCE_ID: &str = "x-worker-instance-id";
+pub const HEADER_PREFILL_INSTANCE_ID: &str = "x-prefill-instance-id";
+
+/// Resolved routing hints from headers and nvext.
+/// Values are read from the header first, falling back to nvext.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedRoutingHints {
+    pub backend_instance_id: Option<u64>,
+    pub prefill_worker_id: Option<u64>,
+    pub decode_worker_id: Option<u64>,
+}
+
+impl ResolvedRoutingHints {
+    /// Resolve routing hints from HTTP headers and nvext.
+    ///
+    /// Resolution order for each field:
+    /// 1. Check the corresponding HTTP header
+    /// 2. Fall back to the nvext field
+    ///
+    /// Header mappings:
+    /// - `x-worker-instance-id` -> `backend_instance_id` and `decode_worker_id`
+    /// - `x-prefill-instance-id` -> `prefill_worker_id`
+    pub fn resolve(headers: &HeaderMap, nvext: Option<&NvExt>) -> Self {
+        let backend_instance_id =
+            resolve_worker_id(headers, nvext, HEADER_WORKER_INSTANCE_ID, |ext| {
+                ext.backend_instance_id
+            });
+
+        let decode_worker_id =
+            resolve_worker_id(headers, nvext, HEADER_WORKER_INSTANCE_ID, |ext| {
+                ext.decode_worker_id
+            });
+
+        let prefill_worker_id =
+            resolve_worker_id(headers, nvext, HEADER_PREFILL_INSTANCE_ID, |ext| {
+                ext.prefill_worker_id
+            });
+
+        Self {
+            backend_instance_id,
+            prefill_worker_id,
+            decode_worker_id,
+        }
+    }
+}
+
+/// Resolve a single worker ID value from header first, then nvext.
+fn resolve_worker_id<F>(
+    headers: &HeaderMap,
+    nvext: Option<&NvExt>,
+    header_name: &str,
+    nvext_getter: F,
+) -> Option<u64>
+where
+    F: FnOnce(&NvExt) -> Option<u64>,
+{
+    // Try header first
+    if let Some(value) = headers
+        .get(header_name)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+    {
+        return Some(value);
+    }
+
+    // Fall back to nvext
+    nvext.and_then(nvext_getter)
+}
+
+/// Resolve routing hints from headers and nvext, then apply to a mutable nvext.
+///
+/// This is a convenience function that:
+/// 1. Resolves routing values (header priority, nvext fallback)
+/// 2. Applies the resolved values to the nvext
+/// 3. Returns the nvext (creating one if it was None and hints were found)
+pub fn resolve_and_apply_routing_hints(
+    nvext: Option<NvExt>,
+    headers: &HeaderMap,
+) -> Option<NvExt> {
+    let hints = ResolvedRoutingHints::resolve(headers, nvext.as_ref());
+
+    // Only create/modify nvext if we have any resolved hints
+    if hints.backend_instance_id.is_some()
+        || hints.decode_worker_id.is_some()
+        || hints.prefill_worker_id.is_some()
+    {
+        let mut ext = nvext.unwrap_or_default();
+        ext.apply_resolved_hints(&hints);
+        Some(ext)
+    } else {
+        nvext
+    }
+}
 
 pub trait NvExtProvider {
     fn nvext(&self) -> Option<&NvExt>;
@@ -134,6 +229,21 @@ impl NvExt {
     pub fn builder() -> NvExtBuilder {
         NvExtBuilder::default()
     }
+
+    /// Apply resolved routing hints to this NvExt.
+    /// This updates the routing fields with the resolved values.
+    /// Doing it here because the PreProcessor and the pipeline do not have access to the headers.
+    pub fn apply_resolved_hints(&mut self, hints: &ResolvedRoutingHints) {
+        if let Some(id) = hints.backend_instance_id {
+            self.backend_instance_id = Some(id);
+        }
+        if let Some(id) = hints.decode_worker_id {
+            self.decode_worker_id = Some(id);
+        }
+        if let Some(id) = hints.prefill_worker_id {
+            self.prefill_worker_id = Some(id);
+        }
+    }
 }
 
 fn validate_nv_ext(_nv_ext: &NvExt) -> Result<(), ValidationError> {
@@ -209,5 +319,31 @@ mod tests {
         assert_eq!(nv_ext.prefill_worker_id, Some(100));
         assert_eq!(nv_ext.decode_worker_id, Some(200));
         assert!(nv_ext.validate().is_ok());
+    }
+
+    // Test ResolvedRoutingHints - header takes priority, nvext used as fallback
+    #[test]
+    fn test_resolved_routing_hints_header_priority() {
+        use axum::http::HeaderMap;
+
+        // Only HEADER_WORKER_INSTANCE_ID is in the header
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_WORKER_INSTANCE_ID, "123".parse().unwrap());
+        // Note: HEADER_PREFILL_INSTANCE_ID is NOT in the header
+
+        let nvext = NvExt::builder()
+            .backend_instance_id(999)
+            .decode_worker_id(888)
+            .prefill_worker_id(777)
+            .build()
+            .unwrap();
+
+        let resolved = ResolvedRoutingHints::resolve(&headers, Some(&nvext));
+
+        // Header should override backend_instance_id and decode_worker_id
+        assert_eq!(resolved.backend_instance_id, Some(123));
+        assert_eq!(resolved.decode_worker_id, Some(123));
+        // prefill_worker_id should fall back to nvext since header is absent
+        assert_eq!(resolved.prefill_worker_id, Some(777));
     }
 }

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -249,9 +249,9 @@ mod tests {
         assert!(nv_ext.validate().is_ok());
     }
 
-    // Test apply_header_routing_overrides - header takes priority
+    // Test apply_header_routing_overrides - worker header present, prefill header absent
     #[test]
-    fn test_apply_header_routing_overrides_header_priority() {
+    fn test_apply_header_routing_overrides() {
         use axum::http::HeaderMap;
 
         // Only HEADER_WORKER_INSTANCE_ID is in the header
@@ -273,50 +273,5 @@ mod tests {
         assert_eq!(result.decode_worker_id, Some(123));
         // prefill_worker_id should remain from original nvext (not overwritten by header)
         assert_eq!(result.prefill_worker_id, Some(777));
-    }
-
-    // Test apply_header_routing_overrides - no headers returns original nvext
-    #[test]
-    fn test_apply_header_routing_overrides_no_headers() {
-        use axum::http::HeaderMap;
-
-        let headers = HeaderMap::new();
-
-        let nvext = NvExt::builder()
-            .backend_instance_id(999)
-            .prefill_worker_id(777)
-            .build()
-            .unwrap();
-
-        let result = apply_header_routing_overrides(Some(nvext.clone()), &headers).unwrap();
-
-        // Should return original values unchanged
-        assert_eq!(result.backend_instance_id, Some(999));
-        assert_eq!(result.prefill_worker_id, Some(777));
-    }
-
-    // Test apply_header_routing_overrides - creates nvext if None and headers present
-    #[test]
-    fn test_apply_header_routing_overrides_creates_nvext() {
-        use axum::http::HeaderMap;
-
-        let mut headers = HeaderMap::new();
-        headers.insert(HEADER_WORKER_INSTANCE_ID, "42".parse().unwrap());
-
-        let result = apply_header_routing_overrides(None, &headers).unwrap();
-
-        assert_eq!(result.backend_instance_id, Some(42));
-        assert_eq!(result.decode_worker_id, Some(42));
-    }
-
-    // Test apply_header_routing_overrides - returns None if no nvext and no headers
-    #[test]
-    fn test_apply_header_routing_overrides_none_passthrough() {
-        use axum::http::HeaderMap;
-
-        let headers = HeaderMap::new();
-        let result = apply_header_routing_overrides(None, &headers);
-
-        assert!(result.is_none());
     }
 }

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -84,10 +84,7 @@ where
 /// 1. Resolves routing values (header priority, nvext fallback)
 /// 2. Applies the resolved values to the nvext
 /// 3. Returns the nvext (creating one if it was None and hints were found)
-pub fn resolve_and_apply_routing_hints(
-    nvext: Option<NvExt>,
-    headers: &HeaderMap,
-) -> Option<NvExt> {
+pub fn resolve_and_apply_routing_hints(nvext: Option<NvExt>, headers: &HeaderMap) -> Option<NvExt> {
     let hints = ResolvedRoutingHints::resolve(headers, nvext.as_ref());
 
     // Only create/modify nvext if we have any resolved hints


### PR DESCRIPTION
#### Overview:
DEP-729

Slack: https://nvidia.slack.com/archives/C06850J381Y/p1768329568417749



#### Details:
Add support for reading backend_instance_id, decode_worker_id, and prefill_worker_id from HTTP headers with nvext as fallback:

x-worker-instance-id header -> backend_instance_id and decode_worker_id
x-prefill-instance-id header -> prefill_worker_id
Headers take priority over nvext values when present. This enables external orchestrators (EPP/GAIE) to specify worker routing via headers.

We read them and re-apply them to the nvext in the HTTP handler instead of doing it in the PreProcessor because the routing pipeline uses NvCreateChatCompletionRequest and does not have access to the headers.


<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to ignore compiled static library files.

* **Refactor**
  * Enhanced OpenAI request handling with improved routing hint resolution via HTTP headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->