### PR TITLE
feat: sync connector leader/worker integration from kvbm-scheduler

### DIFF
--- a/lib/kvbm/src/v2/integrations/connector/leader/scheduler.rs
+++ b/lib/kvbm/src/v2/integrations/connector/leader/scheduler.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::ConnectorLeader;
@@ -33,6 +33,9 @@ pub struct KvConnectorMetadata {
 
     /// This will hold the G2 source and G1 destination block_ids
     pub intra_pass_load: Option<IntraPassLoad>,
+
+    /// This will hold the G1 source and G2 destination block_ids
+    pub intra_pass_store: Option<IntraPassStore>,
 }
 
 // impl std::fmt::Debug for IterationSession {
@@ -64,6 +67,12 @@ impl KvConnectorMetadata {
 pub struct IntraPassLoad {
     pub g2_src_block_ids: Vec<BlockId>,
     pub g1_dst_block_ids: Vec<BlockId>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IntraPassStore {
+    pub g1_src_block_ids: Vec<BlockId>,
+    pub g2_dst_block_ids: Vec<BlockId>,
 }
 
 impl KvConnectorMetadata {
@@ -372,6 +381,16 @@ impl ConnectorLeader {
                 );
             }
 
+            // TODO: Intra-pass offload for P/D disaggregation
+            // When a prefill request is finishing and needs immediate offload to decode node:
+            // 1. Call aggregate_intra_pass_offload() to collect pending offload data
+            // 2. Set metadata.intra_pass_store = Some(offload_data)
+            // 3. Worker will execute layer-wise G1→G2 transfers during save_kv_layer
+            // let intra_pass_store = self.aggregate_intra_pass_offload();
+            // if let Some(ref store) = intra_pass_store {
+            //     metadata.intra_pass_store = Some(store.clone());
+            // }
+
             // Spawn unified cleanup task that:
             // 1. Awaits the merge of all worker events (lazy - only creates merge here)
             // 2. Triggers the forward_pass_promise (unblocks preconditions)
@@ -408,6 +427,42 @@ impl ConnectorLeader {
             })
         }
     }
+
+    // /// Prepare intra-pass offload for a request.
+    // ///
+    // /// This is called on the last pass of prefill when we intend to offload
+    // /// the prefill KV cache to a remote node immediately (within the forward pass).
+    // ///
+    // /// Unlike inter-pass offload which happens between forward passes with preconditions,
+    // /// intra-pass offload executes synchronously layer-by-layer during the forward pass.
+    // ///
+    // /// # When to use
+    // /// - Prefill offload to decode nodes in P/D disaggregation
+    // /// - Request is finishing prefill and being handed off to decode worker
+    // ///
+    // /// # Arguments
+    // /// * `req_id` - Request identifier
+    // /// * `g1_block_ids` - Source blocks on GPU (computed KV cache)
+    // /// * `g2_block_ids` - Destination blocks on host (for RDMA transfer)
+    // fn prepare_intra_pass_offload(
+    //     &self,
+    //     req_id: &str,
+    //     g1_block_ids: Vec<BlockId>,
+    //     g2_block_ids: Vec<BlockId>,
+    // ) -> Result<()> {
+    //     // Store pending intra-pass offload data in slot (similar to extend_pending_intra_pass)
+    //     // This will be aggregated by aggregate_intra_pass_offload() during process_scheduler_output
+    //     todo!("Implement when P/D disaggregation prefill offload is ready")
+    // }
+    //
+    // /// Aggregate pending intra-pass offload data from all active slots.
+    // ///
+    // /// Similar to aggregate_intra_pass_onboarding but for G1→G2 direction.
+    // fn aggregate_intra_pass_offload(&self) -> Option<IntraPassStore> {
+    //     // Collect pending intra-pass offload from all slots
+    //     // Return IntraPassStore with g1_src_block_ids and g2_dst_block_ids
+    //     todo!("Implement when P/D disaggregation prefill offload is ready")
+    // }
 
     /// Create one event per worker for forward pass completion tracking.
     fn create_worker_foward_pass_completion_events(
@@ -682,6 +737,7 @@ impl KvConnectorMetadata {
             iteration,
             foward_pass_completion_events: None,
             intra_pass_load: None,
+            intra_pass_store: None,
         }
     }
 

--- a/lib/kvbm/src/v2/integrations/connector/worker/mod.rs
+++ b/lib/kvbm/src/v2/integrations/connector/worker/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //! There are four action that the [`ConnectorWorker`] is allowed to perform:
@@ -36,6 +36,7 @@ mod init;
 mod nova;
 mod state;
 
+use cudarc::driver::CudaStream;
 pub use nova::client::ConnectorWorkerClient;
 
 use init::PendingWorkerState;
@@ -53,10 +54,12 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
-use crate::KvbmRuntime;
-use crate::v2::distributed::worker::DirectWorker;
+use crate::logical::LogicalLayoutHandle;
+use crate::physical::TransferOptions;
+use crate::v2::distributed::worker::{DirectWorker, WorkerTransfers};
 use crate::v2::integrations::connector::leader::scheduler::KvConnectorMetadata;
 use crate::v2::integrations::vllm::layout::determine_kv_layout;
+use crate::{BlockId, KvbmRuntime};
 
 pub trait ConnectorWorkerInterface: Send + Sync {
     /// Register KV cache tensors (deferred mode - caches state for later).
@@ -80,17 +83,6 @@ pub trait ConnectorWorkerInterface: Send + Sync {
     /// this function will trigger the loading of the KV cache.
     fn start_load_kv(&self) -> Result<()>;
 
-    /// Save KV layer and trigger forward pass completion on last layer.
-    ///
-    /// Always callable - returns immediately if no action is needed for this layer.
-    /// On the last layer, records a CUDA event and spawns a task to trigger
-    /// the Nova forward pass completion event.
-    ///
-    /// # Arguments
-    /// * `layer_index` - The layer index being saved
-    /// * `stream_handle` - Raw CUDA stream handle (u64) from Python's current stream
-    fn save_kv_layer(&self, layer_index: usize, stream_handle: u64) -> Result<()>;
-
     /// Wait for a specific layer's KV cache load to complete.
     ///
     /// If intra-pass onboarding was triggered in `start_load_kv`, this method
@@ -102,6 +94,27 @@ pub trait ConnectorWorkerInterface: Send + Sync {
     /// * `layer_index` - The layer index to wait for
     /// * `stream_handle` - Raw CUDA stream handle (u64) from Python's current torch stream
     fn wait_for_layer_load(&self, layer_index: usize, stream_handle: u64) -> Result<()>;
+
+    /// Save KV layer and trigger forward pass completion on last layer.
+    ///
+    /// Always callable - returns immediately if no action is needed for this layer.
+    /// On the last layer, records a CUDA event and spawns a task to trigger
+    /// the Nova forward pass completion event.
+    ///
+    /// # Arguments
+    /// * `layer_index` - The layer index being saved
+    /// * `stream_handle` - Raw CUDA stream handle (u64) from Python's current stream
+    fn save_kv_layer(&self, layer_index: usize, stream_handle: u64) -> Result<()>;
+
+    /// Wait for the intra-pass offload to complete. This is a blocking call; however, we might choose to make it non-blocking
+    /// in the future.
+    ///
+    /// To make it non-blocking, we would have to put an stream wait event on both the torch stream and intra-pass onboard stream
+    /// to ensure that no cuda stream operations are allowed to modify the kv blocks being offloaded while the offload is in progress.
+    ///
+    /// The CUDA coordination would require that we correctly synchronize any stream, so the intergration with the LLM framework
+    /// needs to be carefully aligned.
+    fn wait_for_save(&self) -> Result<()>;
 
     /// Check if initialization has been completed.
     fn is_initialized(&self) -> bool;
@@ -131,6 +144,12 @@ impl GpuInfo {
     }
 }
 
+struct IntraPassOffloadState {
+    stream: Arc<CudaStream>,
+    g1_src_block_ids: Arc<[BlockId]>,
+    g2_dst_block_ids: Arc<[BlockId]>,
+}
+
 /// Connector worker implementation that uses Nova for communication and
 /// NIXL for RDMA transfers.
 ///
@@ -149,8 +168,8 @@ pub struct ConnectorWorker {
     /// Set to true in bind_connector_metadata when a Nova event is present,
     /// used by save_kv_layer to decide whether to record events.
     forward_pass_completion_active: Arc<AtomicBool>,
-    /// Flag for direct offloading (stub for future use, always false for now).
-    is_direct_offloading_active: Arc<AtomicBool>,
+
+    intra_pass_offload_active: Arc<Mutex<Option<IntraPassOffloadState>>>,
 
     /// Start Forward Pass
     forward_pass_start: Mutex<Option<Instant>>,
@@ -174,7 +193,7 @@ impl ConnectorWorker {
             metadata: Mutex::new(None),
             intra_pass_onboard_active: Arc::new(AtomicBool::new(false)),
             forward_pass_completion_active: Arc::new(AtomicBool::new(false)),
-            is_direct_offloading_active: Arc::new(AtomicBool::new(false)),
+            intra_pass_offload_active: Arc::new(Mutex::new(None)),
             forward_pass_start: Mutex::new(None),
         }
     }
@@ -211,7 +230,7 @@ impl ConnectorWorker {
     /// - Forward pass completion is active AND this is the last layer
     fn needs_offload_action(&self, layer_index: usize) -> bool {
         // Stub for future direct offloading support
-        let is_direct_offloading = self.is_direct_offloading_active.load(Ordering::Relaxed);
+        let is_direct_offloading = self.intra_pass_offload_active.lock().is_some();
 
         // Forward pass completion triggers on last layer only
         let is_last_layer = layer_index == self.num_layers() - 1;
@@ -232,16 +251,10 @@ impl ConnectorWorker {
         let forward_pass_active = self.forward_pass_completion_active.load(Ordering::Relaxed);
 
         // Get pre-allocated save layer events
-        let layer_events = self.state.save_layer_events()?;
+        let layer_events = self.state.compute_layer_events()?;
 
         // Validate layer_index
-        if layer_index >= layer_events.len() {
-            return Err(anyhow::anyhow!(
-                "layer_index {} out of range (num_layers={})",
-                layer_index,
-                layer_events.len()
-            ));
-        }
+        assert!(layer_index < layer_events.len(), "layer_index out of range");
 
         let event = &layer_events[layer_index];
 
@@ -255,11 +268,48 @@ impl ConnectorWorker {
 
         tracing::trace!(layer_index, "Recorded save layer CUDA event");
 
-        // If direct offloading is active, perform enqueue into a kvbm stream the event and the offload action
-        // to take once the event is complete.
-        // todo: add method to DirectWorker for this operation. - this will be a local operation from g1 -> g2
-        // note: the operation might be a permute kernel if we are gathering or scattering kv to remote workers
-        // with different tensor parallel world sizes.
+        if let Some(intra_pass_offload_state) = &self.intra_pass_offload_active.lock().as_ref() {
+            // record a stream wait event on the intra_pass_offload_state.stream with the event just recorded
+            // Insert cudaStreamWaitEvent to make torch stream wait for this layer's onboard
+            unsafe {
+                let status = cuStreamWaitEvent(
+                    intra_pass_offload_state.stream.cu_stream(),
+                    event.cu_event(),
+                    0, // flags = 0
+                );
+                if status != cudaError_enum::CUDA_SUCCESS {
+                    bail!("cuStreamWaitEvent failed with status: {:?}", status);
+                }
+            }
+
+            let worker = self.state.service.get().expect("service not set").worker();
+
+            let options = TransferOptions::builder()
+                .layer_range(layer_index..layer_index + 1)
+                .cuda_stream(intra_pass_offload_state.stream.clone())
+                .build()?;
+
+            // trigger a local transfer operation from g1 to g2 with the block ids using the intra_pass_offload_state.stream
+            // the clones of the block ids are cheap because they are Arc<[BlockId]>
+            worker.execute_local_transfer(
+                LogicalLayoutHandle::G1,
+                LogicalLayoutHandle::G2,
+                intra_pass_offload_state.g1_src_block_ids.clone(),
+                intra_pass_offload_state.g2_dst_block_ids.clone(),
+                options,
+            )?;
+
+            // if this is the last layer, record the final event on the stream
+            if is_last_layer {
+                let event = self
+                    .state
+                    .offload_complete_event
+                    .get()
+                    .expect("offload_complete_event not set")
+                    .clone();
+                event.record(intra_pass_offload_state.stream.as_ref())?;
+            }
+        }
 
         // On last layer with forward pass completion: spawn task to trigger Nova
         if is_last_layer && forward_pass_active {
@@ -401,6 +451,35 @@ impl ConnectorWorkerInterface for ConnectorWorker {
             tracing::info!("Binding connector metadata: {:?}", metadata.summary());
         }
 
+        // TODO: if intra_pass_store is present, we need to mark `is_direct_offloading_active` to true
+        // then we need to prepare the Arc<[BlockId]> for the G1 source block_ids and G2 destination block_ids
+        // so we can immediately clone them into `execute_local_transfer` operations on the worker
+        // we are going to have to grab a d2h_stream from the worker and hold it for this forward pass and clean
+        // it up after the forward pass is complete.
+        if let Some(intra_pass_store) = &metadata.intra_pass_store {
+            let stream = self
+                .state
+                .service
+                .get()
+                .expect("service not set")
+                .worker()
+                .transfer_manager()
+                .context()
+                .acquire_d2h_stream();
+
+            // create a Arc<[BlockId]> for the G1 source block_ids and G2 destination block_ids
+            let g1_src_block_ids: Arc<[BlockId]> =
+                Arc::from(intra_pass_store.g1_src_block_ids.clone());
+            let g2_dst_block_ids: Arc<[BlockId]> =
+                Arc::from(intra_pass_store.g2_dst_block_ids.clone());
+
+            *self.intra_pass_offload_active.lock() = Some(IntraPassOffloadState {
+                stream,
+                g1_src_block_ids,
+                g2_dst_block_ids,
+            });
+        }
+
         // Store the metadata for use by start_load_kv
         *self.metadata.lock() = Some(metadata);
 
@@ -423,9 +502,8 @@ impl ConnectorWorkerInterface for ConnectorWorker {
         *self.metadata.lock() = None;
         self.intra_pass_onboard_active
             .store(false, Ordering::Relaxed);
+        *self.intra_pass_offload_active.lock() = None;
         self.forward_pass_completion_active
-            .store(false, Ordering::Relaxed);
-        self.is_direct_offloading_active
             .store(false, Ordering::Relaxed);
 
         Ok(())
@@ -469,6 +547,21 @@ impl ConnectorWorkerInterface for ConnectorWorker {
                 .store(true, Ordering::Relaxed);
 
             tracing::debug!("Intra-pass onboard initiated - events recorded on transfer stream");
+        }
+
+        Ok(())
+    }
+
+    fn wait_for_save(&self) -> Result<()> {
+        // Wait for the last layer to be saved
+        if self.intra_pass_offload_active.lock().is_some() {
+            let event = self
+                .state
+                .offload_complete_event
+                .get()
+                .expect("offload_complete_event not set")
+                .clone();
+            event.synchronize()?;
         }
 
         Ok(())
@@ -552,3 +645,6 @@ pub struct FinishedRequests {
     pub offloading: HashSet<String>,
     pub onboarding: HashSet<String>,
 }
+
+#[cfg(test)]
+mod tests;

--- a/lib/kvbm/src/v2/integrations/connector/worker/state.rs
+++ b/lib/kvbm/src/v2/integrations/connector/worker/state.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //! State module for the [`ConnectorWorker`]
@@ -140,8 +140,14 @@ pub struct WorkerState {
     /// CUDA events for layer-wise offloading, one per layer.
     /// Created during initialization and reused every iteration.
     /// Recorded on the torch stream during save_kv_layer,
-    /// last layer event triggers Nova forward pass completion notification.
-    pub(crate) save_layer_events: OnceLock<Vec<Arc<CudaEvent>>>,
+    /// and represents the moment in time when the layer has been computed
+    /// and is ready to be offloaded.
+    /// The last layer event triggers Nova forward pass completion notification.
+    pub(crate) compute_layer_events: OnceLock<Vec<Arc<CudaEvent>>>,
+
+    /// Recorded on the offload stream when the last layer is complete.
+    /// This event is then synchronously awaited by the workers in wait_for_save.
+    pub(crate) offload_complete_event: OnceLock<Arc<CudaEvent>>,
 
     // --- Finished tracking (encapsulated with own lock) ---
     /// Tracks finished onboarding/offloading requests and failed blocks.
@@ -159,7 +165,8 @@ impl WorkerState {
             pending: Mutex::new(None),
             forward_pass_nova_event: Mutex::new(None),
             onboard_layer_events: OnceLock::new(),
-            save_layer_events: OnceLock::new(),
+            compute_layer_events: OnceLock::new(),
+            offload_complete_event: OnceLock::new(),
             finished_state: FinishedState::default(),
         }
     }
@@ -230,9 +237,14 @@ impl WorkerState {
             save_events.push(Arc::new(event));
         }
 
-        self.save_layer_events
+        self.compute_layer_events
             .set(save_events)
-            .map_err(|_| anyhow::anyhow!("save_layer_events already set (race condition)"))?;
+            .map_err(|_| anyhow::anyhow!("compute_layer_events already set (race condition)"))?;
+
+        // Create the offload complete event to be awaited by the workers in wait_for_save.
+        self.offload_complete_event
+            .set(Arc::new(d2h_stream.record_event(None)?))
+            .map_err(|_| anyhow::anyhow!("offload_complete_event already set (race condition)"))?;
 
         tracing::debug!(
             num_layers,
@@ -302,11 +314,11 @@ impl WorkerState {
     ///
     /// Returns a reference to the events if they have been allocated (during initialize),
     /// or an error if initialization hasn't completed yet.
-    pub(crate) fn save_layer_events(&self) -> Result<&[Arc<CudaEvent>]> {
-        self.save_layer_events
+    pub(crate) fn compute_layer_events(&self) -> Result<&[Arc<CudaEvent>]> {
+        self.compute_layer_events
             .get()
             .map(|v| v.as_slice())
-            .ok_or_else(|| anyhow::anyhow!("save_layer_events not initialized"))
+            .ok_or_else(|| anyhow::anyhow!("compute_layer_events not initialized"))
     }
 
     /// Store the Nova event handle for forward pass completion.

--- a/lib/kvbm/src/v2/integrations/connector/worker/tests.rs
+++ b/lib/kvbm/src/v2/integrations/connector/worker/tests.rs
@@ -1,0 +1,484 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for ConnectorWorker intra-pass operations.
+//!
+//! These tests focus on:
+//! - Flag lifecycle for intra-pass onboard (`intra_pass_onboard_active`)
+//! - Flag lifecycle for intra-pass offload (`intra_pass_offload_active`)
+//! - Logic paths in `needs_offload_action`
+//! - Early-exit paths in `wait_for_layer_load`, `wait_for_save`, `save_kv_layer`
+
+use std::sync::atomic::Ordering;
+
+use crate::v2::integrations::connector::leader::scheduler::{
+    IntraPassLoad, IntraPassStore, KvConnectorMetadata,
+};
+use crate::v2::testing::connector::{ConnectorTestConfig, TestConnectorInstance};
+
+use super::ConnectorWorkerInterface;
+
+/// Helper to create a minimal test instance with a single worker.
+async fn create_test_instance() -> TestConnectorInstance {
+    let config = ConnectorTestConfig::new().leader_cache_blocks(128);
+
+    TestConnectorInstance::builder()
+        .num_workers(1)
+        .test_config(config)
+        .build()
+        .await
+        .expect("Should create test instance")
+}
+
+// ============================================================================
+// Intra-Pass Onboard Tests
+// ============================================================================
+
+/// Test that intra_pass_onboard_active flag transitions correctly through lifecycle.
+///
+/// Expected flow:
+/// 1. Initially false
+/// 2. After start_load_kv with intra_pass_load metadata -> true
+/// 3. After clear_connector_metadata -> false
+#[tokio::test(flavor = "multi_thread")]
+async fn test_intra_pass_onboard_flag_lifecycle() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+        .with_test_writer()
+        .try_init();
+
+    let instance = create_test_instance().await;
+    instance
+        .register_all_workers()
+        .expect("Should register workers");
+    instance.initialize().await.expect("Should initialize");
+
+    let worker = &instance.workers[0].worker;
+
+    // 1. Initially false
+    assert!(
+        !worker.intra_pass_onboard_active.load(Ordering::Relaxed),
+        "intra_pass_onboard_active should be false initially"
+    );
+
+    // 2. Bind metadata WITH intra_pass_load
+    let metadata = KvConnectorMetadata {
+        iteration: 1,
+        foward_pass_completion_events: None,
+        intra_pass_load: Some(IntraPassLoad {
+            g2_src_block_ids: vec![0, 1, 2],
+            g1_dst_block_ids: vec![0, 1, 2],
+        }),
+        intra_pass_store: None,
+    };
+    worker
+        .bind_connector_metadata(metadata)
+        .expect("Should bind metadata");
+
+    // 3. Call start_load_kv - this should set the flag
+    // Note: This will fail if G2 layout is not available, but the flag should still transition
+    // based on whether intra_pass_load was present in metadata
+    let _ = worker.start_load_kv();
+
+    // The flag should be true if start_load_kv processed the intra_pass_load
+    // (may fail the transfer, but flag should be set)
+    // Note: In practice, this needs the DirectWorker to be fully initialized
+    // For this test, we verify the flag is accessible and the clear resets it
+
+    // 4. Clear metadata - flag should be false
+    worker
+        .clear_connector_metadata()
+        .expect("Should clear metadata");
+    assert!(
+        !worker.intra_pass_onboard_active.load(Ordering::Relaxed),
+        "intra_pass_onboard_active should be false after clear"
+    );
+
+    // Cleanup in spawn_blocking to avoid runtime-in-runtime panic
+    tokio::task::spawn_blocking(move || drop(instance))
+        .await
+        .expect("Cleanup should succeed");
+}
+
+/// Test that start_load_kv with no intra_pass_load returns Ok and doesn't set flag.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_intra_pass_onboard_no_metadata() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+        .with_test_writer()
+        .try_init();
+
+    let instance = create_test_instance().await;
+    instance
+        .register_all_workers()
+        .expect("Should register workers");
+    instance.initialize().await.expect("Should initialize");
+
+    let worker = &instance.workers[0].worker;
+
+    // Bind metadata WITHOUT intra_pass_load
+    let metadata = KvConnectorMetadata {
+        iteration: 1,
+        foward_pass_completion_events: None,
+        intra_pass_load: None,
+        intra_pass_store: None,
+    };
+    worker
+        .bind_connector_metadata(metadata)
+        .expect("Should bind metadata");
+
+    // start_load_kv should succeed (no-op)
+    worker
+        .start_load_kv()
+        .expect("start_load_kv should succeed");
+
+    // Flag should still be false
+    assert!(
+        !worker.intra_pass_onboard_active.load(Ordering::Relaxed),
+        "intra_pass_onboard_active should remain false when no intra_pass_load"
+    );
+
+    worker
+        .clear_connector_metadata()
+        .expect("Should clear metadata");
+
+    tokio::task::spawn_blocking(move || drop(instance))
+        .await
+        .expect("Cleanup should succeed");
+}
+
+/// Test that wait_for_layer_load returns immediately when flag is false.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wait_for_layer_load_early_exit() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+        .with_test_writer()
+        .try_init();
+
+    let instance = create_test_instance().await;
+    instance
+        .register_all_workers()
+        .expect("Should register workers");
+    instance.initialize().await.expect("Should initialize");
+
+    let worker = &instance.workers[0].worker;
+
+    // No metadata bound, flag is false
+    assert!(
+        !worker.intra_pass_onboard_active.load(Ordering::Relaxed),
+        "Flag should be false"
+    );
+
+    // wait_for_layer_load should return Ok immediately (early exit path)
+    // Using a dummy stream handle since it won't be used
+    worker
+        .wait_for_layer_load(0, 0)
+        .expect("wait_for_layer_load should succeed with early exit");
+
+    tokio::task::spawn_blocking(move || drop(instance))
+        .await
+        .expect("Cleanup should succeed");
+}
+
+// ============================================================================
+// Intra-Pass Offload Tests
+// ============================================================================
+
+/// Test that intra_pass_offload_active state transitions correctly through lifecycle.
+///
+/// Expected flow:
+/// 1. Initially None
+/// 2. After bind_connector_metadata with intra_pass_store -> Some
+/// 3. After clear_connector_metadata -> None
+#[tokio::test(flavor = "multi_thread")]
+async fn test_intra_pass_offload_flag_lifecycle() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+        .with_test_writer()
+        .try_init();
+
+    let instance = create_test_instance().await;
+    instance
+        .register_all_workers()
+        .expect("Should register workers");
+    instance.initialize().await.expect("Should initialize");
+
+    let worker = &instance.workers[0].worker;
+
+    // 1. Initially None
+    assert!(
+        worker.intra_pass_offload_active.lock().is_none(),
+        "intra_pass_offload_active should be None initially"
+    );
+
+    // 2. Bind metadata WITH intra_pass_store
+    let metadata = KvConnectorMetadata {
+        iteration: 1,
+        foward_pass_completion_events: None,
+        intra_pass_load: None,
+        intra_pass_store: Some(IntraPassStore {
+            g1_src_block_ids: vec![0, 1, 2],
+            g2_dst_block_ids: vec![0, 1, 2],
+        }),
+    };
+    worker
+        .bind_connector_metadata(metadata)
+        .expect("Should bind metadata");
+
+    // Flag should be Some now (state created)
+    assert!(
+        worker.intra_pass_offload_active.lock().is_some(),
+        "intra_pass_offload_active should be Some after binding with intra_pass_store"
+    );
+
+    // 3. Clear metadata - state should be None
+    worker
+        .clear_connector_metadata()
+        .expect("Should clear metadata");
+    assert!(
+        worker.intra_pass_offload_active.lock().is_none(),
+        "intra_pass_offload_active should be None after clear"
+    );
+
+    tokio::task::spawn_blocking(move || drop(instance))
+        .await
+        .expect("Cleanup should succeed");
+}
+
+/// Test needs_offload_action returns true for any layer when direct offload is active.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_needs_offload_action_direct_offload() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+        .with_test_writer()
+        .try_init();
+
+    let instance = create_test_instance().await;
+    instance
+        .register_all_workers()
+        .expect("Should register workers");
+    instance.initialize().await.expect("Should initialize");
+
+    let worker = &instance.workers[0].worker;
+
+    // Bind metadata WITH intra_pass_store (enables direct offloading)
+    let metadata = KvConnectorMetadata {
+        iteration: 1,
+        foward_pass_completion_events: None,
+        intra_pass_load: None,
+        intra_pass_store: Some(IntraPassStore {
+            g1_src_block_ids: vec![0, 1, 2],
+            g2_dst_block_ids: vec![0, 1, 2],
+        }),
+    };
+    worker
+        .bind_connector_metadata(metadata)
+        .expect("Should bind metadata");
+
+    // needs_offload_action should return true for ANY layer (not just last)
+    assert!(
+        worker.needs_offload_action(0),
+        "needs_offload_action should return true for layer 0 with direct offload"
+    );
+    assert!(
+        worker.needs_offload_action(1),
+        "needs_offload_action should return true for layer 1 with direct offload"
+    );
+    assert!(
+        worker.needs_offload_action(2),
+        "needs_offload_action should return true for layer 2 with direct offload"
+    );
+
+    worker
+        .clear_connector_metadata()
+        .expect("Should clear metadata");
+
+    tokio::task::spawn_blocking(move || drop(instance))
+        .await
+        .expect("Cleanup should succeed");
+}
+
+/// Test needs_offload_action with only forward_pass_completion_active.
+///
+/// Should return:
+/// - false for non-last layers
+/// - true for last layer only
+#[tokio::test(flavor = "multi_thread")]
+async fn test_needs_offload_action_forward_pass_only() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+        .with_test_writer()
+        .try_init();
+
+    let instance = create_test_instance().await;
+    instance
+        .register_all_workers()
+        .expect("Should register workers");
+    instance.initialize().await.expect("Should initialize");
+
+    let worker = &instance.workers[0].worker;
+
+    // Manually set forward_pass_completion_active (simulating metadata with events)
+    worker
+        .forward_pass_completion_active
+        .store(true, Ordering::Relaxed);
+
+    // Get num_layers from the worker (default test config has 4 layers)
+    let num_layers = worker.num_layers();
+    assert!(num_layers >= 2, "Test requires at least 2 layers");
+
+    // Non-last layers should return false
+    assert!(
+        !worker.needs_offload_action(0),
+        "needs_offload_action should return false for layer 0 (not last)"
+    );
+
+    // Last layer should return true
+    assert!(
+        worker.needs_offload_action(num_layers - 1),
+        "needs_offload_action should return true for last layer"
+    );
+
+    // Clean up
+    worker
+        .forward_pass_completion_active
+        .store(false, Ordering::Relaxed);
+
+    tokio::task::spawn_blocking(move || drop(instance))
+        .await
+        .expect("Cleanup should succeed");
+}
+
+/// Test that wait_for_save returns immediately when no offload is active.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wait_for_save_no_offload_active() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+        .with_test_writer()
+        .try_init();
+
+    let instance = create_test_instance().await;
+    instance
+        .register_all_workers()
+        .expect("Should register workers");
+    instance.initialize().await.expect("Should initialize");
+
+    let worker = &instance.workers[0].worker;
+
+    // No offload active (default state)
+    assert!(
+        worker.intra_pass_offload_active.lock().is_none(),
+        "Offload should not be active"
+    );
+
+    // wait_for_save should return Ok immediately (early exit path)
+    worker
+        .wait_for_save()
+        .expect("wait_for_save should succeed with early exit");
+
+    tokio::task::spawn_blocking(move || drop(instance))
+        .await
+        .expect("Cleanup should succeed");
+}
+
+/// Test that save_kv_layer returns immediately when no action is needed.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_save_kv_layer_early_exit() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+        .with_test_writer()
+        .try_init();
+
+    let instance = create_test_instance().await;
+    instance
+        .register_all_workers()
+        .expect("Should register workers");
+    instance.initialize().await.expect("Should initialize");
+
+    let worker = &instance.workers[0].worker;
+
+    // No offload or forward pass completion active
+    assert!(
+        worker.intra_pass_offload_active.lock().is_none(),
+        "Offload should not be active"
+    );
+    assert!(
+        !worker
+            .forward_pass_completion_active
+            .load(Ordering::Relaxed),
+        "Forward pass completion should not be active"
+    );
+
+    // save_kv_layer should return Ok immediately (early exit via needs_offload_action)
+    worker
+        .save_kv_layer(0, 0)
+        .expect("save_kv_layer should succeed with early exit");
+
+    tokio::task::spawn_blocking(move || drop(instance))
+        .await
+        .expect("Cleanup should succeed");
+}
+
+// ============================================================================
+// Combined Lifecycle Tests
+// ============================================================================
+
+/// Test full iteration lifecycle with metadata bind/clear cycle.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_full_iteration_lifecycle() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::new("warn"))
+        .with_test_writer()
+        .try_init();
+
+    let instance = create_test_instance().await;
+    instance
+        .register_all_workers()
+        .expect("Should register workers");
+    instance.initialize().await.expect("Should initialize");
+
+    let worker = &instance.workers[0].worker;
+
+    // Simulate multiple iterations
+    for iteration in 1..=3 {
+        // Bind metadata (no intra-pass operations, simulating normal decode)
+        let metadata = KvConnectorMetadata {
+            iteration,
+            foward_pass_completion_events: None,
+            intra_pass_load: None,
+            intra_pass_store: None,
+        };
+        worker
+            .bind_connector_metadata(metadata)
+            .expect("Should bind metadata");
+
+        // start_load_kv should be safe to call
+        worker
+            .start_load_kv()
+            .expect("start_load_kv should succeed");
+
+        // wait_for_layer_load should early exit
+        worker
+            .wait_for_layer_load(0, 0)
+            .expect("wait_for_layer_load should succeed");
+
+        // save_kv_layer should early exit
+        worker
+            .save_kv_layer(0, 0)
+            .expect("save_kv_layer should succeed");
+
+        // wait_for_save should early exit
+        worker
+            .wait_for_save()
+            .expect("wait_for_save should succeed");
+
+        // Clear for next iteration
+        worker
+            .clear_connector_metadata()
+            .expect("Should clear metadata");
+    }
+
+    tokio::task::spawn_blocking(move || drop(instance))
+        .await
+        .expect("Cleanup should succeed");
+}


### PR DESCRIPTION
- Update connector leader scheduler with ForwardPassSample builder and iteration session management
- Add worker connector state machine with scheduler output processing
- Add comprehensive worker connector tests (484 lines)
- Update worker mod with scheduler-driven metadata handling

