### PR TITLE
chore: rename terminate_existing to terminate_all_matching_processes

### DIFF
--- a/tests/basic/test_autodeploy_backend.py
+++ b/tests/basic/test_autodeploy_backend.py
@@ -73,7 +73,7 @@ class DynamoWorkerProcess(ManagedProcess):
             ],
             timeout=360,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             log_dir=log_dir,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,7 +278,7 @@ class EtcdServer(ManagedProcess):
             command=command,
             timeout=timeout,
             display_output=False,
-            terminate_existing=not use_random_port,  # Disabled for parallel test execution with random ports
+            terminate_all_matching_process_names=not use_random_port,  # For distributed tests, do not terminate all matching processes
             health_check_ports=[port],
             data_dir=data_dir,
             log_dir=request.node.name,
@@ -325,7 +325,7 @@ class NatsServer(ManagedProcess):
             command=command,
             timeout=timeout,
             display_output=False,
-            terminate_existing=not use_random_port,  # Disabled for parallel test execution with random ports
+            terminate_all_matching_process_names=not use_random_port,  # For distributed tests, do not terminate all matching processes
             data_dir=data_dir,
             health_check_ports=[port],
             health_check_funcs=[self._nats_ready],

--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -142,7 +142,7 @@ class DynamoWorkerProcess(ManagedProcess):
             health_check_urls=health_check_urls,
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             # Ensure any orphaned SGLang engine cores or child helpers are cleaned up
             stragglers=[
                 "SGLANG:EngineCore",

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -134,7 +134,7 @@ class DynamoWorkerProcess(ManagedProcess):
             health_check_urls=health_check_urls,
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             log_dir=log_dir,
         )
 

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -123,7 +123,7 @@ class DynamoWorkerProcess(ManagedProcess):
             health_check_urls=health_check_urls,
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             # Ensure any orphaned vLLM engine cores or child helpers are cleaned up
             stragglers=[
                 "VLLM::EngineCore",

--- a/tests/fault_tolerance/cancellation/utils.py
+++ b/tests/fault_tolerance/cancellation/utils.py
@@ -36,7 +36,7 @@ class DynamoFrontendProcess(BaseDynamoFrontendProcess):
             frontend_port=0,  # allocate a free port (xdist-safe)
             router_mode="round-robin",
             extra_env=extra_env,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
         )
 
 

--- a/tests/fault_tolerance/etcd_ha/test_sglang.py
+++ b/tests/fault_tolerance/etcd_ha/test_sglang.py
@@ -118,7 +118,7 @@ class DynamoWorkerProcess(ManagedProcess):
             health_check_urls=health_check_urls,
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             # Ensure any orphaned SGLang engine cores or child helpers are cleaned up
             stragglers=[
                 "SGLANG:EngineCore",

--- a/tests/fault_tolerance/etcd_ha/test_trtllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_trtllm.py
@@ -107,7 +107,7 @@ class DynamoWorkerProcess(ManagedProcess):
             health_check_urls=health_check_urls,
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             log_dir=log_dir,
         )
 

--- a/tests/fault_tolerance/etcd_ha/test_vllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_vllm.py
@@ -84,7 +84,7 @@ class DynamoWorkerProcess(ManagedProcess):
             health_check_urls=health_check_urls,
             timeout=120,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=[
                 "VLLM::EngineCore",
             ],

--- a/tests/fault_tolerance/etcd_ha/utils.py
+++ b/tests/fault_tolerance/etcd_ha/utils.py
@@ -31,11 +31,16 @@ class DynamoFrontendProcess(BaseDynamoFrontendProcess):
             "DYN_LOG": "debug",
             "ETCD_ENDPOINTS": ",".join(etcd_endpoints),
         }
+        # WARNING: terminate_all_matching_process_names=True is NOT pytest-xdist safe!
+        # DANGER: Kills ALL dynamo-frontend processes system-wide, including other parallel tests.
+        # For parallel-safe alternative, use terminate_all_matching_process_names=False.
+        # See tests/kvbm_integration/common.py:llm_server_kvbm for example.
+        # TODO: Switch to terminate_all_matching_process_names=False with dynamic ports
         super().__init__(
             request,
             router_mode="round-robin",
             extra_env=extra_env,
-            terminate_existing=True,
+            terminate_all_matching_process_names=True,  # TODO: Change to False
         )
 
 
@@ -90,7 +95,7 @@ class EtcdReplicaServer(ManagedProcess):
             command=command,
             timeout=timeout,
             display_output=False,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             data_dir=data_dir,
             log_dir=log_dir,
         )

--- a/tests/fault_tolerance/gpu_memory_service/utils/common.py
+++ b/tests/fault_tolerance/gpu_memory_service/utils/common.py
@@ -96,7 +96,7 @@ class GMSServerProcess(ManagedProcess):
             env={**os.environ, "DYN_LOG": "debug"},
             timeout=60,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             log_dir=log_dir,
             health_check_funcs=[self._socket_ready],
         )

--- a/tests/fault_tolerance/gpu_memory_service/utils/sglang.py
+++ b/tests/fault_tolerance/gpu_memory_service/utils/sglang.py
@@ -60,7 +60,7 @@ class SGLangWithGMSProcess(ManagedProcess):
             ],
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=[],
             log_dir=log_dir,
         )

--- a/tests/fault_tolerance/gpu_memory_service/utils/vllm.py
+++ b/tests/fault_tolerance/gpu_memory_service/utils/vllm.py
@@ -61,7 +61,7 @@ class VLLMWithGMSProcess(ManagedProcess):
             ],
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=[],
             log_dir=log_dir,
         )

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -184,7 +184,7 @@ class DynamoWorkerProcess(ManagedProcess):
             health_check_urls=health_check_urls,
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=["SGLANG:EngineCore"],
             straggler_commands=["-m dynamo.sglang"],
             log_dir=log_dir,

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -173,7 +173,7 @@ class DynamoWorkerProcess(ManagedProcess):
             health_check_urls=health_check_urls,
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             log_dir=log_dir,
             display_name=worker_id,
         )

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -167,7 +167,7 @@ class DynamoWorkerProcess(ManagedProcess):
             health_check_urls=health_check_urls,
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=["VLLM::EngineCore"],
             straggler_commands=["-m dynamo.vllm"],
             log_dir=log_dir,

--- a/tests/fault_tolerance/migration/utils.py
+++ b/tests/fault_tolerance/migration/utils.py
@@ -37,7 +37,7 @@ class DynamoFrontendProcess(BaseDynamoFrontendProcess):
             router_mode="round-robin",
             extra_args=extra_args if extra_args else None,
             extra_env=extra_env,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             display_name="frontend",
         )
 

--- a/tests/fault_tolerance/test_vllm_health_check.py
+++ b/tests/fault_tolerance/test_vllm_health_check.py
@@ -63,7 +63,7 @@ class DynamoWorkerProcess(ManagedProcess):
             ],
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=["VLLM::EngineCore"],
             straggler_commands=["-m dynamo.vllm"],
             log_dir=log_dir,

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -58,7 +58,7 @@ def start_services_with_http(
     with DynamoFrontendProcess(
         request,
         frontend_port=ports.frontend_port,
-        terminate_existing=False,
+        terminate_all_matching_process_names=False,
     ):
         logger.info(f"HTTP Frontend started on port {ports.frontend_port}")
         yield ports.frontend_port, ports.system_ports[0]
@@ -188,7 +188,7 @@ def start_services_with_grpc(
         with DynamoFrontendProcess(
             request,
             frontend_port=ports.frontend_port,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             extra_args=[
                 "--kserve-grpc-server",
                 "--grpc-metrics-port",
@@ -261,7 +261,7 @@ class MockerWorkerProcess(ManagedProcess):
             ],
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=["VLLM::EngineCore"],
             straggler_commands=["-m dynamo.mocker"],
             log_dir=log_dir,

--- a/tests/frontend/grpc/test_tensor_mocker_engine.py
+++ b/tests/frontend/grpc/test_tensor_mocker_engine.py
@@ -63,7 +63,7 @@ class MockWorkerProcess(ManagedProcess):
             ],
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=[],
             straggler_commands=["echo_tensor_worker.py"],
             log_dir=log_dir,

--- a/tests/frontend/grpc/test_tensor_parameters.py
+++ b/tests/frontend/grpc/test_tensor_parameters.py
@@ -54,7 +54,7 @@ class EchoTensorWorkerProcess(ManagedProcess):
             timeout=300,
             display_output=True,
             log_dir=log_dir,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
         )
 
 

--- a/tests/frontend/test_prompt_embeds.py
+++ b/tests/frontend/test_prompt_embeds.py
@@ -107,7 +107,7 @@ class VllmPromptEmbedsWorkerProcess(ManagedProcess):
             ],
             timeout=500,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=["VLLM::EngineCore"],
             straggler_commands=["-m dynamo.vllm"],
             log_dir=log_dir,
@@ -151,7 +151,7 @@ def start_services(
     with DynamoFrontendProcess(
         request,
         frontend_port=frontend_port,
-        terminate_existing=False,
+        terminate_all_matching_process_names=False,
         extra_args=["--store-kv", "file", "--request-plane", "tcp"],
     ):
         logger.info("Frontend started for prompt embeds tests")

--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -118,7 +118,7 @@ class VllmWorkerProcess(ManagedProcess):
             ],
             timeout=500,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=["VLLM::EngineCore"],
             straggler_commands=["-m dynamo.vllm"],
             log_dir=log_dir,
@@ -180,7 +180,7 @@ def start_services(
         # If the frontend hits a Rust panic, enabling backtraces makes failures diagnosable
         # from CI logs without needing to repro locally.
         # extra_env={"RUST_BACKTRACE": "1", "TOKIO_BACKTRACE": "1"},
-        terminate_existing=False,
+        terminate_all_matching_process_names=False,
     ):
         logger.info("Frontend started for tests")
         with VllmWorkerProcess(

--- a/tests/kvbm_integration/common.py
+++ b/tests/kvbm_integration/common.py
@@ -635,7 +635,7 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
             except Exception:
                 pass  # Continue cleanup even if one process fails
 
-    # SAFETY: Do NOT use terminate_existing=True or stragglers=["vllm"] here.
+    # SAFETY: Do NOT use terminate_all_matching_process_names=True or stragglers=["vllm"] here.
     # Those kill ALL vLLM processes system-wide, breaking parallel test execution.
     # Port-based cleanup above is targeted and xdist-safe.
     with ManagedProcess(
@@ -644,7 +644,7 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
         health_check_ports=[port, metrics_port],  # vLLM server + KVBM metrics
         timeout=timeout,
         display_output=True,
-        terminate_existing=False,  # Port-based cleanup done above instead
+        terminate_all_matching_process_names=False,  # Port-based cleanup done above instead
         stragglers=[],  # Empty - we handle cleanup manually per port
         straggler_commands=[],  # Empty - we handle cleanup manually per port
         log_dir=log_dir,

--- a/tests/kvbm_integration/test_consolidator_router_e2e.py
+++ b/tests/kvbm_integration/test_consolidator_router_e2e.py
@@ -312,7 +312,7 @@ def frontend_server(test_directory, runtime_services):
         working_dir=str(test_directory),
         display_output=False,
         log_dir=str(frontend_log_dir),  # Absolute path keeps logs in test directory
-        terminate_existing=False,  # Don't kill nats-server/etcd started by runtime_services
+        terminate_all_matching_process_names=False,  # Don't kill nats-server/etcd started by runtime_services
     ) as frontend_process:
         # Get actual log file path from ManagedProcess (it may modify log_dir to use temp directory)
         log_file = Path(frontend_process._log_path)
@@ -405,7 +405,7 @@ def llm_worker(frontend_server, test_directory, runtime_services, engine_type):
         working_dir=str(test_directory),
         display_output=False,
         log_dir=str(worker_log_dir),  # Absolute path keeps logs in test directory
-        terminate_existing=False,
+        terminate_all_matching_process_names=False,
     ) as worker_process:
         # Get actual log file path from ManagedProcess (it may modify log_dir to use temp directory)
         log_file = Path(worker_process._log_path)
@@ -743,7 +743,7 @@ class TestConsolidatorRouterE2E:
             working_dir=str(test_directory),
             display_output=False,
             log_dir=str(frontend_log_dir),  # Absolute path keeps logs in test directory
-            terminate_existing=False,  # Don't kill nats-server/etcd started by runtime_services
+            terminate_all_matching_process_names=False,  # Don't kill nats-server/etcd started by runtime_services
         ) as _frontend_process:
             # Get actual log file path from ManagedProcess
             frontend_log = Path(_frontend_process._log_path)
@@ -829,7 +829,7 @@ class TestConsolidatorRouterE2E:
                 log_dir=str(
                     worker_log_dir
                 ),  # Absolute path keeps logs in test directory
-                terminate_existing=False,
+                terminate_all_matching_process_names=False,
             ) as _worker_process:
                 # Get actual log file path from ManagedProcess (it may modify log_dir to use temp directory)
                 worker_log = Path(_worker_process._log_path)

--- a/tests/kvbm_integration/test_cuda_graph.py
+++ b/tests/kvbm_integration/test_cuda_graph.py
@@ -88,7 +88,7 @@ class DynamoWorkerProcess(ManagedProcess):
             ],
             timeout=300,
             display_output=True,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             log_dir=log_dir,
         )
 

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -94,7 +94,7 @@ class KVRouterProcess(ManagedProcess):
                 (f"http://localhost:{frontend_port}/v1/models", self._check_ready)
             ],
             log_dir=request.node.name,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
         )
         self.port = frontend_port
 
@@ -1222,7 +1222,7 @@ def _test_router_overload_503(
                 )
             ],
             log_dir=request.node.name,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
         )
         kv_router.__enter__()
 

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -208,7 +208,7 @@ class MockerProcess:
             health_check_ports=[],
             health_check_urls=[],
             log_dir=request.node.name,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
         )
         logger.info(
             f"Created mocker process with {num_mockers} worker(s), endpoint: {self.endpoint}"
@@ -294,7 +294,7 @@ class DisaggMockerProcess:
             health_check_ports=[],
             health_check_urls=[],
             log_dir=request.node.name,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
         )
         logger.info(
             f"Created {worker_type} mocker process with {num_mockers} worker(s), "

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -209,7 +209,7 @@ class SGLangProcess:
                 health_check_ports=[],
                 health_check_urls=[],
                 log_dir=request.node.name,
-                terminate_existing=False,
+                terminate_all_matching_process_names=False,
             )
             self.worker_processes.append(process)
             if data_parallel_size is not None:
@@ -251,7 +251,7 @@ class SGLangProcess:
                 if process.data_dir:
                     process._remove_directory(process.data_dir)
 
-                process._terminate_existing()
+                process._terminate_all_matching_process_names()
                 logger.info(
                     f"[SGLangProcess] Launching process {i} (pid will be assigned)..."
                 )

--- a/tests/router/test_router_e2e_with_trtllm.py
+++ b/tests/router/test_router_e2e_with_trtllm.py
@@ -189,7 +189,7 @@ class TRTLLMProcess:
                 health_check_ports=[],
                 health_check_urls=[],
                 log_dir=request.node.name,
-                terminate_existing=False,
+                terminate_all_matching_process_names=False,
             )
             self.worker_processes.append(process)
             logger.info(
@@ -224,7 +224,7 @@ class TRTLLMProcess:
                 if process.data_dir:
                     process._remove_directory(process.data_dir)
 
-                process._terminate_existing()
+                process._terminate_all_matching_process_names()
                 logger.info(
                     f"[TRTLLMProcess] Launching process {i} (pid will be assigned)..."
                 )

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -226,7 +226,7 @@ class VLLMProcess:
                 health_check_ports=[],
                 health_check_urls=[],
                 log_dir=request.node.name,
-                terminate_existing=False,
+                terminate_all_matching_process_names=False,
             )
             self.worker_processes.append(process)
             if data_parallel_size is not None:
@@ -268,7 +268,7 @@ class VLLMProcess:
                 if process.data_dir:
                     process._remove_directory(process.data_dir)
 
-                process._terminate_existing()
+                process._terminate_all_matching_process_names()
                 logger.info(
                     f"[VLLMProcess] Launching process {i} (pid will be assigned)..."
                 )

--- a/tests/utils/engine_process.py
+++ b/tests/utils/engine_process.py
@@ -187,7 +187,7 @@ class EngineProcess(ManagedProcess):
                 ),
             ],
             delayed_start=config.delayed_start,
-            terminate_existing=False,
+            terminate_all_matching_process_names=False,
             stragglers=config.stragglers,
             log_dir=request.node.name,
         )


### PR DESCRIPTION
#### Overview:

No logic change. Renamed `terminate_existing` to `terminate_all_matching_process_names` for clarity. The old name was misleading - it kills ALL system processes matching the name, not just what we launched.

#### Details:

- Renamed parameter/field/method across 33 test files
- Added kill sequence documentation (SIGTERM → wait → SIGKILL)
- Added pytest-xdist safety warnings and TODO comments
- Enhanced logging to clarify SIGTERM vs SIGKILL
- No logic changes - verified all changes are naming and documentation only

#### Where should the reviewer start?

tests/utils/managed_process.py: Review documentation additions explaining the dangerous system-wide killing behavior and recommended usage patterns

#### Related Issues:

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test process termination semantics with clearer parameter naming for process cleanup operations.

* **Chores**
  * Refactored internal process management parameter naming for better clarity in test infrastructure across multiple test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->