### PR TITLE
fix: correct SGLang metrics prefix from sglang_ to sglang

### DIFF
--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -163,7 +163,6 @@ def setup_prometheus_registry(
         endpoint=generate_endpoint,
         registry=registry,
         metric_prefix_filters=["sglang:"],
-        add_prefix="sglang_",
     )
     return registry
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -634,8 +634,8 @@ class MetricsPayload(BasePayload):
             metrics_to_check.append(
                 MetricCheck(
                     # Check: Minimum count of unique sglang:* metrics
-                    name="sglang_*",
-                    pattern=lambda name: r"^sglang_\w+",
+                    name="sglang:*",
+                    pattern=lambda name: r"^sglang:\w+",
                     validator=lambda value: len(set(value))
                     >= 20,  # 80% of typical ~25 sglang metrics (excluding _bucket) as of 2025-10-22 (but will grow)
                     error_msg=lambda name, value: f"Expected at least 20 unique sglang:* metrics, but found only {len(set(value))}",


### PR DESCRIPTION
fix: correct SGLang metrics prefix from sglang_ to sglang