### PR TITLE
fix: mm_item keys for SGLang API

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -114,17 +114,28 @@ class EmbeddingsProcessor:
     def create_multimodal_item(
         embeddings: torch.Tensor, request: SglangMultimodalRequest
     ) -> dict:
-        """Create multimodal item for SGLang generation"""
+        """
+        Create multimodal item for SGLang generation.
 
-        precomputed_embeddings = embeddings.to(MultimodalConfig.EMBEDDINGS_DTYPE)
+        Uses format="precomputed_embedding" since Dynamo's Encoder has already
+        run the vision encoder. SGLang expects 2D embeddings (num_patches, hidden_dim).
+        """
+        precomputed = embeddings.to(MultimodalConfig.EMBEDDINGS_DTYPE)
+
+        # SGLang expects 2D tensor for precomputed_embedding format
+        # Encoder outputs 3D (1, num_patches, hidden_dim) for internal consistency
+        # Squeeze batch dimension at SGLang boundary
+        if precomputed.dim() == 3 and precomputed.shape[0] == 1:
+            precomputed = precomputed.squeeze(0)
+
         grid_thw_tensor = torch.tensor(request.image_grid_thw)
 
-        mm_item = dict(
-            format="processor_output",
-            modality="IMAGE",
-            image_grid_thw=grid_thw_tensor,
-            precomputed_embeddings=precomputed_embeddings,
-        )
+        mm_item = {
+            "format": "precomputed_embedding",
+            "feature": precomputed,
+            "image_grid_thw": grid_thw_tensor,
+            "modality": "IMAGE",
+        }
 
         return mm_item
 

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -120,6 +120,7 @@ class EmbeddingsProcessor:
         grid_thw_tensor = torch.tensor(request.image_grid_thw)
 
         mm_item = dict(
+            format="processor_output",
             modality="IMAGE",
             image_grid_thw=grid_thw_tensor,
             precomputed_embeddings=precomputed_embeddings,


### PR DESCRIPTION
#### Overview:

SGLang [PR#14091](https://github.com/sgl-project/sglang/pull/14091) standardized the multimodal item dict schema. By making certain fields required, this led to breaking changes in dynamo's EPD flow, such as:
```
2026-02-02T23:02:03.518196Z ERROR worker_handler.process_sglang_stream: Error in stream processing: An exception occurred while loading multimodal data: Error while loading data {'modality': 'IMAGE', 'image_grid_thw': tensor([[ 1, 30, 46]]), 'precomputed_embeddings': tensor([[[ 1.2354,  1.2725, -1.2822,  ...,  0.8950, -0.9429, -0.5669],
         [-1.5225,  1.4619, -0.6025,  ...,  0.7544, -0.3940, -1.7881],
         [-0.2168,  1.3652, -0.0756,  ..., -0.5845,  0.0179, -1.1748],
         ...,
         [-0.0677,  0.2947, -0.1929,  ..., -0.1968, -0.4055, -0.2668],
         [ 0.5752, -0.0920,  0.2206,  ...,  0.1470,  0.4141, -1.1084],
         [ 0.6523,  0.2115,  0.4751,  ..., -0.3186,  0.8994, -1.2617]]],
       dtype=torch.float16)}: 'dict' object has no attribute 'startswith'
2026-02-02T23:02:03.521238Z  WARN http-request: dynamo_runtime::pipeline::network::egress::addressed_router: Failed deserializing JSON to response err=unknown variant `error`, expected one of `stop`, `length`, `tool_calls`, `content_filter`, `function_call` at line 1 column 232 json_str={"data":{"data":{"id":"chatcmpl-7feca0d0fbbc433f902f92fa660939a8","object":"chat.completion.chunk","created":1770073323,"model":"Qwen/Qwen2.5-VL-7B-Instruct","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":"error"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}},"complete_final":false} method=POST uri=/v1/chat/completions version=HTTP/1.1
2026-02-02T23:02:03.521403Z ERROR http-request: dynamo_llm::http::service::openai: Backend error detected: (500, Json(ErrorMessage { message: "unknown variant `error`, expected one of `stop`, `length`, `tool_calls`, `content_filter`, `function_call` at line 1 column 232", error_type: "Internal Server Error", code: 500 })) request_id="6eace276-0a1b-4462-bfdc-37315afb0ea4" method=POST uri=/v1/chat/completions version=HTTP/1.1
2026-02-02T23:02:03.521681Z ERROR http-request: dynamo_llm::http::service::service_v2: request completed with server error status=500 latency_ms=956 method=POST uri=/v1/chat/completions version=HTTP/1.1
```

 #### Details:
Updates mm_item to match:

- `format`: `processor_output` → `precomputed_embedding`
- `precomputed_embeddings` → `feature`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of precomputed embeddings in multimodal requests to ensure proper data formatting and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->