### PR TITLE
fix(recipes): change componentType from "main" to "worker" for TRT-LL…

### DIFF
--- a/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
@@ -48,7 +48,7 @@ spec:
           image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
       replicas: 1
     TrtllmWorker:
-      componentType: main
+      componentType: worker
       envFromSecret: hf-token-secret
       volumeMounts:
         - name: model-cache

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml
@@ -57,7 +57,7 @@ spec:
             - /bin/sh
             - -c
     TrtllmWorker:
-      componentType: main
+      componentType: worker
       envFromSecret: hf-token-secret
       sharedMemory:
         size: 256Gi

--- a/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml
+++ b/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml
@@ -64,7 +64,7 @@ spec:
           image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
       replicas: 1
     TrtllmWorker:
-      componentType: main
+      componentType: worker
       envFromSecret: hf-token-secret
       volumeMounts:
         - name: model-cache


### PR DESCRIPTION
### Summary

Fix TRT-LLM aggregated mode recipes that use invalid `componentType: main` value, causing worker discovery failures.

### Problem

TRT-LLM aggregated mode deployments fail because the frontend cannot discover workers. The worker initializes successfully and registers its endpoints, but the frontend's `KubeDiscoveryClient` never receives any discovery events.

**Root Cause**: The recipes specify `componentType: main`, but the Dynamo operator's `isWorkerComponent()` function only recognizes:
- `worker`
- `prefill`
- `decode`

When an unrecognized `componentType` is used, the operator does not create the `DynamoWorkerMetadata` Custom Resource, which the frontend watches for worker discovery.

**Reference**: `deploy/cloud/operator/internal/dynamo/graph.go`

```go
func isWorkerComponent(deployType consts.ComponentType) bool {
    return deployType == consts.ComponentTypeWorker ||
           deployType == consts.ComponentTypePrefill ||
           deployType == consts.ComponentTypeDecode
}
```

### Solution

Change `componentType: main` to `componentType: worker` in all affected TRT-LLM aggregated recipes.

### Files Changed

| File | Change |
|------|--------|
| `recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml` | `componentType: main` → `componentType: worker` |
| `recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml` | `componentType: main` → `componentType: worker` |
| `recipes/gpt-oss-120b/trtllm/agg/deploy.yaml` | `componentType: main` → `componentType: worker` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration across multiple recipe versions to reflect changes in worker component type designation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->