### PR TITLE
fix: scheduler continues on watch error instead of exiting

### DIFF
--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -145,8 +145,11 @@ impl KvScheduler {
                     }
                     result = change_rx.changed() => {
                         if result.is_err() {
-                            tracing::warn!("KvScheduler: config watch sender dropped, shutting down");
-                            break;
+                            tracing::warn!("KvScheduler: config watch sender dropped, continuing with last known config");
+                            tokio::select! {
+                                _ = monitor_cancel_token.cancelled() => break,
+                                _ = tokio::time::sleep(Duration::from_secs(1)) => continue,
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Change scheduler monitor task to `continue` instead of `break` when the config watch sender is dropped
- Previously, a transient etcd reconnection would kill the monitor task entirely, leaving routing stuck with stale worker lists
- Now continues with last known config, allowing self-healing when the watch channel is re-established

## Test plan
- [x] `cargo check` / `cargo clippy` pass
- [x] Integration tested with Qwen2.5-0.5B-Instruct on sglang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved scheduler resilience: configuration is now retained on communication errors instead of triggering shutdown.

* **Breaking Changes**
  * Response handling API now requires mutable reference; existing implementations must be updated accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->