### PR TITLE
fix: on a bad network day, uv timeout too easily when building dev/local-dev containers

### DIFF
--- a/container/dev/Dockerfile.dev
+++ b/container/dev/Dockerfile.dev
@@ -345,8 +345,8 @@ RUN git lfs install
 ARG FRAMEWORK
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
     --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.test.txt \
-    UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 uv pip install \
-        --no-cache \
+    --mount=type=cache,target=/root/.cache/uv \
+    UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 uv pip install \
         --index-strategy unsafe-best-match \
         --extra-index-url https://download.pytorch.org/whl/cu130 \
         --requirement /tmp/requirements.txt \

--- a/container/dev/Dockerfile.dev
+++ b/container/dev/Dockerfile.dev
@@ -345,7 +345,7 @@ RUN git lfs install
 ARG FRAMEWORK
 RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
     --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.test.txt \
-    UV_GIT_LFS=1 uv pip install \
+    UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 uv pip install \
         --no-cache \
         --index-strategy unsafe-best-match \
         --extra-index-url https://download.pytorch.org/whl/cu130 \


### PR DESCRIPTION
#### Overview:

Increase HTTP timeout for uv pip install to prevent timeouts on slow networks during dev container builds.

#### Details:

- Add UV_HTTP_TIMEOUT=300 environment variable to uv pip install in container/dev/Dockerfile.dev

#### Where should the reviewer start?

container/dev/Dockerfile.dev

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)



/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized development environment build process with improved HTTP timeout configuration during dependency installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->