### PR TITLE
chore: Fix tests logging setup

### DIFF
--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -1890,7 +1890,6 @@ mod test_integration_publisher {
     use crate::kv_router::protocols::ActiveLoad;
     use dynamo_runtime::distributed_test_utils::create_test_drt_async;
     use dynamo_runtime::transports::event_plane::EventSubscriber;
-    use futures::StreamExt;
 
     #[tokio::test]
     #[ignore] // Mark as ignored as requested, because CI's integrations still don't have NATS

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -673,10 +673,7 @@ mod tests {
     #[tokio::test]
     async fn test_graceful_shutdown_waits_for_inflight_tcp_requests() {
         // Initialize tracing for test debugging
-        let _ = tracing_subscriber::fmt()
-            .with_test_writer()
-            .with_max_level(tracing::Level::DEBUG)
-            .try_init();
+        crate::logging::init();
 
         let cancellation_token = CancellationToken::new();
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
@@ -877,10 +874,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_worker_pool_bounds_concurrency() {
-        let _ = tracing_subscriber::fmt()
-            .with_test_writer()
-            .with_max_level(tracing::Level::DEBUG)
-            .try_init();
+        crate::logging::init();
 
         // Use a small pool size for testing
         let pool_size = 3;


### PR DESCRIPTION
Fixes problems:
```
$ cargo test --locked --all-targets
...
...
---- logging::tests::test_json_log_capture stdout ----

thread 'logging::tests::test_json_log_capture' panicked at /home/dynamo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-subscriber-0.3.22/src/util.rs:94:14:
failed to set global default subscriber: SetGlobalDefaultError("a global default trace dispatcher has already been set")

---- storage::kv::tests::test_broadcast_stream stdout ----

thread 'storage::kv::tests::test_broadcast_stream' panicked at lib/runtime/src/logging.rs:872:10:
Once instance has previously been poisoned

---- storage::kv::tests::test_memory_storage stdout ----

thread 'storage::kv::tests::test_memory_storage' panicked at lib/runtime/src/logging.rs:872:10:
Once instance has previously been poisoned
```