### PR TITLE
fix: Add cupy-cuda12x to sglang extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ sglang = [
     "uvloop",
     "sglang==0.5.7",
     "nixl[cu12]<=0.9.0",
+    "cupy-cuda12x>=13.0.0",
 ]
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
Overview:
Adds missing cupy-cuda12x dependency to SGLang optional dependencies.

Details:
SGLang's multimodal encode worker requires CuPy for GPU-accelerated array operations but it wasn't listed in the [project.optional-dependencies] section. This caused the worker to fall back to NumPy (CPU-only mode), degrading performance. The vLLM extras already include CuPy transitively through the vllm package, but SGLang does not.

Changes:
Added "cupy-cuda12x>=13.0.0" to sglang extras in pyproject.toml

Testing:

✅ Verified CuPy is NOT installed when using main branch
✅ Verified CuPy IS installed (v13.6.0) with this fix
✅ Pre-commit hooks passed

Where should the reviewer start?
pyproject.toml line 62-67 (single line addition)

Related Issues:
Fixes #5526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an optional dependency to support GPU-accelerated computing capabilities for enhanced performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->