### PR TITLE
feat: add __all__ exports and __repr__ methods for better debugging

### DIFF
--- a/components/src/dynamo/planner/utils/exceptions.py
+++ b/components/src/dynamo/planner/utils/exceptions.py
@@ -22,6 +22,21 @@ contextual information to help with debugging and error handling.
 
 from typing import List
 
+__all__ = [
+    "PlannerError",
+    "DynamoGraphDeploymentNotFoundError",
+    "ComponentError",
+    "ModelNameNotFoundError",
+    "DeploymentModelNameMismatchError",
+    "UserProvidedModelNameMismatchError",
+    "BackendFrameworkNotFoundError",
+    "BackendFrameworkInvalidError",
+    "SubComponentNotFoundError",
+    "DuplicateSubComponentError",
+    "DeploymentValidationError",
+    "EmptyTargetReplicasError",
+]
+
 
 class PlannerError(Exception):
     """Base exception for all planner-related errors.
@@ -48,6 +63,9 @@ class DynamoGraphDeploymentNotFoundError(PlannerError):
         message = f"Parent DynamoGraphDeployment not found (name: '{deployment_name}' in namespace '{namespace}')"
 
         super().__init__(message)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(deployment_name={self.deployment_name!r}, namespace={self.namespace!r})"
 
 
 class ComponentError(PlannerError):
@@ -78,6 +96,9 @@ class DeploymentModelNameMismatchError(PlannerError):
         message = f"Model name mismatch in DynamoGraphDeployment: prefill model name {prefill_model_name} != decode model name {decode_model_name}"
         self.message = message
         super().__init__(self.message)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(prefill_model_name={self.prefill_model_name!r}, decode_model_name={self.decode_model_name!r})"
 
 
 class UserProvidedModelNameMismatchError(PlannerError):
@@ -130,6 +151,11 @@ class SubComponentNotFoundError(ComponentError):
 
         super().__init__(message)
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(sub_component_type={self.sub_component_type!r})"
+        )
+
 
 class DuplicateSubComponentError(ComponentError):
     """Raised when multiple services have the same subComponentType.
@@ -149,6 +175,9 @@ class DuplicateSubComponentError(ComponentError):
         )
 
         super().__init__(message)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(sub_component_type={self.sub_component_type!r}, service_names={self.service_names!r})"
 
 
 class DeploymentValidationError(PlannerError):

--- a/lib/bindings/python/src/dynamo/health_check.py
+++ b/lib/bindings/python/src/dynamo/health_check.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["HealthCheckPayload", "load_health_check_from_env"]
+
 
 def load_health_check_from_env(
     env_var: str = "DYN_HEALTH_CHECK_PAYLOAD",
@@ -94,3 +96,9 @@ class HealthCheckPayload:
             # Check for environment override
             self._payload = load_health_check_from_env() or self.default_payload
         return self._payload
+
+    def __repr__(self) -> str:
+        """Return a string representation of the health check payload."""
+        class_name = self.__class__.__name__
+        payload = self.to_dict()
+        return f"{class_name}(payload={payload!r})"


### PR DESCRIPTION
## Summary
Add Python best practice improvements for module exports and debugging.

## Changes

### lib/bindings/python/src/dynamo/health_check.py
- Add `__all__` export: `["HealthCheckPayload", "load_health_check_from_env"]`
- Add `__repr__()` method for readable debugging output

### components/src/dynamo/planner/utils/exceptions.py
- Add `__all__` export listing all 11 exception classes
- Add `__repr__()` methods to exceptions with stored context:
  - `DynamoGraphDeploymentNotFoundError`
  - `DeploymentModelNameMismatchError`
  - `SubComponentNotFoundError`
  - `DuplicateSubComponentError`

## Type of Change
- [x] Code improvement (Python best practices)
- [x] No new features or behavior changes

## Benefits
- Better IDE autocompletion via explicit `__all__` exports
- Improved debugging with readable exception representations
- Follows Python conventions for module public API

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have signed off all commits (DCO)
- [x] Pre-commit hooks pass
- [x] Changes are <100 lines (no GitHub Issue required per CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Exception messages now provide more detailed diagnostic information including deployment names, namespaces, and component types for improved troubleshooting.
  * Health check payloads now have improved string representations for better debugging visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->