### PR TITLE
feat: get block ids with load errors

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/dynamo_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/dynamo_connector.py
@@ -139,3 +139,10 @@ class DynamoConnector(KVConnectorBase_V1):
         self, finished_req_ids: set[str]
     ) -> tuple[Optional[set[str]], Optional[set[str]]]:
         return self._worker.get_finished(finished_req_ids)
+
+    @override
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Return block IDs that failed to load asynchronously."""
+        if self._worker is None:
+            return set()
+        return self._worker.get_block_ids_with_load_errors()

--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector_worker.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector_worker.py
@@ -203,3 +203,7 @@ class KvConnectorWorker:
         # finished_ids = [id for id in finished_req_ids]
         # return set(sending_ids), set(receiving_ids)
         return self._connector.get_finished(finished_req_ids)
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        """Get block IDs that failed to load and clear the set."""
+        return self._connector.get_block_ids_with_load_errors()

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
@@ -1002,6 +1002,7 @@ impl VllmConnectorSlot {
             uuid: operation_id,
             transfer_type: TransferType::Store,
             request_type: RequestType::Scheduled,
+            block_ids: block_ids.iter().map(|b| *b as usize).collect(),
         };
 
         if let Err(e) = self.xfer_tx.send(xfer_req) {
@@ -1035,6 +1036,9 @@ impl VllmConnectorSlot {
         let src_storage_pool = src_blocks.storage_pool();
         let operation_id = uuid::Uuid::new_v4();
 
+        // Capture block_ids before moving dst_block_ids
+        let block_ids: Vec<usize> = dst_block_ids.iter().map(|b| *b as usize).collect();
+
         let xfer_req = LocalTransferRequest::Onboard(LocalOnboardRequest::new(
             self.request_id.clone(),
             src_blocks,
@@ -1047,6 +1051,7 @@ impl VllmConnectorSlot {
             uuid: operation_id,
             transfer_type: TransferType::Load,
             request_type: RequestType::Immediate,
+            block_ids,
         };
 
         if let Err(e) = self.xfer_tx.send(xfer_req) {

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
@@ -160,7 +160,7 @@ impl KvConnectorWorker {
         self.maybe_finished_onboarding.remove(request_id);
         self.request_to_blocks.remove(request_id);
         if self.connector.has_slot(request_id) {
-            self.connector.remove_slot(request_id);
+            self.connector.remove_slot(&request_id.to_string());
         }
     }
 }

--- a/lib/llm/src/block_manager/connector/protocol.rs
+++ b/lib/llm/src/block_manager/connector/protocol.rs
@@ -149,6 +149,9 @@ pub struct WorkerTransferRequest {
     pub uuid: uuid::Uuid,
     pub transfer_type: TransferType,
     pub request_type: RequestType,
+    /// Block IDs for this transfer (for error tracking)
+    #[serde(default)]
+    pub block_ids: Vec<usize>,
 }
 
 /// Sent by Worker to Scheduler.

--- a/lib/llm/src/block_manager/connector/scheduler.rs
+++ b/lib/llm/src/block_manager/connector/scheduler.rs
@@ -537,7 +537,9 @@ impl Scheduler {
                 "immediate transfer failed; notifying worker"
             );
             // Send failure notification to worker (ignore send errors during shutdown)
-            let _ = self.failure_tx.send((result.request_id.clone(), result.uuid));
+            let _ = self
+                .failure_tx
+                .send((result.request_id.clone(), result.uuid));
         }
 
         match self.slots.get_mut(&result.request_id) {

--- a/lib/llm/src/block_manager/connector/scheduler.rs
+++ b/lib/llm/src/block_manager/connector/scheduler.rs
@@ -808,6 +808,7 @@ mod tests {
             uuid: operation_id,
             transfer_type: TransferType::Load,
             request_type: RequestType::Immediate,
+            block_ids: vec![],
         };
         worker_client.enqueue_request(worker_request);
         assert_eq!(worker_client.slots.get("test").unwrap().operations.len(), 1);
@@ -864,6 +865,7 @@ mod tests {
             uuid: operation_id,
             transfer_type: TransferType::Load,
             request_type: RequestType::Immediate,
+            block_ids: vec![],
         };
 
         // immediate requests are not passed to the scheduler, but the completion will be automatically
@@ -949,6 +951,7 @@ mod tests {
             uuid: operation_id,
             transfer_type: TransferType::Store,
             request_type: RequestType::Scheduled,
+            block_ids: vec![],
         };
 
         // worker arrives last
@@ -1005,6 +1008,7 @@ mod tests {
             uuid: operation_id,
             transfer_type: TransferType::Store,
             request_type: RequestType::Scheduled,
+            block_ids: vec![],
         };
 
         // worker arrives first


### PR DESCRIPTION
#### Overview:

Add infrastructure to track and report block IDs that fail during asynchronous KV cache load operations in the KVBM connector. This enables vLLM to identify failed blocks and take corrective action (e.g., mark for recomputation).


#### Details:
- Add `block_ids` field to `WorkerTransferRequest` protocol for tracking which blocks belong to each transfer operation
- Add `failed_block_ids` field and `get_block_ids_with_load_errors()` method to `KvConnectorWorker`
- Expose the method through Python bindings (`connector_worker.py`, `dynamo_connector.py`)
- Add `failure_tx`/`failure_rx` channel between `Scheduler` and `WorkerSchedulerClient` to propagate transfer failures
- Add `drain_failures()` method to collect pending failure notifications
- Track `request_id` → `uuid` → `block_ids` mapping in worker to convert failure notifications to block IDs
- Update `handle_immediate_result()` to send failure notifications when `result.status.is_err()`
- Clean up tracking state when requests complete

#### Where should the reviewer start?

1. `lib/llm/src/block_manager/connector/scheduler.rs` - Core failure notification channel implementation
2. `lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs` - Block ID tracking and error aggregation logic
3. `lib/llm/src/block_manager/connector/protocol.rs` - Protocol changes (`block_ids` field)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: #5243


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end error tracking for block load failures with a public way to retrieve failed block IDs for diagnostics.
  * Transfer operations now include block identifiers to improve error correlation during transfers.
  * Scheduler and workers gain failure signaling so load failures are propagated and recorded.

* **Tests**
  * Updated tests to accommodate the new failure-tracking fields and behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->