### PR TITLE
chore: Add "LGPL-3.0-only" to allowed licenses

### DIFF
--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -75,7 +75,7 @@ jobs:
       working-directory: ${{ matrix.dir }}
       run: |
         cargo-deny --version || cargo install cargo-deny@0.16.4
-        cargo-deny --no-default-features check --hide-inclusion-graph licenses bans --config ${{ github.workspace }}/deny.toml
+        cargo-deny -L error --no-default-features check --hide-inclusion-graph licenses bans --config ${{ github.workspace }}/deny.toml
     # Have an explicit step to build tests first to separate time spent on build vs execution.
     - name: Compile Tests
       working-directory: ${{ matrix.dir }}

--- a/.github/workflows/pre-merge-rust.yml
+++ b/.github/workflows/pre-merge-rust.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Install and Run cargo-deny
       working-directory: ${{ matrix.dir }}
       run: |
-        cargo-deny --version || cargo install cargo-deny@0.16.4
+        cargo-deny --version || cargo install cargo-deny@0.19.0
         cargo-deny -L error --no-default-features check --hide-inclusion-graph licenses bans --config ${{ github.workspace }}/deny.toml
     # Have an explicit step to build tests first to separate time spent on build vs execution.
     - name: Compile Tests

--- a/deny.toml
+++ b/deny.toml
@@ -35,6 +35,7 @@ allow = [
     "Zlib",
     "NCSA",
     "LGPL-3.0",
+    "LGPL-3.0-only",
     "CC0-1.0",
     "Unicode-DFS-2016"
 ]


### PR DESCRIPTION
And silence cargo-deny warnings about multiple versions of a crate, often nothing we can do about that.

Strangely I only got this warning locally, not in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions workflow configuration for Rust dependency checks
  * Added LGPL-3.0-only to the list of permitted licenses

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->