### PR TITLE
fix: emit first token creation signal after sleeping.

### DIFF
--- a/lib/llm/src/mocker/scheduler.rs
+++ b/lib/llm/src/mocker/scheduler.rs
@@ -390,7 +390,7 @@ async fn simulate_prefill(
     worker_type: WorkerType,
     speedup_ratio: f64,
 ) -> Duration {
-    let start_time = std::time::Instant::now();
+    let start_time = tokio::time::Instant::now();
     let mut total_time = Duration::ZERO;
 
     while let Some((prefill_compute, maybe_creation_signal, is_full_prefill)) =
@@ -415,13 +415,9 @@ async fn simulate_prefill(
         }
     }
 
-    // Compute elapsed time and adjust sleep duration for accuracy
-    let elapsed = start_time.elapsed();
-    let expected_sleep = Duration::from_secs_f64(total_time.as_secs_f64() / speedup_ratio);
-    let sleep_duration = expected_sleep.saturating_sub(elapsed);
-    if sleep_duration > Duration::ZERO {
-        tokio::time::sleep(sleep_duration).await;
-    }
+    let deadline = start_time + Duration::from_secs_f64(total_time.as_secs_f64() / speedup_ratio);
+    tokio::time::sleep_until(deadline).await;
+
     total_time
 }
 
@@ -435,7 +431,7 @@ async fn simulate_decode(
     block_size: usize,
     speedup_ratio: f64,
 ) -> Duration {
-    let start_time = std::time::Instant::now();
+    let start_time = tokio::time::Instant::now();
     // Compute decode timing
     let active_kv_tokens = kv_manager.num_active_blocks() * block_size;
     // Compute average context length across all active decode requests
@@ -498,13 +494,8 @@ async fn simulate_decode(
         }
     }
 
-    // Compute elapsed time and adjust sleep duration for accuracy
-    let elapsed = start_time.elapsed();
-    let expected_sleep = Duration::from_secs_f64(total_time.as_secs_f64() / speedup_ratio);
-    let sleep_duration = expected_sleep.saturating_sub(elapsed);
-    if sleep_duration > Duration::ZERO {
-        tokio::time::sleep(sleep_duration).await;
-    }
+    let deadline = start_time + Duration::from_secs_f64(total_time.as_secs_f64() / speedup_ratio);
+    tokio::time::sleep_until(deadline).await;
 
     total_time
 }

--- a/lib/llm/src/mocker/scheduler.rs
+++ b/lib/llm/src/mocker/scheduler.rs
@@ -320,7 +320,8 @@ impl Scheduler {
                     &args.perf_model,
                     args.block_size,
                     args.speedup_ratio,
-                    iteration_start + Duration::from_secs_f64(prefill_time.as_secs_f64() / args.speedup_ratio),
+                    iteration_start
+                        + Duration::from_secs_f64(prefill_time.as_secs_f64() / args.speedup_ratio),
                 )
                 .await;
 

--- a/lib/llm/src/mocker/scheduler.rs
+++ b/lib/llm/src/mocker/scheduler.rs
@@ -456,17 +456,8 @@ async fn simulate_decode(
 
     state.reset_active_tokens();
 
-    // Compute elapsed time and adjust sleep duration for accuracy
-    let elapsed = start_time.elapsed();
-    let expected_sleep = Duration::from_secs_f64(total_time.as_secs_f64() / speedup_ratio);
-    let sleep_duration = expected_sleep.saturating_sub(elapsed);
-    if sleep_duration > Duration::ZERO {
-        tokio::time::sleep(sleep_duration).await;
-    }
-
-    // Process decoding - first process all KV signals
+    // Process decoding
     let uuids: Vec<Uuid> = state.decode.keys().cloned().collect();
-
     for uuid in uuids {
         let Some(sequence) = state.run(uuid) else {
             continue;
@@ -505,6 +496,14 @@ async fn simulate_decode(
         if send_failed || is_complete {
             state.complete(&uuid);
         }
+    }
+
+    // Compute elapsed time and adjust sleep duration for accuracy
+    let elapsed = start_time.elapsed();
+    let expected_sleep = Duration::from_secs_f64(total_time.as_secs_f64() / speedup_ratio);
+    let sleep_duration = expected_sleep.saturating_sub(elapsed);
+    if sleep_duration > Duration::ZERO {
+        tokio::time::sleep(sleep_duration).await;
     }
 
     total_time


### PR DESCRIPTION
#### Overview:

There's a timing issue in the Dynamo mocker. Instead of simulating the generation of a token (aka `sleep`) first and then emitting the signal that the token has been created, it immediately creates the signal; and then sleeps. This leads to unrealistically low TTFT and high TTST (which is effectively measuring TTFT). 

#### Details:

In the mocker, the process of creating a new token is emulated by sleeping for the duration it would take a real device to compute the token. The estimation of this duration is done in two functions `simulate_prefill` and `simulate_decode`. Prior to this commits, after callig the two functions, the simulation sleeps for `t_prefill + t_decode`.

The timing information is collected in a separate process: `aiperf`. The signal that a new token has been generated is located in the `simulate_decode` function. Therefore, prior to this patch, the signal is sent before sleeping. As a result, the Time To First Token (TTFT) recorded by AIPerf is unrealistically low; while Time To Second Token (TTST) includes the prefilling time for the sequence and is therefore overestimated.

This patch moves the sleep into the two functions `simulate_*`.

The effect can be seen clearly when using
  benchmarks/router/real_data_benchmark.py

on a workload file that contains a single request. Shown below are the timings obtained before and after applying this patch for one line from the mooncake_trace.jsonl found in this repo (timestamp = 3052, isl = 9416, osl = 145).

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┓
┃                    Metric ┃     main ┃    patch ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━┩
│  Time to First Token (ms) │    19.60 │   255.95 │
│ Time to Second Token (ms) │   226.47 │    28.88 │
│  Inter Token Latency (ms) │    30.17 │    29.21 │
│  Request Count (requests) │     1.00 │     1.00 │
└───────────────────────────┴──────────┴──────────┘
```
main: `cde3b2a5b464e27c837446626612e75e65fd9e86`

From the log files of the mocker, we can see that prefill (and decode) time computed by the polynomial formla is 200ms (and 30ms), respectively.

```
    2026-01-23T09:38:10.591535Z DEBUG dynamo_llm::mocker::perf_model: Prefill time prediction: new_tokens=9421, time=196.91ms
    2026-01-23T09:38:10.591588Z DEBUG dynamo_llm::mocker::perf_model: Decode time prediction: active_kv_tokens=9728, context_length=9421, time=28.73ms
```

#### Where should the reviewer start?

Possible things to consider/do:
 * when events should be sent to the KV manager: before the prefill/decode happens or after.
 * run `real_data_benchmark.py` to confirm the described behaviour. I've attached the script I use to run `real_benchmark.py` and the input file I use (it's a JSONL, i.e. lines of JSON).
[single-job.json](https://github.com/user-attachments/files/24885779/single-job.json)
[run_experiment.sh](https://github.com/user-attachments/files/24885780/run_experiment.sh)


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

No known related issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal timing accuracy in the scheduling system by restructuring timing control mechanisms.
  * Enhanced asynchronous task management within scheduler helpers for better performance reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->