### PR TITLE
fix: Remove TRTLLM version from config dump

### DIFF
--- a/components/src/dynamo/common/config_dump/config_dumper.py
+++ b/components/src/dynamo/common/config_dump/config_dumper.py
@@ -39,24 +39,6 @@ def _get_sglang_version() -> Optional[str]:
         return None
 
 
-def _get_trtllm_version() -> Optional[str]:
-    """Get TensorRT-LLM version if available.
-
-    Returns:
-        Version string if TensorRT-LLM is installed, None otherwise.
-    """
-    try:
-        import tensorrt_llm
-
-        return tensorrt_llm.__version__
-    except ImportError:
-        logger.debug("TensorRT-LLM not available")
-        return None
-    except AttributeError:
-        logger.warning("TensorRT-LLM installed but version not available")
-        return None
-
-
 def _get_vllm_version() -> Optional[str]:
     """Get vLLM version if available.
 
@@ -151,8 +133,14 @@ def get_config_dump(config: Any, extra_info: Optional[Dict[str, Any]] = None) ->
         # Add common versions
         if ver := _get_sglang_version():
             config_dump["sglang_version"] = ver
-        if ver := _get_trtllm_version():
-            config_dump["trtllm_version"] = ver
+
+        # TODO(jothomson, warnold): To check the TRTLLM version, we need to import it.
+        # When imported, TRTLLM has the side effect of initializing MPI.
+        # In a slurm environment, this enforces that --mpi pmix is set on ALL nodes, including the frontend.
+        # Bring this back once we have a way to check the TRTLLM version without initializing MPI.
+        # if ver := _get_trtllm_version():
+        #     config_dump["trtllm_version"] = ver
+
         if ver := _get_vllm_version():
             config_dump["vllm_version"] = ver
 


### PR DESCRIPTION
When dumping the config, we import trtllm in order to get the version. A side effect of importing trtllm is that MPI gets initialized. In a slurm environment, this enforces the constraint that all tasks be launched with --mpi pmix, even the frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled TensorRT-LLM version retrieval in configuration dump to resolve compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->