### PR TITLE
fix: Wrap default_multimodal_input_loader in asyncio.to_thread

### DIFF
--- a/components/src/dynamo/trtllm/encode_helper.py
+++ b/components/src/dynamo/trtllm/encode_helper.py
@@ -298,15 +298,18 @@ class EncodeHelper:
         # for tokenizer loading. `model_type` is needed to retrieve the correct
         # multimodal placeholders and apply model-specific preprocessing.
 
-        # Pass tokenizer to reuse the pre-initialized tokenizer instead of
-        # creating a new one per request
-        inputs = default_multimodal_input_loader(
-            tokenizer=tokenizer,
-            model_dir=model_dir,
-            model_type=model_type,
-            modality="image",
-            prompts=[text_prompt],
-            media=image_urls[0],
+        # NOTE: default_multimodal_input_loader downloads images and preprocesses them
+        # synchronously. Wrap in asyncio.to_thread to allow concurrent image loading
+        # across multiple requests, improving throughput at high concurrency.
+        inputs = await asyncio.to_thread(
+            lambda: default_multimodal_input_loader(
+                tokenizer=tokenizer,
+                model_dir=model_dir,
+                model_type=model_type,
+                modality="image",
+                prompts=[text_prompt],
+                media=image_urls[0],
+            )
         )
 
         # NOTE: MultimodalEncoder.generate() is synchronous. Run it off-thread to avoid


### PR DESCRIPTION
#### Overview:

Improves multimodal throughput by running `default_multimodal_input_loader` off the async event loop, enabling concurrent image downloads across requests.

Closes DIS-1409

#### Details:

`default_multimodal_input_loader` performs synchronous I/O (image download) and CPU preprocessing. Without `asyncio.to_thread`, this blocks the event loop, serializing all image loading even at high concurrency.

#### Where should the reviewer start?

`components/src/dynamo/trtllm/encode_helper.py` - EPD encode worker
`components/src/dynamo/trtllm/multimodal_processor.py`- Agg/PD multimodal processor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized concurrent image loading for multimodal inputs through asynchronous processing
  * Enhanced request handling efficiency to enable parallel image processing across multiple requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->