### PR TITLE
fix: remove cupy-cuda13x from dev container

### DIFF
--- a/container/dev/Dockerfile.dev
+++ b/container/dev/Dockerfile.dev
@@ -351,8 +351,7 @@ RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requi
         --index-strategy unsafe-best-match \
         --extra-index-url https://download.pytorch.org/whl/cu130 \
         --requirement /tmp/requirements.txt \
-        --requirement /tmp/requirements.test.txt \
-        cupy-cuda13x && \
+        --requirement /tmp/requirements.test.txt && \
     if [ "${FRAMEWORK}" = "sglang" ]; then \
         uv pip install --force-reinstall --no-deps pytest; \
     fi


### PR DESCRIPTION
#### Overview:

Conflicted 12 & 13. Remove cupy-cuda13x from the dev container to fix CUDA driver compatibility issues. 

#### Details:

- Remove cupy-cuda13x installation from container/dev/Dockerfile.dev
- Keep only cupy-cuda12x which is compatible with CUDA 12.x drivers (12.9+)
- Prevents conflicting CUDA runtime versions in the same environment

#### Where should the reviewer start?

container/dev/Dockerfile.dev - Single line change removing cupy-cuda13x from the uv pip install command

#### Related Issues:

DIS-1340

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified development build configuration to streamline dependency installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->