### PR TITLE
fix: KV subscriber continues on channel send failure instead of exiting

### DIFF
--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -615,9 +615,9 @@ pub async fn start_kv_router_background(
                             // Forward the RouterEvent to the indexer
                             if let Err(e) = kv_events_tx.send(event).await {
                                 tracing::warn!(
-                                    "failed to send kv event to indexer; shutting down: {e:?}"
+                                    "failed to send kv event to indexer; skipping event, continuing: {e:?}"
                                 );
-                                break;
+                                continue;
                             }
                         },
                         Ok(None) => {
@@ -911,9 +911,9 @@ pub async fn start_kv_router_background_event_plane(
                     // Forward the RouterEvent to the indexer
                     if let Err(e) = kv_events_tx.send(event).await {
                         tracing::warn!(
-                            "failed to send kv event to indexer; shutting down: {e:?}"
+                            "failed to send kv event to indexer; skipping event, continuing: {e:?}"
                         );
-                        break;
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Change KV subscriber to `continue` instead of `break` on channel send failure (2 locations in `subscriber.rs`)
- A transient send failure (e.g. slow indexer) would kill the entire KV subscriber loop, causing the router to lose all future KV cache events until restart
- Now skips the failed event and continues processing to maintain routing availability

## Test plan
- [x] `cargo check` / `cargo clippy` pass
- [x] Integration tested with Qwen2.5-0.5B-Instruct on sglang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KV router background service resilience by allowing it to continue processing events even when a single forwarding operation fails, preventing unexpected service interruption from isolated failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->