### PR TITLE
feat: add ZMQ broker for scalable event plane pub/sub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11330,6 +11330,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "zmq-broker"
+version = "0.9.0"
+dependencies = [
+ "anyhow",
+ "dynamo-runtime",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "zmq",
+]
+
+[[package]]
 name = "zmq-sys"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@
 [workspace]
 members = [
     "launch/dynamo-run",
+    "launch/zmq-broker",
     "lib/llm",
     "lib/runtime",
     "lib/config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ strum = { version = "0.27", features = ["derive"] }
 tempfile = "3"
 thiserror = { version = "2.0.17" }
 tmq = { version = "0.5.0" }
-zmq = { version = "0.10" }
+zmq = { version = "0.10", features = ["vendored"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7", features = ["codec", "net", "rt", "io-util"] }

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -447,6 +447,17 @@ RUN if [ "$ENABLE_GPU_MEMORY_SERVICE" = "true" ]; then \
         uv build --wheel --out-dir /opt/dynamo/dist /opt/dynamo/lib/gpu_memory_service; \
     fi
 
+# Build zmq-broker binary for scalable pub/sub event plane
+RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+    export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export RUSTC_WRAPPER="sccache"; \
+    fi && \
+    cd /opt/dynamo && \
+    cargo build --release -p zmq-broker && \
+    /tmp/use-sccache.sh show-stats "zmq-broker"
+
 ##############################################
 ########## Runtime image ##############
 ##############################################
@@ -492,6 +503,7 @@ RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/loca
 # Copy built artifacts
 COPY --chown=dynamo: --from=wheel_builder $CARGO_TARGET_DIR $CARGO_TARGET_DIR
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
+COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/target/release/zmq-broker /usr/local/bin/zmq-broker
 
 # Install Python for framework=none runtime (cuda-dl-base doesn't include Python)
 # This is needed to create venv and install dynamo packages

--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -458,6 +458,17 @@ RUN if [ "$ENABLE_GPU_MEMORY_SERVICE" = "true" ]; then \
         uv build --wheel --out-dir /opt/dynamo/dist /opt/dynamo/lib/gpu_memory_service; \
     fi
 
+# Build zmq-broker binary for scalable pub/sub event plane
+RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+    export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export RUSTC_WRAPPER="sccache"; \
+    fi && \
+    cd /opt/dynamo && \
+    cargo build --release -p zmq-broker && \
+    /tmp/use-sccache.sh show-stats "zmq-broker"
+
 ##################################
 ########## Runtime Image #########
 ##################################
@@ -513,6 +524,7 @@ COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
+COPY --chown=dynamo:0 --from=wheel_builder /opt/dynamo/target/release/zmq-broker /usr/local/bin/zmq-broker
 
 ENV SGLANG_VERSION="${RUNTIME_IMAGE_TAG%%-*}"
 # Install packages as root to ensure they go to system location (/usr/local/lib/python3.12/dist-packages)

--- a/container/Dockerfile.trtllm
+++ b/container/Dockerfile.trtllm
@@ -478,6 +478,17 @@ RUN if [ "$ENABLE_GPU_MEMORY_SERVICE" = "true" ]; then \
         uv build --wheel --out-dir /opt/dynamo/dist /opt/dynamo/lib/gpu_memory_service; \
     fi
 
+# Build zmq-broker binary for scalable pub/sub event plane
+RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+    export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export RUSTC_WRAPPER="sccache"; \
+    fi && \
+    cd /opt/dynamo && \
+    cargo build --release -p zmq-broker && \
+    /tmp/use-sccache.sh show-stats "zmq-broker"
+
 ##################################################
 ########## Framework Builder Stage ##############
 ##################################################
@@ -818,6 +829,7 @@ COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/
 ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
+COPY --chown=dynamo:0 --from=wheel_builder /opt/dynamo/target/release/zmq-broker /usr/local/bin/zmq-broker
 RUN uv pip install \
       --no-cache \
       /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \

--- a/container/Dockerfile.vllm
+++ b/container/Dockerfile.vllm
@@ -497,6 +497,17 @@ RUN if [ "$ENABLE_GPU_MEMORY_SERVICE" = "true" ]; then \
         uv build --wheel --out-dir /opt/dynamo/dist /opt/dynamo/lib/gpu_memory_service; \
     fi
 
+# Build zmq-broker binary for scalable pub/sub event plane
+RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
+    export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
+    if [ "$USE_SCCACHE" = "true" ]; then \
+        export RUSTC_WRAPPER="sccache"; \
+    fi && \
+    cd /opt/dynamo && \
+    cargo build --release -p zmq-broker && \
+    /tmp/use-sccache.sh show-stats "zmq-broker"
+
 ########################################################
 ########## Framework Development Image ################
 ########################################################
@@ -765,6 +776,7 @@ COPY --chmod=775 --chown=dynamo:0 benchmarks/ /workspace/benchmarks/
 ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
+COPY --chown=dynamo:0 --from=wheel_builder /opt/dynamo/target/release/zmq-broker /usr/local/bin/zmq-broker
 RUN uv pip install \
       /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
       /opt/dynamo/wheelhouse/ai_dynamo*any.whl \

--- a/launch/zmq-broker/Cargo.toml
+++ b/launch/zmq-broker/Cargo.toml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "zmq-broker"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ZMQ Broker for Dynamo Event Plane - Scalable pub/sub proxy"
+
+[dependencies]
+dynamo-runtime = { workspace = true }
+
+anyhow = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+zmq = { workspace = true }

--- a/launch/zmq-broker/src/main.rs
+++ b/launch/zmq-broker/src/main.rs
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use dynamo_runtime::DistributedRuntime;
+use dynamo_runtime::config::environment_names::zmq_broker as env;
+use dynamo_runtime::discovery::{DiscoverySpec, EventTransport};
+use dynamo_runtime::distributed::DistributedConfig;
+use dynamo_runtime::runtime::Runtime;
+use std::env as std_env;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    // Parse configuration from env vars
+    let xsub_bind = std_env::var(env::ZMQ_BROKER_XSUB_BIND)
+        .unwrap_or_else(|_| "tcp://0.0.0.0:5555".to_string());
+    let xpub_bind = std_env::var(env::ZMQ_BROKER_XPUB_BIND)
+        .unwrap_or_else(|_| "tcp://0.0.0.0:5556".to_string());
+    let namespace =
+        std_env::var(env::ZMQ_BROKER_NAMESPACE).unwrap_or_else(|_| "dynamo".to_string());
+
+    tracing::info!(
+        xsub_bind = %xsub_bind,
+        xpub_bind = %xpub_bind,
+        namespace = %namespace,
+        "Starting ZMQ broker"
+    );
+
+    // Create ZMQ context (shared across sockets)
+    let ctx = Arc::new(zmq::Context::new());
+
+    // Resolve actual endpoints (handles port 0 -> random port)
+    let (xsub_endpoint, xpub_endpoint) = {
+        let ctx = Arc::clone(&ctx);
+        let xsub_bind = xsub_bind.clone();
+        let xpub_bind = xpub_bind.clone();
+
+        tokio::task::spawn_blocking(move || -> Result<(String, String)> {
+            // Bind XSUB socket
+            let xsub = ctx.socket(zmq::XSUB)?;
+            xsub.bind(&xsub_bind)?;
+            let xsub_ep = xsub
+                .get_last_endpoint()?
+                .map_err(|e| anyhow::anyhow!("Invalid XSUB endpoint: {:?}", e))?;
+
+            // Bind XPUB socket
+            let xpub = ctx.socket(zmq::XPUB)?;
+            xpub.bind(&xpub_bind)?;
+            let xpub_ep = xpub
+                .get_last_endpoint()?
+                .map_err(|e| anyhow::anyhow!("Invalid XPUB endpoint: {:?}", e))?;
+
+            // Drop sockets so we can rebind in the proxy thread
+            drop(xsub);
+            drop(xpub);
+
+            Ok((xsub_ep, xpub_ep))
+        })
+        .await??
+    };
+
+    tracing::info!(
+        xsub_endpoint = %xsub_endpoint,
+        xpub_endpoint = %xpub_endpoint,
+        "Resolved broker endpoints"
+    );
+
+    // Start the proxy in a blocking thread
+    let proxy_xsub_bind = xsub_bind.clone();
+    let proxy_xpub_bind = xpub_bind.clone();
+    let proxy_handle = tokio::task::spawn_blocking(move || -> Result<()> {
+        let ctx = zmq::Context::new();
+
+        // XSUB socket for publishers to connect
+        let xsub = ctx.socket(zmq::XSUB)?;
+        xsub.bind(&proxy_xsub_bind)?;
+        tracing::info!(endpoint = %proxy_xsub_bind, "XSUB socket bound");
+
+        // XPUB socket for subscribers to connect
+        let xpub = ctx.socket(zmq::XPUB)?;
+        xpub.bind(&proxy_xpub_bind)?;
+        tracing::info!(endpoint = %proxy_xpub_bind, "XPUB socket bound");
+
+        tracing::info!("Starting ZMQ proxy (XSUB <-> XPUB)");
+
+        // Run proxy (blocking - forwards all messages bidirectionally)
+        // XSUB receives from publishers, XPUB sends to subscribers
+        // Subscription messages flow XPUB -> XSUB
+        zmq::proxy(&xsub, &xpub)?;
+
+        Ok(())
+    });
+
+    let _discovery_handle = if std_env::var("ETCD_ENDPOINTS").is_ok() {
+        tracing::info!("Registering broker with discovery plane");
+
+        let rt = Runtime::from_handle(tokio::runtime::Handle::current())?;
+        let config = DistributedConfig::from_settings();
+        let drt = DistributedRuntime::new(rt, config).await?;
+        let _ns = drt.namespace(&namespace)?;
+
+        // Convert local bind to public endpoint
+        // Replace 0.0.0.0 with actual IP for discovery
+        let public_xsub = make_public_endpoint(&xsub_endpoint)?;
+        let public_xpub = make_public_endpoint(&xpub_endpoint)?;
+
+        let spec = DiscoverySpec::EventChannel {
+            namespace: namespace.clone(),
+            component: "zmq_broker".to_string(),
+            topic: "broker".to_string(),
+            transport: EventTransport::zmq_broker(vec![public_xsub], vec![public_xpub]),
+        };
+
+        let instance = drt.discovery().register(spec).await?;
+        tracing::info!(
+            instance_id = %instance.instance_id(),
+            "Broker registered with discovery plane"
+        );
+
+        Some((drt, instance))
+    } else {
+        tracing::warn!("ETCD_ENDPOINTS not set, skipping discovery registration");
+        tracing::info!("Clients should use DYN_ZMQ_BROKER_URL to connect directly");
+        None
+    };
+
+    // Setup signal handler for graceful shutdown
+    let shutdown_signal = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("Failed to listen for Ctrl+C");
+        tracing::info!("Received shutdown signal");
+    };
+
+    // Wait for shutdown signal or proxy error
+    tokio::select! {
+        result = proxy_handle => {
+            match result {
+                Ok(Ok(())) => {
+                    tracing::info!("Proxy thread completed normally");
+                }
+                Ok(Err(e)) => {
+                    tracing::error!(error = %e, "Proxy thread failed");
+                    return Err(e);
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Proxy thread panicked");
+                    return Err(anyhow::anyhow!("Proxy thread panicked: {}", e));
+                }
+            }
+        }
+        _ = shutdown_signal => {
+            tracing::info!("Shutting down broker");
+        }
+    }
+
+    Ok(())
+}
+
+/// Convert a local bind address to a public endpoint for discovery.
+/// Replaces 0.0.0.0 with the local IP address.
+fn make_public_endpoint(endpoint: &str) -> Result<String> {
+    if endpoint.contains("0.0.0.0") {
+        let local_ip = dynamo_runtime::utils::ip_resolver::get_local_ip_for_advertise();
+        Ok(endpoint.replace("0.0.0.0", &local_ip.to_string()))
+    } else {
+        Ok(endpoint.to_string())
+    }
+}

--- a/launch/zmq-broker/src/main.rs
+++ b/launch/zmq-broker/src/main.rs
@@ -75,20 +75,20 @@ async fn main() -> Result<()> {
     );
 
     // Start the proxy in a blocking thread
-    let proxy_xsub_bind = xsub_bind.clone();
-    let proxy_xpub_bind = xpub_bind.clone();
+    let proxy_xsub_endpoint = xsub_endpoint.clone();
+    let proxy_xpub_endpoint = xpub_endpoint.clone();
     let proxy_handle = tokio::task::spawn_blocking(move || -> Result<()> {
         let ctx = zmq::Context::new();
 
         // XSUB socket for publishers to connect
         let xsub = ctx.socket(zmq::XSUB)?;
-        xsub.bind(&proxy_xsub_bind)?;
-        tracing::info!(endpoint = %proxy_xsub_bind, "XSUB socket bound");
+        xsub.bind(&proxy_xsub_endpoint)?;
+        tracing::info!(endpoint = %proxy_xsub_endpoint, "XSUB socket bound");
 
         // XPUB socket for subscribers to connect
         let xpub = ctx.socket(zmq::XPUB)?;
-        xpub.bind(&proxy_xpub_bind)?;
-        tracing::info!(endpoint = %proxy_xpub_bind, "XPUB socket bound");
+        xpub.bind(&proxy_xpub_endpoint)?;
+        tracing::info!(endpoint = %proxy_xpub_endpoint, "XPUB socket bound");
 
         tracing::info!("Starting ZMQ proxy (XSUB <-> XPUB)");
 

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -327,6 +327,10 @@ pub mod zmq_broker {
     /// Enable ZMQ broker discovery mode
     pub const DYN_ZMQ_BROKER_ENABLED: &str = "DYN_ZMQ_BROKER_ENABLED";
 
+    /// Namespace to query for broker discovery (default: "dynamo")
+    /// Clients query this namespace regardless of their own namespace
+    pub const DYN_ZMQ_BROKER_DISCOVERY_NAMESPACE: &str = "DYN_ZMQ_BROKER_DISCOVERY_NAMESPACE";
+
     /// XSUB bind address (broker binary only)
     pub const ZMQ_BROKER_XSUB_BIND: &str = "ZMQ_BROKER_XSUB_BIND";
 
@@ -447,6 +451,7 @@ mod tests {
             // ZMQ Broker
             zmq_broker::DYN_ZMQ_BROKER_URL,
             zmq_broker::DYN_ZMQ_BROKER_ENABLED,
+            zmq_broker::DYN_ZMQ_BROKER_DISCOVERY_NAMESPACE,
             zmq_broker::ZMQ_BROKER_XSUB_BIND,
             zmq_broker::ZMQ_BROKER_XPUB_BIND,
             zmq_broker::ZMQ_BROKER_NAMESPACE,

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -170,6 +170,14 @@ impl EventTransport {
         }
     }
 
+    /// Create a ZMQ broker transport with XSUB/XPUB endpoints
+    pub fn zmq_broker(xsub_endpoints: Vec<String>, xpub_endpoints: Vec<String>) -> Self {
+        Self::ZmqBroker {
+            xsub_endpoints,
+            xpub_endpoints,
+        }
+    }
+
     /// Get the subject prefix (NATS) or endpoint (ZMQ)
     /// For ZmqBroker, returns the first XSUB endpoint
     pub fn address(&self) -> &str {


### PR DESCRIPTION
#### Overview:

Add ZMQ broker mode using XSUB/XPUB sockets to reduce connection complexity from O(N×M) to O(N+M). 

- zmq-broker binary with XSUB/XPUB proxy
- discovery support with namespace-agnostic broker lookup
- Dockerfile/K8s manifests for broker deployment
- launch scripts and documentation


Configuration:
- DYN_ZMQ_BROKER_URL: Explicit broker endpoints
- DYN_ZMQ_BROKER_ENABLED: Enable discovery-based broker lookup. Brokers register in a well-known namespace (default: "dynamo") and can be discovered by components in any namespace via DYN_ZMQ_BROKER_ENABLED.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
