### PR TITLE
fix: gpu memory service cli not found

### DIFF
--- a/lib/gpu_memory_service/setup.py
+++ b/lib/gpu_memory_service/setup.py
@@ -65,6 +65,7 @@ setup(
     # Package directory mapping: the current directory IS the gpu_memory_service package
     packages=[
         "gpu_memory_service",
+        "gpu_memory_service.cli",
         "gpu_memory_service.common",
         "gpu_memory_service.common.protocol",
         "gpu_memory_service.server",
@@ -75,6 +76,7 @@ setup(
     ],
     package_dir={
         "gpu_memory_service": ".",
+        "gpu_memory_service.cli": "cli",
         "gpu_memory_service.common": "common",
         "gpu_memory_service.common.protocol": "common/protocol",
         "gpu_memory_service.server": "server",


### PR DESCRIPTION
[DYN-1977](https://linear.app/nvidia/issue/DYN-1977/dynamorelease090gpu-memory-serviceno-module-named-gpu-memory)

Added gpu_memory_service.cli to setup.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line interface for GPU memory service operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->