### PR TITLE
docs: fix prometheusEndpoint helm value path in metrics guide

### DIFF
--- a/docs/kubernetes/observability/metrics.md
+++ b/docs/kubernetes/observability/metrics.md
@@ -29,11 +29,11 @@ helm install prometheus -n monitoring --create-namespace prometheus-community/ku
 
 ### Install Dynamo Operator
 Before setting up metrics collection, you'll need to have the Dynamo operator installed in your cluster. Follow our [Installation Guide](../installation_guide.md) for detailed instructions on deploying the Dynamo operator.
-Make sure to set the `prometheusEndpoint` to the Prometheus endpoint you installed in the previous step.
+Make sure to set the `dynamo-operator.dynamo.metrics.prometheusEndpoint` to the Prometheus endpoint you installed in the previous step.
 
 ```bash
 helm install dynamo-platform ...
-  --set prometheusEndpoint=http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
+  --set dynamo-operator.dynamo.metrics.prometheusEndpoint=http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
 ```
 
 

--- a/fern/pages/kubernetes/observability/metrics.md
+++ b/fern/pages/kubernetes/observability/metrics.md
@@ -34,11 +34,11 @@ helm install prometheus -n monitoring --create-namespace prometheus-community/ku
 
 ### Install Dynamo Operator
 Before setting up metrics collection, you'll need to have the Dynamo operator installed in your cluster. Follow our [Installation Guide](../installation-guide.md) for detailed instructions on deploying the Dynamo operator.
-Make sure to set the `prometheusEndpoint` to the Prometheus endpoint you installed in the previous step.
+Make sure to set the `dynamo-operator.dynamo.metrics.prometheusEndpoint` to the Prometheus endpoint you installed in the previous step.
 
 ```bash
 helm install dynamo-platform ...
-  --set prometheusEndpoint=http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
+  --set dynamo-operator.dynamo.metrics.prometheusEndpoint=http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
 ```
 
 


### PR DESCRIPTION
## Summary
- Updates the `prometheusEndpoint` helm value path to the correct `dynamo-operator.dynamo.metrics.prometheusEndpoint` in the metrics documentation

## Test plan
- [ ] Verify the helm value path matches the actual chart values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Prometheus endpoint configuration reference in Kubernetes observability metrics documentation to use the operator-specific configuration path, ensuring consistency with current deployment requirements.
* Corrected Helm CLI installation example command to reference the proper endpoint configuration syntax for Prometheus integration setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->