### PR TITLE
docs: improve support-matrix and release-artifacts clarity

### DIFF
--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -10,8 +10,7 @@ This document provides a comprehensive inventory of all Dynamo release artifacts
 
 > **See also:** [Support Matrix](support-matrix.md) for hardware and platform compatibility | [Feature Matrix](feature-matrix.md) for backend feature support
 
-> [!Note]
-> Release history in this document begins at v0.6.0, as we expect the majority of users to be on v0.6.0 or later.
+Release history in this document begins at v0.6.0.
 
 ## Current Release: Dynamo v0.8.1
 
@@ -21,8 +20,7 @@ This document provides a comprehensive inventory of all Dynamo release artifacts
 
 ### Patch Release: v0.8.1.post1 (Jan 23, 2026)
 
-> [!Note]
-> **v0.8.1.post1** is a patch release for PyPI wheels and TRT-LLM container only. There is no GitHub release for this version. All other artifacts (vLLM/SGLang containers, Helm charts, Rust crates) remain at v0.8.1.
+**v0.8.1.post1** is a patch release for PyPI wheels and TRT-LLM container only (no GitHub release). All other artifacts remain at v0.8.1.
 
 | Artifact | Version | Change | Link |
 |----------|---------|--------|------|
@@ -42,13 +40,11 @@ This document provides a comprehensive inventory of all Dynamo release artifacts
 | `dynamo-frontend:0.8.1` | API gateway with Endpoint Prediction Protocol (EPP) | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/dynamo-frontend?version=0.8.1) | |
 | `kubernetes-operator:0.8.1` | Kubernetes operator for Dynamo deployments | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/kubernetes-operator?version=0.8.1) | |
 
-> [!Note]
-> \* Multimodality is not expected to work on ARM64 for CUDA 13 images (`vllm-runtime:*-cuda13`, `sglang-runtime:*-cuda13`). Multimodal inference works on AMD64 for these images.
+\* Multimodality is not expected to work on ARM64 for CUDA 13 images. Multimodal inference works on AMD64.
 
 ### Python Wheels
 
-> [!Important]
-> We recommend using the TensorRT-LLM NGC container instead of the `ai-dynamo[trtllm]` wheel. See the [NGC container collection](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo) for supported images.
+We recommend using the TensorRT-LLM NGC container instead of the `ai-dynamo[trtllm]` wheel. See the [NGC container collection](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo) for supported images.
 
 | Package | Description | Python | Platform | PyPI |
 |---------|-------------|--------|----------|------|
@@ -178,6 +174,11 @@ For a complete list of known issues, refer to the release notes for each patch:
 
 ### Container Images
 
+> **NGC Collection:** [ai-dynamo](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)
+>
+> To access a specific version, append `?version=TAG` to the container URL:
+> `https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/{container}?version={tag}`
+
 #### vllm-runtime
 
 | Image:Tag | vLLM | Arch | CUDA | Notes |
@@ -245,6 +246,10 @@ For a complete list of known issues, refer to the release notes for each patch:
 
 ### Python Wheels
 
+> **PyPI:** [ai-dynamo](https://pypi.org/project/ai-dynamo/) | [ai-dynamo-runtime](https://pypi.org/project/ai-dynamo-runtime/) | [kvbm](https://pypi.org/project/kvbm/)
+>
+> To access a specific version: `https://pypi.org/project/{package}/{version}/`
+
 #### ai-dynamo (wheel)
 
 | Package | Python | Platform | Notes |
@@ -280,6 +285,10 @@ For a complete list of known issues, refer to the release notes for each patch:
 
 ### Helm Charts
 
+> **NGC Helm Registry:** [ai-dynamo](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)
+>
+> Direct download: `https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/{chart}-{version}.tgz`
+
 #### dynamo-crds (Helm chart)
 
 | Chart | Notes |
@@ -314,6 +323,10 @@ For a complete list of known issues, refer to the release notes for each patch:
 | `dynamo-graph-0.6.0` | |
 
 ### Rust Crates
+
+> **crates.io:** [dynamo-runtime](https://crates.io/crates/dynamo-runtime) | [dynamo-llm](https://crates.io/crates/dynamo-llm) | [dynamo-async-openai](https://crates.io/crates/dynamo-async-openai) | [dynamo-parsers](https://crates.io/crates/dynamo-parsers) | [dynamo-memory](https://crates.io/crates/dynamo-memory) | [dynamo-config](https://crates.io/crates/dynamo-config)
+>
+> To access a specific version: `https://crates.io/crates/{crate}/{version}`
 
 #### dynamo-runtime (crate)
 

--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -40,7 +40,7 @@ Release history in this document begins at v0.6.0.
 | `dynamo-frontend:0.8.1` | API gateway with Endpoint Prediction Protocol (EPP) | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/dynamo-frontend?version=0.8.1) | |
 | `kubernetes-operator:0.8.1` | Kubernetes operator for Dynamo deployments | — | — | AMD64/ARM64 | [link](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/containers/kubernetes-operator?version=0.8.1) | |
 
-\* Multimodality is not expected to work on ARM64 for CUDA 13 images. Multimodal inference works on AMD64.
+\* Multimodal inference on CUDA 13 images: works on AMD64 for all backends; works on ARM64 only for TensorRT-LLM (`vllm-runtime:*-cuda13` and `sglang-runtime:*-cuda13` do not support multimodality on ARM64).
 
 ### Python Wheels
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -8,8 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 
 This document provides the support matrix for Dynamo, including hardware, software and build instructions.
 
-> [!Note]
-> **See also:** [Release Artifacts](release-artifacts.md) for container images, wheels, Helm charts, and crates | [Feature Matrix](feature-matrix.md) for backend feature support
+**See also:** [Release Artifacts](release-artifacts.md) for container images, wheels, Helm charts, and crates | [Feature Matrix](feature-matrix.md) for backend feature support
 
 ## Backend Dependencies
 
@@ -22,8 +21,7 @@ The following table shows the backend framework versions included with each Dyna
 | TensorRT-LLM   | `1.2.0rc6.post2` | `1.2.0rc6.post2` | `1.2.0rc6.post1`  | `1.2.0rc6.post1` | `1.2.0rc3` | `1.2.0rc3`     | `1.2.0rc2` |
 | NIXL           | `0.9.0`        | `0.8.0`          | `0.8.0`             | `0.8.0`    | `0.8.0`    | `0.8.0`          | `0.8.0`    |
 
-> [!Note]
-> **main (ToT)** reflects the current development branch. **v0.8.1.post1** is a patch release for PyPI wheels and TRT-LLM container only (no GitHub release).
+**main (ToT)** reflects the current development branch. **v0.8.1.post1** is a patch release for PyPI wheels and TRT-LLM container only (no GitHub release).
 
 > [!Important]
 > Currently TensorRT-LLM does not support Python 3.11 so installation of the ai-dynamo[trtllm] Python wheel will fail.
@@ -35,8 +33,7 @@ The following table shows the backend framework versions included with each Dyna
 | **Dynamo 0.7.1**   | CUDA 12.8                 | CUDA 13.0        | CUDA 12.9                |
 | **Dynamo 0.7.0**   | CUDA 12.9                 | CUDA 13.0        | CUDA 12.8                |
 
-> [!Note]
-> Patch versions (e.g., v0.8.1.post1, v0.7.0.post1) have the same CUDA support as their base version.
+Patch versions (e.g., v0.8.1.post1, v0.7.0.post1) have the same CUDA support as their base version.
 
 For detailed artifact versions and NGC links (including container images, Python wheels, Helm charts, and Rust crates), see the [Release Artifacts](release-artifacts.md) page.
 
@@ -71,10 +68,7 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 | **Ubuntu**           | 24.04       | ARM64            | Supported    |
 | **CentOS Stream**    | 9           | x86_64           | Experimental |
 
-> [!Note]
-> Wheels are built using a manylinux_2_28-compatible environment and they have been validated on CentOS Stream 9 and Ubuntu (22.04, 24.04).
->
-> Compatibility with other Linux distributions is expected but has not been officially verified yet.
+Wheels are built using a manylinux_2_28-compatible environment and validated on CentOS Stream 9 and Ubuntu (22.04, 24.04). Compatibility with other Linux distributions is expected but not officially verified.
 
 > [!Caution]
 > KV Block Manager is supported only with Python 3.12. Python 3.12 support is currently limited to Ubuntu 24.04.
@@ -104,8 +98,7 @@ Dynamo container images include CUDA toolkit libraries. The host machine must ha
 | | **SGLang** | 12.9 | 575.xx+ | 576.xx+ | |
 | | **TensorRT-LLM** | 13.0 | 580.xx+ | 581.xx+ | |
 
-> [!Note]
-> Experimental CUDA 13 images are not published for all versions. Check [Release Artifacts](release-artifacts.md) for availability.
+Experimental CUDA 13 images are not published for all versions. Check [Release Artifacts](release-artifacts.md) for availability.
 
 #### CUDA Compatibility Resources
 
@@ -117,8 +110,7 @@ For detailed information on CUDA driver compatibility, forward compatibility, an
 - [Forward Compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/forward-compatibility.html)
 - [FAQ](https://docs.nvidia.com/deploy/cuda-compatibility/frequently-asked-questions.html)
 
-> [!Tip]
-> For extended driver compatibility beyond the minimum versions listed above, consider using `cuda-compat` packages on the host. See [Forward Compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/forward-compatibility.html) for details.
+For extended driver compatibility beyond the minimum versions listed above, consider using `cuda-compat` packages on the host. See [Forward Compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/forward-compatibility.html) for details.
 
 ## Cloud Service Provider Compatibility
 
@@ -133,8 +125,7 @@ For detailed information on CUDA driver compatibility, forward compatibility, an
 
 ## Build Support
 
-> [!Note]
-> For version-specific artifact details, installation commands, and release history, see [Release Artifacts](release-artifacts.md).
+For version-specific artifact details, installation commands, and release history, see [Release Artifacts](release-artifacts.md).
 
 **Dynamo** currently provides build support in the following ways:
 


### PR DESCRIPTION
## Summary

- Restructures Backend Dependencies table: transposes to Dynamo-version rows (easier to find "what backend works with Dynamo X.Y.Z")
- Extends version history back to v0.6.0
- Adds CUDA Versions table with Notes column indicating when CUDA 13 support was introduced
- Adds compatibility warning: unsupported backend versions are not recommended
- Reduces admonition clutter in both `support-matrix.md` and `release-artifacts.md`
- Clarifies multimodal ARM64 limitation applies only to vLLM/SGLang CUDA 13 images (TensorRT-LLM unaffected)
- Adds URL patterns to Release History sections for direct artifact access

Addresses #5454 and #4773

## Test plan

- [ ] Verify Sphinx docs build: `uv run --python .venv-docs --no-project docs/generate_docs.py`
- [ ] Visual review of rendered tables in PR diff