### PR TITLE
fix: Disable calls to abort() at TRT-LLM backend - temporary

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -198,11 +198,12 @@ class HandlerBase:
             )
 
             # Abort the generation
-            # Temporary: Disabled on DECODE workers to prevent engine hangs in
-            # disaggregated setups where abort() may cause the engine to get stuck
-            if self.disaggregation_mode != DisaggregationMode.DECODE:
-                generation_result.abort()
-                logging.debug(f"Aborted Request ID: {context.id()}")
+            # Temporary:
+            #   Disable calling abort() on the engine, which may get stuck if a
+            #   sufficiently large number of concurrent requests is cancelled.
+            # Note to restore:
+            #   call `generation_result.abort()`; and then
+            #   log `logging.debug(f"Aborted Request ID: {context.id()}")`
 
             # Clean up any remaining background task
             for task in pending:

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -90,7 +90,7 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 | **KV Block Manager** | ✅ | ✅ | ✅ | — | | | | | | |
 | **Multimodal** | ✅<sup>1</sup> | <sup>2</sup> | — | ✅ | — | | | | | |
 | **Request Migration** | 🚧<sup>3</sup> | ✅ | ✅ | ✅ | 🚧 | — | | | | |
-| **Request Cancellation** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | | | |
+| **Request Cancellation** | ✅<sup>5</sup> | ✅<sup>5</sup> | ✅<sup>5</sup> | ✅<sup>5</sup> | ✅<sup>5</sup> | ✅<sup>5</sup> | — | | | |
 | **LoRA** | | | | | | | | — | | |
 | **Tool Calling** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | | — | |
 | **Speculative Decoding** | ✅ | ✅ | — | ✅ | — | ✅ | ✅ | | ✅ | — |
@@ -100,6 +100,7 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 > 2. **Multimodal + KV-Aware Routing**: Not supported. The KV router currently tracks token-based blocks only. ([Source][kv-routing])
 > 3. **Request Migration**: Supported on **Decode/Aggregated** workers only. **Prefill** workers do not support migration. ([Source][trtllm-readme])
 > 4. **Speculative Decoding**: Llama 4 + Eagle support documented. ([Source][trtllm-eagle])
+> 5. **Request Cancellation**: Due to known issues, the TensorRT-LLM engine is temporarily not notified of request cancellations, meaning allocated resources for cancelled requests are not freed.
 
 ---
 

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -38,6 +38,7 @@ pytestmark = [
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.post_merge,  # post_merge to pinpoint failure commit
     pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
+    pytest.mark.xfail(reason="Cancellation is temporarily disabled", strict=True),
 ]
 
 
@@ -253,9 +254,6 @@ def test_request_cancellation_trtllm_aggregated(
                 logger.info(f"{description} detected successfully")
 
 
-@pytest.mark.xfail(
-    reason="Decode worker cancellation is temporarily disabled", strict=True
-)
 @pytest.mark.timeout(195)  # 3x average
 def test_request_cancellation_trtllm_decode_cancel(
     request, runtime_services_dynamic_ports, predownload_models
@@ -432,9 +430,6 @@ def test_request_cancellation_trtllm_prefill_cancel(
                 )
 
 
-@pytest.mark.xfail(
-    reason="Decode worker cancellation is temporarily disabled", strict=True
-)
 @pytest.mark.xfail(reason="Test fails only on CI", strict=False)
 @pytest.mark.timeout(195)  # 3x average
 def test_request_cancellation_trtllm_kv_transfer_cancel(


### PR DESCRIPTION
#### Overview:

Disable calls to abort() at TRT-LLM backend due to known issues.

#### Details:

Request cancellation is still functional at Dynamo level, and processed normally at TRT-LLM backend, but TRT-LLM engine will not be notified when request is no longer needed, so the TRT-LLM engine will not free up resources allocated to cancelled requests.

Cancellation Tests:
```
fault_tolerance/cancellation/test_trtllm.py::test_request_cancellation_trtllm_aggregated[nats] XFAIL (Cancellation is temporarily disabled)                                                                              [ 35%]
fault_tolerance/cancellation/test_trtllm.py::test_request_cancellation_trtllm_aggregated[tcp] XFAIL (Cancellation is temporarily disabled)                                                                               [ 42%]
fault_tolerance/cancellation/test_trtllm.py::test_request_cancellation_trtllm_decode_cancel[nats] XFAIL (Cancellation is temporarily disabled)                                                                           [ 50%]
fault_tolerance/cancellation/test_trtllm.py::test_request_cancellation_trtllm_decode_cancel[tcp] XFAIL (Cancellation is temporarily disabled)                                                                            [ 57%]
fault_tolerance/cancellation/test_trtllm.py::test_request_cancellation_trtllm_prefill_cancel[nats] XFAIL (Cancellation is temporarily disabled)                                                                          [ 64%]
fault_tolerance/cancellation/test_trtllm.py::test_request_cancellation_trtllm_prefill_cancel[tcp] XFAIL (Cancellation is temporarily disabled)                                                                           [ 71%]
fault_tolerance/cancellation/test_trtllm.py::test_request_cancellation_trtllm_kv_transfer_cancel[nats] XFAIL (Test fails only on CI)                                                                                     [ 78%]
fault_tolerance/cancellation/test_trtllm.py::test_request_cancellation_trtllm_kv_transfer_cancel[tcp] XFAIL (Test fails only on CI)                                                                                      [ 85%]
```

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified request cancellation handling behavior.
  * Updated test expectations for cancellation-related scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->