### PR TITLE
ci: Report missing markers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
   hooks:
     - id: pytest-marker-report
       name: Report pytest markers (static + inherited)
-      entry: python3 scripts/report_pytest_markers.py
+      entry: python3 scripts/report_pytest_markers.py --tests tests components/src/dynamo
       language: python
       pass_filenames: false
       additional_dependencies:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -6,12 +6,23 @@ from unittest import mock
 
 import pytest
 
-from dynamo.trtllm.request_handlers.handler_base import HandlerBase
+# Try to import HandlerBase, but allow collection to proceed if tensorrt_llm is missing
+try:
+    from dynamo.trtllm.request_handlers.handler_base import HandlerBase
+
+    _HANDLER_BASE_AVAILABLE = True
+except ImportError:
+    HandlerBase = None  # type: ignore[misc, assignment]
+    _HANDLER_BASE_AVAILABLE = False
 
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.trtllm,
     pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.skipif(
+        not _HANDLER_BASE_AVAILABLE, reason="tensorrt_llm not installed"
+    ),
 ]
 
 

--- a/scripts/report_pytest_markers.py
+++ b/scripts/report_pytest_markers.py
@@ -112,6 +112,7 @@ STUB_MODULES = [
     "gpu_memory_service",
     "gpu_memory_service.common",
     "gpu_memory_service.common.utils",
+    "torch",
 ]
 
 # Project paths for local imports
@@ -350,12 +351,15 @@ def parse_args():
         help="Enable strict validation (undeclared markers, missing config, naming)",
     )
     parser.add_argument(
-        "--tests", default="tests", help="Path to test directory (default: tests)"
+        "--tests",
+        nargs="+",
+        default=["tests"],
+        help="Path(s) to test directory (default: tests)",
     )
     return parser.parse_args()
 
 
-def run_collection(test_path: str, use_stubbing: bool) -> tuple[int, Report]:
+def run_collection(test_paths: List[str], use_stubbing: bool) -> tuple[int, Report]:
     """Run pytest collection and return exit code and report."""
     if use_stubbing:
         stubber = DependencyStubber()
@@ -384,7 +388,7 @@ def run_collection(test_path: str, use_stubbing: bool) -> tuple[int, Report]:
             "addopts=",
             "-o",
             "filterwarnings=",
-            test_path,
+            *test_paths,
         ],
         plugins=[plugin],
     )


### PR DESCRIPTION
#### Overview:

Attempt at getting the `pytest-marker-report` pre-commit hook to flag offending entries under `components/src/dynamo/`.

#### Details:

I extended `scripts/report_pytest_markers.py` and the pre-commit config YAML to include `components/src/dynamo/` as well in the 1st commit.

However, it turns out that the various frameworks' `conftest.py` explicitly skip collection, which is what motivated the 2nd commit, which is hackier than I'd like.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
