### PR TITLE
docs: fix markdown formatting in Distributed_Inference README

### DIFF
--- a/examples/basics/kubernetes/Distributed_Inference/README.md
+++ b/examples/basics/kubernetes/Distributed_Inference/README.md
@@ -69,6 +69,7 @@ aiconfigurator cli --model LLAMA3.1_70B --total_gpus 16 --system h200_sxm
 ```
 and from the output, you can see the Pareto curve with suggest P/D settings
 ![text](images/pareto.png)
+
 3. Start the serving with 1 prefill worker with tensor parallelism 4 and 1 decoding worker with tensor parallelism 8 as AI Configurator suggested. Update the `0.9.0` in `disagg_router.yaml` with the latest Dynamo version and your local cache folder path and run following command.
 ![text](images/settings.png)
 ```sh


### PR DESCRIPTION
## Summary
- Cherry-pick of #5947 to release/0.9.0
- Add blank line between image and step 3 to fix rendering issue where the step appeared on the same line as the image

Fixes DYN-2016

## Original PR
- Main PR: #5947
- Merge commit: ef292944fdda00f08448ea0eac801884cacb9f3e

## Test plan
- [ ] CI passes
- [ ] Verified markdown renders correctly

Made with [Cursor](https://cursor.com)