### PR TITLE
fix: enable http2 for http request plane

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ reqwest = { version = "0.12.24", default-features = false, features = [
     "json",
     "stream",
     "rustls-tls",
+    "http2",
 ] }
 rmp-serde = { version = "1" }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
- reqwest crate feature needs to be enabled
- configure client settings from env
- use http2_prior_knowledge for non TLS connections

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP/2 prior knowledge support for enhanced connection optimization.
  * New configuration option enables HTTP/2 prior knowledge for improved connection handling.
  * Prior knowledge setting can be customized via environment variable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->