### PR TITLE
fix: add ZMQ production socket options (linger, keepalive, reconnect)

### DIFF
--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -82,6 +82,13 @@ impl ZmqPubTransport {
             // Set send timeout to 0 (non-blocking)
             socket.set_sndtimeo(0)?;
 
+            // Production socket options
+            socket.set_linger(1000)?;
+            socket.set_tcp_keepalive(1)?;
+            socket.set_tcp_keepalive_idle(60)?;
+            socket.set_reconnect_ivl(1000)?;
+            socket.set_reconnect_ivl_max(30000)?;
+
             // Bind to endpoint
             socket.bind(&endpoint_for_closure)?;
 
@@ -125,6 +132,13 @@ impl ZmqPubTransport {
             // Set send timeout to 0 (non-blocking)
             socket.set_sndtimeo(0)?;
 
+            // Production socket options
+            socket.set_linger(1000)?;
+            socket.set_tcp_keepalive(1)?;
+            socket.set_tcp_keepalive_idle(60)?;
+            socket.set_reconnect_ivl(1000)?;
+            socket.set_reconnect_ivl_max(30000)?;
+
             // Connect (not bind) to broker's XSUB
             socket.connect(&endpoint_owned)?;
 
@@ -164,6 +178,13 @@ impl ZmqPubTransport {
 
             // Set send timeout to 0 (non-blocking)
             socket.set_sndtimeo(0)?;
+
+            // Production socket options
+            socket.set_linger(1000)?;
+            socket.set_tcp_keepalive(1)?;
+            socket.set_tcp_keepalive_idle(60)?;
+            socket.set_reconnect_ivl(1000)?;
+            socket.set_reconnect_ivl_max(30000)?;
 
             // Connect to all XSUB endpoints (ZMQ handles load balancing)
             for endpoint in &endpoints_owned {
@@ -257,6 +278,13 @@ impl ZmqSubTransport {
             // Set receive timeout to avoid blocking forever (fixes test hangs)
             socket.set_rcvtimeo(ZMQ_RCVTIMEOUT_MS)?;
 
+            // Production socket options
+            socket.set_linger(1000)?;
+            socket.set_tcp_keepalive(1)?;
+            socket.set_tcp_keepalive_idle(60)?;
+            socket.set_reconnect_ivl(1000)?;
+            socket.set_reconnect_ivl_max(30000)?;
+
             // Connect to endpoint
             socket.connect(&endpoint_owned)?;
 
@@ -319,6 +347,13 @@ impl ZmqSubTransport {
 
             // Set receive timeout to avoid blocking forever (fixes test hangs)
             socket.set_rcvtimeo(ZMQ_RCVTIMEOUT_MS)?;
+
+            // Production socket options
+            socket.set_linger(1000)?;
+            socket.set_tcp_keepalive(1)?;
+            socket.set_tcp_keepalive_idle(60)?;
+            socket.set_reconnect_ivl(1000)?;
+            socket.set_reconnect_ivl_max(30000)?;
 
             // Connect to all endpoints
             for endpoint in &endpoints_owned {
@@ -444,8 +479,8 @@ impl ZmqSubTransport {
                         continue;
                     }
                     Ok(Err(e)) => {
-                        tracing::error!(error = %e, "ZMQ receive error in socket pump");
-                        break;
+                        tracing::warn!(error = %e, "ZMQ receive error in socket pump, retrying");
+                        continue;
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "Task join error in socket pump");


### PR DESCRIPTION
## Summary
- Add production socket options to all 5 ZMQ socket setup closures (3 PUB, 2 SUB):
  - `linger(1000)` - prevent close() from hanging indefinitely
  - `tcp_keepalive(1)` + `tcp_keepalive_idle(60)` - detect dead connections
  - `reconnect_ivl(1000)` + `reconnect_ivl_max(30000)` - exponential backoff reconnect to avoid thundering herd
- Change socket pump receive error from `break` to `continue` so transient ZMQ errors don't terminate event subscription

## Test plan
- [x] `cargo check` / `cargo clippy` pass
- [x] Integration tested with Qwen2.5-0.5B-Instruct on sglang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Reliability & Stability**
  * Enhanced transport connection stability with optimized socket configuration including improved linger time, TCP keepalive monitoring, and reconnection parameters for better network resilience.
  * Improved error handling for network communication with graceful retry logic instead of immediate failures, and enhanced logging for connection anomalies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->