### PR TITLE
fix: add recv timeout for zmq transport

### DIFF
--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -25,6 +25,7 @@ use std::sync::{Arc, Mutex};
 /// Default ZMQ HWM is 1000, which limits scalability.
 const ZMQ_SNDHWM: i32 = 100_000; // Send buffer: 100K messages
 const ZMQ_RCVHWM: i32 = 100_000; // Receive buffer: 100K messages
+const ZMQ_RCVTIMEOUT_MS: i32 = 100; // Receive timeout: 100ms (avoids blocking forever)
 
 use super::codec::MsgpackCodec;
 use super::frame::Frame;
@@ -244,8 +245,8 @@ impl ZmqSubTransport {
             // Configure High Water Mark for better scalability
             socket.set_rcvhwm(ZMQ_RCVHWM)?;
 
-            // Set receive timeout to -1 (blocking)
-            socket.set_rcvtimeo(-1)?;
+            // Set receive timeout to avoid blocking forever (fixes test hangs)
+            socket.set_rcvtimeo(ZMQ_RCVTIMEOUT_MS)?;
 
             // Connect to endpoint
             socket.connect(&endpoint_owned)?;
@@ -307,8 +308,8 @@ impl ZmqSubTransport {
             // Configure High Water Mark for better scalability
             socket.set_rcvhwm(ZMQ_RCVHWM)?;
 
-            // Set receive timeout to -1 (blocking)
-            socket.set_rcvtimeo(-1)?;
+            // Set receive timeout to avoid blocking forever (fixes test hangs)
+            socket.set_rcvtimeo(ZMQ_RCVTIMEOUT_MS)?;
 
             // Connect to all endpoints
             for endpoint in &endpoints_owned {
@@ -350,6 +351,7 @@ impl ZmqSubTransport {
     ///
     /// This task holds the socket lock only briefly during each recv operation,
     /// allowing multiple subscribers to receive concurrently via broadcast channel.
+    /// Uses finite timeout to avoid blocking forever (fixes test hangs from ZMQ "slow joiner" problem).
     fn start_socket_pump(
         socket: Arc<Mutex<zmq::Socket>>,
         broadcast_tx: tokio::sync::broadcast::Sender<Bytes>,
@@ -359,11 +361,15 @@ impl ZmqSubTransport {
                 // Receive multipart message in blocking task: [topic, publisher_id, sequence, frame_bytes]
                 let socket_clone = Arc::clone(&socket);
                 let result =
-                    tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, u64, u64, Vec<u8>)> {
+                    tokio::task::spawn_blocking(move || -> Result<Option<(Vec<u8>, u64, u64, Vec<u8>)>> {
                         let socket = socket_clone.lock().unwrap();
 
-                        // Receive topic frame
-                        let topic = socket.recv_bytes(0)?;
+                        // Receive topic frame (may timeout with EAGAIN)
+                        let topic = match socket.recv_bytes(0) {
+                            Ok(data) => data,
+                            Err(zmq::Error::EAGAIN) => return Ok(None), // Timeout, retry
+                            Err(e) => return Err(e.into()),
+                        };
 
                         // Receive publisher_id frame (8 bytes, u64 big-endian)
                         let publisher_id_bytes = socket.recv_bytes(0)?;
@@ -389,12 +395,12 @@ impl ZmqSubTransport {
                         // Receive data frame
                         let data = socket.recv_bytes(0)?;
 
-                        Ok((topic, publisher_id, sequence, data))
+                        Ok(Some((topic, publisher_id, sequence, data)))
                     })
                     .await;
 
                 match result {
-                    Ok(Ok((_topic, publisher_id, sequence, frame_bytes))) => {
+                    Ok(Ok(Some((_topic, publisher_id, sequence, frame_bytes)))) => {
                         // Log dedup metadata for debugging
                         tracing::trace!(
                             publisher_id = publisher_id,
@@ -415,6 +421,10 @@ impl ZmqSubTransport {
                                 continue;
                             }
                         }
+                    }
+                    Ok(Ok(None)) => {
+                        // Timeout (EAGAIN), continue polling
+                        continue;
                     }
                     Ok(Err(e)) => {
                         tracing::error!(error = %e, "ZMQ receive error in socket pump");

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -360,8 +360,8 @@ impl ZmqSubTransport {
             loop {
                 // Receive multipart message in blocking task: [topic, publisher_id, sequence, frame_bytes]
                 let socket_clone = Arc::clone(&socket);
-                let result =
-                    tokio::task::spawn_blocking(move || -> Result<Option<(Vec<u8>, u64, u64, Vec<u8>)>> {
+                let result = tokio::task::spawn_blocking(
+                    move || -> Result<Option<(Vec<u8>, u64, u64, Vec<u8>)>> {
                         let socket = socket_clone.lock().unwrap();
 
                         // Receive topic frame (may timeout with EAGAIN)
@@ -396,8 +396,9 @@ impl ZmqSubTransport {
                         let data = socket.recv_bytes(0)?;
 
                         Ok(Some((topic, publisher_id, sequence, data)))
-                    })
-                    .await;
+                    },
+                )
+                .await;
 
                 match result {
                     Ok(Ok(Some((_topic, publisher_id, sequence, frame_bytes)))) => {


### PR DESCRIPTION
#### Overview:
Fixes indefinite hangs in ZMQ transport tests (`test_zmq_pubsub_basic`, `test_zmq_multiple_messages`) caused by blocking receive operations in the socket pump. The fix replaces infinite timeout with a finite 100ms timeout and handles timeout errors gracefully.

#### Details:

**Root Cause:**
- ZMQ SUB socket was configured with `set_rcvtimeo(-1)` (infinite blocking timeout)
- Socket pump's `recv_bytes(0)` call would block forever if no message arrived
- This is exacerbated by ZMQ's "slow joiner" problem where early messages can be lost
- Test timeouts only affect the broadcast channel receive, not the underlying blocking ZMQ socket
- Multiple parallel tests exhaust the blocking thread pool, causing CI hangs

**Solution:**
1. **Added finite timeout constant**: `ZMQ_RCVTIMEOUT_MS = 100ms` to replace infinite blocking
2. **Updated socket configuration**: Changed `set_rcvtimeo(-1)` to `set_rcvtimeo(ZMQ_RCVTIMEOUT_MS)` in both `connect()` and `connect_multiple()` methods
3. **Enhanced socket pump error handling**: Modified `start_socket_pump()` to handle `zmq::Error::EAGAIN` (timeout) by returning `Ok(None)` and continuing the polling loop, rather than blocking indefinitely

**Changes:**
- `lib/runtime/src/transports/event_plane/zmq_transport.rs`:
  - Added `ZMQ_RCVTIMEOUT_MS` constant
  - Updated socket timeout configuration
  - Modified socket pump to handle timeouts gracefully

## Where should the reviewer start?

Start at `lib/runtime/src/transports/event_plane/zmq_transport.rs`:


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event transport hangs in test environments by implementing finite timeout handling for message reception.
  * Improved reliability of multi-endpoint event transport connections with enhanced timeout semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->