### PR TITLE
docs: fix markdown formatting in Distributed_Inference README

### DIFF
--- a/examples/basics/kubernetes/Distributed_Inference/README.md
+++ b/examples/basics/kubernetes/Distributed_Inference/README.md
@@ -69,6 +69,7 @@ aiconfigurator cli default --model LLAMA3.1_70B --total_gpus 16 --system h200_sx
 ```
 and from the output, you can see the Pareto curve with the suggested P/D settings
 ![text](images/pareto.png)
+
 3. Start the serving with 1 prefill worker with tensor parallelism 4 and 1 decoding worker with tensor parallelism 8 as AI Configurator suggested. Update the `my-tag` in `disagg_router.yaml` with the latest Dynamo version and your local cache folder path and run following command.
 ![text](images/settings.png)
 ```sh


### PR DESCRIPTION
## Summary
- Add blank line between image and step 3 to fix rendering issue where the step appeared on the same line as the image

## Details
In the Distributed_Inference README section "Deploy Single-Node-Sized Models using AIConfigurator", step 3 was rendering on the same line as the preceding image due to a missing newline. This fix adds the required blank line for proper Markdown formatting.

Note: The aiconfigurator command issue (missing `default` subcommand) reported in the same bug was already fixed in a previous commit on main.

## Where should the reviewer start?
`examples/basics/kubernetes/Distributed_Inference/README.md`

## Related Issues
Fixes DYN-2016
Fixes https://nvbugs/5620036

## Test Plan
- [ ] CI passes
- [ ] Verify README renders correctly on GitHub with proper spacing between image and step 3

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor formatting update to documentation file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->