### PR TITLE
feat: integrate KV Router with Event Plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -142,7 +142,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -703,7 +703,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -721,7 +721,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2132,7 +2132,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2502,6 +2502,7 @@ dependencies = [
  "libc",
  "local-ip-address",
  "log",
+ "lru",
  "nid",
  "nix 0.29.0",
  "notify",
@@ -2725,7 +2726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4319,7 +4320,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4382,7 +4383,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4842,6 +4843,15 @@ dependencies = [
  "num-traits",
  "sparsevec",
  "vob",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5784,7 +5794,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7883,7 +7893,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9152,7 +9162,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10776,7 +10786,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -153,7 +153,7 @@ pub(crate) struct ZmqKvEventPublisher {
 impl ZmqKvEventPublisher {
     #[new]
     fn new(component: Component, config: ZmqKvEventPublisherConfig) -> PyResult<Self> {
-        let inner = llm_rs::kv_router::publisher::KvEventPublisher::new_with_local_indexer(
+        let inner = llm_rs::kv_router::publisher::KvEventPublisher::new(
             component.inner,
             config.kv_block_size as u32,
             Some(KvEventSourceConfig::Zmq {
@@ -267,7 +267,7 @@ impl KvEventPublisher {
         // The actual worker_id is inferred from component's connection_id in the Rust implementation.
         let _ = worker_id;
 
-        let inner = llm_rs::kv_router::publisher::KvEventPublisher::new_with_local_indexer(
+        let inner = llm_rs::kv_router::publisher::KvEventPublisher::new(
             component.inner,
             kv_block_size as u32,
             None,

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -242,12 +242,9 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                             break;
                         };
 
-                        let active_load = match event_result {
-                            Ok((_envelope, event)) => event,
-                            Err(e) => {
-                                tracing::error!("Error receiving KV metrics event: {e:?}");
-                                continue;
-                            }
+                        let Ok((_envelope, active_load)) = event_result else {
+                            tracing::error!("Error receiving KV metrics event: {event_result:?}");
+                            continue;
                         };
 
                         let worker_id = active_load.worker_id;

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -245,7 +245,7 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                         let active_load = match event_result {
                             Ok((_envelope, event)) => event,
                             Err(e) => {
-                                tracing::error!("Error receiving KV metrics event: {:?}", e);
+                                tracing::error!("Error receiving KV metrics event: {e:?}");
                                 continue;
                             }
                         };

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -527,7 +527,7 @@ impl KvRouter {
         let isl_tokens = tokens.len();
 
         let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, None);
-        let overlap_scores = self.indexer.find_matches(block_hashes.clone()).await?;
+        let overlap_scores = self.indexer.find_matches(block_hashes).await?;
 
         // Compute seq_hashes only if scheduler needs it for active blocks tracking
         let maybe_seq_hashes = self

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -424,6 +424,11 @@ impl KvRouter {
 
             // Start subscriber - setup runs synchronously, then spawns background loop internally
             if transport_kind == EventTransportKind::Zmq {
+                if !all_local_indexer {
+                    anyhow::bail!(
+                        "ZMQ event plane requires local_indexer=true for all workers."
+                    );
+                }
                 if kv_router_config.router_snapshot_threshold.is_some()
                     || kv_router_config.router_reset_states
                 {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use derive_builder::Builder;
 use dynamo_runtime::{
     component::{Client, Endpoint},
-    discovery::{DiscoveryQuery, watch_and_extract_field},
+    discovery::{DiscoveryQuery, EventTransportKind, watch_and_extract_field},
     pipeline::{
         AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, PushRouter, ResponseStream,
         SingleIn, async_trait,
@@ -50,7 +50,7 @@ use crate::{
         },
         scheduler::{KvScheduler, KvSchedulerError, PotentialLoad, SchedulingRequest},
         sequence::SequenceError,
-        subscriber::{start_kv_router_background, start_kv_router_background_nats_core},
+        subscriber::{start_kv_router_background, start_kv_router_background_event_plane},
     },
     local_model::runtime_config::ModelRuntimeConfig,
     model_card::ModelDeploymentCard,
@@ -420,13 +420,19 @@ impl KvRouter {
 
             tracing::info!("Found {count} worker(s), starting KV event subscriber");
 
-            // Start subscriber - setup runs synchronously, then spawns background loop internally
-            if all_local_indexer {
-                tracing::info!(
-                    "All {count} workers have local_indexer enabled, using NATS Core subscription"
-                );
+            let transport_kind = EventTransportKind::from_env_or_default();
 
-                start_kv_router_background_nats_core(
+            // Start subscriber - setup runs synchronously, then spawns background loop internally
+            if transport_kind == EventTransportKind::Zmq {
+                if kv_router_config.router_snapshot_threshold.is_some()
+                    || kv_router_config.router_reset_states
+                {
+                    tracing::warn!(
+                        "ZMQ event plane does not support KV snapshots or state reset; ignoring snapshot/reset settings"
+                    );
+                }
+
+                start_kv_router_background_event_plane(
                     component.clone(),
                     kv_indexer.event_sender(),
                     kv_indexer.remove_worker_sender(),
@@ -435,6 +441,24 @@ impl KvRouter {
                         component.clone(),
                         runtime_configs_rx.clone(),
                     ),
+                    transport_kind,
+                )
+                .await?;
+            } else if all_local_indexer {
+                tracing::info!(
+                    "All {count} workers have local_indexer enabled, using NATS Core subscription"
+                );
+
+                start_kv_router_background_event_plane(
+                    component.clone(),
+                    kv_indexer.event_sender(),
+                    kv_indexer.remove_worker_sender(),
+                    cancellation_token.clone(),
+                    worker_query::WorkerQueryClient::new(
+                        component.clone(),
+                        runtime_configs_rx.clone(),
+                    ),
+                    transport_kind,
                 )
                 .await?;
             } else {
@@ -498,7 +522,7 @@ impl KvRouter {
         let isl_tokens = tokens.len();
 
         let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, None);
-        let overlap_scores = self.indexer.find_matches(block_hashes).await?;
+        let overlap_scores = self.indexer.find_matches(block_hashes.clone()).await?;
 
         // Compute seq_hashes only if scheduler needs it for active blocks tracking
         let maybe_seq_hashes = self
@@ -596,7 +620,7 @@ impl KvRouter {
     pub async fn get_potential_loads(&self, tokens: &[u32]) -> Result<Vec<PotentialLoad>> {
         let isl_tokens = tokens.len();
         let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, None);
-        let overlap_scores = self.indexer.find_matches(block_hashes).await?;
+        let overlap_scores = self.indexer.find_matches(block_hashes.clone()).await?;
 
         let maybe_seq_hashes = self
             .kv_router_config

--- a/lib/llm/src/kv_router/indexer.rs
+++ b/lib/llm/src/kv_router/indexer.rs
@@ -979,13 +979,16 @@ impl KvIndexer {
 
                         Some(event) = event_rx.recv() => {
                             let event_type = KvIndexerMetrics::get_event_type(&event.event.data);
-                            let result = trie.apply_event(event.clone());
+                            // Only clone if we need the event for prune_manager afterward
+                            let event_for_prune = prune_manager.is_some().then(|| event.clone());
+                            let result = trie.apply_event(event);
                             let result_is_ok = result.is_ok();
                             metrics.increment_event_applied(event_type, result);
 
                             // Track blocks in PruneManager if TTL is enabled and event was stored successfully
                             let Some(ref mut pm) = prune_manager else { continue };
                             if !result_is_ok { continue };
+                            let Some(ref event) = event_for_prune else { continue };
                             let KvCacheEventData::Stored(ref store_data) = event.event.data else { continue };
 
                             let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
@@ -1707,13 +1710,16 @@ impl KvIndexerSharded {
 
                             Some(event) = shard_event_rx.recv() => {
                                 let event_type = KvIndexerMetrics::get_event_type(&event.event.data);
-                                let result = trie.apply_event(event.clone());
+                                // Only clone if we need the event for prune_manager afterward
+                                let event_for_prune = prune_manager.is_some().then(|| event.clone());
+                                let result = trie.apply_event(event);
                                 let result_is_ok = result.is_ok();
                                 metrics.increment_event_applied(event_type, result);
 
                                 // Track blocks in PruneManager if TTL is enabled and event was stored successfully
                                 let Some(ref mut pm) = prune_manager else { continue };
                                 if !result_is_ok { continue };
+                                let Some(ref event) = event_for_prune else { continue };
                                 let KvCacheEventData::Stored(ref store_data) = event.event.data else { continue };
 
                                 let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);

--- a/lib/llm/src/kv_router/indexer.rs
+++ b/lib/llm/src/kv_router/indexer.rs
@@ -979,16 +979,13 @@ impl KvIndexer {
 
                         Some(event) = event_rx.recv() => {
                             let event_type = KvIndexerMetrics::get_event_type(&event.event.data);
-                            // Only clone if we need the event for prune_manager afterward
-                            let event_for_prune = prune_manager.is_some().then(|| event.clone());
-                            let result = trie.apply_event(event);
+                            let result = trie.apply_event(event.clone());
                             let result_is_ok = result.is_ok();
                             metrics.increment_event_applied(event_type, result);
 
                             // Track blocks in PruneManager if TTL is enabled and event was stored successfully
                             let Some(ref mut pm) = prune_manager else { continue };
                             if !result_is_ok { continue };
-                            let Some(ref event) = event_for_prune else { continue };
                             let KvCacheEventData::Stored(ref store_data) = event.event.data else { continue };
 
                             let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
@@ -1710,16 +1707,13 @@ impl KvIndexerSharded {
 
                             Some(event) = shard_event_rx.recv() => {
                                 let event_type = KvIndexerMetrics::get_event_type(&event.event.data);
-                                // Only clone if we need the event for prune_manager afterward
-                                let event_for_prune = prune_manager.is_some().then(|| event.clone());
-                                let result = trie.apply_event(event);
+                                let result = trie.apply_event(event.clone());
                                 let result_is_ok = result.is_ok();
                                 metrics.increment_event_applied(event_type, result);
 
                                 // Track blocks in PruneManager if TTL is enabled and event was stored successfully
                                 let Some(ref mut pm) = prune_manager else { continue };
                                 if !result_is_ok { continue };
-                                let Some(ref event) = event_for_prune else { continue };
                                 let KvCacheEventData::Stored(ref store_data) = event.event.data else { continue };
 
                                 let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -720,9 +720,13 @@ enum RawKvEvent {
         parent_block_hash: Option<BlockHashValue>,
         token_ids: Vec<u32>,
         block_size: usize,
+        /// Deprecated in vLLM 0.14.0: use `lora_name` instead
         lora_id: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         medium: Option<String>,
+        /// LoRA adapter name (added in vLLM 0.14.0, replaces lora_id)
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        lora_name: Option<String>,
         /// Multimodal extra info for each block (length should match block_hashes)
         #[serde(default, skip_serializing_if = "Option::is_none")]
         block_mm_infos: Option<Vec<Option<BlockExtraInfo>>>,
@@ -771,6 +775,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
         let mut block_size: Option<usize> = None;
         let mut lora_id: Option<Option<u64>> = None;
         let mut medium: Option<Option<String>> = None;
+        let mut lora_name: Option<Option<String>> = None;
         let mut block_mm_infos: Option<Option<Vec<Option<BlockExtraInfo>>>> = None;
 
         while let Some(key) = map.next_key::<String>()? {
@@ -796,6 +801,9 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 "medium" => {
                     medium = Some(map.next_value()?);
                 }
+                "lora_name" => {
+                    lora_name = Some(map.next_value()?);
+                }
                 "block_mm_infos" => {
                     block_mm_infos = Some(map.next_value()?);
                 }
@@ -819,6 +827,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                     block_size,
                     lora_id: lora_id.unwrap_or(None),
                     medium: medium.unwrap_or(None),
+                    lora_name: lora_name.unwrap_or(None),
                     block_mm_infos: block_mm_infos.unwrap_or(None),
                 })
             }
@@ -865,6 +874,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                     .ok_or_else(|| de::Error::invalid_length(4, &"missing block_size"))?;
                 let lora_id: Option<u64> = seq.next_element()?.unwrap_or(None);
                 let medium: Option<String> = seq.next_element()?.unwrap_or(None);
+                let lora_name: Option<String> = seq.next_element()?.unwrap_or(None);
                 let block_mm_infos: Option<Vec<Option<BlockExtraInfo>>> =
                     seq.next_element()?.unwrap_or(None);
 
@@ -877,6 +887,7 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                     block_size,
                     lora_id,
                     medium,
+                    lora_name,
                     block_mm_infos,
                 })
             }
@@ -1123,6 +1134,7 @@ mod test_event_processing {
             block_size: 4,
             lora_id: Some(0),
             medium: None,
+            lora_name: None,
             block_mm_infos: None,
         };
 
@@ -1566,6 +1578,7 @@ mod tests_startup_helpers {
             block_size: 4,
             lora_id: None,
             medium: None,
+            lora_name: None,
             block_mm_infos: None,
         }];
 

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -16,7 +16,9 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use zeromq::{Socket, SocketRecv, SubSocket};
 
-use dynamo_runtime::traits::{DistributedRuntimeProvider, events::EventPublisher as EventPublisherTrait};
+use dynamo_runtime::traits::{
+    DistributedRuntimeProvider, events::EventPublisher as EventPublisherTrait,
+};
 use dynamo_runtime::transports::event_plane::EventPublisher;
 use dynamo_runtime::{
     component::{Component, Namespace},

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -126,14 +126,6 @@ impl KvEventPublisher {
         component: Component,
         kv_block_size: u32,
         source_config: Option<KvEventSourceConfig>,
-    ) -> Result<Self> {
-        Self::new_with_local_indexer(component, kv_block_size, source_config, false)
-    }
-
-    pub fn new_with_local_indexer(
-        component: Component,
-        kv_block_size: u32,
-        source_config: Option<KvEventSourceConfig>,
         enable_local_indexer: bool,
     ) -> Result<Self> {
         let cancellation_token = CancellationToken::new();

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -30,14 +30,14 @@ use dynamo_runtime::{
 /// Generates a slugified stream name in the format:
 /// `namespace-{namespace}-component-{component}-{subject}`
 fn create_kv_stream_name(component: &Component, subject: &str) -> String {
-    let event_plane_subject = format!(
-        "namespace.{}.component.{}",
+    Slug::slugify(&format!(
+        "namespace.{}.component.{}.{}",
         component.namespace().name(),
-        component.name()
-    );
-    Slug::slugify(&format!("{}.{}", event_plane_subject, subject))
-        .to_string()
-        .replace("_", "-")
+        component.name(),
+        subject
+    ))
+    .to_string()
+    .replace("_", "-")
 }
 
 use crate::kv_router::{

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use rmp_serde as rmps;
 use serde::Deserialize;
 use serde::Serialize;
@@ -15,11 +16,27 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use zeromq::{Socket, SocketRecv, SubSocket};
 
-use dynamo_runtime::traits::{DistributedRuntimeProvider, events::EventPublisher};
+use dynamo_runtime::traits::{DistributedRuntimeProvider, events::EventPublisher as EventPublisherTrait};
+use dynamo_runtime::transports::event_plane::EventPublisher;
 use dynamo_runtime::{
     component::{Component, Namespace},
     transports::nats::{NatsQueue, Slug},
 };
+
+/// Helper function to create a KV stream name from a component and subject.
+///
+/// Generates a slugified stream name in the format:
+/// `namespace-{namespace}-component-{component}-{subject}`
+fn create_kv_stream_name(component: &Component, subject: &str) -> String {
+    let event_plane_subject = format!(
+        "namespace.{}.component.{}",
+        component.namespace().name(),
+        component.name()
+    );
+    Slug::slugify(&format!("{}.{}", event_plane_subject, subject))
+        .to_string()
+        .replace("_", "-")
+}
 
 use crate::kv_router::{
     KV_EVENT_SUBJECT, KV_METRICS_SUBJECT, WORKER_KV_INDEXER_BUFFER_SIZE,
@@ -176,19 +193,27 @@ impl KvEventPublisher {
                 ))
         });
 
-        // Connect the NatsQueue before passing it to the event processor
         let cancellation_token_clone = cancellation_token.clone();
         let local_indexer_clone = local_indexer.clone();
 
         if enable_local_indexer {
-            // When local indexer is enabled, use NATS Core (Component) for publishing.
-            // This is simpler and doesn't require JetStream durability since recovery
-            // is handled via the local indexer's event buffer.
-            tracing::info!("Using NATS Core for KV event publishing (local_indexer mode)");
+            // When local indexer is enabled, use the event plane directly.
+            // EventPublisher handles transport selection (ZMQ or NATS) based on environment.
+            // Durability is provided by the local indexer's event buffer.
+            tracing::info!("Using event plane for KV event publishing (local_indexer mode)");
             let component_clone = component.clone();
             component.drt().runtime().secondary().spawn(async move {
+                let event_publisher =
+                    match EventPublisher::for_component(&component_clone, KV_EVENT_SUBJECT).await {
+                        Ok(publisher) => publisher,
+                        Err(e) => {
+                            tracing::error!("Failed to create event publisher: {}", e);
+                            return;
+                        }
+                    };
+
                 start_event_processor(
-                    component_clone,
+                    event_publisher,
                     worker_id,
                     cancellation_token_clone,
                     rx,
@@ -198,10 +223,7 @@ impl KvEventPublisher {
             });
         } else {
             // When local indexer is disabled, use JetStream (NatsQueue) for durability.
-            let stream_name =
-                Slug::slugify(&format!("{}.{}", component.subject(), KV_EVENT_SUBJECT))
-                    .to_string()
-                    .replace("_", "-");
+            let stream_name = create_kv_stream_name(&component, KV_EVENT_SUBJECT);
             let nats_server = std::env::var(env_nats::NATS_SERVER)
                 .unwrap_or_else(|_| "nats://localhost:4222".to_string());
             let mut nats_queue = NatsQueue::new_without_consumer(
@@ -215,7 +237,7 @@ impl KvEventPublisher {
                     tracing::error!("Failed to connect NatsQueue: {e}");
                     return;
                 }
-                start_event_processor(
+                start_event_processor_jetstream(
                     nats_queue,
                     worker_id,
                     cancellation_token_clone,
@@ -259,7 +281,27 @@ impl Drop for KvEventPublisher {
     }
 }
 
-async fn start_event_processor<P: EventPublisher + Send + Sync + 'static>(
+#[async_trait]
+trait EventSink: Send + Sync {
+    async fn publish_event(&self, event: &RouterEvent) -> Result<()>;
+}
+
+#[async_trait]
+impl EventSink for EventPublisher {
+    async fn publish_event(&self, event: &RouterEvent) -> Result<()> {
+        self.publish(event).await
+    }
+}
+
+#[async_trait]
+impl EventSink for NatsQueue {
+    async fn publish_event(&self, event: &RouterEvent) -> Result<()> {
+        self.publish(KV_EVENT_SUBJECT, event).await
+    }
+}
+
+/// Event processor for ephemeral transports (NATS Core / ZMQ).
+async fn start_event_processor<P: EventSink + Send + Sync + 'static>(
     publisher: P,
     worker_id: u64,
     cancellation_token: CancellationToken,
@@ -294,11 +336,55 @@ async fn start_event_processor<P: EventPublisher + Send + Sync + 'static>(
                     }
                 }
 
-                // Then publish to NATS for global distribution
-                // Use KV_EVENT_SUBJECT so both JetStream and NATS Core subscribers
-                // can receive events on the expected subject.
-                if let Err(e) = publisher.publish(KV_EVENT_SUBJECT, &router_event).await {
-                    tracing::error!("Failed to publish event to NATS: {}", e);
+                // Then publish to event plane for global distribution.
+                if let Err(e) = publisher.publish_event(&router_event).await {
+                    tracing::error!("Failed to publish event: {}", e);
+                }
+
+            }
+        }
+    }
+}
+
+/// Event processor using JetStream (durable).
+async fn start_event_processor_jetstream(
+    publisher: NatsQueue,
+    worker_id: u64,
+    cancellation_token: CancellationToken,
+    mut rx: mpsc::UnboundedReceiver<KvCacheEvent>,
+    local_indexer: Option<Arc<LocalKvIndexer>>,
+) {
+    loop {
+        tokio::select! {
+            _ = cancellation_token.cancelled() => {
+                tracing::info!("KV Event source received cancellation signal");
+                break;
+            }
+            event = rx.recv() => {
+                let Some(event) = event else {
+                    tracing::debug!("Event processor channel closed.");
+                    break;
+                };
+
+                // Encapsulate in a router event.
+                tracing::trace!("Event processor for worker_id {} processing event: {:?}", worker_id, event.data);
+                let router_event = RouterEvent::new(worker_id, event);
+
+                // Apply to local indexer first (if present)
+                if let Some(indexer) = &local_indexer {
+                    // Adds event into local indexer, and logs it into internal buffer
+                    if let Err(e) = indexer.apply_event_with_buffer(router_event.clone()).await {
+                        tracing::warn!(
+                            "Failed to send event to local indexer for worker {}: {}",
+                            worker_id,
+                            e
+                        );
+                    }
+                }
+
+                // Then publish to event plane for global distribution
+                if let Err(e) = publisher.publish_event(&router_event).await {
+                    tracing::error!("Failed to publish event to event plane: {}", e);
                 }
 
             }
@@ -634,13 +720,9 @@ enum RawKvEvent {
         parent_block_hash: Option<BlockHashValue>,
         token_ids: Vec<u32>,
         block_size: usize,
-        /// Deprecated in vLLM 0.14.0: use `lora_name` instead
         lora_id: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         medium: Option<String>,
-        /// LoRA adapter name (added in vLLM 0.14.0, replaces lora_id)
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        lora_name: Option<String>,
         /// Multimodal extra info for each block (length should match block_hashes)
         #[serde(default, skip_serializing_if = "Option::is_none")]
         block_mm_infos: Option<Vec<Option<BlockExtraInfo>>>,
@@ -689,7 +771,6 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
         let mut block_size: Option<usize> = None;
         let mut lora_id: Option<Option<u64>> = None;
         let mut medium: Option<Option<String>> = None;
-        let mut lora_name: Option<Option<String>> = None;
         let mut block_mm_infos: Option<Option<Vec<Option<BlockExtraInfo>>>> = None;
 
         while let Some(key) = map.next_key::<String>()? {
@@ -715,9 +796,6 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 "medium" => {
                     medium = Some(map.next_value()?);
                 }
-                "lora_name" => {
-                    lora_name = Some(map.next_value()?);
-                }
                 "block_mm_infos" => {
                     block_mm_infos = Some(map.next_value()?);
                 }
@@ -741,7 +819,6 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                     block_size,
                     lora_id: lora_id.unwrap_or(None),
                     medium: medium.unwrap_or(None),
-                    lora_name: lora_name.unwrap_or(None),
                     block_mm_infos: block_mm_infos.unwrap_or(None),
                 })
             }
@@ -788,7 +865,6 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                     .ok_or_else(|| de::Error::invalid_length(4, &"missing block_size"))?;
                 let lora_id: Option<u64> = seq.next_element()?.unwrap_or(None);
                 let medium: Option<String> = seq.next_element()?.unwrap_or(None);
-                let lora_name: Option<String> = seq.next_element()?.unwrap_or(None);
                 let block_mm_infos: Option<Vec<Option<BlockExtraInfo>>> =
                     seq.next_element()?.unwrap_or(None);
 
@@ -801,7 +877,6 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                     block_size,
                     lora_id,
                     medium,
-                    lora_name,
                     block_mm_infos,
                 })
             }
@@ -886,6 +961,15 @@ impl WorkerMetricsPublisher {
         let nats_rx = self.rx.clone();
 
         tokio::spawn(async move {
+            let event_publisher =
+                match EventPublisher::for_namespace(&namespace, KV_METRICS_SUBJECT).await {
+                    Ok(publisher) => publisher,
+                    Err(e) => {
+                        tracing::error!("Failed to create metrics publisher: {}", e);
+                        return;
+                    }
+                };
+
             let mut rx = nats_rx;
             let mut last_active_decode_blocks: Option<u64> = Some(0);
             let mut pending_publish: Option<WorkerMetrics> = None;
@@ -933,10 +1017,8 @@ impl WorkerMetricsPublisher {
                                 active_prefill_tokens: None,
                             };
 
-                            if let Err(e) =
-                                namespace.publish(KV_METRICS_SUBJECT, &active_load).await
-                            {
-                                tracing::warn!("Failed to publish metrics over NATS: {}", e);
+                            if let Err(e) = event_publisher.publish(&active_load).await {
+                                tracing::warn!("Failed to publish metrics: {}", e);
                             }
                         }
 
@@ -1041,7 +1123,6 @@ mod test_event_processing {
             block_size: 4,
             lora_id: Some(0),
             medium: None,
-            lora_name: None,
             block_mm_infos: None,
         };
 
@@ -1076,7 +1157,6 @@ mod tests_startup_helpers {
     use crate::kv_router::KvIndexer;
     use crate::kv_router::indexer::KvIndexerInterface;
     use crate::kv_router::protocols::{ExternalSequenceBlockHash, LocalBlockHash};
-    use async_trait;
     use bytes::Bytes;
     use std::sync::{Arc, Mutex};
     use zeromq::{PubSocket, Socket, SocketSend, ZmqMessage};
@@ -1105,34 +1185,14 @@ mod tests_startup_helpers {
     }
 
     #[async_trait::async_trait]
-    impl EventPublisher for MockComponent {
-        async fn publish(
-            &self,
-            event_name: impl AsRef<str> + Send + Sync,
-            event: &(impl serde::Serialize + Send + Sync),
-        ) -> anyhow::Result<()> {
+    impl EventSink for MockComponent {
+        async fn publish_event(&self, event: &RouterEvent) -> anyhow::Result<()> {
             let bytes = rmp_serde::to_vec(event).unwrap();
             self.published
                 .lock()
                 .unwrap()
-                .push((event_name.as_ref().to_string(), bytes));
+                .push((KV_EVENT_SUBJECT.to_string(), bytes));
             Ok(())
-        }
-
-        async fn publish_bytes(
-            &self,
-            event_name: impl AsRef<str> + Send + Sync,
-            bytes: Vec<u8>,
-        ) -> anyhow::Result<()> {
-            self.published
-                .lock()
-                .unwrap()
-                .push((event_name.as_ref().to_string(), bytes));
-            Ok(())
-        }
-
-        fn subject(&self) -> String {
-            "mock.subject".into()
         }
     }
 
@@ -1330,7 +1390,7 @@ mod tests_startup_helpers {
         }
         assert!(no_blocks, "worker should have no blocks after removal");
 
-        // Global kvindexer should have received two events (create/remove)
+        // Global kvindexer should have recieved two events (create/remove)
         let published = published.lock().unwrap();
         assert_eq!(
             published.len(),
@@ -1409,7 +1469,7 @@ mod tests_startup_helpers {
         }
         assert!(no_blocks, "worker should have no blocks after clearing");
 
-        // Global kvindexer should have received two events (create/remove)
+        // Global kvindexer should have recieved two events (create/remove)
         let published = published.lock().unwrap();
         assert_eq!(
             published.len(),
@@ -1506,7 +1566,6 @@ mod tests_startup_helpers {
             block_size: 4,
             lora_id: None,
             medium: None,
-            lora_name: None,
             block_mm_infos: None,
         }];
 
@@ -1815,7 +1874,7 @@ mod test_integration_publisher {
     use super::*;
     use crate::kv_router::protocols::ActiveLoad;
     use dynamo_runtime::distributed_test_utils::create_test_drt_async;
-    use dynamo_runtime::traits::events::EventSubscriber;
+    use dynamo_runtime::transports::event_plane::EventSubscriber;
     use futures::StreamExt;
 
     #[tokio::test]
@@ -1825,11 +1884,11 @@ mod test_integration_publisher {
         let drt = create_test_drt_async().await;
         let namespace = drt.namespace("ns2001".to_string())?;
 
-        // Create a subscriber for the metrics events using subscribe_with_type
-        let mut subscriber = namespace
-            .subscribe_with_type::<ActiveLoad>(KV_METRICS_SUBJECT)
+        // Create a subscriber for the metrics events
+        let mut subscriber = EventSubscriber::for_namespace(&namespace, KV_METRICS_SUBJECT)
             .await
-            .unwrap();
+            .unwrap()
+            .typed::<ActiveLoad>();
 
         // Create WorkerMetricsPublisher
         let publisher = WorkerMetricsPublisher::new().unwrap();
@@ -1857,7 +1916,7 @@ mod test_integration_publisher {
                 .await
                 .unwrap();
 
-        let event = result.unwrap().unwrap(); // Unwrap the Option and the Result
+        let (_envelope, event) = result.unwrap().unwrap(); // Unwrap the Option and the Result
         assert_eq!(event.worker_id, worker_id);
         assert_eq!(event.active_decode_blocks, Some(900)); // Last value: 9 * 100
         assert_eq!(event.active_prefill_tokens, None); // Worker doesn't publish prefill tokens

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -6,7 +6,7 @@ use crate::local_model::runtime_config::ModelRuntimeConfig;
 use anyhow::Result;
 use dynamo_runtime::component::Component;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
-use dynamo_runtime::traits::events::EventPublisher;
+use dynamo_runtime::transports::event_plane::EventPublisher;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -50,6 +50,9 @@ pub enum KvSchedulerError {
 
     #[error("endpoint subscriber shutdown")]
     SubscriberShutdown,
+
+    #[error("failed to initialize event publisher: {0}")]
+    InitFailed(String),
 }
 
 #[derive(Debug)]
@@ -111,13 +114,17 @@ impl KvScheduler {
             .map(|r| (*r.key(), r.value().clone()))
             .collect();
 
-        let slots = Arc::new(ActiveSequencesMultiWorker::new(
-            component.clone(),
-            block_size as usize,
-            initial_workers,
-            replica_sync,
-            router_id,
-        ));
+        let slots = Arc::new(
+            ActiveSequencesMultiWorker::new(
+                component.clone(),
+                block_size as usize,
+                initial_workers,
+                replica_sync,
+                router_id,
+            )
+            .await
+            .map_err(|e| KvSchedulerError::InitFailed(e.to_string()))?,
+        );
 
         // Spawn background task to sync slots with DashMap when notified of changes.
         // ModelManager's watcher updates the DashMap and notifies; we wait on notify here.
@@ -160,7 +167,10 @@ impl KvScheduler {
         let workers_scheduler = workers_with_configs.clone();
         let (request_tx, request_rx) = tokio::sync::mpsc::channel::<SchedulingRequest>(1024);
         let scheduler_cancel_token = component.drt().primary_token();
-        let ns_clone = component.namespace().clone();
+        let hit_rate_publisher =
+            EventPublisher::for_namespace(component.namespace(), KV_HIT_RATE_SUBJECT)
+                .await
+                .map_err(|e| KvSchedulerError::InitFailed(e.to_string()))?;
 
         // Background task to handle scheduling requests
         tokio::spawn(async move {
@@ -206,7 +216,7 @@ impl KvScheduler {
                             isl_blocks: selection.required_blocks as usize,
                             overlap_blocks: selection.overlap_blocks,
                         };
-                        if let Err(e) = ns_clone.publish(KV_HIT_RATE_SUBJECT, &event).await {
+                        if let Err(e) = hit_rate_publisher.publish(&event).await {
                             tracing::warn!("Failed to publish KV hit rate event: {:?}", e);
                         }
 

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -30,14 +30,14 @@ use crate::kv_router::{
 /// Generates a slugified stream name in the format:
 /// `namespace-{namespace}-component-{component}-{subject}`
 fn create_kv_stream_name(component: &Component, subject: &str) -> String {
-    let event_plane_subject = format!(
-        "namespace.{}.component.{}",
+    Slug::slugify(&format!(
+        "namespace.{}.component.{}.{}",
         component.namespace().name(),
-        component.name()
-    );
-    Slug::slugify(&format!("{}.{}", event_plane_subject, subject))
-        .to_string()
-        .replace("_", "-")
+        component.name(),
+        subject
+    ))
+    .to_string()
+    .replace("_", "-")
 }
 
 /// Delay between snapshot reads to verify stability

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -7,9 +7,9 @@ use anyhow::Result;
 use dynamo_runtime::{
     component::Component,
     config::environment_names::nats as env_nats,
-    discovery::{DiscoveryEvent, DiscoveryQuery},
+    discovery::{DiscoveryEvent, DiscoveryQuery, EventTransportKind},
     prelude::*,
-    traits::events::{EventPublisher, EventSubscriber},
+    transports::event_plane::EventSubscriber,
     transports::nats::{NatsQueue, Slug},
 };
 use futures::StreamExt;
@@ -24,6 +24,21 @@ use crate::kv_router::{
     router_discovery_query,
     worker_query::WorkerQueryClient,
 };
+
+/// Helper function to create a KV stream name from a component and subject.
+///
+/// Generates a slugified stream name in the format:
+/// `namespace-{namespace}-component-{component}-{subject}`
+fn create_kv_stream_name(component: &Component, subject: &str) -> String {
+    let event_plane_subject = format!(
+        "namespace.{}.component.{}",
+        component.namespace().name(),
+        component.name()
+    );
+    Slug::slugify(&format!("{}.{}", event_plane_subject, subject))
+        .to_string()
+        .replace("_", "-")
+}
 
 /// Delay between snapshot reads to verify stability
 const SNAPSHOT_STABILITY_DELAY: Duration = Duration::from_millis(100);
@@ -463,9 +478,7 @@ pub async fn start_kv_router_background(
     router_reset_states: bool,
 ) -> Result<()> {
     // Set up NATS connections
-    let stream_name = Slug::slugify(&format!("{}.{}", component.subject(), KV_EVENT_SUBJECT))
-        .to_string()
-        .replace("_", "-");
+    let stream_name = create_kv_stream_name(&component, KV_EVENT_SUBJECT);
     let nats_server = std::env::var(env_nats::NATS_SERVER)
         .unwrap_or_else(|_| "nats://localhost:4222".to_string());
 
@@ -485,7 +498,12 @@ pub async fn start_kv_router_background(
     let nats_client = client_options.connect().await?;
 
     // Create bucket name for snapshots/state
-    let bucket_name = Slug::slugify(&format!("{}-{RADIX_STATE_BUCKET}", component.subject()))
+    let event_plane_subject = format!(
+        "namespace.{}.component.{}",
+        component.namespace().name(),
+        component.name()
+    );
+    let bucket_name = Slug::slugify(&format!("{}-{RADIX_STATE_BUCKET}", event_plane_subject))
         .to_string()
         .replace("_", "-");
 
@@ -726,11 +744,11 @@ async fn handle_worker_discovery(
     }
 }
 
-/// Start a simplified background task for event consumption using NATS Core.
+/// Start a simplified background task for event consumption using the event plane.
 ///
 /// This is used when local indexer mode is enabled. Unlike `start_kv_router_background`,
 /// this function:
-/// - Uses NATS Core pub/sub instead of JetStream
+/// - Uses the event plane (NATS Core or ZMQ) instead of JetStream
 /// - Does not support snapshots, purging, or durable consumers
 /// - On worker Added: dumps worker's local indexer into router
 /// - On worker Removed: removes worker from router indexer
@@ -739,21 +757,40 @@ async fn handle_worker_discovery(
 /// spawning the background task, ensuring the router is ready before returning.
 ///
 /// This is appropriate when workers have local indexers enabled.
-pub async fn start_kv_router_background_nats_core(
+pub async fn start_kv_router_background_event_plane(
     component: Component,
     kv_events_tx: mpsc::Sender<RouterEvent>,
     remove_worker_tx: mpsc::Sender<WorkerId>,
     cancellation_token: CancellationToken,
     worker_query_client: WorkerQueryClient,
+    transport_kind: EventTransportKind,
 ) -> Result<()> {
-    // Subscribe to KV events using NATS Core
-    let mut subscriber = component.subscribe(KV_EVENT_SUBJECT).await?;
-    let kv_event_subject = format!("{}.{}", component.subject(), KV_EVENT_SUBJECT);
-
-    tracing::info!(
-        subject = %kv_event_subject,
-        "KV Router using NATS Core subscription (local_indexer mode)"
+    // Subscribe to KV events using the selected event plane transport
+    let mut subscriber =
+        EventSubscriber::for_component_with_transport(&component, KV_EVENT_SUBJECT, transport_kind)
+            .await?
+            .typed::<RouterEvent>();
+    let kv_event_subject = format!(
+        "namespace.{}.component.{}.{}",
+        component.namespace().name(),
+        component.name(),
+        KV_EVENT_SUBJECT
     );
+
+    match transport_kind {
+        EventTransportKind::Nats => {
+            tracing::info!(
+                subject = %kv_event_subject,
+                "KV Router using NATS Core subscription (local_indexer mode)"
+            );
+        }
+        EventTransportKind::Zmq => {
+            tracing::info!(
+                subject = %kv_event_subject,
+                "KV Router using ZMQ event plane subscription (local_indexer mode)"
+            );
+        }
+    }
 
     // Wait for at least one worker instance before proceeding
     let mut instance_event_stream =
@@ -802,7 +839,7 @@ pub async fn start_kv_router_background_nats_core(
                 biased;
 
                 _ = cancellation_token.cancelled() => {
-                    tracing::debug!("KV Router NATS Core background task received cancellation signal");
+                    tracing::debug!("KV Router event plane background task received cancellation signal");
                     break;
                 }
 
@@ -821,18 +858,25 @@ pub async fn start_kv_router_background_nats_core(
                     .await;
                 }
 
-                // Handle event consumption from NATS Core subscription
-                Some(msg) = subscriber.next() => {
-                    let event: RouterEvent = match serde_json::from_slice(&msg.payload) {
-                        Ok(event) => event,
+                // Handle event consumption from event plane subscription
+                Some(result) = subscriber.next() => {
+                    let (envelope, event) = match result {
+                        Ok((envelope, event)) => (envelope, event),
                         Err(e) => {
-                            tracing::warn!("Failed to deserialize RouterEvent from NATS Core: {e:?}");
+                            tracing::warn!("Failed to receive RouterEvent from event plane: {e:?}");
                             continue;
                         }
                     };
 
                     let worker_id = event.worker_id;
                     let event_id = event.event.event_id;
+
+                    // Use envelope metadata for additional debugging
+                    tracing::trace!(
+                        "Received event from publisher {} (seq {})",
+                        envelope.publisher_id,
+                        envelope.sequence
+                    );
 
                     // Gap detection: check if event ID is monotonically increasing per worker
                     // Note: event_id <= last_id is duplicate/out-of-order, apply anyway (idempotent)
@@ -847,7 +891,7 @@ pub async fn start_kv_router_background_nats_core(
                             "Event ID gap detected for worker {worker_id}, recovering events [{gap_start}, {gap_end}], gap_size: {gap_size}"
                         );
 
-                        // Note: While recovering, new events may queue in the NATS subscriber's
+                        // Note: While recovering, new events may queue in the subscriber's
                         // internal buffer. We don't explicitly buffer them here for simplicity.
                         // The subscriber will process them in order after recovery completes.
                         if let Err(e) = recover_from_worker(
@@ -884,10 +928,29 @@ pub async fn start_kv_router_background_nats_core(
             }
         }
 
-        tracing::debug!("KV Router NATS Core background task exiting");
+        tracing::debug!("KV Router event plane background task exiting");
     });
 
     Ok(())
+}
+
+/// Backwards-compatible wrapper for NATS Core local-indexer mode.
+pub async fn start_kv_router_background_nats_core(
+    component: Component,
+    kv_events_tx: mpsc::Sender<RouterEvent>,
+    remove_worker_tx: mpsc::Sender<WorkerId>,
+    cancellation_token: CancellationToken,
+    worker_query_client: WorkerQueryClient,
+) -> Result<()> {
+    start_kv_router_background_event_plane(
+        component,
+        kv_events_tx,
+        remove_worker_tx,
+        cancellation_token,
+        worker_query_client,
+        EventTransportKind::Nats,
+    )
+    .await
 }
 
 /// Cleanup orphaned NATS consumers that no longer have corresponding router entries

--- a/lib/llm/src/mocker/kv_manager.rs
+++ b/lib/llm/src/mocker/kv_manager.rs
@@ -91,7 +91,7 @@ impl KvManager {
                 "Initializing KV event publisher for DP rank {dp_rank} with block_size {block_size}, enable_local_indexer={enable_local_indexer}"
             );
             Arc::new(
-                KvEventPublisher::new_with_local_indexer(comp, block_size as u32, None, enable_local_indexer)
+                KvEventPublisher::new(comp, block_size as u32, None, enable_local_indexer)
                     .expect("Failed to create KV event publisher"),
             )
         });

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -29,6 +29,7 @@ async-trait = { workspace = true }
 async_zmq = { workspace = true }
 tmq = { workspace = true }
 zmq = { workspace = true }
+lru = { version = "0.12" }
 axum = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true }

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -313,6 +313,26 @@ pub mod event_plane {
     pub const DYN_EVENT_PLANE_CODEC: &str = "DYN_EVENT_PLANE_CODEC";
 }
 
+/// ZMQ Broker environment variables
+pub mod zmq_broker {
+    /// Explicit ZMQ broker URL (takes precedence over discovery)
+    /// Format: "xsub=<url1>[;<url2>...] , xpub=<url1>[;<url2>...]"
+    /// Example: "xsub=tcp://broker:5555 , xpub=tcp://broker:5556"
+    pub const DYN_ZMQ_BROKER_URL: &str = "DYN_ZMQ_BROKER_URL";
+
+    /// Enable ZMQ broker discovery mode
+    pub const DYN_ZMQ_BROKER_ENABLED: &str = "DYN_ZMQ_BROKER_ENABLED";
+
+    /// XSUB bind address (broker binary only)
+    pub const ZMQ_BROKER_XSUB_BIND: &str = "ZMQ_BROKER_XSUB_BIND";
+
+    /// XPUB bind address (broker binary only)
+    pub const ZMQ_BROKER_XPUB_BIND: &str = "ZMQ_BROKER_XPUB_BIND";
+
+    /// Namespace for broker discovery registration
+    pub const ZMQ_BROKER_NAMESPACE: &str = "ZMQ_BROKER_NAMESPACE";
+}
+
 /// CUDA and GPU environment variables
 pub mod cuda {
     /// Path to custom CUDA fatbin file
@@ -419,6 +439,12 @@ mod tests {
             // Event Plane
             event_plane::DYN_EVENT_PLANE,
             event_plane::DYN_EVENT_PLANE_CODEC,
+            // ZMQ Broker
+            zmq_broker::DYN_ZMQ_BROKER_URL,
+            zmq_broker::DYN_ZMQ_BROKER_ENABLED,
+            zmq_broker::ZMQ_BROKER_XSUB_BIND,
+            zmq_broker::ZMQ_BROKER_XPUB_BIND,
+            zmq_broker::ZMQ_BROKER_NAMESPACE,
             // CUDA
             cuda::DYNAMO_FATBIN_PATH,
             // Build

--- a/lib/runtime/src/transports/event_plane/codec.rs
+++ b/lib/runtime/src/transports/event_plane/codec.rs
@@ -9,6 +9,57 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use super::EventEnvelope;
 
+/// Codec for serializing and deserializing event envelopes and payloads.
+///
+/// Currently only supports MessagePack for all transports.
+#[derive(Debug, Clone, Copy)]
+pub enum Codec {
+    Msgpack(MsgpackCodec),
+}
+
+impl Default for Codec {
+    fn default() -> Self {
+        Codec::Msgpack(MsgpackCodec)
+    }
+}
+
+impl Codec {
+    /// Encode an EventEnvelope to wire bytes
+    pub fn encode_envelope(&self, envelope: &EventEnvelope) -> Result<Bytes> {
+        match self {
+            Codec::Msgpack(c) => c.encode_envelope(envelope),
+        }
+    }
+
+    /// Decode wire bytes to an EventEnvelope
+    pub fn decode_envelope(&self, bytes: &Bytes) -> Result<EventEnvelope> {
+        match self {
+            Codec::Msgpack(c) => c.decode_envelope(bytes),
+        }
+    }
+
+    /// Encode a typed payload to bytes (for embedding in envelope)
+    pub fn encode_payload<T: Serialize>(&self, payload: &T) -> Result<Bytes> {
+        match self {
+            Codec::Msgpack(c) => c.encode_payload(payload),
+        }
+    }
+
+    /// Decode payload bytes to a typed value
+    pub fn decode_payload<T: DeserializeOwned>(&self, bytes: &Bytes) -> Result<T> {
+        match self {
+            Codec::Msgpack(c) => c.decode_payload(bytes),
+        }
+    }
+
+    /// Codec name for debugging
+    pub fn name(&self) -> &'static str {
+        match self {
+            Codec::Msgpack(c) => c.name(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MsgpackCodec;
 

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Event Plane: Transport-agnostic pub/sub communication layer.
+//! Generic Event Plane for transport-agnostic pub/sub communication.
 
 mod codec;
 mod dynamic_subscriber;
@@ -9,12 +9,791 @@ mod frame;
 mod nats_transport;
 mod traits;
 mod transport;
-mod zmq_transport;
+pub mod zmq_transport;
 
-pub use codec::MsgpackCodec;
+pub use codec::{Codec, MsgpackCodec};
 pub use dynamic_subscriber::DynamicSubscriber;
-pub use frame::{Frame, FrameError, FrameHeader};
-pub use nats_transport::NatsTransport;
+pub use frame::{FRAME_HEADER_SIZE, FRAME_VERSION, Frame, FrameError, FrameHeader};
 pub use traits::{EventEnvelope, EventStream, TypedEventStream};
 pub use transport::{EventTransportRx, EventTransportTx, WireStream};
 pub use zmq_transport::{ZmqPubTransport, ZmqSubTransport};
+
+// Re-export transport kind from discovery for convenience
+pub use crate::discovery::EventTransportKind;
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use lru::LruCache;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::DistributedRuntime;
+use crate::component::{Component, Namespace};
+use crate::discovery::{Discovery, DiscoveryInstance, DiscoveryQuery, DiscoverySpec, EventChannelQuery, EventTransport};
+use crate::traits::DistributedRuntimeProvider;
+use crate::utils::ip_resolver::get_local_ip_for_advertise;
+
+/// Scope of the event plane - determines the subject prefix for pub/sub.
+#[derive(Debug, Clone)]
+pub enum EventScope {
+    /// Namespace-level scope: `namespace.{name}`
+    Namespace { name: String },
+    /// Component-level scope: `namespace.{namespace}.component.{component}`
+    Component {
+        namespace: String,
+        component: String,
+    },
+}
+
+impl EventScope {
+    /// Returns the subject prefix for this scope.
+    pub fn subject_prefix(&self) -> String {
+        match self {
+            EventScope::Namespace { name } => format!("namespace.{}", name),
+            EventScope::Component {
+                namespace,
+                component,
+            } => {
+                format!("namespace.{}.component.{}", namespace, component)
+            }
+        }
+    }
+
+    /// Get the namespace name
+    pub fn namespace(&self) -> &str {
+        match self {
+            EventScope::Namespace { name } => name,
+            EventScope::Component { namespace, .. } => namespace,
+        }
+    }
+
+    /// Get the component name (if component-scoped)
+    pub fn component(&self) -> Option<&str> {
+        match self {
+            EventScope::Namespace { .. } => None,
+            EventScope::Component { component, .. } => Some(component),
+        }
+    }
+}
+
+// ============================================================================
+// Broker Resolution Logic
+// ============================================================================
+
+/// Broker endpoints for ZMQ broker mode
+#[derive(Debug, Clone)]
+struct BrokerEndpoints {
+    xsub_endpoints: Vec<String>,
+    xpub_endpoints: Vec<String>,
+}
+
+/// Resolve ZMQ broker endpoints from environment or discovery
+/// Returns None if broker mode is not configured (direct mode)
+async fn resolve_zmq_broker(
+    drt: &DistributedRuntime,
+    scope: &EventScope,
+) -> Result<Option<BrokerEndpoints>> {
+    // Priority 1: Explicit URL from DYN_ZMQ_BROKER_URL
+    if let Ok(broker_url) = std::env::var(crate::config::environment_names::zmq_broker::DYN_ZMQ_BROKER_URL) {
+        let (xsub_endpoints, xpub_endpoints) = parse_broker_url(&broker_url)?;
+        tracing::info!(
+            num_xsub = xsub_endpoints.len(),
+            num_xpub = xpub_endpoints.len(),
+            "Using explicit ZMQ broker URL"
+        );
+        return Ok(Some(BrokerEndpoints {
+            xsub_endpoints,
+            xpub_endpoints,
+        }));
+    }
+
+    // Priority 2: Discovery-based lookup if DYN_ZMQ_BROKER_ENABLED=true
+    if std::env::var(crate::config::environment_names::zmq_broker::DYN_ZMQ_BROKER_ENABLED)
+        .unwrap_or_default()
+        == "true"
+    {
+        let query = DiscoveryQuery::EventChannels(EventChannelQuery::component(
+            scope.namespace().to_string(),
+            "zmq_broker".to_string(),
+        ));
+
+        let instances = drt.discovery().list(query).await?;
+
+        // Collect all broker instances (multiple brokers for HA)
+        let mut xsub_endpoints = Vec::new();
+        let mut xpub_endpoints = Vec::new();
+
+        for instance in instances {
+            if let DiscoveryInstance::EventChannel { transport, .. } = instance
+                && let EventTransport::ZmqBroker {
+                    xsub_endpoints: xsubs,
+                    xpub_endpoints: xpubs,
+                } = transport
+            {
+                xsub_endpoints.extend(xsubs);
+                xpub_endpoints.extend(xpubs);
+            }
+        }
+
+        if xsub_endpoints.is_empty() {
+            anyhow::bail!(
+                "DYN_ZMQ_BROKER_ENABLED=true but no broker found in discovery for namespace '{}'",
+                scope.namespace()
+            );
+        }
+
+        tracing::info!(
+            num_brokers = xsub_endpoints.len(),
+            "Discovered ZMQ brokers from discovery plane"
+        );
+
+        return Ok(Some(BrokerEndpoints {
+            xsub_endpoints,
+            xpub_endpoints,
+        }));
+    }
+
+    // No broker configured - use direct mode
+    Ok(None)
+}
+
+/// Parse broker URL format: "xsub=tcp://host1:5555;tcp://host2:5555 , xpub=tcp://host1:5556;tcp://host2:5556"
+fn parse_broker_url(url: &str) -> Result<(Vec<String>, Vec<String>)> {
+    let parts: Vec<&str> = url.split(',').map(|s| s.trim()).collect();
+    if parts.len() != 2 {
+        anyhow::bail!(
+            "Invalid broker URL format. Expected 'xsub=<urls> , xpub=<urls>', got: {}",
+            url
+        );
+    }
+
+    let mut xsub_endpoints = Vec::new();
+    let mut xpub_endpoints = Vec::new();
+
+    for part in parts {
+        if let Some(urls_str) = part.strip_prefix("xsub=") {
+            xsub_endpoints = urls_str
+                .split(';')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        } else if let Some(urls_str) = part.strip_prefix("xpub=") {
+            xpub_endpoints = urls_str
+                .split(';')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        } else {
+            anyhow::bail!(
+                "Invalid broker URL part. Expected 'xsub=' or 'xpub=' prefix, got: {}",
+                part
+            );
+        }
+    }
+
+    if xsub_endpoints.is_empty() || xpub_endpoints.is_empty() {
+        anyhow::bail!(
+            "Broker URL must contain at least one xsub and one xpub endpoint. Got xsub={:?}, xpub={:?}",
+            xsub_endpoints,
+            xpub_endpoints
+        );
+    }
+
+    Ok((xsub_endpoints, xpub_endpoints))
+}
+
+/// Deduplicates events based on (publisher_id, sequence) tuple
+/// Required when connecting to multiple brokers in HA mode
+struct DeduplicatingStream {
+    inner: WireStream,
+    codec: Arc<Codec>,
+    seen_events: LruCache<(u64, u64), ()>, // (publisher_id, sequence) -> ()
+}
+
+impl DeduplicatingStream {
+    fn new(inner: WireStream, codec: Arc<Codec>, cache_size: usize) -> Self {
+        Self {
+            inner,
+            codec,
+            seen_events: LruCache::new(
+                NonZeroUsize::new(cache_size).expect("cache_size must be non-zero"),
+            ),
+        }
+    }
+}
+
+impl Stream for DeduplicatingStream {
+    type Item = Result<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match Pin::new(&mut self.inner).poll_next(cx) {
+                Poll::Ready(Some(Ok(bytes))) => {
+                    // Decode envelope to extract publisher_id and sequence
+                    match self.codec.decode_envelope(&bytes) {
+                        Ok(envelope) => {
+                            let key = (envelope.publisher_id, envelope.sequence);
+
+                            // Check if we've seen this event before
+                            if self.seen_events.contains(&key) {
+                                // Duplicate - skip and continue loop
+                                tracing::debug!(
+                                    publisher_id = envelope.publisher_id,
+                                    sequence = envelope.sequence,
+                                    "Filtered duplicate event from multi-broker setup"
+                                );
+                                continue;
+                            }
+
+                            // New event - record and return
+                            self.seen_events.put(key, ());
+                            return Poll::Ready(Some(Ok(bytes)));
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "Failed to decode envelope for deduplication");
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                    }
+                }
+                Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+/// Event publisher for a specific topic.
+pub struct EventPublisher {
+    transport_kind: EventTransportKind,
+    scope: EventScope,
+    topic: String,
+    publisher_id: u64,
+    sequence: AtomicU64,
+    tx: Arc<dyn EventTransportTx>,
+    codec: Arc<Codec>,
+    /// Discovery client and registered instance for unregistration on drop
+    discovery_client: Option<Arc<dyn Discovery>>,
+    discovery_instance: Option<crate::discovery::DiscoveryInstance>,
+}
+
+impl EventPublisher {
+    /// Create a publisher for a component-scoped topic.
+    pub async fn for_component(comp: &Component, topic: impl Into<String>) -> Result<Self> {
+        Self::for_component_with_transport(comp, topic, EventTransportKind::from_env_or_default())
+            .await
+    }
+
+    /// Create a publisher with explicit transport.
+    pub async fn for_component_with_transport(
+        comp: &Component,
+        topic: impl Into<String>,
+        transport_kind: EventTransportKind,
+    ) -> Result<Self> {
+        let drt = comp.drt();
+        let scope = EventScope::Component {
+            namespace: comp.namespace().name(),
+            component: comp.name().to_string(),
+        };
+        Self::new_internal(drt, scope, topic.into(), transport_kind).await
+    }
+
+    /// Create a publisher for a namespace-scoped topic.
+    pub async fn for_namespace(ns: &Namespace, topic: impl Into<String>) -> Result<Self> {
+        Self::for_namespace_with_transport(ns, topic, EventTransportKind::from_env_or_default())
+            .await
+    }
+
+    /// Create a namespace publisher with explicit transport.
+    pub async fn for_namespace_with_transport(
+        ns: &Namespace,
+        topic: impl Into<String>,
+        transport_kind: EventTransportKind,
+    ) -> Result<Self> {
+        let drt = ns.drt();
+        let scope = EventScope::Namespace { name: ns.name() };
+        Self::new_internal(drt, scope, topic.into(), transport_kind).await
+    }
+
+    async fn new_internal(
+        drt: &DistributedRuntime,
+        scope: EventScope,
+        topic: String,
+        transport_kind: EventTransportKind,
+    ) -> Result<Self> {
+        let publisher_id = drt.discovery().instance_id();
+        let discovery = Some(drt.discovery());
+
+        // Use Msgpack codec for all transports
+        enum TransportSetup {
+            Nats(Arc<dyn EventTransportTx>, Arc<Codec>),
+            ZmqDirect(Arc<dyn EventTransportTx>, Arc<Codec>, String), // includes public endpoint
+            ZmqBroker(Arc<dyn EventTransportTx>, Arc<Codec>),
+        }
+
+        let transport_setup = match transport_kind {
+            EventTransportKind::Nats => {
+                let transport = Arc::new(nats_transport::NatsTransport::new(drt.clone()));
+                let codec = Arc::new(Codec::Msgpack(MsgpackCodec));
+                TransportSetup::Nats(transport as Arc<dyn EventTransportTx>, codec)
+            }
+            EventTransportKind::Zmq => {
+                // Check for broker mode
+                if let Some(broker) = resolve_zmq_broker(drt, &scope).await? {
+                    // BROKER MODE: Connect to broker (single or multiple endpoints)
+                    let pub_transport = if broker.xsub_endpoints.len() == 1 {
+                        zmq_transport::ZmqPubTransport::connect(&broker.xsub_endpoints[0], &topic)
+                            .await?
+                    } else {
+                        zmq_transport::ZmqPubTransport::connect_multiple(&broker.xsub_endpoints, &topic)
+                            .await?
+                    };
+
+                    let codec = Arc::new(Codec::Msgpack(MsgpackCodec));
+                    TransportSetup::ZmqBroker(Arc::new(pub_transport) as Arc<dyn EventTransportTx>, codec)
+                } else {
+                    // DIRECT MODE: Bind PUB socket
+                    let (pub_transport, actual_bind_endpoint) = std::thread::spawn({
+                        let topic = topic.clone();
+                        move || {
+                            let rt = tokio::runtime::Builder::new_current_thread()
+                                .enable_all()
+                                .build()
+                                .expect("Failed to create Tokio runtime for ZMQ");
+
+                            rt.block_on(async move {
+                                zmq_transport::ZmqPubTransport::bind("tcp://0.0.0.0:0", &topic)
+                                    .await
+                                    .expect("Failed to bind ZMQ publisher")
+                            })
+                        }
+                    })
+                    .join()
+                    .expect("Failed to join ZMQ initialization thread");
+
+                    // Get local IP for public endpoint
+                    let actual_port: u16 = actual_bind_endpoint
+                        .rsplit(':')
+                        .next()
+                        .and_then(|s| s.parse().ok())
+                        .expect("Failed to parse port from bind endpoint");
+                    let local_ip = get_local_ip_for_advertise();
+                    let public_endpoint = format!("tcp://{}:{}", local_ip, actual_port);
+
+                    let codec = Arc::new(Codec::Msgpack(MsgpackCodec));
+                    TransportSetup::ZmqDirect(
+                        Arc::new(pub_transport) as Arc<dyn EventTransportTx>,
+                        codec,
+                        public_endpoint,
+                    )
+                }
+            }
+        };
+
+        // Extract transport and codec, and register if needed
+        let (tx, codec, discovery_instance) = match transport_setup {
+            TransportSetup::Nats(tx, codec) => {
+                let transport_config = EventTransport::nats(scope.subject_prefix());
+                let spec = DiscoverySpec::EventChannel {
+                    namespace: scope.namespace().to_string(),
+                    component: scope.component().unwrap_or("").to_string(),
+                    topic: topic.clone(),
+                    transport: transport_config,
+                };
+
+                let registered_instance = drt.discovery().register(spec).await?;
+                tracing::info!(
+                    topic = %topic,
+                    transport = ?transport_kind,
+                    instance_id = %registered_instance.instance_id(),
+                    "EventPublisher registered with discovery"
+                );
+                (tx, codec, Some(registered_instance))
+            }
+            TransportSetup::ZmqDirect(tx, codec, public_endpoint) => {
+                let transport_config = EventTransport::zmq(public_endpoint);
+                let spec = DiscoverySpec::EventChannel {
+                    namespace: scope.namespace().to_string(),
+                    component: scope.component().unwrap_or("").to_string(),
+                    topic: topic.clone(),
+                    transport: transport_config,
+                };
+
+                let registered_instance = drt.discovery().register(spec).await?;
+                tracing::info!(
+                    topic = %topic,
+                    transport = ?transport_kind,
+                    instance_id = %registered_instance.instance_id(),
+                    "EventPublisher registered with discovery (direct mode)"
+                );
+                (tx, codec, Some(registered_instance))
+            }
+            TransportSetup::ZmqBroker(tx, codec) => {
+                tracing::info!(
+                    topic = %topic,
+                    transport = ?transport_kind,
+                    "EventPublisher in broker mode - skipping discovery registration"
+                );
+                (tx, codec, None)
+            }
+        };
+
+        Ok(Self {
+            transport_kind,
+            scope,
+            topic,
+            publisher_id,
+            sequence: AtomicU64::new(0),
+            tx,
+            codec,
+            discovery_client: discovery,
+            discovery_instance,
+        })
+    }
+
+    /// Publish a serializable event.
+    pub async fn publish<T: Serialize + Send + Sync>(&self, event: &T) -> Result<()> {
+        let payload = self.codec.encode_payload(event)?;
+        self.publish_bytes(payload.to_vec()).await
+    }
+
+    /// Publish raw bytes.
+    pub async fn publish_bytes(&self, bytes: Vec<u8>) -> Result<()> {
+        let envelope = EventEnvelope {
+            publisher_id: self.publisher_id,
+            sequence: self.sequence.fetch_add(1, Ordering::SeqCst),
+            published_at: current_timestamp_ms(),
+            topic: self.topic.clone(),
+            payload: Bytes::from(bytes),
+        };
+
+        let envelope_bytes = self.codec.encode_envelope(&envelope)?;
+        let subject = format!("{}.{}", self.scope.subject_prefix(), self.topic);
+
+        self.tx.publish(&subject, envelope_bytes).await
+    }
+
+    /// Get the publisher ID.
+    pub fn publisher_id(&self) -> u64 {
+        self.publisher_id
+    }
+
+    /// Get the topic.
+    pub fn topic(&self) -> &str {
+        &self.topic
+    }
+
+    /// Get the transport kind.
+    pub fn transport_kind(&self) -> EventTransportKind {
+        self.transport_kind
+    }
+}
+
+impl Drop for EventPublisher {
+    fn drop(&mut self) {
+        // Unregister from discovery on drop
+        if let (Some(discovery), Some(instance)) =
+            (self.discovery_client.take(), self.discovery_instance.take())
+        {
+            let topic = self.topic.clone();
+            let instance_id = instance.instance_id();
+
+            // Spawn background task for async unregister since Drop is sync
+            tokio::spawn(async move {
+                match discovery.unregister(instance).await {
+                    Ok(()) => {
+                        tracing::info!(
+                            topic = %topic,
+                            instance_id = %instance_id,
+                            "EventPublisher unregistered from discovery"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            topic = %topic,
+                            instance_id = %instance_id,
+                            error = %e,
+                            "Failed to unregister EventPublisher from discovery"
+                        );
+                    }
+                }
+            });
+        }
+    }
+}
+
+/// Event subscriber for a specific topic.
+pub struct EventSubscriber {
+    stream: EventStream,
+    #[allow(dead_code)]
+    scope: EventScope,
+    #[allow(dead_code)]
+    topic: String,
+    codec: Arc<Codec>,
+}
+
+impl EventSubscriber {
+    /// Create a subscriber for a component-scoped topic.
+    pub async fn for_component(comp: &Component, topic: impl Into<String>) -> Result<Self> {
+        Self::for_component_with_transport(comp, topic, EventTransportKind::from_env_or_default())
+            .await
+    }
+
+    /// Create a subscriber with explicit transport.
+    pub async fn for_component_with_transport(
+        comp: &Component,
+        topic: impl Into<String>,
+        transport_kind: EventTransportKind,
+    ) -> Result<Self> {
+        let drt = comp.drt();
+        let scope = EventScope::Component {
+            namespace: comp.namespace().name(),
+            component: comp.name().to_string(),
+        };
+        Self::new_internal(drt, scope, topic.into(), transport_kind).await
+    }
+
+    /// Create a subscriber for a namespace-scoped topic.
+    pub async fn for_namespace(ns: &Namespace, topic: impl Into<String>) -> Result<Self> {
+        Self::for_namespace_with_transport(ns, topic, EventTransportKind::from_env_or_default())
+            .await
+    }
+
+    /// Create a namespace subscriber with explicit transport.
+    pub async fn for_namespace_with_transport(
+        ns: &Namespace,
+        topic: impl Into<String>,
+        transport_kind: EventTransportKind,
+    ) -> Result<Self> {
+        let drt = ns.drt();
+        let scope = EventScope::Namespace { name: ns.name() };
+        Self::new_internal(drt, scope, topic.into(), transport_kind).await
+    }
+
+    async fn new_internal(
+        drt: &DistributedRuntime,
+        scope: EventScope,
+        topic: String,
+        transport_kind: EventTransportKind,
+    ) -> Result<Self> {
+        let discovery = drt.discovery();
+
+        // Use Msgpack codec for all transports
+        let (wire_stream, codec): (WireStream, Arc<Codec>) = match transport_kind {
+            EventTransportKind::Nats => {
+                let transport = nats_transport::NatsTransport::new(drt.clone());
+                let subject = format!("{}.{}", scope.subject_prefix(), topic);
+                let stream = transport.subscribe(&subject).await?;
+                let codec = Arc::new(Codec::Msgpack(MsgpackCodec));
+                (stream, codec)
+            }
+            EventTransportKind::Zmq => {
+                // Check for broker mode
+                if let Some(broker) = resolve_zmq_broker(drt, &scope).await? {
+                    // BROKER MODE: Connect to broker's XPUB (single or multiple endpoints)
+                    let codec = Arc::new(Codec::Msgpack(MsgpackCodec));
+
+                    let stream: WireStream = if broker.xpub_endpoints.len() == 1 {
+                        // Single broker - no deduplication needed
+                        let sub_transport =
+                            zmq_transport::ZmqSubTransport::connect_broker(&broker.xpub_endpoints[0], &topic)
+                                .await?;
+                        sub_transport.subscribe(&topic).await?
+                    } else {
+                        // Multiple brokers - need deduplication
+                        let sub_transport =
+                            zmq_transport::ZmqSubTransport::connect_broker_multiple(&broker.xpub_endpoints, &topic)
+                                .await?;
+                        let inner_stream = sub_transport.subscribe(&topic).await?;
+
+                        // Wrap with deduplication (default cache size: 100,000 entries)
+                        Box::pin(DeduplicatingStream::new(inner_stream, codec.clone(), 100_000))
+                    };
+
+                    (stream, codec)
+                } else {
+                    // DIRECT MODE: Use dynamic subscriber to discover and connect to publishers
+                    let query = match &scope {
+                        EventScope::Namespace { name } => {
+                            crate::discovery::DiscoveryQuery::EventChannels(
+                                crate::discovery::EventChannelQuery::namespace(name.clone()),
+                            )
+                        }
+                        EventScope::Component {
+                            namespace,
+                            component,
+                        } => crate::discovery::DiscoveryQuery::EventChannels(
+                            crate::discovery::EventChannelQuery::topic(
+                                namespace.clone(),
+                                component.clone(),
+                                topic.clone(),
+                            ),
+                        ),
+                    };
+
+                    let subscriber = Arc::new(DynamicSubscriber::new(discovery, query, topic.clone()));
+
+                    let stream = subscriber.start_zmq().await?;
+                    let codec = Arc::new(Codec::Msgpack(MsgpackCodec));
+                    (stream, codec)
+                }
+            }
+        };
+
+        // Filter by topic and decode envelopes
+        let topic_filter = topic.clone();
+        let codec_for_stream = codec.clone();
+        let stream = wire_stream.filter_map(move |result| {
+            let codec = codec_for_stream.clone();
+            let topic_filter = topic_filter.clone();
+            async move {
+                match result {
+                    Ok(bytes) => match codec.decode_envelope(&bytes) {
+                        Ok(envelope) => {
+                            // Filter by topic for transports that don't support native filtering
+                            if envelope.topic == topic_filter {
+                                Some(Ok(envelope))
+                            } else {
+                                None
+                            }
+                        }
+                        Err(e) => Some(Err(e)),
+                    },
+                    Err(e) => Some(Err(e)),
+                }
+            }
+        });
+
+        tracing::info!(
+            topic = %topic,
+            transport = ?transport_kind,
+            "EventSubscriber created"
+        );
+
+        Ok(Self {
+            stream: Box::pin(stream),
+            scope,
+            topic,
+            codec,
+        })
+    }
+
+    /// Get the next event envelope.
+    pub async fn next(&mut self) -> Option<Result<EventEnvelope>> {
+        self.stream.next().await
+    }
+
+    /// Subscribe with automatic deserialization.
+    pub fn typed<T: DeserializeOwned + Send + 'static>(self) -> TypedEventSubscriber<T> {
+        TypedEventSubscriber {
+            stream: self.stream,
+            codec: self.codec,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+/// Typed event subscriber that deserializes payloads.
+pub struct TypedEventSubscriber<T> {
+    stream: EventStream,
+    codec: Arc<Codec>,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: DeserializeOwned + Send + 'static> TypedEventSubscriber<T> {
+    /// Get the next typed event with its envelope.
+    pub async fn next(&mut self) -> Option<Result<(EventEnvelope, T)>> {
+        let envelope = self.stream.next().await?;
+        match envelope {
+            Ok(env) => match self.codec.decode_payload(&env.payload) {
+                Ok(typed) => Some(Ok((env, typed))),
+                Err(e) => Some(Err(e)),
+            },
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+/// Get current timestamp in milliseconds since Unix epoch.
+fn current_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::environment_names::event_plane as env;
+
+    #[test]
+    fn test_event_scope_subject_prefix() {
+        let ns_scope = EventScope::Namespace {
+            name: "test-ns".to_string(),
+        };
+        assert_eq!(ns_scope.subject_prefix(), "namespace.test-ns");
+
+        let comp_scope = EventScope::Component {
+            namespace: "test-ns".to_string(),
+            component: "test-comp".to_string(),
+        };
+        assert_eq!(
+            comp_scope.subject_prefix(),
+            "namespace.test-ns.component.test-comp"
+        );
+    }
+
+    #[test]
+    fn test_event_scope_accessors() {
+        let ns_scope = EventScope::Namespace {
+            name: "my-ns".to_string(),
+        };
+        assert_eq!(ns_scope.namespace(), "my-ns");
+        assert_eq!(ns_scope.component(), None);
+
+        let comp_scope = EventScope::Component {
+            namespace: "my-ns".to_string(),
+            component: "my-comp".to_string(),
+        };
+        assert_eq!(comp_scope.namespace(), "my-ns");
+        assert_eq!(comp_scope.component(), Some("my-comp"));
+    }
+
+    #[test]
+    fn test_timestamp_generation() {
+        let ts = current_timestamp_ms();
+
+        // Should be after Jan 1, 2020 (1577836800000) and before Jan 1, 2100 (4102444800000)
+        assert!(ts > 1577836800000, "Timestamp should be after 2020");
+        assert!(ts < 4102444800000, "Timestamp should be before 2100");
+    }
+
+    #[test]
+    fn test_event_envelope_serde() {
+        let envelope = EventEnvelope {
+            publisher_id: 42,
+            sequence: 10,
+            published_at: 1700000000000,
+            topic: "test-topic".to_string(),
+            payload: Bytes::from("test data"),
+        };
+
+        let json = serde_json::to_string(&envelope).expect("serialize");
+        let deserialized: EventEnvelope = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(deserialized.publisher_id, 42);
+        assert_eq!(deserialized.sequence, 10);
+        assert_eq!(deserialized.published_at, 1700000000000);
+        assert_eq!(deserialized.topic, "test-topic");
+        assert_eq!(deserialized.payload, Bytes::from("test data"));
+    }
+}


### PR DESCRIPTION
#### Overview:
This PR integrates the KV Router to use the Event Plane abstraction, supporting both NATS and ZMQ transports with automatic discovery.

#### Details:
**KV Router** (kv_router.rs):
      - Switch from NATS Core to Event Plane API
      - Use start_kv_router_background_event_plane() for both NATS and ZMQ
      - Add EventTransportKind detection from environment
      - Add warning for ZMQ: snapshots/state reset not supported
      - Clone block_hashes to fix borrow checker issues

**Publisher** (kv_router/publisher.rs):
      - Create EventSink trait to abstract EventPublisher and NatsQueue
      - Update event processor to use transport-agnostic publisher
      - Replace NATS JetStream-specific code with event plane API
      - Import EventPublisherTrait to disambiguate publish() method

**Subscriber** (kv_router/subscriber.rs):
      - Rename start_kv_router_background_nats_core to event_plane
      - Use EventSubscriber::for_component() for auto-discovery
      - Remove NATS-specific subscription logic
      - Add transport_kind parameter for flexibility

**Supporting Changes**:
      - indexer.rs: Minor compatibility updates
      - scheduler.rs: Updated for new event handling
      - sequence.rs: Refactored for event plane
      - discovery/worker_monitor.rs: Updated discovery queries

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event delivery infrastructure with enhanced transport flexibility and reliability.
  * Strengthened error handling and initialization failure reporting.
  * Optimized event publishing and subscription mechanisms for consistency.
  * Added event gap recovery logic for improved data synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->