### PR TITLE
docs: add performance warning for --store-kv file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Dynamo uses TCP for inter-component communication. External services are optiona
 
 For local development without external dependencies, pass `--store-kv file` (avoids etcd) to both the frontend and workers. vLLM users should also pass `--kv-events-config '{"enable_kv_cache_events": false}'` to disable KV event publishing (avoids NATS) while keeping local prefix caching enabled; SGLang and TRT-LLM don't require this flag.
 
+> ⚠️ **Performance Note:** `--store-kv file` is for local development only and adds latency overhead. Do not use for benchmarking or production. For accurate performance measurements, use etcd (`--store-kv etcd` or run `./etcd` locally).
+
 For distributed non-Kubernetes deployments or KV-aware routing:
 
 - [etcd](https://etcd.io/) can be run directly as `./etcd`.

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -291,7 +291,7 @@ def parse_args():
         type=str,
         choices=["etcd", "file", "mem"],
         default=os.environ.get("DYN_STORE_KV", "etcd"),
-        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv. WARNING: 'file' is for local development only and adds latency overhead - do not use for benchmarking or production.",
     )
     parser.add_argument(
         "--request-plane",

--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -320,7 +320,7 @@ def parse_args():
         type=str,
         choices=["etcd", "file", "mem"],
         default=os.environ.get("DYN_STORE_KV", "etcd"),
-        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv. WARNING: 'file' is for local development only and adds latency overhead - do not use for benchmarking or production.",
     )
     parser.add_argument(
         "--request-plane",

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -108,7 +108,7 @@ DYNAMO_ARGS: Dict[str, Dict[str, Any]] = {
         "type": str,
         "choices": ["etcd", "file", "mem"],
         "default": os.environ.get("DYN_STORE_KV", "etcd"),
-        "help": "Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+        "help": "Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv. WARNING: 'file' is for local development only and adds latency overhead - do not use for benchmarking or production.",
     },
     "request-plane": {
         "flags": ["--request-plane"],

--- a/components/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -324,7 +324,7 @@ def cmd_line_args():
         type=str,
         choices=["etcd", "file", "mem"],
         default=os.environ.get("DYN_STORE_KV", "etcd"),
-        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv. WARNING: 'file' is for local development only and adds latency overhead - do not use for benchmarking or production.",
     )
     parser.add_argument(
         "--request-plane",

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -249,7 +249,7 @@ def parse_args() -> Config:
         type=str,
         choices=["etcd", "file", "mem"],
         default=os.environ.get("DYN_STORE_KV", "etcd"),
-        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv.",
+        help="Which key-value backend to use: etcd, mem, file. Etcd uses the ETCD_* env vars (e.g. ETCD_ENDPOINTS) for connection details. File uses root dir from env var DYN_FILE_KV or defaults to $TMPDIR/dynamo_store_kv. WARNING: 'file' is for local development only and adds latency overhead - do not use for benchmarking or production.",
     )
     parser.add_argument(
         "--request-plane",


### PR DESCRIPTION
## Summary

Adds a warning to the `--store-kv` CLI help text and README that the `file` option adds latency overhead and should only be used for local development, not for benchmarking or production.

**Changes:**
- Updated CLI help text in 5 component args files (vllm, sglang, trtllm, frontend, mocker)
- Added performance note to README.md Service Discovery section

## Context

During customer benchmarking, we identified that `--store-kv file` introduces measurable latency overhead compared to etcd. This warning helps users avoid using the file backend for performance-sensitive workloads.

## Test plan

- [x] Verified help text appears correctly with `python -m dynamo.frontend --help`
- [x] No functional changes, documentation only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying warnings in README and CLI help text across multiple components indicating that the file-based KV storage backend is for local development only and should not be used for benchmarking or production environments due to latency overhead. Recommends etcd for accurate performance measurements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->