### PR TITLE
fix: Add CUDA synchronization to prevent sleep/wake race conditions

### DIFF
--- a/lib/gpu_memory_service/vllm_integration/worker.py
+++ b/lib/gpu_memory_service/vllm_integration/worker.py
@@ -128,6 +128,11 @@ class GMSWorker(Worker):
         allocator = CuMemAllocator.get_instance()
         allocator.sleep(offload_tags=tuple())
 
+        # Ensure all CUDA VMM unmap operations complete before returning.
+        # Without this sync, wake_up() may race with pending unmaps, causing OOM
+        # when it tries to allocate new memory while old memory is still mapped.
+        torch.cuda.synchronize()
+
         free_bytes_after, total = torch.cuda.mem_get_info()
         freed_bytes = free_bytes_after - free_bytes_before
         used_bytes = total - free_bytes_after
@@ -154,6 +159,10 @@ class GMSWorker(Worker):
         if "kv_cache" in tags:
             allocator = CuMemAllocator.get_instance()
             allocator.wake_up(tags=["kv_cache"])
+
+            # Ensure KV cache mappings are complete before returning.
+            # Without this sync, inference may start before mappings are ready.
+            torch.cuda.synchronize()
 
             # Reinitialize FP8 KV scales if needed
             if self.cache_config.cache_dtype.startswith("fp8") and hasattr(


### PR DESCRIPTION
## Summary
- Cherry-pick of 0e6bc8012b5f223701c047994e3df283d9058f59 to release/0.9.0
- Adds CUDA synchronization to prevent sleep/wake race conditions

## Test plan
- [ ] Verify sleep/wake functionality works without OOM errors