### PR TITLE
fix: Use fixed vLLM DSR1 checkpoint path

### DIFF
--- a/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
+++ b/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
@@ -14,6 +14,9 @@ spec:
     Frontend:
       componentType: frontend
       replicas: 1
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /model-cache
       extraPodSpec:
         mainContainer:
           startupProbe:

--- a/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
+++ b/recipes/deepseek-r1/vllm/disagg/deploy_hopper_16gpu.yaml
@@ -7,9 +7,6 @@ metadata:
   name: vllm-dsr1
 spec:
   backendFramework: vllm
-  envs:
-    - name: HF_HOME
-      value: /model-cache
   pvcs:
     - name: model-cache
       create: false
@@ -73,7 +70,7 @@ spec:
           args:
             - |
               exec python3 -m dynamo.vllm \
-                --model deepseek-ai/DeepSeek-R1 \
+                --model /model-cache/deepseek-r1 \
                 --served-model-name deepseek-ai/DeepSeek-R1 \
                 --all2all-backend deepep_low_latency \
                 --data-parallel-hybrid-lb \
@@ -132,7 +129,7 @@ spec:
           args:
             - |
               exec python3 -m dynamo.vllm \
-                --model deepseek-ai/DeepSeek-R1 \
+                --model /model-cache/deepseek-r1 \
                 --is-prefill-worker \
                 --served-model-name deepseek-ai/DeepSeek-R1 \
                 --all2all-backend deepep_high_throughput \


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Use fixed checkpoint path matching https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-r1/model-cache/model-download.yaml#L30 

#### Details:

<!-- Describe the changes made in this PR. -->

Current reliance on HF hub path was raising errors because we download to a specific path different from HF hub defaults.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vLLM deployment configuration to use local model caching instead of registry paths for improved deployment reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->