### PR TITLE
test: [DYN-1988] skip TRTLLM KVBM disagg test for now until upstream's fix is released

### DIFF
--- a/tests/kvbm_integration/common.py
+++ b/tests/kvbm_integration/common.py
@@ -336,7 +336,7 @@ class DeterminismTester(ApiTester):
 
         top_k = -1
         if check_module_available("tensorrt_llm"):
-            top_k = 0
+            top_k = 1  # TensorRT-LLM requires top_k>=0 and dynamo frontend does not support top_k=0
         # For determinism: use temperature=0 which should trigger greedy decoding in vLLM
         # Setting top_p=1.0 and top_k=-1 to avoid any sampling/filtering
         return super().make_request(

--- a/tests/kvbm_integration/test_determinism_disagg.py
+++ b/tests/kvbm_integration/test_determinism_disagg.py
@@ -547,6 +547,10 @@ def tester(llm_server):
 class TestDeterminismDisagg(BaseTestDeterminism):
     """Test class for determinism validation."""
 
+    @pytest.mark.skipif(
+        check_module_available("tensorrt_llm"),
+        reason="Skipping test until the TRT-LLM disagg hang issue is fixed. (https://github.com/NVIDIA/TensorRT-LLM/pull/11247)",
+    )
     @pytest.mark.parametrize(
         "llm_server",
         [


### PR DESCRIPTION
#### Overview:

Skip the TRTLLM KVBM disagg since the TRTLLM KVBM disagg currently doesn't support disabling the block partial use yet, 
KVBM requires to disable the block partial reuse to improve the cache hit rate. 

we need this PR (https://github.com/NVIDIA/TensorRT-LLM/pull/11247) in to make trtllm + KVBM + disagg functional. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected test request parameters to align with TensorRT-LLM constraints.

* **Tests**
  * Tests now skip problematic scenarios to prevent known compatibility hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->