### PR TITLE
chore: remove media-nixl feature

### DIFF
--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -91,15 +91,15 @@ jobs:
         working-directory: ./deploy
         run: |
           docker compose up -d nats-server etcd-server
-      - name: Run Rust checks (block-manager + media-nixl + media-ffmpeg + integration tests)
+      - name: Run Rust checks (block-manager + media-ffmpeg + integration tests)
         run: |
           docker run --rm -w /workspace/lib/llm \
             --name ${{ env.CONTAINER_ID }}_rust_checks \
             ${{ steps.define_image_tag.outputs.image_tag }} \
             bash -ec 'rustup component add rustfmt clippy && \
                       cargo fmt -- --check && \
-                      cargo clippy --features block-manager,media-nixl,media-ffmpeg --no-deps --all-targets -- -D warnings && \
-                      cargo test --locked --all-targets --features=block-manager,media-nixl,media-ffmpeg,testing-nixl && \
+                      cargo clippy --features block-manager,media-ffmpeg --no-deps --all-targets -- -D warnings && \
+                      cargo test --locked --all-targets --features=block-manager,media-ffmpeg,testing-nixl && \
                       cargo test --locked --features integration -- --nocapture'
       - name: Cleanup services
         if: always()

--- a/container/README.md
+++ b/container/README.md
@@ -272,8 +272,6 @@ The build process automatically:
 
 For more details, see [`deploy/inference-gateway/README.md`](../deploy/inference-gateway/README.md).
 
-**Note:** `--framework none` defaults `ENABLE_MEDIA_NIXL=false`.
-
 #### Frontend Image Contents
 
 The frontend image includes:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -25,7 +25,6 @@ dynamo:
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
   nixl_libfabric_ref: v2.3.0
   enable_kvbm: "false"
-  enable_media_nixl: "false"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "false"
   ffmpeg_version: "7.1"
@@ -39,7 +38,6 @@ vllm:
   flashinf_ref: v0.5.3
   lmcache_ref: 0.3.12
   max_jobs: "10"
-  enable_media_nixl: "true"
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
@@ -57,7 +55,6 @@ sglang:
   cuda13.0:
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: v0.5.8-cu130-runtime
-  enable_media_nixl: "true"
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"
@@ -67,7 +64,6 @@ trtllm:
   base_image_tag: 25.12-py3
   runtime_image: nvcr.io/nvidia/cuda-dl-base
   runtime_image_tag: 25.10-cuda13.0-runtime-ubuntu24.04
-  enable_media_nixl: "true"
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "false"
   enable_kvbm: "true"

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -50,7 +50,6 @@ ARG CARGO_BUILD_JOBS
 ARG NATS_VERSION={{ context.dynamo.nats_version }}
 ARG ETCD_VERSION={{ context.dynamo.etcd_version }}
 
-ARG ENABLE_MEDIA_NIXL={{ context[framework].enable_media_nixl }}
 ARG ENABLE_MEDIA_FFMPEG={{ context[framework].enable_media_ffmpeg }}
 ARG FFMPEG_VERSION={{ context.dynamo.ffmpeg_version }}
 ARG ENABLE_GPU_MEMORY_SERVICE={{ context[framework].enable_gpu_memory_service }}

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -347,15 +347,8 @@ RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     cd /opt/dynamo && \
     uv build --wheel --out-dir /opt/dynamo/dist && \
     cd /opt/dynamo/lib/bindings/python && \
-    FEATURES=""; \
-    if [ "$ENABLE_MEDIA_NIXL" = "true" ]; then \
-        FEATURES="$FEATURES dynamo-llm/media-nixl"; \
-    fi; \
     if [ "$ENABLE_MEDIA_FFMPEG" = "true" ]; then \
-        FEATURES="$FEATURES media-ffmpeg"; \
-    fi; \
-    if [ -n "$FEATURES" ]; then \
-        maturin build --release --features "$FEATURES" --out /opt/dynamo/dist; \
+        maturin build --release --features "media-ffmpeg" --out /opt/dynamo/dist; \
     else \
         maturin build --release --out /opt/dynamo/dist; \
     fi && \

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -13,7 +13,7 @@ readme.workspace = true
 description = "Dynamo LLM Library"
 
 [features]
-default = ["media-nixl", "block-manager"]
+default = ["block-manager"]
 # todo(ops): get this working in CI as a default.
 # default = ["block-manager", "testing-full"]
 
@@ -25,8 +25,7 @@ block-manager = ["dep:nixl-sys", "dep:cudarc", "dep:nix", "dep:aligned-vec"]
 block-manager-bench = ["block-manager", "testing-full", "dep:clap", "dep:indicatif"]
 cuda = ["dep:cudarc"]
 integration = ["dynamo-runtime/integration"]
-media-nixl = ["dep:nixl-sys", "dep:flate2"]
-media-ffmpeg = ["dep:video-rs", "dep:ffmpeg-next", "dep:memfile", "media-nixl"]
+media-ffmpeg = ["dep:video-rs", "dep:ffmpeg-next", "dep:memfile"]
 bench = ["dynamo-kv-router/bench"]
 kv-router-stress = ["dep:clap", "dep:indicatif", "bench"]
 
@@ -117,8 +116,8 @@ nixl-sys = { version = "=0.9.0", optional = true }
 cudarc = { workspace = true, optional = true }
 nix = { version = "0.26", optional = true }
 
-# media-nixl (zlib compression for NIXL metadata)
-flate2 = { version = "1", optional = true }
+# media (zlib compression for NIXL metadata)
+flate2 = { version = "1" }
 
 # block_manager_bench
 clap = { version = "4.5.49", features = ["derive"], optional = true }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -28,7 +28,6 @@ use std::{collections::HashMap, pin::Pin, sync::Arc};
 use tracing;
 
 use crate::model_card::{ModelDeploymentCard, ModelInfo};
-#[cfg(feature = "media-nixl")]
 use crate::preprocessor::media::MediaLoader;
 use crate::preprocessor::prompt::OAIChatLikeRequest;
 use crate::protocols::common::preprocessor::{
@@ -141,7 +140,6 @@ pub struct OpenAIPreprocessor {
     /// Per-model runtime configuration propagated to response generator (e.g., reasoning/tool parser)
     runtime_config: crate::local_model::runtime_config::ModelRuntimeConfig,
     tool_call_parser: Option<String>,
-    #[cfg(feature = "media-nixl")]
     media_loader: Option<MediaLoader>,
 }
 
@@ -177,7 +175,6 @@ impl OpenAIPreprocessor {
         // // Initialize runtime config from the ModelDeploymentCard
         let runtime_config = mdc.runtime_config.clone();
 
-        #[cfg(feature = "media-nixl")]
         let media_loader = match mdc.media_decoder {
             Some(media_decoder) => Some(MediaLoader::new(media_decoder, mdc.media_fetcher)?),
             None => None,
@@ -191,7 +188,6 @@ impl OpenAIPreprocessor {
             lora_name,
             runtime_config,
             tool_call_parser,
-            #[cfg(feature = "media-nixl")]
             media_loader,
         }))
     }
@@ -336,7 +332,6 @@ impl OpenAIPreprocessor {
         builder: &mut PreprocessedRequestBuilder,
     ) -> Result<()> {
         let mut media_map: MultimodalDataMap = HashMap::new();
-        #[cfg(feature = "media-nixl")]
         let mut fetch_tasks: Vec<(String, ChatCompletionRequestUserMessageContentPart)> =
             Vec::new();
 
@@ -366,7 +361,6 @@ impl OpenAIPreprocessor {
                     _ => continue,
                 };
 
-                #[cfg(feature = "media-nixl")]
                 if self.media_loader.is_some() {
                     fetch_tasks.push((type_str, content_part.clone()));
                     continue;
@@ -381,7 +375,6 @@ impl OpenAIPreprocessor {
         }
 
         // Execute all fetch tasks
-        #[cfg(feature = "media-nixl")]
         if !fetch_tasks.is_empty() {
             let loader = self.media_loader.as_ref().unwrap();
             let media_io_kwargs = request.media_io_kwargs();

--- a/lib/llm/src/preprocessor/media.rs
+++ b/lib/llm/src/preprocessor/media.rs
@@ -10,6 +10,4 @@ pub use common::EncodedMediaData;
 pub use decoders::{Decoder, ImageDecoder, MediaDecoder};
 pub use loader::{MediaFetcher, MediaLoader};
 
-pub use rdma::{DecodedMediaData, RdmaMediaDataDescriptor};
-#[cfg(feature = "media-nixl")]
-pub use rdma::{get_nixl_agent, get_nixl_metadata};
+pub use rdma::{DecodedMediaData, RdmaMediaDataDescriptor, get_nixl_agent, get_nixl_metadata};

--- a/lib/llm/src/preprocessor/media/README.md
+++ b/lib/llm/src/preprocessor/media/README.md
@@ -44,7 +44,7 @@ register_llm(
 ## Known Limitations
 
 > [!WARNING]
-> **Incompatible with `Dockerfile.frontend`**: Frontend media decoding (enabled with `--features media-nixl`) is not supported when using `Dockerfile.frontend`. The frontend image built from `Dockerfile.frontend` does not enable the feature + include the required NIXL/UCX dependencies.
+> **Incompatible with `Dockerfile.frontend`**: Frontend media decoding is not supported when using `Dockerfile.frontend`. The frontend image built from `Dockerfile.frontend` does not include the required NIXL/UCX dependencies.
 
 > [!WARNING]
 > **Requires GPU node**: The frontend must run on a node with GPU access. During media processing, decoded tensors are written to GPU memory via NIXL, which requires `libcuda.so.1` to be available. Running the frontend on a CPU-only node will fail with something like: `Failed to initialize required backends: [UCX: No UCX plugin found]`.

--- a/lib/llm/src/preprocessor/media/loader.rs
+++ b/lib/llm/src/preprocessor/media/loader.rs
@@ -7,15 +7,11 @@ use std::time::Duration;
 use anyhow::Result;
 
 use dynamo_async_openai::types::ChatCompletionRequestUserMessageContentPart;
+use dynamo_memory::nixl::NixlAgent;
 
-use super::decoders::MediaDecoder;
-use super::rdma::RdmaMediaDataDescriptor;
-
-#[cfg(feature = "media-nixl")]
-use {
-    super::common::EncodedMediaData, super::decoders::Decoder, super::rdma::get_nixl_agent,
-    dynamo_memory::nixl::NixlAgent,
-};
+use super::common::EncodedMediaData;
+use super::decoders::{Decoder, MediaDecoder};
+use super::rdma::{RdmaMediaDataDescriptor, get_nixl_agent};
 
 const DEFAULT_HTTP_USER_AGENT: &str = "dynamo-ai/dynamo";
 const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
@@ -75,7 +71,6 @@ pub struct MediaLoader {
     http_client: reqwest::Client,
     #[allow(dead_code)]
     media_fetcher: MediaFetcher,
-    #[cfg(feature = "media-nixl")]
     nixl_agent: NixlAgent,
 }
 
@@ -91,14 +86,12 @@ impl MediaLoader {
 
         let http_client = http_client_builder.build()?;
 
-        #[cfg(feature = "media-nixl")]
         let nixl_agent = get_nixl_agent()?;
 
         Ok(Self {
             media_decoder,
             http_client,
             media_fetcher,
-            #[cfg(feature = "media-nixl")]
             nixl_agent,
         })
     }
@@ -108,66 +101,58 @@ impl MediaLoader {
         oai_content_part: &ChatCompletionRequestUserMessageContentPart,
         media_io_kwargs: Option<&MediaDecoder>,
     ) -> Result<RdmaMediaDataDescriptor> {
-        #[cfg(not(feature = "media-nixl"))]
-        anyhow::bail!(
-            "NIXL is not supported, cannot decode and register media data {oai_content_part:?} with media_io_kwargs {media_io_kwargs:?}"
-        );
+        // fetch the media, decode and NIXL-register
+        let decoded = match oai_content_part {
+            ChatCompletionRequestUserMessageContentPart::ImageUrl(image_part) => {
+                let mdc_decoder = self
+                    .media_decoder
+                    .image
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("Model does not support image inputs"))?;
 
-        #[cfg(feature = "media-nixl")]
-        {
-            // fetch the media, decode and NIXL-register
-            let decoded = match oai_content_part {
-                ChatCompletionRequestUserMessageContentPart::ImageUrl(image_part) => {
+                let url = &image_part.image_url.url;
+                self.media_fetcher.check_if_url_allowed(url)?;
+                let data = EncodedMediaData::from_url(url, &self.http_client).await?;
+
+                // Use runtime decoder if provided, with MDC limits enforced
+                let decoder =
+                    mdc_decoder.with_runtime(media_io_kwargs.and_then(|k| k.image.as_ref()));
+                decoder.decode_async(data).await?
+            }
+            #[allow(unused_variables)]
+            ChatCompletionRequestUserMessageContentPart::VideoUrl(video_part) => {
+                #[cfg(not(feature = "media-ffmpeg"))]
+                anyhow::bail!("Video decoding requires the 'media-ffmpeg' feature to be enabled");
+
+                #[cfg(feature = "media-ffmpeg")]
+                {
                     let mdc_decoder =
-                        self.media_decoder.image.as_ref().ok_or_else(|| {
-                            anyhow::anyhow!("Model does not support image inputs")
+                        self.media_decoder.video.as_ref().ok_or_else(|| {
+                            anyhow::anyhow!("Model does not support video inputs")
                         })?;
 
-                    let url = &image_part.image_url.url;
+                    let url = &video_part.video_url.url;
                     self.media_fetcher.check_if_url_allowed(url)?;
                     let data = EncodedMediaData::from_url(url, &self.http_client).await?;
 
                     // Use runtime decoder if provided, with MDC limits enforced
                     let decoder =
-                        mdc_decoder.with_runtime(media_io_kwargs.and_then(|k| k.image.as_ref()));
+                        mdc_decoder.with_runtime(media_io_kwargs.and_then(|k| k.video.as_ref()));
                     decoder.decode_async(data).await?
                 }
-                #[allow(unused_variables)]
-                ChatCompletionRequestUserMessageContentPart::VideoUrl(video_part) => {
-                    #[cfg(not(feature = "media-ffmpeg"))]
-                    anyhow::bail!(
-                        "Video decoding requires the 'media-ffmpeg' feature to be enabled"
-                    );
+            }
+            ChatCompletionRequestUserMessageContentPart::AudioUrl(_) => {
+                anyhow::bail!("Audio decoding is not supported yet");
+            }
+            _ => anyhow::bail!("Unsupported media type"),
+        };
 
-                    #[cfg(feature = "media-ffmpeg")]
-                    {
-                        let mdc_decoder = self.media_decoder.video.as_ref().ok_or_else(|| {
-                            anyhow::anyhow!("Model does not support video inputs")
-                        })?;
-
-                        let url = &video_part.video_url.url;
-                        self.media_fetcher.check_if_url_allowed(url)?;
-                        let data = EncodedMediaData::from_url(url, &self.http_client).await?;
-
-                        // Use runtime decoder if provided, with MDC limits enforced
-                        let decoder = mdc_decoder
-                            .with_runtime(media_io_kwargs.and_then(|k| k.video.as_ref()));
-                        decoder.decode_async(data).await?
-                    }
-                }
-                ChatCompletionRequestUserMessageContentPart::AudioUrl(_) => {
-                    anyhow::bail!("Audio decoding is not supported yet");
-                }
-                _ => anyhow::bail!("Unsupported media type"),
-            };
-
-            let rdma_descriptor = decoded.into_rdma_descriptor(&self.nixl_agent)?;
-            Ok(rdma_descriptor)
-        }
+        let rdma_descriptor = decoded.into_rdma_descriptor(&self.nixl_agent)?;
+        Ok(rdma_descriptor)
     }
 }
 
-#[cfg(all(test, feature = "media-nixl", feature = "testing-nixl"))]
+#[cfg(all(test, feature = "testing-nixl"))]
 mod tests {
     use super::super::decoders::ImageDecoder;
     use super::super::rdma::DataType;

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 use super::timing::RequestTracker;
 use super::{OutputOptions, SamplingOptions, StopConditions};
 use crate::kv_router::RouterConfigOverride;
-#[cfg(feature = "media-nixl")]
 use crate::preprocessor::media::RdmaMediaDataDescriptor;
 use crate::protocols::TokenIdType;
 
@@ -78,7 +77,6 @@ pub struct PrefillResult {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum MultimodalData {
     Url(url::Url),
-    #[cfg(feature = "media-nixl")]
     Decoded(RdmaMediaDataDescriptor),
 }
 


### PR DESCRIPTION
Feature was made default, now a feature flag is not needed anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed the `--enable-media-nixl` build flag; NIXL/UCX dependencies are now required for media decoding functionality.
  * Simplified build configuration by consolidating feature toggles; media-ffmpeg remains the configurable media feature.
  * Made media loading capabilities unconditionally available in the codebase rather than optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->