### PR TITLE
chore: do not default to privileged mode when mounting workspace.

### DIFF
--- a/container/run.sh
+++ b/container/run.sh
@@ -264,10 +264,6 @@ get_options() {
             HF_HOME=$DEFAULT_HF_HOME
         fi
 
-        if [ -z "${PRIVILEGED}" ]; then
-            PRIVILEGED="TRUE"
-        fi
-
         ENVIRONMENT_VARIABLES+=" -e HF_TOKEN"
     fi
 
@@ -348,7 +344,7 @@ show_help() {
     echo "  [--image image]"
     echo "  [--framework framework one of ${!FRAMEWORKS[*]}]"
     echo "  [--name name for launched container, default NONE]"
-    echo "  [--privileged whether to launch in privileged mode, default FALSE unless mounting workspace]"
+    echo "  [--privileged whether to launch in privileged mode, default FALSE]"
     echo "  [--dry-run print docker commands without running]"
     echo "  [--hf-home|--hf-cache directory to volume mount as the hf home, default is NONE unless mounting workspace]"
     echo "  [--gpus gpus to enable, default is 'all', 'none' disables gpu support]"


### PR DESCRIPTION
#### Overview:

do not default to privileged mode when mounting workspace.

#### Details:

the run.sh set privileged mode to True when mount-workspace is used. This is not necessary for dynamo container to work, and it had other side effects such as forcing all GPUs to be visible regardless of what `-gpus` parameter is. 

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace mounting no longer automatically enables privileged mode by default.

* **Documentation**
  * Updated help text to clarify that privileged mode defaults to FALSE and is only enabled when explicitly specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->