### PR TITLE
chore: Bump NONE_BASE_IMAGE_TAG to 12.9

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -128,7 +128,7 @@ VLLM_RUNTIME_IMAGE_TAG="12.9.1-runtime-ubuntu24.04"
 VLLM_RUNTIME_IMAGE_TAG_CU13="13.0.2-runtime-ubuntu24.04"
 
 NONE_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
-NONE_BASE_IMAGE_TAG="25.01-cuda12.8-devel-ubuntu24.04"
+NONE_BASE_IMAGE_TAG="25.06-cuda12.9-devel-ubuntu24.04"
 
 
 SGLANG_BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image to CUDA 12.9 (previously 12.8) with Ubuntu 24.04 support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->