### PR TITLE
chore: add back Prometheus for kvstats using the Python MetricsRegistry

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -526,7 +526,7 @@ async def init(runtime: DistributedRuntime, config: Config):
 
     # TODO Hack to get data, move this to registering in TBD
     factory.set_num_gpu_blocks_all(vllm_config.cache_config.num_gpu_blocks)
-    factory.set_request_total_slots_all(vllm_config.scheduler_config.max_num_seqs)
+    # Note: set_request_total_slots_all was removed in metrics refactor (commit 24b4bff05)
     factory.init_publish()
 
     handler = DecodeWorkerHandler(

--- a/examples/multimodal/components/worker.py
+++ b/examples/multimodal/components/worker.py
@@ -150,9 +150,7 @@ class VllmBaseWorker:
         self.stats_logger.set_num_gpu_blocks_all(
             vllm_config.cache_config.num_gpu_blocks
         )
-        self.stats_logger.set_request_total_slots_all(
-            vllm_config.scheduler_config.max_num_seqs
-        )
+        # Note: set_request_total_slots_all was removed in metrics refactor (commit 24b4bff05)
         self.stats_logger.init_publish()
 
         # TODO: We start off with a valid endpoint, then we increment it by dp_rank


### PR DESCRIPTION
#### Overview:

Simplifies metrics publishing to minimal routing contract (active_decode_blocks + dp_rank) while restoring kvstats Prometheus gauges for observability.

#### Details:

- Remove complex metrics structs (ForwardPassMetrics, WorkerStats, KvStats, SpecDecodeStats)
- Simplify WorkerMetricsPublisher: only publish dp_rank + active_decode_blocks to NATS
- Restore 4 kvstats Prometheus gauges using prometheus_names constants
- Remove obsolete set_request_total_slots_all() calls

#### Where should the reviewer start?

- `lib/llm/src/kv_router/publisher.rs` - simplified publisher
- Python publishers (vLLM, SGLang, TRT-LLM) - restored kvstats gauges

#### Related Issues:

DIS-835

/coderabbit profile chill