### PR TITLE
docs: update support matrix with backend dependencies for Dynamo 0.9.0 + 1.0.0

### DIFF
--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -17,8 +17,11 @@ The following table shows the backend framework versions included with each Dyna
 | **Dynamo** | **vLLM** | **SGLang** | **TensorRT-LLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
 | **main (ToT)** | `0.14.1` | `0.5.8` | `1.3.0rc1` | `0.9.0` |
-| **v0.8.1.post2** | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post1` | `0.8.0` |
-| **v0.8.1.post1** | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post2` | `0.8.0` |
+| **v1.0.0** *(planned)* | `0.15.0` | *Latest as of 2/17* | *Latest as of 2/17* | `0.10.0` |
+| **v0.9.0** *(in progress)* | `0.14.1` | `0.5.8` | `1.3.0rc1` | `0.9.0` |
+| **v0.8.1.post3** *(in progress)* | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post3` | `0.8.0` |
+| **v0.8.1.post2** | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post2` | `0.8.0` |
+| **v0.8.1.post1** | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post1` | `0.8.0` |
 | **v0.8.1** | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post1` | `0.8.0` |
 | **v0.8.0** | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post1` | `0.8.0` |
 | **v0.7.1** | `0.11.0` | `0.5.4.post3` | `1.2.0rc3` | `0.8.0` |
@@ -28,13 +31,15 @@ The following table shows the backend framework versions included with each Dyna
 | **v0.6.1** | `0.11.0` | `0.5.3.post2` | `1.1.0rc5` | `0.6.0` |
 | **v0.6.0** | `0.11.0` | `0.5.3.post2` | `1.1.0rc5` | `0.6.0` |
 
-> [!Important]
-> These are the only backend versions tested and supported with each Dynamo release. Using other backend versions is not recommended and compatibility is not guaranteed.
+#### Version Labels
 
-**main (ToT)** reflects the current development branch. Patch versions (e.g., v0.8.1.post1) inherit backend versions from their base release unless otherwise noted.
+- **main (ToT)** reflects the current development branch.
+- Releases marked *(in progress)* or *(planned)* show target versions that may change before final release.
 
-> [!Important]
-> Currently TensorRT-LLM does not support Python 3.11 so installation of the ai-dynamo[trtllm] Python wheel will fail.
+#### Version Compatibility
+
+- Backend versions listed are the only versions tested and supported for each release.
+- TensorRT-LLM does not support Python 3.11; installation of the `ai-dynamo[trtllm]` wheel will fail on Python 3.11.
 
 ### CUDA Versions by Backend
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -31,12 +31,12 @@ The following table shows the backend framework versions included with each Dyna
 | **v0.6.1** | `0.11.0` | `0.5.3.post2` | `1.1.0rc5` | `0.6.0` |
 | **v0.6.0** | `0.11.0` | `0.5.3.post2` | `1.1.0rc5` | `0.6.0` |
 
-#### Version Labels
+### Version Labels
 
 - **main (ToT)** reflects the current development branch.
 - Releases marked *(in progress)* or *(planned)* show target versions that may change before final release.
 
-#### Version Compatibility
+### Version Compatibility
 
 - Backend versions listed are the only versions tested and supported for each release.
 - TensorRT-LLM does not support Python 3.11; installation of the `ai-dynamo[trtllm]` wheel will fail on Python 3.11.


### PR DESCRIPTION
## Summary

- Add backend dependency versions for v1.0.0 (planned), v0.9.0 (in progress), and v0.8.1.post3 (in progress)
- Fix swapped TensorRT-LLM versions for v0.8.1.post1 and v0.8.1.post2
- Restructure notes into "Version Labels" and "Version Compatibility" sections

## Details

Updates the Backend Dependencies table in the support matrix to include upcoming releases:

| Release | vLLM | SGLang | TensorRT-LLM | NIXL |
|---------|------|--------|--------------|------|
| v1.0.0 (planned) | 0.15.0 | Latest as of 2/17 | Latest as of 2/17 | 0.10.0 |
| v0.9.0 (in progress) | 0.14.1 | 0.5.8 | 1.3.0rc1 | 0.9.0 |
| v0.8.1.post3 (in progress) | 0.12.0 | 0.5.6.post2 | 1.2.0rc6.post3 | 0.8.0 |

Also fixes the TRT-LLM version swap where v0.8.1.post1 incorrectly showed `1.2.0rc6.post2` and v0.8.1.post2 incorrectly showed `1.2.0rc6.post1`.

## Where should the reviewer start?

`docs/reference/support-matrix.md` - Backend Dependencies section

## Test Plan

- [ ] CI passes
- [ ] Docs build successfully

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the backend version support matrix with new planned and in-progress versions (v1.0.0, v0.9.0, v0.8.1.post3).
* Reorganized and clarified version compatibility guidance, including Python version support information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->