### PR TITLE
docs: Add description clarifying quickstart is for local CLI usage

### DIFF
--- a/examples/basics/quickstart/README.md
+++ b/examples/basics/quickstart/README.md
@@ -1,6 +1,10 @@
 # Quickstart
 
-This is a simple example showing how you can quickly get started deploying Large Language Models with Dynamo.
+This guide is for running Dynamo **using the CLI on your local machine or VM**. It's a simple example showing how you can quickly get started deploying Large Language Models with Dynamo.
+
+> [!IMPORTANT]
+> **Looking to deploy on Kubernetes instead?**
+> Skip these steps and see the [Kubernetes Installation Guide](/docs/kubernetes/installation_guide.md) and [Kubernetes Quickstart](/docs/kubernetes/README.md) for instructions on deploying Dynamo in a Kubernetes cluster.
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR updates the quickstart README to clarify that the guide is for running Dynamo using the CLI on local hardware (local machine or VM).

## Changes
- Added description clarifying this is a local CLI quickstart
- Added an important callout box with links to the Kubernetes Installation Guide and Kubernetes Quickstart for users who want to deploy on Kubernetes instead

## Why
Users landing on the quickstart page should immediately understand what deployment method the guide covers, and have easy access to alternative guides if they're looking to deploy on Kubernetes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Quickstart README to clarify the guide is for running Dynamo via CLI on local machines and VMs
* Added Kubernetes-specific note with caution block directing users to dedicated Kubernetes Installation and Quickstart documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->