### PR TITLE
chore: remove dead AllWorkersBusy handling in KvScheduler

### DIFF
--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -44,9 +44,6 @@ pub enum KvSchedulerError {
     #[error("no endpoints available to route work")]
     NoEndpoints,
 
-    #[error("all workers busy")]
-    AllWorkersBusy,
-
     #[error("endpoint subscriber shutdown")]
     SubscriberShutdown,
 
@@ -259,12 +256,6 @@ impl KvScheduler {
                     }
                     Err(KvSchedulerError::NoEndpoints) => {
                         tracing::trace!("no endpoints available; waiting for endpoints update");
-                        tokio::time::sleep(Duration::from_millis(5)).await;
-                        continue;
-                    }
-                    // TODO: this is not actually hooked up
-                    Err(KvSchedulerError::AllWorkersBusy) => {
-                        tracing::trace!("all workers busy; waiting for more capacity");
                         tokio::time::sleep(Duration::from_millis(5)).await;
                         continue;
                     }


### PR DESCRIPTION
It's not hooked up, and we have a systematic way to handle request rejection now


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal error handling for worker scheduling to provide cleaner error paths and improved system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->