### PR TITLE
refactor: clean up SGLang sleep/wake implementation

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -164,9 +164,6 @@ async def init(runtime: DistributedRuntime, config: Config):
     runtime.register_engine_route(
         "resume_memory_occupation", handler.resume_memory_occupation
     )
-    logging.info(
-        "Registered engine routes: /engine/release_memory_occupation, /engine/resume_memory_occupation"
-    )
 
     print(f"Config: {config}")
     health_check_payload = SglangHealthCheckPayload(
@@ -278,9 +275,6 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
     )
     runtime.register_engine_route(
         "resume_memory_occupation", handler.resume_memory_occupation
-    )
-    logging.info(
-        "Registered engine routes: /engine/release_memory_occupation, /engine/resume_memory_occupation"
     )
 
     health_check_payload = SglangPrefillHealthCheckPayload(engine).to_dict()

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -139,26 +139,7 @@ async def init(runtime: DistributedRuntime, config: Config):
     handler = DecodeWorkerHandler(
         component, engine, config, publisher, generate_endpoint
     )
-
-    # Register engine routes
-    async def start_profile_handler(body: dict) -> dict:
-        """Handle /engine/start_profile requests"""
-        await engine.tokenizer_manager.start_profile(**body)
-        return {"status": "ok", "message": "Profiling started"}
-
-    async def stop_profile_handler(body: dict) -> dict:
-        """Handle /engine/stop_profile requests"""
-        await engine.tokenizer_manager.stop_profile()
-        return {"status": "ok", "message": "Profiling stopped"}
-
-    runtime.register_engine_route("start_profile", start_profile_handler)
-    runtime.register_engine_route("stop_profile", stop_profile_handler)
-    runtime.register_engine_route(
-        "release_memory_occupation", handler.release_memory_occupation
-    )
-    runtime.register_engine_route(
-        "resume_memory_occupation", handler.resume_memory_occupation
-    )
+    handler.register_engine_routes(runtime)
 
     print(f"Config: {config}")
     health_check_payload = SglangHealthCheckPayload(
@@ -246,26 +227,7 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
     handler = PrefillWorkerHandler(
         component, engine, config, publisher, generate_endpoint
     )
-
-    # Register engine routes
-    async def start_profile_handler(body: dict) -> dict:
-        """Handle /engine/start_profile requests"""
-        await engine.tokenizer_manager.start_profile(**body)
-        return {"status": "ok", "message": "Profiling started"}
-
-    async def stop_profile_handler(body: dict) -> dict:
-        """Handle /engine/stop_profile requests"""
-        await engine.tokenizer_manager.stop_profile()
-        return {"status": "ok", "message": "Profiling stopped"}
-
-    runtime.register_engine_route("start_profile", start_profile_handler)
-    runtime.register_engine_route("stop_profile", stop_profile_handler)
-    runtime.register_engine_route(
-        "release_memory_occupation", handler.release_memory_occupation
-    )
-    runtime.register_engine_route(
-        "resume_memory_occupation", handler.resume_memory_occupation
-    )
+    handler.register_engine_routes(runtime)
 
     health_check_payload = SglangPrefillHealthCheckPayload(engine).to_dict()
 

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -124,23 +124,6 @@ async def init(runtime: DistributedRuntime, config: Config):
         await _handle_non_leader_node(engine, generate_endpoint)
         return
 
-    # Register engine routes for profiling
-    async def start_profile_handler(body: dict) -> dict:
-        """Handle /engine/start_profile requests"""
-        await engine.tokenizer_manager.start_profile(**body)
-        return {"status": "ok", "message": "Profiling started"}
-
-    async def stop_profile_handler(body: dict) -> dict:
-        """Handle /engine/stop_profile requests"""
-        await engine.tokenizer_manager.stop_profile()
-        return {"status": "ok", "message": "Profiling stopped"}
-
-    runtime.register_engine_route("start_profile", start_profile_handler)
-    runtime.register_engine_route("stop_profile", stop_profile_handler)
-    logging.info(
-        "Registered engine routes: /engine/start_profile, /engine/stop_profile"
-    )
-
     # publisher instantiates the metrics and kv event publishers
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
         engine, config, component, generate_endpoint
@@ -157,7 +140,19 @@ async def init(runtime: DistributedRuntime, config: Config):
         component, engine, config, publisher, generate_endpoint
     )
 
-    # Register memory management routes using handler methods
+    # Register engine routes
+    async def start_profile_handler(body: dict) -> dict:
+        """Handle /engine/start_profile requests"""
+        await engine.tokenizer_manager.start_profile(**body)
+        return {"status": "ok", "message": "Profiling started"}
+
+    async def stop_profile_handler(body: dict) -> dict:
+        """Handle /engine/stop_profile requests"""
+        await engine.tokenizer_manager.stop_profile()
+        return {"status": "ok", "message": "Profiling stopped"}
+
+    runtime.register_engine_route("start_profile", start_profile_handler)
+    runtime.register_engine_route("stop_profile", stop_profile_handler)
     runtime.register_engine_route(
         "release_memory_occupation", handler.release_memory_occupation
     )
@@ -235,23 +230,6 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
         await _handle_non_leader_node(engine, generate_endpoint)
         return
 
-    # Register engine routes for profiling
-    async def start_profile_handler(body: dict) -> dict:
-        """Handle /engine/start_profile requests"""
-        await engine.tokenizer_manager.start_profile(**body)
-        return {"status": "ok", "message": "Profiling started"}
-
-    async def stop_profile_handler(body: dict) -> dict:
-        """Handle /engine/stop_profile requests"""
-        await engine.tokenizer_manager.stop_profile()
-        return {"status": "ok", "message": "Profiling stopped"}
-
-    runtime.register_engine_route("start_profile", start_profile_handler)
-    runtime.register_engine_route("stop_profile", stop_profile_handler)
-    logging.info(
-        "Registered engine routes: /engine/start_profile, /engine/stop_profile"
-    )
-
     # Perform dummy warmup for prefill worker to avoid initial TTFT hit
     # Only needed on leader node that handles requests
     await _warmup_prefill_engine(engine, server_args)
@@ -269,7 +247,19 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
         component, engine, config, publisher, generate_endpoint
     )
 
-    # Register memory management routes using handler methods
+    # Register engine routes
+    async def start_profile_handler(body: dict) -> dict:
+        """Handle /engine/start_profile requests"""
+        await engine.tokenizer_manager.start_profile(**body)
+        return {"status": "ok", "message": "Profiling started"}
+
+    async def stop_profile_handler(body: dict) -> dict:
+        """Handle /engine/stop_profile requests"""
+        await engine.tokenizer_manager.stop_profile()
+        return {"status": "ok", "message": "Profiling stopped"}
+
+    runtime.register_engine_route("start_profile", start_profile_handler)
+    runtime.register_engine_route("stop_profile", stop_profile_handler)
     runtime.register_engine_route(
         "release_memory_occupation", handler.release_memory_occupation
     )

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -17,8 +17,6 @@ from dynamo.common.utils.input_params import InputParamManager
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 
-logger = logging.getLogger(__name__)
-
 
 class BaseWorkerHandler(ABC):
     """Abstract base class for SGLang worker handlers."""
@@ -81,8 +79,8 @@ class BaseWorkerHandler(ABC):
             try:
                 await self.generate_endpoint.unregister_endpoint_instance()
             except Exception as unreg_err:
-                logger.warning(
-                    f"[ReleaseMemory] Failed to unregister endpoint from discovery: {unreg_err}"
+                logging.warning(
+                    f"Failed to unregister endpoint from discovery: {unreg_err}"
                 )
 
             # Step 2: Pause generation to drain in-flight requests
@@ -96,7 +94,7 @@ class BaseWorkerHandler(ABC):
                 "message": f"Memory released for tags: {tags}",
             }
         except Exception as e:
-            logger.error(f"Failed to release memory occupation: {e}")
+            logging.error(f"Failed to release memory occupation: {e}")
             return {"status": "error", "message": str(e)}
 
     async def resume_memory_occupation(self, body: dict) -> dict:
@@ -126,8 +124,8 @@ class BaseWorkerHandler(ABC):
             try:
                 await self.generate_endpoint.register_endpoint_instance()
             except Exception as reg_err:
-                logger.warning(
-                    f"[ResumeMemory] Failed to re-register endpoint to discovery: {reg_err}"
+                logging.warning(
+                    f"Failed to re-register endpoint to discovery: {reg_err}"
                 )
 
             return {
@@ -135,7 +133,7 @@ class BaseWorkerHandler(ABC):
                 "message": f"Memory resumed for tags: {tags}",
             }
         except Exception as e:
-            logger.error(f"Failed to resume memory occupation: {e}")
+            logging.error(f"Failed to resume memory occupation: {e}")
             return {"status": "error", "message": str(e)}
 
     @abstractmethod

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -136,6 +136,39 @@ class BaseWorkerHandler(ABC):
             logging.error(f"Failed to resume memory occupation: {e}")
             return {"status": "error", "message": str(e)}
 
+    async def start_profile(self, body: dict) -> dict:
+        """Start profiling on the engine.
+
+        Args:
+            body: Dict with profiling parameters passed to start_profile.
+        """
+        await self.engine.tokenizer_manager.start_profile(**body)
+        return {"status": "ok", "message": "Profiling started"}
+
+    async def stop_profile(self, body: dict) -> dict:
+        """Stop profiling on the engine.
+
+        Args:
+            body: Unused, but required for handler signature.
+        """
+        await self.engine.tokenizer_manager.stop_profile()
+        return {"status": "ok", "message": "Profiling stopped"}
+
+    def register_engine_routes(self, runtime) -> None:
+        """Register all engine routes for this handler.
+
+        Args:
+            runtime: The DistributedRuntime instance to register routes on.
+        """
+        runtime.register_engine_route("start_profile", self.start_profile)
+        runtime.register_engine_route("stop_profile", self.stop_profile)
+        runtime.register_engine_route(
+            "release_memory_occupation", self.release_memory_occupation
+        )
+        runtime.register_engine_route(
+            "resume_memory_occupation", self.resume_memory_occupation
+        )
+
     @abstractmethod
     async def generate(self, request: Dict[str, Any], context: Context):
         """Generate response from request.


### PR DESCRIPTION
Clean up logging and move entrypoint registration into BaseWorkerHandler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profiling controls (start/stop) are now accessible as engine routes for remote invocation and performance monitoring.

* **Refactor**
  * Consolidated engine route registration into centralized handler methods, reducing scattered registration logic.
  * Standardized logging implementation across worker handlers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->