### PR TITLE
perf: optimize file-based KV store with async I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2491,6 +2491,7 @@ dependencies = [
  "env_logger",
  "etcd-client",
  "figment",
+ "filetime",
  "futures",
  "humantime",
  "hyper 1.8.1",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -579,7 +579,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1483,7 +1483,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1785,6 +1785,7 @@ dependencies = [
  "either",
  "etcd-client",
  "figment",
+ "filetime",
  "futures",
  "humantime",
  "hyper",
@@ -1795,6 +1796,7 @@ dependencies = [
  "libc",
  "local-ip-address",
  "log",
+ "lru",
  "nid",
  "nix 0.29.0",
  "notify",
@@ -1815,6 +1817,7 @@ dependencies = [
  "serde_json",
  "socket2 0.5.10",
  "thiserror 2.0.17",
+ "tmq",
  "tokio",
  "tokio-rayon",
  "tokio-stream",
@@ -1828,6 +1831,7 @@ dependencies = [
  "uuid",
  "validator",
  "xxhash-rust",
+ "zmq",
 ]
 
 [[package]]
@@ -1964,7 +1968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3317,7 +3321,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3699,6 +3703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4262,7 +4275,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6068,7 +6081,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6864,7 +6877,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8094,7 +8107,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -75,6 +75,7 @@ console-subscriber = { version = "0.4", optional = true }
 educe = { version = "0.6.0" }
 figment = { version = "0.10.19", features = ["env", "json", "toml", "test"] }
 notify = { version = "6.1", default-features = false, features = ["macos_fsevent"] }
+filetime = { version = "0.2" }
 inotify = { version = "0.11" }
 libc = { version = "0.2" }
 local-ip-address = { version = "0.6.3" }


### PR DESCRIPTION
## Summary
- Replace blocking `std::fs` with non-blocking `tokio::fs` in async functions
- Use `filetime::set_file_mtime()` instead of opening files to update mtime
- Optimize lock patterns: collect items then release lock before I/O
- Remove TOCTOU race conditions

## Performance
- Before: ~4% latency overhead with `--store-kv file`
- After: ~0% latency overhead (matches etcd performance)

## Test plan
- [x] Unit tests pass (`cargo test -p dynamo-runtime storage::kv`)
- [x] Local latency benchmarks show 0% overhead vs direct vLLM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new dependency for file timestamp utilities.

* **Bug Fixes**
  * Improved file system reliability through enhanced error handling and robust path validation.

* **Refactor**
  * Optimized file storage operations with asynchronous processing and improved concurrency handling to reduce lock contention and enhance performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->