### PR TITLE
feat: add --remote-runtime option for faster dev builds

### DIFF
--- a/container/dev/Dockerfile.dev
+++ b/container/dev/Dockerfile.dev
@@ -185,6 +185,7 @@ USER root
 
 # Redeclare build args for use in this stage
 ARG PYTHON_VERSION
+ENV HOME=/root
 
 # Ensure the runtime stage always has /usr/bin/python3.
 # - vLLM/TRTLLM runtime images may only have Python in /opt/dynamo/venv/bin/{python,python3}
@@ -313,8 +314,13 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
         /opt/dynamo/venv/bin/pip install maturin[patchelf] && \
         cp /opt/dynamo/venv/bin/maturin /usr/local/bin/maturin; \
     else \
-        pip3 install maturin[patchelf] && \
-        cp $(which maturin) /usr/local/bin/maturin; \
+        if python3 -m venv /tmp/maturin-venv >/dev/null 2>&1; then \
+            /tmp/maturin-venv/bin/pip install maturin[patchelf] && \
+            cp /tmp/maturin-venv/bin/maturin /usr/local/bin/maturin; \
+        else \
+            python3 -m pip install --break-system-packages maturin[patchelf] && \
+            cp "$(command -v maturin)" /usr/local/bin/maturin; \
+        fi; \
     fi && \
     chmod +x /usr/local/bin/maturin
 

--- a/container/dev/Dockerfile.dev
+++ b/container/dev/Dockerfile.dev
@@ -306,10 +306,16 @@ ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
 
 # Install Rust/Cargo/Maturin directly in dev stage.
 # This avoids dependency on wheel_builder stage, enabling --remote-runtime builds.
+# Guard maturin install: use venv pip if available, else fall back to system pip3.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable && \
     chmod -R a+rx /usr/local/rustup /usr/local/cargo && \
-    /opt/dynamo/venv/bin/pip install maturin[patchelf] && \
-    cp /opt/dynamo/venv/bin/maturin /usr/local/bin/maturin && \
+    if [ -x /opt/dynamo/venv/bin/pip ]; then \
+        /opt/dynamo/venv/bin/pip install maturin[patchelf] && \
+        cp /opt/dynamo/venv/bin/maturin /usr/local/bin/maturin; \
+    else \
+        pip3 install maturin[patchelf] && \
+        cp $(which maturin) /usr/local/bin/maturin; \
+    fi && \
     chmod +x /usr/local/bin/maturin
 
 # Provide an `uv` binary for SGLang venv creation below.

--- a/container/dev/Dockerfile.dev
+++ b/container/dev/Dockerfile.dev
@@ -15,8 +15,8 @@
 #   - container/Dockerfile.sglang
 #
 # The concatenated file provides the stages this Dockerfile depends on:
-#   - `dynamo_base`   (framework base stage; used for cached tool binaries like maturin)
-#   - `wheel_builder` (framework wheel_builder stage; used for cached Rust/Cargo and SGLang NIXL deps)
+#   - `runtime`       (framework runtime stage; base for dev image)
+#   - `wheel_builder` (framework wheel_builder stage; only used for SGLang NIXL deps)
 #
 # Dependency graph (concat flow):
 #
@@ -39,7 +39,7 @@
 #
 # Both targets share:
 # - Developer utilities and tools from dynamo-tools
-# - Rust toolchain + maturin for editable installs (from concatenated framework stages)
+# - Rust toolchain + maturin for editable installs (installed directly in dev stage)
 # - NIXL dependencies for SGLang (from concatenated framework wheel_builder stage)
 #
 # Note on build args:
@@ -304,12 +304,13 @@ ENV WORKSPACE_DIR=${WORKSPACE_DIR} \
     VIRTUAL_ENV=/opt/dynamo/venv \
     PATH=/opt/dynamo/venv/bin:/usr/local/cargo/bin:$PATH
 
-# Copy Rust/Cargo/Maturin from the concatenated framework stages.
-# - Rust/Cargo: from `wheel_builder` (already installed there)
-# - maturin: from `wheel_builder` venv (installed there via uv pip)
-COPY --from=wheel_builder --chown=dynamo:0 --chmod=775 /usr/local/rustup /usr/local/rustup
-COPY --from=wheel_builder --chown=dynamo:0 --chmod=775 /usr/local/cargo /usr/local/cargo
-COPY --from=wheel_builder --chown=dynamo:0 --chmod=775 /workspace/.venv/bin/maturin /usr/local/bin/maturin
+# Install Rust/Cargo/Maturin directly in dev stage.
+# This avoids dependency on wheel_builder stage, enabling --remote-runtime builds.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable && \
+    chmod -R a+rx /usr/local/rustup /usr/local/cargo && \
+    /opt/dynamo/venv/bin/pip install maturin[patchelf] && \
+    cp /opt/dynamo/venv/bin/maturin /usr/local/bin/maturin && \
+    chmod +x /usr/local/bin/maturin
 
 # Provide an `uv` binary for SGLang venv creation below.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /tmp/uv-binary
@@ -403,7 +404,7 @@ ARG USER_UID
 ARG USER_GID
 
 # Copy rustup home into a writable per-user location so sanity_check passes.
-# (dev target already has rustup/cargo/maturin from concatenated wheel_builder/dynamo_base)
+# (dev target already has rustup/cargo/maturin installed directly)
 RUN cp -r /usr/local/rustup /home/dynamo/.rustup && \
     chown -R dynamo:0 /home/dynamo/.rustup
 


### PR DESCRIPTION
## Summary
Add `--remote-runtime` flag to `build.sh` that uses a pre-built runtime image instead of building from source, significantly speeding up dev image builds.

## Motivation
Building dev images from source can take a long time because it builds all the framework stages (dynamo_base, wheel_builder, framework, runtime). When a pre-built runtime image is available from CI, we can skip these stages entirely.

## Changes
- Add `--remote-runtime <image>` option to `build.sh`
- Generate a shim Dockerfile that:
  - Uses the remote image directly as the `runtime` stage
  - Creates a stub `wheel_builder` stage (required by Dockerfile.dev mount)
  - Appends Dockerfile.dev for the dev/local-dev stages
- Install Rust/Cargo/Maturin directly in dev stage (removes dependency on wheel_builder for non-SGLang builds)
- Validate constraints:
  - Only works with `--target dev` or `--target local-dev`
  - Blocked for SGLang (requires wheel_builder NIXL deps)

## Usage
```bash
./container/build.sh --framework vllm --remote-runtime dynamo:<tag>
```

## Test Plan
- [x] Tested with vLLM framework and remote runtime image
- [x] Verified dev image builds successfully
- [x] Verified error handling for invalid combinations (SGLang, non-dev targets)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added --remote-runtime option to accelerate builds by using pre-built runtime images and skipping framework-specific Dockerfile stages.

* **Refactor**
  * Restructured development Dockerfile to install build tools directly in the dev stage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->