### PR TITLE
[multimodal streamline] Add worker handlers

### DIFF
--- a/components/src/dynamo/common/memory/__init__.py
+++ b/components/src/dynamo/common/memory/__init__.py
@@ -3,6 +3,8 @@
 
 """Memory management utilities for Dynamo components."""
 
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 
-__all__ = ["EncoderCacheManager"]
+__all__ = ["MultimodalEmbeddingCacheManager"]

--- a/components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py
+++ b/components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py
@@ -8,7 +8,7 @@ A simple LRU cache for encoder embeddings (tensors).
 Maps content hash keys to tensors with capacity-based eviction.
 
 Usage:
-    cache = EncoderCacheManager(capacity_bytes=4 * 1024**3)  # 4GB
+    cache = MultimodalEmbeddingCacheManager(capacity_bytes=4 * 1024**3)  # 4GB
 
     # Store embedding
     cache.set("abc123", embedding_tensor)
@@ -26,7 +26,7 @@ import torch
 logger = logging.getLogger(__name__)
 
 
-class EncoderCacheManager:
+class MultimodalEmbeddingCacheManager:
     """
     LRU cache for encoder embeddings.
 
@@ -56,7 +56,7 @@ class EncoderCacheManager:
         self._misses = 0
 
         logger.info(
-            f"EncoderCacheManager initialized: capacity={capacity_bytes / 1024**3:.2f}GB"
+            f"MultimodalEmbeddingCacheManager initialized: capacity={capacity_bytes / 1024**3:.2f}GB"
         )
 
     @staticmethod

--- a/components/src/dynamo/common/multimodal/async_encoder_cache.py
+++ b/components/src/dynamo/common/multimodal/async_encoder_cache.py
@@ -4,11 +4,11 @@
 """
 Async Encoder Cache
 
-Async wrapper over EncoderCacheManager with request coalescing.
+Async wrapper over MultimodalEmbeddingCacheManager with request coalescing.
 Prevents duplicate encoding when multiple requests arrive for the same content.
 
 Usage:
-    cache = EncoderCacheManager(capacity_bytes=4 * 1024**3)
+    cache = MultimodalEmbeddingCacheManager(capacity_bytes=4 * 1024**3)
     async_cache = AsyncEncoderCache(cache)
 
     # Get from cache or compute with coalescing
@@ -21,7 +21,9 @@ from typing import Awaitable, Callable, Dict, Optional
 
 import torch
 
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +45,7 @@ def _suppress_unhandled_future_exception(future: asyncio.Future) -> None:
 
 class AsyncEncoderCache:
     """
-    Async wrapper with request coalescing over EncoderCacheManager.
+    Async wrapper with request coalescing over MultimodalEmbeddingCacheManager.
 
     Provides async get_or_compute that deduplicates concurrent requests
     for the same key, ensuring only one encoding runs at a time per key.
@@ -53,12 +55,12 @@ class AsyncEncoderCache:
         asyncio event loop. All access must be from the same thread.
     """
 
-    def __init__(self, cache: EncoderCacheManager):
+    def __init__(self, cache: MultimodalEmbeddingCacheManager):
         """
         Initialize the async encoder cache.
 
         Args:
-            cache: Underlying EncoderCacheManager for storage.
+            cache: Underlying MultimodalEmbeddingCacheManager for storage.
         """
         self._cache = cache
         self._in_flight: Dict[str, asyncio.Future[torch.Tensor]] = {}

--- a/components/src/dynamo/common/tests/multimodal/test_async_encoder_cache.py
+++ b/components/src/dynamo/common/tests/multimodal/test_async_encoder_cache.py
@@ -8,7 +8,9 @@ import asyncio
 import pytest
 import torch
 
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.common.multimodal.async_encoder_cache import AsyncEncoderCache
 
 
@@ -18,7 +20,7 @@ class TestAsyncEncoderCacheBasicOperations:
     @pytest.fixture
     def cache(self):
         """Create a cache for testing."""
-        ecm = EncoderCacheManager(capacity_bytes=1024 * 1024)
+        ecm = MultimodalEmbeddingCacheManager(capacity_bytes=1024 * 1024)
         return AsyncEncoderCache(ecm)
 
     def test_sync_get_returns_none_for_missing_key(self, cache):
@@ -74,7 +76,7 @@ class TestAsyncEncoderCacheRequestCoalescing:
     @pytest.fixture
     def cache(self):
         """Create a cache for testing."""
-        ecm = EncoderCacheManager(capacity_bytes=1024 * 1024)
+        ecm = MultimodalEmbeddingCacheManager(capacity_bytes=1024 * 1024)
         return AsyncEncoderCache(ecm)
 
     @pytest.mark.asyncio
@@ -137,7 +139,7 @@ class TestAsyncEncoderCacheExceptionHandling:
     @pytest.fixture
     def cache(self):
         """Create a cache for testing."""
-        ecm = EncoderCacheManager(capacity_bytes=1024 * 1024)
+        ecm = MultimodalEmbeddingCacheManager(capacity_bytes=1024 * 1024)
         return AsyncEncoderCache(ecm)
 
     @pytest.mark.asyncio
@@ -209,7 +211,7 @@ class TestAsyncEncoderCacheStats:
     @pytest.fixture
     def cache(self):
         """Create a cache for testing."""
-        ecm = EncoderCacheManager(capacity_bytes=1024 * 1024)
+        ecm = MultimodalEmbeddingCacheManager(capacity_bytes=1024 * 1024)
         return AsyncEncoderCache(ecm)
 
     def test_stats_includes_in_flight(self, cache):

--- a/components/src/dynamo/trtllm/multimodal/cuda_ipc.py
+++ b/components/src/dynamo/trtllm/multimodal/cuda_ipc.py
@@ -27,7 +27,7 @@ async def extract_embeddings_from_handles(
     properly.
 
     Args:
-        handles: List of CUDA IPC handle dictionaries from encoder response
+        handles: List of CUDA IPC handle dictionaries from encoder response.
 
     Returns:
         List of embedding tensors on CPU.

--- a/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
+++ b/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
@@ -14,7 +14,9 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from tensorrt_llm.llmapi import DisaggregatedParams
 
-from dynamo.common.multimodal.async_encoder_cache import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.trtllm.multimodal.cuda_ipc import extract_embeddings_from_handles
 from dynamo.trtllm.multimodal.hasher import MultimodalHasher
 
@@ -25,7 +27,7 @@ async def fetch_embeddings_from_encoder(
     image_urls: List[str],
     request: Dict[str, Any],
     encode_client: Any,
-    encoder_cache: Optional[EncoderCacheManager] = None,
+    encoder_cache: Optional[MultimodalEmbeddingCacheManager] = None,
 ) -> Union[List[torch.Tensor], DisaggregatedParams]:
     """
     Fetch embeddings from remote encode worker.
@@ -112,7 +114,7 @@ async def _remote_encode_full_epd(
 async def _fetch_embeddings_with_cache(
     image_urls: List[str],
     request: Dict[str, Any],
-    cache: EncoderCacheManager,
+    cache: MultimodalEmbeddingCacheManager,
     encode_fn: Callable[[Dict[str, Any]], DisaggregatedParams],
 ) -> List[torch.Tensor]:
     """

--- a/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Handler for aggregated (prefill + decode) mode with optional encoder disaggregation."""
+
+import logging
+from typing import Optional
+
+from dynamo._core import Context
+from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.trtllm.multimodal.embedding_fetcher import fetch_embeddings_from_encoder
+from dynamo.trtllm.request_handlers.handler_base import (
+    HandlerBase,
+    RequestHandlerConfig,
+)
+
+
+class AggregatedHandler(HandlerBase):
+    """
+    Handler for aggregated mode (prefill + decode in single worker).
+
+    Supports optional encoder disaggregation (E_PD flow) when encode_client
+    and encoder_cache are configured.
+    """
+
+    def __init__(
+        self,
+        config: RequestHandlerConfig,
+        encoder_cache: Optional[EncoderCacheManager] = None,
+    ):
+        super().__init__(config)
+        self._encoder_cache = encoder_cache
+
+    async def generate(self, request: dict, context: Context):
+        """Generate response, optionally using remote encoder for multimodal."""
+        logging.debug(f"AggregatedHandler Request ID: {context.id()}")
+
+        embeddings = None
+        ep_disaggregated_params = None
+        if self.multimodal_processor and self.encode_client:
+            messages = request.get("extra_args", {}).get(
+                "messages", request.get("messages", [])
+            )
+            _, image_urls, _ = self.multimodal_processor.extract_prompt_and_media(
+                messages
+            )
+            if image_urls:
+                logging.info(f"AggregatedHandler: image_urls={image_urls}")
+                result = await fetch_embeddings_from_encoder(
+                    image_urls,
+                    request,
+                    self.encode_client,
+                    self._encoder_cache,
+                )
+                if isinstance(result, list):
+                    embeddings = result
+                else:
+                    ep_disaggregated_params = result
+
+        async for res in self.generate_locally(
+            request, context, embeddings, ep_disaggregated_params
+        ):
+            yield res

--- a/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
@@ -7,7 +7,9 @@ import logging
 from typing import Optional
 
 from dynamo._core import Context
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.trtllm.multimodal.embedding_fetcher import fetch_embeddings_from_encoder
 from dynamo.trtllm.request_handlers.handler_base import (
     HandlerBase,
@@ -26,7 +28,7 @@ class AggregatedHandler(HandlerBase):
     def __init__(
         self,
         config: RequestHandlerConfig,
-        encoder_cache: Optional[EncoderCacheManager] = None,
+        encoder_cache: Optional[MultimodalEmbeddingCacheManager] = None,
     ):
         super().__init__(config)
         self._encoder_cache = encoder_cache

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -9,6 +9,7 @@ from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.trtllm.encode_helper import EncodeHelper
 from dynamo.trtllm.multimodal.embedding_fetcher import fetch_embeddings_from_encoder
+from dynamo.trtllm.request_handlers.aggregated_handler import AggregatedHandler
 from dynamo.trtllm.request_handlers.handler_base import (
     HandlerBase,
     RequestHandlerConfig,
@@ -31,33 +32,19 @@ class RequestHandlerFactory:
             raise ValueError(
                 f"Invalid disaggregation_mode '{config.disaggregation_mode.value}'"
             )
+        encoder_cache = None
+        if config.encoder_cache_capacity_gb > 0:
+            capacity_bytes = int(config.encoder_cache_capacity_gb * 1024**3)
+            encoder_cache = EncoderCacheManager(capacity_bytes)
         if config.disaggregation_mode.value == "prefill":
-            encoder_cache = None
-            if config.encoder_cache_capacity_gb > 0:
-                # Create encoder cache for prefill handler
-                capacity_bytes = int(config.encoder_cache_capacity_gb * 1024**3)
-                encoder_cache = EncoderCacheManager(capacity_bytes)
             return PrefillHandler(config, encoder_cache=encoder_cache)
+        if config.disaggregation_mode.value == "prefill_and_decode":
+            return AggregatedHandler(config, encoder_cache=encoder_cache)
         return self.handlers[config.disaggregation_mode.value](config)
 
 
 def get_request_handler(config: RequestHandlerConfig) -> HandlerBase:
     return RequestHandlerFactory().get_request_handler(config)
-
-
-class AggregatedHandler(HandlerBase):
-    """
-    Handler for the aggregated mode.
-    """
-
-    def __init__(self, config: RequestHandlerConfig):
-        super().__init__(config)
-
-    async def generate(self, request: dict, context: Context):
-        logging.debug(f"New Request ID: {context.id()}")
-        # Implement all steps locally.
-        async for res in self.generate_locally(request, context):
-            yield res
 
 
 class EncodeHandler(HandlerBase):

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -5,7 +5,9 @@ import logging
 from typing import Optional
 
 from dynamo._core import Context
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.trtllm.encode_helper import EncodeHelper
 from dynamo.trtllm.multimodal.embedding_fetcher import fetch_embeddings_from_encoder
@@ -35,7 +37,7 @@ class RequestHandlerFactory:
         encoder_cache = None
         if config.encoder_cache_capacity_gb > 0:
             capacity_bytes = int(config.encoder_cache_capacity_gb * 1024**3)
-            encoder_cache = EncoderCacheManager(capacity_bytes)
+            encoder_cache = MultimodalEmbeddingCacheManager(capacity_bytes)
         if config.disaggregation_mode.value == "prefill":
             return PrefillHandler(config, encoder_cache=encoder_cache)
         if config.disaggregation_mode.value == "prefill_and_decode":
@@ -90,7 +92,7 @@ class PrefillHandler(HandlerBase):
     def __init__(
         self,
         config: RequestHandlerConfig,
-        encoder_cache: Optional[EncoderCacheManager] = None,
+        encoder_cache: Optional[MultimodalEmbeddingCacheManager] = None,
     ):
         super().__init__(config)
         self._encoder_cache = encoder_cache

--- a/components/src/dynamo/trtllm/tests/multimodal/test_trtllm_embedding_fetcher.py
+++ b/components/src/dynamo/trtllm/tests/multimodal/test_trtllm_embedding_fetcher.py
@@ -10,7 +10,9 @@ import pytest
 import torch
 from tensorrt_llm.llmapi import DisaggregatedParams
 
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.trtllm.multimodal.embedding_fetcher import fetch_embeddings_from_encoder
 from dynamo.trtllm.multimodal.hasher import MultimodalHasher
 
@@ -53,9 +55,9 @@ def create_mock_encode_client(
 
 
 @pytest.fixture
-def encoder_cache() -> EncoderCacheManager:
+def encoder_cache() -> MultimodalEmbeddingCacheManager:
     """Create encoder cache with 10MB capacity."""
-    return EncoderCacheManager(capacity_bytes=10 * 1024 * 1024)
+    return MultimodalEmbeddingCacheManager(capacity_bytes=10 * 1024 * 1024)
 
 
 class TestFetchEmbeddingsFromEncoder:

--- a/components/src/dynamo/trtllm/tests/request_handlers/test_trtllm_request_handler_factory.py
+++ b/components/src/dynamo/trtllm/tests/request_handlers/test_trtllm_request_handler_factory.py
@@ -29,6 +29,14 @@ def mock_config():
 class TestRequestHandlerFactory:
     """Tests for RequestHandlerFactory."""
 
+    def test_invalid_mode_raises(self, mock_config):
+        """Test factory raises ValueError for invalid disaggregation_mode."""
+        mock_config.disaggregation_mode.value = "invalid_mode"
+        factory = RequestHandlerFactory()
+
+        with pytest.raises(ValueError, match="Invalid disaggregation_mode"):
+            factory.get_request_handler(mock_config)
+
     def test_creates_aggregated_handler(self, mock_config):
         """Test factory creates AggregatedHandler for prefill_and_decode mode."""
         factory = RequestHandlerFactory()
@@ -43,14 +51,6 @@ class TestRequestHandlerFactory:
         handler = factory.get_request_handler(mock_config)
 
         assert isinstance(handler, PrefillHandler)
-
-    def test_invalid_mode_raises(self, mock_config):
-        """Test factory raises ValueError for invalid disaggregation_mode."""
-        mock_config.disaggregation_mode.value = "invalid_mode"
-        factory = RequestHandlerFactory()
-
-        with pytest.raises(ValueError, match="Invalid disaggregation_mode"):
-            factory.get_request_handler(mock_config)
 
     def test_prefill_handler_with_encoder_cache(self):
         """Test factory creates PrefillHandler with EncoderCacheManager when capacity > 0."""

--- a/components/src/dynamo/trtllm/tests/request_handlers/test_trtllm_request_handler_factory.py
+++ b/components/src/dynamo/trtllm/tests/request_handlers/test_trtllm_request_handler_factory.py
@@ -5,7 +5,9 @@
 
 import pytest
 
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.trtllm.request_handlers.handlers import (
     AggregatedHandler,
     PrefillHandler,
@@ -53,7 +55,7 @@ class TestRequestHandlerFactory:
         assert isinstance(handler, PrefillHandler)
 
     def test_prefill_handler_with_encoder_cache(self):
-        """Test factory creates PrefillHandler with EncoderCacheManager when capacity > 0."""
+        """Test factory creates PrefillHandler with MultimodalEmbeddingCacheManager when capacity > 0."""
         mock_config = create_mock_request_handler_config(
             disaggregation_mode="prefill",
             encoder_cache_capacity_gb=1.0,
@@ -62,7 +64,7 @@ class TestRequestHandlerFactory:
         handler = factory.get_request_handler(mock_config)
 
         assert isinstance(handler, PrefillHandler)
-        assert isinstance(handler._encoder_cache, EncoderCacheManager)
+        assert isinstance(handler._encoder_cache, MultimodalEmbeddingCacheManager)
 
     def test_prefill_handler_without_encoder_cache(self):
         """Test factory creates PrefillHandler with no cache when capacity is 0."""

--- a/components/src/dynamo/trtllm/tests/request_handlers/utils.py
+++ b/components/src/dynamo/trtllm/tests/request_handlers/utils.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared test utilities for request handler tests."""
+
+from typing import Any, List, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def create_mock_encoder_cache() -> MagicMock:
+    """Create mock EncoderCacheManager."""
+    cache = MagicMock()
+    cache.get = MagicMock(return_value=None)
+    cache.set = MagicMock(return_value=True)
+    return cache
+
+
+def create_mock_context(request_id: str = "test-id") -> MagicMock:
+    """Create mock Context."""
+    ctx = MagicMock()
+    ctx.id = MagicMock(return_value=request_id)
+    ctx.is_stopped = MagicMock(return_value=False)
+    ctx.is_killed = MagicMock(return_value=False)
+    return ctx
+
+
+def setup_multimodal_config(config: MagicMock, image_urls: List[str]) -> None:
+    """Configure multimodal_processor and encode_client on config."""
+    config.multimodal_processor = MagicMock()
+    config.multimodal_processor.extract_prompt_and_media = MagicMock(
+        return_value=("text", image_urls, [])
+    )
+    config.encode_client = MagicMock()
+
+
+async def run_generate_with_mock_fetch(
+    handler: Any,
+    fetch_patch_path: str,
+    mock_return_value: Any,
+) -> Tuple[Any, Any]:
+    """
+    Run handler.generate() with mocked fetch_embeddings_from_encoder.
+
+    Args:
+        handler: Handler instance (PrefillHandler or AggregatedHandler)
+        fetch_patch_path: Full path to patch fetch_embeddings_from_encoder
+        mock_return_value: Value to return from mocked fetch
+
+    Returns:
+        Tuple of (captured_embeddings, captured_ep_params)
+    """
+    captured_embeddings = None
+    captured_ep_params = None
+
+    async def mock_generate_locally(request, context, embeddings, ep_params):
+        nonlocal captured_embeddings, captured_ep_params
+        captured_embeddings = embeddings
+        captured_ep_params = ep_params
+        yield {"result": "mock"}
+
+    request: dict[str, Any] = {"messages": []}
+
+    with patch(
+        fetch_patch_path,
+        new_callable=AsyncMock,
+        return_value=mock_return_value,
+    ) as mock_fetch:
+        with patch.object(handler, "generate_locally", mock_generate_locally):
+            async for _ in handler.generate(request, create_mock_context()):
+                pass
+
+    mock_fetch.assert_called_once()
+    return captured_embeddings, captured_ep_params

--- a/components/src/dynamo/trtllm/tests/request_handlers/utils.py
+++ b/components/src/dynamo/trtllm/tests/request_handlers/utils.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 
 def create_mock_encoder_cache() -> MagicMock:
-    """Create mock EncoderCacheManager."""
+    """Create mock MultimodalEmbeddingCacheManager."""
     cache = MagicMock()
     cache.get = MagicMock(return_value=None)
     cache.set = MagicMock(return_value=True)

--- a/components/src/dynamo/vllm/multimodal_handlers/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/__init__.py
@@ -5,6 +5,17 @@ from dynamo.vllm.multimodal_handlers.encode_worker_handler import (
     EncodeWorkerHandler,
     VLLMEncodeWorkerHandler,
 )
+
+# Multimodal Streamline handlers (simplified F→P architecture)
+from dynamo.vllm.multimodal_handlers.multimodal_streamline_encoder_worker_handler import (
+    MultimodalStreamlineEncoderWorkerHandler,
+)
+from dynamo.vllm.multimodal_handlers.multimodal_streamline_pd_worker_handler import (
+    MultimodalStreamlinePdWorkerHandler,
+)
+from dynamo.vllm.multimodal_handlers.multimodal_streamline_prefill_worker_handler import (
+    MultimodalStreamlinePrefillWorkerHandler,
+)
 from dynamo.vllm.multimodal_handlers.preprocessed_handler import (
     ECProcessorHandler,
     PreprocessedHandler,
@@ -21,4 +32,8 @@ __all__ = [
     "ECProcessorHandler",
     "MultimodalPDWorkerHandler",
     "MultimodalDecodeWorkerHandler",
+    # Multimodal Streamline handlers
+    "MultimodalStreamlineEncoderWorkerHandler",
+    "MultimodalStreamlinePrefillWorkerHandler",
+    "MultimodalStreamlinePdWorkerHandler",
 ]

--- a/components/src/dynamo/vllm/multimodal_handlers/multimodal_streamline_encoder_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/multimodal_streamline_encoder_worker_handler.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Multimodal Streamline Encoder Worker Handler
+
+Architecture: Frontend → PrefillWorker → Encoder → (PrefillWorker) → DecodeWorker
+
+Streamline design philosophy:
+- Frontend always talks to P/PD worker (single entry point)
+- No separate Processor component
+- P/PD worker orchestrates encoding internally
+- Simpler deployment with fewer components
+"""
+
+import logging
+
+from dynamo.runtime import Component, DistributedRuntime
+
+from ..multimodal_utils import ImageLoader
+
+logger = logging.getLogger(__name__)
+
+
+class MultimodalStreamlineEncoderWorkerHandler:
+    """
+    Encoder worker for Multimodal Streamline path.
+
+    Responsibilities:
+    - Receive requests (URL or data) from Prefill/PD worker
+    - Load and process media through vision model
+    - Return embeddings to the calling worker
+
+    This handler does NOT register as a model endpoint - it's called
+    internally by MultimodalStreamlinePrefillWorkerHandler or MultimodalStreamlinePdWorkerHandler.
+    """
+
+    def __init__(
+        self,
+        runtime: DistributedRuntime,
+        component: Component,
+        config,
+    ):
+        self.runtime = runtime
+        self.component = component
+        self.config = config
+
+        # Vision model components (lazy initialized)
+        self._vision_model = None
+        self._image_processor = None
+        self._vision_encoder = None
+        self._projector = None
+
+        self.image_loader = ImageLoader()
+
+        logger.info("MultimodalStreamlineEncoderWorkerHandler initialized")
+
+    async def encode(self, request, context):
+        """
+        Encode multimodal inputs and return embeddings.
+
+        Args:
+            request: Request containing multimodal URLs to encode
+            context: Request context for cancellation handling
+
+        Yields:
+            Encoded embeddings for each multimodal input
+        """
+        # TODO: Implement encoding logic
+        # 1. Parse request to extract image/video URLs
+        # 2. Load media using self.image_loader
+        # 3. Process through vision model
+        # 4. Return embeddings
+        raise NotImplementedError("MultimodalStreamlineEncoderWorkerHandler.encode")
+        yield

--- a/components/src/dynamo/vllm/multimodal_handlers/multimodal_streamline_pd_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/multimodal_streamline_pd_worker_handler.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Multimodal Streamline PD (Prefill+Decode) Worker Handler
+
+Architecture: Frontend → PDWorker → Encoder
+
+Streamline design philosophy:
+- Frontend always talks to P/PD worker (single entry point)
+- No separate Processor component
+- P/PD worker orchestrates encoding internally
+- Simpler deployment with fewer components
+"""
+
+import logging
+
+from vllm.v1.engine.async_llm import AsyncLLM
+
+from dynamo.runtime import Client, Component, DistributedRuntime
+
+from ..handlers import BaseWorkerHandler
+from ..multimodal_utils import ImageLoader
+
+logger = logging.getLogger(__name__)
+
+
+class MultimodalStreamlinePdWorkerHandler(BaseWorkerHandler):
+    """
+    Aggregated Prefill+Decode worker for Multimodal Streamline path.
+
+    Responsibilities:
+    - Receive requests from Frontend (registers as model endpoint)
+    - Orchestrate encoding by calling encoder worker
+    - Run both prefill and decode (no separate decode worker)
+
+    Architecture:
+        Frontend → [This Worker] <-> Encoder
+                         ↓
+            (orchestrate + prefill + decode)
+
+    Use this for simpler deployments where P/D disaggregation is not needed.
+    """
+
+    def __init__(
+        self,
+        runtime: DistributedRuntime,
+        component: Component,
+        engine_client: AsyncLLM,
+        config,
+        encoder_worker_client: Client = None,
+    ):
+        # Get default_sampling_params from config
+        default_sampling_params = (
+            config.engine_args.create_model_config().get_diff_sampling_param()
+        )
+
+        super().__init__(
+            runtime,
+            component,
+            engine_client,
+            default_sampling_params,
+            enable_multimodal=True,
+        )
+        self.config = config
+        self.encoder_worker_client = encoder_worker_client
+
+        self.image_loader = ImageLoader()
+
+        logger.info("MultimodalStreamlinePdWorkerHandler initialized")
+
+    async def generate(self, request, context):
+        """
+        Process multimodal request: encode → prefill + decode.
+
+        Args:
+            request: Preprocessed request with token_ids and multimodal URLs
+            context: Request context for cancellation handling
+
+        Yields:
+            Token outputs from inference
+        """
+        # TODO: Implement Streamline PD logic
+        # 1. Extract multimodal URLs from request
+        # 2. If has URLs, dispatch to encoder worker (async)
+        # 3. Gather embeddings
+        # 4. Run prefill + decode with embeddings
+        # 5. Stream responses back
+        raise NotImplementedError("MultimodalStreamlinePdWorkerHandler.generate")
+        yield

--- a/components/src/dynamo/vllm/multimodal_handlers/multimodal_streamline_prefill_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/multimodal_streamline_prefill_worker_handler.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Multimodal Streamline Prefill Worker Handler
+
+Architecture: Frontend → PrefillWorker → Encoder → (PrefillWorker) → DecodeWorker
+
+Streamline design philosophy:
+- Frontend always talks to P/PD worker (single entry point)
+- No separate Processor component
+- P/PD worker orchestrates encoding internally
+- Simpler deployment with fewer components
+"""
+
+import logging
+
+from vllm.v1.engine.async_llm import AsyncLLM
+
+from dynamo.runtime import Client, Component, DistributedRuntime
+
+from ..handlers import BaseWorkerHandler
+
+logger = logging.getLogger(__name__)
+
+
+class MultimodalStreamlinePrefillWorkerHandler(BaseWorkerHandler):
+    """
+    Prefill worker for Multimodal Streamline path (disaggregated mode).
+
+    Responsibilities:
+    - Receive requests from Frontend (registers as model endpoint)
+    - Orchestrate encoding by calling encoder worker
+    - Run prefill with embeddings
+    - Forward to decode worker for token generation
+
+    Architecture:
+        Frontend → [This Worker] → Encoder → [This Worker] → Decode Worker
+                         ↓                         ↓
+                    (orchestrate)              (prefill)
+    """
+
+    def __init__(
+        self,
+        runtime: DistributedRuntime,
+        component: Component,
+        engine_client: AsyncLLM,
+        config,
+        encoder_worker_client: Client = None,
+        decode_worker_client: Client = None,
+    ):
+        # Get default_sampling_params from config
+        default_sampling_params = (
+            config.engine_args.create_model_config().get_diff_sampling_param()
+        )
+
+        super().__init__(
+            runtime,
+            component,
+            engine_client,
+            default_sampling_params,
+            enable_multimodal=config.enable_multimodal,
+        )
+
+        self.config = config
+        self.encoder_worker_client = encoder_worker_client
+        self.decode_worker_client = decode_worker_client
+
+        logger.info("MultimodalStreamlinePrefillWorkerHandler initialized")
+
+    async def generate(self, request, context):
+        """
+        Process multimodal request: encode → prefill → forward to decode.
+
+        Args:
+            request: Preprocessed request with token_ids and multimodal URLs
+            context: Request context for cancellation handling
+
+        Yields:
+            Token outputs from decode worker
+        """
+        # TODO: Implement Streamline prefill logic
+        # 1. Extract multimodal URLs from request
+        # 2. If has URLs, dispatch to encoder worker (async)
+        # 3. Gather embeddings
+        # 4. Run prefill with embeddings
+        # 5. Forward to decode worker with kv_transfer_params
+        # 6. Stream decode responses back
+        raise NotImplementedError("MultimodalStreamlinePrefillWorkerHandler.generate")
+        yield

--- a/components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_streamline_encoder_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_streamline_encoder_worker_handler.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for MultimodalStreamlineEncoderWorkerHandler."""
+
+import pytest
+
+from dynamo.vllm.multimodal_handlers import MultimodalStreamlineEncoderWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+class TestMultimodalStreamlineEncoderWorkerHandler:
+    """Test suite for MultimodalStreamlineEncoderWorkerHandler."""
+
+    pass

--- a/components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_streamline_pd_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_streamline_pd_worker_handler.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for MultimodalStreamlinePdWorkerHandler."""
+
+import pytest
+
+from dynamo.vllm.multimodal_handlers import MultimodalStreamlinePdWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+class TestMultimodalStreamlinePdWorkerHandler:
+    """Test suite for MultimodalStreamlinePdWorkerHandler."""
+
+    pass

--- a/components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_streamline_prefill_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_streamline_prefill_worker_handler.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for MultimodalStreamlinePrefillWorkerHandler."""
+
+import pytest
+
+from dynamo.vllm.multimodal_handlers import MultimodalStreamlinePrefillWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+class TestMultimodalStreamlinePrefillWorkerHandler:
+    """Test suite for MultimodalStreamlinePrefillWorkerHandler."""
+
+    pass

--- a/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/agg.yaml
+++ b/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/agg.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tensor_parallel_size: 1
+moe_expert_parallel_size: 1
+enable_attention_dp: false
+max_num_tokens: 8192
+max_batch_size: 16
+trust_remote_code: true
+backend: pytorch
+enable_chunked_prefill: true
+
+kv_cache_config:
+  free_gpu_memory_fraction: 0.60
+  enable_block_reuse: false
+
+cache_transceiver_config:
+  backend: DEFAULT

--- a/examples/backends/trtllm/launch/e_pd_disagg.sh
+++ b/examples/backends/trtllm/launch/e_pd_disagg.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# 1 Encode + 1 PD worker for llava-v1.6-mistral-7b-hf
+# GPU 0: Encode (vision encoder)
+# GPU 1: PD worker (prefill + decode, TP=1)
+
+# Environment variables with defaults
+export DYNAMO_HOME=${DYNAMO_HOME:-"/workspace"}
+export MODEL_PATH=${MODEL_PATH:-"llava-hf/llava-v1.6-mistral-7b-hf"}
+export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"llava-v1.6-mistral-7b-hf"}
+export ENCODE_ENGINE_ARGS=${ENCODE_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/encode.yaml"}
+export PD_ENGINE_ARGS=${PD_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/llava-v1.6-mistral-7b-hf/agg.yaml"}
+export ENCODE_CUDA_VISIBLE_DEVICES=${ENCODE_CUDA_VISIBLE_DEVICES:-"0"}
+export ENCODE_ENDPOINT=${ENCODE_ENDPOINT:-"dyn://dynamo.tensorrt_llm_encode.generate"}
+export MODALITY=${MODALITY:-"multimodal"}
+export ALLOWED_LOCAL_MEDIA_PATH=${ALLOWED_LOCAL_MEDIA_PATH:-"/tmp"}
+export MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
+export DYN_ENCODER_CACHE_CAPACITY_GB=${DYN_ENCODER_CACHE_CAPACITY_GB:-4}
+export CUSTOM_TEMPLATE=${CUSTOM_TEMPLATE:-"$DYNAMO_HOME/examples/backends/trtllm/templates/llava_multimodal.jinja"}
+
+# Setup cleanup trap
+cleanup() {
+    echo "Cleaning up background processes..."
+    kill $DYNAMO_PID $ENCODE_PID $PD_PID_1 2>/dev/null || true
+    wait $DYNAMO_PID $ENCODE_PID $PD_PID_1 2>/dev/null || true
+    echo "Cleanup complete."
+}
+trap cleanup EXIT INT TERM
+
+# run frontend
+# dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
+python3 -m dynamo.frontend &
+DYNAMO_PID=$!
+
+# run encode worker (vision encoder on GPU 0)
+CUDA_VISIBLE_DEVICES=$ENCODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
+  --model-path "$MODEL_PATH" \
+  --served-model-name "$SERVED_MODEL_NAME" \
+  --extra-engine-args "$ENCODE_ENGINE_ARGS" \
+  --modality "$MODALITY" \
+  --allowed-local-media-path "$ALLOWED_LOCAL_MEDIA_PATH" \
+  --max-file-size-mb "$MAX_FILE_SIZE_MB" \
+  --disaggregation-mode encode &
+ENCODE_PID=$!
+
+# run PD worker 1 (GPU 1)
+CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.trtllm \
+  --model-path "$MODEL_PATH" \
+  --served-model-name "$SERVED_MODEL_NAME" \
+  --extra-engine-args "$PD_ENGINE_ARGS" \
+  --modality "$MODALITY" \
+  --custom-jinja-template "$CUSTOM_TEMPLATE" \
+  --encode-endpoint "$ENCODE_ENDPOINT" \
+  --dyn-encoder-cache-capacity-gb "$DYN_ENCODER_CACHE_CAPACITY_GB" &
+PD_PID_1=$!
+
+wait $DYNAMO_PID

--- a/examples/backends/trtllm/launch/e_pd_disagg.sh
+++ b/examples/backends/trtllm/launch/e_pd_disagg.sh
@@ -53,6 +53,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.trtllm \
   --modality "$MODALITY" \
   --custom-jinja-template "$CUSTOM_TEMPLATE" \
   --encode-endpoint "$ENCODE_ENDPOINT" \
+  --disaggregation-mode prefill_and_decode \
   --dyn-encoder-cache-capacity-gb "$DYN_ENCODER_CACHE_CAPACITY_GB" &
 PD_PID_1=$!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,12 @@ filterwarnings = [
     "ignore:.*Benchmarks are automatically disabled.*:pytest_benchmark.logger.PytestBenchmarkWarning",
 
     ################################################################################################
+    # vLLM
+    ################################################################################################
+    # vLLM deprecation warning for AnyTokenizer moved to vllm.tokenizers.TokenizerLike (will be removed in v0.14)
+    "ignore:.*has been moved to.*vllm.tokenizers.TokenizerLike.*:DeprecationWarning",
+
+    ################################################################################################
     # TRT-LLM
     ################################################################################################
     # torchao sometimes emits SyntaxWarning from docstrings (e.g. invalid escape sequences) at import


### PR DESCRIPTION
# This PR 

see design overview and details in [this PR](https://github.com/ai-dynamo/enhancements/pull/66/changes)

- adds worker handlers for
  - PD
  - Prefill
  - Encode
- unit test them
- add 2 .sh scripts to kick off E/P/D and E/PD workflows 

# Test Plan

```
pytest -v --tb=short components/src/dynamo/vllm/tests/multimodal_handlers/*
```
