### PR TITLE
fix(docs): remove trailing transition causing Sphinx build failure

### DIFF
--- a/docs/backends/trtllm/README.md
+++ b/docs/backends/trtllm/README.md
@@ -324,5 +324,3 @@ cache_transceiver_config:
 For example, see `examples/backends/trtllm/engine_configs/gpt-oss-120b/prefill.yaml`.
 
 **Related Issue:** [#4327](https://github.com/ai-dynamo/dynamo/issues/4327)
-
----


### PR DESCRIPTION
## Summary
- Remove trailing horizontal rule (`---`) from TRT-LLM README that caused Sphinx to fail with "Document may not end with a transition" warning

## Test plan
- [x] Verified locally that `make html` in docs/ now succeeds without warnings
- CI will verify the fix

Fixes the docs build failure introduced in PR #5801. 

https://github.com/ai-dynamo/dynamo/actions/runs/21504909115/job/61959035313 is the example failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor formatting improvements to backend documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->