### PR TITLE
fix: avoid Prometheus collisions via multi-registry scrape

### DIFF
--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -236,12 +236,15 @@ impl Component {
     }
 
     pub fn endpoint(&self, endpoint: impl Into<String>) -> Endpoint {
-        Endpoint {
+        let endpoint = Endpoint {
             component: self.clone(),
             name: endpoint.into(),
             labels: Vec::new(),
             metrics_registry: crate::MetricsRegistry::new(),
-        }
+        };
+        self.get_metrics_registry()
+            .register_child_registry(endpoint.get_metrics_registry());
+        endpoint
     }
 
     pub async fn list_instances(&self) -> anyhow::Result<Vec<Instance>> {
@@ -453,27 +456,45 @@ impl std::fmt::Display for Namespace {
 
 impl Namespace {
     pub(crate) fn new(runtime: DistributedRuntime, name: String) -> anyhow::Result<Self> {
-        Ok(NamespaceBuilder::default()
+        let ns = NamespaceBuilder::default()
             .runtime(Arc::new(runtime))
             .name(name)
-            .build()?)
+            .build()?;
+        ns.drt()
+            .get_metrics_registry()
+            .register_child_registry(ns.get_metrics_registry());
+        Ok(ns)
     }
 
     /// Create a [`Component`] in the namespace who's endpoints can be discovered with etcd
     pub fn component(&self, name: impl Into<String>) -> anyhow::Result<Component> {
-        ComponentBuilder::from_runtime(self.runtime.clone())
+        let component = ComponentBuilder::from_runtime(self.runtime.clone())
             .name(name)
             .namespace(self.clone())
-            .build()
+            .build()?;
+        // Attach component metrics under this namespace so namespace.metrics().prometheus_expfmt()
+        // includes component (and endpoint) metrics via recursive child traversal.
+        self.get_metrics_registry()
+            .register_child_registry(component.get_metrics_registry());
+        Ok(component)
     }
 
     /// Create a [`Namespace`] in the parent namespace
     pub fn namespace(&self, name: impl Into<String>) -> anyhow::Result<Namespace> {
-        Ok(NamespaceBuilder::default()
+        let child = NamespaceBuilder::default()
             .runtime(self.runtime.clone())
             .name(name.into())
             .parent(Some(Arc::new(self.clone())))
-            .build()?)
+            .build()?;
+        child
+            .drt()
+            .get_metrics_registry()
+            .register_child_registry(child.get_metrics_registry());
+        // Also attach child namespace under this namespace so namespace.metrics().prometheus_expfmt()
+        // includes descendants naturally.
+        self.get_metrics_registry()
+            .register_child_registry(child.get_metrics_registry());
+        Ok(child)
     }
 
     pub fn name(&self) -> String {

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -291,11 +291,10 @@ async fn metrics_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
     // Update the uptime gauge with current value
     state.drt().system_health().lock().update_uptime_gauge();
 
-    // Get all metrics from DistributedRuntime
-    // Note: In the new hierarchy-based architecture, metrics are automatically registered
-    // at all parent levels, so DRT's metrics include all metrics from children
-    // (Namespace, Component, Endpoint). The prometheus_expfmt() method also executes
-    // all update callbacks and expfmt callbacks before returning the metrics.
+    // Get all metrics from the DistributedRuntime.
+    //
+    // NOTE: We use a multi-registry model (e.g. one registry per endpoint) and merge at scrape time,
+    // so /metrics traverses registered child registries and produces a single combined output.
     let response = match state.drt().metrics().prometheus_expfmt() {
         Ok(r) => r,
         Err(e) => {


### PR DESCRIPTION
#### Overview:

Work around Prometheus metric registration collisions by moving to a multi-registry scrape model. This allows the same metric name across endpoints as long as label sets differ.

#### Details:

- Add child-registry tracking + recursive traversal + merge/dedupe logic in `MetricsRegistry` to produce one combined exposition output.
- Update `/metrics` handler to use `drt.metrics().prometheus_expfmt()` (which now returns the combined output).

#### Where should the reviewer start?

- `lib/runtime/src/metrics.rs` (multi-registry merge logic + changed registration semantics)
- `lib/runtime/src/component.rs` (child registry wiring)
- `lib/runtime/src/system_status_server.rs` (scrape path)

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)

DIS-1339, [DGH-503](https://linear.app/nvidia/issue/DGH-503/prometheus-metrics-collision-when-enable-local-indexer-is-enabled-vllm)


/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The /metrics endpoint now properly consolidates and exposes metrics from all components, namespaces, and endpoints, providing comprehensive system observability and visibility into overall health and performance.

* **Bug Fixes**
  * Improved error handling for the metrics endpoint with clearer HTTP error responses when metric collection fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->