### PR TITLE
chore: Fix tests logging setup

### DIFF
--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -1890,7 +1890,6 @@ mod test_integration_publisher {
     use crate::kv_router::protocols::ActiveLoad;
     use dynamo_runtime::distributed_test_utils::create_test_drt_async;
     use dynamo_runtime::transports::event_plane::EventSubscriber;
-    use futures::StreamExt;
 
     #[tokio::test]
     #[ignore] // Mark as ignored as requested, because CI's integrations still don't have NATS

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -673,10 +673,7 @@ mod tests {
     #[tokio::test]
     async fn test_graceful_shutdown_waits_for_inflight_tcp_requests() {
         // Initialize tracing for test debugging
-        let _ = tracing_subscriber::fmt()
-            .with_test_writer()
-            .with_max_level(tracing::Level::DEBUG)
-            .try_init();
+        crate::logging::init();
 
         let cancellation_token = CancellationToken::new();
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
@@ -877,10 +874,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_worker_pool_bounds_concurrency() {
-        let _ = tracing_subscriber::fmt()
-            .with_test_writer()
-            .with_max_level(tracing::Level::DEBUG)
-            .try_init();
+        crate::logging::init();
 
         // Use a small pool size for testing
         let pool_size = 3;


### PR DESCRIPTION
The two tests in `src/pipeline/network/ingress/shared_tcp_endpoint.rs` were initializing their own tracing subscriber directly with tracing_subscriber::fmt()...try_init(). This bypassed the global INIT: Once guard in crate::logging::init().

When tests ran in parallel:
1. A shared_tcp_endpoint.rs test would run first and call try_init(), which set up both the tracing subscriber AND the log-to-tracing bridge
2. Later, test_json_log_capture (or another test) would call crate::logging::init()
3. Since INIT hadn't been used yet, setup_logging() would run and call .init() on a new subscriber
4. This tried to set up another log bridge, which panicked with SetLoggerError because the log bridge was already set

The fix: Changed both tests in shared_tcp_endpoint.rs to use crate::logging::init() instead of setting up their own subscriber. This ensures all logging initialization goes through the same INIT: Once guard, preventing duplicate log bridge setup.

Thanks Claude!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused imports in test modules
  * Improved test logging initialization with centralized setup

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->