### PR TITLE
sync block_manager connector bindings from kvbm-scheduler

### DIFF
--- a/lib/bindings/kvbm/src/block_manager/vllm/connector.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_llm::block_manager::{
@@ -133,23 +133,13 @@ impl std::fmt::Debug for CachedRequestData {
     }
 }
 
-/// Information about a new slot to be created on the worker.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NewSlotInfo {
-    /// The request ID for the new slot.
-    pub request_id: String,
-    /// Expected number of immediate (onboard) operations for this slot.
-    /// This enables proper completion tracking and avoids race conditions in TP>1.
-    pub expected_immediate_ops: u64,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConnectorMetadata {
     /// The iteration at which the metadata was built.
     pub iteration: u64,
 
     /// The new slots that were created in this iteration.
-    pub new_slots: Vec<NewSlotInfo>,
+    pub new_slots: Vec<String>,
 
     /// The operations that were initialized in this iteration.
     pub operations: Vec<WorkerTransferRequest>,
@@ -164,12 +154,8 @@ impl ConnectorMetadata {
         }
     }
 
-    /// Create a slot with the expected number of immediate operations.
-    pub fn create_slot(&mut self, request_id: String, expected_immediate_ops: u64) {
-        self.new_slots.push(NewSlotInfo {
-            request_id,
-            expected_immediate_ops,
-        });
+    pub fn create_slot(&mut self, request_id: String) {
+        self.new_slots.push(request_id);
     }
 
     pub fn add_operations(&mut self, xfer_reqs: Vec<WorkerTransferRequest>) {

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod recorder;
@@ -21,7 +21,7 @@ use dynamo_llm::block_manager::{
         data::logical::distributed_leader_worker::DistributedLeaderWorkerResources,
         locality::Logical,
     },
-    connector::{*, protocol::RequestType},
+    connector::*,
     kv_consolidator::EventSource,
 };
 use dynamo_llm::tokens::{SaltHash, TokenBlockSequence, Tokens};
@@ -348,32 +348,17 @@ impl Leader for KvConnectorLeader {
         //
         // This is kind of a nice abstraction as it keeps the events simplier; however, we now create the request-slot
         // once for onboarding (this loop), then again for prefill/decode (new_requests loop).
-        //
-        // TODO(krish): Consider a more deterministic way to count immediate ops.
-        // Currently we count by filtering pending_ops at runtime. A higher-level approach
-        // (e.g., tracking count when onboard_blocks is called, or deriving from architecture
-        // config) might be more robust against potential timing-related issues.
         for request_id in onboarding_slots.iter() {
             let shared_slot = self.slot_manager().get_slot(request_id)?;
             let mut slot = shared_slot
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
 
-            let pending_ops_opt = slot.take_pending_operations();
+            md.create_slot(request_id.clone());
 
-            if let Some(pending_ops) = pending_ops_opt {
-                // Count immediate (onboard) operations for this slot
-                let num_immediate = pending_ops
-                    .iter()
-                    .filter(|op| op.request_type == RequestType::Immediate)
-                    .count() as u64;
-
-                // Create slot with expected immediate ops BEFORE adding operations
-                md.create_slot(request_id.clone(), num_immediate);
+            if let Some(pending_ops) = slot.take_pending_operations() {
+                tracing::debug!("adding {} pending onboarding operations", pending_ops.len());
                 md.add_operations(pending_ops);
-            } else {
-                // No operations, create slot with 0 expected immediate ops
-                md.create_slot(request_id.clone(), 0);
             }
 
             assert!(
@@ -388,19 +373,6 @@ impl Leader for KvConnectorLeader {
         // todo: update the code and abstraction to account for this two-phase lifecycle.
         for new_req in &scheduler_output.new_requests {
             let request_id = &new_req.request_id;
-
-            let already_created = md.new_slots.iter().any(|s| &s.request_id == request_id);
-
-            // Skip if this slot was already created in the onboarding_slots loop above.
-            // This prevents overwriting the slot with expected_immediate_ops=0 when it should have the correct count.
-            if already_created {
-                assert!(
-                    inflight_requests.remove(request_id),
-                    "request_id {request_id} not found in inflight_requests: "
-                );
-                continue;
-            }
-
             assert!(
                 inflight_requests.remove(request_id),
                 "request_id {request_id} not found in inflight_requests: "
@@ -410,6 +382,9 @@ impl Leader for KvConnectorLeader {
             let mut slot = shared_slot
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
+
+            // inform the worker that a new request-slot should be created
+            md.create_slot(new_req.request_id.clone());
 
             slot.record_start_iteration(iteration)?;
 
@@ -429,21 +404,13 @@ impl Leader for KvConnectorLeader {
 
             slot.apply_scheduler_output(&[], &[], new_req.num_computed_tokens, scheduled_tokens)?;
 
-            let pending_ops_opt = slot.take_pending_operations();
-
-            if let Some(pending_ops) = pending_ops_opt {
-                // Count immediate (onboard) operations for this slot
-                let num_immediate = pending_ops
-                    .iter()
-                    .filter(|op| op.request_type == RequestType::Immediate)
-                    .count() as u64;
-
-                // Create slot with expected immediate ops BEFORE adding operations
-                md.create_slot(new_req.request_id.clone(), num_immediate);
+            if let Some(pending_ops) = slot.take_pending_operations() {
+                tracing::debug!(
+                    "adding {} pending operations for slot {}",
+                    pending_ops.len(),
+                    new_req.request_id
+                );
                 md.add_operations(pending_ops);
-            } else {
-                // No operations, create slot with 0 expected immediate ops
-                md.create_slot(new_req.request_id.clone(), 0);
             }
         }
 

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{any::Any, cmp::max, sync::Arc};
@@ -108,6 +108,18 @@ pub trait Slot: std::fmt::Debug {
         block_ids: &[usize],
         num_computed_tokens: usize,
         num_scheduled_tokens: usize,
+    ) -> Result<(), SlotError>;
+
+    // TRT-LLM does not include scheduled tokens in the scheduler output.
+    // Ideally, we should have a dedicated implementation for the TRT-LLM slot.
+    // However, since only this single function needs to be rewritten for now,
+    // we keep it as a separate function in Slot.
+    fn apply_scheduler_output_with_computed_position(
+        &mut self,
+        tokens: &[u32],
+        block_ids: &[usize],
+        computed_position: usize,
+        is_new_request: bool,
     ) -> Result<(), SlotError>;
 
     fn record_start_iteration(&mut self, iteration: u64) -> Result<(), SlotError>;
@@ -626,6 +638,111 @@ impl Slot for VllmConnectorSlot {
 
         // advance current and computed position
         self.current_position += num_scheduled_tokens;
+
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(request_id = self.request_id.as_str()))]
+    fn apply_scheduler_output_with_computed_position(
+        &mut self,
+        tokens: &[u32],
+        block_ids: &[usize],
+        computed_position: usize,
+        is_new_request: bool,
+    ) -> Result<(), SlotError> {
+        // TRTLLM's KV Connector Manager will have (computed_position - external matches)
+        // in onborading case
+        if computed_position < self.current_position {
+            tracing::debug!(
+                "computed_position={} < current_position={}, so we are onboarding during prefilling phase",
+                computed_position,
+                self.current_position
+            );
+            return Ok(());
+        }
+
+        // now we decide what we should do for the new computed tokens
+        tracing::debug!(
+            "applying scheduler output, computed_position={}, sequence_total_tokens={}",
+            computed_position,
+            self.sequence.total_tokens()
+        );
+
+        if computed_position < self.sequence.total_tokens() {
+            // no need to apply new tokens, since it's applied when created the slot during prefilling
+            self.state = SlotState::Prefilling;
+        } else {
+            tracing::debug!(
+                "appending {} newly decoded tokens to sequence",
+                tokens.len()
+            );
+            self.sequence.extend(tokens.into()).unwrap();
+            self.state = SlotState::Decoding;
+        }
+
+        // apply new block_ids, this should be applied for both prefilling and decoding
+        // because this is unknown when creating the slot
+        if !block_ids.is_empty() {
+            tracing::debug!("assigning {} new device blocks slot", block_ids.len());
+            self.device_blocks.extend(block_ids);
+        }
+
+        // This approach is fragile, but it’s the only way currently to skip evaluating
+        // the device matched blocks and to avoid offloading them again.
+        // TODO: Consider adding an indicator in the scheduler output to distinguish between
+        // matched and unmatched device blocks/tokens from the scheduler.
+        let maybe_have_device_matched_blocks =
+            is_new_request && computed_position > 0 && self.evaluated_blocks == 0;
+
+        if maybe_have_device_matched_blocks {
+            self.evaluated_blocks = (computed_position + 1) / self.block_size;
+        }
+
+        let num_candidate_blocks =
+            ((computed_position + 1) / self.block_size).saturating_sub(self.evaluated_blocks);
+
+        if num_candidate_blocks > 0 {
+            // do we have a mechanism for skipping gpu cache hit blocks?  not sure yet.
+            // for now, offload all the blocks to the host
+            let offload_block_ids: Vec<usize> = self
+                .device_blocks
+                .iter()
+                .skip(self.evaluated_blocks)
+                .take(num_candidate_blocks)
+                .copied()
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                offload_block_ids.len(),
+                num_candidate_blocks,
+                "device block overflow - candidate blocks exceed block count at offset {}",
+                self.evaluated_blocks
+            );
+
+            let offload_token_blocks: Vec<TokenBlock> = self
+                .sequence
+                .blocks()
+                .iter()
+                .skip(self.evaluated_blocks)
+                .take(num_candidate_blocks)
+                .cloned()
+                .collect::<Vec<_>>();
+
+            self.offload_blocks(&offload_block_ids, &offload_token_blocks)
+                .expect("failed to offload blocks");
+
+            self.evaluated_blocks += num_candidate_blocks;
+        }
+
+        // done applying policy
+        tracing::debug!(
+            "done applying kv cache policy at current_position: {}; computed_position: {}",
+            self.current_position,
+            computed_position,
+        );
+
+        // advance current position to computed position
+        self.current_position = computed_position;
 
         Ok(())
     }

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/trtllm_leader.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/trtllm_leader.rs
@@ -1,11 +1,9 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
 
 use crate::block_manager::BlockManagerBuilder;
-use dynamo_llm::block_manager::connector::protocol::RequestType;
-use dynamo_llm::block_manager::kv_consolidator::EventSource;
 use crate::block_manager::vllm::connector::leader::slot::{
     ConnectorSlotManager, SlotManager, SlotState,
 };
@@ -15,6 +13,7 @@ use crate::block_manager::vllm::connector::leader::{
 use crate::block_manager::{distributed::KvbmLeader as PyKvbmLeader, vllm::KvbmRequest};
 use crate::dynamo::get_current_tokio_handle;
 use anyhow;
+use dynamo_llm::block_manager::kv_consolidator::EventSource;
 use dynamo_llm::block_manager::metrics_kvbm::{KvbmMetrics, KvbmMetricsRegistry};
 use std::collections::HashSet;
 use std::sync::{Arc, OnceLock};
@@ -311,50 +310,23 @@ impl Leader for KvConnectorLeader {
         //
         // This is kind of a nice abstraction as it keeps the events simplier; however, we now create the request-slot
         // once for onboarding (this loop), then again for prefill/decode (new_requests loop).
-        //
-        // TODO(krish): Consider a more deterministic way to count immediate ops.
-        // Currently we count by filtering pending_ops at runtime. A higher-level approach
-        // (e.g., tracking count when onboard_blocks is called, or deriving from architecture
-        // config) might be more robust against potential timing-related issues.
         for request_id in onboarding_slots.iter() {
             let shared_slot = self.slot_manager().get_slot(request_id)?;
             let mut slot = shared_slot
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
 
-            let pending_ops_opt = slot.take_pending_operations();
+            md.create_slot(request_id.clone());
 
-            if let Some(pending_ops) = pending_ops_opt {
-                // Count immediate (onboard) operations for this slot
-                let num_immediate = pending_ops
-                    .iter()
-                    .filter(|op| op.request_type == RequestType::Immediate)
-                    .count() as u64;
-
-                // Create slot with expected immediate ops BEFORE adding operations
-                md.create_slot(request_id.clone(), num_immediate);
+            if let Some(pending_ops) = slot.take_pending_operations() {
+                tracing::debug!("adding {} pending onboarding operations", pending_ops.len());
                 md.add_operations(pending_ops);
-            } else {
-                md.create_slot(request_id.clone(), 0);
             }
         }
 
         // todo: update the code and abstraction to account for this two-phase lifecycle.
         for new_req in &scheduler_output.new_requests {
             let request_id = &new_req.request_id;
-
-            let already_created = md.new_slots.iter().any(|s| &s.request_id == request_id);
-
-            // Skip if this slot was already created in the onboarding_slots loop above.
-            // This prevents overwriting the slot with expected_immediate_ops=0 when it should have the correct count.
-            if already_created {
-                assert!(
-                    inflight_requests.remove(request_id),
-                    "request_id {request_id} not found in inflight_requests: "
-                );
-                continue;
-            }
-
             assert!(
                 inflight_requests.remove(request_id),
                 "request_id {request_id} not found in inflight_requests: "
@@ -364,6 +336,9 @@ impl Leader for KvConnectorLeader {
             let mut slot = shared_slot
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
+
+            // inform the worker that a new request-slot should be created
+            md.create_slot(new_req.request_id.clone());
 
             slot.record_start_iteration(iteration)?;
 
@@ -376,39 +351,20 @@ impl Leader for KvConnectorLeader {
                 slot.state()
             );
 
-            let scheduled_tokens = *scheduler_output
-                .num_scheduled_tokens
-                .get(request_id)
-                .unwrap_or(&0);
-
-            slot.apply_scheduler_output(
-                &[],
+            slot.apply_scheduler_output_with_computed_position(
+                &new_req.prompt_token_ids,
                 &new_req.block_ids,
                 new_req.num_computed_tokens,
-                scheduled_tokens,
+                true,
             )?;
 
-            let pending_ops_opt = slot.take_pending_operations();
-
-            if let Some(pending_ops) = pending_ops_opt {
-                // Count immediate (onboard) operations for this slot
-                let num_immediate = pending_ops
-                    .iter()
-                    .filter(|op| op.request_type == RequestType::Immediate)
-                    .count() as u64;
-
-                // Create slot with expected immediate ops BEFORE adding operations
-                md.create_slot(new_req.request_id.clone(), num_immediate);
-
+            if let Some(pending_ops) = slot.take_pending_operations() {
                 tracing::debug!(
-                    "adding {} pending operations for slot {} ({} immediate)",
+                    "adding {} pending operations for slot {}",
                     pending_ops.len(),
-                    new_req.request_id,
-                    num_immediate
+                    new_req.request_id
                 );
                 md.add_operations(pending_ops);
-            } else {
-                md.create_slot(new_req.request_id.clone(), 0);
             }
         }
 
@@ -426,16 +382,11 @@ impl Leader for KvConnectorLeader {
                 .lock()
                 .map_err(|e| anyhow::anyhow!("Failed to lock slot: {}", e))?;
 
-            let scheduled_tokens = *scheduler_output
-                .num_scheduled_tokens
-                .get(request_id)
-                .unwrap_or(&0);
-
-            slot.apply_scheduler_output(
+            slot.apply_scheduler_output_with_computed_position(
                 &cached_req.new_token_ids,
                 &cached_req.new_block_ids,
                 cached_req.num_computed_tokens,
-                scheduled_tokens,
+                false,
             )?;
 
             if let Some(pending_ops) = slot.take_pending_operations() {

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/trtllm_worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/trtllm_worker.rs
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_llm::block_manager::connector::protocol::TransferType;
 use dynamo_llm::block_manager::connector::scheduler::{
-    Scheduler, SchedulerMessage, TransferSchedulerClient, WorkerSchedulerClient,
+    Scheduler, TransferSchedulerClient, WorkerSchedulerClient,
 };
 
 use std::collections::HashSet;
@@ -48,11 +48,6 @@ pub trait Worker: Send + Sync {
         finished_gen_req_ids: Vec<u64>,
         started_loading_req_ids: Vec<u64>,
     ) -> (Vec<u64>, Vec<u64>);
-
-    /// Submit offload operations to execute after the CUDA event completes (non-blocking).
-    /// Does slot bookkeeping synchronously, then spawns an async task to poll the event
-    /// and send operations to the scheduler when complete.
-    fn submit_offload_on_event(&mut self, event: u64) -> anyhow::Result<()>;
 }
 
 pub struct KvConnectorWorker {
@@ -187,17 +182,9 @@ impl Worker for KvConnectorWorker {
         // - for each action in the metadata, add the action to the request slot
         // - send the list of actions to the engine to track completion
 
-        for slot_info in metadata.new_slots {
-            debug_assert!(
-                !self.connector.has_slot(&slot_info.request_id),
-                "slot already exists"
-            );
-            // Create slot with expected immediate ops count BEFORE any operations arrive.
-            // This ensures proper completion tracking and avoids race conditions in TP>1.
-            self.connector.create_slot_with_immediate_ops(
-                slot_info.request_id,
-                slot_info.expected_immediate_ops,
-            )?;
+        for slot in metadata.new_slots {
+            debug_assert!(!self.connector.has_slot(&slot), "slot already exists");
+            self.connector.create_slot(slot)?;
         }
 
         let mut onboarding_operations = Vec::new();
@@ -407,33 +394,6 @@ impl Worker for KvConnectorWorker {
 
         (finished_offloading, finished_onboarding)
     }
-
-    fn submit_offload_on_event(&mut self, event: u64) -> anyhow::Result<()> {
-        let operations = std::mem::take(&mut self.offloading_operations);
-
-        // Bookkeeping done synchronously while we have &mut self
-        for op in &operations {
-            self.connector.record_operation(&op.request_id, op.uuid);
-        }
-
-        // Clone channel for async use
-        let tx = self.connector.get_scheduler_tx();
-
-        // Use std::thread since we may be in a subprocess without tokio runtime
-        std::thread::spawn(move || {
-            // Block this thread until event completes (doesn't block main thread)
-            event_sync_blocking(event);
-
-            // Send operations to scheduler
-            for op in operations {
-                if let Err(e) = tx.send(SchedulerMessage::EnqueueRequest(op)) {
-                    tracing::error!("Failed to send offload operation: {}", e);
-                }
-            }
-        });
-
-        Ok(())
-    }
 }
 
 #[pyclass]
@@ -512,11 +472,5 @@ impl PyTrtllmKvConnectorWorker {
     ) -> (Vec<u64>, Vec<u64>) {
         self.connector_worker
             .get_finished(finished_gen_req_ids, started_loading_req_ids)
-    }
-
-    pub fn submit_offload_on_event(&mut self, event: u64) -> PyResult<()> {
-        self.connector_worker
-            .submit_offload_on_event(event)
-            .map_err(to_pyerr)
     }
 }

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_llm::block_manager::connector::protocol::TransferType;
@@ -251,17 +251,9 @@ impl Worker for KvConnectorWorker {
         // - for each action in the metadata, add the action to the request slot
         // - send the list of actions to the engine to track completion
 
-        for slot_info in &metadata.new_slots {
-            debug_assert!(
-                !self.connector.has_slot(&slot_info.request_id),
-                "slot already exists"
-            );
-            // Create slot with expected immediate ops count BEFORE any operations arrive.
-            // This ensures proper completion tracking and avoids race conditions in TP>1.
-            self.connector.create_slot_with_immediate_ops(
-                slot_info.request_id.clone(),
-                slot_info.expected_immediate_ops,
-            )?;
+        for slot in metadata.new_slots {
+            debug_assert!(!self.connector.has_slot(&slot), "slot already exists");
+            self.connector.create_slot(slot)?;
         }
 
         let mut onboarding_operations = Vec::new();


### PR DESCRIPTION
- Simplify ConnectorMetadata::create_slot to single request_id arg
- Remove NewSlotInfo struct and expected_immediate_ops tracking
- Simplify leader slot creation for onboarding and new requests
- Update trtllm leader/worker for simplified slot API
- Fix update_cache_hit_rates call to include object_rate arg
