### PR TITLE
chore: reduce verbosity during dynamo start

### DIFF
--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -86,8 +86,6 @@ impl EndpointConfigBuilder {
 
         let system_health = endpoint.drt().system_health();
 
-        let request_plane_mode = endpoint.drt().request_plane();
-
         // Register with graceful shutdown tracker if needed
         if graceful_shutdown {
             tracing::debug!(

--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -87,7 +87,6 @@ impl EndpointConfigBuilder {
         let system_health = endpoint.drt().system_health();
 
         let request_plane_mode = endpoint.drt().request_plane();
-        tracing::debug!("Endpoint starting with request plane mode: {request_plane_mode}",);
 
         // Register with graceful shutdown tracker if needed
         if graceful_shutdown {

--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -87,7 +87,7 @@ impl EndpointConfigBuilder {
         let system_health = endpoint.drt().system_health();
 
         let request_plane_mode = endpoint.drt().request_plane();
-        tracing::info!("Endpoint starting with request plane mode: {request_plane_mode}",);
+        tracing::debug!("Endpoint starting with request plane mode: {request_plane_mode}",);
 
         // Register with graceful shutdown tracker if needed
         if graceful_shutdown {
@@ -140,7 +140,7 @@ impl EndpointConfigBuilder {
             }
         }
 
-        tracing::info!(
+        tracing::debug!(
             endpoint = %endpoint_name_for_task,
             transport = server.transport_name(),
             "Registering endpoint with request plane server"


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

1. remove repeated redundant logs
```
026-01-20T22:15:44.079136Z  INFO _core: Registered base model 'Qwen/Qwen3-0.6B' MDC
2026-01-20T22:15:44.080945Z  INFO dynamo_runtime::component::endpoint: Endpoint starting with request plane mode: tcp
2026-01-20T22:15:44.080953Z  INFO dynamo_runtime::component::endpoint: Endpoint starting with request plane mode: tcp
2026-01-20T22:15:44.080945Z  INFO dynamo_runtime::component::endpoint: Endpoint starting with request plane mode: tcp
2026-01-20T22:15:44.080955Z  INFO dynamo_runtime::component::endpoint: Endpoint starting with request plane mode: tcp
```

2. marked as debug log `Registering endpoint with request plane server`

```
2026-01-20T22:15:43.606994Z  INFO dynamo_runtime::component::endpoint: Registering endpoint with request plane server endpoint=load_lora transport="tcp"
2026-01-20T22:15:43.607010Z  INFO dynamo_runtime::component::endpoint: Registering endpoint with request plane server endpoint=clear_kv_blocks transport="tcp"
2026-01-20T22:15:43.607034Z  INFO dynamo_runtime::pipeline::network::ingress::shared_tcp_endpoint: Registered endpoint 'load_lora' with shared TCP server on 10.110.41.106:44821
2026-01-20T22:15:43.607017Z  INFO dynamo_runtime::component::endpoint: Registering endpoint with request plane server endpoint=list_loras transport="tcp"
2026-01-20T22:15:43.607067Z  INFO dynamo_runtime::pipeline::network::ingress::shared_tcp_endpoint: Registered endpoint 'list_loras' with shared TCP server on 10.110.41.106:44821
2026-01-20T22:15:43.607081Z  INFO dynamo_runtime::pipeline::network::ingress::shared_tcp_endpoint: Registered endpoint 'clear_kv_blocks' with shared TCP server on 10.110.41.106:44821
2026-01-20T22:15:43.607136Z  INFO dynamo_runtime::component::endpoint: Registering endpoint with request plane server endpoint=unload_lora transport="tcp"
2026-01-20T22:15:43.607204Z  INFO dynamo_runtime::pipeline::network::ingress::shared_tcp_endpoint: Registered endpoint 'unload_lora' with shared TCP server on 10.110.41.106:44821
2026-01-20T22:15:43.607203Z  INFO dynamo_runtime::component::endpoint: Registering endpoint with request plane server endpoint=generate transport="tcp"
2026-01-20T22:15:43.607255Z  INFO dynamo_runtime::pipeline::network::ingress::shared_tcp_endpoint: Registered endpoint 'generate' with shared TCP server on 10.110.41.106:44821

```

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging levels for endpoint registration and startup operations to reduce verbosity and focus on critical information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->