### PR TITLE
Use correct service name in kubectl portforward command

### DIFF
--- a/docs/kubernetes/installation_guide.md
+++ b/docs/kubernetes/installation_guide.md
@@ -281,7 +281,7 @@ kubectl get pods -n ${NAMESPACE}
    kubectl apply -f examples/backends/vllm/deploy/agg.yaml -n ${NAMESPACE}
 
    # Port forward and test
-   kubectl port-forward svc/agg-vllm-frontend 8000:8000 -n ${NAMESPACE}
+   kubectl port-forward svc/vllm-agg-frontend 8000:8000 -n ${NAMESPACE}
    curl http://localhost:8000/v1/models
    ```
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
The [documentation](https://github.com/ai-dynamo/dynamo/blob/main/docs/kubernetes/installation_guide.md#verify-installation) uses an incorrect reference for the frontend service.

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes installation guide with the correct service name for port-forwarding the vLLM frontend service.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->