### PR TITLE
chore: added forced audit logging

### DIFF
--- a/lib/llm/src/audit/config.rs
+++ b/lib/llm/src/audit/config.rs
@@ -6,6 +6,7 @@ use std::sync::OnceLock;
 #[derive(Clone, Copy)]
 pub struct AuditPolicy {
     pub enabled: bool,
+    pub force_logging: bool,
 }
 
 static POLICY: OnceLock<AuditPolicy> = OnceLock::new();
@@ -14,6 +15,10 @@ static POLICY: OnceLock<AuditPolicy> = OnceLock::new();
 pub fn init_from_env() -> AuditPolicy {
     AuditPolicy {
         enabled: std::env::var("DYN_AUDIT_SINKS").is_ok(),
+        force_logging: std::env::var("DYN_AUDIT_FORCE_LOGGING")
+            .ok()
+            .and_then(|v| v.parse::<bool>().ok())
+            .unwrap_or(false),
     }
 }
 


### PR DESCRIPTION
#### Overview:

- DYN_AUDIT_FORCE_LOGGING -> This will force audit logging and ignore the value of request param "store"

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added force logging capability through environment variable configuration.
  * Audit logging can now be created regardless of storage settings when force logging is enabled.

* **Tests**
  * Added validation tests confirming force logging functionality correctly bypasses standard storage requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->