### PR TITLE
fix: cherry-pick #5471 - restrict pod hash for worker/instance id to <2^53

### DIFF
--- a/lib/runtime/src/discovery/kube/utils.rs
+++ b/lib/runtime/src/discovery/kube/utils.rs
@@ -8,9 +8,11 @@ use std::hash::{Hash, Hasher};
 
 /// Hash a pod name to get a consistent instance ID
 pub fn hash_pod_name(pod_name: &str) -> u64 {
+    // Clear top 11 bits to ensure it can be safely rounded to IEEE-754 f64
+    const INSTANCE_ID_MASK: u64 = 0x001F_FFFF_FFFF_FFFFu64;
     let mut hasher = DefaultHasher::new();
     pod_name.hash(&mut hasher);
-    hasher.finish()
+    hasher.finish() & INSTANCE_ID_MASK
 }
 
 /// Extract endpoint information from an EndpointSlice
@@ -84,5 +86,54 @@ impl PodInfo {
             pod_uid,
             system_port,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_json_serialization_roundtrip() {
+        // Verify that JSON serialization/deserialization preserves exact values
+        let pod_names = [
+            "worker-0",
+            "worker-99999",
+            "deployment-with-hash-suffix-a1b2c3d4e5f6",
+            "fake-name-1-0-worker-nrdfv",
+        ];
+
+        for pod_name in &pod_names {
+            let original_hash = hash_pod_name(pod_name);
+            let json = serde_json::to_string(&original_hash).unwrap();
+            let deserialized_hash: u64 = serde_json::from_str(&json).unwrap();
+
+            assert_eq!(
+                original_hash, deserialized_hash,
+                "JSON roundtrip changed hash value for pod_name={:?}: {} -> {} (json: {})",
+                pod_name, original_hash, deserialized_hash, json
+            );
+        }
+    }
+
+    #[test]
+    fn test_hash_in_struct_serialization() {
+        // Test serialization when the hash is embedded in a struct
+        #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+        struct WorkerInfo {
+            instance_id: u64,
+            name: String,
+        }
+
+        let pod_name = "fake-name-1-0-worker-nrdfv";
+        let info = WorkerInfo {
+            instance_id: hash_pod_name(pod_name),
+            name: pod_name.to_string(),
+        };
+
+        let json = serde_json::to_string(&info).unwrap();
+        let deserialized: WorkerInfo = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(info, deserialized);
     }
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #5471 to release/0.8.1.

- Clears the high bit in `hash_pod_name` so all resulting values are under 2^53 to maintain precision from f64 casting due to JSON serialization
- Fixes worker_id/instance_id precision issues that caused KV router routing failures

**Original PR:** https://github.com/ai-dynamo/dynamo/pull/5471
**Closes:** DEP-741

## Test plan

- [ ] CI passes
- [ ] Verify worker_ids remain consistent across JSON serialization/deserialization