### PR TITLE
feat: Lazy ETCD initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,6 +2508,7 @@ dependencies = [
  "notify",
  "nuid",
  "once_cell",
+ "oneshot",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1587,7 +1587,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "utoipa",
  "uuid",
 ]
 
@@ -1800,6 +1799,7 @@ dependencies = [
  "notify",
  "nuid",
  "once_cell",
+ "oneshot",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -7795,8 +7795,6 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.110",
- "url",
- "uuid",
 ]
 
 [[package]]

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -42,6 +42,7 @@ either = { workspace = true }
 etcd-client = { workspace = true }
 futures = { workspace = true }
 humantime = { workspace = true }
+oneshot = { workspace = true }
 parking_lot = { workspace = true }
 prometheus = { workspace = true }
 rand = { workspace = true }

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -600,7 +600,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_kv_store_discovery_register_endpoint() {
-        let store = kv::Manager::memory();
+        let store = kv::Manager::default();
         let cancel_token = CancellationToken::new();
         let client = KVStoreDiscovery::new(store, cancel_token);
 
@@ -625,7 +625,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_kv_store_discovery_list() {
-        let store = kv::Manager::memory();
+        let store = kv::Manager::default();
         let cancel_token = CancellationToken::new();
         let client = KVStoreDiscovery::new(store, cancel_token);
 
@@ -680,7 +680,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_kv_store_discovery_watch() {
-        let store = kv::Manager::memory();
+        let store = kv::Manager::default();
         let cancel_token = CancellationToken::new();
         let client = Arc::new(KVStoreDiscovery::new(store, cancel_token.clone()));
 

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -103,19 +103,7 @@ impl DistributedRuntime {
     pub async fn new(runtime: Runtime, config: DistributedConfig) -> Result<Self> {
         let (selected_kv_store, nats_config, request_plane) = config.dissolve();
 
-        let runtime_clone = runtime.clone();
-
-        let store = match selected_kv_store {
-            kv::Selector::Etcd(etcd_config) => {
-                let etcd_client = etcd::Client::new(*etcd_config, runtime_clone).await.inspect_err(|err|
-                    // The returned error doesn't show because of a dropped runtime error, so
-                    // log it first.
-                    tracing::error!(%err, "Could not connect to etcd. Pass `--store-kv ..` to use a different backend or start etcd."))?;
-                kv::Manager::etcd(etcd_client)
-            }
-            kv::Selector::File(root) => kv::Manager::file(runtime.primary_token(), root),
-            kv::Selector::Memory => kv::Manager::memory(),
-        };
+        let store = kv::Manager::new(selected_kv_store, Some(runtime.clone()));
 
         let nats_client = match nats_config {
             Some(nc) => Some(nc.connect().await?),
@@ -577,7 +565,7 @@ impl DistributedConfig {
         let nats_enabled = request_plane.is_nats()
             || std::env::var(crate::config::environment_names::nats::NATS_SERVER).is_ok();
         DistributedConfig {
-            store_backend: kv::Selector::Etcd(Box::new(etcd_config)),
+            store_backend: kv::Selector::Etcd(etcd_config),
             nats_config: if nats_enabled {
                 Some(nats::ClientOptions::default())
             } else {

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -565,7 +565,7 @@ impl DistributedConfig {
         let nats_enabled = request_plane.is_nats()
             || std::env::var(crate::config::environment_names::nats::NATS_SERVER).is_ok();
         DistributedConfig {
-            store_backend: kv::Selector::Etcd(etcd_config),
+            store_backend: kv::Selector::Etcd(Box::new(etcd_config)),
             nats_config: if nats_enabled {
                 Some(nats::ClientOptions::default())
             } else {

--- a/lib/runtime/src/storage/kv.rs
+++ b/lib/runtime/src/storage/kv.rs
@@ -315,9 +315,8 @@ impl Manager {
 
     fn get_kv_store(&self) -> Result<&KeyValueStoreEnum, StoreError> {
         let selector = self.selector.clone();
-        self.kv_store.get_or_try_init(|| {
-            selector
-                .build(self.runtime.clone())})
+        self.kv_store
+            .get_or_try_init(|| selector.build(self.runtime.clone()))
     }
 
     pub async fn get_or_create_bucket(


### PR DESCRIPTION
ETCD seems to be very sensitive to network and memory pressure. During the network and memory-intensive model loading process (especially when loading from ETCD), pings from the ETCD server can take several seconds to be delivered. To get around this, we lazily initialize ETCD, and only create our lease after the model loading has completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Enhanced key-value store initialization with improved runtime integration and lazy loading capabilities
* Streamlined storage backend configuration and initialization logic

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->