### PR TITLE
Feature/multi image per request support

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -426,23 +426,13 @@ async def init_multimodal_encode_worker(runtime: DistributedRuntime, config: Con
 
     await pd_worker_client.wait_for_instances()
 
-    ready_event = asyncio.Event()
-
     try:
-        await asyncio.gather(
-            generate_endpoint.serve_endpoint(
-                handler.generate,
-                graceful_shutdown=True,
-                metrics_labels=[("model", server_args.served_model_name)],
-            ),
-            register_llm_with_readiness_gate(
-                None,  # encode worker doesn't have engine
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Text,
-                readiness_gate=ready_event,
-            ),
+        # Encode Worker is an internal component, should not register with Frontend
+        # Only needs to provide internal service endpoint for Processor to call
+        await generate_endpoint.serve_endpoint(
+            handler.generate,
+            graceful_shutdown=True,
+            metrics_labels=[("model", server_args.served_model_name)],
         )
     except Exception as e:
         logging.error(f"Failed to serve endpoints: {e}")
@@ -481,21 +471,32 @@ async def init_multimodal_worker(runtime: DistributedRuntime, config: Config):
     ready_event = asyncio.Event()
 
     try:
-        await asyncio.gather(
-            generate_endpoint.serve_endpoint(
+        if config.serving_mode == DisaggregationMode.DECODE:
+            # Decode Worker is an internal component, should not register with Frontend
+            # Only needs to provide internal service endpoint for Processor to call
+            await generate_endpoint.serve_endpoint(
                 handler.generate,
                 metrics_labels=[("model", server_args.served_model_name)],
                 graceful_shutdown=True,
                 health_check_payload=health_check_payload,
-            ),
-            register_llm_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                readiness_gate=ready_event,
-            ),
-        )
+            )
+        else:
+            # In aggregated mode, need to register with Frontend
+            await asyncio.gather(
+                generate_endpoint.serve_endpoint(
+                    handler.generate,
+                    metrics_labels=[("model", server_args.served_model_name)],
+                    graceful_shutdown=True,
+                    health_check_payload=health_check_payload,
+                ),
+                register_llm_with_readiness_gate(
+                    engine,
+                    generate_endpoint,
+                    server_args,
+                    dynamo_args,
+                    readiness_gate=ready_event,
+                ),
+            )
     except Exception as e:
         logging.error(f"Failed to serve endpoints: {e}")
         raise
@@ -519,23 +520,15 @@ async def init_multimodal_prefill_worker(runtime: DistributedRuntime, config: Co
     await handler.async_init()
 
     health_check_payload = SglangPrefillHealthCheckPayload(engine).to_dict()
-    ready_event = asyncio.Event()
 
     try:
-        await asyncio.gather(
-            generate_endpoint.serve_endpoint(
-                handler.generate,
-                graceful_shutdown=True,
-                metrics_labels=[("model", server_args.served_model_name)],
-                health_check_payload=health_check_payload,
-            ),
-            register_llm_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                readiness_gate=ready_event,
-            ),
+        # Prefill Worker is an internal component, should not register with Frontend
+        # Only needs to provide internal service endpoint for Decode Worker to call
+        await generate_endpoint.serve_endpoint(
+            handler.generate,
+            graceful_shutdown=True,
+            metrics_labels=[("model", server_args.served_model_name)],
+            health_check_payload=health_check_payload,
         )
     except Exception as e:
         logging.error(f"Failed to serve endpoints: {e}")

--- a/components/src/dynamo/sglang/multimodal_utils/multimodal_encode_utils.py
+++ b/components/src/dynamo/sglang/multimodal_utils/multimodal_encode_utils.py
@@ -82,7 +82,18 @@ def is_model_supported(model_name: str, supported_model: str) -> bool:
     normalized_name = normalize_model_name(model_name).lower()
     normalized_supported = normalize_model_name(supported_model).lower()
 
-    return normalized_name == normalized_supported
+    # Exact match
+    if normalized_name == normalized_supported:
+        return True
+
+    # Handle local path case: compare only the model name part (without organization)
+    # e.g., "qwen2.5-vl-7b-instruct" matches "qwen/qwen2.5-vl-7b-instruct"
+    if "/" in normalized_supported:
+        model_part = normalized_supported.split("/")[-1]
+        if normalized_name == model_part:
+            return True
+
+    return False
 
 
 def get_qwen_image_features(

--- a/components/src/dynamo/sglang/protocol.py
+++ b/components/src/dynamo/sglang/protocol.py
@@ -112,18 +112,32 @@ class MultiModalRequest(BaseModel):
 
 
 class MultiModalInput(BaseModel):
-    image_url: Optional[str] = None
+    # Support multiple image URLs per request
+    image_urls: Optional[List[str]] = None
     video_url: Optional[str] = None
+
+    def get_first_image_url(self) -> Optional[str]:
+        """Get first image URL for backward compatibility"""
+        if self.image_urls and len(self.image_urls) > 0:
+            return self.image_urls[0]
+        return None
 
 
 class SglangMultimodalRequest(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     request: PreprocessedRequest
     multimodal_input: Optional[MultiModalInput] = Field(default_factory=MultiModalInput)
+    # Combined grid_thw for all images: [[t1,h1,w1], [t2,h2,w2], ...]
     image_grid_thw: Optional[List[Any]] = None
+    # Total shape of concatenated embeddings tensor
     embeddings_shape: Optional[
-        Union[Tuple[int, int, int], Tuple[int, int, int, int]]
+        Union[Tuple[int, int, int], Tuple[int, int, int, int], List[Tuple]]
     ] = None
+    # Number of images in this request
+    num_images: int = 1
+    # Per-image token counts for unpacking concatenated embeddings
+    # e.g., [1024, 1024, 512] means image1 has 1024 tokens, image2 has 1024, image3 has 512
+    per_image_num_tokens: Optional[List[int]] = None
     serialized_request: Optional[connect.RdmaMetadata] = None
 
 

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -241,7 +241,8 @@ class MultimodalWorkerHandler(BaseWorkerHandler):
         config: Config,
         prefill_client: Client = None,
     ):
-        super().__init__(component, engine, config, None, prefill_client)
+        #super().__init__(component, engine, config, None, prefill_client)
+        super().__init__(component, engine, config, None)
 
         # Initialize processors
         self.embeddings_processor = EmbeddingsProcessor()

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -4,7 +4,7 @@
 import asyncio
 import json
 import logging
-from typing import AsyncIterator
+from typing import AsyncIterator, List
 
 import sglang as sgl
 import torch
@@ -111,21 +111,79 @@ class EmbeddingsProcessor:
         return embeddings, descriptor
 
     @staticmethod
-    def create_multimodal_item(
+    def create_multimodal_items(
         embeddings: torch.Tensor, request: SglangMultimodalRequest
-    ) -> dict:
-        """Create multimodal item for SGLang generation"""
+    ) -> List[dict]:
+        """
+        Create list of multimodal items for SGLang generation.
+        Creates one mm_item per image by splitting the concatenated embeddings.
 
-        precomputed_embeddings = embeddings.to(MultimodalConfig.EMBEDDINGS_DTYPE)
-        grid_thw_tensor = torch.tensor(request.image_grid_thw)
+        Args:
+            embeddings: Concatenated precomputed embeddings tensor [1, total_tokens, hidden_dim]
+            request: The multimodal request with per-image metadata
 
-        mm_item = dict(
-            modality="IMAGE",
-            image_grid_thw=grid_thw_tensor,
-            precomputed_embeddings=precomputed_embeddings,
+        Returns:
+            List of multimodal item dicts, one per image
+        """
+        num_images = request.num_images
+        per_image_num_tokens = request.per_image_num_tokens
+        image_grid_thw = request.image_grid_thw
+
+        # For single image, create a simple item
+        if num_images == 1 or per_image_num_tokens is None:
+            # Squeeze batch dimension: [1, tokens, hidden] -> [tokens, hidden]
+            # SGLang expects 2D embeddings tensor
+            precomputed_embeddings = embeddings.squeeze(0).to(MultimodalConfig.EMBEDDINGS_DTYPE)
+            grid_thw_tensor = torch.tensor(image_grid_thw)
+
+            mm_item = dict(
+                modality="IMAGE",
+                image_grid_thw=grid_thw_tensor,
+                precomputed_embeddings=precomputed_embeddings,
+            )
+
+            logger.debug(
+                f"Created single multimodal item with grid_thw shape: {grid_thw_tensor.shape}, "
+                f"embeddings shape: {precomputed_embeddings.shape}"
+            )
+            return [mm_item]
+
+        # For multiple images, split the concatenated embeddings
+        mm_items = []
+        current_offset = 0
+
+        for idx in range(num_images):
+            num_tokens = per_image_num_tokens[idx]
+
+            # Extract this image's embeddings from the concatenated tensor
+            # embeddings shape: [1, total_tokens, hidden_dim] -> [num_tokens, hidden_dim]
+            # SGLang expects 2D embeddings tensor (no batch dimension)
+            image_embeddings = embeddings[:, current_offset:current_offset + num_tokens, :]
+            image_embeddings = image_embeddings.squeeze(0).to(MultimodalConfig.EMBEDDINGS_DTYPE)
+
+            # Get this image's grid_thw (each image has one [t, h, w] entry)
+            image_grid_thw_entry = [image_grid_thw[idx]]
+            grid_thw_tensor = torch.tensor(image_grid_thw_entry)
+
+            mm_item = dict(
+                modality="IMAGE",
+                image_grid_thw=grid_thw_tensor,
+                precomputed_embeddings=image_embeddings,
+            )
+
+            mm_items.append(mm_item)
+            current_offset += num_tokens
+
+            logger.debug(
+                f"Created mm_item {idx + 1}/{num_images}: "
+                f"grid_thw={image_grid_thw_entry}, embeddings_shape={image_embeddings.shape}"
+            )
+
+        logger.debug(
+            f"Created {len(mm_items)} multimodal items from {num_images} images"
         )
 
-        return mm_item
+        return mm_items
 
 
 class StreamProcessor:
@@ -342,19 +400,19 @@ class MultimodalWorkerHandler(BaseWorkerHandler):
                 request
             )
 
-            # Create multimodal item
-            mm_item = self.embeddings_processor.create_multimodal_item(
+            # Create multimodal items (supports multiple images)
+            mm_items = self.embeddings_processor.create_multimodal_items(
                 embeddings, request
             )
 
             logger.debug(
-                f"Generated multimodal item with embeddings shape: {embeddings.shape}"
+                f"Generated {len(mm_items)} multimodal item(s) with embeddings shape: {embeddings.shape}"
             )
             logger.debug(f"Input token sequence length: {len(input_ids)}")
 
             agg_stream = await self.engine.async_generate(
                 input_ids=input_ids,
-                image_data=[mm_item],
+                image_data=mm_items,
                 sampling_params=sampling_params,
                 stream=True,
             )
@@ -497,13 +555,18 @@ class MultimodalPrefillWorkerHandler(BaseWorkerHandler):
             request
         )
 
-        # Create multimodal item for prefill generation
-        mm_item = self.embeddings_processor.create_multimodal_item(embeddings, request)
+        # Create multimodal items for prefill generation (supports multiple images)
+        mm_items = self.embeddings_processor.create_multimodal_items(embeddings, request)
+
+        logger.debug(
+            f"Prefill: generated {len(mm_items)} multimodal item(s) with "
+            f"embeddings shape: {embeddings.shape}"
+        )
 
         # Start SGLang prefill generation (like regular SGLang)
         results = await self.engine.async_generate(
             input_ids=input_ids,
-            image_data=[mm_item],
+            image_data=mm_items,
             sampling_params=sampling_params,
             stream=True,
             bootstrap_host=self.bootstrap_host,


### PR DESCRIPTION
#### Overview:

multi image per request support

#### Details:

sample sgl bench for poc:
python -m sglang.bench_serving --model /raid/model_hub/Qwen2.5-VL-7B-Instruct --num-prompts 64 --dataset-name image --random-input-len 128 --random-output-len 256 --image-count 8 --image-resolution 1080p --host localhost --port 8000 --backend vllm-chat --request-rate 1

sample curl client request for validation:
curl http://localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "/raid/model_hub/Qwen2.5-VL-7B-Instruct",
    "messages": [
      {
        "role": "user",
        "content": [
          {"type": "text", "text": "比较这两张图片有什么不同"},
          {"type": "image_url", "image_url": {"url": "http://images.cocodataset.org/test2017/000000155781.jpg
"}},
          {"type": "image_url", "image_url": {"url": "http://images.cocodataset.org/test2017/000000000001.jpg
"}} 
        ]                                                                                                          }
    ],
    "max_tokens": 256
  }'

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
