### PR TITLE
feat(frontend): Use vllm for pre and post processing

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 def setup_engine_factory(
     runtime: DistributedRuntime,
     router_mode: RouterMode,
-    kv_cache_block_size: int | None,
+    flags: argparse.Namespace,
 ):  # Returns EngineFactory:
     """
     When using vllm pre and post processor, create the EngineFactory that
@@ -58,7 +58,7 @@ def setup_engine_factory(
     """
     from .vllm_processor import EngineFactory
 
-    return EngineFactory(runtime, router_mode, kv_cache_block_size).engine_factory
+    return EngineFactory(runtime, router_mode, flags).engine_factory
 
 
 def validate_model_name(value):
@@ -472,9 +472,7 @@ async def async_main():
     if flags.processor == "vllm":
         # TODO: Do we also need to tell the engine factory when the model is removed,
         # so it can "stop" vllm?
-        kwargs["engine_factory"] = setup_engine_factory(
-            runtime, router_config, flags.kv_cache_block_size
-        )
+        kwargs["engine_factory"] = setup_engine_factory(runtime, router_config, flags)
 
     e = EntrypointArgs(EngineType.Dynamic, **kwargs)
     engine = await make_engine(runtime, e)

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -47,14 +47,16 @@ configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
 
-def setup_engine_factory(runtime: DistributedRuntime):  # Returns EngineFactory:
+def setup_engine_factory(
+    runtime: DistributedRuntime, router_mode: RouterMode
+):  # Returns EngineFactory:
     """
     When using vllm pre and post processor, create the EngineFactory that
     creates the engines that run requests.
     """
     from .vllm_processor import EngineFactory
 
-    return EngineFactory(runtime).engine_factory
+    return EngineFactory(runtime, router_mode).engine_factory
 
 
 def validate_model_name(value):
@@ -468,7 +470,7 @@ async def async_main():
     if flags.processor == "vllm":
         # TODO: Do we also need to tell the engine factory when the model is removed,
         # so it can "stop" vllm?
-        kwargs["engine_factory"] = setup_engine_factory(runtime)
+        kwargs["engine_factory"] = setup_engine_factory(runtime, router_mode)
 
     e = EntrypointArgs(EngineType.Dynamic, **kwargs)
     engine = await make_engine(runtime, e)

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 
 def setup_engine_factory(
     runtime: DistributedRuntime,
-    router_mode: RouterMode,
+    router_config: RouterConfig,
     flags: argparse.Namespace,
 ):  # Returns EngineFactory:
     """
@@ -58,7 +58,7 @@ def setup_engine_factory(
     """
     from .vllm_processor import EngineFactory
 
-    return EngineFactory(runtime, router_mode, flags).engine_factory
+    return EngineFactory(runtime, router_config, flags).engine_factory
 
 
 def validate_model_name(value):
@@ -103,10 +103,8 @@ def parse_args():
         except ImportError:
             try:
                 from vllm.utils.argparse_utils import FlexibleArgumentParser
-            except ModuleNotFoundError as e:
-                logger.error(
-                    f"Flag '--processor vllm' requires vllm be installed. {e}."
-                )
+            except ModuleNotFoundError:
+                logger.exception("Flag '--processor vllm' requires vllm be installed.")
                 sys.exit(1)
 
         parser = FlexibleArgumentParser(
@@ -342,8 +340,8 @@ def parse_args():
 
             parser = FrontendArgs.add_cli_args(parser)
             parser = AsyncEngineArgs.add_cli_args(parser)
-        except ModuleNotFoundError as e:
-            logger.error(f"Flag '--processor vllm' requires vllm be installed. {e}.")
+        except ModuleNotFoundError:
+            logger.exception("Flag '--processor vllm' requires vllm be installed.")
             sys.exit(1)
 
     flags = parser.parse_args()

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -21,16 +21,8 @@ import logging
 import os
 import pathlib
 import signal
-import time
-import uuid
 
 import uvloop
-from vllm.config import CacheConfig, LoadConfig, ModelConfig, VllmConfig
-from vllm.sampling_params import RequestOutputKind, SamplingParams
-from vllm.tokenizers import TokenizerLike, cached_tokenizer_from_config
-from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest
-from vllm.v1.engine.input_processor import InputProcessor
-from vllm.v1.engine.output_processor import OutputProcessor, OutputProcessorOutput
 
 from dynamo.common.config_dump import dump_config
 from dynamo.common.config_dump.config_dumper import add_config_dump_args
@@ -38,16 +30,12 @@ from dynamo.llm import (
     EngineType,
     EntrypointArgs,
     KvRouterConfig,
-    ModelCardInstanceId,
-    ModelDeploymentCard,
-    PythonAsyncEngine,
     RouterConfig,
     RouterMode,
-    fetch_llm,
     make_engine,
     run_input,
 )
-from dynamo.runtime import Client, DistributedRuntime
+from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
 from . import __version__
@@ -58,240 +46,13 @@ configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
 
-MASK_64_BITS = (1 << 64) - 1
+def setup_engine_factory(runtime: DistributedRuntime):  # Returns EngineFactory:
+    """
+    When using vllm pre and post processing, create the EngineFactory that
+    creates the engines that run requests.
+    """
+    from .vllm_processor import EngineFactory
 
-
-def random_uuid() -> str:
-    return f"{uuid.uuid4().int & MASK_64_BITS:016x}"  # 16 hex chars
-
-
-class VllmProcessor:
-    def __init__(
-        self,
-        tokenizer: TokenizerLike,
-        input_processor: InputProcessor,
-        output_processor: OutputProcessor,
-        router: Client,
-    ):
-        self.tokenizer = tokenizer
-        self.input_processor = input_processor
-        self.output_processor = output_processor
-        self.router = router
-
-    # Ideally we would map NVCreateChatCompletionRequest into Python so it can be type checked, but
-    # it has a lot of fields.
-    # request: dynamo.NVCreateChatCompletionRequest
-    async def generator(self, request):
-        """document"""
-
-        # ** VllmProcessor.generator called: {'messages': [{'role': 'user', 'content': 'What is the capital of Tuvalu?'}], 'model': '/home/grahamk/llms/Qwen3-0.6B', 'max_completion_tokens': 1000, 'stream': False}
-        print(f"** VllmProcessor.generator request: {request}")
-
-        # tokenizer is CachedQwen2TokenizerFast, subclass of PreTrainedTokenizerBase (part of `transformers` library, not vllm)
-        templated = self.tokenizer.apply_chat_template(
-            conversation=request["messages"],
-            tokenize=False,
-        )
-
-        print(f"*** Templated: {templated}")
-
-        if "max_completion_tokens" in request:
-            max_tokens = request["max_completion_tokens"]
-        elif "max_tokens" in request:
-            max_tokens = request["max_tokens"]
-        else:
-            max_tokens = 8192  # TODO what does rest of Dynamo do?
-
-        request_id = random_uuid()
-        vllm_preproc: EngineCoreRequest = self.input_processor.process_inputs(
-            request_id,
-            templated,
-            SamplingParams(
-                output_kind=RequestOutputKind.DELTA,
-                max_tokens=max_tokens,
-                # TODO: so many sampling params user could set
-            ),
-            # arrival_time: float | None = None,
-            # lora_request: LoRARequest | None = None,
-            # tokenization_kwargs: dict[str, Any] | None = None,
-            # trace_headers: Mapping[str, str] | None = None,
-            # priority: int = 0,
-            # data_parallel_rank: int | None = None,
-        )
-
-        # Processed: EngineCoreRequest(request_id='a2b76a85cd65e151', prompt_token_ids=[3838, 374, 279, 6722, 315, 28649, 25510, 30], mm_features=None, sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=16, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, structured_outputs=None, extra_args=None), pooling_params=None, eos_token_id=151645, arrival_time=1769036937.9417946, lora_request=None, cache_salt=None, data_parallel_rank=None, prompt_embeds=None, client_index=0, current_wave=0, priority=0, trace_headers=None)
-        print(f"Processed: {vllm_preproc}")
-
-        self.output_processor.add_request(
-            vllm_preproc,
-            request["messages"][0]["content"],  # prompt
-            # parent_req: ParentRequest | None = None,
-            # request_index: int = 0,
-            # queue: RequestOutputCollector | None = None,
-        )
-
-        # Convert to a Python object that has fields that match our PreprocessedRequest
-        sp = vllm_preproc.sampling_params
-        dynamo_preproc = {
-            "model": request["model"],
-            "token_ids": vllm_preproc.prompt_token_ids,
-            # protocols.common.StopConditions
-            "stop_conditions": {
-                "max_tokens": sp.max_tokens,
-                "stop": sp.stop,
-                "min_tokens": sp.min_tokens,
-                "ignore_eos": sp.ignore_eos,
-            },
-            # protocols.common.SamplingOptions
-            "sampling_options": {
-                # Is there a better way than typing it out like this?
-                "n": sp.n,
-                "presence_penalty": sp.presence_penalty,
-                "frequency_penalty": sp.frequency_penalty,
-                "repetition_penalty": sp.repetition_penalty,
-                "temperature": sp.temperature,
-                "top_p": sp.top_p,
-                "top_k": sp.top_k,
-                "min_p": sp.min_p,
-                "seed": sp.seed,
-            },
-            # protocols.common.OutputOptions
-            "output_options": {
-                "logprobs": sp.logprobs,
-                "prompt_logprobs": sp.prompt_logprobs,
-                "skip_special_tokens": sp.skip_special_tokens,
-            },
-            "eos_token_ids": [vllm_preproc.eos_token_id],
-            "annotations": [],
-            # "prompt_embeds": vllm_preproc.prompt_embeds,
-        }
-
-        # Dynamo Router. This goes to the backend, waits, gets the streaming response, returns it.
-        # Stream is AsyncResponseStream
-        dynamo_stream = await self.router.random(dynamo_preproc)
-
-        # dynamo_response: Annotated
-        async for dynamo_response in dynamo_stream:
-            # Mock
-            # Stream got: Annotated(data={'token_ids': [1714], 'tokens': [' method'], 'text': ' method', 'cum_log_probs': None, 'log_probs': None, 'top_logprobs': None, 'finish_reason': None, 'index': None}, event=None, comment=[], id=None)
-            #
-            # vllm
-            # Stream got: Annotated(data={'token_ids': [7281]}, event=None, comment=[], id=None)
-            print(f"Stream got: {dynamo_response}")
-
-            output = dynamo_response.data()
-            if output is None:
-                yield {
-                    "finish_reason": "error: No outputs from vLLM engine",
-                    "token_ids": [],
-                }
-                break
-
-            finish_reason = (
-                output["finish_reason"] if hasattr(output, "finish_reason") else None
-            )
-            vllm_response = EngineCoreOutput(
-                request_id=request_id,
-                new_token_ids=output["token_ids"],
-                finish_reason=finish_reason,
-                # new_logprobs=new_logprobs,
-                # new_prompt_logprobs_tensors=prompt_logprobs_tensors,
-                # pooling_output=pooler_output,
-                # stop_reason=request.stop_reason,
-                # events=request.take_events(),
-                # kv_transfer_params=kv_transfer_params,
-                # trace_headers=request.trace_headers,
-                # num_cached_tokens=request.num_cached_tokens,
-                # num_nans_in_logits=request.num_nans_in_logits,
-            )
-
-            # Let vllm handle all post-processing
-            vllm_out: OutputProcessorOutput = self.output_processor.process_outputs(
-                [vllm_response]
-            )
-            # vllm
-            # RequestOutput: OutputProcessorOutput(request_outputs=[RequestOutput(request_id=9dbe240d8de78db3, prompt='What is the capital of Tuvalu?', prompt_token_ids=[3838, 374, 279, 6722, 315, 28649, 25510, 30], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text=' The', token_ids=[576], cumulative_logprob=None, logprobs=None, finish_reason=None, stop_reason=None)], finished=False, metrics=RequestStateStats(num_generation_tokens=0, arrival_time=1769118902.2172132, queued_ts=0.0, scheduled_ts=0.0, first_token_ts=0.0, last_token_ts=0.0, first_token_latency=0.0, is_corrupted=False), lora_request=None, num_cached_tokens=0, multi_modal_placeholders={})], reqs_to_abort=[])
-
-            print(f"RequestOutput: {vllm_out}")
-
-            # Vec<ChatChoiceStream>
-            choices = []
-            for output in vllm_out.request_outputs[0].outputs:
-                choices.append(
-                    {
-                        "index": output.index,
-                        # ChatCompletionStreamResponseDelta
-                        "delta": {"content": output.text, "role": "assistant"},
-                        # TODO: These three likely need converting, it won't just work
-                        "finish_reason": output.finish_reason,
-                        "stop_reason": output.stop_reason,
-                        "logprobs": output.logprobs,
-                    }
-                )
-            # dynamo_out: NvCreateChatCompletionStreamResponse
-            dynamo_out = {
-                "id": request_id,
-                "choices": choices,
-                "created": int(time.time()),
-                "model": request["model"],
-                "object": "chat.completion.chunk",
-                # usage (from output.metrics maybe)
-            }
-            # Rust handles Server Sent Events back to user
-            yield dynamo_out
-
-
-class EngineFactory:
-    def __init__(self, runtime: DistributedRuntime):
-        self.runtime = runtime
-
-    async def engine_factory(
-        self, instance_id: ModelCardInstanceId, mdc: ModelDeploymentCard
-    ) -> PythonAsyncEngine:
-        """
-        Called by Rust when a model is discovered.
-        """
-        logger.info(f"Engine_factory called with MDC: {mdc.to_json_str()}")
-        logger.info(f"Engine_factory called with instance ID: {instance_id}")
-        loop = asyncio.get_running_loop()
-
-        source_path = mdc.source_path()
-        if not os.path.exists(source_path):
-            print("** Fetching model '{source_path}'")
-            await fetch_llm(source_path)
-
-        model_config = ModelConfig(
-            model=source_path,
-        )
-        tokenizer = cached_tokenizer_from_config(model_config)
-        vllm_config = VllmConfig(
-            model_config=model_config,
-            load_config=LoadConfig(load_format="dummy"),
-            cache_config=CacheConfig(),
-            # scheduler_config=SchedulerConfig(),
-        )
-
-        input_processor = InputProcessor(vllm_config, tokenizer)
-        output_processor = OutputProcessor(
-            tokenizer,
-            log_stats=False,
-            stream_interval=1,
-        )
-
-        (namespace_name, component_name, endpoint_name) = instance_id.triple()
-        generate_endpoint = (
-            self.runtime.namespace(namespace_name)
-            .component(component_name)
-            .endpoint(endpoint_name)
-        )
-        router = await generate_endpoint.client()
-        gen = VllmProcessor(tokenizer, input_processor, output_processor, router)
-
-        return PythonAsyncEngine(gen.generator, loop)
-
-
-def setup_engine_factory(runtime: DistributedRuntime) -> EngineFactory:
-    """Create the EngineFactory that creates the engines that run requests."""
     return EngineFactory(runtime).engine_factory
 
 
@@ -669,8 +430,8 @@ async def async_main():
         kwargs["http_metrics_port"] = flags.grpc_metrics_port
 
     if flags.exp_python_factory:
-        # TODO: I think we also need to tell the engine factory when the model is removed,
-        # so it can stop vllm
+        # TODO: Do we also need to tell the engine factory when the model is removed,
+        # so it can "stop" vllm?
         kwargs["engine_factory"] = setup_engine_factory(runtime)
 
     e = EntrypointArgs(EngineType.Dynamic, **kwargs)

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -27,6 +27,12 @@ class PreprocessResult:
 def _materialize_assistant_tool_calls(
     messages: Sequence[Any],
 ) -> list[dict[str, Any] | Any]:
+    # Mistral chat templating expects assistant tool_calls to be materialized
+    # as a concrete list of dict-like values. Our validated message models may
+    # still carry non-list sequence-like containers here, which can break or
+    # mis-render when tokenize=True is used in-template. This helper converts
+    # model objects to dicts and normalizes assistant.tool_calls to list when
+    # possible, while preserving original values if they are not iterable.
     normalized: list[dict[str, Any] | Any] = []
     for message in messages:
         if hasattr(message, "model_dump"):

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -1,0 +1,289 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage, DeltaToolCall
+from vllm.reasoning import ReasoningParser
+from vllm.sampling_params import SamplingParams
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers import ToolParser
+
+
+@dataclass
+class PreprocessResult:
+    request_for_sampling: ChatCompletionRequest
+    tool_parser: ToolParser | None
+    chat_template_kwargs: dict[str, Any]
+    engine_prompt: dict[str, Any]
+    prompt_token_ids: list[int]
+
+
+def _materialize_assistant_tool_calls(
+    messages: Sequence[Any],
+) -> list[dict[str, Any] | Any]:
+    normalized: list[dict[str, Any] | Any] = []
+    for message in messages:
+        if hasattr(message, "model_dump"):
+            msg: dict[str, Any] | Any = message.model_dump(exclude_none=False)
+        else:
+            msg = message
+
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            tool_calls = msg.get("tool_calls")
+            if tool_calls is not None and not isinstance(tool_calls, list):
+                try:
+                    msg["tool_calls"] = list(tool_calls)
+                except TypeError:
+                    # Keep original object if it is not iterable.
+                    pass
+
+        normalized.append(msg)
+    return normalized
+
+
+async def preprocess_chat_request(
+    request: dict[str, Any],
+    *,
+    tokenizer: TokenizerLike,
+    renderer,
+    tool_parser_class: type[ToolParser] | None,
+) -> PreprocessResult:
+    request_for_sampling = ChatCompletionRequest.model_validate(request)
+
+    tool_parser: ToolParser | None = None
+    if tool_parser_class and request_for_sampling.tools:
+        if request_for_sampling.tool_choice != "none":
+            tool_parser = tool_parser_class(tokenizer)
+            request_for_sampling = tool_parser.adjust_request(request_for_sampling)
+
+    tool_dicts = (
+        [tool.model_dump() for tool in request_for_sampling.tools]
+        if request_for_sampling.tools
+        else None
+    )
+    chat_template_kwargs = dict(request_for_sampling.chat_template_kwargs or {})
+    chat_template_kwargs["reasoning_effort"] = request_for_sampling.reasoning_effort
+
+    # Mistral warns that tokenize=False is unsafe for chat templates.
+    is_mistral_tokenizer = (
+        tokenizer.__class__.__name__ == "MistralTokenizer"
+        or "tokenizers.mistral" in tokenizer.__class__.__module__
+    )
+    tokenize_in_template = is_mistral_tokenizer
+    messages_for_render = (
+        _materialize_assistant_tool_calls(request_for_sampling.messages)
+        if is_mistral_tokenizer
+        else request_for_sampling.messages
+    )
+
+    _, engine_prompt = await renderer.render_messages_async(
+        messages_for_render,
+        chat_template=request_for_sampling.chat_template,
+        chat_template_content_format="auto",
+        add_generation_prompt=request_for_sampling.add_generation_prompt,
+        continue_final_message=request_for_sampling.continue_final_message,
+        tools=tool_dicts,
+        documents=request_for_sampling.documents,
+        tokenize=tokenize_in_template,
+        **chat_template_kwargs,
+    )
+
+    if "prompt_token_ids" in engine_prompt:
+        tokens = list(engine_prompt["prompt_token_ids"])
+    else:
+        tokens = tokenizer.encode(
+            engine_prompt["prompt"],
+            add_special_tokens=request_for_sampling.add_special_tokens,
+        )
+
+    return PreprocessResult(
+        request_for_sampling=request_for_sampling,
+        tool_parser=tool_parser,
+        chat_template_kwargs=chat_template_kwargs,
+        engine_prompt=engine_prompt,
+        prompt_token_ids=tokens,
+    )
+
+
+class StreamingPostProcessor:
+    def __init__(
+        self,
+        *,
+        tokenizer: TokenizerLike,
+        request_for_sampling: ChatCompletionRequest,
+        sampling_params: SamplingParams,
+        prompt_token_ids: Sequence[int],
+        tool_parser: ToolParser | None,
+        reasoning_parser_class: type[ReasoningParser] | None,
+        chat_template_kwargs: dict[str, Any],
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.request_for_sampling = request_for_sampling
+        self.sampling_params = sampling_params
+        self.tool_parser = tool_parser
+        self.reasoning_parser = (
+            reasoning_parser_class(
+                tokenizer,
+                chat_template_kwargs=chat_template_kwargs,
+            )
+            if reasoning_parser_class
+            else None
+        )
+
+        self._control_markers = tuple(
+            t for t in getattr(tokenizer, "all_special_tokens", ()) if t
+        )
+
+        self.previous_text = ""
+        self.previous_token_ids: list[int] = []
+        self.reasoning_is_done = False
+        self.in_progress_tool_calls: dict[int, DeltaToolCall] = {}
+
+    @staticmethod
+    def _merge_tool_call(
+        existing: DeltaToolCall | None, incoming: DeltaToolCall
+    ) -> DeltaToolCall:
+        if existing is None:
+            if incoming.function and incoming.function.arguments is None:
+                incoming.function.arguments = ""
+            return incoming
+        if incoming.id and not existing.id:
+            existing.id = incoming.id
+        if incoming.type and not existing.type:
+            existing.type = incoming.type
+        if incoming.function:
+            if existing.function is None:
+                existing.function = incoming.function
+                if existing.function.arguments is None:
+                    existing.function.arguments = ""
+            else:
+                if incoming.function.name and not existing.function.name:
+                    existing.function.name = incoming.function.name
+                if incoming.function.arguments:
+                    if existing.function.arguments is None:
+                        existing.function.arguments = ""
+                    existing.function.arguments += incoming.function.arguments
+        return existing
+
+    def _is_control_only_content(self, content: str | None) -> bool:
+        if not content:
+            return True
+        stripped = content
+        for marker in self._control_markers:
+            stripped = stripped.replace(marker, "")
+        return stripped.strip() == ""
+
+    def process_output(self, output: Any) -> dict[str, Any] | None:
+        delta_token_ids = list(output.token_ids or [])
+        # vLLM output_processor already applies stop-token/stop-string trimming
+        # to text. Re-detokenizing from token_ids can reintroduce stop markers.
+        delta_text = output.text or ""
+
+        current_text = self.previous_text + delta_text
+        current_token_ids = self.previous_token_ids + delta_token_ids
+
+        delta_message: DeltaMessage | None = DeltaMessage(content=delta_text)
+
+        if not self.reasoning_is_done and self.reasoning_parser:
+            delta_message = self.reasoning_parser.extract_reasoning_streaming(
+                self.previous_text,
+                current_text,
+                delta_text,
+                self.previous_token_ids,
+                current_token_ids,
+                delta_token_ids,
+            )
+
+        should_parse_tools = (
+            self.tool_parser is not None
+            and self.request_for_sampling.tool_choice != "none"
+        )
+        if should_parse_tools:
+            no_prev_reasoning = (
+                delta_message and delta_message.content and not delta_message.reasoning
+            )
+            if self.reasoning_is_done or no_prev_reasoning:
+                delta_message = self.tool_parser.extract_tool_calls_streaming(
+                    previous_text=self.previous_text,
+                    current_text=current_text,
+                    delta_text=delta_text,
+                    previous_token_ids=self.previous_token_ids,
+                    current_token_ids=current_token_ids,
+                    delta_token_ids=delta_token_ids,
+                    request=self.request_for_sampling,
+                )
+
+        if (
+            not self.reasoning_is_done
+            and self.reasoning_parser
+            and self.reasoning_parser.is_reasoning_end_streaming(
+                current_token_ids, delta_token_ids
+            )
+        ):
+            self.reasoning_is_done = True
+            self.previous_text = ""
+            self.previous_token_ids = []
+            current_text = ""
+            current_token_ids = []
+
+        choice = None
+        if delta_message is None:
+            pass
+        elif delta_message.tool_calls:
+            for tool_delta in delta_message.tool_calls:
+                existing = self.in_progress_tool_calls.get(tool_delta.index)
+                merged = self._merge_tool_call(existing, tool_delta)
+                self.in_progress_tool_calls[tool_delta.index] = merged
+        elif delta_message.content or delta_message.reasoning:
+            delta: dict[str, Any] = {"role": "assistant"}
+            content = delta_message.content
+            if self.in_progress_tool_calls and self._is_control_only_content(content):
+                content = None
+            if content:
+                delta["content"] = content
+            if delta_message.reasoning:
+                delta["reasoning_content"] = delta_message.reasoning
+            if self.in_progress_tool_calls:
+                delta["tool_calls"] = [
+                    tool_call.model_dump(exclude_none=True)
+                    for _, tool_call in sorted(self.in_progress_tool_calls.items())
+                ]
+                self.in_progress_tool_calls.clear()
+            if len(delta) > 1:
+                choice = {
+                    "index": output.index,
+                    "delta": delta,
+                    "finish_reason": output.finish_reason,
+                    "logprobs": output.logprobs,
+                }
+        elif self.in_progress_tool_calls:
+            choice = {
+                "index": output.index,
+                "delta": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        tool_call.model_dump(exclude_none=True)
+                        for _, tool_call in sorted(self.in_progress_tool_calls.items())
+                    ],
+                },
+                "finish_reason": output.finish_reason,
+                "logprobs": output.logprobs,
+            }
+            self.in_progress_tool_calls.clear()
+        elif output.finish_reason:
+            choice = {
+                "index": output.index,
+                "delta": {},
+                "finish_reason": output.finish_reason,
+                "logprobs": output.logprobs,
+            }
+
+        self.previous_text = current_text
+        self.previous_token_ids = current_token_ids
+        return choice

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -56,11 +56,20 @@ class VllmProcessor:
         # ** VllmProcessor.generator called: {'messages': [{'role': 'user', 'content': 'What is the capital of Tuvalu?'}], 'model': '/home/grahamk/llms/Qwen3-0.6B', 'max_completion_tokens': 1000, 'stream': False}
         print(f"** VllmProcessor.generator request: {request}")
 
-        # tokenizer is CachedQwen2TokenizerFast, subclass of PreTrainedTokenizerBase (part of `transformers` library, not vllm)
-        templated = self.tokenizer.apply_chat_template(
-            conversation=request["messages"],
-            tokenize=False,
-        )
+        # There seem to be two incompatible versions of apply_chat_template, depending on the model
+        try:
+            # tokenizer is CachedQwen2TokenizerFast, subclass of PreTrainedTokenizerBase (part of `transformers` library, not vllm)
+            # This is not the type the source code declares.
+            templated = self.tokenizer.apply_chat_template(
+                conversation=request["messages"],
+                tokenize=False,
+            )
+        except TypeError:
+            # tokenizer is an impl of TokenizerLike. This is the declared type.
+            templated = self.tokenizer.apply_chat_template(
+                messages=request["messages"],
+                tokenize=False,
+            )
 
         print(f"*** Templated: {templated}")
 

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -23,6 +23,7 @@ from dynamo.llm import (
     ModelCardInstanceId,
     ModelDeploymentCard,
     PythonAsyncEngine,
+    RouterMode,
     fetch_llm,
 )
 from dynamo.runtime import Client, DistributedRuntime
@@ -224,11 +225,14 @@ class VllmProcessor:
 
 
 class EngineFactory:
-    def __init__(self, runtime: DistributedRuntime):
+    def __init__(self, runtime: DistributedRuntime, router_mode: RouterMode):
         self.runtime = runtime
+        self.router_mode = router_mode
 
     async def engine_factory(
-        self, instance_id: ModelCardInstanceId, mdc: ModelDeploymentCard
+        self,
+        instance_id: ModelCardInstanceId,
+        mdc: ModelDeploymentCard,
     ) -> PythonAsyncEngine:
         """
         Called by Rust when a model is discovered.
@@ -264,7 +268,7 @@ class EngineFactory:
             .component(component_name)
             .endpoint(endpoint_name)
         )
-        router = await generate_endpoint.client()
+        router = await generate_endpoint.client2(self.router_mode)
         gen = VllmProcessor(tokenizer, input_processor, output_processor, router)
 
         return PythonAsyncEngine(gen.generator, loop)

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -1,0 +1,259 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+#
+# Use vllm for input and output processing
+#
+
+import asyncio
+import logging
+import os
+import time
+import uuid
+
+from vllm.config import CacheConfig, LoadConfig, ModelConfig, VllmConfig
+from vllm.sampling_params import RequestOutputKind, SamplingParams
+from vllm.tokenizers import TokenizerLike, cached_tokenizer_from_config
+from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest
+from vllm.v1.engine.input_processor import InputProcessor
+from vllm.v1.engine.output_processor import OutputProcessor, OutputProcessorOutput
+
+from dynamo.llm import (
+    ModelCardInstanceId,
+    ModelDeploymentCard,
+    PythonAsyncEngine,
+    fetch_llm,
+)
+from dynamo.runtime import Client, DistributedRuntime
+
+logger = logging.getLogger(__name__)
+
+
+def random_uuid() -> str:
+    MASK_64_BITS = (1 << 64) - 1
+    return f"{uuid.uuid4().int & MASK_64_BITS:016x}"  # 16 hex chars
+
+
+class VllmProcessor:
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        input_processor: InputProcessor,
+        output_processor: OutputProcessor,
+        router: Client,
+    ):
+        self.tokenizer = tokenizer
+        self.input_processor = input_processor
+        self.output_processor = output_processor
+        self.router = router
+
+    # Ideally we would map NVCreateChatCompletionRequest into Python so it can be type checked, but
+    # it has a lot of fields.
+    # request: dynamo.NVCreateChatCompletionRequest
+    async def generator(self, request):
+        """TODO: document"""
+
+        # ** VllmProcessor.generator called: {'messages': [{'role': 'user', 'content': 'What is the capital of Tuvalu?'}], 'model': '/home/grahamk/llms/Qwen3-0.6B', 'max_completion_tokens': 1000, 'stream': False}
+        print(f"** VllmProcessor.generator request: {request}")
+
+        # tokenizer is CachedQwen2TokenizerFast, subclass of PreTrainedTokenizerBase (part of `transformers` library, not vllm)
+        templated = self.tokenizer.apply_chat_template(
+            conversation=request["messages"],
+            tokenize=False,
+        )
+
+        print(f"*** Templated: {templated}")
+
+        if "max_completion_tokens" in request:
+            max_tokens = request["max_completion_tokens"]
+        elif "max_tokens" in request:
+            max_tokens = request["max_tokens"]
+        else:
+            max_tokens = 8192  # TODO what does rest of Dynamo do?
+
+        request_id = random_uuid()
+        vllm_preproc: EngineCoreRequest = self.input_processor.process_inputs(
+            request_id,
+            templated,
+            SamplingParams(
+                output_kind=RequestOutputKind.DELTA,
+                max_tokens=max_tokens,
+                # TODO: so many sampling params user could set
+            ),
+            # arrival_time: float | None = None,
+            # lora_request: LoRARequest | None = None,
+            # tokenization_kwargs: dict[str, Any] | None = None,
+            # trace_headers: Mapping[str, str] | None = None,
+            # priority: int = 0,
+            # data_parallel_rank: int | None = None,
+        )
+
+        # Processed: EngineCoreRequest(request_id='a2b76a85cd65e151', prompt_token_ids=[3838, 374, 279, 6722, 315, 28649, 25510, 30], mm_features=None, sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=16, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, structured_outputs=None, extra_args=None), pooling_params=None, eos_token_id=151645, arrival_time=1769036937.9417946, lora_request=None, cache_salt=None, data_parallel_rank=None, prompt_embeds=None, client_index=0, current_wave=0, priority=0, trace_headers=None)
+        print(f"Processed: {vllm_preproc}")
+
+        self.output_processor.add_request(
+            vllm_preproc,
+            request["messages"][0]["content"],  # prompt
+            # parent_req: ParentRequest | None = None,
+            # request_index: int = 0,
+            # queue: RequestOutputCollector | None = None,
+        )
+
+        # Convert to a Python object that has fields that match our PreprocessedRequest
+        sp = vllm_preproc.sampling_params
+        dynamo_preproc = {
+            "model": request["model"],
+            "token_ids": vllm_preproc.prompt_token_ids,
+            # protocols.common.StopConditions
+            "stop_conditions": {
+                "max_tokens": sp.max_tokens,
+                "stop": sp.stop,
+                "min_tokens": sp.min_tokens,
+                "ignore_eos": sp.ignore_eos,
+            },
+            # protocols.common.SamplingOptions
+            "sampling_options": {
+                # Is there a better way than typing it out like this?
+                "n": sp.n,
+                "presence_penalty": sp.presence_penalty,
+                "frequency_penalty": sp.frequency_penalty,
+                "repetition_penalty": sp.repetition_penalty,
+                "temperature": sp.temperature,
+                "top_p": sp.top_p,
+                "top_k": sp.top_k,
+                "min_p": sp.min_p,
+                "seed": sp.seed,
+            },
+            # protocols.common.OutputOptions
+            "output_options": {
+                "logprobs": sp.logprobs,
+                "prompt_logprobs": sp.prompt_logprobs,
+                "skip_special_tokens": sp.skip_special_tokens,
+            },
+            "eos_token_ids": [vllm_preproc.eos_token_id],
+            "annotations": [],
+            # "prompt_embeds": vllm_preproc.prompt_embeds,
+        }
+
+        # Dynamo Router. This goes to the backend, waits, gets the streaming response, returns it.
+        # Stream is AsyncResponseStream
+        dynamo_stream = await self.router.random(dynamo_preproc)
+
+        # dynamo_response: Annotated
+        async for dynamo_response in dynamo_stream:
+            # Mock
+            # Stream got: Annotated(data={'token_ids': [1714], 'tokens': [' method'], 'text': ' method', 'cum_log_probs': None, 'log_probs': None, 'top_logprobs': None, 'finish_reason': None, 'index': None}, event=None, comment=[], id=None)
+            #
+            # vllm
+            # Stream got: Annotated(data={'token_ids': [7281]}, event=None, comment=[], id=None)
+            print(f"Stream got: {dynamo_response}")
+
+            output = dynamo_response.data()
+            if output is None:
+                yield {
+                    "finish_reason": "error: No outputs from vLLM engine",
+                    "token_ids": [],
+                }
+                break
+
+            finish_reason = (
+                output["finish_reason"] if hasattr(output, "finish_reason") else None
+            )
+            vllm_response = EngineCoreOutput(
+                request_id=request_id,
+                new_token_ids=output["token_ids"],
+                finish_reason=finish_reason,
+                # new_logprobs=new_logprobs,
+                # new_prompt_logprobs_tensors=prompt_logprobs_tensors,
+                # pooling_output=pooler_output,
+                # stop_reason=request.stop_reason,
+                # events=request.take_events(),
+                # kv_transfer_params=kv_transfer_params,
+                # trace_headers=request.trace_headers,
+                # num_cached_tokens=request.num_cached_tokens,
+                # num_nans_in_logits=request.num_nans_in_logits,
+            )
+
+            # Let vllm handle all post-processing
+            vllm_out: OutputProcessorOutput = self.output_processor.process_outputs(
+                [vllm_response]
+            )
+            # vllm
+            # RequestOutput: OutputProcessorOutput(request_outputs=[RequestOutput(request_id=9dbe240d8de78db3, prompt='What is the capital of Tuvalu?', prompt_token_ids=[3838, 374, 279, 6722, 315, 28649, 25510, 30], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text=' The', token_ids=[576], cumulative_logprob=None, logprobs=None, finish_reason=None, stop_reason=None)], finished=False, metrics=RequestStateStats(num_generation_tokens=0, arrival_time=1769118902.2172132, queued_ts=0.0, scheduled_ts=0.0, first_token_ts=0.0, last_token_ts=0.0, first_token_latency=0.0, is_corrupted=False), lora_request=None, num_cached_tokens=0, multi_modal_placeholders={})], reqs_to_abort=[])
+
+            print(f"RequestOutput: {vllm_out}")
+
+            # Vec<ChatChoiceStream>
+            choices = []
+            for output in vllm_out.request_outputs[0].outputs:
+                choices.append(
+                    {
+                        "index": output.index,
+                        # ChatCompletionStreamResponseDelta
+                        "delta": {"content": output.text, "role": "assistant"},
+                        # TODO: These three likely need converting, it won't just work
+                        "finish_reason": output.finish_reason,
+                        "stop_reason": output.stop_reason,
+                        "logprobs": output.logprobs,
+                    }
+                )
+            # dynamo_out: NvCreateChatCompletionStreamResponse
+            dynamo_out = {
+                "id": request_id,
+                "choices": choices,
+                "created": int(time.time()),
+                "model": request["model"],
+                "object": "chat.completion.chunk",
+                # usage (from output.metrics maybe)
+            }
+            # Rust handles Server Sent Events back to user
+            yield dynamo_out
+
+
+class EngineFactory:
+    def __init__(self, runtime: DistributedRuntime):
+        self.runtime = runtime
+
+    async def engine_factory(
+        self, instance_id: ModelCardInstanceId, mdc: ModelDeploymentCard
+    ) -> PythonAsyncEngine:
+        """
+        Called by Rust when a model is discovered.
+        """
+        logger.info(f"Engine_factory called with MDC: {mdc.to_json_str()}")
+        logger.info(f"Engine_factory called with instance ID: {instance_id}")
+        loop = asyncio.get_running_loop()
+
+        source_path = mdc.source_path()
+        if not os.path.exists(source_path):
+            print("** Fetching model '{source_path}'")
+            await fetch_llm(source_path)
+
+        model_config = ModelConfig(
+            model=source_path,
+        )
+        tokenizer = cached_tokenizer_from_config(model_config)
+        vllm_config = VllmConfig(
+            model_config=model_config,
+            load_config=LoadConfig(load_format="dummy"),
+            cache_config=CacheConfig(),
+            # scheduler_config=SchedulerConfig(),
+        )
+
+        input_processor = InputProcessor(vllm_config, tokenizer)
+        output_processor = OutputProcessor(
+            tokenizer,
+            log_stats=False,
+            stream_interval=1,
+        )
+
+        (namespace_name, component_name, endpoint_name) = instance_id.triple()
+        generate_endpoint = (
+            self.runtime.namespace(namespace_name)
+            .component(component_name)
+            .endpoint(endpoint_name)
+        )
+        router = await generate_endpoint.client()
+        gen = VllmProcessor(tokenizer, input_processor, output_processor, router)
+
+        return PythonAsyncEngine(gen.generator, loop)

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -15,15 +15,10 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from vllm.config import CacheConfig, LoadConfig, ModelConfig, VllmConfig
-from vllm.entrypoints.openai.protocol import (
-    ChatCompletionRequest,
-    DeltaMessage,
-    DeltaToolCall,
-)
 from vllm.inputs.data import TokensPrompt
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.sampling_params import RequestOutputKind, SamplingParams
-from vllm.tokenizers import TokenizerLike, cached_tokenizer_from_config
+from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParser, ToolParserManager
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
 from vllm.v1.engine.input_processor import InputProcessor
@@ -40,6 +35,8 @@ from dynamo.llm import (
 )
 from dynamo.runtime import DistributedRuntime
 
+from .prepost import StreamingPostProcessor, preprocess_chat_request
+
 logger = logging.getLogger(__name__)
 
 
@@ -50,7 +47,7 @@ _FINISH_REASON_MAP: dict[str, FinishReason] = {
     "length": FinishReason.LENGTH,
     "error": FinishReason.ERROR,
     "cancelled": FinishReason.ABORT,
-    "content_filter": FinishReason.ERROR,
+    "content_filter": FinishReason.STOP,
 }
 
 
@@ -61,6 +58,10 @@ def random_uuid() -> str:
 def map_finish_reason(raw_reason: str | None) -> FinishReason | None:
     if raw_reason is None:
         return None
+    if raw_reason.startswith("error"):
+        return FinishReason.ERROR
+    if raw_reason.startswith("abort"):
+        return FinishReason.ABORT
     mapped = _FINISH_REASON_MAP.get(raw_reason)
     if mapped is None:
         logger.warning("Unknown finish_reason from router: %s", raw_reason)
@@ -98,82 +99,34 @@ class VllmProcessor:
 
         # ** VllmProcessor.generator called: {'messages': [{'role': 'user', 'content': 'What is the capital of Tuvalu?'}], 'model': '/home/grahamk/llms/Qwen3-0.6B', 'max_completion_tokens': 1000, 'stream': False}
 
-        template_kwargs: dict[str, Any] = {}
-        if request.get("chat_template") is not None:
-            template_kwargs["chat_template"] = request["chat_template"]
-        if request.get("chat_template_kwargs") is not None:
-            template_kwargs["chat_template_kwargs"] = request["chat_template_kwargs"]
+        pre = await preprocess_chat_request(
+            request,
+            tokenizer=self.tokenizer,
+            renderer=self.input_processor.renderer,
+            tool_parser_class=self.tool_parser_class,
+        )
+        request_for_sampling = pre.request_for_sampling
+        tool_parser = pre.tool_parser
+        chat_template_kwargs = pre.chat_template_kwargs
+        engine_prompt = pre.engine_prompt
+        tokens = pre.prompt_token_ids
 
-        def apply_chat_template(**kwargs: Any) -> list[int]:
-            all_kwargs = {**kwargs, **template_kwargs}
-            try:
-                return self.tokenizer.apply_chat_template(**all_kwargs)
-            except TypeError:
-                if template_kwargs:
-                    return self.tokenizer.apply_chat_template(**kwargs)
-                raise
-
-        # There seem to be two incompatible versions of apply_chat_template, depending on the model
-        try:
-            # tokenizer is a subclass of PreTrainedTokenizerBase (part of `transformers` library, not vllm)
-            # This is not the type the source code declares.
-            tokens = apply_chat_template(
-                conversation=request["messages"],
-                tools=request.get("tools", None),
-                tokenize=True,
-                add_generation_prompt=request.get("add_generation_prompt", True),
-            )
-        except TypeError:
-            # apply_chat_template has two incompatible signatures depending on tokenizer type:
-            # PreTrainedTokenizerBase uses 'conversation=' while TokenizerLike uses 'messages='
-
-            # For "role":"user" messages, mistral-common only allows 'role' and 'content', nothing else or pydantic validation breaks.
-            # This deletes the optional 'name' field.
-            filtered_messages = [
-                {k: v for k, v in d.items() if k != "name"} for d in request["messages"]
-            ]
-            tokens = apply_chat_template(
-                messages=filtered_messages,
-                tools=request.get("tools", None),
-                tokenize=True,
-                add_generation_prompt=request.get("add_generation_prompt", True),
-            )
-
-        if "max_completion_tokens" in request:
-            max_tokens = request["max_completion_tokens"]
-        elif "max_tokens" in request:
-            max_tokens = request["max_tokens"]
+        if request_for_sampling.max_completion_tokens is not None:
+            max_tokens = request_for_sampling.max_completion_tokens
+        elif request_for_sampling.max_tokens is not None:
+            max_tokens = request_for_sampling.max_tokens
         else:
-            # Match what Rust does
-            max_tokens = 8192
+            # This should mean model max - prompt len.
+            max_tokens = None
 
         sampling_params = SamplingParams(
             output_kind=RequestOutputKind.DELTA,
             max_tokens=max_tokens,
         )
-        # Only affects eos_token_id
-        sampling_params.update_from_generation_config(
-            self.input_processor.generation_config_fields, self.tokenizer.eos_token_id
-        )
         # generation_config.json
         for k, v in self.input_processor.generation_config_fields.items():
             if hasattr(sampling_params, k):
                 setattr(sampling_params, k, v)
-
-        tool_parser: ToolParser | None = None
-        tool_request: ChatCompletionRequest | None = None
-        request_for_sampling: ChatCompletionRequest | dict[str, Any] = request
-        if self.tool_parser_class and request.get("tools"):
-            candidate_request = ChatCompletionRequest(**request)
-            if getattr(candidate_request, "tool_choice", "none") != "none":
-                tool_parser = self.tool_parser_class(self.tokenizer)
-                tool_request = tool_parser.adjust_request(candidate_request)
-                request_for_sampling = tool_request
-
-        def get_request_value(key: str) -> Any:
-            if isinstance(request_for_sampling, dict):
-                return request_for_sampling.get(key)
-            return getattr(request_for_sampling, key, None)
 
         # User request
         sampling_fields = {
@@ -201,29 +154,35 @@ class VllmProcessor:
             "structured_outputs",
         }
         for k in sampling_fields:
-            v = get_request_value(k)
+            v = getattr(request_for_sampling, k, None)
             if v is not None:
                 setattr(sampling_params, k, v)
-        logprobs = get_request_value("logprobs")
-        top_logprobs = get_request_value("top_logprobs")
+        logprobs = request_for_sampling.logprobs
+        top_logprobs = request_for_sampling.top_logprobs
         if logprobs is True:
             sampling_params.logprobs = top_logprobs or 1
         elif isinstance(logprobs, int) and not isinstance(logprobs, bool):
             sampling_params.logprobs = logprobs
         elif top_logprobs not in (None, 0):
             sampling_params.logprobs = top_logprobs
+        if sampling_params.logprobs is not None and sampling_params.logprobs > 0:
+            logger.warning(
+                "Logprobs requested but not supported in distributed inference mode"
+            )
 
         request_id = random_uuid()
         # This calls update_from_generation_config and update_from_tokenizer on SamplingParams
         prompt_inputs = TokensPrompt(prompt_token_ids=tokens)
-        if request.get("cache_salt") is not None:
-            prompt_inputs["cache_salt"] = request["cache_salt"]
-        if request.get("mm_processor_kwargs") is not None:
-            prompt_inputs["mm_processor_kwargs"] = request["mm_processor_kwargs"]
-        if request.get("multi_modal_data") is not None:
-            prompt_inputs["multi_modal_data"] = request["multi_modal_data"]
-        if request.get("multi_modal_uuids") is not None:
-            prompt_inputs["multi_modal_uuids"] = request["multi_modal_uuids"]
+        if "multi_modal_data" in engine_prompt:
+            prompt_inputs["multi_modal_data"] = engine_prompt["multi_modal_data"]
+        if "multi_modal_uuids" in engine_prompt:
+            prompt_inputs["multi_modal_uuids"] = engine_prompt["multi_modal_uuids"]
+        if request_for_sampling.cache_salt is not None:
+            prompt_inputs["cache_salt"] = request_for_sampling.cache_salt
+        if request_for_sampling.mm_processor_kwargs is not None:
+            prompt_inputs[
+                "mm_processor_kwargs"
+            ] = request_for_sampling.mm_processor_kwargs
         vllm_preproc: EngineCoreRequest = self.input_processor.process_inputs(
             request_id,
             prompt_inputs,
@@ -235,11 +194,28 @@ class VllmProcessor:
             # priority: int = 0,
             # data_parallel_rank: int | None = None,
         )
-        # TODO: Copy this from our request if present
-        # vllm does not set this in process_inputs, but requires it in add_request
-        vllm_preproc.external_req_id = request_id
+        InputProcessor.assign_request_id(vllm_preproc)
 
         # Processed: EngineCoreRequest(request_id='a2b76a85cd65e151', prompt_token_ids=[3838, 374, 279, 6722, 315, 28649, 25510, 30], mm_features=None, sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=16, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, structured_outputs=None, extra_args=None), pooling_params=None, eos_token_id=151645, arrival_time=1769036937.9417946, lora_request=None, cache_salt=None, data_parallel_rank=None, prompt_embeds=None, client_index=0, current_wave=0, priority=0, trace_headers=None)
+
+        # Convert to a Python object that has fields that match our PreprocessedRequest
+        sp = vllm_preproc.sampling_params
+        if sp.n != 1:
+            logger.error("Unsupported SamplingParams.n=%d, only n=1 is supported", sp.n)
+            yield {
+                "id": request_id,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "error",
+                    }
+                ],
+                "created": int(time.time()),
+                "model": request["model"],
+                "object": "chat.completion.chunk",
+            }
+            return
 
         prompt = None
         self.output_processor.add_request(
@@ -249,12 +225,6 @@ class VllmProcessor:
             # request_index: int = 0,
             # queue: RequestOutputCollector | None = None,
         )
-
-        # Convert to a Python object that has fields that match our PreprocessedRequest
-        sp = vllm_preproc.sampling_params
-        if sp.n != 1:
-            logger.error("Ignoring unsupported SamplingParams.n != 1")
-            sp.n = 1
         dynamo_preproc = {
             "model": request["model"],
             "token_ids": tokens,
@@ -262,6 +232,7 @@ class VllmProcessor:
             "stop_conditions": {
                 "max_tokens": sp.max_tokens,
                 "stop": sp.stop,
+                "stop_token_ids": sp.stop_token_ids,
                 "min_tokens": sp.min_tokens,
                 "ignore_eos": sp.ignore_eos,
             },
@@ -291,61 +262,32 @@ class VllmProcessor:
             # "prompt_embeds": vllm_preproc.prompt_embeds,
         }
 
-        # Dynamo Router. This goes to the backend, waits, gets the streaming response, returns it.
-        # Stream is AsyncResponseStream
-        if self.is_kv_router:
-            dynamo_stream = await self.router.generate(
-                token_ids=tokens,
-                model=dynamo_preproc["model"],
-                stop_conditions=dynamo_preproc["stop_conditions"],
-                sampling_options=dynamo_preproc["sampling_options"],
-                output_options=dynamo_preproc["output_options"],
-            )
-        else:
-            # Round robin or random, depending on cmd line flag
-            dynamo_stream = await self.router.generate(dynamo_preproc)
-
-        reasoning_parser = (
-            self.reasoning_parser_class(
-                self.tokenizer,
-                # chat_template_kwargs=..
-            )
-            if self.reasoning_parser_class
-            else None
+        post = StreamingPostProcessor(
+            tokenizer=self.tokenizer,
+            request_for_sampling=request_for_sampling,
+            sampling_params=sampling_params,
+            prompt_token_ids=tokens,
+            tool_parser=tool_parser,
+            reasoning_parser_class=self.reasoning_parser_class,
+            chat_template_kwargs=chat_template_kwargs,
         )
-
-        previous_text = ""
-        previous_token_ids: list[int] = []
-        reasoning_is_done = False
-        in_progress_tool_calls: dict[int, DeltaToolCall] = {}
-
-        def merge_tool_call(
-            existing: DeltaToolCall | None, incoming: DeltaToolCall
-        ) -> DeltaToolCall:
-            if existing is None:
-                if incoming.function and incoming.function.arguments is None:
-                    incoming.function.arguments = ""
-                return incoming
-            if incoming.id and not existing.id:
-                existing.id = incoming.id
-            if incoming.type and not existing.type:
-                existing.type = incoming.type
-            if incoming.function:
-                if existing.function is None:
-                    existing.function = incoming.function
-                    if existing.function.arguments is None:
-                        existing.function.arguments = ""
-                else:
-                    if incoming.function.name and not existing.function.name:
-                        existing.function.name = incoming.function.name
-                    if incoming.function.arguments:
-                        if existing.function.arguments is None:
-                            existing.function.arguments = ""
-                        existing.function.arguments += incoming.function.arguments
-            return existing
 
         # dynamo_response: Annotated
         try:
+            # Dynamo Router. This goes to the backend, waits, gets the streaming response, returns it.
+            # Stream is AsyncResponseStream
+            if self.is_kv_router:
+                dynamo_stream = await self.router.generate(
+                    token_ids=tokens,
+                    model=dynamo_preproc["model"],
+                    stop_conditions=dynamo_preproc["stop_conditions"],
+                    sampling_options=dynamo_preproc["sampling_options"],
+                    output_options=dynamo_preproc["output_options"],
+                )
+            else:
+                # Round robin or random, depending on cmd line flag
+                dynamo_stream = await self.router.generate(dynamo_preproc)
+
             async for dynamo_response in dynamo_stream:
                 # dynamo_response looks like this for regular router:
                 # Stream got: Annotated(data={'token_ids': [7281]}, event=None, comment=[], id=None)
@@ -361,9 +303,19 @@ class VllmProcessor:
                 # Last: {'token_ids': [151645], 'finish_reason': 'stop', 'completion_usage': {'prompt_tokens': 190, 'completion_tokens': 168, 'total_tokens': 358, 'prompt_tokens_details': {'cached_tokens': 176}}}
 
                 if engine_response is None or "token_ids" not in engine_response:
+                    logger.error("No outputs from engine for request %s", request_id)
                     yield {
-                        "finish_reason": "error: No outputs from vLLM engine",
-                        "token_ids": [],
+                        "id": request_id,
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {},
+                                "finish_reason": "error",
+                            }
+                        ],
+                        "created": int(time.time()),
+                        "model": request["model"],
+                        "object": "chat.completion.chunk",
                     }
                     break
 
@@ -372,7 +324,7 @@ class VllmProcessor:
                 stop_reason = engine_response.get("stop_reason")
 
                 vllm_response = EngineCoreOutput(
-                    request_id=request_id,
+                    request_id=vllm_preproc.request_id,
                     new_token_ids=engine_response["token_ids"],
                     finish_reason=finish_reason,
                     stop_reason=stop_reason,
@@ -402,135 +354,9 @@ class VllmProcessor:
                 if not vllm_out.request_outputs:
                     continue
                 for output in vllm_out.request_outputs[0].outputs:
-                    delta_text = output.text
-                    delta_token_ids = output.token_ids
-
-                    current_text = previous_text + delta_text
-                    current_token_ids = previous_token_ids + delta_token_ids
-
-                    # Default if no reasoning or tool parsers
-                    delta_message = DeltaMessage(content=delta_text)
-
-                    if not reasoning_is_done and reasoning_parser:
-                        # Reasoning comes first in the response
-                        delta_message: DeltaMessage | None = (
-                            reasoning_parser.extract_reasoning_streaming(
-                                previous_text,
-                                current_text,
-                                delta_text,
-                                previous_token_ids,
-                                current_token_ids,
-                                delta_token_ids,
-                            )
-                        )
-
-                    should_parse_tools = (
-                        tool_parser is not None and tool_request is not None
-                    )
-                    if should_parse_tools:
-                        # Maybe we don't have a reasoning parser, or there was no reasoning to parse
-                        no_prev_reasoning = (
-                            delta_message
-                            and delta_message.content
-                            and not delta_message.reasoning_content
-                        )
-
-                        if reasoning_is_done or no_prev_reasoning:
-                            delta_message: DeltaMessage | None = (
-                                tool_parser.extract_tool_calls_streaming(
-                                    previous_text=previous_text,
-                                    current_text=current_text,
-                                    delta_text=delta_text,
-                                    previous_token_ids=previous_token_ids,
-                                    current_token_ids=current_token_ids,
-                                    delta_token_ids=delta_token_ids,
-                                    request=tool_request,
-                                )
-                            )
-
-                    if (
-                        not reasoning_is_done
-                        and reasoning_parser
-                        and reasoning_parser.is_reasoning_end_streaming(
-                            current_token_ids, delta_token_ids
-                        )
-                    ):
-                        reasoning_is_done = True
-                        previous_text = ""
-                        previous_token_ids = []
-                        current_text = ""
-                        current_token_ids = []
-
-                    if delta_message is None:
-                        # tokens being held back, might be tool call marker
-                        pass
-
-                    elif delta_message.tool_calls:
-                        # delta_message.tool_calls = DeltaToolCall objects to stream
-                        for tool_delta in delta_message.tool_calls:
-                            existing = in_progress_tool_calls.get(tool_delta.index)
-                            merged = merge_tool_call(existing, tool_delta)
-                            in_progress_tool_calls[tool_delta.index] = merged
-
-                    elif delta_message.content or delta_message.reasoning_content:
-                        # Stream content to user
-                        # ChatCompletionStreamResponseDelta
-                        delta = {"role": "assistant"}
-                        if delta_message.content:
-                            delta["content"] = delta_message.content
-                        if delta_message.reasoning_content:
-                            delta["reasoning_content"] = delta_message.reasoning_content
-
-                        if in_progress_tool_calls:
-                            delta["tool_calls"] = [
-                                tool_call.model_dump(exclude_none=True)
-                                for _, tool_call in sorted(
-                                    in_progress_tool_calls.items()
-                                )
-                            ]
-                            in_progress_tool_calls.clear()
-                        choices.append(
-                            {
-                                "index": output.index,
-                                "delta": delta,
-                                "finish_reason": output.finish_reason,
-                                "logprobs": output.logprobs,
-                            }
-                        )
-
-                    elif in_progress_tool_calls:
-                        # Empty content of any kind. Send any outstanding tool calls.
-                        choices.append(
-                            {
-                                "index": output.index,
-                                # ChatCompletionStreamResponseDelta
-                                "delta": {
-                                    "role": "assistant",
-                                    "tool_calls": [
-                                        tool_call.model_dump(exclude_none=True)
-                                        for _, tool_call in sorted(
-                                            in_progress_tool_calls.items()
-                                        )
-                                    ],
-                                },
-                                "finish_reason": output.finish_reason,
-                                "logprobs": output.logprobs,
-                            }
-                        )
-                        in_progress_tool_calls.clear()
-                    elif output.finish_reason:
-                        # Last response often has no content, but we need the finish reason
-                        choices.append(
-                            {
-                                "index": output.index,
-                                "delta": {},
-                                "finish_reason": output.finish_reason,
-                                "logprobs": output.logprobs,
-                            }
-                        )
-
-                    previous_text = current_text
-                    previous_token_ids = current_token_ids
+                    choice = post.process_output(output)
+                    if choice:
+                        choices.append(choice)
 
                 if choices:
                     # dynamo_out: NvCreateChatCompletionStreamResponse
@@ -548,8 +374,10 @@ class VllmProcessor:
                     # Rust handles HTTP / Server Sent Events back to user
                     yield dynamo_out
         finally:
-            if request_id in self.output_processor.request_states:
-                self.output_processor.abort_requests([request_id], internal=True)
+            if vllm_preproc.request_id in self.output_processor.request_states:
+                self.output_processor.abort_requests(
+                    [vllm_preproc.request_id], internal=True
+                )
 
 
 class EngineFactory:
@@ -571,25 +399,31 @@ class EngineFactory:
         """
         Called by Rust when a model is discovered.
         """
-        logger.debug(f"Engine_factory called with MDC: {mdc.to_json_str()}")
+        logger.debug("Engine_factory called with MDC: %s", mdc.to_json_str())
         loop = asyncio.get_running_loop()
 
         source_path = mdc.source_path()
         if not os.path.exists(source_path):
-            await fetch_llm(source_path)
+            await fetch_llm(source_path, ignore_weights=True)
+
+        tokenizer_mode = getattr(self.flags, "tokenizer_mode", None) or "auto"
+        config_format = getattr(self.flags, "config_format", None) or "auto"
+        load_format = getattr(self.flags, "load_format", None) or "dummy"
 
         model_config = ModelConfig(
             model=source_path,
+            tokenizer_mode=tokenizer_mode,
+            config_format=config_format,
         )
-        tokenizer = cached_tokenizer_from_config(model_config)
         vllm_config = VllmConfig(
             model_config=model_config,
-            load_config=LoadConfig(load_format="dummy"),
+            load_config=LoadConfig(load_format=load_format),
             cache_config=CacheConfig(),
             # scheduler_config=SchedulerConfig(),
         )
 
-        input_processor = InputProcessor(vllm_config, tokenizer)
+        input_processor = InputProcessor(vllm_config)
+        tokenizer = input_processor.get_tokenizer()
         output_processor = OutputProcessor(
             tokenizer,
             log_stats=False,

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -63,6 +63,9 @@ def map_finish_reason(raw_reason: str | None) -> FinishReason | None:
         return FinishReason.ERROR
     if raw_reason.startswith("abort"):
         return FinishReason.ABORT
+    if raw_reason.startswith("content_filter"):
+        logger.info("Router finish_reason indicates content filtering: %s", raw_reason)
+        raw_reason = "content_filter"
     mapped = _FINISH_REASON_MAP.get(raw_reason)
     if mapped is None:
         logger.warning("Unknown finish_reason from router: %s", raw_reason)

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -69,17 +69,22 @@ class VllmProcessor:
         elif "max_tokens" in request:
             max_tokens = request["max_tokens"]
         else:
-            max_tokens = 8192  # TODO what does rest of Dynamo do?
+            max_tokens = 8192
+
+        sampling_params = SamplingParams(
+            output_kind=RequestOutputKind.DELTA,
+            max_tokens=max_tokens,
+        )
+        for (k, v) in request.items():
+            if hasattr(sampling_params, k):
+                setattr(sampling_params, k, v)
 
         request_id = random_uuid()
+        # This calls update_from_generation_config and update_from_tokenizer on SamplingParams
         vllm_preproc: EngineCoreRequest = self.input_processor.process_inputs(
             request_id,
             templated,
-            SamplingParams(
-                output_kind=RequestOutputKind.DELTA,
-                max_tokens=max_tokens,
-                # TODO: so many sampling params user could set
-            ),
+            sampling_params,
             # arrival_time: float | None = None,
             # lora_request: LoRARequest | None = None,
             # tokenization_kwargs: dict[str, Any] | None = None,

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -25,6 +25,7 @@ from vllm.v1.engine.input_processor import InputProcessor
 from vllm.v1.engine.output_processor import OutputProcessor, OutputProcessorOutput
 
 from dynamo.llm import (
+    EngineFactoryUnsupportedModelTypeError,
     KvPushRouter,
     ModelCardInstanceId,
     ModelDeploymentCard,
@@ -400,6 +401,11 @@ class EngineFactory:
         Called by Rust when a model is discovered.
         """
         logger.debug("Engine_factory called with MDC: %s", mdc.to_json_str())
+        model_type = mdc.model_type()
+        if not model_type.supports_chat():
+            raise EngineFactoryUnsupportedModelTypeError(
+                f"model type {model_type} is not supported by this factory"
+            )
         loop = asyncio.get_running_loop()
 
         source_path = mdc.source_path()

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -25,7 +25,6 @@ from vllm.v1.engine.input_processor import InputProcessor
 from vllm.v1.engine.output_processor import OutputProcessor, OutputProcessorOutput
 
 from dynamo.llm import (
-    EngineFactoryUnsupportedModelTypeError,
     KvPushRouter,
     ModelCardInstanceId,
     ModelDeploymentCard,
@@ -395,7 +394,7 @@ class EngineFactory:
         self.router_config = router_config
         self.flags = flags
 
-    async def engine_factory(
+    async def chat_engine_factory(
         self,
         instance_id: ModelCardInstanceId,
         mdc: ModelDeploymentCard,
@@ -403,10 +402,9 @@ class EngineFactory:
         """
         Called by Rust when a model is discovered.
         """
-        logger.debug("Engine_factory called with MDC: %s", mdc.to_json_str())
         model_type = mdc.model_type()
         if not model_type.supports_chat():
-            raise EngineFactoryUnsupportedModelTypeError(
+            raise RuntimeError(
                 f"model type {model_type} is not supported by this factory"
             )
         loop = asyncio.get_running_loop()

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -75,7 +75,7 @@ class VllmProcessor:
             output_kind=RequestOutputKind.DELTA,
             max_tokens=max_tokens,
         )
-        for (k, v) in request.items():
+        for k, v in request.items():
             if hasattr(sampling_params, k):
                 setattr(sampling_params, k, v)
 

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -148,7 +148,7 @@ async fn engine_for(
             // Auto-discover backends
             Ok(EngineConfig::Dynamic {
                 model: Box::new(local_model),
-                engine_factory: None,
+                chat_engine_factory: None,
             })
         }
         Output::Echo => Ok(EngineConfig::InProcessText {

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -7,7 +7,6 @@ use dynamo_runtime::storage::kv;
 use futures::StreamExt;
 use once_cell::sync::OnceCell;
 use pyo3::IntoPyObjectExt;
-use pyo3::create_exception;
 use pyo3::exceptions::PyStopAsyncIteration;
 use pyo3::types::PyCapsule;
 use pyo3::types::{PyDict, PyString};
@@ -74,12 +73,6 @@ type JsonServerStreamingIngress =
 static INIT: OnceCell<()> = OnceCell::new();
 
 const DEFAULT_ANNOTATED_SETTING: Option<bool> = Some(true);
-
-create_exception!(
-    _core,
-    EngineFactoryUnsupportedModelTypeError,
-    pyo3::exceptions::PyException
-);
 
 // Helper to get appropriate span for instrumentation - always emit spans
 fn get_span_for_context(context: &context::Context, operation: &str) -> tracing::Span {
@@ -185,10 +178,6 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<llm::kv::KvPushRouter>()?;
     m.add_class::<llm::kv::KvPushRouterStream>()?;
     m.add_class::<RouterMode>()?;
-    m.add(
-        "EngineFactoryUnsupportedModelTypeError",
-        m.py().get_type::<EngineFactoryUnsupportedModelTypeError>(),
-    )?;
     m.add_class::<kserve_grpc::KserveGrpcService>()?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<planner::VirtualConnectorCoordinator>()?;

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -149,6 +149,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Namespace>()?;
     m.add_class::<Component>()?;
     m.add_class::<Endpoint>()?;
+    m.add_class::<ModelCardInstanceId>()?;
     m.add_class::<Client>()?;
     m.add_class::<AsyncResponseStream>()?;
     m.add_class::<llm::entrypoint::EntrypointArgs>()?;
@@ -479,6 +480,12 @@ struct Component {
 struct Endpoint {
     inner: rs::component::Endpoint,
     event_loop: PyObject,
+}
+
+#[pyclass]
+#[derive(Clone)]
+struct ModelCardInstanceId {
+    inner: rs::discovery::ModelCardInstanceId,
 }
 
 #[pyclass]
@@ -889,6 +896,19 @@ impl Namespace {
             inner,
             event_loop: self.event_loop.clone(),
         })
+    }
+}
+
+#[pymethods]
+impl ModelCardInstanceId {
+    // (namespace, component, endpoint)
+    // TODO: Can these be borrowed as &str?
+    fn triple(&self) -> (String, String, String) {
+        (
+            self.inner.namespace.clone(),
+            self.inner.component.clone(),
+            self.inner.endpoint.clone(),
+        )
     }
 }
 

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -11,8 +11,8 @@ use pyo3::{exceptions::PyException, prelude::*};
 use pyo3_async_runtimes::TaskLocals;
 
 use dynamo_llm::discovery::LoadThresholdConfig as RsLoadThresholdConfig;
-use dynamo_llm::entrypoint::EngineConfig as RsEngineConfig;
 use dynamo_llm::entrypoint::ChatEngineFactoryCallback;
+use dynamo_llm::entrypoint::EngineConfig as RsEngineConfig;
 use dynamo_llm::entrypoint::RouterConfig as RsRouterConfig;
 use dynamo_llm::entrypoint::input::Input;
 use dynamo_llm::kv_router::KvRouterConfig as RsKvRouterConfig;
@@ -385,9 +385,7 @@ async fn select_engine(
         }
         EngineType::Dynamic => {
             //  Convert Python chat engine factory to Rust callback
-            let chat_engine_factory = args
-                .chat_engine_factory
-                .map(py_engine_factory_to_callback);
+            let chat_engine_factory = args.chat_engine_factory.map(py_engine_factory_to_callback);
             RsEngineConfig::Dynamic {
                 model: Box::new(local_model),
                 chat_engine_factory,

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -92,8 +92,12 @@ impl KvRouterConfig {
 #[pyclass]
 #[derive(Clone, Debug)]
 pub struct RouterConfig {
-    router_mode: RouterMode,
-    kv_router_config: KvRouterConfig,
+    #[pyo3(get, set)]
+    pub router_mode: RouterMode,
+
+    #[pyo3(get, set)]
+    pub kv_router_config: KvRouterConfig,
+
     /// Threshold for active decode blocks utilization (0.0-1.0)
     active_decode_blocks_threshold: Option<f64>,
     /// Threshold for active prefill tokens utilization (literal token count)

--- a/lib/bindings/python/rust/llm/model_card.rs
+++ b/lib/bindings/python/rust/llm/model_card.rs
@@ -40,4 +40,9 @@ impl ModelDeploymentCard {
     fn name(&self) -> &str {
         self.inner.name()
     }
+
+    fn runtime_config(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let rc = pythonize::pythonize(py, &self.inner.runtime_config).map_err(to_pyerr)?;
+        Ok(rc.unbind())
+    }
 }

--- a/lib/bindings/python/rust/llm/model_card.rs
+++ b/lib/bindings/python/rust/llm/model_card.rs
@@ -36,4 +36,8 @@ impl ModelDeploymentCard {
     fn source_path(&self) -> &str {
         self.inner.source_path()
     }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
 }

--- a/lib/bindings/python/rust/llm/model_card.rs
+++ b/lib/bindings/python/rust/llm/model_card.rs
@@ -32,4 +32,8 @@ impl ModelDeploymentCard {
         let json = self.inner.to_json().map_err(to_pyerr)?;
         Ok(json)
     }
+
+    fn source_path(&self) -> &str {
+        self.inner.source_path()
+    }
 }

--- a/lib/bindings/python/rust/llm/model_card.rs
+++ b/lib/bindings/python/rust/llm/model_card.rs
@@ -10,8 +10,6 @@ pub(crate) struct ModelDeploymentCard {
     pub(crate) inner: RsModelDeploymentCard,
 }
 
-impl ModelDeploymentCard {}
-
 #[pymethods]
 impl ModelDeploymentCard {
     // Previously called "from_local_path"
@@ -39,6 +37,12 @@ impl ModelDeploymentCard {
 
     fn name(&self) -> &str {
         self.inner.name()
+    }
+
+    fn model_type(&self) -> ModelType {
+        ModelType {
+            inner: self.inner.model_type,
+        }
     }
 
     fn runtime_config(&self, py: Python<'_>) -> PyResult<PyObject> {

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -251,6 +251,18 @@ class Client:
         ...
 
 
+class ModelCardInstanceId:
+    """
+    Unique identifier for a worker instance: namespace, component, endpoint and instance_id.
+    The instance_id is not currently exposed in the Python bindings.
+    """
+    def triple(self) -> (str, str, str):
+        """
+        Triple of namespace, component and endpoint this worker is serving.
+        """
+        ...
+
+
 def compute_block_hash_for_seq_py(
     tokens: List[int],
     kv_block_size: int,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -166,7 +166,14 @@ class Endpoint:
 
     async def client(self) -> Client:
         """
-        Create a `Client` capable of calling served instances of this endpoint
+        Create a `Client` capable of calling served instances of this endpoint using round-robin routing.
+        """
+        ...
+
+    async def client2(self, router_mode: RouterMode) -> Client:
+        """
+        Create a `Client` capable of calling served instances of this endpoint, using a specific
+        router mode (random, round-robin, kv).
         """
         ...
 
@@ -1595,4 +1602,5 @@ __all__ = [
     "ModelDeploymentCard",
     "PythonAsyncEngine",
     "prometheus_names",
+    "ModelCardInstanceId",
 ]

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1523,7 +1523,7 @@ class EntrypointArgs:
         namespace: Optional[str] = None,
         is_prefill: bool = False,
         migration_limit: int = 0,
-        engine_factory: Optional[Callable] = None,
+        chat_engine_factory: Optional[Callable] = None,
     ) -> None:
         """
         Create EntrypointArgs.
@@ -1546,7 +1546,7 @@ class EntrypointArgs:
             namespace: Dynamo namespace for model discovery scoping
             is_prefill: Whether this is a prefill worker
             migration_limit: Maximum number of request migrations (0=disabled)
-            engine_factory: Optional Python engine factory callback
+            chat_engine_factory: Optional Python chat completions engine factory callback
         """
         ...
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -263,7 +263,7 @@ class ModelCardInstanceId:
     Unique identifier for a worker instance: namespace, component, endpoint and instance_id.
     The instance_id is not currently exposed in the Python bindings.
     """
-    def triple(self) -> (str, str, str):
+    def triple(self) -> Tuple[str, str, str]:
         """
         Triple of namespace, component and endpoint this worker is serving.
         """

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -18,6 +18,7 @@ from dynamo._core import KvRouterConfig as KvRouterConfig
 from dynamo._core import LoRADownloader as LoRADownloader
 from dynamo._core import MediaDecoder as MediaDecoder
 from dynamo._core import MediaFetcher as MediaFetcher
+from dynamo._core import ModelCardInstanceId as ModelCardInstanceId
 from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
 from dynamo._core import ModelInput as ModelInput
 from dynamo._core import ModelRuntimeConfig as ModelRuntimeConfig

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -6,7 +6,7 @@
 import logging
 
 from dynamo._core import ApproxKvIndexer as ApproxKvIndexer
-from dynamo._core import EngineFactoryUnsupportedModelTypeError, EngineType
+from dynamo._core import EngineType
 from dynamo._core import EntrypointArgs as EntrypointArgs
 from dynamo._core import HttpAsyncEngine as HttpAsyncEngine
 from dynamo._core import HttpService as HttpService

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -6,8 +6,7 @@
 import logging
 
 from dynamo._core import ApproxKvIndexer as ApproxKvIndexer
-from dynamo._core import EngineType
-from dynamo._core import EngineFactoryUnsupportedModelTypeError
+from dynamo._core import EngineFactoryUnsupportedModelTypeError, EngineType
 from dynamo._core import EntrypointArgs as EntrypointArgs
 from dynamo._core import HttpAsyncEngine as HttpAsyncEngine
 from dynamo._core import HttpService as HttpService

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -7,6 +7,7 @@ import logging
 
 from dynamo._core import ApproxKvIndexer as ApproxKvIndexer
 from dynamo._core import EngineType
+from dynamo._core import EngineFactoryUnsupportedModelTypeError
 from dynamo._core import EntrypointArgs as EntrypointArgs
 from dynamo._core import HttpAsyncEngine as HttpAsyncEngine
 from dynamo._core import HttpService as HttpService

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -487,9 +487,9 @@ impl ModelWatcher {
 
             // Add chat engine only if the model supports chat
             if card.model_type.supports_chat() {
-                // Work in progress. This will allow creating  a chat_engine from Python.
+                // Use Python to create the chat engine
                 let chat_engine = if let Some(ref factory) = self.engine_factory {
-                    factory(card.clone())
+                    factory(mcid.clone(), card.clone())
                         .await
                         .context("python engine_factory")?
                 } else {

--- a/lib/llm/src/entrypoint.rs
+++ b/lib/llm/src/entrypoint.rs
@@ -20,6 +20,20 @@ use crate::{
     types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine,
 };
 
+#[derive(Debug, thiserror::Error)]
+#[error("engine factory unsupported model type: {message}")]
+pub struct EngineFactoryUnsupportedModelTypeError {
+    message: String,
+}
+
+impl EngineFactoryUnsupportedModelTypeError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
 /// Callback type for engine factory (async)
 pub type EngineFactoryCallback = Arc<
     dyn Fn(

--- a/lib/llm/src/entrypoint.rs
+++ b/lib/llm/src/entrypoint.rs
@@ -12,7 +12,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use dynamo_runtime::pipeline::RouterMode;
+use dynamo_runtime::{discovery::ModelCardInstanceId, pipeline::RouterMode};
 
 use crate::{
     backend::ExecutionContext, discovery::LoadThresholdConfig, engines::StreamingEngine,
@@ -23,6 +23,7 @@ use crate::{
 /// Callback type for engine factory (async)
 pub type EngineFactoryCallback = Arc<
     dyn Fn(
+            ModelCardInstanceId,
             ModelDeploymentCard,
         ) -> Pin<
             Box<dyn Future<Output = anyhow::Result<OpenAIChatCompletionsStreamingEngine>> + Send>,

--- a/lib/llm/src/entrypoint.rs
+++ b/lib/llm/src/entrypoint.rs
@@ -20,22 +20,8 @@ use crate::{
     types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine,
 };
 
-#[derive(Debug, thiserror::Error)]
-#[error("engine factory unsupported model type: {message}")]
-pub struct EngineFactoryUnsupportedModelTypeError {
-    message: String,
-}
-
-impl EngineFactoryUnsupportedModelTypeError {
-    pub fn new(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-        }
-    }
-}
-
-/// Callback type for engine factory (async)
-pub type EngineFactoryCallback = Arc<
+/// Callback type for chat engine factory (async)
+pub type ChatEngineFactoryCallback = Arc<
     dyn Fn(
             ModelCardInstanceId,
             ModelDeploymentCard,
@@ -80,7 +66,7 @@ pub enum EngineConfig {
     /// Remote networked engines that we discover via etcd
     Dynamic {
         model: Box<LocalModel>,
-        engine_factory: Option<EngineFactoryCallback>,
+        chat_engine_factory: Option<ChatEngineFactoryCallback>,
     },
 
     /// A Text engine receives text, does it's own tokenization and prompt formatting.
@@ -107,9 +93,12 @@ impl EngineConfig {
         }
     }
 
-    pub fn engine_factory(&self) -> Option<&EngineFactoryCallback> {
+    pub fn chat_engine_factory(&self) -> Option<&ChatEngineFactoryCallback> {
         match self {
-            EngineConfig::Dynamic { engine_factory, .. } => engine_factory.as_ref(),
+            EngineConfig::Dynamic {
+                chat_engine_factory,
+                ..
+            } => chat_engine_factory.as_ref(),
             _ => None,
         }
     }

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -7,7 +7,7 @@ use crate::{
     discovery::{ModelManager, ModelUpdate, ModelWatcher},
     endpoint_type::EndpointType,
     engines::StreamingEngineAdapter,
-    entrypoint::{EngineConfig, EngineFactoryCallback, RouterConfig, input::common},
+    entrypoint::{ChatEngineFactoryCallback, EngineConfig, RouterConfig, input::common},
     http::service::service_v2::{self, HttpService},
     namespace::is_global_namespace,
     types::openai::{
@@ -54,7 +54,7 @@ pub async fn run(
     let http_service = match engine_config {
         EngineConfig::Dynamic {
             ref model,
-            ref engine_factory,
+            ref chat_engine_factory,
         } => {
             // This allows the /health endpoint to query store for active instances
             http_service_builder = http_service_builder.store(distributed_runtime.store().clone());
@@ -79,7 +79,7 @@ pub async fn run(
                 target_namespace,
                 Arc::new(http_service.clone()),
                 http_service.state().metrics_clone(),
-                engine_factory.clone(),
+                chat_engine_factory.clone(),
             )
             .await?;
             http_service
@@ -157,14 +157,14 @@ async fn run_watcher(
     target_namespace: Option<String>,
     http_service: Arc<HttpService>,
     metrics: Arc<crate::http::service::metrics::Metrics>,
-    engine_factory: Option<EngineFactoryCallback>,
+    chat_engine_factory: Option<ChatEngineFactoryCallback>,
 ) -> anyhow::Result<()> {
     let mut watch_obj = ModelWatcher::new(
         runtime.clone(),
         model_manager,
         router_config,
         migration_limit,
-        engine_factory,
+        chat_engine_factory,
         metrics.clone(),
     );
     tracing::debug!("Waiting for remote model");

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1051,6 +1051,7 @@ impl
         let (mut common_request, annotations) = self
             .preprocess_request(&request, tracker.as_deref())
             .await?;
+        tracing::trace!(request = ?common_request, "Pre-processed request");
 
         // Attach the timing tracker to the request so downstream components can record metrics
         common_request.tracker = tracker;


### PR DESCRIPTION
Part of: https://github.com/ai-dynamo/enhancements/pull/52

Depends on [vllm 0.15.1 upgrade](https://github.com/ai-dynamo/dynamo/pull/6102).

## Qwen3 usage

- Frontend with vllm pre/post:
```
python -m dynamo.frontend --store-kv file --request-plane tcp --chat_processor vllm
```

- vllm (however you run it normally)
```
python -m dynamo.vllm --connector none --max-model-len 4096 --model ~/llms/Qwen3-0.6B --served-model-name Qwen/Qwen3-0.6B --store-kv file --request-plane tcp --kv-events-config '{"enable_kv_cache_events": false}'
```

- Make a request
```
curl -v http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{"model": "Qwen/Qwen3-0.6B", "max_completion_tokens": 2000, "stream": false, "messages": [{"role": 2, "content": "What is the capital of Tuvalu?"}]}'
```

---

## Mistral usage

```
python -m dynamo.frontend --store-kv file --request-plane tcp --chat_processor vllm --tokenizer_mode mistral --config_format mistral --load_format mistral
```

and

```
python -m dynamo.vllm --connector none --max-model-len 4096 --model mistralai/Ministral-3-3B-Reasoning-2512 --store-kv file --request-plane tcp --kv-events-config '{"enable_kv_cache_events": false}' --tokenizer_mode mistral --config_format mistral --load_format mistral
```

For now that means the frontend can only serve a single model if using mistral.

## Features

Larger features it supports that I verified:

- Reasoning parsing
- Tool use / parsing
- generation_config.json
- KV routing, regular routing
- Usage stats on last request
- vllm doesn't load or download the weights, as it's pre/post processing only
- All sampling params

## Validation

- Tested manually with Qwen3 0.6B
- Tested manually with Ministral 3B
- Many rounds of AI-assisted review with Opus 4.5, GPT 5.3 Codex, and Code Rabbit.
- Ran multiple concurrent long requests manually
- Used [aiperf](https://github.com/ai-dynamo/aiperf) for basic load testing

 # Architecture Summary                                         
```                                  
  HTTP Request                                                                                                                 
    → Rust HTTP server (axum)                                  
      → PythonAsyncEngine (engine.rs) — acquires GIL via spawn_blocking                                                                                                                                                                                       
        → VllmProcessor.generator() [Python]                                                                                                                                                                                                                  
          → preprocess_chat_request()        # Pydantic validation, template rendering, tokenization                           
          → input_processor.process_inputs() # vLLM preprocessing, grammar validation                                          
          → router.generate()                # → Rust router → backend worker (GIL released here)                              
          → for each token:                                    
              → output_processor.process_outputs()  # detokenization, stop-string checking
              → post.process_output()               # tool/reasoning parsing                                                                                                                                                                                  
              → yield dict                          # → Rust deserializes (acquires GIL again) 
```