### PR TITLE
chore: Update cache_transceiver_config to UCX backend + set `max_tokens_in_buffer`

### DIFF
--- a/examples/backends/trtllm/engine_configs/deepseek-r1-distill-llama-8b/decode.yaml
+++ b/examples/backends/trtllm/engine_configs/deepseek-r1-distill-llama-8b/decode.yaml
@@ -28,4 +28,6 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.85
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/deepseek-r1-distill-llama-8b/prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/deepseek-r1-distill-llama-8b/prefill.yaml
@@ -27,4 +27,6 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.85
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/mtp/mtp_decode.yaml
+++ b/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/mtp/mtp_decode.yaml
@@ -54,4 +54,6 @@ cuda_graph_config:
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/mtp/mtp_prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/mtp/mtp_prefill.yaml
@@ -38,4 +38,6 @@ speculative_config:
   num_nextn_predict_layers: 1
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/simple/decode.yaml
+++ b/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/simple/decode.yaml
@@ -57,4 +57,6 @@ cuda_graph_config:
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/simple/prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/simple/prefill.yaml
@@ -36,4 +36,6 @@ disable_overlap_scheduler: true
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/wide_ep/wide_ep_decode.yaml
+++ b/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/wide_ep/wide_ep_decode.yaml
@@ -63,4 +63,6 @@ cuda_graph_config:
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/wide_ep/wide_ep_prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/deepseek-r1/disagg/wide_ep/wide_ep_prefill.yaml
@@ -41,4 +41,6 @@ disable_overlap_scheduler: true
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/gemma3/vswa_decode.yaml
+++ b/examples/backends/trtllm/engine_configs/gemma3/vswa_decode.yaml
@@ -26,4 +26,6 @@ kv_cache_config:
     - 32768
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/gemma3/vswa_prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/gemma3/vswa_prefill.yaml
@@ -27,4 +27,6 @@ kv_cache_config:
     - 32768
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/llama4/eagle/eagle_decode.yaml
+++ b/examples/backends/trtllm/engine_configs/llama4/eagle/eagle_decode.yaml
@@ -49,4 +49,6 @@ cuda_graph_config:
 print_iter_log: true
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/llama4/eagle/eagle_prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/llama4/eagle/eagle_prefill.yaml
@@ -34,4 +34,6 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/llama4/multimodal/agg.yaml
+++ b/examples/backends/trtllm/engine_configs/llama4/multimodal/agg.yaml
@@ -26,7 +26,7 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
 # NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
 # NOTE: overlap_scheduler enabled by default since this commit and changed
 # config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':

--- a/examples/backends/trtllm/engine_configs/llama4/multimodal/decode.yaml
+++ b/examples/backends/trtllm/engine_configs/llama4/multimodal/decode.yaml
@@ -26,4 +26,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX

--- a/examples/backends/trtllm/engine_configs/llama4/multimodal/llama4-Scout/decode.yaml
+++ b/examples/backends/trtllm/engine_configs/llama4/multimodal/llama4-Scout/decode.yaml
@@ -26,4 +26,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX

--- a/examples/backends/trtllm/engine_configs/llama4/multimodal/llama4-Scout/encode.yaml
+++ b/examples/backends/trtllm/engine_configs/llama4/multimodal/llama4-Scout/encode.yaml
@@ -26,4 +26,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX

--- a/examples/backends/trtllm/engine_configs/llama4/multimodal/llama4-Scout/prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/llama4/multimodal/llama4-Scout/prefill.yaml
@@ -28,4 +28,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX

--- a/examples/backends/trtllm/engine_configs/llama4/multimodal/prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/llama4/multimodal/prefill.yaml
@@ -28,4 +28,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX

--- a/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/agg.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/agg.yaml
@@ -26,7 +26,7 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
 # NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
 # NOTE: overlap_scheduler enabled by default since this commit and changed
 # config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':

--- a/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/decode.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/decode.yaml
@@ -26,4 +26,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX

--- a/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/encode.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/encode.yaml
@@ -27,4 +27,4 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.85
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX

--- a/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/prefill.yaml
@@ -28,4 +28,4 @@ kv_cache_config:
   enable_block_reuse: false
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX

--- a/examples/backends/trtllm/engine_configs/qwen3/decode.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3/decode.yaml
@@ -28,4 +28,6 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.85
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384

--- a/examples/backends/trtllm/engine_configs/qwen3/prefill.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen3/prefill.yaml
@@ -27,4 +27,6 @@ kv_cache_config:
   free_gpu_memory_fraction: 0.85
 
 cache_transceiver_config:
-  backend: DEFAULT
+  backend: UCX
+  # Must exceed max ISL to avoid transfer failures and perf degradation
+  max_tokens_in_buffer: 16384


### PR DESCRIPTION
#### Overview:

Update TRT-LLM engine configs to use UCX backend and set max_tokens_in_buffer for disaggregated inference. This prevents KV cache transfer failures being experienced with the default backend (NIXL) and performance degradation when processing requests with large input sequence lengths (ISL).

When running disaggregated TRT-LLM inference with large input sequences, the CacheTransceiver includes warnings like:
```
  [TensorRT-LLM][WARNING] CacheTransceiver getOrAllocateBuffers: bufferCoverTargetNum:0 < targetNum:1,
  may use dynamic buffer which will fail with NIXL backend. It is recommended to set
  cacheTransceiverConfig.MaxTokensInBuffer to a value greater than the maximum ISL of processed requests.
```

#### Details:
- Update `cache_transceiver_config.backend` from `DEFAULT` to `UCX` across all TRT-LLM engine configs
- Add `max_tokens_in_buffer: 16384` to disaggregated configs to prevent transfer failures
- Switch to UCX backend for reliable KV cache transfers
- Set `max_tokens_in_buffer: 16384` for text-only models (exceeds typical max ISL)
- Multimodal models only get the UCX backend change (no max_tokens_in_buffer) due to variable token counts from image inputs
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- #4327 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cache transceiver backend configuration from DEFAULT to UCX across multiple model engine configs (DeepSeek-R1, Gemma3, LLaMA4, Qwen variants)
  * Added buffer size parameters to optimize data transfer handling in prefill and decode stages for enhanced stability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->