### PR TITLE
feat: expose Python Prometheus metric via LLMComponentMetrics

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -148,9 +148,8 @@ async def init(runtime: DistributedRuntime, config: Config):
     )
 
     # Record model load time immediately after publisher setup (which creates the gauges)
-    if publisher.component_gauges:
-        publisher.component_gauges.set_model_load_time(load_time)
-        logging.debug(f"SGLang model load time: {load_time:.2f}s")
+    publisher.component_gauges.set_model_load_time(load_time)
+    logging.debug(f"SGLang model load time: {load_time:.2f}s")
 
     # Register Prometheus metrics callback if enabled
     if engine.server_args.enable_metrics:

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -23,11 +23,7 @@ from dynamo.sglang.health_check import (
     SglangHealthCheckPayload,
     SglangPrefillHealthCheckPayload,
 )
-from dynamo.sglang.publisher import (
-    DynamoSglangPublisher,
-    setup_prometheus_registry,
-    setup_sgl_metrics,
-)
+from dynamo.sglang.publisher import DynamoSglangPublisher, setup_sgl_metrics
 from dynamo.sglang.register import (
     register_image_diffusion_model,
     register_llm_with_readiness_gate,
@@ -151,10 +147,6 @@ async def init(runtime: DistributedRuntime, config: Config):
     publisher.component_gauges.set_model_load_time(load_time)
     logging.debug(f"SGLang model load time: {load_time:.2f}s")
 
-    # Register Prometheus metrics callback if enabled
-    if engine.server_args.enable_metrics:
-        setup_prometheus_registry(engine, generate_endpoint)
-
     # Handle non-leader nodes (multi-node parallelism)
     # Non-leader nodes run schedulers and publish KV events, but don't serve requests
     if server_args.node_rank >= 1:
@@ -237,10 +229,6 @@ async def init_prefill(runtime: DistributedRuntime, config: Config):
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
         engine, config, component, generate_endpoint
     )
-
-    # Register Prometheus metrics callback if enabled
-    if engine.server_args.enable_metrics:
-        setup_prometheus_registry(engine, generate_endpoint)
 
     # Handle non-leader nodes (multi-node parallelism)
     # Non-leader nodes run schedulers and publish KV events, but don't serve requests
@@ -325,10 +313,6 @@ async def init_diffusion(runtime: DistributedRuntime, config: Config):
         engine, config, component, generate_endpoint
     )
 
-    # Register Prometheus metrics callback if enabled
-    if engine.server_args.enable_metrics:
-        setup_prometheus_registry(engine, generate_endpoint)
-
     # Handle non-leader nodes (multi-node parallelism)
     # Non-leader nodes run schedulers and publish KV events, but don't serve requests
     if server_args.node_rank >= 1:
@@ -398,10 +382,6 @@ async def init_embedding(runtime: DistributedRuntime, config: Config):
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
         engine, config, component, generate_endpoint
     )
-
-    # Register Prometheus metrics callback if enabled
-    if engine.server_args.enable_metrics:
-        setup_prometheus_registry(engine, generate_endpoint)
 
     # Readiness gate: requests wait until model is registered
     ready_event = asyncio.Event()

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -32,10 +32,34 @@ from typing import Awaitable, Callable, Dict, Optional, Union
 
 import msgpack
 import zmq
+from prometheus_client import CollectorRegistry
 
+from dynamo.common.utils.prometheus import LLMBackendMetrics
 from dynamo.llm import KvEventPublisher, WorkerMetricsPublisher
 
 logging.basicConfig(level=logging.DEBUG)
+
+# Create a dedicated registry for dynamo_component metrics
+# This ensures these metrics are isolated and can be exposed via their own callback
+DYNAMO_COMPONENT_REGISTRY = CollectorRegistry()
+
+# Gauges will be lazily initialized when model name is available
+DYNAMO_COMPONENT_GAUGES: LLMBackendMetrics | None = None
+
+
+def _ensure_gauges_initialized(
+    model_name: str = "",
+    component_name: str = "",
+):
+    """Lazy initialization of gauges."""
+    global DYNAMO_COMPONENT_GAUGES
+    if DYNAMO_COMPONENT_GAUGES is None:
+        DYNAMO_COMPONENT_GAUGES = LLMBackendMetrics(
+            registry=DYNAMO_COMPONENT_REGISTRY,
+            model_name=model_name,
+            component_name=component_name,
+        )  # pyright: ignore[reportConstantRedefinition]
+
 
 # Use non-blocking RPC calls; control overhead with backoff sleeps.
 _STATS_TIMEOUT_SEC = 0.01
@@ -391,7 +415,10 @@ class Publisher:
             return
 
         # Publish initial metrics with 0 active blocks
+        # TRT-LLM doesn't use data parallelism currently (dp_rank="0")
         self.metrics_publisher.publish(None, 0)
+        DYNAMO_COMPONENT_GAUGES.set_total_blocks("0", 0)
+        DYNAMO_COMPONENT_GAUGES.set_gpu_cache_usage("0", 0.0)
 
         # Prepare threads for publishing stats but don't start them yet.
         # TRTLLM needs to start generating tokens first before stats
@@ -451,11 +478,23 @@ class Publisher:
             logging.error("KV metrics publisher not initialized!")
             return False
 
+        _ensure_gauges_initialized()
+
         def handle_stat(stat):
             kv_active_blocks = stat["kvCacheStats"]["usedNumBlocks"]
+            kv_total_blocks = stat["kvCacheStats"]["maxNumBlocks"]
             logging.debug(f"Publishing stats: kv_active_blocks: {kv_active_blocks}")
-            # TRT-LLM doesn't use data parallelism currently (dp_rank=None)
+            # TRT-LLM doesn't use data parallelism currently (dp_rank=None for NATS, "0" for Prometheus)
             self.metrics_publisher.publish(None, kv_active_blocks)
+
+            # Publish Prometheus metrics
+            DYNAMO_COMPONENT_GAUGES.set_total_blocks("0", kv_total_blocks)
+
+            # Calculate and publish GPU cache usage percentage
+            gpu_cache_usage = (
+                kv_active_blocks / kv_total_blocks if kv_total_blocks > 0 else 0.0
+            )
+            DYNAMO_COMPONENT_GAUGES.set_gpu_cache_usage("0", gpu_cache_usage)
 
         await self._polling_loop(
             lambda: self.engine.llm.get_stats_async(timeout=_STATS_TIMEOUT_SEC),

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -50,8 +50,14 @@ DYNAMO_COMPONENT_GAUGES: LLMBackendMetrics | None = None
 def _ensure_gauges_initialized(
     model_name: str = "",
     component_name: str = "",
-):
-    """Lazy initialization of gauges."""
+) -> LLMBackendMetrics:
+    """Lazy initialization of gauges.
+
+    Returns the initialized LLMBackendMetrics instance. Callers in other modules
+    MUST use the returned value rather than the module-level DYNAMO_COMPONENT_GAUGES
+    binding, because Python's `from module import name` copies the reference at
+    import time and won't see later reassignments to the module global.
+    """
     global DYNAMO_COMPONENT_GAUGES
     if DYNAMO_COMPONENT_GAUGES is None:
         DYNAMO_COMPONENT_GAUGES = LLMBackendMetrics(
@@ -59,6 +65,7 @@ def _ensure_gauges_initialized(
             model_name=model_name,
             component_name=component_name,
         )  # pyright: ignore[reportConstantRedefinition]
+    return DYNAMO_COMPONENT_GAUGES
 
 
 # Use non-blocking RPC calls; control overhead with backoff sleeps.

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -18,23 +18,6 @@ from dynamo.runtime import Component
 # This ensures these metrics are isolated and can be exposed via their own callback
 DYNAMO_COMPONENT_REGISTRY = CollectorRegistry()
 
-# Gauges will be lazily initialized after PROMETHEUS_MULTIPROC_DIR is set
-DYNAMO_COMPONENT_GAUGES: LLMBackendMetrics | None = None
-
-
-def _ensure_gauges_initialized(
-    model_name: str = "",
-    component_name: str = "",
-):
-    """Lazy initialization of gauges after PROMETHEUS_MULTIPROC_DIR is set."""
-    global DYNAMO_COMPONENT_GAUGES
-    if DYNAMO_COMPONENT_GAUGES is None:
-        DYNAMO_COMPONENT_GAUGES = LLMBackendMetrics(
-            registry=DYNAMO_COMPONENT_REGISTRY,
-            model_name=model_name,
-            component_name=component_name,
-        )  # pyright: ignore[reportConstantRedefinition]
-
 
 class NullStatLogger(StatLoggerBase):
     def __init__(self):
@@ -61,11 +44,13 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
         self,
         component: Component,
         dp_rank: int,
+        component_gauges: LLMBackendMetrics,
         metrics_labels: Optional[List[Tuple[str, str]]] = None,
     ) -> None:
         self.inner = WorkerMetricsPublisher()
         self._component = component
         self.dp_rank = dp_rank
+        self.component_gauges = component_gauges
         self.num_gpu_block = 1
         # Schedule async endpoint creation
         self._endpoint_task = asyncio.create_task(self._create_endpoint())
@@ -95,21 +80,21 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
         self.inner.publish(self.dp_rank, active_decode_blocks)
 
         dp_rank_str = str(self.dp_rank)
-        DYNAMO_COMPONENT_GAUGES.set_total_blocks(dp_rank_str, self.num_gpu_block)
+        self.component_gauges.set_total_blocks(dp_rank_str, self.num_gpu_block)
 
         # Set GPU cache usage percentage directly from scheduler_stats
         # Note: vLLM's scheduler_stats.kv_cache_usage returns very small values
         # (e.g., 0.0000834 for ~0.08% usage), which Prometheus outputs in scientific
         # notation (8.34e-05). This is the correct value and will be properly parsed.
-        DYNAMO_COMPONENT_GAUGES.set_gpu_cache_usage(
+        self.component_gauges.set_gpu_cache_usage(
             dp_rank_str, scheduler_stats.kv_cache_usage
         )
 
     def init_publish(self):
         self.inner.publish(self.dp_rank, 0)
         dp_rank_str = str(self.dp_rank)
-        DYNAMO_COMPONENT_GAUGES.set_total_blocks(dp_rank_str, 0)
-        DYNAMO_COMPONENT_GAUGES.set_gpu_cache_usage(dp_rank_str, 0.0)
+        self.component_gauges.set_total_blocks(dp_rank_str, 0)
+        self.component_gauges.set_gpu_cache_usage(dp_rank_str, 0.0)
 
     def log_engine_initialized(self) -> None:
         pass
@@ -121,10 +106,12 @@ class StatLoggerFactory:
     def __init__(
         self,
         component: Component,
+        component_gauges: Optional[LLMBackendMetrics] = None,
         dp_rank: int = 0,
         metrics_labels: Optional[List[Tuple[str, str]]] = None,
     ) -> None:
         self.component = component
+        self.component_gauges = component_gauges
         self.created_logger: Optional[DynamoStatLoggerPublisher] = None
         self.dp_rank = dp_rank
         self.metrics_labels = metrics_labels or []
@@ -132,8 +119,16 @@ class StatLoggerFactory:
     def create_stat_logger(self, dp_rank: int) -> StatLoggerBase:
         if self.dp_rank != dp_rank:
             return NullStatLogger()
+        # component_gauges must be set by setup_vllm_engine() before vLLM
+        # calls create_stat_logger() during engine initialization.
+        assert (
+            self.component_gauges is not None
+        ), "component_gauges must be set before creating stat loggers"
         logger = DynamoStatLoggerPublisher(
-            self.component, dp_rank, metrics_labels=self.metrics_labels
+            self.component,
+            dp_rank,
+            component_gauges=self.component_gauges,
+            metrics_labels=self.metrics_labels,
         )
         self.created_logger = logger
 

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -140,6 +140,13 @@ class kvrouter:
     KV_CACHE_EVENTS_APPLIED = "kv_cache_events_applied"
 
 
+class kvstats:
+    # Total number of KV cache blocks available on the worker
+    TOTAL_BLOCKS = "total_blocks"
+    # GPU cache usage as a percentage (0.0-1.0)
+    GPU_CACHE_USAGE_PERCENT = "gpu_cache_usage_percent"
+
+
 class labels:
     """Automatically inserted Prometheus label names used across the metrics system"""
 
@@ -149,6 +156,19 @@ class labels:
     NAMESPACE = "dynamo_namespace"
     # Label for endpoint identification
     ENDPOINT = "dynamo_endpoint"
+    # Label for worker data-parallel rank.
+    # Note: this is not an auto-inserted label like `dynamo_namespace`/`dynamo_component`.
+    # It is used by worker/load-style metrics that need to disambiguate per-worker series.
+    DP_RANK = "dp_rank"
+    # Label for model name
+    MODEL = "model"
+    # Label for worker type (e.g., "aggregated", "prefill", "decode", "encoder", etc.)
+    WORKER_TYPE = "worker_type"
+
+
+class model_info:
+    # Model load time in seconds
+    LOAD_TIME_SECONDS = "model_load_time_seconds"
 
 
 class name_prefix:

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -47,11 +47,11 @@
 //! - ✅ `dynamo_component_errors_total` - Total error counter (not `total_errors`)
 //! - ✅ `dynamo_component_memory_usage_bytes` - Memory usage gauge
 //! - ✅ `dynamo_frontend_inflight_requests` - Current inflight requests gauge
-//! - ✅ `nats_client_connection_duration_ms` - Connection time in milliseconds
 //! - ✅ `dynamo_component_cpu_usage_percent` - CPU usage percentage
 //! - ✅ `dynamo_frontend_tokens_per_second` - Token generation rate
-//! - ✅ `nats_client_current_connections` - Current active connections gauge
-//! - ✅ `nats_client_in_messages` - Total messages received counter
+//! - ✅ `dynamo_messaging_client_connection_duration_ms` - Connection time in milliseconds
+//! - ✅ `dynamo_messaging_client_current_connections` - Current active connections gauge
+//! - ✅ `dynamo_messaging_client_in_messages_total` - Total messages received counter
 //!
 //! ## Key Differences: Prometheus Metric Names vs Prometheus Label Names
 //!
@@ -80,6 +80,18 @@ pub mod labels {
 
     /// Label for endpoint identification
     pub const ENDPOINT: &str = "dynamo_endpoint";
+
+    /// Label for worker data-parallel rank.
+    ///
+    /// Note: this is not an auto-inserted label like `dynamo_namespace`/`dynamo_component`.
+    /// It is used by worker/load-style metrics that need to disambiguate per-worker series.
+    pub const DP_RANK: &str = "dp_rank";
+
+    /// Label for model name
+    pub const MODEL: &str = "model";
+
+    /// Label for worker type (e.g., "aggregated", "prefill", "decode", "encoder", etc.)
+    pub const WORKER_TYPE: &str = "worker_type";
 }
 
 /// Frontend service metrics (LLM HTTP service)
@@ -329,6 +341,21 @@ pub mod kvbm {
 pub mod kvrouter {
     /// Number of KV cache events applied to the index (including status)
     pub const KV_CACHE_EVENTS_APPLIED: &str = "kv_cache_events_applied";
+}
+
+// KV cache statistics metrics
+pub mod kvstats {
+    /// Total number of KV cache blocks available on the worker
+    pub const TOTAL_BLOCKS: &str = "total_blocks";
+
+    /// GPU cache usage as a percentage (0.0-1.0)
+    pub const GPU_CACHE_USAGE_PERCENT: &str = "gpu_cache_usage_percent";
+}
+
+// Model information metrics
+pub mod model_info {
+    /// Model load time in seconds
+    pub const LOAD_TIME_SECONDS: &str = "model_load_time_seconds";
 }
 
 // Shared regex patterns for Prometheus sanitization


### PR DESCRIPTION
#### Overview:

Adds Prometheus metrics (`model_load_time_seconds`, `total_blocks`, `gpu_cache_usage_percent`) to vLLM, SGLang, and TRT-LLM backends via a new `DynamoComponentMetrics` factory class.

#### Details:

- Add `DynamoComponentMetrics` factory with `dynamo_component_` prefixed gauges
- Track model load time in all backends (vLLM, SGLang, TRT-LLM)
- Publish KV cache stats (total blocks, GPU cache usage) via each backend's publisher
- Add shared metric name constants in Python and Rust
- Use dedicated `DYNAMO_COMPONENT_REGISTRY` per backend to isolate metrics

#### Where should the reviewer start?

`components/src/dynamo/common/utils/prometheus.py`

#### Related Issues:

Closes DIS-295
Closes DIS-341

/coderabbit profile chill

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Prometheus metrics for monitoring active decode blocks across distributed workers, enabling real-time visibility into KV cache utilization and per-worker system performance characteristics. This allows operators to better track resource usage patterns and identify potential performance bottlenecks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->