### PR TITLE
fix: fuse unfold streams to prevent panics from poll after termination

### DIFF
--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -262,7 +262,8 @@ impl
 
                 None => None,
             }
-        });
+        })
+        .fuse();
 
         // convert stream of processed Annotated<LLMEngineOutput> to Annotated<BackendOutput>
         //let mdcsum = self.mdcsum.clone();

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -73,7 +73,8 @@ impl
                 .next()
                 .await
                 .map(|response| (response, retry_manager))
-        });
+        })
+        .fuse();
         Ok(ResponseStream::new(Box::pin(response_stream), engine_ctx_))
     }
 }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -723,6 +723,7 @@ impl OpenAIPreprocessor {
                 }
             }
         })
+        .fuse();
     }
 
     /// Transform engine embedding output stream to OpenAI embedding response stream
@@ -889,6 +890,7 @@ impl OpenAIPreprocessor {
                 None
             }
         })
+        .fuse();
     }
 }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -723,7 +723,7 @@ impl OpenAIPreprocessor {
                 }
             }
         })
-        .fuse();
+        .fuse()
     }
 
     /// Transform engine embedding output stream to OpenAI embedding response stream
@@ -890,7 +890,7 @@ impl OpenAIPreprocessor {
                 None
             }
         })
-        .fuse();
+        .fuse()
     }
 }
 


### PR DESCRIPTION
#### Overview:

- currently, when we poll streams that have already been exhausted, the stream panics. this is because the `Stream` trait does not define what must happen after `None` has been returned. 
- adding `.fuse()` wraps the stream in a `Fuse<S>` adapter, which makes it so that once the stream returns `None`, all subsequent polls will also return `None`. 
- the `.fuse()` works by adding a single boolean flag `done` to the stream that it is called on. this boolean is checked on every poll, and the performance effect of this should be negligible (since it is a single instruction).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced stream termination behavior in the LLM backend to prevent potential polling issues and ensure more reliable stream completion handling across multiple components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->