### PR TITLE
fix(sglang): Fix YAML config parsing for store_true arguments

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -372,15 +372,24 @@ async def parse_args(args: list[str]) -> Config:
             # Remove --config-key from args (not recognized by SGLang)
             args = args[:key_index] + args[key_index + 2 :]
 
-        # Extract boolean actions from the parser to handle them correctly in YAML
-        boolean_actions = []
-        for action in parser._actions:
-            if hasattr(action, "dest") and hasattr(action, "action"):
-                if action.action in ["store_true", "store_false"]:
-                    boolean_actions.append(action.dest)
+        # Merge config file arguments with CLI arguments.
+        # SGLang >= 0.5.8 accepts parser= parameter for proper store_true detection.
+        # SGLang < 0.5.8 only accepts boolean_actions= parameter.
+        # Related upstream issue: https://github.com/sgl-project/sglang/issues/16256
+        # Upstream fix PR: https://github.com/sgl-project/sglang/pull/16638
+        import inspect
 
-        # Merge config file arguments with CLI arguments
-        config_merger = ConfigArgumentMerger(boolean_actions=boolean_actions)
+        sig = inspect.signature(ConfigArgumentMerger.__init__)
+        if "parser" in sig.parameters:
+            config_merger = ConfigArgumentMerger(parser=parser)
+        else:
+            # Legacy path: extract store_true actions manually
+            boolean_actions = [
+                action.dest
+                for action in parser._actions
+                if isinstance(action, argparse._StoreTrueAction)
+            ]
+            config_merger = ConfigArgumentMerger(boolean_actions=boolean_actions)
         args = config_merger.merge_config_with_args(args)
 
     parsed_args = parser.parse_args(args)

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -373,8 +373,11 @@ async def parse_args(args: list[str]) -> Config:
             args = args[:key_index] + args[key_index + 2 :]
 
         # Merge config file arguments with CLI arguments.
-        # SGLang >= 0.5.8 accepts parser= parameter for proper store_true detection.
-        # SGLang < 0.5.8 only accepts boolean_actions= parameter.
+        # ConfigArgumentMerger API changed after SGLang v0.5.7:
+        # - New API (post-v0.5.7): accepts parser= for proper store_true detection
+        # - Old API (v0.5.7 and earlier): only accepts boolean_actions=
+        # We use inspect.signature to detect the API rather than version checking
+        # since unreleased builds may have the new API while still reporting v0.5.7.
         # Related upstream issue: https://github.com/sgl-project/sglang/issues/16256
         # Upstream fix PR: https://github.com/sgl-project/sglang/pull/16638
         import inspect


### PR DESCRIPTION
## Summary
- Fix YAML config parsing that was broken for `store_true` arguments (e.g., `trust-remote-code`, `enable-metrics`)
- Add backwards compatibility for both old (< 0.5.8) and new SGLang versions

## Context
The original code attempted to detect `store_true` argparse actions using `hasattr(action, "action")`, but argparse action objects don't have an `action` attribute - they ARE the action class (e.g., `_StoreTrueAction`). This caused `boolean_actions` to always be empty, making YAML boolean values like `trust-remote-code: true` incorrectly converted to `--trust-remote-code true` (with a string argument) instead of just `--trust-remote-code` (the flag alone).

Closes https://github.com/ai-dynamo/dynamo/issues/5202

Related upstream:
- Issue: https://github.com/sgl-project/sglang/issues/16256
- Fix PR: https://github.com/sgl-project/sglang/pull/16638

## Testing
- [x] Test with SGLang v0.5.7: `cd ~/sglang && git checkout v0.5.7 && uv pip install -e "python"`
- [x] Test with SGLang main: `cd ~/sglang && git checkout main && uv pip install -e "python"`
- [x] Run reproduction command: `CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang --config test.yaml --config-key prefill`

## Checklist
- [x] Human has reviewed AI code
- [x] Relevant context for this fix has been tracked in this issue and/or in associated linear ticket for future debugging
- [x] Code follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of boolean options in configuration files for more reliable argument merging.

* **Refactor**
  * Updated configuration parsing to maintain compatibility across different argument parser versions while preserving backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->