### PR TITLE
docs: remove incorrect HighConfidence dLLM algorithm reference

### DIFF
--- a/docs/backends/sglang/diffusion-lm.md
+++ b/docs/backends/sglang/diffusion-lm.md
@@ -44,10 +44,7 @@ python -m dynamo.sglang \
 
 ## Diffusion Algorithms
 
-The diffusion worker supports different algorithms for the iterative refinement process:
-
-- **LowConfidence** (default): Refines tokens with low confidence scores
-- **HighConfidence**: Alternative algorithm focusing on high-confidence refinement
+The diffusion worker uses the **LowConfidence** algorithm for the iterative refinement process. This algorithm refines tokens with low confidence scores, progressively replacing masked tokens with the model's predictions until confidence thresholds are met.
 
 For more details on diffusion algorithms and configuration options, refer to the [SGLang Diffusion Language Models documentation](https://github.com/sgl-project/sglang/blob/main/docs/supported_models/diffusion_language_models.md).
 


### PR DESCRIPTION
## Summary
- Removes incorrect documentation claiming `HighConfidence` is a supported dLLM algorithm
- SGLang only implements `LowConfidence` - there is no `HighConfidence` implementation

## Root Cause
The documentation at `docs/backends/sglang/diffusion-lm.md` incorrectly stated that both `LowConfidence` and `HighConfidence` algorithms were supported. Investigation of SGLang's codebase shows only `LowConfidence` exists in `/python/sglang/srt/dllm/algorithm/`.

## Test plan
- [x] Verified SGLang only has `low_confidence.py` in the algorithm directory
- [x] Confirmed SGLang's own documentation only references `LowConfidence`

Fixes [DYN-1965](https://linear.app/nvidia/issue/DYN-1965)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified diffusion worker documentation to specify the LowConfidence algorithm used for iterative token refinement through progressive replacement until confidence thresholds are reached.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->