### PR TITLE
fix: Frontend Memory Profiling Repro

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Backend worker for memory growth repro.
+#
+# Usage:
+#   python3 backend.py                # Worker mode
+#   python3 backend.py --proxy-mode   # Proxy mode
+
+import asyncio
+import os
+import sys
+
+import uvloop
+
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "."))
+from memory_monitor import create_monitor, setup_background_monitor
+
+# Create monitor if profiling is enabled
+monitor = create_monitor("BACKEND")
+
+uvloop.install()
+
+
+class RequestHandler:
+    def __init__(self, proxy_client=None):
+        print(
+            f"Initialized backend request handler {'proxy' if proxy_client else 'worker'} with memory monitoring"
+        )
+        if monitor:
+            monitor.log_memory("Initial:")
+        self.proxy_client = proxy_client
+        self.request_count = 0
+
+    async def generate(self, request, context):
+        if monitor:
+            monitor.increment_request()
+
+        self.request_count += 1
+        if self.request_count % 1000 == 0:
+            print(f"Processed {self.request_count} requests")
+
+        max_tokens = request.get("max_tokens", 10)
+        if self.proxy_client:
+            stream = await self.proxy_client.random(request)
+            i = 0
+            async for chunk in stream:
+                i += 1
+                yield f"chunk{i}"
+        else:
+            for i in range(max_tokens):
+                await asyncio.sleep(1e-5)  # yield / switch context
+                yield f"chunk{i}"
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime, proxy_mode: bool = False):
+    name = "worker" if not proxy_mode else "proxy_worker"
+    component = runtime.namespace("openai/pipeline").component(name)
+    # await component.create_service()
+
+    endpoint = component.endpoint("generate")
+
+    # Setup background memory monitoring
+    monitor_task = setup_background_monitor(monitor)
+    # Create pipeline client if in proxy mode
+    if proxy_mode:
+        proxy_client = (
+            await runtime.namespace("openai/pipeline")
+            .component("worker")
+            .endpoint("generate")
+            .client()
+        )
+    else:
+        proxy_client = None
+
+    try:
+        await endpoint.serve_endpoint(RequestHandler(proxy_client).generate)
+    finally:
+        if monitor:
+            print("\nShutdown - Final memory state:")
+            monitor.log_memory("Final:")
+        if monitor_task:
+            monitor_task.cancel()
+        raise
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--proxy-mode", action="store_true", help="Run in proxy mode")
+    args = parser.parse_args()
+    asyncio.run(worker(proxy_mode=args.proxy_mode))

--- a/frontend.py
+++ b/frontend.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Frontend for memory growth repro using Python HttpService.
+#
+# Usage:
+#   python3 frontend.py
+
+import asyncio
+import os
+import sys
+import time
+import uuid
+
+import uvloop
+
+from dynamo.llm import HttpAsyncEngine, HttpError, HttpService
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+
+# Import shared memory monitoring
+sys.path.append(os.path.join(os.path.dirname(__file__), "."))
+from memory_monitor import create_monitor, setup_background_monitor
+
+# Create monitor if profiling is enabled
+monitor = create_monitor("FRONTEND")
+
+
+class MockEngine:
+    def __init__(self, model_name, pipeline_client):
+        self.model_name = model_name
+        self.pipeline_client = pipeline_client
+        if monitor:
+            print("Initialized frontend engine with memory monitoring")
+            monitor.log_memory("Initial:")
+
+    def generate(self, request):
+        if monitor:
+            monitor.increment_request()
+
+        id = f"chat-{uuid.uuid4()}"
+        created = int(time.time())
+        model = self.model_name
+        # print(f"{created} | Received request: {request}")
+
+        async def generator():
+            num_chunks = 10
+            i = 0
+            for _ in range(5):
+                try:
+                    stream = await self.pipeline_client.random(request)
+                    break
+                except Exception as e:
+                    print(f"Error contacting pipeline: {e}")
+                    await asyncio.sleep(0.1)
+            else:
+                print(f"Failed to contact pipeline after retries for request {id}")
+                raise HttpError(401, "Failed to contact pipeline after retries")
+
+            async for output in stream:
+                mock_content = f"chunk{i}"
+                finish_reason = "stop" if (i == num_chunks - 1) else None
+                chunk = {
+                    "id": id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": i,
+                            "delta": {"role": "assistant", "content": mock_content},
+                            "logprobs": None,
+                            "finish_reason": finish_reason,
+                        }
+                    ],
+                }
+                i += 1
+                yield chunk
+
+        return generator()
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime):
+    model: str = "mock_model"
+    served_model_name: str = "mock_model"
+
+    pipeline = (
+        await runtime.namespace("openai/pipeline")
+        .component("proxy_worker")
+        .endpoint("generate")
+        .client()
+    )
+
+    loop = asyncio.get_running_loop()
+    python_engine = MockEngine(model, pipeline)
+    engine = HttpAsyncEngine(python_engine.generate, loop)
+    # test the engine with a dummy request
+    async for _ in python_engine.generate(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 2,
+        }
+    ):
+        pass
+
+    host: str = "localhost"
+    port: int = 8000
+    service: HttpService = HttpService(port=port)
+    service.add_chat_completions_model(served_model_name, "mdcsum", engine)
+    service.enable_endpoint("chat", True)
+
+    print("Starting service")
+    shutdown_signal = service.run(runtime.child_token())
+
+    # Setup background memory monitoring
+    monitor_task = setup_background_monitor(monitor)
+
+    try:
+        print(f"Serving endpoint: {host}:{port}/v1/models")
+        print(f"Serving endpoint: {host}:{port}/v1/chat/completions")
+        print(f"Serving the following models: {service.list_chat_completions_models()}")
+        # Block until shutdown signal received
+        await shutdown_signal
+    except asyncio.CancelledError:
+        # Handle cancellation during shutdown gracefully
+        print("Service shutdown requested...")
+    except KeyboardInterrupt:
+        # Handle Ctrl+C gracefully
+        print("Keyboard interrupt received, shutting down...")
+    except Exception as e:
+        print(f"Unexpected error occurred: {e}")
+    finally:
+        if monitor:
+            print("\nShutdown - Final memory state:")
+            monitor.log_memory("Final:")
+        if monitor_task:
+            monitor_task.cancel()
+        print("Shutting down worker...")
+
+
+if __name__ == "__main__":
+    uvloop.install()
+    asyncio.run(worker())

--- a/heaptrack/analyze_heaptrack.sh
+++ b/heaptrack/analyze_heaptrack.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Analyze heaptrack output
+#
+# Usage:
+#   ./analyze_heaptrack.sh <heaptrack.gz> [output_dir]
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <heaptrack.gz> [output_dir]"
+    exit 1
+fi
+
+INPUT="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Handle raw heaptrack files (from LD_PRELOAD)
+if [[ "$INPUT" != *.gz ]]; then
+    echo "Converting raw heaptrack file..."
+    PID=$(basename "$INPUT" | grep -oE '[0-9]+$' || echo "unknown")
+    OUTPUT_GZ="$(dirname "$INPUT")/heaptrack.${PID}.gz"
+    /usr/lib/heaptrack/libexec/heaptrack_interpret < "$INPUT" | gzip > "$OUTPUT_GZ"
+    INPUT="$OUTPUT_GZ"
+    echo "Created: $OUTPUT_GZ"
+fi
+
+# Output directory
+if [[ $# -ge 2 ]]; then
+    if [[ "$2" == */* ]]; then
+        OUTPUT_DIR="$2"
+    else
+        OUTPUT_DIR="$SCRIPT_DIR/$2"
+    fi
+else
+    OUTPUT_DIR="$(dirname "$INPUT")"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+# Copy heaptrack.gz
+HEAPTRACK_GZ="$OUTPUT_DIR/heaptrack.gz"
+if [[ "$(realpath "$INPUT")" != "$(realpath "$HEAPTRACK_GZ" 2>/dev/null || echo '')" ]]; then
+    cp "$INPUT" "$HEAPTRACK_GZ"
+fi
+
+# Move rss.csv if exists at repo root
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+if [[ -f "$REPO_ROOT/rss.csv" ]]; then
+    mv "$REPO_ROOT/rss.csv" "$OUTPUT_DIR/rss.csv"
+    echo "Moved rss.csv to output dir"
+fi
+
+echo "Generating analysis..."
+
+# Summary
+heaptrack_print "$HEAPTRACK_GZ" > "$OUTPUT_DIR/summary.txt" 2>&1 || true
+
+# Massif format
+heaptrack_print --print-massif "$OUTPUT_DIR/massif.out" "$HEAPTRACK_GZ" 2>/dev/null || true
+
+# Flamegraph
+STACKS=$(mktemp)
+if heaptrack_print -F "$STACKS" "$HEAPTRACK_GZ" 2>/dev/null; then
+    if [[ -x "$HOME/FlameGraph/flamegraph.pl" ]]; then
+        "$HOME/FlameGraph/flamegraph.pl" < "$STACKS" > "$OUTPUT_DIR/flamegraph.svg" 2>/dev/null || true
+    fi
+fi
+rm -f "$STACKS"
+
+# HTML chart
+if [[ -f "$OUTPUT_DIR/massif.out" ]]; then
+    CMD=(python3 "$SCRIPT_DIR/massif_visualize.py" "$OUTPUT_DIR/massif.out" --html)
+    if [[ -f "$OUTPUT_DIR/rss.csv" ]]; then
+        CMD+=(--rss "$OUTPUT_DIR/rss.csv")
+    fi
+    "${CMD[@]}" > "$OUTPUT_DIR/memory_chart.html" 2>/dev/null || true
+fi
+
+echo ""
+echo "Done. Output: $OUTPUT_DIR"
+echo "  summary.txt"
+echo "  massif.out"
+echo "  flamegraph.svg"
+echo "  memory_chart.html"

--- a/heaptrack/collect_rss.py
+++ b/heaptrack/collect_rss.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Collect RSS for a process.
+
+Usage:
+  python3 collect_rss.py --pid <PID>
+  python3 collect_rss.py --pid <PID> --output rss.csv
+"""
+
+import argparse
+import csv
+import signal
+import time
+from pathlib import Path
+
+
+def get_rss(pid: int):
+    try:
+        with open(f"/proc/{pid}/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) * 1024  # KB to bytes
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pid", type=int, required=True)
+    parser.add_argument("--output", type=Path, default=Path("rss.csv"))
+    parser.add_argument("--interval", type=float, default=0.1)
+    args = parser.parse_args()
+
+    running = True
+
+    def stop(sig, frame):
+        nonlocal running
+        running = False
+
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGTERM, stop)
+
+    start = time.time()
+
+    with args.output.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["elapsed_s", "rss_bytes"])
+
+        while running:
+            rss = get_rss(args.pid)
+            if rss is None:
+                print(f"Process {args.pid} gone")
+                break
+
+            elapsed = time.time() - start
+            w.writerow([f"{elapsed:.3f}", rss])
+            f.flush()
+
+            time.sleep(args.interval)
+
+    print(f"Saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/heaptrack/massif_visualize.py
+++ b/heaptrack/massif_visualize.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+Visualize massif.out files from heaptrack_print --print-massif.
+
+Usage:
+  python3 massif_visualize.py <massif.out> --html > chart.html
+  python3 massif_visualize.py <massif.out> --html --rss rss.csv > chart.html
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass
+class Snapshot:
+    time: float
+    mem_heap_b: int
+
+
+@dataclass
+class RssSample:
+    elapsed_s: float
+    rss_bytes: int
+
+
+def parse_massif(path: Path) -> List[Snapshot]:
+    snapshots = []
+    current = {}
+
+    with path.open("r") as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith("snapshot="):
+                if current.get("time") is not None:
+                    snapshots.append(
+                        Snapshot(
+                            time=current.get("time", 0.0),
+                            mem_heap_b=current.get("mem_heap_B", 0),
+                        )
+                    )
+                current = {}
+            elif "=" in line and not line.startswith("#"):
+                key, val = line.split("=", 1)
+                val = val.strip()
+                if not val:
+                    continue
+                if key == "time":
+                    current[key] = float(val)
+                elif key == "mem_heap_B":
+                    current[key] = int(val)
+
+    if current.get("time") is not None:
+        snapshots.append(
+            Snapshot(
+                time=current.get("time", 0.0),
+                mem_heap_b=current.get("mem_heap_B", 0),
+            )
+        )
+
+    return snapshots
+
+
+def parse_rss_csv(path: Path) -> List[RssSample]:
+    samples = []
+    with path.open("r") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                samples.append(
+                    RssSample(
+                        elapsed_s=float(row["elapsed_s"]),
+                        rss_bytes=int(row["rss_bytes"]),
+                    )
+                )
+            except (KeyError, ValueError):
+                continue
+    return samples
+
+
+def format_bytes(b: int) -> str:
+    if b >= 1024 * 1024 * 1024:
+        return f"{b / 1024 / 1024 / 1024:.2f} GB"
+    elif b >= 1024 * 1024:
+        return f"{b / 1024 / 1024:.2f} MB"
+    elif b >= 1024:
+        return f"{b / 1024:.2f} KB"
+    return f"{b} B"
+
+
+def to_html(
+    snapshots: List[Snapshot],
+    rss_samples: Optional[List[RssSample]] = None,
+    title: str = "Memory Profile",
+) -> str:
+    if not snapshots:
+        return "<html><body>No data</body></html>"
+
+    # Downsample if needed
+    max_points = 500
+    if len(snapshots) > max_points:
+        step = len(snapshots) / max_points
+        snapshots = [snapshots[int(i * step)] for i in range(max_points)]
+
+    if rss_samples and len(rss_samples) > max_points:
+        step = len(rss_samples) / max_points
+        rss_samples = [rss_samples[int(i * step)] for i in range(max_points)]
+
+    # Stats
+    peak = max(snapshots, key=lambda s: s.mem_heap_b)
+    first = snapshots[0]
+    last = snapshots[-1]
+
+    heap_data = [{"x": s.time, "y": s.mem_heap_b / 1024 / 1024} for s in snapshots]
+    rss_data = []
+    rss_stats = ""
+    slider_html = ""
+
+    if rss_samples:
+        rss_data = [
+            {"x": r.elapsed_s, "y": r.rss_bytes / 1024 / 1024} for r in rss_samples
+        ]
+        peak_rss = max(rss_samples, key=lambda r: r.rss_bytes)
+        last_rss = rss_samples[-1]
+
+        rss_stats = f"""
+        <div class="stat">
+            <div class="label">Peak RSS</div>
+            <div class="value">{format_bytes(peak_rss.rss_bytes)}</div>
+        </div>
+        <div class="stat">
+            <div class="label">Final RSS</div>
+            <div class="value">{format_bytes(last_rss.rss_bytes)}</div>
+        </div>
+        """
+
+        slider_html = """
+        <div class="slider">
+            <label>RSS Time Offset: <span id="offsetVal">0.0s</span></label>
+            <input type="range" id="offset" min="-60" max="60" step="0.5" value="0">
+        </div>
+        """
+
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>{title}</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        body {{ font-family: system-ui, sans-serif; margin: 20px; background: #f5f5f5; }}
+        .stats {{ display: flex; gap: 15px; flex-wrap: wrap; margin-bottom: 15px; }}
+        .stat {{ background: #fff; padding: 12px 16px; border-radius: 6px; }}
+        .stat .label {{ font-size: 11px; color: #666; text-transform: uppercase; }}
+        .stat .value {{ font-size: 20px; font-weight: bold; }}
+        .chart {{ height: 400px; background: #fff; border-radius: 6px; padding: 15px; }}
+        .slider {{ background: #fff; padding: 15px; border-radius: 6px; margin-bottom: 15px; }}
+        .slider input {{ width: 300px; }}
+    </style>
+</head>
+<body>
+    <h2>{title}</h2>
+
+    <div class="stats">
+        <div class="stat">
+            <div class="label">Initial Heap</div>
+            <div class="value">{format_bytes(first.mem_heap_b)}</div>
+        </div>
+        <div class="stat">
+            <div class="label">Peak Heap</div>
+            <div class="value">{format_bytes(peak.mem_heap_b)}</div>
+        </div>
+        <div class="stat">
+            <div class="label">Final Heap</div>
+            <div class="value">{format_bytes(last.mem_heap_b)}</div>
+        </div>
+        {rss_stats}
+    </div>
+
+    {slider_html}
+
+    <div class="chart">
+        <canvas id="chart"></canvas>
+    </div>
+
+    <script>
+        const heapData = {json.dumps(heap_data)};
+        const rssData = {json.dumps(rss_data)};
+
+        function buildDatasets(offset) {{
+            const ds = [{{
+                label: 'Heap (MB)',
+                data: heapData,
+                borderColor: 'rgb(75, 192, 192)',
+                fill: false,
+                pointRadius: 0,
+            }}];
+            if (rssData.length) {{
+                ds.push({{
+                    label: 'RSS (MB)',
+                    data: rssData.map(p => ({{ x: p.x + offset, y: p.y }})),
+                    borderColor: 'rgb(255, 99, 132)',
+                    fill: false,
+                    pointRadius: 0,
+                }});
+            }}
+            return ds;
+        }}
+
+        const chart = new Chart(document.getElementById('chart'), {{
+            type: 'scatter',
+            data: {{ datasets: buildDatasets(0) }},
+            options: {{
+                responsive: true,
+                maintainAspectRatio: false,
+                animation: false,
+                scales: {{
+                    x: {{ title: {{ display: true, text: 'Time (s)' }} }},
+                    y: {{ title: {{ display: true, text: 'Memory (MB)' }}, beginAtZero: true }}
+                }}
+            }}
+        }});
+
+        const slider = document.getElementById('offset');
+        const valDisplay = document.getElementById('offsetVal');
+        if (slider) {{
+            slider.oninput = function() {{
+                const v = parseFloat(this.value);
+                valDisplay.textContent = v.toFixed(1) + 's';
+                chart.data.datasets = buildDatasets(v);
+                chart.update('none');
+            }};
+        }}
+    </script>
+</body>
+</html>"""
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("massif_file", type=Path)
+    parser.add_argument("--html", action="store_true")
+    parser.add_argument("--rss", type=Path)
+    args = parser.parse_args()
+
+    snapshots = parse_massif(args.massif_file)
+    if not snapshots:
+        print("No data", file=sys.stderr)
+        sys.exit(1)
+
+    rss_samples = None
+    if args.rss and args.rss.exists():
+        rss_samples = parse_rss_csv(args.rss)
+
+    if args.html:
+        title = args.massif_file.parent.name
+        print(to_html(snapshots, rss_samples, title=title))
+    else:
+        peak = max(snapshots, key=lambda s: s.mem_heap_b)
+        print(f"Snapshots: {len(snapshots)}")
+        print(f"Peak heap: {format_bytes(peak.mem_heap_b)} at t={peak.time:.1f}s")
+        print(f"Final heap: {format_bytes(snapshots[-1].mem_heap_b)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/heaptrack/massif_visualize.py
+++ b/heaptrack/massif_visualize.py
@@ -199,6 +199,7 @@ def to_html(
                 borderColor: 'rgb(75, 192, 192)',
                 fill: false,
                 pointRadius: 0,
+                showLine: true,
             }}];
             if (rssData.length) {{
                 ds.push({{
@@ -207,6 +208,7 @@ def to_html(
                     borderColor: 'rgb(255, 99, 132)',
                     fill: false,
                     pointRadius: 0,
+                    showLine: true,
                 }});
             }}
             return ds;

--- a/load_test.py
+++ b/load_test.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+"""
+Simple, memory-bounded load test for the repro harness.
+
+This is modeled after PR #5269's `pipeline_openai/load_test.py`, but with CLI flags:
+  --concurrency, --durations, --payload-size, --base-url, --wait-period
+
+Supports multiple "bumps" of traffic with idle periods between them:
+  --durations 60,60,60  # Three 60-second load bursts
+  --wait-period 30      # 30 seconds idle between each burst
+
+Each duration runs until all in-flight requests complete before starting the wait period.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import functools
+import json
+import time
+import traceback
+from collections import deque
+from typing import Deque, Optional
+
+import aiohttp
+
+
+@functools.lru_cache(maxsize=1)
+def _payload_text(payload_size: int) -> str:
+    return "Hello from request. " * payload_size
+
+
+def _powers_of_two_in_range(lo: int, hi: int) -> list[int]:
+    """
+    Return powers of 2 in [lo, hi] as an up-then-down cycle.
+
+    Example: _powers_of_two_in_range(3, 20) -> [4, 8, 16, 8, 4]
+    """
+    if lo > hi or lo < 1:
+        return []
+
+    # Find powers of two within bounds.
+    pows: list[int] = []
+    p = 1
+    while p <= hi:
+        if p >= lo:
+            pows.append(p)
+        p *= 2
+
+    if not pows:
+        return []
+
+    # Build up-then-down cycle (exclude endpoints on the way down to avoid duplicates).
+    if len(pows) == 1:
+        return pows
+    return pows + list(reversed(pows[1:-1]))
+
+
+class _DynamicConcurrencyLimiter:
+    """A small async limiter with a dynamically adjustable limit."""
+
+    def __init__(self, limit: int):
+        self._limit = max(1, int(limit))
+        self._in_flight = 0
+        self._cond = asyncio.Condition()
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    def set_limit(self, new_limit: int) -> None:
+        # Called from the event loop; keep it simple.
+        self._limit = max(1, int(new_limit))
+
+        # Wake waiters so they can re-check limit.
+        async def _notify() -> None:
+            async with self._cond:
+                self._cond.notify_all()
+
+        asyncio.create_task(_notify())
+
+    async def acquire(self) -> None:
+        async with self._cond:
+            while self._in_flight >= self._limit:
+                await self._cond.wait()
+            self._in_flight += 1
+
+    async def release(self) -> None:
+        async with self._cond:
+            self._in_flight -= 1
+            self._cond.notify_all()
+
+
+class LoadTest:
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+        self.session: Optional[aiohttp.ClientSession] = None
+
+        self.request_times: Deque[float] = deque(maxlen=10_000)
+        self.errors: Deque[str] = deque(maxlen=1_000)
+        self.total_requests = 0
+        self.total_errors = 0
+
+    async def start(self) -> None:
+        connector = aiohttp.TCPConnector(
+            limit=0,
+            limit_per_host=2000,
+            ttl_dns_cache=300,
+            use_dns_cache=True,
+            keepalive_timeout=30,
+            enable_cleanup_closed=True,
+            force_close=False,
+            ssl=False,
+        )
+
+        timeout = aiohttp.ClientTimeout(
+            total=120,
+            connect=10,
+            sock_read=30,
+        )
+
+        self.session = aiohttp.ClientSession(
+            connector=connector, timeout=timeout, headers={"Connection": "keep-alive"}
+        )
+
+    async def stop(self) -> None:
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def test_connection(self) -> bool:
+        assert self.session is not None
+        try:
+            async with self.session.get(
+                f"{self.base_url}/v1/models", timeout=aiohttp.ClientTimeout(total=5)
+            ) as response:
+                if response.status == 200:
+                    print(f"✓ Frontend is accessible at {self.base_url}")
+                    return True
+                print(f"✗ Frontend returned status {response.status}")
+                return False
+        except Exception as e:
+            print(f"✗ Cannot connect to frontend at {self.base_url}: {e}")
+            return False
+
+    async def send_request(self, request_id: int, payload_size: int) -> None:
+        assert self.session is not None
+        start_time = time.time()
+
+        payload = {
+            "model": "mock_model",
+            "messages": [
+                {"role": "user", "content": _payload_text(payload_size)},
+                {"role": "user", "content": f"request id {request_id}"},
+            ],
+            "max_tokens": 2,
+        }
+        body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode(
+            "utf-8"
+        )
+
+        # Guardrail: NATS request plane has a 16MB payload limit (documented).
+        # This check estimates the HTTP request size; the internal dyn RPC payload will be similar.
+        if len(body) > 15 * 1024 * 1024:
+            raise RuntimeError(
+                f"Payload JSON is {len(body)/1024/1024:.2f}MB. "
+                "This is likely to exceed NATS request-plane limits (~16MB). "
+                "Reduce --payload-size or switch request plane to TCP for larger payloads."
+            )
+
+        try:
+            async with self.session.post(
+                f"{self.base_url}/v1/chat/completions",
+                data=body,
+                headers={"Content-Type": "application/json"},
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as response:
+                if response.status == 200:
+                    # Consume streaming response without storing chunks.
+                    async for line in response.content:
+                        if line.strip():
+                            pass
+
+                    end_time = time.time()
+                    self.request_times.append(end_time - start_time)
+                    self.total_requests += 1
+
+                    if request_id % 1000 == 0:
+                        recent = list(self.request_times)[-100:] or [
+                            end_time - start_time
+                        ]
+                        print(
+                            f"Request {request_id} completed in {end_time - start_time:.3f}s "
+                            f"(avg last {len(recent)}: {sum(recent)/len(recent):.3f}s)"
+                        )
+                else:
+                    self.errors.append(
+                        f"Request {request_id}: HTTP {response.status} {await response.text()}"
+                    )
+                    self.total_errors += 1
+        except Exception as e:
+            self.errors.append(f"Request {request_id}: {str(e)}")
+            self.total_errors += 1
+            if self.total_errors % 100 == 0:
+                print(f"Total error count: {self.total_errors}")
+
+    async def run_for_duration(
+        self,
+        *,
+        duration_seconds: Optional[float],
+        concurrency: int,
+        payload_size: int,
+        burst_num: int,
+    ) -> int:
+        """
+        Run load test for a specified duration.
+        Returns the number of requests sent in this burst.
+        Waits for all in-flight requests to complete before returning.
+        """
+        if duration_seconds is None:
+            banner = "RUN-FOREVER"
+            duration_str = "∞"
+        else:
+            banner = f"BURST {burst_num}"
+            duration_str = f"{duration_seconds}s"
+
+        print(
+            f"\n{'='*60}\n"
+            f"{banner}: Starting {duration_str} load test "
+            f"(concurrency={concurrency}, payload_size={payload_size})\n"
+            f"{'='*60}"
+        )
+
+        sem = asyncio.Semaphore(concurrency)
+        started = time.time()
+        end_time = None if duration_seconds is None else started + duration_seconds
+        request_id_offset = self.total_requests + self.total_errors
+        burst_requests = 0
+        active_tasks: set[asyncio.Task[None]] = set()
+        last_report = started
+
+        async def bounded(req_id: int) -> None:
+            async with sem:
+                await self.send_request(req_id, payload_size)
+
+        def should_continue() -> bool:
+            return True if end_time is None else (time.time() < end_time)
+
+        try:
+            # Keep spawning requests until duration expires (or forever).
+            while should_continue():
+                # Clean up completed tasks
+                done_tasks = {t for t in active_tasks if t.done()}
+                active_tasks -= done_tasks
+
+                # Spawn new requests up to concurrency limit
+                while len(active_tasks) < concurrency and should_continue():
+                    req_id = request_id_offset + burst_requests
+                    task = asyncio.create_task(bounded(req_id))
+                    active_tasks.add(task)
+                    burst_requests += 1
+
+                now = time.time()
+                if now - last_report >= 10.0:
+                    elapsed = now - started
+                    rate = burst_requests / elapsed if elapsed > 0 else 0.0
+                    print(
+                        f"{banner}: {burst_requests} requests sent, "
+                        f"rate={rate:.1f} req/s, in-flight={len(active_tasks)}, "
+                        f"ok={self.total_requests}, err={self.total_errors}"
+                    )
+                    last_report = now
+
+                # Small sleep to avoid busy loop
+                await asyncio.sleep(0.01)
+        except asyncio.CancelledError:
+            # Ensure we don't leave a pile of tasks running if the load test is cancelled.
+            for t in active_tasks:
+                if not t.done():
+                    t.cancel()
+            await asyncio.gather(*active_tasks, return_exceptions=True)
+            raise
+
+        # Wait for all in-flight requests to complete (finite mode only).
+        if end_time is not None and active_tasks:
+            print(
+                f"Burst {burst_num}: Duration ended, waiting for {len(active_tasks)} in-flight requests..."
+            )
+            await asyncio.gather(*active_tasks, return_exceptions=True)
+
+        burst_time = time.time() - started
+        if end_time is not None:
+            print(
+                f"Burst {burst_num} completed: {burst_requests} requests in {burst_time:.2f}s "
+                f"(rate={burst_requests/burst_time:.1f} req/s)"
+            )
+
+        return burst_requests
+
+    async def run_forever(self, *, concurrency: int, payload_size: int) -> None:
+        """Run indefinitely, maintaining a fixed concurrency, until interrupted."""
+        await self.run_for_duration(
+            duration_seconds=None,
+            concurrency=concurrency,
+            payload_size=payload_size,
+            burst_num=1,
+        )
+
+    async def run_forever_cycling_concurrency(
+        self,
+        *,
+        payload_size: int,
+        cycle_period_seconds: float,
+        min_concurrency: int,
+        max_concurrency: int,
+    ) -> None:
+        """
+        Run indefinitely and vary the target concurrency over time to simulate bursty traffic.
+
+        Concurrency cycles through powers of two within [min_concurrency, max_concurrency],
+        going up and then back down (e.g. 2,4,...,512,256,...,4) and repeats.
+        """
+        # Compute powers of two within the given bounds.
+        cycle = _powers_of_two_in_range(min_concurrency, max_concurrency)
+        if not cycle:
+            raise ValueError(
+                f"No powers of two in range [{min_concurrency}, {max_concurrency}]"
+            )
+
+        limiter = _DynamicConcurrencyLimiter(cycle[0])
+        started = time.time()
+        request_id_offset = self.total_requests + self.total_errors
+        requests_sent = 0
+        active_tasks: set[asyncio.Task[None]] = set()
+
+        print(
+            f"\n{'='*60}\n"
+            f"RUN-FOREVER (cycling concurrency)\n"
+            f"  Range: {min_concurrency}..{max_concurrency}\n"
+            f"  Cycle: {cycle}\n"
+            f"  Switch every: {cycle_period_seconds/60:.1f} minutes\n"
+            f"{'='*60}"
+        )
+
+        async def bounded(req_id: int) -> None:
+            await limiter.acquire()
+            try:
+                await self.send_request(req_id, payload_size)
+            finally:
+                await limiter.release()
+
+        async def cycle_task() -> None:
+            idx = 0
+            while True:
+                current = cycle[idx % len(cycle)]
+                limiter.set_limit(current)
+                elapsed_min = (time.time() - started) / 60.0
+                print(
+                    f"Concurrency shift: target={current} "
+                    f"(elapsed={elapsed_min:.1f} min, ok={self.total_requests}, err={self.total_errors})"
+                )
+                idx += 1
+                await asyncio.sleep(cycle_period_seconds)
+
+        cycler = asyncio.create_task(cycle_task())
+        last_report = started
+        try:
+            while True:
+                done_tasks = {t for t in active_tasks if t.done()}
+                active_tasks -= done_tasks
+
+                # Spawn new requests; limiter enforces current target.
+                while len(active_tasks) < limiter.limit:
+                    req_id = request_id_offset + requests_sent
+                    task = asyncio.create_task(bounded(req_id))
+                    active_tasks.add(task)
+                    requests_sent += 1
+
+                now = time.time()
+                if now - last_report >= 10.0:
+                    elapsed = now - started
+                    rate = requests_sent / elapsed if elapsed > 0 else 0.0
+                    print(
+                        f"RUN-FOREVER: sent={requests_sent}, rate={rate:.1f} req/s, "
+                        f"in-flight={len(active_tasks)}, target={limiter.limit}, "
+                        f"ok={self.total_requests}, err={self.total_errors}"
+                    )
+                    last_report = now
+
+                await asyncio.sleep(0.01)
+        except asyncio.CancelledError:
+            cycler.cancel()
+            await asyncio.gather(cycler, return_exceptions=True)
+            for t in active_tasks:
+                if not t.done():
+                    t.cancel()
+            await asyncio.gather(*active_tasks, return_exceptions=True)
+            raise
+        finally:
+            cycler.cancel()
+            await asyncio.gather(cycler, return_exceptions=True)
+
+    async def run_multi_burst(
+        self,
+        *,
+        durations: list[float],
+        wait_period: float,
+        concurrencies: list[int],
+        payload_size: int,
+    ) -> None:
+        """
+        Run multiple bursts of load with idle periods between them.
+        Each burst can have a different concurrency level.
+        """
+        burst_info = ", ".join(f"{d}s@c{c}" for d, c in zip(durations, concurrencies))
+        print(
+            f"\n{'#'*60}\n"
+            f"MULTI-BURST LOAD TEST\n"
+            f"  Bursts: {burst_info}\n"
+            f"  Wait period: {wait_period}s between bursts\n"
+            f"  Payload size: {payload_size}\n"
+            f"{'#'*60}"
+        )
+
+        overall_start = time.time()
+        total_requests_sent = 0
+
+        for i, (duration, concurrency) in enumerate(zip(durations, concurrencies), 1):
+            burst_requests = await self.run_for_duration(
+                duration_seconds=duration,
+                concurrency=concurrency,
+                payload_size=payload_size,
+                burst_num=i,
+            )
+            total_requests_sent += burst_requests
+
+            # Wait period after each burst (except the last)
+            if i < len(durations):
+                print(f"\n>>> IDLE PERIOD: Waiting {wait_period}s before next burst...")
+                await asyncio.sleep(wait_period)
+                print(f">>> IDLE PERIOD: Complete, starting burst {i+1}\n")
+
+        # Final summary
+        overall_time = time.time() - overall_start
+        print(
+            f"\n{'#'*60}\n"
+            f"MULTI-BURST LOAD TEST COMPLETE\n"
+            f"{'#'*60}\n"
+            f"Total requests sent: {total_requests_sent}\n"
+            f"Successful requests: {self.total_requests}\n"
+            f"Total errors: {self.total_errors}\n"
+            f"Total time (including wait periods): {overall_time:.2f}s\n"
+        )
+        if self.request_times:
+            print(
+                f"Average response time: {sum(self.request_times) / len(self.request_times):.3f}s"
+            )
+        if self.errors:
+            print(f"\nLast 10 errors (of {self.total_errors} total):")
+            for err in list(self.errors)[-10:]:
+                print(f"  {err}")
+
+    async def run(
+        self, *, request_count: int, concurrency: int, payload_size: int
+    ) -> None:
+        """Legacy method for backwards compatibility with --request-count."""
+        print(
+            f"Starting load test: {request_count} requests with concurrency={concurrency}, "
+            f"payload_size={payload_size}"
+        )
+        sem = asyncio.Semaphore(concurrency)
+        started = time.time()
+
+        async def bounded(i: int) -> None:
+            async with sem:
+                await self.send_request(i, payload_size)
+
+        batch_size = 500
+        for batch_start in range(0, request_count, batch_size):
+            batch_end = min(batch_start + batch_size, request_count)
+            tasks = [
+                asyncio.create_task(bounded(i)) for i in range(batch_start, batch_end)
+            ]
+            try:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            finally:
+                # Help GC by removing task refs.
+                for t in tasks:
+                    if not t.done():
+                        t.cancel()
+                del tasks
+
+            if batch_end % 5000 == 0:
+                elapsed = time.time() - started
+                rate = batch_end / elapsed if elapsed > 0 else 0.0
+                print(
+                    f"Progress: {batch_end}/{request_count} requests, rate={rate:.1f} req/s "
+                    f"(ok={self.total_requests}, err={self.total_errors})"
+                )
+
+        total_time = time.time() - started
+        print("\nLoad test completed!")
+        print(f"Total requests sent: {request_count}")
+        print(f"Successful requests: {self.total_requests}")
+        print(f"Total errors: {self.total_errors}")
+        print(f"Total time: {total_time:.2f}s")
+        if self.request_times:
+            print(
+                f"Average response time: {sum(self.request_times) / len(self.request_times):.3f}s"
+            )
+        if self.errors:
+            print(f"\nLast 10 errors (of {self.total_errors} total):")
+            for err in list(self.errors)[-10:]:
+                print(f"  {err}")
+
+
+def parse_durations(value: str) -> list[float]:
+    """Parse comma-separated durations (e.g., '60,60,60' -> [60.0, 60.0, 60.0])"""
+    return [float(d.strip()) for d in value.split(",")]
+
+
+def parse_concurrency(value: str) -> list[int]:
+    """Parse comma-separated concurrency values (e.g., '64,128,256' -> [64, 128, 256])"""
+    return [int(c.strip()) for c in value.split(",")]
+
+
+async def _main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Load test with support for multiple traffic bursts",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Single burst (legacy mode):
+  python3 load_test.py --concurrency 128 --request-count 5000 --payload-size 1000
+
+  # Run forever at fixed concurrency:
+  python3 load_test.py --concurrency 128 --run-forever --payload-size 1000
+
+  # Run forever cycling concurrency (bursty network simulation):
+  python3 load_test.py --run-forever --cycle-concurrency --min-concurrency 2 --max-concurrency 1024 --payload-size 1000
+
+  # Multi-burst mode (3 bursts of 60s each, same concurrency, 30s idle between):
+  python3 load_test.py --concurrency 128 --durations 60,60,60 --wait-period 30 --payload-size 1000
+
+  # Multi-burst with different concurrency per burst (ramp up pattern):
+  python3 load_test.py --concurrency 64,128,256 --durations 60,60,60 --wait-period 30 --payload-size 1000
+
+  # Two bumps with longer idle to observe RSS:
+  python3 load_test.py --concurrency 128 --durations 120,120 --wait-period 60 --payload-size 1000
+        """,
+    )
+    ap.add_argument("--base-url", default="http://localhost:8000")
+    ap.add_argument(
+        "--concurrency",
+        type=parse_concurrency,
+        default=None,
+        help="Max concurrent requests. Single value or comma-separated per burst (e.g., '128' or '64,128,256'). "
+        "Not required when using --cycle-concurrency.",
+    )
+    ap.add_argument(
+        "--payload-size",
+        type=int,
+        required=True,
+        help="Size multiplier for request payload",
+    )
+
+    # Two modes: --request-count (legacy) or --durations (new multi-burst)
+    mode_group = ap.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument(
+        "--request-count",
+        type=int,
+        help="Total number of requests to send (legacy single-burst mode)",
+    )
+    mode_group.add_argument(
+        "--durations",
+        type=parse_durations,
+        help="Comma-separated durations in seconds for each burst (e.g., '60,60,60')",
+    )
+    mode_group.add_argument(
+        "--run-forever",
+        action="store_true",
+        help="Run indefinitely, maintaining a fixed concurrency (requires single --concurrency value)",
+    )
+
+    ap.add_argument(
+        "--wait-period",
+        type=float,
+        default=30.0,
+        help="Seconds to wait between bursts (default: 30). Only used with --durations.",
+    )
+    ap.add_argument(
+        "--cycle-concurrency",
+        action="store_true",
+        help="When used with --run-forever, cycle through powers-of-two between --min-concurrency and --max-concurrency.",
+    )
+    ap.add_argument(
+        "--min-concurrency",
+        type=int,
+        default=2,
+        help="Lower bound for cycling concurrency (default: 2). Used with --cycle-concurrency.",
+    )
+    ap.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=1024,
+        help="Upper bound for cycling concurrency (default: 1024). Used with --cycle-concurrency.",
+    )
+    ap.add_argument(
+        "--cycle-period-seconds",
+        type=float,
+        default=600.0,
+        help="Seconds between concurrency changes (default: 600 = 10 minutes). Used with --cycle-concurrency.",
+    )
+
+    args = ap.parse_args()
+
+    # Validate --concurrency is provided when needed
+    if args.cycle_concurrency:
+        # --concurrency not required for cycling mode
+        pass
+    elif args.concurrency is None:
+        ap.error("--concurrency is required (unless using --cycle-concurrency)")
+
+    # Validate concurrency matches durations if using multi-burst mode
+    if args.durations:
+        if args.concurrency is None:
+            ap.error("--concurrency is required with --durations")
+        if len(args.concurrency) == 1:
+            # Single concurrency value - expand to all bursts
+            args.concurrency = args.concurrency * len(args.durations)
+        elif len(args.concurrency) != len(args.durations):
+            ap.error(
+                f"--concurrency has {len(args.concurrency)} values but --durations has "
+                f"{len(args.durations)} values. Provide either one concurrency for all bursts "
+                f"or one per burst."
+            )
+
+    # Validate run-forever mode
+    if args.run_forever and not args.cycle_concurrency:
+        if args.concurrency is None or len(args.concurrency) != 1:
+            ap.error(
+                "--run-forever requires a single --concurrency value (e.g. --concurrency 128)"
+            )
+    if args.cycle_concurrency and not args.run_forever:
+        ap.error("--cycle-concurrency can only be used with --run-forever")
+
+    # Validate cycling bounds
+    if args.cycle_concurrency:
+        if args.min_concurrency < 1 or args.max_concurrency < 1:
+            ap.error("--min-concurrency and --max-concurrency must be >= 1")
+        if args.min_concurrency > args.max_concurrency:
+            ap.error("--min-concurrency must be <= --max-concurrency")
+        cycle = _powers_of_two_in_range(args.min_concurrency, args.max_concurrency)
+        if not cycle:
+            ap.error(
+                f"No powers of two in range [{args.min_concurrency}, {args.max_concurrency}]"
+            )
+
+    tester = LoadTest(args.base_url)
+    try:
+        await tester.start()
+        if not await tester.test_connection():
+            print("Cannot connect to frontend. Make sure it's running.")
+            return
+
+        if args.durations:
+            # New multi-burst mode
+            await tester.run_multi_burst(
+                durations=args.durations,
+                wait_period=args.wait_period,
+                concurrencies=args.concurrency,  # list of concurrencies
+                payload_size=args.payload_size,
+            )
+        elif args.run_forever:
+            if args.cycle_concurrency:
+                await tester.run_forever_cycling_concurrency(
+                    payload_size=args.payload_size,
+                    cycle_period_seconds=args.cycle_period_seconds,
+                    min_concurrency=args.min_concurrency,
+                    max_concurrency=args.max_concurrency,
+                )
+            else:
+                await tester.run_forever(
+                    concurrency=args.concurrency[0],
+                    payload_size=args.payload_size,
+                )
+        else:
+            # Legacy single-burst mode (use first concurrency value)
+            await tester.run(
+                request_count=args.request_count,
+                concurrency=args.concurrency[0],
+                payload_size=args.payload_size,
+            )
+    except KeyboardInterrupt:
+        print("\nLoad test interrupted")
+    except Exception as e:
+        print(f"Load test failed: {e}")
+        traceback.print_exc()
+    finally:
+        await tester.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/memory_monitor.py
+++ b/memory_monitor.py
@@ -1,0 +1,98 @@
+"""
+Shared memory monitoring utilities for Dynamo repro components.
+
+Enable with:
+  DYNAMO_MEMORY_PROFILE=1  (default: 1)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from typing import Optional, Tuple
+
+
+def _read_proc_status_bytes() -> Tuple[int, int]:
+    """
+    Return (rss_bytes, vms_bytes) for the current process.
+
+    Linux-only (this repro harness targets Linux/k8s). Falls back to (0, 0) if unreadable.
+    """
+    try:
+        rss = 0
+        vms = 0
+        with open("/proc/self/status", encoding="utf-8") as f:
+            for line in f:
+                # Lines look like: "VmRSS:\t  12345 kB"
+                if line.startswith("VmRSS:"):
+                    rss = int(line.split()[1]) * 1024
+                elif line.startswith("VmSize:"):
+                    vms = int(line.split()[1]) * 1024
+        return rss, vms
+    except Exception:  # pragma: no cover
+        return 0, 0
+
+
+class MemoryMonitor:
+    """Memory monitor that can be shared across components."""
+
+    def __init__(self, component_name: str):
+        self.request_count = 0
+        self.start_time = time.time()
+        self.component_name = component_name
+        self.freed_last_mb: float = 0.0
+
+    @property
+    def initial_memory(self) -> int:
+        if not hasattr(self, "_initial_memory"):
+            self._initial_memory = _read_proc_status_bytes()[0]
+        return self._initial_memory
+
+    def log_memory(self, label: str = "") -> None:
+        rss_bytes, vms_bytes = _read_proc_status_bytes()
+        rss_mb = rss_bytes / 1024 / 1024
+        vms_mb = vms_bytes / 1024 / 1024
+        rss_growth = (rss_bytes - self.initial_memory) / 1024 / 1024
+        uptime = time.time() - self.start_time
+
+        print(
+            f"[{self.component_name}] [{uptime:.1f}s] {label} "
+            f"Memory: RSS={rss_mb:.2f}MB (+{rss_growth:.2f}MB), "
+            f"VMS={vms_mb:.2f}MB, Requests={self.request_count}, "
+            f"Last GC freed={self.freed_last_mb:.2f}MB"
+        )
+
+    def increment_request(self) -> None:
+        self.request_count += 1
+        _ = self.initial_memory
+
+        # Log every 5000 requests.
+        if self.request_count % 5000 == 0:
+            threading.Thread(
+                target=self.log_memory,
+                args=(f"After {self.request_count} requests:",),
+                daemon=True,
+            ).start()
+
+
+def create_monitor(component_name: str) -> Optional[MemoryMonitor]:
+    if os.getenv("DYNAMO_MEMORY_PROFILE", "1") == "1":
+        return MemoryMonitor(component_name)
+    return None
+
+
+def setup_background_monitor(
+    monitor: Optional[MemoryMonitor],
+) -> Optional[asyncio.Task]:
+    if not monitor:
+        print("Memory monitoring not enabled.")
+        return None
+
+    async def background_monitor() -> None:
+        while True:
+            await asyncio.sleep(15)
+            monitor.log_memory("Background check:")
+
+    return asyncio.create_task(background_monitor())

--- a/setup_profiling.sh
+++ b/setup_profiling.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Install profiling dependencies
+
+set -euo pipefail
+
+apt-get update -qq
+apt-get install -y -qq heaptrack
+pip3 install -q psutil aiohttp
+
+if [[ ! -d "$HOME/FlameGraph" ]]; then
+    git clone --depth 1 -q https://github.com/brendangregg/FlameGraph.git "$HOME/FlameGraph"
+fi
+
+echo "Done."


### PR DESCRIPTION
#### Overview:

This PR adds a minimal tooling to investigate frontend memory growth under sustained load. It profiles heap allocations and RSS to distinguish between true memory leaks and allocator retention.

---

### Quick Start

**1. Install dependencies:**
```bash
./setup_profiling.sh
```

**2. Start services (4 terminals):**

```bash
# Terminal 1: Backend worker
python3 backend.py

# Terminal 2: Backend proxy
python3 backend.py --proxy-mode

# Terminal 3: Frontend with heaptrack
heaptrack python3 frontend.py
```
After starting the frontend, you should see something along the lines of:
```
heaptrack output will be written to "/workspace/heaptrack.python3.12345.gz"
...
Starting service
Serving endpoint: localhost:8000/v1/models
Serving endpoint: localhost:8000/v1/chat/completions
Serving the following models: ['mock_model']
```

```bash
# Terminal 4: RSS collector (Will stop when frontend stops)
 python3 heaptrack/collect_rss.py --pid $(pgrep -f "python3 frontend.py" | tail -1)
```

**3. Run load test (new terminal):**

```bash
python3 load_test.py --concurrency 128 --durations 120 --payload-size 20000
python3 load_test.py --concurrency 64,128,256 --durations 60,60,60 --wait-period 30 --payload-size 20000
```

**4. Stop services and analyze:**

Press `Ctrl+C` on frontend, then:
```bash
./heaptrack/analyze_heaptrack.sh heaptrack.python3.*.gz my_run
```
```
Generating analysis...
Moved rss.csv to output dir

Done. Output: heaptrack/my_run
  summary.txt
  massif.out
  flamegraph.svg
  memory_chart.html
```

**5. View results:**
```bash
# Interactive memory chart (heap + RSS overlay with time slider)
open heaptrack/my_run/memory_chart.html

# Allocation flamegraph
open heaptrack/my_run/flamegraph.svg

# Text summary
less heaptrack/my_run/summary.txt
```

---

### Output Files

| File | Description |
|------|-------------|
| `memory_chart.html` | Interactive chart showing heap and RSS over time. Includes slider to adjust RSS time alignment. |
| `flamegraph.svg` | Call graph of allocations - click to zoom into hot paths |
| `summary.txt` | Heaptrack text summary with peak memory, allocations, leaks |
| `massif.out` | Raw data in Massif format for other tools |
| `rss.csv` | RSS samples (timestamp, bytes) |

Note: Might be cleaner to visualize `massif.out` with linux tool `massif_visualizer`, but I was running into difficulties downoading/building it. Hence, used cursor to generate `visualize_massif.py` since the data is easy to access/plot.

---

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #5269 
