### PR TITLE
feat: Variable DP rank

### DIFF
--- a/lib/llm/src/kv_router/prefill_router.rs
+++ b/lib/llm/src/kv_router/prefill_router.rs
@@ -299,9 +299,7 @@ impl PrefillRouter {
             InnerPrefillRouter::KvRouter(router) => {
                 router.chooser.client().instances().len() as u64
             }
-            InnerPrefillRouter::SimpleRouter(router) => {
-                router.client.instances().len() as u64
-            }
+            InnerPrefillRouter::SimpleRouter(router) => router.client.instances().len() as u64,
         };
 
         // Encode the chosen DP rank into bootstrap_room

--- a/lib/llm/src/kv_router/prefill_router.rs
+++ b/lib/llm/src/kv_router/prefill_router.rs
@@ -295,7 +295,11 @@ impl PrefillRouter {
         let host = endpoint.bootstrap_host?;
         let port = endpoint.bootstrap_port?;
 
-        let prefill_dp_size = match &self.0 {
+        let prefill_dp_size = match self
+            .prefill_router
+            .get()
+            .expect("prefill_router not initialized")
+        {
             InnerPrefillRouter::KvRouter(router) => {
                 router.chooser.client().instances().len() as u64
             }

--- a/lib/llm/src/kv_router/prefill_router.rs
+++ b/lib/llm/src/kv_router/prefill_router.rs
@@ -8,7 +8,6 @@ use std::sync::{
 
 use anyhow::Result;
 use futures::StreamExt;
-use rand::Rng;
 use tokio::sync::{OwnedSemaphorePermit, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
@@ -296,12 +295,12 @@ impl PrefillRouter {
         let host = endpoint.bootstrap_host?;
         let port = endpoint.bootstrap_port?;
 
-        let prefill_dp_size = match prefill_router {
+        let prefill_dp_size = match &self.0 {
             InnerPrefillRouter::KvRouter(router) => {
                 router.chooser.client().instances().len() as u64
             }
             InnerPrefillRouter::SimpleRouter(router) => {
-                router.client().instances().len() as u64
+                router.client.instances().len() as u64
             }
         };
 


### PR DESCRIPTION
#### Overview:

Encodes prefill dp_rank to `bootstrap_room` so SGLang can use to find the rank to be used for KV cache retrieval during decode

#### Details:

##### Problem

SGLang decode workers use `bootstrap_room % prefill_dp_size` (SGLang [source](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/data_parallel_controller.py#L501)) to identify which prefill worker holds their KV cache. Currently, Dynamo assigns bootstrap_room randomly, which doesn't encode the prefill worker information needed for this calculation.

This forces decode workers to be routed to the same rank as their corresponding prefill workers to ensure correct KV cache retrieval. As a result, prefill and decode must have matching DP sizes, preventing configurations like 4 prefill workers with 8 decode workers and limiting routing flexibility.

#### Related Issues:

- Relates to GitHub issue: #5638 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved prefill router decision-making with enhanced determinism and observability for internal routing logic.
  * Refined router configuration handling to support more consistent distribution of requests across available resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->