### PR TITLE
feat: add guided decoding backend config and choice support for TRT-LLM

### DIFF
--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -341,6 +341,17 @@ class DynamoTrtllmArgGroup(ArgGroup):
             arg_type=int,
             help="FSDP size for DiT.",
         )
+        # --- Guided Decoding ---
+        add_argument(
+            g,
+            flag_name="--guided-decoding-backend",
+            env_var="DYN_TRTLLM_GUIDED_DECODING_BACKEND",
+            default=None,
+            choices=["xgrammar", "llguidance"],
+            help="Backend to use for guided decoding (structured output). "
+            "Options: xgrammar, llguidance.",
+        )
+
         add_negatable_bool_argument(
             diffusion_group,
             flag_name="--enable-async-cpu-offload",
@@ -371,6 +382,7 @@ class DynamoTrtllmConfig(ConfigBase):
     override_engine_args: str
     publish_events_and_metrics: bool
     disable_request_abort: bool
+    guided_decoding_backend: Optional[str] = None
 
     disaggregation_mode: DisaggregationMode
     modality: Modality

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -17,6 +17,7 @@ import asyncio
 import dataclasses
 import logging
 import os
+import re
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass
 from typing import Any, AsyncGenerator, Optional, Union
@@ -876,9 +877,17 @@ class HandlerBase(BaseGenerativeHandler):
         # doesn't know about (e.g. Rust's "backend"/"choice" vs TRT-LLM's fields).
         guided_decoding = overrides.pop("guided_decoding", None)
         if guided_decoding is not None and isinstance(guided_decoding, dict):
+            # TRT-LLM's GuidedDecodingParams doesn't have a "choice" field.
+            # Convert choice list to a regex pattern: (choice1|choice2|...)
+            # This matches the approach used by vLLM's outlines backend.
+            regex = guided_decoding.get("regex")
+            choice = guided_decoding.get("choice")
+            if choice and not regex:
+                regex = "(" + "|".join(re.escape(c) for c in choice) + ")"
+
             overrides["guided_decoding"] = GuidedDecodingParams(
                 json=guided_decoding.get("json"),
-                regex=guided_decoding.get("regex"),
+                regex=regex,
                 grammar=guided_decoding.get("grammar"),
                 json_object=guided_decoding.get("json_object", False),
                 structural_tag=guided_decoding.get("structural_tag"),

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -188,6 +188,14 @@ async def init_llm_worker(
         "kv_connector_config": kv_connector_config,
     }
 
+    # Add guided decoding backend if specified
+    if config.guided_decoding_backend is not None:
+        arg_map["guided_decoding_backend"] = config.guided_decoding_backend
+        logging.info(
+            "Guided decoding enabled with backend: %s",
+            config.guided_decoding_backend,
+        )
+
     if config.extra_engine_args != "":
         # TODO: Support extra engine args from json file as well.
         arg_map = update_llm_args_with_extra_options(arg_map, config.extra_engine_args)


### PR DESCRIPTION
## Summary

- Add `--guided-decoding-backend` CLI arg (`xgrammar` / `llguidance`) to configure guided decoding in the TRT-LLM engine at init time
- Convert `guided_decoding` `choice` lists to regex patterns since TRT-LLM's `GuidedDecodingParams` doesn't have a `choice` field

## Details

### Why `--guided-decoding-backend` is needed

TRT-LLM's `LLM(guided_decoding_backend=...)` must be set at engine init for guided decoding to work. Without it, `GuidedDecodingParams` in per-request `SamplingParams` are **silently ignored** — the model generates unconstrained text even though a JSON schema/regex/grammar was requested.

After #6127 merged the dict→`GuidedDecodingParams` transport fix, the params are correctly passed through, but they have no effect unless the engine has a `GuidedDecoder` initialized with a backend.

### What changed

| File | Change |
|------|--------|
| `backend_args.py` | `--guided-decoding-backend` CLI arg + `DYN_TRTLLM_GUIDED_DECODING_BACKEND` env var + config field |
| `workers/llm_worker.py` | Inject `guided_decoding_backend` into engine `arg_map` when configured |
| `handler_base.py` | Convert `choice` lists → regex `(c1\|c2\|...)` with `re.escape()`, matching vLLM's outlines backend |
| `test_trtllm_handler_base.py` | 4 unit tests for choice conversion |

### Usage

```bash
# Start server with guided decoding enabled
python -m dynamo.trtllm.main --model <path> --guided-decoding-backend xgrammar

# Or via environment variable
DYN_TRTLLM_GUIDED_DECODING_BACKEND=xgrammar python -m dynamo.trtllm.main --model <path>
```

## Test plan

- [x] `test_choice_converted_to_regex` — `["yes", "no", "maybe"]` → `(yes|no|maybe)`
- [x] `test_choice_with_special_chars_escaped` — special chars like `()[]` are escaped
- [x] `test_choice_not_used_when_regex_present` — regex takes priority over choice
- [x] `test_empty_choice_ignored` — empty list produces no regex
- [x] Existing `test_guided_decoding_dict_is_converted` still passes
- [x] All modified files pass syntax validation

## Where should the reviewer start

- `backend_args.py:344-354` — CLI arg definition
- `workers/llm_worker.py:191-197` — engine init injection
- `handler_base.py:880-886` — choice→regex conversion