### PR TITLE
fix: TestProfileSlaAiconfigurator should use new framework versions

### DIFF
--- a/tests/profiler/test_profile_sla_aiconfigurator.py
+++ b/tests/profiler/test_profile_sla_aiconfigurator.py
@@ -128,12 +128,11 @@ class TestProfileSlaAiconfigurator:
         "backend, aic_backend_version",
         [
             ("trtllm", None),
-            ("trtllm", "0.20.0"),
-            ("trtllm", "1.0.0rc3"),
+            ("trtllm", "1.2.0rc5"),
             ("vllm", None),
-            ("vllm", "0.11.0"),
+            ("vllm", "0.12.0"),
             ("sglang", None),
-            ("sglang", "0.5.1.post1"),
+            ("sglang", "0.5.6.post2"),
         ],
     )
     @pytest.mark.parametrize(


### PR DESCRIPTION
#### Overview:

fix: TestProfileSlaAiconfigurator should use new framework versions

#### Details:

Fix these failed tests:

test_aiconfigurator_dense_models[meta-llama/Llama-3.1-405B-vllm-None]

test_aiconfigurator_dense_models[meta-llama/Llama-3.1-405B-vllm-0.11.0]

test_aiconfigurator_dense_models[meta-llama/Llama-3.1-405B-trtllm-None]

test_aiconfigurator_dense_models[meta-llama/Llama-3.1-405B-trtllm-1.0.0rc3]

test_aiconfigurator_dense_models[meta-llama/Llama-3.1-405B-trtllm-0.20.0]

test_aiconfigurator_dense_models[meta-llama/Llama-3.1-405B-sglang-None]

test_aiconfigurator_dense_models[meta-llama/Llama-3.1-405B-sglang-0.5.1.post1]

test_trtllm_aiconfigurator_single_model

test_aiconfigurator_dense_models[Qwen/Qwen3-32B-vllm-None]
test_aiconfigurator_dense_models[Qwen/Qwen3-32B-vllm-0.11.0]

test_aiconfigurator_dense_models[Qwen/Qwen3-32B-trtllm-None]

test_aiconfigurator_dense_models[Qwen/Qwen3-32B-trtllm-1.0.0rc3]

test_aiconfigurator_dense_models[Qwen/Qwen3-32B-trtllm-0.20.0]

test_aiconfigurator_dense_models[Qwen/Qwen3-32B-sglang-None]

test_aiconfigurator_dense_models[Qwen/Qwen3-32B-sglang-0.5.1.post1]


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations to validate compatibility with newer backend versions for AI configurator profiling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->