### PR TITLE
fix: treat `--tool-call-parser` and `--dyn-tool-call-parser` independently for SGLang

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -107,17 +107,16 @@ async def test_tool_call_parser_invalid_with_dynamo_tokenizer(mock_sglang_cli):
 
 
 @pytest.mark.asyncio
-async def test_tool_call_parser_invalid_with_sglang_tokenizer(mock_sglang_cli):
-    """Invalid Dynamo parser name is allowed when using SGLang's tokenizer."""
+async def test_tool_call_parser_both_flags_error(mock_sglang_cli):
+    """Setting both --dyn-tool-call-parser and --tool-call-parser exits with error."""
     mock_sglang_cli(
         "--model",
         "Qwen/Qwen3-0.6B",
         "--dyn-tool-call-parser",
-        "sglang_only_parser",
-        "--use-sglang-tokenizer",
+        "hermes",
+        "--tool-call-parser",
+        "qwen25",
     )
 
-    config = await parse_args(sys.argv[1:])
-
-    assert config.dynamo_args.tool_call_parser == "sglang_only_parser"
-    assert config.dynamo_args.use_sglang_tokenizer is True
+    with pytest.raises(SystemExit):
+        await parse_args(sys.argv[1:])


### PR DESCRIPTION
#### Overview:

Previously, `--dyn-tool-call-parser` and `--tool-call-parser` (SGLang's flag) had confusing validation behavior. This
  PR clarifies the separation:
  • `--dyn-tool-call-parser`: Use Dynamo's parser, validated against Dynamo's supported list
  • `--tool-call-parser`: Pass through to SGLang, validated by SGLang (use with --use-sglang-tokenizer)

```bash
# Use Dynamo's parser (validated against Dynamo's choices)
python -m dynamo.sglang --model Qwen/Qwen3-0.6B --dyn-tool-call-parser hermes
# Use SGLang's parser (validated by SGLang, requires --use-sglang-tokenizer)
python -m dynamo.sglang --model Qwen/Qwen3-0.6B --tool-call-parser qwen25 --use-sglang-tokenizer
# Error: cannot use both flags together
python -m dynamo.sglang --model Qwen/Qwen3-0.6B --dyn-tool-call-parser hermes --tool-call-parser qwen25
```

  Details:
  - Let SGLang validate --tool-call-parser and --reasoning-parser internally
  - Replace `_set_parser()` with simpler `_validate_parser_flags()` that only ensures both flags aren't set
    simultaneously 
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #5743


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Moved parser validation from argument definition to runtime for improved error handling and messaging.

* **Bug Fixes**
  * Enhanced validation of tool-call-parser and reasoning-parser selections when using Dynamo's tokenizer, with clearer error guidance.

* **Tests**
  * Added comprehensive tests for parser validation across different tokenizer configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->