### PR TITLE
fix: correct typos in help text and add missing docstrings

### DIFF
--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -153,6 +153,11 @@ def parse_bootstrap_ports(ports_str: str | None) -> list[int]:
 
 
 def parse_args():
+    """Parse command-line arguments for the Dynamo mocker engine.
+
+    Returns:
+        argparse.Namespace: Parsed command-line arguments.
+    """
     parser = argparse.ArgumentParser(
         description="Mocker engine for testing Dynamo LLM infrastructure with vLLM-style CLI.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -315,7 +320,7 @@ def parse_args():
         type=str,
         choices=["etcd", "file", "mem"],
         default=os.environ.get("DYN_STORE_KV", "etcd"),
-        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
     )
     parser.add_argument(
         "--request-plane",

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -108,7 +108,7 @@ DYNAMO_ARGS: Dict[str, Dict[str, Any]] = {
         "type": str,
         "choices": ["etcd", "file", "mem"],
         "default": os.environ.get("DYN_STORE_KV", "etcd"),
-        "help": "Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+        "help": "Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
     },
     "request-plane": {
         "flags": ["--request-plane"],
@@ -196,6 +196,7 @@ class Config:
 def _preprocess_for_encode_config(
     config: Config,
 ) -> Dict[str, Any]:  # pyright: ignore[reportUnusedFunction]
+    """Convert Config object to dictionary for encoding."""
     return {
         "server_args": config.server_args,
         "dynamo_args": config.dynamo_args,

--- a/components/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -106,10 +106,23 @@ class Config:
 def _preprocess_for_encode_config(
     obj: Config,
 ) -> dict:  # pyright: ignore[reportUnusedFunction]
+    """Convert Config object to dictionary for encoding."""
     return obj.__dict__
 
 
 def parse_endpoint(endpoint: str) -> tuple[str, str, str]:
+    """Parse a Dynamo endpoint string into its components.
+
+    Args:
+        endpoint: Endpoint string in format 'namespace.component.endpoint'
+            or 'dyn://namespace.component.endpoint'.
+
+    Returns:
+        Tuple of (namespace, component, endpoint_name).
+
+    Raises:
+        ValueError: If endpoint format is invalid.
+    """
     endpoint_str = endpoint.replace("dyn://", "", 1)
     endpoint_parts = endpoint_str.split(".")
     if len(endpoint_parts) != 3:
@@ -122,6 +135,11 @@ def parse_endpoint(endpoint: str) -> tuple[str, str, str]:
 
 
 def cmd_line_args():
+    """Parse command-line arguments for the TensorRT-LLM backend.
+
+    Returns:
+        Config: Parsed configuration object.
+    """
     parser = argparse.ArgumentParser(
         description="TensorRT-LLM server integrated with Dynamo LLM."
     )
@@ -306,7 +324,7 @@ def cmd_line_args():
         type=str,
         choices=["etcd", "file", "mem"],
         default=os.environ.get("DYN_STORE_KV", "etcd"),
-        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
     )
     parser.add_argument(
         "--request-plane",

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -102,10 +102,16 @@ class Config:
 
 @register_encoder(Config)
 def _preprocess_for_encode_config(config: Config) -> Dict[str, Any]:
+    """Convert Config object to dictionary for encoding."""
     return config.__dict__
 
 
 def parse_args() -> Config:
+    """Parse command-line arguments for the vLLM backend.
+
+    Returns:
+        Config: Parsed configuration object.
+    """
     parser = FlexibleArgumentParser(
         description="vLLM server integrated with Dynamo LLM."
     )
@@ -243,7 +249,7 @@ def parse_args() -> Config:
         type=str,
         choices=["etcd", "file", "mem"],
         default=os.environ.get("DYN_STORE_KV", "etcd"),
-        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
     )
     parser.add_argument(
         "--request-plane",

--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -121,7 +121,7 @@ pub struct Flags {
     pub migration_limit: Option<u32>,
 
     /// Which key-value backend to use: etcd, mem, file.
-    /// Etcd uses the ETCD_* env vars (e.g. ETCD_ENPOINTS) for connection details.
+    /// Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details.
     /// File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.
     #[arg(long, default_value = "etcd", value_parser = ["etcd", "file", "mem"])]
     pub store_kv: String,


### PR DESCRIPTION
## Summary
Fix typos in user-facing CLI help text, remove outdated TODO, and add missing docstrings.

## Changes

### Typo Fixes
- Fix `ETCD_ENPOINTS` → `ETCD_ENDPOINTS` in `--store-kv` help text (6 files)
- Fix `lama3.2` → `llama3.2` in `--model-path` example

### Stale Comment Update
- Update TODO in `frontend/main.py`: KV routing is already implemented via `--router-mode kv`

### Docstring Coverage
Added docstrings to functions missing them:
- `frontend/main.py`: `parse_args`, `async_main`, `graceful_shutdown`, `main`
- `mocker/args.py`: `parse_args`
- `vllm/args.py`: `_preprocess_for_encode_config`, `parse_args`
- `sglang/args.py`: `_preprocess_for_encode_config`
- `trtllm/utils/trtllm_utils.py`: `_preprocess_for_encode_config`, `parse_endpoint`, `cmd_line_args`

## Type of Change
- [x] Bug fix (typos in help text)
- [x] Documentation (docstrings)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have signed off all commits (DCO)
- [x] Pre-commit hooks pass
- [x] Changes are <100 lines
- [x] Docstring coverage requirements satisfied