### PR TITLE
feat(lora): Add lora aware routing hint and tracking

### DIFF
--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -950,6 +950,7 @@ pub unsafe extern "C" fn dynamo_router_add_request(
                 overlap_blocks,
                 None,
                 worker,
+                None, // lora_name not exposed in C API yet
             )
             .await;
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1248,6 +1248,7 @@ impl KvPushRouter {
                     &token_ids,
                     router_config_override.as_ref(),
                     update_states,
+                    None, // lora_name not exposed in Python API yet
                 )
                 .await
                 .map_err(to_pyerr)?;

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -222,6 +222,8 @@ pub struct ActiveSequenceEvent {
     pub worker: WorkerWithDpRank,
     pub data: ActiveSequenceEventData,
     pub router_id: u64,
+    #[serde(default)]
+    pub lora_name: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/lib/llm/src/kv_router/prefill_router.rs
+++ b/lib/llm/src/kv_router/prefill_router.rs
@@ -266,10 +266,12 @@ impl PrefillRouter {
                 InnerPrefillRouter::KvRouter(r) => r,
                 _ => return None,
             };
+            // Extract LORA name from routing hints
+            let lora_name = req.routing.as_ref().and_then(|r| r.lora_name.clone());
             match async {
                 kv_router
                     .chooser
-                    .find_best_match(None, &req.token_ids, None, false, None)
+                    .find_best_match(None, &req.token_ids, None, false, lora_name)
                     .await
             }
             .instrument(tracing::info_span!("kv_find_best_match"))

--- a/lib/llm/src/kv_router/prefill_router.rs
+++ b/lib/llm/src/kv_router/prefill_router.rs
@@ -269,7 +269,7 @@ impl PrefillRouter {
             match async {
                 kv_router
                     .chooser
-                    .find_best_match(None, &req.token_ids, None, false)
+                    .find_best_match(None, &req.token_ids, None, false, None)
                     .await
             }
             .instrument(tracing::info_span!("kv_find_best_match"))

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -401,21 +401,6 @@ impl KvScheduler {
     pub fn get_active_lora_counts(&self) -> HashMap<String, usize> {
         self.slots.get_active_lora_counts()
     }
-
-    /// Get the number of active requests for a specific LORA
-    pub fn get_active_count_for_lora(&self, lora_name: &str) -> usize {
-        self.slots.get_active_count_for_lora(lora_name)
-    }
-
-    /// Get the LORA name for a specific request
-    pub fn get_lora_for_request(&self, request_id: &str) -> Option<String> {
-        self.slots.get_lora_for_request(request_id)
-    }
-
-    /// Get all active LORAs (names only)
-    pub fn get_active_loras(&self) -> Vec<String> {
-        self.slots.get_active_loras()
-    }
 }
 
 // Helper function for softmax sampling

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -1463,12 +1463,16 @@ mod tests {
     #[tokio::test]
     async fn test_get_active_count_for_lora_tracks_requests() -> Result<()> {
         dynamo_runtime::logging::init();
-        unsafe {
-            std::env::set_var("DYN_EVENT_PLANE", "zmq");
-        }
-
         let runtime = Runtime::from_current()?;
-        let distributed = DistributedRuntime::from_settings(runtime.clone()).await?;
+        let distributed = DistributedRuntime::new(
+            runtime.clone(),
+            dynamo_runtime::distributed::DistributedConfig {
+                store_backend: dynamo_runtime::storage::kv::Selector::Memory,
+                nats_config: None,
+                request_plane: dynamo_runtime::distributed::RequestPlaneMode::Tcp,
+            },
+        )
+        .await?;
         let namespace = distributed.namespace("test_lora_counts")?;
         let component = namespace.component("sequences")?;
 

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -841,6 +841,7 @@ impl ActiveSequencesMultiWorker {
         // Remove expired requests from request_to_worker mapping
         for expired_id in &removed_requests {
             self.request_to_worker.remove(expired_id);
+            self.request_to_lora.remove(expired_id);
         }
 
         // Publish ActiveLoad metrics for this worker

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -1203,6 +1203,12 @@ impl ActiveSequencesMultiWorker {
     }
 
     pub fn get_active_count_for_lora(&self, lora_name: &str) -> usize {
+        let lora_name = lora_name.trim();
+        if lora_name.is_empty() {
+            tracing::warn!("get_active_count_for_lora called with empty lora_name");
+            return 0;
+        }
+
         self.request_to_lora
             .iter()
             .filter(|entry| entry.value() == lora_name)

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -405,6 +405,7 @@ enum UpdateSequences {
 pub struct ActiveSequencesMultiWorker {
     senders: Arc<DashMap<WorkerWithDpRank, tokio::sync::mpsc::UnboundedSender<UpdateSequences>>>,
     request_to_worker: Arc<DashMap<RequestId, WorkerWithDpRank>>,
+    request_to_lora: Arc<DashMap<RequestId, String>>,
     handles: Arc<DashMap<WorkerWithDpRank, std::thread::JoinHandle<()>>>,
     block_size: usize,
     component: Component,
@@ -429,6 +430,7 @@ impl ActiveSequencesMultiWorker {
         let senders = Arc::new(DashMap::new());
         let handles = Arc::new(DashMap::new());
         let request_to_worker = Arc::new(DashMap::new());
+        let request_to_lora = Arc::new(DashMap::new());
 
         // Expand workers by their dp_rank
         for (worker_id, config) in workers_with_configs {
@@ -452,6 +454,7 @@ impl ActiveSequencesMultiWorker {
         let multi_worker = Self {
             senders: senders.clone(),
             request_to_worker: request_to_worker.clone(),
+            request_to_lora: request_to_lora.clone(),
             handles,
             block_size,
             component: component.clone(),
@@ -465,6 +468,7 @@ impl ActiveSequencesMultiWorker {
         if replica_sync {
             let senders_clone = senders.clone();
             let request_to_worker_clone = request_to_worker.clone();
+            let request_to_lora_clone = request_to_lora.clone();
             let component_clone = component.clone();
             let router_id_clone = router_id;
             let cancel_token = component.drt().runtime().child_token();
@@ -474,6 +478,7 @@ impl ActiveSequencesMultiWorker {
                 if let Err(e) = Self::subscribe_to_events(
                     senders_clone,
                     request_to_worker_clone,
+                    request_to_lora_clone,
                     component_clone,
                     router_id_clone,
                     cancel_token,
@@ -603,6 +608,7 @@ impl ActiveSequencesMultiWorker {
             DashMap<WorkerWithDpRank, tokio::sync::mpsc::UnboundedSender<UpdateSequences>>,
         >,
         request_to_worker: Arc<DashMap<RequestId, WorkerWithDpRank>>,
+        request_to_lora: Arc<DashMap<RequestId, String>>,
         component: Component,
         router_id: u64,
         cancel_token: CancellationToken,
@@ -642,6 +648,11 @@ impl ActiveSequencesMultiWorker {
                         } => {
                             request_to_worker.insert(event.request_id.clone(), event.worker);
 
+                            // Store lora_name mapping if present
+                            if let Some(ref lora_name) = event.lora_name {
+                                request_to_lora.insert(event.request_id.clone(), lora_name.clone());
+                            }
+
                             if let Some(sender) = senders.get(&event.worker) {
                                 // For replicated events, we create a dummy response channel since we don't need to handle expired requests
                                 let (resp_tx, _) = tokio::sync::oneshot::channel();
@@ -668,6 +679,8 @@ impl ActiveSequencesMultiWorker {
                                     request_id: event.request_id.clone(),
                                 });
                             }
+                            // Clean up lora_name mapping
+                            request_to_lora.remove(&event.request_id);
                         }
                         ActiveSequenceEventData::MarkPrefillCompleted => {
                             if let Some(worker) = request_to_worker.get(&event.request_id)
@@ -742,6 +755,7 @@ impl ActiveSequencesMultiWorker {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn add_request(
         &self,
         request_id: RequestId,
@@ -750,6 +764,7 @@ impl ActiveSequencesMultiWorker {
         overlap: u32,
         expected_output_tokens: Option<u32>,
         worker: WorkerWithDpRank,
+        lora_name: Option<String>,
     ) -> Result<(), SequenceError> {
         // Check for worker existence
         if !self.senders.contains_key(&worker) {
@@ -779,12 +794,18 @@ impl ActiveSequencesMultiWorker {
                     expected_output_tokens,
                 },
                 router_id: self.router_id,
+                lora_name: lora_name.clone(),
             };
             self.event_publisher.publish(&event).await?;
         }
 
         // Update local state with full WorkerWithDpRank
         self.request_to_worker.insert(request_id.clone(), worker);
+
+        // Store lora_name for later use in Free/MarkPrefillCompleted events
+        if let Some(lora) = lora_name {
+            self.request_to_lora.insert(request_id.clone(), lora);
+        }
 
         self.senders
             .get(&worker)
@@ -833,11 +854,18 @@ impl ActiveSequencesMultiWorker {
 
         // Publish event only if replica_sync is enabled
         if self.replica_sync {
+            // Look up lora_name from mapping
+            let lora_name = self
+                .request_to_lora
+                .get(request_id)
+                .map(|entry| entry.value().clone());
+
             let event = ActiveSequenceEvent {
                 request_id: request_id.clone(),
                 worker,
                 data: ActiveSequenceEventData::Free,
                 router_id: self.router_id,
+                lora_name,
             };
             self.event_publisher.publish(&event).await?;
         }
@@ -852,6 +880,7 @@ impl ActiveSequencesMultiWorker {
             .map_err(|_| SequenceError::WorkerChannelClosed)?;
 
         self.request_to_worker.remove(request_id);
+        self.request_to_lora.remove(request_id);
 
         // Publish ActiveLoad metrics for this worker
         self.publish_active_load_for_worker(worker).await;
@@ -882,11 +911,18 @@ impl ActiveSequencesMultiWorker {
 
         // Publish event only if replica_sync is enabled
         if self.replica_sync {
+            // Look up lora_name from mapping
+            let lora_name = self
+                .request_to_lora
+                .get(request_id)
+                .map(|entry| entry.value().clone());
+
             let event = ActiveSequenceEvent {
                 request_id: request_id.clone(),
                 worker,
                 data: ActiveSequenceEventData::MarkPrefillCompleted,
                 router_id: self.router_id,
+                lora_name,
             };
             self.event_publisher.publish(&event).await?;
         }
@@ -1156,6 +1192,37 @@ impl ActiveSequencesMultiWorker {
         self.query_workers(None, |_, resp_tx| UpdateSequences::ActiveTokens { resp_tx })
             .await
     }
+
+    pub fn get_active_lora_counts(&self) -> HashMap<String, usize> {
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for entry in self.request_to_lora.iter() {
+            let lora_name = entry.value().clone();
+            *counts.entry(lora_name).or_insert(0) += 1;
+        }
+        counts
+    }
+
+    pub fn get_active_count_for_lora(&self, lora_name: &str) -> usize {
+        self.request_to_lora
+            .iter()
+            .filter(|entry| entry.value() == lora_name)
+            .count()
+    }
+
+    pub fn get_lora_for_request(&self, request_id: &str) -> Option<String> {
+        self.request_to_lora
+            .get(request_id)
+            .map(|entry| entry.value().clone())
+    }
+
+    pub fn get_active_loras(&self) -> Vec<String> {
+        self.request_to_lora
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect()
+    }
 }
 
 impl Drop for ActiveSequencesMultiWorker {
@@ -1264,6 +1331,7 @@ mod tests {
                 0,    // no overlap
                 None, // expected_output_tokens
                 WorkerWithDpRank::new(0, 0),
+                None, // lora_name
             )
             .await?;
 
@@ -1276,6 +1344,7 @@ mod tests {
                 0,    // no overlap
                 None, // expected_output_tokens
                 WorkerWithDpRank::new(0, 1),
+                None, // lora_name
             )
             .await?;
 
@@ -1288,6 +1357,7 @@ mod tests {
                 0,    // no overlap
                 None, // expected_output_tokens
                 WorkerWithDpRank::new(1, 0),
+                None, // lora_name
             )
             .await?;
 
@@ -1423,6 +1493,7 @@ mod tests {
                 0,    // no overlap
                 None, // expected_output_tokens
                 WorkerWithDpRank::from_worker_id(0),
+                None, // lora_name
             )
             .await?;
 
@@ -1435,6 +1506,7 @@ mod tests {
                 0,    // no overlap
                 None, // expected_output_tokens
                 WorkerWithDpRank::from_worker_id(1),
+                None, // lora_name
             )
             .await?;
 
@@ -1447,6 +1519,7 @@ mod tests {
                 0,    // no overlap
                 None, // expected_output_tokens
                 WorkerWithDpRank::from_worker_id(2),
+                None, // lora_name
             )
             .await?;
 

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -737,9 +737,22 @@ impl ActiveSequencesMultiWorker {
             }
             self.handles.remove(worker);
 
+            // Collect request_ids to remove from request_to_lora
+            let requests_to_remove: Vec<RequestId> = self
+                .request_to_worker
+                .iter()
+                .filter(|entry| entry.value() == worker)
+                .map(|entry| entry.key().clone())
+                .collect();
+
             // Clean up request_to_worker mappings for this worker
             self.request_to_worker
                 .retain(|_request_id, mapped_worker| mapped_worker != worker);
+
+            // Clean up request_to_lora mappings for removed requests
+            for request_id in requests_to_remove {
+                self.request_to_lora.remove(&request_id);
+            }
         }
 
         // Add new workers

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -480,6 +480,7 @@ impl LocalModel {
     ) -> anyhow::Result<()> {
         self.card.model_type = model_type;
         self.card.model_input = model_input;
+        self.card.lora_name = lora_name.map(|name| name.to_string());
 
         // Compute model_suffix from lora_name if present
         let model_suffix = lora_name.map(|name| Slug::slugify(name).to_string());

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -230,6 +230,11 @@ pub struct ModelDeploymentCard {
     /// `Text` for engines that take care of pre-processing themselves.
     pub model_input: ModelInput,
 
+    /// Optional LoRA adapter name for this model card.
+    /// Present when this card represents a LoRA adapter registered on top of a base model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lora_name: Option<String>,
+
     /// User-defined metadata for custom worker behavior
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_data: Option<serde_json::Value>,
@@ -651,6 +656,7 @@ impl ModelDeploymentCard {
             migration_limit: 0,
             model_type: Default::default(),  // set later
             model_input: Default::default(), // set later
+            lora_name: None,
             user_data: None,
             runtime_config: ModelRuntimeConfig::default(),
             media_decoder: None,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -247,6 +247,7 @@ impl OpenAIPreprocessor {
                 dp_rank: None, // dp_rank is set later in the pipeline
                 enable_local_updates: nvext.enable_local_updates,
                 expected_output_tokens: nvext.expected_output_tokens,
+                lora_name: None, // TODO: Extract from request.model or nvext
             };
             builder.routing(Some(routing));
         }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -113,6 +113,7 @@ pub struct OpenAIPreprocessor {
     formatter: Arc<dyn OAIPromptFormatter>,
     tokenizer: Arc<dyn Tokenizer>,
     model_info: Arc<dyn ModelInfo>,
+    lora_name: Option<String>,
     /// Per-model runtime configuration propagated to response generator (e.g., reasoning/tool parser)
     runtime_config: crate::local_model::runtime_config::ModelRuntimeConfig,
     tool_call_parser: Option<String>,
@@ -136,13 +137,18 @@ impl OpenAIPreprocessor {
     ) -> Result<Arc<Self>> {
         let mdcsum = mdc.mdcsum().to_string();
         let tokenizer = Arc::new(HuggingFaceTokenizer::from_tokenizer(hf_tokenizer));
-        let Some(model_info) = mdc.model_info else {
+        let lora_name = mdc.lora_name.clone();
+        let Some(ref model_info) = mdc.model_info else {
             anyhow::bail!(
                 "Blank ModelDeploymentCard cannot be used for pre-processing, no model_info"
             );
         };
         let model_info = model_info.get_model_info()?;
         let tool_call_parser = mdc.runtime_config.tool_call_parser.clone();
+
+        if let Some(ref lora_name) = lora_name {
+            tracing::info!(model = %mdc.display_name, lora_name, "LoRA adapter detected in MDC");
+        }
 
         // // Initialize runtime config from the ModelDeploymentCard
         let runtime_config = mdc.runtime_config.clone();
@@ -158,6 +164,7 @@ impl OpenAIPreprocessor {
             tokenizer,
             model_info,
             mdcsum,
+            lora_name,
             runtime_config,
             tool_call_parser,
             #[cfg(feature = "media-nixl")]
@@ -237,6 +244,8 @@ impl OpenAIPreprocessor {
         builder.output_options(request.extract_output_options()?);
         builder.annotations(request.annotations().unwrap_or_default());
         builder.mdc_sum(Some(self.mdcsum.clone()));
+        let lora_name = self.lora_name.clone();
+
         // Extract routing hints from nvext if present
         if let Some(nvext) = request.nvext() {
             // Build routing hints from nvext fields
@@ -247,9 +256,15 @@ impl OpenAIPreprocessor {
                 dp_rank: None, // dp_rank is set later in the pipeline
                 enable_local_updates: nvext.enable_local_updates,
                 expected_output_tokens: nvext.expected_output_tokens,
-                lora_name: None, // TODO: Extract from request.model or nvext
+                lora_name,
             };
             builder.routing(Some(routing));
+        } else if lora_name.is_some() {
+            // Ensure LoRA-aware routing still gets hints even when nvext is absent.
+            builder.routing(Some(RoutingHints {
+                lora_name,
+                ..Default::default()
+            }));
         }
 
         Ok(builder)

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -47,6 +47,11 @@ pub struct RoutingHints {
     /// Used as a hint for routing decisions to estimate resource requirements.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_output_tokens: Option<u32>,
+
+    /// LORA adapter name for this request.
+    /// Used for LORA-aware routing and tracking.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lora_name: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]


### PR DESCRIPTION
#### Overview:
Add LoRA name propagation into routing and tracking so LoRA-aware KV routing works end-to-end, and persist LoRA identity in the model card.

Design doc: [lora-placement](https://github.com/ai-dynamo/enhancements/blob/bis/optimal-lora-placement/deps/000N-lora-placement/lora-placement.md)

#### Details:

- Store lora_name on ModelDeploymentCard and set it during model registration. 
- Thread lora_name through preprocessor routing hints and KV router scheduling/match calls.
- Track LoRA names in active sequence state and expose helper accessors.
- Update router replica launch script to support optional KV events configuration.

#### Where should the reviewer start?

Start at lib/llm/src/preprocessor.rs, then review lib/llm/src/kv_router.rs, lib/llm/src/kv_router/sequence.rs, and lib/llm/src/model_card.rs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes DEP-755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated LoRA adapter support across routing and scheduling so requests can carry an optional LoRA adapter name.
  * Routing hints and model deployment metadata now include LoRA adapter identification to preserve adapter context.
  * Added monitoring/query helpers to list active LoRA adapters, get per-adapter active counts, and map requests to their LoRA adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->