### PR TITLE
chore: demote scheduler scoring logs from info to debug

### DIFF
--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -535,7 +535,7 @@ impl WorkerSelector for DefaultWorkerSelector {
 
                 worker_logits.insert(worker, logit);
 
-                tracing::info!(
+                tracing::debug!(
                     "Formula for worker_id={} dp_rank={:?} with {overlap} cached blocks: {logit:.3} \
                      = {overlap_weight:.1} * prefill_blocks + decode_blocks \
                      = {overlap_weight:.1} * {potential_prefill_block:.3} + {decode_block:.3}",
@@ -557,7 +557,7 @@ impl WorkerSelector for DefaultWorkerSelector {
         // If multiple candidates (tied), use tree size as tie-breaker
         // If tree sizes are also equal, min_by_key uses HashMap iteration order (pseudo-random)
         let best_worker = if candidates.len() > 1 {
-            tracing::info!("Multiple workers tied with same logit, using tree size as tie-breaker");
+            tracing::debug!("Multiple workers tied with same logit, using tree size as tie-breaker");
             *candidates
                 .iter()
                 .min_by_key(|worker| {
@@ -592,7 +592,7 @@ impl WorkerSelector for DefaultWorkerSelector {
             .copied()
             .unwrap_or(0);
 
-        tracing::info!(
+        tracing::debug!(
             "Selected worker: worker_id={} dp_rank={:?}, logit: {:.3}, cached blocks: {}, tree size: {}{}",
             best_worker.worker_id,
             best_worker.dp_rank,


### PR DESCRIPTION
## Summary
- Demote 3 per-request scoring log lines (`Formula for worker_id`, `Multiple workers tied`, `Selected worker`) from `info!` to `debug!`
- These generate O(workers × requests/sec) log volume on the hot path, adding measurable tracing overhead in production
- We can actually remove some logs entirely for production

## Test plan
- [x] `cargo check` / `cargo clippy` pass
- [x] Integration tested with Qwen2.5-0.5B-Instruct on sglang - verified 0 scoring log lines at INFO level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted scheduler logging verbosity. Three scheduler diagnostic messages—worker logit computation updates, tie-breaker event scenarios, and final worker selection summaries—have been moved from INFO to DEBUG level. This reduces production log volume during normal operation while ensuring full diagnostic information remains available when debug logging is enabled for investigation and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->