### PR TITLE
chore: linux gate lib/memory

### DIFF
--- a/lib/memory/src/lib.rs
+++ b/lib/memory/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pool;
 pub mod prelude;
 
 mod device;
+#[cfg(target_os = "linux")]
 mod disk;
 mod pinned;
 mod system;
@@ -27,6 +28,7 @@ mod tests;
 
 pub use arena::{ArenaAllocator, ArenaBuffer, ArenaError};
 pub use device::DeviceStorage;
+#[cfg(target_os = "linux")]
 pub use disk::DiskStorage;
 pub use pinned::PinnedStorage;
 pub use system::SystemStorage;

--- a/lib/memory/src/tests.rs
+++ b/lib/memory/src/tests.rs
@@ -55,6 +55,7 @@ fn test_system_storage_zero_size() {
     ));
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn test_disk_storage_temp() {
     let storage = DiskStorage::new(4096).unwrap();
@@ -65,6 +66,7 @@ fn test_disk_storage_temp() {
     assert!(storage.path().exists());
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn test_disk_storage_at_path() {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -98,6 +100,7 @@ fn test_system_storage_unregistered_no_nixl_descriptor() {
     assert!(storage.nixl_descriptor().is_none());
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn test_disk_storage_unregistered_no_nixl_descriptor() {
     let storage = DiskStorage::new(4096).unwrap();
@@ -197,7 +200,8 @@ mod nixl_tests {
     // The current implementation uses mem::zeroed() which is invalid for types with NonNull
     // TODO: Fix NixlRegistered::into_storage() implementation
 
-    // Disk Storage Tests
+    // Disk Storage Tests (Linux only)
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_disk_storage_registration() {
         let storage = DiskStorage::new(4096).unwrap();
@@ -210,6 +214,7 @@ mod nixl_tests {
         assert!(registered.is_registered());
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_disk_storage_descriptor_consistency() {
         let storage = DiskStorage::new(8192).unwrap();


### PR DESCRIPTION
again to allow local dev on non-linux machines, given that lib/memory now is a non-optional feature:
https://github.com/ai-dynamo/dynamo/pull/5602


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized platform-specific compilation: Disk storage functionality is now conditionally compiled for Linux systems only, improving build efficiency on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->