### PR TITLE
docs: fix prometheus helm install namespace selector syntax

### DIFF
--- a/docs/kubernetes/observability/metrics.md
+++ b/docs/kubernetes/observability/metrics.md
@@ -20,8 +20,8 @@ helm repo update
 # Values allow PodMonitors to be picked up that are outside of the kube-prometheus-stack helm release
 helm install prometheus -n monitoring --create-namespace prometheus-community/kube-prometheus-stack \
   --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
-  --set prometheus.prometheusSpec.podMonitorNamespaceSelector="{}" \
-  --set prometheus.prometheusSpec.probeNamespaceSelector="{}"
+  --set prometheus.prometheusSpec.podMonitorNamespaceSelector.matchLabels=null \
+  --set prometheus.prometheusSpec.probeNamespaceSelector.matchLabels=null
 ```
 
 > [!Note]


### PR DESCRIPTION
## Description

The current helm install command for prometheus uses `--set prometheus.prometheusSpec.podMonitorNamespaceSelector="{}"` which fails with an error.

This PR changes it to use `.matchLabels=null` syntax which properly sets empty selectors to allow PodMonitors from all namespaces to be discovered.

### Before (fails) with error:
```bash
$ helm install prometheus -n monitoring --create-namespace prometheus-community/kube-prometheus-stack \
  --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
  --set prometheus.prometheusSpec.podMonitorNamespaceSelector="{}" \
  --set prometheus.prometheusSpec.probeNamespaceSelector="{}"

coalesce.go:298: warning: cannot overwrite table with non table for kube-prometheus-stack.prometheus.prometheusSpec.podMonitorNamespaceSelector (map[])
coalesce.go:298: warning: cannot overwrite table with non table for kube-prometheus-stack.prometheus.prometheusSpec.probeNamespaceSelector (map[])
coalesce.go:298: warning: cannot overwrite table with non table for kube-prometheus-stack.prometheus.prometheusSpec.probeNamespaceSelector (map[])
coalesce.go:298: warning: cannot overwrite table with non table for kube-prometheus-stack.prometheus.prometheusSpec.podMonitorNamespaceSelector (map[])
I0121 17:56:50.196205   74935 warnings.go:110] "Warning: [azurepolicy-k8sazurev2customcontainerallow-db27d7bfaf0671f6e28a] Container image quay.io/prometheus/node-exporter:v1.10.2 for container node-exporter has not been allowed."
I0121 17:56:50.318191   74935 warnings.go:110] "Warning: [azurepolicy-k8sazurev2customcontainerallow-db27d7bfaf0671f6e28a] Container image quay.io/prometheus-operator/prometheus-operator:v0.88.0 for container kube-prometheus-stack has not been allowed."
I0121 17:56:50.325243   74935 warnings.go:110] "Warning: [azurepolicy-k8sazurev2customcontainerallow-db27d7bfaf0671f6e28a] Container image registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0 for container kube-state-metrics has not been allowed."
I0121 17:56:50.325592   74935 warnings.go:110] "Warning: [azurepolicy-k8sazurev2customcontainerallow-db27d7bfaf0671f6e28a] Container image docker.io/grafana/grafana:12.3.1 for container grafana has not been allowed."
I0121 17:56:50.325636   74935 warnings.go:110] "Warning: [azurepolicy-k8sazurev2customcontainerallow-db27d7bfaf0671f6e28a] Container image quay.io/kiwigrid/k8s-sidecar:2.2.1 for container grafana-sc-dashboard has not been allowed."
I0121 17:56:50.325678   74935 warnings.go:110] "Warning: [azurepolicy-k8sazurev2customcontainerallow-db27d7bfaf0671f6e28a] Container image quay.io/kiwigrid/k8s-sidecar:2.2.1 for container grafana-sc-datasources has not been allowed."
Error: INSTALLATION FAILED: 1 error occurred:
        * Prometheus.monitoring.coreos.com "prometheus-kube-prometheus-prometheus" is invalid: [spec.podMonitorNamespaceSelector: Invalid value: "array": spec.podMonitorNamespaceSelector in body must be of type object: "array", spec.probeNamespaceSelector: Invalid value: "array": spec.probeNamespaceSelector in body must be of type object: "array", <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]

```

### After (works):
```bash
helm install prometheus -n monitoring --create-namespace prometheus-community/kube-prometheus-stack \
  --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
  --set prometheus.prometheusSpec.podMonitorNamespaceSelector.matchLabels=null \
  --set prometheus.prometheusSpec.probeNamespaceSelector.matchLabels=null
```