### PR TITLE
docs: revert NIXL backend configuration from kv-cache-transfer.md

### DIFF
--- a/docs/backends/trtllm/kv-cache-transfer.md
+++ b/docs/backends/trtllm/kv-cache-transfer.md
@@ -30,39 +30,7 @@ By default, TensorRT-LLM uses **NIXL** (NVIDIA Inference Xfer Library) with UCX 
 
 ### Specify Backends for NIXL
 
-NIXL supports multiple communication backends that can be configured via environment variables. By default, UCX is used if no backends are explicitly specified.
-
-**Environment Variable Format:**
-```bash
-DYN_KVBM_NIXL_BACKEND_<BACKEND>=<value>
-```
-
-**Supported Backends:**
-- `UCX` - Unified Communication X (default)
-- `GDS` - GPU Direct Storage
-
-**Examples:**
-```bash
-# Enable UCX backend (default behavior)
-export DYN_KVBM_NIXL_BACKEND_UCX=true
-
-# Enable GDS backend
-export DYN_KVBM_NIXL_BACKEND_GDS=true
-
-# Enable multiple backends
-export DYN_KVBM_NIXL_BACKEND_UCX=true
-export DYN_KVBM_NIXL_BACKEND_GDS=true
-
-# Explicitly disable a backend
-export DYN_KVBM_NIXL_BACKEND_GDS=false
-```
-
-**Valid Values:**
-- `true`, `1`, `on`, `yes` - Enable the backend
-- `false`, `0`, `off`, `no` - Disable the backend
-
-> [!Note]
-> If no `DYN_KVBM_NIXL_BACKEND_*` environment variables are set, UCX is used as the default backend.
+TODO: Add instructions for how to specify different backends for NIXL.
 
 ## Alternative Method: UCX
 


### PR DESCRIPTION
## Summary

This PR reverts the NIXL backend configuration documentation that was added in #5564.

## Reason

The instructions for specifying different backends for NIXL need more clarity and testing before being documented. The environment variable format and supported backends require further validation.

Reverting to the TODO placeholder until proper documentation with verified examples can be written.

## Changes

- Reverted `docs/backends/trtllm/kv-cache-transfer.md` to use the TODO placeholder
- Removed 33 lines of unverified NIXL backend configuration docs

## References

Partial revert of https://github.com/ai-dynamo/dynamo/commit/912a4d4b7ef39eda11b93c11f74b32e8eaf1906a

---

**Note:** This is a documentation fix (<100 lines), submitted directly per [CONTRIBUTING.md](https://github.com/ai-dynamo/dynamo/blob/main/CONTRIBUTING.md#when-is-a-github-issue-required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated KV cache transfer configuration guidance to include UCX as an alternative method.
  * Changed configuration approach to use explicit YAML backend specification instead of environment variables.
  * Added clarification on the interaction between environment variable and YAML configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->