### PR TITLE
feat: a backend-agnostic approach to implement request migration when worker shuts down locally

### DIFF
--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -73,7 +73,7 @@ configure_dynamo_logging()
 
 async def graceful_shutdown(runtime):
     logging.info("Received shutdown signal, shutting down DistributedRuntime")
-    runtime.shutdown()
+    runtime.shutdown(True)
     logging.info("DistributedRuntime shutdown complete")
 
 

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -56,7 +56,7 @@ async def graceful_shutdown(runtime):
     For endpoints served with graceful_shutdown=False, the serving function will return immediately.
     """
     logging.info("Received shutdown signal, shutting down DistributedRuntime")
-    runtime.shutdown()
+    runtime.shutdown(True)
     logging.info("DistributedRuntime shutdown complete")
 
 
@@ -67,9 +67,7 @@ async def worker():
     overwrite_args(config)
 
     # Enable NATS based on use_kv_events flag (derived from kv_events_config)
-    runtime = DistributedRuntime(
-        loop, config.store_kv, config.request_plane, config.use_kv_events
-    )
+    runtime = DistributedRuntime(loop, config.store_kv, config.request_plane)
 
     # Set up signal handler for graceful shutdown
     def signal_handler():

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -67,7 +67,9 @@ async def worker():
     overwrite_args(config)
 
     # Enable NATS based on use_kv_events flag (derived from kv_events_config)
-    runtime = DistributedRuntime(loop, config.store_kv, config.request_plane)
+    runtime = DistributedRuntime(
+        loop, config.store_kv, config.request_plane, config.use_kv_events
+    )
 
     # Set up signal handler for graceful shutdown
     def signal_handler():

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -64,9 +64,13 @@ class DistributedRuntime:
         """
         ...
 
-    def shutdown(self) -> None:
+    def shutdown(self, migrate: bool = False) -> None:
         """
         Shutdown the runtime by triggering the cancellation token
+
+        Args:
+            migrate: If True, indicates this is a migration-aware shutdown
+                    where active requests will be interrupted and migrated
         """
         ...
 

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -321,7 +321,11 @@ impl DistributedRuntime {
     }
 
     pub fn shutdown(&self) {
-        self.runtime.shutdown();
+        self.shutdown_with_migrate(false);
+    }
+
+    pub fn shutdown_with_migrate(&self, migrate: bool) {
+        self.runtime.shutdown_with_migrate(migrate);
         self.store.shutdown();
     }
 


### PR DESCRIPTION
#### Overview:

This PR implements request cancellation (abort) functionality , enabling in-flight requests to be properly aborted when worker shuts down locally. 

#### Details:
1. Added a `migrate` flag in runtime.shutdown method to notify whether to migrate in-flight requests.
2. Rust engine ends the stream immediately when it detects endpoint cancellation, and migrate is set to True, this will promptly trigger frontend to find a new worker for this request. This way, we don't need to implement migration in each individual backend module.
3. vllm and trtllm components call runtime with migrate set to True when they receive SIGTERM and SIGINT signal. 

#### Where should the reviewer start?
lib/bindings/python/rust/engine.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration-aware shutdown capability to enable graceful request handling during runtime transitions.

* **Bug Fixes**
  * Enhanced health check payload validation with stricter type checking for improved error detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->