### PR TITLE
chore: update K8s deployment images to use NVCR registry

### DIFF
--- a/benchmarks/incluster/benchmark_job.yaml
+++ b/benchmarks/incluster/benchmark_job.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: benchmark-runner
         # TODO: update to latest public image in next release
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/benchmarks/profiler/deploy/profile_sla_aic_dgdr.yaml
+++ b/benchmarks/profiler/deploy/profile_sla_aic_dgdr.yaml
@@ -12,7 +12,7 @@ spec:
 
   # ProfilingConfig maps directly to the profile_sla.py config format
   profilingConfig:
-    profilerImage: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag"
+    profilerImage: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}"
 
     # NOTE: any image built before January 10 and any release prior to 0.8.1
     # will need to use snake_case within profilingConfig.config
@@ -26,5 +26,5 @@ spec:
         ttft: 500.0
         itl: 30.0
   deploymentOverrides:
-    workersImage: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag"
+    workersImage: "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}"
   autoApply: true

--- a/benchmarks/profiler/deploy/profile_sla_dgdr.yaml
+++ b/benchmarks/profiler/deploy/profile_sla_dgdr.yaml
@@ -12,7 +12,7 @@ spec:
 
   # ProfilingConfig maps directly to the profile_sla.py config format
   profilingConfig:
-    profilerImage: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag"
+    profilerImage: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.0"
 
     # NOTE: any image built before January 10 and any release prior to 0.8.1
     # will need to use snake_case within profilingConfig.config
@@ -25,5 +25,5 @@ spec:
         ttft: 200.0
         itl: 20.0
   deploymentOverrides:
-    workersImage: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag"
+    workersImage: "nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.8.0"
   autoApply: true

--- a/benchmarks/profiler/deploy/profile_sla_moe_dgdr.yaml
+++ b/benchmarks/profiler/deploy/profile_sla_moe_dgdr.yaml
@@ -13,7 +13,7 @@ spec:
 
   # ProfilingConfig maps directly to the profile_sla.py config format
   profilingConfig:
-    profilerImage: "nvcr.io/nvidia/ai-dynamo/sglang-runtime:my-tag"
+    profilerImage: "nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}"
 
     # NOTE: any image built before January 10 and any release prior to 0.8.1
     # will need to use snake_case within profilingConfig.config
@@ -47,6 +47,6 @@ spec:
       key: tep16p-dep16d-disagg.yaml
 
   deploymentOverrides:
-    workersImage: "nvcr.io/nvidia/ai-dynamo/sglang-runtime:my-tag"
+    workersImage: "nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}"
   autoApply: true
 

--- a/examples/backends/mocker/deploy/agg.yaml
+++ b/examples/backends/mocker/deploy/agg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/mocker-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/mocker-runtime:${VERSION}
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -20,7 +20,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/mocker-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/mocker-runtime:${VERSION}
           workingDir: /workspace
           command:
           - python3

--- a/examples/backends/mocker/deploy/disagg.yaml
+++ b/examples/backends/mocker/deploy/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/mocker-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/mocker-runtime:${VERSION}
     prefill:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -20,7 +20,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/mocker-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/mocker-runtime:${VERSION}
           workingDir: /workspace
           command:
           - python3
@@ -43,7 +43,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/mocker-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/mocker-runtime:${VERSION}
           workingDir: /workspace
           command:
           - python3

--- a/examples/backends/sglang/deploy/agg.yaml
+++ b/examples/backends/sglang/deploy/agg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.8.0
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -22,7 +22,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.8.0
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/agg_logging.yaml
+++ b/examples/backends/sglang/deploy/agg_logging.yaml
@@ -15,7 +15,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/agg_router.yaml
+++ b/examples/backends/sglang/deploy/agg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg-multinode.yaml
+++ b/examples/backends/sglang/deploy/disagg-multinode.yaml
@@ -21,7 +21,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
     decode:
       multinode:
         nodeCount: 2
@@ -33,7 +33,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3
@@ -69,7 +69,7 @@ spec:
           gpu: "4"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg.yaml
+++ b/examples/backends/sglang/deploy/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -23,7 +23,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3
@@ -58,7 +58,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/examples/backends/sglang
           command:
           - python3

--- a/examples/backends/sglang/deploy/disagg_planner.yaml
+++ b/examples/backends/sglang/deploy/disagg_planner.yaml
@@ -12,14 +12,14 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
     Planner:
       envFromSecret: hf-token-secret
       componentType: planner
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/components/src/dynamo/planner
           command:
           - python3
@@ -50,7 +50,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/examples/backends/sglang
           command:
             - python3
@@ -85,7 +85,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/examples/backends/sglang
           command:
             - python3

--- a/examples/backends/trtllm/deploy/agg-with-config.yaml
+++ b/examples/backends/trtllm/deploy/agg-with-config.yaml
@@ -33,7 +33,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -48,7 +48,7 @@ spec:
           configMap:
             name: nvidia-config
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/trtllm
           # mount the configmap as a volume
           volumeMounts:

--- a/examples/backends/trtllm/deploy/agg.yaml
+++ b/examples/backends/trtllm/deploy/agg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
     TRTLLMWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -22,7 +22,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/agg_router.yaml
+++ b/examples/backends/trtllm/deploy/agg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/trtllm/deploy/disagg-multinode.yaml
@@ -97,7 +97,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/trtllm
           command:
           - python3
@@ -128,7 +128,7 @@ spec:
             - name: nvidia-config
               mountPath: /workspace/
               readOnly: true
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/
           command:
           - python3
@@ -165,7 +165,7 @@ spec:
             - name: nvidia-config
               mountPath: /workspace/
               readOnly: true
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg.yaml
+++ b/examples/backends/trtllm/deploy/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
     TRTLLMPrefillWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -23,7 +23,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/
           command:
           - python3
@@ -48,7 +48,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/trtllm/deploy/disagg_planner.yaml
+++ b/examples/backends/trtllm/deploy/disagg_planner.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/trtllm
           command:
             - python3
@@ -36,7 +36,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/components/src/dynamo/planner
           ports:
             - name: metrics
@@ -85,7 +85,7 @@ spec:
       extraPodSpec:
         terminationGracePeriodSeconds: 600
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/
           command:
             - python3
@@ -111,7 +111,7 @@ spec:
       extraPodSpec:
         terminationGracePeriodSeconds: 600
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/
           command:
             - python3

--- a/examples/backends/trtllm/deploy/disagg_router.yaml
+++ b/examples/backends/trtllm/deploy/disagg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/
           command:
           - python3
@@ -50,7 +50,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/
           command:
           - python3

--- a/examples/backends/vllm/deploy/agg.yaml
+++ b/examples/backends/vllm/deploy/agg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -22,7 +22,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -29,7 +29,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/agg_router.yaml
+++ b/examples/backends/vllm/deploy/agg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/agg_router_kv_approx.yaml
+++ b/examples/backends/vllm/deploy/agg_router_kv_approx.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           command:
             - python3
           args:
@@ -37,7 +37,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/disagg-multinode.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -32,7 +32,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -54,7 +54,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg.yaml
+++ b/examples/backends/vllm/deploy/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -23,7 +23,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -43,7 +43,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -22,7 +22,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -50,7 +50,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -22,7 +22,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -50,7 +50,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -24,7 +24,7 @@ spec:
           gpu: "2"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -56,7 +56,7 @@ spec:
           value: "100"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/backends/vllm/deploy/disagg_planner.yaml
+++ b/examples/backends/vllm/deploy/disagg_planner.yaml
@@ -12,13 +12,13 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     Planner:
       componentType: planner
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/components/src/dynamo/planner
           command:
           - python3
@@ -49,7 +49,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -68,7 +68,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -25,7 +25,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -44,7 +44,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/examples/basics/kubernetes/Distributed_Inference/agg_router.yaml
+++ b/examples/basics/kubernetes/Distributed_Inference/agg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -33,7 +33,7 @@ spec:
             path: /YOUR/LOCAL/CACHE/FOLDER
             type: DirectoryOrCreate
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           volumeMounts:
           - name: local-model-cache
             mountPath: /root/.cache

--- a/examples/basics/kubernetes/Distributed_Inference/disagg_router.yaml
+++ b/examples/basics/kubernetes/Distributed_Inference/disagg_router.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
       envs:
         - name: DYN_ROUTER_MODE
           value: kv
@@ -33,7 +33,7 @@ spec:
             path: /YOUR/LOCAL/CACHE/FOLDER
             type: DirectoryOrCreate
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           volumeMounts:
           - name: local-model-cache
@@ -60,7 +60,7 @@ spec:
             path: /YOUR/LOCAL/CACHE/FOLDER
             type: DirectoryOrCreate
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           volumeMounts:
           - name: local-model-cache

--- a/examples/custom_backend/hello_world/deploy/hello_world.yaml
+++ b/examples/custom_backend/hello_world/deploy/hello_world.yaml
@@ -40,7 +40,7 @@ spec:
           memory: "2Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/dynamo:my-tag
+          image: my-registry/dynamo:${VERSION}
           workingDir: /workspace/examples/custom_backend/hello_world/
           command:
             - /bin/sh
@@ -78,7 +78,7 @@ spec:
           memory: "4Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/dynamo:my-tag
+          image: my-registry/dynamo:${VERSION}
           workingDir: /workspace/examples/custom_backend/hello_world/
           command:
             - /bin/sh

--- a/examples/deployments/GKE/sglang/disagg.yaml
+++ b/examples/deployments/GKE/sglang/disagg.yaml
@@ -11,7 +11,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -22,7 +22,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/examples/backends/sglang
           command:
             - /bin/sh
@@ -44,7 +44,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace/examples/backends/sglang
           command:
             - /bin/sh

--- a/examples/deployments/GKE/vllm/disagg.yaml
+++ b/examples/deployments/GKE/vllm/disagg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -25,7 +25,7 @@ spec:
         mainContainer:
           startupProbe:
             initialDelaySeconds: 180
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -46,7 +46,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/examples/multimodal/deploy/agg_llava.yaml
+++ b/examples/multimodal/deploy/agg_llava.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     EncodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -23,7 +23,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -39,7 +39,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -55,7 +55,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh

--- a/examples/multimodal/deploy/agg_qwen.yaml
+++ b/examples/multimodal/deploy/agg_qwen.yaml
@@ -13,7 +13,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     EncodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -23,7 +23,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -39,7 +39,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh
@@ -55,7 +55,7 @@ spec:
           gpu: "1"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/multimodal
           command:
             - /bin/sh

--- a/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
@@ -21,7 +21,7 @@ spec:
           mountPoint: /opt/model
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
     decode:
       componentType: worker
       subComponentType: decode
@@ -38,7 +38,7 @@ spec:
         size: 80Gi
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /sgl-workspace/dynamo
           command:
             - python3
@@ -83,7 +83,7 @@ spec:
         size: 80Gi
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /sgl-workspace/dynamo
           command:
             - python3

--- a/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
@@ -21,7 +21,7 @@ spec:
           mountPoint: /opt/model
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
     decode:
       componentType: worker
       subComponentType: decode
@@ -36,7 +36,7 @@ spec:
         size: 80Gi
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace
           command:
             - python3
@@ -78,7 +78,7 @@ spec:
         size: 80Gi
       extraPodSpec:
         mainContainer:
-          image: my-registry/sglang-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:${VERSION}
           workingDir: /workspace
           command:
             - python3

--- a/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
+++ b/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml
@@ -126,7 +126,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           args:
           - |
             python3 -m dynamo.frontend --http-port 8000
@@ -158,7 +158,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/components/backends/trtllm
           # NOTE: If your PVCs (Persistent Volume Claims) are really slow,
           #       you might need to increase 'failureThreshold' below to allow more time for startup
@@ -216,7 +216,7 @@ spec:
         tolerations: []
         affinity: {}
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/components/backends/trtllm
           # NOTE: If your PVCs (Persistent Volume Claims) are really slow,
           #       you might need to increase 'failureThreshold' below to allow more time for startup

--- a/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
+++ b/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
@@ -23,7 +23,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1800
             failureThreshold: 60
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     decode:
       componentType: worker
       subComponentType: decode
@@ -49,7 +49,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/dynamo
           env:
             - name: VLLM_USE_DEEP_GEMM
@@ -110,7 +110,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 600
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/dynamo
           env:
             - name: VLLM_USE_DEEP_GEMM

--- a/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
@@ -45,7 +45,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
       replicas: 1
     TrtllmWorker:
       componentType: main
@@ -79,7 +79,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: my-registry/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"

--- a/recipes/llama-3-70b/vllm/agg/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/agg/deploy.yaml
@@ -17,7 +17,7 @@ spec:
           mountPoint: /opt/models
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
       envs:
         - name: HF_HOME
@@ -45,7 +45,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-multi-node/deploy.yaml
@@ -17,7 +17,7 @@ spec:
           mountPoint: /opt/models
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
       envs:
         - name: HF_HOME
@@ -46,7 +46,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:
@@ -77,7 +77,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-single-node/deploy.yaml
@@ -17,7 +17,7 @@ spec:
           mountPoint: /opt/models
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
       envs:
         - name: HF_HOME
@@ -58,7 +58,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
       replicas: 2
       resources:
@@ -101,7 +101,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
       replicas: 1
       resources:

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
@@ -54,7 +54,7 @@ spec:
                     - qwen3-235b-a22b-agg-frontend
               topologyKey: kubernetes.io/hostname
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           args:
             - python3 -m dynamo.frontend --router-mode kv --http-port 8000
           command:
@@ -90,7 +90,7 @@ spec:
               --model-path "${MODEL_PATH}" \
               --served-model-name "Qwen/Qwen3-235B-A22B-FP8" \
               --extra-engine-args "${ENGINE_ARGS}"
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/components/backends/trtllm
           volumeMounts:
             - name: agg-config

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml
@@ -83,7 +83,7 @@ spec:
                     - qwen3-235b-a22b-disagg-frontend
               topologyKey: kubernetes.io/hostname
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           args:
             - python3 -m dynamo.frontend --router-mode kv --http-port 8000
           command:
@@ -115,7 +115,7 @@ spec:
               value: /mnt/model-cache/hub/models--Qwen--Qwen3-235B-A22B-FP8/snapshots/39eb2b067ea6b8e3e1dd97d3cd0c7ffeaf3e1a35
             - name: ENGINE_ARGS
               value: /engine_configs/prefill.yaml
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh
@@ -166,7 +166,7 @@ spec:
               value: /mnt/model-cache/hub/models--Qwen--Qwen3-235B-A22B-FP8/snapshots/39eb2b067ea6b8e3e1dd97d3cd0c7ffeaf3e1a35
             - name: ENGINE_ARGS
               value: /engine_configs/decode.yaml
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           workingDir: /workspace/components/backends/trtllm
           command:
             - /bin/sh

--- a/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml
@@ -61,7 +61,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
       replicas: 1
     TrtllmWorker:
       componentType: main
@@ -94,7 +94,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"

--- a/recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml
@@ -218,7 +218,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
       replicas: 1
     TrtllmPrefillWorker:
       componentType: worker
@@ -253,7 +253,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"
@@ -313,7 +313,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:${VERSION}
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"

--- a/recipes/qwen3-32b/vllm/agg-round-robin/deploy.yaml
+++ b/recipes/qwen3-32b/vllm/agg-round-robin/deploy.yaml
@@ -18,7 +18,7 @@ spec:
           value: /home/dynamo/.cache/huggingface
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace
           command:
             - python3
@@ -63,7 +63,7 @@ spec:
           - python3
           - -m
           - dynamo.vllm
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           env:
           - name: DYN_HEALTH_CHECK_ENABLED
             value: "false"

--- a/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml
+++ b/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml
@@ -26,7 +26,7 @@ spec:
             - python
             - -m
             - dynamo.frontend
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace
       replicas: 1
       resources:
@@ -60,7 +60,7 @@ spec:
           - python3
           - -m
           - dynamo.vllm
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace
           env:
           - name: DYN_HEALTH_CHECK_ENABLED
@@ -112,7 +112,7 @@ spec:
           - python3
           - -m
           - dynamo.vllm
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           env:
           - name: DYN_HEALTH_CHECK_ENABLED
             value: "false"

--- a/tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_agg.yaml
@@ -12,7 +12,7 @@ spec:
       replicas: 1
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -48,7 +48,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/tests/fault_tolerance/deploy/templates/vllm/moe_disagg.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/moe_disagg.yaml
@@ -14,7 +14,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -51,7 +51,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3
@@ -116,7 +116,7 @@ spec:
         imagePullSecrets:
         - name: nvcr-imagepullsecret
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
           - python3

--- a/tests/planner/perf_test_configs/agg_8b.yaml
+++ b/tests/planner/perf_test_configs/agg_8b.yaml
@@ -37,7 +37,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_2p2d.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_2p2d.yaml
@@ -37,7 +37,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -131,7 +131,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_3p1d.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_3p1d.yaml
@@ -37,7 +37,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -131,7 +131,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/disagg_8b_planner.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_planner.yaml
@@ -40,7 +40,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -72,7 +72,7 @@ spec:
         failureThreshold: 10
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/components/src/dynamo/planner
           ports:
             - name: metrics
@@ -133,7 +133,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3
@@ -187,7 +187,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - python3

--- a/tests/planner/perf_test_configs/disagg_8b_tp2.yaml
+++ b/tests/planner/perf_test_configs/disagg_8b_tp2.yaml
@@ -37,7 +37,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -131,7 +131,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh

--- a/tests/planner/perf_test_configs/image_cache_daemonset.yaml
+++ b/tests/planner/perf_test_configs/image_cache_daemonset.yaml
@@ -20,7 +20,7 @@ spec:
       - name: nvcr-imagepullsecret
       containers:
       - name: image-cache
-        image: my-registry/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
         command:
         - /bin/sh
         - -c

--- a/tests/planner/profiling_results/H200_TP1P_TP1D/disagg.yaml
+++ b/tests/planner/profiling_results/H200_TP1P_TP1D/disagg.yaml
@@ -37,7 +37,7 @@ spec:
           memory: "100Gi"
       extraPodSpec:
         mainContainer:
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -84,7 +84,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh
@@ -131,7 +131,7 @@ spec:
               port: 9090
             periodSeconds: 10
             failureThreshold: 60
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
           workingDir: /workspace/examples/backends/vllm
           command:
             - /bin/sh


### PR DESCRIPTION
## Summary

This PR updates Kubernetes deployment YAML files to use the official NVCR container registry instead of placeholder values.

### Changes

1. **Use official NVCR registry** - Replaced placeholder `my-registry/` with the actual NVCR path `nvcr.io/nvidia/ai-dynamo/` for all runtime images:
   - `vllm-runtime`
   - `sglang-runtime`
   - `tensorrtllm-runtime`
   - `mocker-runtime`

2. **Parameterize image tags** - Replaced placeholder `:my-tag` with `:${VERSION}` environment variable for easier version management

## Stats

- **60 files changed**, 159 insertions(+), 159 deletions(-)

### Files affected:
- `benchmarks/` - profiler and incluster configs
- `examples/backends/` - vllm, sglang, trtllm, mocker deployments
- `examples/deployments/GKE/` - GKE-specific configs
- `examples/multimodal/deploy/` - multimodal examples
- `recipes/` - deepseek, llama, qwen, gpt recipes
- `tests/` - planner and fault tolerance test configs

### Example change:
```diff
-          image: my-registry/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:${VERSION}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image references across deployment manifests to use the NVIDIA public registry with dynamic versioning support via environment variable (${VERSION}) or fixed version tags. This replaces previous private registry references, enabling standardized and versioned image sourcing across all deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->