### PR TITLE
feat: Lazy ETCD initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,6 +2497,7 @@ dependencies = [
  "notify",
  "nuid",
  "once_cell",
+ "oneshot",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1587,7 +1587,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "utoipa",
  "uuid",
 ]
 
@@ -1800,6 +1799,7 @@ dependencies = [
  "notify",
  "nuid",
  "once_cell",
+ "oneshot",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -7793,8 +7793,6 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.110",
- "url",
- "uuid",
 ]
 
 [[package]]

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -39,6 +39,7 @@ either = { workspace = true }
 etcd-client = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
+oneshot = { workspace = true }
 parking_lot = { workspace = true }
 prometheus = { workspace = true }
 rand = { workspace = true }

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -483,7 +483,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_kv_store_discovery_register_endpoint() {
-        let store = kv::Manager::memory();
+        let store = kv::Manager::default();
         let cancel_token = CancellationToken::new();
         let client = KVStoreDiscovery::new(store, cancel_token);
 
@@ -508,7 +508,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_kv_store_discovery_list() {
-        let store = kv::Manager::memory();
+        let store = kv::Manager::default();
         let cancel_token = CancellationToken::new();
         let client = KVStoreDiscovery::new(store, cancel_token);
 
@@ -563,7 +563,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_kv_store_discovery_watch() {
-        let store = kv::Manager::memory();
+        let store = kv::Manager::default();
         let cancel_token = CancellationToken::new();
         let client = Arc::new(KVStoreDiscovery::new(store, cancel_token.clone()));
 

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -533,7 +533,7 @@ impl DistributedConfig {
         let nats_enabled = request_plane.is_nats()
             || std::env::var(crate::config::environment_names::nats::NATS_SERVER).is_ok();
         DistributedConfig {
-            store_backend: kv::Selector::Etcd(etcd::ClientOptions::default()),
+            store_backend: kv::Selector::Etcd(Box::default()),
             nats_config: if nats_enabled {
                 Some(nats::ClientOptions::default())
             } else {
@@ -552,7 +552,7 @@ impl DistributedConfig {
         let nats_enabled = request_plane.is_nats()
             || std::env::var(crate::config::environment_names::nats::NATS_SERVER).is_ok();
         DistributedConfig {
-            store_backend: kv::Selector::Etcd(etcd_config),
+            store_backend: kv::Selector::Etcd(Box::new(etcd_config)),
             nats_config: if nats_enabled {
                 Some(nats::ClientOptions::default())
             } else {

--- a/lib/runtime/src/storage/kv.rs
+++ b/lib/runtime/src/storage/kv.rs
@@ -315,9 +315,8 @@ impl Manager {
 
     fn get_kv_store(&self) -> Result<&KeyValueStoreEnum, StoreError> {
         let selector = self.selector.clone();
-        self.kv_store.get_or_try_init(|| {
-            selector
-                .build(self.runtime.clone())})
+        self.kv_store
+            .get_or_try_init(|| selector.build(self.runtime.clone()))
     }
 
     pub async fn get_or_create_bucket(


### PR DESCRIPTION
ETCD seems to be very sensitive to network and memory pressure. During the network and memory-intensive model loading process (especially when loading from ETCD), pings from the ETCD server can take several seconds to be delivered. To get around this, we lazily initialize ETCD, and only create our lease after the model loading has completed.