### PR TITLE
test: remove hardcoded ports and add timeouts to KVBM tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,9 @@ markers = [
     "usefixtures: use fixtures",
     "parametrize: parameterized test",
     "filterwarnings: filter warnings",
-    "asyncio: asyncio test marker"
+    "asyncio: asyncio test marker",
+    # Third-party plugin markers
+    "timeout: test timeout in seconds (pytest-timeout plugin)",
 ]
 
 # Linting/formatting

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,8 @@ def pytest_configure(config):
         "custom_build: marks tests that require custom builds or special setup (e.g., MoE models)",
         "k8s: marks tests as requiring Kubernetes",
         "fault_tolerance: marks tests as fault tolerance tests",
+        # Third-party plugin markers
+        "timeout: test timeout in seconds (pytest-timeout plugin)",
     ]
     for marker in markers:
         config.addinivalue_line("markers", marker)

--- a/tests/kvbm_integration/test_kvbm.py
+++ b/tests/kvbm_integration/test_kvbm.py
@@ -59,11 +59,12 @@ def print_phase(phase_num: int, description: str) -> None:
     print(f"\n=== Phase {phase_num}: {description} ===")
 
 
-def check_kvbm_metrics(phase_name: str) -> dict[str, int]:
+def check_kvbm_metrics(phase_name: str, metrics_port: int) -> dict[str, int]:
     """Fetch and display KVBM metrics.
 
     Args:
         phase_name: Name of the test phase for logging
+        metrics_port: Port number for the KVBM metrics endpoint
 
     Returns:
         Dictionary containing KVBM metrics with keys:
@@ -71,7 +72,7 @@ def check_kvbm_metrics(phase_name: str) -> dict[str, int]:
         - kvbm_onboard_blocks_h2d: Blocks onboarded from CPU to GPU
     """
     print(f"\n--- Checking KVBM metrics after {phase_name} ---")
-    metrics = fetch_kvbm_metrics()
+    metrics = fetch_kvbm_metrics(port=metrics_port)
 
     offload_d2h = metrics.get("kvbm_offload_blocks_d2h", 0)
     onboard_h2d = metrics.get("kvbm_onboard_blocks_h2d", 0)
@@ -113,6 +114,7 @@ def tester(llm_server_kvbm):  # noqa: F811
 
 # Tests
 @pytest.mark.parametrize("llm_server_kvbm", [{"model": KVBM_TEST_MODEL}], indirect=True)
+@pytest.mark.timeout(110)  # 3x measured time (36.31s), rounded up
 def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     """
     Test offload → cache reset → onboard cycle with determinism verification.
@@ -135,7 +137,7 @@ def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     response_1 = tester.make_request(prompt, max_tokens=MAX_TOKENS)
     print(f"Response 1: {response_1}")
 
-    metrics = check_kvbm_metrics("Phase 1")
+    metrics = check_kvbm_metrics("Phase 1", llm_server_kvbm.metrics_port)
     assert (
         metrics["kvbm_offload_blocks_d2h"] > 0
     ), "Phase 1: No blocks offloaded. KVBM may not be triggering offloads."
@@ -155,7 +157,7 @@ def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     response_2 = tester.make_request(prompt, max_tokens=MAX_TOKENS)
     print(f"Response 2: {response_2}")
 
-    metrics = check_kvbm_metrics("Phase 3")
+    metrics = check_kvbm_metrics("Phase 3", llm_server_kvbm.metrics_port)
     assert (
         metrics["kvbm_onboard_blocks_h2d"] > 0
     ), "Phase 3: No blocks onboarded. Expected CPU→GPU transfer after cache reset."
@@ -179,6 +181,7 @@ def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     [{"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL}],
     indirect=True,
 )
+@pytest.mark.timeout(190)  # 3x measured time (63.39s), rounded up
 def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
     """
     Test GPU cache eviction mechanics.
@@ -204,7 +207,7 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
 
     tester.make_request(prompt_1, max_tokens=MAX_TOKENS)
 
-    metrics_p1 = check_kvbm_metrics("Phase 1")
+    metrics_p1 = check_kvbm_metrics("Phase 1", llm_server_kvbm.metrics_port)
     assert metrics_p1["kvbm_offload_blocks_d2h"] >= MIN_OFFLOAD_BLOCKS, (
         f"Phase 1: Expected >= {MIN_OFFLOAD_BLOCKS} blocks offloaded, "
         f"got {metrics_p1['kvbm_offload_blocks_d2h']}"
@@ -220,7 +223,7 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
 
     tester.make_request(prompt_2, max_tokens=MAX_TOKENS)
 
-    metrics_p2 = check_kvbm_metrics("Phase 2")
+    metrics_p2 = check_kvbm_metrics("Phase 2", llm_server_kvbm.metrics_port)
     assert (
         metrics_p2["kvbm_offload_blocks_d2h"] > metrics_p1["kvbm_offload_blocks_d2h"]
     ), (
@@ -238,7 +241,7 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
 
     tester.make_request(prompt_1, max_tokens=MAX_TOKENS)
 
-    metrics_p3 = check_kvbm_metrics("Phase 3")
+    metrics_p3 = check_kvbm_metrics("Phase 3", llm_server_kvbm.metrics_port)
     assert (
         metrics_p3["kvbm_onboard_blocks_h2d"] > 0
     ), "Phase 3: No blocks onboarded. Expected CPU→GPU retrieval after eviction."
@@ -253,6 +256,7 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
     [{"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL}],
     indirect=True,
 )
+@pytest.mark.timeout(107)  # 3x measured time (35.40s), rounded up
 def test_onboarding_determinism(tester, llm_server_kvbm):  # noqa: F811
     """
     Test onboarding determinism under eviction scenario.
@@ -276,41 +280,41 @@ def test_onboarding_determinism(tester, llm_server_kvbm):  # noqa: F811
     print_phase(1, "Send first request")
     print(f"Prompt 1: {prompt_1[:80]}...")
     tester.make_request(prompt_1, max_tokens=MAX_TOKENS)
-    check_kvbm_metrics("Phase 1")
+    check_kvbm_metrics("Phase 1", llm_server_kvbm.metrics_port)
 
     # Phase 2: Second request (may evict first from GPU)
     print_phase(2, "Send second request (may evict first from GPU)")
     print(f"Prompt 2: {prompt_2[:80]}...")
     tester.make_request(prompt_2, max_tokens=MAX_TOKENS)
-    check_kvbm_metrics("Phase 2")
+    check_kvbm_metrics("Phase 2", llm_server_kvbm.metrics_port)
 
     # Phase 3: Re-request prompt 1 (first onboard cycle)
     print_phase(3, "Re-request Prompt 1 (first onboard cycle)")
     print(f"Re-sending Prompt 1: {prompt_1[:80]}...")
     response_1_first_onboard = tester.make_request(prompt_1, max_tokens=MAX_TOKENS)
     print(f"Response 1 (first onboard): {response_1_first_onboard}")
-    check_kvbm_metrics("Phase 3")
+    check_kvbm_metrics("Phase 3", llm_server_kvbm.metrics_port)
 
     # Phase 4: Re-request prompt 2 (first onboard cycle)
     print_phase(4, "Re-request Prompt 2 (first onboard cycle)")
     print(f"Re-sending Prompt 2: {prompt_2[:80]}...")
     response_2_first_onboard = tester.make_request(prompt_2, max_tokens=MAX_TOKENS)
     print(f"Response 2 (first onboard): {response_2_first_onboard}")
-    check_kvbm_metrics("Phase 4")
+    check_kvbm_metrics("Phase 4", llm_server_kvbm.metrics_port)
 
     # Phase 5: Re-request prompt 1 (second onboard cycle)
     print_phase(5, "Re-request Prompt 1 (second onboard cycle)")
     print(f"Re-sending Prompt 1 (third time): {prompt_1[:80]}...")
     response_1_second_onboard = tester.make_request(prompt_1, max_tokens=MAX_TOKENS)
     print(f"Response 1 (second onboard): {response_1_second_onboard}")
-    check_kvbm_metrics("Phase 5")
+    check_kvbm_metrics("Phase 5", llm_server_kvbm.metrics_port)
 
     # Phase 6: Re-request prompt 2 (second onboard cycle)
     print_phase(6, "Re-request Prompt 2 (second onboard cycle)")
     print(f"Re-sending Prompt 2 (third time): {prompt_2[:80]}...")
     response_2_second_onboard = tester.make_request(prompt_2, max_tokens=MAX_TOKENS)
     print(f"Response 2 (second onboard): {response_2_second_onboard}")
-    check_kvbm_metrics("Phase 6")
+    check_kvbm_metrics("Phase 6", llm_server_kvbm.metrics_port)
 
     # Verify determinism between onboarded requests
     print_test_header("DETERMINISM VERIFICATION")


### PR DESCRIPTION
#### Overview:

Use dynamic ports instead of hardcoded ports so that multiple tests on the same machine don't collide ports. Also add proper timeout guards and port-based cleanup for pytest-xdist safety.

#### Details:

- **Dynamic port allocation**: vLLM HTTP (8000→dynamic), KVBM metrics (6880→dynamic), ZMQ pub (56001→dynamic), ZMQ ack (56002→dynamic), NATS (4222→dynamic), etcd (2379→dynamic)
- **Timeout guards**: Added `@pytest.mark.timeout()` to all three tests using 3x measured time formula (110s, 190s, 107s)
- **xdist-safe cleanup**: Replaced system-wide process killing (`terminate_existing=True`, `stragglers=["vllm"]`) with port-based cleanup using `psutil` to only terminate processes listening on our specific allocated ports
- **xdist compatibility**: Switched from `runtime_services` to `runtime_services_dynamic_ports` fixture for parallel test safety
- **Port cleanup**: Added proper deallocation in fixture teardown for all 6 dynamic ports (vLLM, metrics, ZMQ pub, ZMQ ack, NATS, etcd) to prevent port leaks
- **API hardening**: `ApiTester` and `fetch_kvbm_metrics` now require explicit ports instead of defaulting to hardcoded values
- **Marker registration**: Registered `timeout` marker in `pyproject.toml` and `tests/conftest.py` for `--strict-markers` compliance

#### Where should the reviewer start?

- `tests/kvbm_integration/common.py`: Review the `llm_server_kvbm` fixture changes for:
  - Dynamic ZMQ port allocation (now in i16-compatible range: 20001-20002 instead of 56001-56002)
  - Port-based cleanup logic (lines ~630-655) that only kills processes on our allocated ports
  - Updated `ApiTester`/`fetch_kvbm_metrics` signatures
  - TODO comment about optional GPU memory allocation for single-GPU parallel execution
- `tests/kvbm_integration/test_kvbm.py`: Verify timeout values and metrics port parameter passing
- `tests/conftest.py` and `pyproject.toml`: Verify `timeout` marker registration

#### Related Issues:

1. Job 62096454660
   Link: https://github.com/ai-dynamo/dynamo/actions/runs/21549672481/job/62096454660
   Test: tests/kvbm_integration/test_kvbm.py::test_onboarding_determinism[llm_server_kvbm0]
   Error: Exception: Zmq error: Address already in use
          at kvbm/vllm_integration/connector_leader.py:69 in KvbmLeader(world_size, drt=self.drt)
   [https://grafana.nvidia.com/d/bf0set70vqygwb/test-details?orgId=283&var-branch=All&var-test_status=All&var-test=test_onboarding_determinism%5Bllm_server_kvbm0%5D&from=now-30d&to=now](https://grafana.nvidia.com/d/bf0set70vqygwb/test-details?orgId=283&var-branch=All&var-test_status=All&var-test=test_onboarding_determinism%5Bllm_server_kvbm0%5D&from=now-30d&to=now)

2. Job 61820662924
   Link: https://github.com/ai-dynamo/dynamo/actions/runs/21463495672/job/61820662924
   Test: tests/kvbm_integration/test_kvbm.py::test_offload_and_onboard[llm_server_kvbm0]
   Error: Exception: Zmq error: Address already in use
          at kvbm/vllm_integration/connector_leader.py:69 in KvbmLeader(world_size, drt=self.drt)
   And the past 30 days of failures. It says 1%, it doesn't sound like a lot, but when we have hundreds of tests and each range between 1-5%... it happens a lot more often.
   [https://grafana.nvidia.com/d/bf0set70vqygwb/test-details?orgId=283&var-branch=All&var-test_status=All&var-test=test_offload_and_onboard%5Bllm_server_kvbm0%5D&from=now-30d&to=now](https://grafana.nvidia.com/d/bf0set70vqygwb/test-details?orgId=283&var-branch=All&var-test_status=All&var-test=test_offload_and_onboard%5Bllm_server_kvbm0%5D&from=now-30d&to=now)


/coderabbit profile chill