### PR TITLE
feat: warmup dataset for planner load predictor

### DIFF
--- a/benchmarks/burstgpt_loadgen/README.md
+++ b/benchmarks/burstgpt_loadgen/README.md
@@ -56,13 +56,15 @@ If `--output-file` is not specified, the output will use the input filename with
 **Filtering:**
 - `--model`: Filter by model (`ChatGPT` or `GPT-4`), None for no filtering
 - `--log-type`: Filter by log type (`Conversation log` or `API log`), None for no filtering
-- `--num-prompt`: Limit number of rows in the final output, None for no filtering
+- `--skip-num-prompt`: Skip the first N rows after filtering (default: 0). Applied **before** `--num-prompt`.
+- `--num-prompt`: Limit number of rows in the final output, None for no filtering (applied **after** `--skip-num-prompt`)
 
 **Timestamp Adjustment:**
 - `--speed-ratio`: Adjust request timing (default: 1.0)
   - Values > 1: Speed up (e.g., 2.0 = 2x faster)
   - Values < 1: Slow down (e.g., 0.5 = 2x slower)
   - Formula: `new_timestamp = old_timestamp / speed_ratio`
+  - After filtering/skip/cap and speed-ratio adjustment, timestamps are shifted so the first kept request starts at `t=0`.
 
 **Hash Generation:**
 - `--block-size`: Block size in mooncake traces (default: 128)

--- a/components/src/dynamo/planner/utils/dryrun_plot_utils.py
+++ b/components/src/dynamo/planner/utils/dryrun_plot_utils.py
@@ -31,6 +31,10 @@ def create_dryrun_plot(
     d_thpt: list,
     safe_d_thpt: list,
     output_path: str,
+    warmup_time: list | None = None,
+    warmup_rr: list | None = None,
+    warmup_isl: list | None = None,
+    warmup_osl: list | None = None,
 ) -> None:
     """
     Create a comprehensive dryrun plot with 4 subplots showing various metrics over time.
@@ -50,12 +54,27 @@ def create_dryrun_plot(
         d_thpt: List of actual decode throughputs
         safe_d_thpt: List of safe decode throughput limits
         output_path: Path where the plot should be saved
+        warmup_time: Optional list of warmup time points (negative seconds)
+        warmup_rr: Optional list of warmup request rates (same units as rr)
+        warmup_isl: Optional list of warmup input sequence lengths
+        warmup_osl: Optional list of warmup output sequence lengths
     """
     fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(15, 10))
 
     # Plot 1: Request Rate
+    if warmup_time is not None and warmup_rr is not None and len(warmup_time) > 0:
+        ax1.plot(
+            warmup_time,
+            warmup_rr,
+            "b-",
+            alpha=0.35,
+            linewidth=2,
+            label="Warmup Request Rate",
+        )
     ax1.plot(time, rr, "b-", label="Actual Request Rate", linewidth=2)
     ax1.plot(time, est_rr, "r--", label="Predicted Request Rate", linewidth=2)
+    if warmup_time is not None and warmup_rr is not None:
+        ax1.axvline(0, color="k", linestyle=":", linewidth=2, label="Warmup Boundary")
     ax1.set_xlabel("Time (s)")
     ax1.set_ylabel("Request Rate")
     ax1.set_ylim(bottom=0)
@@ -64,10 +83,34 @@ def create_dryrun_plot(
     ax1.grid(True, alpha=0.3)
 
     # Plot 2: Sequence Lengths
+    if (
+        warmup_time is not None
+        and warmup_isl is not None
+        and warmup_osl is not None
+        and len(warmup_time) > 0
+    ):
+        ax2.plot(
+            warmup_time,
+            warmup_isl,
+            "g-",
+            alpha=0.35,
+            linewidth=2,
+            label="Warmup ISL",
+        )
+        ax2.plot(
+            warmup_time,
+            warmup_osl,
+            "m-",
+            alpha=0.35,
+            linewidth=2,
+            label="Warmup OSL",
+        )
     ax2.plot(time, isl, "g-", label="Actual ISL", linewidth=2)
     ax2.plot(time, est_isl, "g--", label="Predicted ISL", linewidth=2)
     ax2.plot(time, osl, "m-", label="Actual OSL", linewidth=2)
     ax2.plot(time, est_osl, "m--", label="Predicted OSL", linewidth=2)
+    if warmup_time is not None and warmup_isl is not None and warmup_osl is not None:
+        ax2.axvline(0, color="k", linestyle=":", linewidth=2, label="Warmup Boundary")
     ax2.set_xlabel("Time (s)")
     ax2.set_ylabel("Num Tokens")
     ax2.set_ylim(bottom=0)

--- a/components/src/dynamo/planner/utils/planner_argparse.py
+++ b/components/src/dynamo/planner/utils/planner_argparse.py
@@ -110,6 +110,12 @@ def create_sla_planner_parser() -> argparse.ArgumentParser:
         help="Load prediction window size",
     )
     parser.add_argument(
+        "--load-predictor-warmup-trace",
+        type=str,
+        default=None,
+        help="Optional path to a mooncake-style JSONL trace file used to warm up load predictors before observing live traffic",
+    )
+    parser.add_argument(
         "--metric-pulling-prometheus-endpoint",
         type=str,
         default=SLAPlannerDefaults.metric_pulling_prometheus_endpoint,


### PR DESCRIPTION
- planner now can take mooncake-style trace to warmup the load predictor
- fix a bug in pmdarima, now will continue to update the model instead of creating new models, which is important for the auto config adjustment.
- update burstgpt loadgen to allow dataset splition

<img width="1663" height="564" alt="image" src="https://github.com/user-attachments/assets/fb9769f2-42be-4484-b297-4776fb894510" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI options to skip rows and configure hash block parameters in the benchmark tool.
  * Added support for loading warmup trace data to initialize load predictors before live traffic.
  * Warmup data is now visualized in dry-run plots with boundary markers.

* **Improvements**
  * Timestamps are now normalized to start at zero for consistency.
  * Enhanced load prediction with idle-period handling and incremental model updates for better efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->