### PR TITLE
fix: revert helm template change

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
         {{- end }}
         {{- if .Values.etcdAddr }}
           - --etcdAddr={{ .Values.etcdAddr }}
-        {{- else if and .Values.etcd .Values.etcd.enabled }}
+        {{- else }}
           - --etcdAddr={{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.cluster.local:2379
         {{- end }}
         {{- if and .Values.dynamo.istio.enabled .Values.dynamo.istio.gateway }}


### PR DESCRIPTION
#### Overview:

Fixes --etcdAddr not being passed to the operator due to a broken helm template condition.

Problem
PR  #5592 changed the template to check .Values.etcd.enabled, but this value doesn't exist in the operator subchart's scope. This caused ETCD_ENDPOINTS to not be injected into pods, resulting in CrashLoopBackOff with localhost:2379 connection errors.

closes https://linear.app/nvidia/issue/DYN-1969/dynamorelease090k8sdisagg-exception-unable-to-create-lease-check-etcd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified default etcd address configuration in deployment settings. The default etcd address will now be applied automatically when no explicit address is provided, regardless of additional configuration flags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->