### PR TITLE
chore: Remove binding OAIChatPreprocessor

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -159,7 +159,6 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<llm::kv::WorkerMetricsPublisher>()?;
     m.add_class::<llm::model_card::ModelDeploymentCard>()?;
     m.add_class::<llm::local_model::ModelRuntimeConfig>()?;
-    m.add_class::<llm::preprocessor::OAIChatPreprocessor>()?;
     m.add_class::<llm::preprocessor::MediaDecoder>()?;
     m.add_class::<llm::preprocessor::MediaFetcher>()?;
     m.add_class::<llm::kv::OverlapScores>()?;

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -534,19 +534,6 @@ class ModelRuntimeConfig:
         """Get an engine-specific runtime configuration value"""
         ...
 
-class OAIChatPreprocessor:
-    """
-    A preprocessor for OpenAI chat completions
-    """
-
-    ...
-
-    async def start(self) -> None:
-        """
-        Start the preprocessor
-        """
-        ...
-
 class OverlapScores:
     """
     A collection of prefix matching scores of workers for a given token ids.
@@ -1670,7 +1657,6 @@ __all__ = [
     "Context",
     "KserveGrpcService",
     "ModelDeploymentCard",
-    "OAIChatPreprocessor",
     "PythonAsyncEngine",
     "prometheus_names",
 ]

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -17,7 +17,6 @@ from dynamo._core import DistributedRuntime as DistributedRuntime
 from dynamo._core import Endpoint as Endpoint
 from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
 from dynamo._core import Namespace as Namespace
-from dynamo._core import OAIChatPreprocessor as OAIChatPreprocessor
 
 
 def dynamo_worker(enable_nats: bool = True):


### PR DESCRIPTION
It seems this used Python to serve a pre-processing endpoint.

- It was copied directly from nim-nvllm 11 months ago, and untouched aside from maintenance since.
- AFAICT it has never been used.
- If we did need it, it wouldn't need to be a binding because as it is served from an endpoint - it isn't a Python function call.
- The `tokenizers` library from pypi would be the correct choice for Python pre-processing right now. That wraps the Rust library Dynamo uses.
- It was not mentioned in documentation or used in examples.

Part of v1 prep.

## Summary

* **Breaking Changes**
  * Removed chat preprocessor component from the API.
