### PR TITLE
fix: Add mpi arg to all srun commands

### DIFF
--- a/examples/basics/multinode/trtllm/srun_aggregated.sh
+++ b/examples/basics/multinode/trtllm/srun_aggregated.sh
@@ -41,6 +41,7 @@ fi
 # the stdout/stderr to files.
 echo "Launching frontend services in background."
 srun \
+  --mpi pmix \
   --overlap \
   --container-image "${IMAGE}" \
   --container-mounts "${MOUNTS}" \

--- a/examples/basics/multinode/trtllm/srun_disaggregated.sh
+++ b/examples/basics/multinode/trtllm/srun_disaggregated.sh
@@ -44,6 +44,7 @@ fi
 # the stdout/stderr to files.
 echo "Launching frontend services in background."
 srun \
+  --mpi pmix \
   --overlap \
   --container-image "${IMAGE}" \
   --container-mounts "${MOUNTS}" \


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Fixes DIS-1399

#### Details:

<!-- Describe the changes made in this PR. -->

Summary:

When running [srun_aggregated.sh](https://github.com/ai-dynamo/dynamo/blob/release/0.9.0/examples/basics/multinode/trtllm/srun_aggregated.sh) script on Slurm clusters (like ptyche) with Pyxis container support, the following MPI initialization error occurred:

```
The application appears to have been direct launched using "srun",
but OMPI was not built with SLURM's PMI support and therefore cannot execute.
```

This error can occur even for the frontend srun (which doesn't use MPI) when using container images that include OpenMPI. 

After adding `--mpi=pmix` to the first srun command in the script manually, it works fine.

This script previously used to work as is as far as I know, so maybe something about the container environments has changed recently. Since the script is more targeted for internal slurm usage, I didn't dive deep into root causing this for now if this suitably works around the issue.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example scripts for multi-node deployments with enhanced MPI launcher configuration options, enabling more reliable distributed system operations across cluster environments
  * Fixed file formatting standards in example documentation scripts to ensure proper execution and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->