### PR TITLE
fix to adapt VLM multi img benchmarking with sglang.bench

### DIFF
--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -111,7 +111,8 @@ class EncodeWorkerHandler:
 
         try:
             time_start = time.perf_counter()
-            for idx in range(len(request.multimodal_inputs)):
+            multimodal_inputs = request.multimodal_inputs or []
+            for idx in range(len(multimodal_inputs)):
                 if not request.multimodal_inputs[idx].multimodal_input.image_url:
                     raise ValueError("image_url is required for the encode worker.")
 

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -77,9 +77,25 @@ def normalize_model_name(model_name: str) -> str:
                 return f"{org}/{model}"
 
     # Handle local directory paths - extract the last directory name
+    # and try to infer organization from known model patterns
     path = Path(model_name)
     if path.exists() and path.is_dir():
-        return path.name
+        name = path.name
+        # Try to infer org from known model patterns
+        if "Qwen" in name:
+            return f"Qwen/{name}"
+        if "llava" in name.lower():
+            return f"llava-hf/{name}"
+        return name
+
+    # If path doesn't exist but looks like a local path, still try to extract name
+    if model_name.startswith("/"):
+        name = Path(model_name).name
+        if "Qwen" in name:
+            return f"Qwen/{name}"
+        if "llava" in name.lower():
+            return f"llava-hf/{name}"
+        return name
 
     # If no pattern matches, return the original name
     return model_name

--- a/components/src/dynamo/vllm/multimodal_utils/protocol.py
+++ b/components/src/dynamo/vllm/multimodal_utils/protocol.py
@@ -86,7 +86,10 @@ class vLLMGenerateRequest(BaseModel):
         if isinstance(v, str):
             v = json.loads(v)
         if isinstance(v, dict):
-            return SamplingParams(**v)
+            # Filter out private/internal fields that shouldn't be passed to constructor
+            # These fields are serialized but cause issues when deserialized (e.g., sets become lists)
+            filtered = {k: val for k, val in v.items() if not k.startswith("_")}
+            return SamplingParams(**filtered)
         return v
 
     @field_serializer("sampling_params")
@@ -156,7 +159,7 @@ class MultiModalGroup(BaseModel):
 
 class vLLMMultimodalRequest(vLLMGenerateRequest):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    multimodal_inputs: List[MultiModalGroup] = Field(default_factory=list)
+    multimodal_inputs: Optional[List[MultiModalGroup]] = Field(default_factory=list)
 
 
 class VLLMNativeEncoderRequest(BaseModel):


### PR DESCRIPTION
#### Overview:

benchmark CLI based on sglang.bench to allign withg sglang's PR
`python -m sglang.bench_serving --model /raid/model_hub/Qwen/Qwen2.5-VL-7B-Instruct --num-prompts 1 --dataset-name image --random-input-len 128 --random-output-len 256 --image-count 8 --image-resolution 1080p --host localhost --port 8000 --backend vllm-chat --request-rate 1`

Made some modifications to make this work, will init a PRI fixed qps =1 and only tune the total num_prompt to be 1 or 10

seems like `--multimodal-encode-prefill-worker` only works with llama4 but not qwen3 vl series due to vLLM limitations, so I put E and P processes on same GPU id 0 to demonstrate EP/D and limit P worker memory allocation to be 0.4 to avoid OOM.

#### Details:

sucess benchmark
<img width="720" height="433" alt="image" src="https://github.com/user-attachments/assets/db931ac8-0c81-4b36-966e-4086c05f05f5" />

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
