### PR TITLE
fix: correct SGLang metrics prefix from sglang_ to sglang:

### DIFF
--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -163,7 +163,6 @@ def setup_prometheus_registry(
         endpoint=generate_endpoint,
         registry=registry,
         metric_prefix_filters=["sglang:"],
-        add_prefix="sglang_",
     )
     return registry
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -634,8 +634,8 @@ class MetricsPayload(BasePayload):
             metrics_to_check.append(
                 MetricCheck(
                     # Check: Minimum count of unique sglang:* metrics
-                    name="sglang_*",
-                    pattern=lambda name: r"^sglang_\w+",
+                    name="sglang:*",
+                    pattern=lambda name: r"^sglang:\w+",
                     validator=lambda value: len(set(value))
                     >= 20,  # 80% of typical ~25 sglang metrics (excluding _bucket) as of 2025-10-22 (but will grow)
                     error_msg=lambda name, value: f"Expected at least 20 unique sglang:* metrics, but found only {len(set(value))}",


### PR DESCRIPTION
#### Overview:

SGLang metrics natively use the `sglang:` prefix (with colon), not `sglang_` (with underscore).

#### Details:

- Removed `add_prefix="sglang_"` parameter from `setup_prometheus_registry()` in `publisher.py` to preserve native `sglang:` prefix
- Updated metrics validation pattern in `payloads.py` from `sglang_*` to `sglang:*` to match actual format
- Verified fix with end-to-end aggregated deployment test showing correct `sglang:` metrics exposure
- Ensures consistency between code, documentation, and actual metrics output

#### Where should the reviewer start?

- `components/src/dynamo/sglang/publisher.py` - Review the removal of `add_prefix` parameter
- `tests/utils/payloads.py` - Review the updated validation pattern for SGLang metrics
- Documentation at `fern/pages/backends/sglang/prometheus.md` already correctly states metrics use `sglang:` prefix

#### Related Issues:

DYN-1962

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified metrics prefix handling in registry configuration.

* **Tests**
  * Updated metrics validation pattern for backend verification to use colon-delimited naming format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->