### PR TITLE
feat(sglang): enforce stream_output=True for optimal streaming performance

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -495,10 +495,6 @@ async def parse_args(args: list[str]) -> Config:
     # tokens since last output), not cumulative tokens. When stream_output=True,
     # SGLang sends disjoint segments which Dynamo passes through directly.
     # Force stream_output=True for optimal streaming performance.
-    if not server_args.stream_output:
-        logging.info(
-            "Enabling stream_output=True for optimal streaming performance with Dynamo."
-        )
     server_args.stream_output = True
 
     if parsed_args.use_sglang_tokenizer:

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -491,6 +491,16 @@ async def parse_args(args: list[str]) -> Config:
     # contain code to download a model, it should only parse the args.
     server_args = ServerArgs.from_cli_args(parsed_args)
 
+    # Dynamo's streaming handlers expect disjoint output_ids from SGLang (only new
+    # tokens since last output), not cumulative tokens. When stream_output=True,
+    # SGLang sends disjoint segments which Dynamo passes through directly.
+    # Force stream_output=True for optimal streaming performance.
+    if not server_args.stream_output:
+        logging.info(
+            "Enabling stream_output=True for optimal streaming performance with Dynamo."
+        )
+    server_args.stream_output = True
+
     if parsed_args.use_sglang_tokenizer:
         logging.info(
             "Using SGLang's built in tokenizer. Setting skip_tokenizer_init to False"

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -166,6 +166,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process token-based stream output.
 
+        With stream_output=True (enforced by Dynamo), SGLang sends disjoint segments
+        containing only new tokens since the last output. We pass these through directly.
+
         Args:
             stream_source: Async generator from engine.async_generate.
             context: Context object for cancellation handling.
@@ -173,8 +176,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         Yields:
             Dict with token_ids and optional finish_reason.
         """
-        num_output_tokens_so_far = 0
-
         # Use Future pattern for request ID - will be set when first response arrives
         request_id_future = asyncio.Future()
         async with self._cancellation_monitor(request_id_future, context):
@@ -196,6 +197,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 if finish_reason:
                     out["finish_reason"] = finish_reason["type"]
 
+                # With stream_output=True, output_ids contains only new tokens (disjoint)
                 output_ids = res.get("output_ids", [])
                 # If request is not finished yet, but there are no outputs, return an error.
                 if not output_ids and not finish_reason:
@@ -203,9 +205,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         yield {"finish_reason": "error", "token_ids": []}
                     break
 
-                next_total_toks = len(output_ids)
-                out["token_ids"] = output_ids[num_output_tokens_so_far:]
-                num_output_tokens_so_far = next_total_toks
+                # Pass through disjoint token segments directly
+                out["token_ids"] = output_ids
                 if finish_reason:
                     input_tokens = res["meta_info"]["prompt_tokens"]
                     completion_tokens = res["meta_info"]["completion_tokens"]


### PR DESCRIPTION
## Summary
- Enforce `stream_output=True` in SGLang ServerArgs for Dynamo
- Update streaming handlers to pass through disjoint token segments directly (no more cumulative-to-delta conversion)
- Applies to both LLM decode handler and multimodal worker handler

## Description
With `stream_output=True`, SGLang sends only new tokens since the last output (disjoint segments) rather than all tokens generated so far (cumulative). This change:

1. Forces `stream_output=True` in `args.py` after parsing ServerArgs
2. Simplifies `_process_token_stream` in decode_handler - removes tracking/slicing logic
3. Simplifies `process_sglang_stream` in multimodal worker_handler - same fix

This aligns Dynamo with SGLang's efficient streaming mode, reducing redundant data transfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token streaming to deliver disjoint segments instead of cumulative tokens, ensuring more accurate and granular token delivery during streaming operations.
  * Enabled stream output mode in server configuration for consistent streaming behavior across LLM and multimodal handlers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->