### PR TITLE
chore: add top_p=1 recommendation for gpt-oss to avoid token repetition

### DIFF
--- a/docs/pages/backends/trtllm/gpt-oss.md
+++ b/docs/pages/backends/trtllm/gpt-oss.md
@@ -509,6 +509,22 @@ flowchart TD
    - Check Docker daemon is running with GPU support
    - Ensure sufficient disk space for model weights and container images
 
+5. **Token Repetition / Generation Won't Stop**
+   - When using `reasoning_effort: high`, the model may produce repeated tokens and fail to stop
+   - **Solution**: Set `top_p=1` in your request. These are the [recommended sampling parameters from OpenAI](https://huggingface.co/openai/gpt-oss-120b/discussions/21)
+   - Example request with recommended parameters:
+     ```bash
+     curl localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{
+       "model": "openai/gpt-oss-120b",
+       "messages": [{"role": "user", "content": "Hello"}],
+       "chat_template_args": {
+          "reasoning_effort": "high"
+        },
+       "top_p": 1,
+       "max_tokens": 300
+     }'
+     ```
+
 ## Next Steps
 
 - **Production Deployment**: For multi-node deployments, see the [Multi-node Guide](https://github.com/ai-dynamo/dynamo/tree/main/examples/basics/multinode/README.md)


### PR DESCRIPTION
#### Overview:

 When using reasoning_effort: high, the model may produce repeated tokens
 and fail to stop. Setting top_p=1 resolves this issue per OpenAI's
 recommended sampling parameters.

 Reference: https://huggingface.co/openai/gpt-oss-120b/discussions/21
#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Enhanced troubleshooting documentation with guidance for addressing token repetition and generation issues
- Updated CUDA out-of-memory error handling with improved best practices and configuration recommendations
- Added usage examples for parameter configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->