### PR TITLE
fix: correct restart state for parallel restarts

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -697,9 +697,6 @@ func (r *DynamoGraphDeploymentReconciler) computeParallelRestartStatus(
 		sort.Strings(servicesToCheck)
 
 		// For a new restart request with services, immediately return Restarting phase without checking readiness.
-		// This prevents a race condition where we check pod readiness before the restart annotation
-		// has been applied and propagated, which would incorrectly mark the restart as completed
-		// when checking the status of pods that haven't been restarted yet.
 		if len(servicesToCheck) > 0 {
 			return &nvidiacomv1alpha1.RestartStatus{
 				ObservedID: specID,


### PR DESCRIPTION
correct restart state for parallel restarts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment restart handling to immediately mark restarting services before performing readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->