### PR TITLE
fix: specifiy triton worker dynamo base [DYN-1984]

### DIFF
--- a/examples/backends/tritonserver/README.md
+++ b/examples/backends/tritonserver/README.md
@@ -39,7 +39,7 @@ From the Dynamo repository root:
 
 ```bash
 # Build the base Dynamo image
-./container/build.sh
+./container/build.sh --framework NONE
 
 # Build the Triton worker image
 cd examples/backends/tritonserver


### PR DESCRIPTION
#### Overview:

Specify that you must use `--framework NONE` to build the triton worker container, in order to match CUDA versions. 

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Resolves DYN-1984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions for Triton Server container images. The build command now requires an additional framework configuration parameter to be specified when executing the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->