### PR TITLE
fix: prevent duplicate Prometheus metrics from Python expfmt callbacks

### DIFF
--- a/lib/bindings/python/rust/prometheus_metrics.rs
+++ b/lib/bindings/python/rust/prometheus_metrics.rs
@@ -64,19 +64,12 @@ impl RuntimeMetrics {
             })
         });
 
-        // Register the callback at this hierarchy level
+        // Register the callback at this hierarchy level only.
+        // Do NOT register on parent hierarchies - combined scrapes automatically
+        // traverse child registries and include their callbacks.
         self.hierarchy
             .get_metrics_registry()
             .add_expfmt_callback(callback_arc.clone());
-
-        // Also register at all parent hierarchy levels so the callback is accessible
-        // when prometheus_expfmt() is called on any parent (e.g., DRT)
-        let parents = self.hierarchy.parent_hierarchies();
-        for parent in parents.iter() {
-            parent
-                .get_metrics_registry()
-                .add_expfmt_callback(callback_arc.clone());
-        }
 
         Ok(())
     }


### PR DESCRIPTION
#### Overview:

Fixed duplicate Prometheus metrics in `/metrics` output caused by Python expfmt callbacks being registered on multiple hierarchy levels. vLLM metrics were appearing 4 times instead of once.

#### Details:

- **Fix**: Register callbacks only on the current hierarchy level. The runtime's combined scrape automatically traverses child registries and includes their callbacks, so parent registration is redundant and causes duplicates.

- **Validation**: Added test `test_expfmt_callback_only_registered_on_endpoint_is_included_once` that registers a callback on an endpoint and verifies it appears exactly once when scraping from root. Test fails with the bug (4 occurrences) and passes with the fix (1 occurrence).

#### Where should the reviewer start?

- `lib/bindings/python/rust/prometheus_metrics.rs` (lines 67-74): The fix - removed parent hierarchy registration loop
- `lib/runtime/src/metrics.rs` (lines 1254-1283): Test validating the fix

#### Related Issues:

DIS-1339, https://github.com/ai-dynamo/dynamo/pull/5678

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus metrics registration to prevent duplicate callbacks when scraping from hierarchical registries. Metrics are now registered only on the relevant hierarchy level, eliminating unnecessary propagation while maintaining accurate combined scrape results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->