### PR TITLE
fix: check --served-model-name first before --model/--model-path

### DIFF
--- a/benchmarks/profiler/profile_sla.py
+++ b/benchmarks/profiler/profile_sla.py
@@ -160,7 +160,7 @@ async def run_profile(args):
         logger.info(f"Profiling GPU counts: {profile_num_gpus}")
         os.makedirs(args.output_dir, exist_ok=True)
 
-        model_name = config_modifier.get_model_name(config)
+        model_name, model_path = config_modifier.get_model_name(config)
 
         # Determine sweep max context length: allow user-provided cap to override model's if smaller
         use_specified_max_context_len = getattr(args, "max_context_length", None)
@@ -302,7 +302,7 @@ async def run_profile(args):
                         args.isl,
                         ai_perf_artifact_dir,
                         model_name,
-                        model_name,
+                        model_path,
                         base_url,
                         attention_dp_size=mapping.get_attn_dp_size(),
                     )
@@ -449,7 +449,7 @@ async def run_profile(args):
                                 num_request,
                                 ai_perf_artifact_dir,
                                 model_name,
-                                model_name,
+                                model_path,
                                 base_url=base_url,
                                 num_gpus=num_gpus,
                                 attention_dp_size=mapping.get_attn_dp_size(),
@@ -631,7 +631,7 @@ async def run_profile(args):
             profile_prefill(
                 work_dir,
                 model_name,
-                model_name,
+                model_path,
                 base_url,
                 best_prefill_gpus,
                 sweep_max_context_length,
@@ -718,7 +718,7 @@ async def run_profile(args):
             profile_decode(
                 work_dir,
                 model_name,
-                model_name,
+                model_path,
                 base_url,
                 best_decode_gpus,
                 max_kv_tokens,

--- a/benchmarks/profiler/utils/config_modifiers/protocol.py
+++ b/benchmarks/profiler/utils/config_modifiers/protocol.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import Any, Protocol, Tuple
 
 from benchmarks.profiler.utils.config import (
     Config,
@@ -69,7 +69,7 @@ class ConfigModifierProtocol(Protocol):
         ...
 
     @classmethod
-    def get_model_name(cls, config: dict) -> str:
+    def get_model_name(cls, config: dict) -> Tuple[str, str]:
         ...
 
     @classmethod

--- a/benchmarks/profiler/utils/config_modifiers/sglang.py
+++ b/benchmarks/profiler/utils/config_modifiers/sglang.py
@@ -291,29 +291,8 @@ class SGLangConfigModifier(BaseConfigModifier):
             )
             return DEFAULT_MODEL_NAME, DEFAULT_MODEL_NAME
 
-        model_name = DEFAULT_MODEL_NAME
         args = break_arguments(args)
-        # Check for --served-model-name first (API model name)
-        for i, arg in enumerate(args):
-            if arg == "--served-model-name" and i + 1 < len(args):
-                model_name = args[i + 1]
-                break
-
-        model_path = model_name
-        # Fall back to --model-path only if --served-model-name not found
-        for i, arg in enumerate(args):
-            if arg == "--model-path" and i + 1 < len(args):
-                model_path = args[i + 1]
-                break
-
-        if model_name == DEFAULT_MODEL_NAME and model_path == DEFAULT_MODEL_NAME:
-            logger.warning(
-                f"Model name not found in configuration args, using default model name: {DEFAULT_MODEL_NAME}"
-            )
-            return DEFAULT_MODEL_NAME, DEFAULT_MODEL_NAME
-        elif model_name == DEFAULT_MODEL_NAME:
-            model_name = model_path
-        return model_name, model_path
+        return cls._get_model_name_and_path_from_args(args, DEFAULT_MODEL_NAME, logger)
 
     @classmethod
     def get_port(cls, config: dict) -> int:

--- a/benchmarks/profiler/utils/config_modifiers/sglang.py
+++ b/benchmarks/profiler/utils/config_modifiers/sglang.py
@@ -291,14 +291,14 @@ class SGLangConfigModifier(BaseConfigModifier):
             return DEFAULT_MODEL_NAME
 
         args = break_arguments(args)
-        # Check for --model-path first (primary argument for SGLang)
-        for i, arg in enumerate(args):
-            if arg == "--model-path" and i + 1 < len(args):
-                return args[i + 1]
-
-        # Fall back to --served-model-name if --model-path not found
+        # Check for --served-model-name first (API model name)
         for i, arg in enumerate(args):
             if arg == "--served-model-name" and i + 1 < len(args):
+                return args[i + 1]
+
+        # Fall back to --model-path only if --served-model-name not found
+        for i, arg in enumerate(args):
+            if arg == "--model-path" and i + 1 < len(args):
                 return args[i + 1]
 
         logger.warning(

--- a/benchmarks/profiler/utils/config_modifiers/trtllm.py
+++ b/benchmarks/profiler/utils/config_modifiers/trtllm.py
@@ -4,6 +4,7 @@
 import json
 import logging
 import re
+from typing import Tuple
 
 import yaml
 
@@ -253,7 +254,7 @@ class TrtllmConfigModifier(BaseConfigModifier):
         )
 
     @classmethod
-    def get_model_name(cls, config: dict) -> str:
+    def get_model_name(cls, config: dict) -> Tuple[str, str]:
         cfg = Config.model_validate(config)
         try:
             worker_service = get_worker_service_from_config(cfg, backend="trtllm")
@@ -262,17 +263,10 @@ class TrtllmConfigModifier(BaseConfigModifier):
             logger.warning(
                 f"Worker service missing or invalid, using default model name: {DEFAULT_MODEL_NAME}"
             )
-            return DEFAULT_MODEL_NAME
+            return DEFAULT_MODEL_NAME, DEFAULT_MODEL_NAME
 
         args = break_arguments(args)
-        for i, arg in enumerate(args):
-            if arg == "--served-model-name" and i + 1 < len(args):
-                return args[i + 1]
-
-        logger.warning(
-            f"Model name not found in configuration args, using default model name: {DEFAULT_MODEL_NAME}"
-        )
-        return DEFAULT_MODEL_NAME
+        return cls._get_model_name_and_path_from_args(args, DEFAULT_MODEL_NAME, logger)
 
     @classmethod
     def get_port(cls, config: dict) -> int:

--- a/benchmarks/profiler/utils/config_modifiers/vllm.py
+++ b/benchmarks/profiler/utils/config_modifiers/vllm.py
@@ -291,6 +291,12 @@ class VllmV1ConfigModifier(BaseConfigModifier):
             return DEFAULT_MODEL_NAME
 
         args = break_arguments(args)
+        # Check for --served-model-name first (API model name)
+        for i, arg in enumerate(args):
+            if arg == "--served-model-name" and i + 1 < len(args):
+                return args[i + 1]
+
+        # Fall back to --model only if --served-model-name not found
         for i, arg in enumerate(args):
             if arg == "--model" and i + 1 < len(args):
                 return args[i + 1]

--- a/benchmarks/profiler/utils/config_modifiers/vllm.py
+++ b/benchmarks/profiler/utils/config_modifiers/vllm.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import Tuple
 
 import yaml
 
@@ -279,7 +280,7 @@ class VllmV1ConfigModifier(BaseConfigModifier):
         return cfg.model_dump()
 
     @classmethod
-    def get_model_name(cls, config: dict) -> str:
+    def get_model_name(cls, config: dict) -> Tuple[str, str]:
         cfg = Config.model_validate(config)
         try:
             worker_service = get_worker_service_from_config(cfg, backend="vllm")
@@ -288,23 +289,10 @@ class VllmV1ConfigModifier(BaseConfigModifier):
             logger.warning(
                 f"Worker service missing or invalid, using default model name: {DEFAULT_MODEL_NAME}"
             )
-            return DEFAULT_MODEL_NAME
+            return DEFAULT_MODEL_NAME, DEFAULT_MODEL_NAME
 
         args = break_arguments(args)
-        # Check for --served-model-name first (API model name)
-        for i, arg in enumerate(args):
-            if arg == "--served-model-name" and i + 1 < len(args):
-                return args[i + 1]
-
-        # Fall back to --model only if --served-model-name not found
-        for i, arg in enumerate(args):
-            if arg == "--model" and i + 1 < len(args):
-                return args[i + 1]
-
-        logger.warning(
-            f"Model name not found in configuration args, using default model name: {DEFAULT_MODEL_NAME}"
-        )
-        return DEFAULT_MODEL_NAME
+        return cls._get_model_name_and_path_from_args(args, DEFAULT_MODEL_NAME, logger)
 
     @classmethod
     def get_port(cls, config: dict) -> int:

--- a/benchmarks/profiler/utils/search_space_autogen.py
+++ b/benchmarks/profiler/utils/search_space_autogen.py
@@ -80,8 +80,8 @@ def auto_generate_search_space(args: argparse.Namespace) -> None:
             model_name_or_path = args.model
     else:
         # get the model name from config
-        args.model = config_modifier.get_model_name(config)
-        model_name_or_path = args.model
+        args.model, args.model_path = config_modifier.get_model_name(config)
+        model_name_or_path = args.model_path
     logger.info(f"Getting model info for {args.model} at {model_name_or_path}...")
     try:
         model_info = get_model_info(model_name_or_path)


### PR DESCRIPTION
#### Overview:

Bug fix: the incorrect model name was being passed to AIPerf -- it should be served model name if available

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark profiler utilities to change model name resolution logic. The system now prioritizes API-facing model identifiers when determining model references during benchmark profiling, with fallback to conventional model path identifiers if API-facing names are not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->