### PR TITLE
test: clarify Python test structure (and update .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,11 @@ generated-values.yaml
 **/.devcontainer/.env
 TensorRT-LLM
 
+# The Linux kernel generates core dump files when a process crashes (receives signals
+# like SIGSEGV, SIGABRT, SIGBUS, etc.). The Linux container's /proc/sys/kernel/core_pattern
+# determines the filename (typically core or core.<pid>)
+core
+
 # Ruler Generated Files
 /.cursor/instructions.md
 /.cursor/instructions.md.bak

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,7 +22,13 @@ dynamo/
 ├── components/
 │   ├── src/dynamo/
 │   |   └── planner/
+│   |   |   └── zoo.py
+│   |   |   └── foo/
+│   |   |   |   └── bar.py
 │   │   │   └── tests/              # Python unit/integration tests for planner
+│   │   │   |   └── test_zoo.py
+│   │   │   |   └── foo/            # Mirror the source code file hierarchy
+│   │   │   |   |   └── test_bar.py
 │   |   └── router/
 │   │   │   └── tests/
 │   |   └── ...


### PR DESCRIPTION
## Why

  The Python test directory structure lacked a clear convention, making it harder for contributors to know where
   to place new test files. This adds a documented pattern (mirror source hierarchy under `tests/`) and cleans
  up `.gitignore`.

  ## What Changed

  - Added `core` to `.gitignore`
  - Updated `tests/README.md` with a concrete example showing how test files should mirror the source code
  hierarchy (e.g. `planner/foo/bar.py` → `tests/foo/test_bar.py`)

  ## Test Plan

  No functional code changes — documentation and gitignore only.