### PR TITLE
feat: add Prometheus auto and custom label injection for engine metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,3 +98,4 @@ repos:
         - pydantic
         - filelock
         - pyyaml
+        - prometheus_client>=0.23.1

--- a/components/src/dynamo/common/utils/label_injecting_collector.py
+++ b/components/src/dynamo/common/utils/label_injecting_collector.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Custom Prometheus collector that injects additional labels into metrics.
+
+Wraps a source registry and clones metrics during collection, injecting user-specified
+labels without modifying the original metrics. Preserves all metric types, reserved
+labels (histogram 'le', summary 'quantile'), timestamps, and exemplars.
+"""
+
+from typing import TYPE_CHECKING, Iterator
+
+from prometheus_client.registry import Collector
+
+# Import prometheus_client types for type hints only
+# Actual prometheus_client imports happen inside methods to respect initialization order
+if TYPE_CHECKING:
+    from prometheus_client import CollectorRegistry
+    from prometheus_client.metrics_core import Metric as MetricFamily
+
+
+class LabelInjectingCollector(Collector):
+    """
+    Prometheus collector that injects labels into metrics during collection.
+    Preserves all metric types, reserved labels, timestamps, and exemplars.
+    """
+
+    def __init__(
+        self,
+        source_registry: "CollectorRegistry",
+        labels_to_inject: dict[str, str],
+    ):
+        """
+        Args:
+            source_registry: Source registry to collect from
+            labels_to_inject: Labels to inject (e.g. {"dynamo_namespace": "prod"})
+
+        Raises:
+            ValueError: If labels_to_inject is empty or contains reserved labels (le, quantile)
+        """
+        if not labels_to_inject:
+            raise ValueError("labels_to_inject cannot be empty")
+
+        # Check for reserved label names that should not be overwritten
+        reserved_labels = {"le", "quantile"}
+        conflicting_labels = reserved_labels.intersection(labels_to_inject.keys())
+        if conflicting_labels:
+            raise ValueError(
+                f"Cannot inject reserved label names: {conflicting_labels}. "
+                f"Reserved labels: {reserved_labels}"
+            )
+
+        self.source_registry = source_registry
+        self.labels_to_inject = labels_to_inject
+
+    def collect(self) -> Iterator["MetricFamily"]:
+        """
+        Collect metrics from source registry with injected labels.
+        Preserves all metric types, reserved labels, timestamps, and exemplars.
+        """
+        # Delayed import here to respect prometheus_client multiprocess initialization order
+        from prometheus_client.metrics_core import Metric as MetricFamily
+        from prometheus_client.samples import Sample
+
+        for metric_family in self.source_registry.collect():
+            # Clone the metric family with injected labels
+            new_samples = []
+            for sample in metric_family.samples:
+                # Merge existing labels with injected labels
+                # Existing labels take precedence (don't overwrite if already present)
+                merged_labels = {**self.labels_to_inject, **sample.labels}
+
+                # Create new sample with merged labels
+                new_sample = Sample(
+                    name=sample.name,
+                    labels=merged_labels,
+                    value=sample.value,
+                    timestamp=sample.timestamp,
+                    exemplar=sample.exemplar,
+                )
+                new_samples.append(new_sample)
+
+            # Create new metric family with updated samples
+            new_metric_family = MetricFamily(
+                name=metric_family.name,
+                documentation=metric_family.documentation,
+                typ=metric_family.type,
+                unit=metric_family.unit,
+            )
+            new_metric_family.samples = new_samples
+
+            yield new_metric_family
+
+    def describe(self) -> Iterator["MetricFamily"]:
+        """Describe metrics from source registry (forwards to source)."""
+        return iter(self.source_registry.collect())

--- a/components/src/dynamo/common/utils/tests/test_label_injecting_collector.py
+++ b/components/src/dynamo/common/utils/tests/test_label_injecting_collector.py
@@ -1,0 +1,410 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for LabelInjectingCollector.
+
+Tests the custom Prometheus collector that injects labels into metrics without
+modifying the source metrics.
+"""
+
+import pytest
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, Summary
+
+
+class TestLabelInjectingCollector:
+    """Test suite for LabelInjectingCollector"""
+
+    def test_counter_label_injection(self):
+        """Test injecting labels into Counter metrics"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        # Create source registry with a counter
+        source_registry = CollectorRegistry()
+        counter = Counter(
+            "test_counter",
+            "Test counter",
+            registry=source_registry,
+        )
+        counter.inc(5)
+
+        # Create collector that injects labels
+        labels_to_inject = {
+            "dynamo_namespace": "prod",
+            "dynamo_component": "test-component",
+        }
+        collector = LabelInjectingCollector(source_registry, labels_to_inject)
+
+        # Collect metrics
+        metric_families = list(collector.collect())
+
+        # Verify counter exists with injected labels
+        assert len(metric_families) == 1
+        mf = metric_families[0]
+        assert mf.name == "test_counter"
+        assert mf.type == "counter"
+
+        # Verify samples have injected labels
+        # Counter may have multiple samples: _total (value) and _created (timestamp)
+        assert len(mf.samples) >= 1
+
+        # Find the _total sample (the actual counter value)
+        total_sample = next(s for s in mf.samples if s.name.endswith("_total"))
+        assert total_sample.labels["dynamo_namespace"] == "prod"
+        assert total_sample.labels["dynamo_component"] == "test-component"
+        assert total_sample.value == 5
+
+    def test_gauge_label_injection(self):
+        """Test injecting labels into Gauge metrics"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        # Create source registry with a gauge
+        source_registry = CollectorRegistry()
+        gauge = Gauge(
+            "test_gauge",
+            "Test gauge",
+            registry=source_registry,
+        )
+        gauge.set(42)
+
+        # Create collector that injects labels
+        labels_to_inject = {"dynamo_endpoint": "generate", "model": "llama-3-70b"}
+        collector = LabelInjectingCollector(source_registry, labels_to_inject)
+
+        # Collect metrics
+        metric_families = list(collector.collect())
+
+        # Verify gauge exists with injected labels
+        assert len(metric_families) == 1
+        mf = metric_families[0]
+        assert mf.name == "test_gauge"
+        assert mf.type == "gauge"
+
+        # Verify samples have injected labels
+        assert len(mf.samples) == 1
+        sample = mf.samples[0]
+        assert sample.labels["dynamo_endpoint"] == "generate"
+        assert sample.labels["model"] == "llama-3-70b"
+        assert sample.value == 42
+
+    def test_histogram_preserves_le_label(self):
+        """Test that histogram 'le' label is preserved and not overwritten"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        # Create source registry with a histogram
+        source_registry = CollectorRegistry()
+        histogram = Histogram(
+            "test_histogram",
+            "Test histogram",
+            registry=source_registry,
+        )
+        histogram.observe(0.5)
+        histogram.observe(1.5)
+        histogram.observe(2.5)
+
+        # Create collector that injects labels
+        labels_to_inject = {
+            "dynamo_namespace": "prod",
+            "dynamo_component": "vllm-worker",
+        }
+        collector = LabelInjectingCollector(source_registry, labels_to_inject)
+
+        # Collect metrics
+        metric_families = list(collector.collect())
+
+        # Find histogram metric family
+        histogram_mf = next(mf for mf in metric_families if mf.name == "test_histogram")
+        assert histogram_mf.type == "histogram"
+
+        # Verify histogram buckets have 'le' label preserved
+        bucket_samples = [s for s in histogram_mf.samples if s.name.endswith("_bucket")]
+        assert len(bucket_samples) > 0
+
+        for sample in bucket_samples:
+            # Verify 'le' label exists (reserved for histogram buckets)
+            assert "le" in sample.labels
+            # Verify injected labels are present
+            assert sample.labels["dynamo_namespace"] == "prod"
+            assert sample.labels["dynamo_component"] == "vllm-worker"
+
+        # Verify sum and count samples also have injected labels
+        sum_sample = next(s for s in histogram_mf.samples if s.name.endswith("_sum"))
+        assert sum_sample.labels["dynamo_namespace"] == "prod"
+        assert sum_sample.labels["dynamo_component"] == "vllm-worker"
+
+        count_sample = next(
+            s for s in histogram_mf.samples if s.name.endswith("_count")
+        )
+        assert count_sample.labels["dynamo_namespace"] == "prod"
+        assert count_sample.labels["dynamo_component"] == "vllm-worker"
+
+    def test_summary_preserves_quantile_label(self):
+        """Test that summary 'quantile' label is preserved"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        # Create source registry with a summary
+        source_registry = CollectorRegistry()
+        summary = Summary(
+            "test_summary",
+            "Test summary",
+            registry=source_registry,
+        )
+        summary.observe(1.0)
+        summary.observe(2.0)
+        summary.observe(3.0)
+
+        # Create collector that injects labels
+        labels_to_inject = {"dynamo_endpoint": "generate", "rank": "0"}
+        collector = LabelInjectingCollector(source_registry, labels_to_inject)
+
+        # Collect metrics
+        metric_families = list(collector.collect())
+
+        # Find summary metric family
+        summary_mf = next(mf for mf in metric_families if mf.name == "test_summary")
+        assert summary_mf.type == "summary"
+
+        # Verify summary quantiles have 'quantile' label preserved (if present)
+        # Note: Not all summary implementations expose quantiles, so this is optional
+        quantile_samples = [s for s in summary_mf.samples if "quantile" in s.labels]
+        for sample in quantile_samples:
+            # Verify 'quantile' label exists (reserved for summary quantiles)
+            assert "quantile" in sample.labels
+            # Verify injected labels are present
+            assert sample.labels["dynamo_endpoint"] == "generate"
+            assert sample.labels["rank"] == "0"
+
+        # Verify sum and count samples have injected labels
+        sum_sample = next(s for s in summary_mf.samples if s.name.endswith("_sum"))
+        assert sum_sample.labels["dynamo_endpoint"] == "generate"
+        assert sum_sample.labels["rank"] == "0"
+
+        count_sample = next(s for s in summary_mf.samples if s.name.endswith("_count"))
+        assert count_sample.labels["dynamo_endpoint"] == "generate"
+        assert count_sample.labels["rank"] == "0"
+
+    def test_multiple_labels_injection(self):
+        """Test injecting multiple labels at once"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        # Create source registry with a counter
+        source_registry = CollectorRegistry()
+        counter = Counter("test_counter", "Test counter", registry=source_registry)
+        counter.inc()
+
+        # Create collector with multiple labels to inject
+        labels_to_inject = {
+            "dynamo_namespace": "prod",
+            "dynamo_component": "vllm-worker",
+            "dynamo_endpoint": "generate",
+            "model": "llama-3-70b",
+            "instance_id": "worker-0",
+            "rank": "0",
+        }
+        collector = LabelInjectingCollector(source_registry, labels_to_inject)
+
+        # Collect metrics
+        metric_families = list(collector.collect())
+        assert len(metric_families) == 1
+
+        # Verify all labels are present
+        sample = metric_families[0].samples[0]
+        assert sample.labels["dynamo_namespace"] == "prod"
+        assert sample.labels["dynamo_component"] == "vllm-worker"
+        assert sample.labels["dynamo_endpoint"] == "generate"
+        assert sample.labels["model"] == "llama-3-70b"
+        assert sample.labels["instance_id"] == "worker-0"
+        assert sample.labels["rank"] == "0"
+
+    def test_merge_with_existing_labels(self):
+        """Test injecting labels into metrics that already have labels"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        # Create source registry with a counter that has labels
+        source_registry = CollectorRegistry()
+        counter = Counter(
+            "test_counter",
+            "Test counter",
+            labelnames=["status", "method"],
+            registry=source_registry,
+        )
+        counter.labels(status="success", method="GET").inc(10)
+        counter.labels(status="error", method="POST").inc(5)
+
+        # Create collector that injects additional labels
+        labels_to_inject = {
+            "dynamo_namespace": "prod",
+            "dynamo_component": "vllm-worker",
+        }
+        collector = LabelInjectingCollector(source_registry, labels_to_inject)
+
+        # Collect metrics
+        metric_families = list(collector.collect())
+        assert len(metric_families) == 1
+
+        # Verify both original and injected labels are present
+        samples = metric_families[0].samples
+        # Counter may have _total and _created samples for each label combination
+        assert len(samples) >= 2
+
+        # Filter to only _total samples (the actual counter values)
+        total_samples = [s for s in samples if s.name.endswith("_total")]
+        assert len(total_samples) == 2
+
+        # First sample: status=success, method=GET
+        sample1 = total_samples[0]
+        assert sample1.labels["status"] == "success"
+        assert sample1.labels["method"] == "GET"
+        assert sample1.labels["dynamo_namespace"] == "prod"
+        assert sample1.labels["dynamo_component"] == "vllm-worker"
+        assert sample1.value == 10
+
+        # Second sample: status=error, method=POST
+        sample2 = total_samples[1]
+        assert sample2.labels["status"] == "error"
+        assert sample2.labels["method"] == "POST"
+        assert sample2.labels["dynamo_namespace"] == "prod"
+        assert sample2.labels["dynamo_component"] == "vllm-worker"
+        assert sample2.value == 5
+
+    def test_existing_label_not_overwritten(self):
+        """Test that existing labels take precedence over injected labels"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        # Create source registry with a counter that has a 'model' label
+        source_registry = CollectorRegistry()
+        counter = Counter(
+            "test_counter",
+            "Test counter",
+            labelnames=["model"],
+            registry=source_registry,
+        )
+        counter.labels(model="original-model").inc()
+
+        # Try to inject a 'model' label with different value
+        labels_to_inject = {
+            "model": "injected-model",  # This should NOT overwrite existing label
+            "dynamo_namespace": "prod",
+        }
+        collector = LabelInjectingCollector(source_registry, labels_to_inject)
+
+        # Collect metrics
+        metric_families = list(collector.collect())
+        sample = metric_families[0].samples[0]
+
+        # Verify original label is preserved (not overwritten)
+        assert sample.labels["model"] == "original-model"
+        assert sample.labels["dynamo_namespace"] == "prod"
+
+    def test_empty_labels_raises_error(self):
+        """Test that empty labels dict raises ValueError"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        source_registry = CollectorRegistry()
+
+        # Empty labels dict should raise ValueError
+        with pytest.raises(ValueError, match="labels_to_inject cannot be empty"):
+            LabelInjectingCollector(source_registry, {})
+
+    def test_reserved_label_le_raises_error(self):
+        """Test that trying to inject reserved label 'le' raises ValueError"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        source_registry = CollectorRegistry()
+
+        # Trying to inject reserved 'le' label should raise ValueError
+        with pytest.raises(ValueError, match="Cannot inject reserved label names"):
+            LabelInjectingCollector(
+                source_registry,
+                {"le": "1.0", "dynamo_namespace": "prod"},
+            )
+
+    def test_reserved_label_quantile_raises_error(self):
+        """Test that trying to inject reserved label 'quantile' raises ValueError"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        source_registry = CollectorRegistry()
+
+        # Trying to inject reserved 'quantile' label should raise ValueError
+        with pytest.raises(ValueError, match="Cannot inject reserved label names"):
+            LabelInjectingCollector(
+                source_registry,
+                {"quantile": "0.99", "dynamo_namespace": "prod"},
+            )
+
+    def test_multiple_metrics_all_get_labels(self):
+        """Test that all metrics in registry get injected labels"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        # Create source registry with multiple metrics
+        source_registry = CollectorRegistry()
+        counter = Counter("test_counter", "Test counter", registry=source_registry)
+        gauge = Gauge("test_gauge", "Test gauge", registry=source_registry)
+        histogram = Histogram(
+            "test_histogram", "Test histogram", registry=source_registry
+        )
+
+        counter.inc(5)
+        gauge.set(42)
+        histogram.observe(1.5)
+
+        # Create collector that injects labels
+        labels_to_inject = {
+            "dynamo_namespace": "prod",
+            "dynamo_component": "vllm-worker",
+        }
+        collector = LabelInjectingCollector(source_registry, labels_to_inject)
+
+        # Collect metrics
+        metric_families = list(collector.collect())
+        assert len(metric_families) == 3
+
+        # Verify all metric families have injected labels in their samples
+        for mf in metric_families:
+            for sample in mf.samples:
+                assert sample.labels["dynamo_namespace"] == "prod"
+                assert sample.labels["dynamo_component"] == "vllm-worker"
+
+    def test_timestamp_preservation(self):
+        """Test that timestamps are preserved"""
+        from dynamo.common.utils.label_injecting_collector import (
+            LabelInjectingCollector,
+        )
+
+        # Create source registry with a gauge
+        source_registry = CollectorRegistry()
+        gauge = Gauge("test_gauge", "Test gauge", registry=source_registry)
+        gauge.set(42)
+
+        # Create collector
+        labels_to_inject = {"dynamo_namespace": "prod"}
+        collector = LabelInjectingCollector(source_registry, labels_to_inject)
+
+        # Collect metrics
+        metric_families = list(collector.collect())
+        sample = metric_families[0].samples[0]
+
+        # Verify timestamp attribute exists (may be None)
+        assert sample.timestamp is None or isinstance(sample.timestamp, (float, int))

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -10,6 +10,7 @@ import time
 import sglang as sgl
 import uvloop
 
+from dynamo import prometheus_names
 from dynamo.common.config_dump import dump_config
 from dynamo.common.storage import get_fs
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
@@ -530,11 +531,14 @@ async def init_multimodal_processor(runtime: DistributedRuntime, config: Config)
     await encode_worker_client.wait_for_instances()
 
     try:
-        await asyncio.gather(
+        _ = await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
                 graceful_shutdown=True,
-                metrics_labels=[("model", server_args.served_model_name)],
+                metrics_labels=[
+                    (prometheus_names.labels.MODEL, server_args.served_model_name),
+                    (prometheus_names.labels.MODEL_NAME, server_args.served_model_name),
+                ],
             ),
             register_llm_with_readiness_gate(
                 None,  # engine
@@ -581,7 +585,10 @@ async def init_multimodal_encode_worker(runtime: DistributedRuntime, config: Con
         await generate_endpoint.serve_endpoint(
             handler.generate,
             graceful_shutdown=True,
-            metrics_labels=[("model", server_args.served_model_name)],
+            metrics_labels=[
+                (prometheus_names.labels.MODEL, server_args.served_model_name),
+                (prometheus_names.labels.MODEL_NAME, server_args.served_model_name),
+            ],
         )
     except Exception as e:
         logging.error(f"Failed to serve endpoints: {e}")

--- a/components/src/dynamo/trtllm/tests/test_trtllm_main_init.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_main_init.py
@@ -71,8 +71,7 @@ def test_prometheus_metrics_integration():
         register_engine_metrics_callback(
             endpoint=mock_endpoint,
             registry=REGISTRY,
-            exclude_prefixes=["python_", "process_"],
-            add_prefix="trtllm_",
+            metric_prefix_filters=["trtllm_"],
         )
 
         print("✅ Prometheus metrics integration test passed")

--- a/docs/backends/trtllm/prometheus.md
+++ b/docs/backends/trtllm/prometheus.md
@@ -173,7 +173,7 @@ TensorRT-LLM provides extensive performance data beyond the basic Prometheus met
 ## Implementation Details
 
 - **Prometheus Integration**: Uses the `MetricsCollector` class from `tensorrt_llm.metrics` (see [collector.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/metrics/collector.py))
-- **Dynamo Integration**: Uses `register_engine_metrics_callback()` function with `add_prefix="trtllm_"`
+- **Dynamo Integration**: Uses `register_engine_metrics_callback()` function with `metric_prefix_filter=["trtllm_"]`
 - **Engine Configuration**: `return_perf_metrics` set to `True` when `--publish-events-and-metrics` is enabled
 - **Initialization**: Metrics appear after TensorRT-LLM engine initialization completes
 - **Metadata**: `MetricsCollector` initialized with model metadata (model name, engine type)

--- a/fern/pages/backends/trtllm/prometheus.md
+++ b/fern/pages/backends/trtllm/prometheus.md
@@ -11,7 +11,7 @@ When running TensorRT-LLM through Dynamo, TensorRT-LLM's Prometheus metrics are 
 
 Additional performance metrics are available via non-Prometheus APIs (see [Non-Prometheus Performance Metrics](#non-prometheus-performance-metrics) below).
 
-As of the date of this documentation, the included TensorRT-LLM version 1.1.0rc5 exposes **5 basic Prometheus metrics**. Note that the `trtllm_` prefix is added by Dynamo.
+TensorRT-LLM natively exposes several Prometheus metrics with the `trtllm_` prefix. The specific metrics available depend on your TensorRT-LLM version.
 
 **For Dynamo runtime metrics**, see the [Dynamo Metrics Guide](../../observability/metrics.md).
 
@@ -114,7 +114,7 @@ TensorRT-LLM provides metrics in the following categories (all prefixed with `tr
 
 ## Available Metrics
 
-The following metrics are exposed via Dynamo's `/metrics` endpoint (with the `trtllm_` prefix added by Dynamo) for TensorRT-LLM version 1.1.0rc5:
+TensorRT-LLM exposes metrics via Dynamo's `/metrics` endpoint with the `trtllm_` prefix. Common metrics include:
 
 - `trtllm_request_success_total` (Counter) — Count of successfully processed requests by finish reason
   - Labels: `model_name`, `engine_type`, `finished_reason`
@@ -127,7 +127,7 @@ The following metrics are exposed via Dynamo's `/metrics` endpoint (with the `tr
 - `trtllm_request_queue_time_seconds` (Histogram) — Time a request spends waiting in the queue (seconds)
   - Labels: `model_name`, `engine_type`
 
-These metric names and availability are subject to change with TensorRT-LLM version updates.
+**Note:** The specific metrics available depend on your TensorRT-LLM version. Always inspect your actual `/metrics` endpoint to see the current list of metrics for your version.
 
 TensorRT-LLM provides Prometheus metrics through the `MetricsCollector` class (see [tensorrt_llm/metrics/collector.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/metrics/collector.py)).
 
@@ -168,14 +168,14 @@ TensorRT-LLM provides extensive performance data beyond the basic Prometheus met
 }
 ```
 
-**Note:** These structures are valid as of the date of this documentation but are subject to change with TensorRT-LLM version updates.
+**Note:** These structures may vary depending on your TensorRT-LLM version. Refer to the [TensorRT-LLM source code](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/executor/result.py) for the most up-to-date structure for your version.
 
 ## Implementation Details
 
 - **Prometheus Integration**: Uses the `MetricsCollector` class from `tensorrt_llm.metrics` (see [collector.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/metrics/collector.py))
-- **Dynamo Integration**: Uses `register_engine_metrics_callback()` function with `add_prefix="trtllm_"`
+- **Dynamo Integration**: Uses `register_engine_metrics_callback()` function to pass through TRT-LLM's native `trtllm_*` metrics
 - **Engine Configuration**: `return_perf_metrics` set to `True` when `--publish-events-and-metrics` is enabled
-- **Initialization**: Metrics appear after TensorRT-LLM engine initialization completes
+- **Initialization**: Metrics appear after TensorRT-LLM engine initialization completes and after at least one request is processed
 - **Metadata**: `MetricsCollector` initialized with model metadata (model name, engine type)
 
 ## Related Documentation

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -164,8 +164,15 @@ class labels:
     # Note: this is not an auto-inserted label like `dynamo_namespace`/`dynamo_component`.
     # It is used by worker/load-style metrics that need to disambiguate per-worker series.
     DP_RANK = "dp_rank"
-    # Label for model name
+    # Label for model name/path (OpenAI API standard, injected by Dynamo)
+    # This is the standard label name injected by all backends in metrics_labels=[("model", ...)].
+    # Ensures compatibility with OpenAI-compatible tooling.
     MODEL = "model"
+    # Label for model name/path (alternative/native engine label, injected by Dynamo)
+    # Some engines natively use model_name, so we inject both model and model_name
+    # to ensure maximum compatibility with both OpenAI standard and engine-native tooling.
+    # When a metric already has a label, injection does not overwrite it (original is preserved).
+    MODEL_NAME = "model_name"
     # Label for worker type (e.g., "aggregated", "prefill", "decode", "encoder", etc.)
     WORKER_TYPE = "worker_type"
 

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -71,6 +71,12 @@ pub mod name_prefix {
 }
 
 /// Automatically inserted Prometheus label names used across the metrics system
+///
+/// These labels are auto-injected into metrics by the hierarchy system:
+/// - Rust: lib/runtime/src/metrics.rs create_metric() function
+/// - Python: components/src/dynamo/common/utils/prometheus.py register_engine_metrics_callback()
+///
+/// Python codegen: These constants are exported to lib/bindings/python/src/dynamo/prometheus_names.py
 pub mod labels {
     /// Label for component identification
     pub const COMPONENT: &str = "dynamo_component";
@@ -87,8 +93,16 @@ pub mod labels {
     /// It is used by worker/load-style metrics that need to disambiguate per-worker series.
     pub const DP_RANK: &str = "dp_rank";
 
-    /// Label for model name
+    /// Label for model name/path (OpenAI API standard, injected by Dynamo)
+    /// This is the standard label name injected by all backends in metrics_labels=[("model", ...)].
+    /// Ensures compatibility with OpenAI-compatible tooling.
     pub const MODEL: &str = "model";
+
+    /// Label for model name/path (alternative/native engine label, injected by Dynamo)
+    /// Some engines natively use model_name, so we inject both model and model_name
+    /// to ensure maximum compatibility with both OpenAI standard and engine-native tooling.
+    /// When a metric already has a label, injection does not overwrite it (original is preserved).
+    pub const MODEL_NAME: &str = "model_name";
 
     /// Label for worker type (e.g., "aggregated", "prefill", "decode", "encoder", etc.)
     pub const WORKER_TYPE: &str = "worker_type";

--- a/tests/planner/test_replica_calculation.py
+++ b/tests/planner/test_replica_calculation.py
@@ -12,31 +12,11 @@ import argparse
 import asyncio
 import math
 import os
-
-# Mock dependencies before importing planner modules
-import sys
-
-# We'll import the actual Planner class to test its calculation logic
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
-# Create mock modules for dependencies that might not be available in test environment
-mock_prometheus = MagicMock()
-mock_prometheus.Gauge = MagicMock()
-mock_prometheus.start_http_server = MagicMock()
-
-mock_runtime = MagicMock()
-mock_runtime.logging = MagicMock()
-mock_runtime.logging.configure_dynamo_logging = MagicMock()
-
-# Patch them into sys.modules before importing
-sys.modules["prometheus_client"] = mock_prometheus
-sys.modules["dynamo.runtime"] = mock_runtime
-sys.modules["dynamo.runtime.logging"] = mock_runtime.logging
-
-# Now import after mocking
-from dynamo.planner.utils.planner_core import (  # noqa: E402
+from dynamo.planner.utils.planner_core import (
     DecodePlanner,
     Metrics,
     PlannerSharedState,

--- a/tests/serve/test_prometheus_exposition_format_injection.py
+++ b/tests/serve/test_prometheus_exposition_format_injection.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for Prometheus label injection via get_prometheus_expfmt.
+
+Tests the complete flow of label injection through the exposition format generation:
+get_prometheus_expfmt with inject_custom_labels -> verify labels in output text format.
+"""
+
+import pytest
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+
+from dynamo import prometheus_names
+from dynamo.common.utils.prometheus import get_prometheus_expfmt
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+
+
+class TestPrometheusExpositionFormatInjection:
+    """Integration tests for label injection through exposition format generation"""
+
+    def test_inject_labels_into_counter_expfmt(self):
+        """Test label injection produces correct exposition format for Counter"""
+        # Create registry with a counter
+        registry = CollectorRegistry()
+        counter = Counter("requests_total", "Total requests", registry=registry)
+        counter.inc(5)
+
+        # Get exposition format with label injection (using prometheus_names constants)
+        labels_to_inject = {
+            prometheus_names.labels.NAMESPACE: "prod",
+            prometheus_names.labels.COMPONENT: "vllm-worker",
+            prometheus_names.labels.ENDPOINT: "generate",
+        }
+        expfmt = get_prometheus_expfmt(registry, inject_custom_labels=labels_to_inject)
+
+        # Verify exposition format contains injected labels
+        assert f'{prometheus_names.labels.NAMESPACE}="prod"' in expfmt
+        assert f'{prometheus_names.labels.COMPONENT}="vllm-worker"' in expfmt
+        assert f'{prometheus_names.labels.ENDPOINT}="generate"' in expfmt
+
+        # Verify counter value is present
+        assert "requests_total_total" in expfmt or "requests_total{" in expfmt
+
+        # Verify HELP and TYPE comments are present
+        assert "# HELP requests_total" in expfmt
+        assert "# TYPE requests_total counter" in expfmt
+
+    def test_inject_labels_into_gauge_expfmt(self):
+        """Test label injection produces correct exposition format for Gauge"""
+        # Create registry with a gauge
+        registry = CollectorRegistry()
+        gauge = Gauge("active_requests", "Active requests", registry=registry)
+        gauge.set(10)
+
+        # Get exposition format with label injection (using prometheus_names constants)
+        labels_to_inject = {
+            prometheus_names.labels.MODEL: "llama-3-70b",
+            "instance_id": "worker-0",
+        }
+        expfmt = get_prometheus_expfmt(registry, inject_custom_labels=labels_to_inject)
+
+        # Verify exposition format contains injected labels
+        assert f'{prometheus_names.labels.MODEL}="llama-3-70b"' in expfmt
+        assert 'instance_id="worker-0"' in expfmt
+
+        # Verify gauge value
+        assert "active_requests" in expfmt
+        assert "10" in expfmt or "10.0" in expfmt
+
+    def test_inject_labels_into_histogram_expfmt(self):
+        """Test label injection preserves histogram structure and le label"""
+        # Create registry with a histogram
+        registry = CollectorRegistry()
+        histogram = Histogram(
+            "request_duration_seconds",
+            "Request duration",
+            registry=registry,
+        )
+        histogram.observe(0.5)
+        histogram.observe(1.5)
+
+        # Get exposition format with label injection (using prometheus_names constants)
+        labels_to_inject = {
+            prometheus_names.labels.NAMESPACE: "prod",
+            prometheus_names.labels.ENDPOINT: "generate",
+        }
+        expfmt = get_prometheus_expfmt(registry, inject_custom_labels=labels_to_inject)
+
+        # Verify injected labels are present
+        assert f'{prometheus_names.labels.NAMESPACE}="prod"' in expfmt
+        assert f'{prometheus_names.labels.ENDPOINT}="generate"' in expfmt
+
+        # Verify histogram structure (buckets with 'le' label)
+        assert "request_duration_seconds_bucket" in expfmt
+        assert "le=" in expfmt  # Histogram buckets must have 'le' label
+
+        # Verify sum and count
+        assert "request_duration_seconds_sum" in expfmt
+        assert "request_duration_seconds_count" in expfmt
+
+    def test_inject_labels_with_prefix_filter(self):
+        """Test label injection works with metric prefix filtering"""
+        # Create registry with multiple metrics
+        registry = CollectorRegistry()
+        vllm_counter = Counter("vllm:requests", "vLLM requests", registry=registry)
+        other_counter = Counter("python_gc_objects", "GC objects", registry=registry)
+
+        vllm_counter.inc(5)
+        other_counter.inc(100)
+
+        # Get exposition format with filtering and label injection
+        labels_to_inject = {
+            prometheus_names.labels.NAMESPACE: "prod",
+            prometheus_names.labels.MODEL: "llama-3-70b",
+        }
+        expfmt = get_prometheus_expfmt(
+            registry,
+            metric_prefix_filters=["vllm:"],
+            inject_custom_labels=labels_to_inject,
+        )
+
+        # Verify vllm metric is present with injected labels
+        assert "vllm:requests" in expfmt
+        assert f'{prometheus_names.labels.NAMESPACE}="prod"' in expfmt
+        assert f'{prometheus_names.labels.MODEL}="llama-3-70b"' in expfmt
+
+        # Verify other metric is filtered out
+        assert "python_gc_objects" not in expfmt
+
+    def test_inject_labels_with_exclude_prefix(self):
+        """Test label injection works with exclude prefixes"""
+        # Create registry with multiple metrics
+        registry = CollectorRegistry()
+        app_counter = Counter("app_requests", "App requests", registry=registry)
+        python_counter = Counter("python_gc_objects", "GC objects", registry=registry)
+
+        app_counter.inc(5)
+        python_counter.inc(100)
+
+        # Get exposition format with exclude and label injection
+        labels_to_inject = {prometheus_names.labels.COMPONENT: "test-component"}
+        expfmt = get_prometheus_expfmt(
+            registry,
+            exclude_prefixes=["python_"],
+            inject_custom_labels=labels_to_inject,
+        )
+
+        # Verify app metric is present with injected label
+        assert "app_requests" in expfmt
+        assert f'{prometheus_names.labels.COMPONENT}="test-component"' in expfmt
+
+        # Verify python metric is excluded
+        assert "python_gc_objects" not in expfmt
+
+    def test_inject_labels_with_prefix_filter_trtllm(self):
+        """Test label injection works with metric prefix filtering for trtllm"""
+        # Create registry with a counter that has trtllm_ prefix
+        registry = CollectorRegistry()
+        counter = Counter("trtllm_requests", "TensorRT-LLM Requests", registry=registry)
+        counter.inc(5)
+
+        # Get exposition format filtering for trtllm metrics and inject labels
+        labels_to_inject = {
+            prometheus_names.labels.NAMESPACE: "prod",
+            prometheus_names.labels.MODEL: "qwen-32b",
+        }
+        expfmt = get_prometheus_expfmt(
+            registry,
+            metric_prefix_filters=["trtllm_"],
+            inject_custom_labels=labels_to_inject,
+        )
+
+        # Verify metric is present with injected labels
+        assert "trtllm_requests" in expfmt
+        assert f'{prometheus_names.labels.NAMESPACE}="prod"' in expfmt
+        assert f'{prometheus_names.labels.MODEL}="qwen-32b"' in expfmt
+
+    def test_inject_labels_with_existing_labels(self):
+        """Test label injection merges with existing metric labels"""
+        # Create registry with a counter that has labels
+        registry = CollectorRegistry()
+        counter = Counter(
+            "requests",
+            "Requests",
+            labelnames=["status", "method"],
+            registry=registry,
+        )
+        counter.labels(status="success", method="GET").inc(10)
+
+        # Get exposition format with label injection
+        labels_to_inject = {
+            prometheus_names.labels.NAMESPACE: "prod",
+            prometheus_names.labels.COMPONENT: "vllm-worker",
+        }
+        expfmt = get_prometheus_expfmt(registry, inject_custom_labels=labels_to_inject)
+
+        # Verify both existing and injected labels are present
+        assert 'status="success"' in expfmt
+        assert 'method="GET"' in expfmt
+        assert f'{prometheus_names.labels.NAMESPACE}="prod"' in expfmt
+        assert f'{prometheus_names.labels.COMPONENT}="vllm-worker"' in expfmt
+
+    def test_inject_multiple_labels(self):
+        """Test injecting many labels at once"""
+        # Create registry with a gauge
+        registry = CollectorRegistry()
+        gauge = Gauge("memory_usage_bytes", "Memory usage", registry=registry)
+        gauge.set(1024)
+
+        # Get exposition format with many injected labels
+        labels_to_inject = {
+            prometheus_names.labels.NAMESPACE: "prod",
+            prometheus_names.labels.COMPONENT: "vllm-worker",
+            prometheus_names.labels.ENDPOINT: "generate",
+            prometheus_names.labels.MODEL: "llama-3-70b",
+            "instance_id": "worker-0",
+            "rank": "0",
+            "gpu_id": "0",
+        }
+        expfmt = get_prometheus_expfmt(registry, inject_custom_labels=labels_to_inject)
+
+        # Verify all labels are present
+        for label_name, label_value in labels_to_inject.items():
+            assert f'{label_name}="{label_value}"' in expfmt
+
+    def test_inject_labels_none_is_noop(self):
+        """Test that inject_custom_labels=None doesn't modify output"""
+        # Create registry with a counter
+        registry = CollectorRegistry()
+        counter = Counter("requests", "Requests", registry=registry)
+        counter.inc(5)
+
+        # Get exposition format without label injection
+        expfmt_without = get_prometheus_expfmt(registry, inject_custom_labels=None)
+
+        # Get exposition format with empty dict (should raise error in collector)
+        # But inject_custom_labels=None should work fine
+        expfmt_with_none = get_prometheus_expfmt(registry, inject_custom_labels=None)
+
+        # Both should be identical (no label injection)
+        assert expfmt_without == expfmt_with_none
+        assert "requests" in expfmt_without
+
+    def test_inject_labels_align_with_rust_labels(self):
+        """Test injecting labels that align with Rust auto-labels"""
+        # Create registry with vllm metrics
+        registry = CollectorRegistry()
+        counter = Counter("vllm:requests_total", "Total requests", registry=registry)
+        counter.inc(100)
+
+        # Inject labels that match Rust auto-labels
+        labels_to_inject = {
+            prometheus_names.labels.NAMESPACE: "prod-inference",
+            prometheus_names.labels.COMPONENT: "vllm-decode-worker",
+            prometheus_names.labels.ENDPOINT: "generate",
+        }
+        expfmt = get_prometheus_expfmt(
+            registry,
+            metric_prefix_filters=["vllm:"],
+            inject_custom_labels=labels_to_inject,
+        )
+
+        # Verify Rust-compatible labels are present
+        assert f'{prometheus_names.labels.NAMESPACE}="prod-inference"' in expfmt
+        assert f'{prometheus_names.labels.COMPONENT}="vllm-decode-worker"' in expfmt
+        assert f'{prometheus_names.labels.ENDPOINT}="generate"' in expfmt
+
+        # Verify metric is present
+        assert "vllm:requests" in expfmt

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -12,7 +12,11 @@ from tests.utils.payloads import (
     CompletionPayload,
     CompletionPayloadWithLogprobs,
     EmbeddingPayload,
+    LMCacheMetricsPayload,
     MetricsPayload,
+    SGLangMetricsPayload,
+    TRTLLMMetricsPayload,
+    VLLMMetricsPayload,
 )
 
 # Common default text prompt used across tests
@@ -178,15 +182,39 @@ def metric_payload_default(
     backend: Optional[str] = None,
     port: int = DefaultPort.SYSTEM1.value,
 ) -> MetricsPayload:
-    return MetricsPayload(
-        body={},
-        repeat_count=repeat_count,
-        expected_log=expected_log or [],
-        expected_response=[],
-        min_num_requests=min_num_requests,
-        backend=backend,
-        port=port,
-    )
+    """Create a metrics payload for the specified backend.
+
+    Args:
+        min_num_requests: Minimum number of requests expected in metrics
+        repeat_count: Number of times to repeat the request
+        expected_log: Expected log messages
+        backend: Backend type ('vllm', 'sglang', 'trtllm', 'lmcache')
+        port: Port to use for metrics endpoint
+
+    Returns:
+        Backend-specific MetricsPayload subclass based on backend parameter
+    """
+    common_args = {
+        "body": {},
+        "repeat_count": repeat_count,
+        "expected_log": expected_log or [],
+        "expected_response": [],
+        "min_num_requests": min_num_requests,
+        "port": port,
+    }
+
+    # Return backend-specific payload class
+    if backend == "vllm":
+        return VLLMMetricsPayload(**common_args)
+    elif backend == "sglang":
+        return SGLangMetricsPayload(**common_args)
+    elif backend == "trtllm":
+        return TRTLLMMetricsPayload(**common_args)
+    elif backend == "lmcache":
+        return LMCacheMetricsPayload(**common_args)
+    else:
+        # Default to base MetricsPayload for unknown backends
+        return MetricsPayload(**common_args)
 
 
 def chat_payload(

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -540,13 +540,16 @@ class MetricCheck:
 
 @dataclass
 class MetricsPayload(BasePayload):
+    """Base class for Prometheus metrics validation payloads.
+
+    Validates common dynamo_component_* metrics shared across all backends.
+    Backend-specific subclasses handle engine-specific metrics.
+    """
+
     endpoint: str = "/metrics"
     method: str = "GET"
     port: int = DefaultPort.SYSTEM1.value
     min_num_requests: int = 1
-    backend: Optional[
-        str
-    ] = None  # Backend identifier for metrics validation (e.g., 'vllm', 'sglang', 'trtllm')
 
     def with_model(self, model):
         # Metrics does not use model in request body
@@ -556,16 +559,14 @@ class MetricsPayload(BasePayload):
         response.raise_for_status()
         return response.text
 
-    def validate(self, response: Any, content: str) -> None:
-        # Use backend from payload configuration
-        backend = self.backend
-
-        # Filter out _bucket metrics from content (histogram buckets inflate counts)
+    def _filter_bucket_metrics(self, content: str) -> str:
+        """Filter out histogram bucket metrics to avoid count inflation"""
         content_lines = content.split("\n")
         filtered_lines = [line for line in content_lines if "_bucket{" not in line]
-        content = "\n".join(filtered_lines)
+        return "\n".join(filtered_lines)
 
-        # Build full metric names with prefix
+    def _get_common_metric_checks(self) -> list[MetricCheck]:
+        """Get common dynamo_component_* metric checks shared across all backends"""
         prefix = prometheus_names.name_prefix.COMPONENT
 
         # Define metrics to check
@@ -577,7 +578,7 @@ class MetricsPayload(BasePayload):
         def metric_pattern(name):
             return rf"{name}(?:\{{[^}}]*\}})?\s+([\d.eE+-]+)"
 
-        metrics_to_check = [
+        return [
             MetricCheck(
                 # Check: Minimum count of unique dynamo_component_* metrics
                 name=f"{prefix}_*",
@@ -625,61 +626,14 @@ class MetricsPayload(BasePayload):
             ),
         ]
 
-        # Add backend-specific metric checks
-        if backend == "vllm":
-            metrics_to_check.append(
-                MetricCheck(
-                    # Check: Minimum count of unique vllm:* metrics
-                    name="vllm:*",
-                    pattern=lambda name: r"^vllm:\w+",
-                    validator=lambda value: len(set(value))
-                    >= 52,  # 80% of typical ~65 vllm metrics (excluding _bucket) as of 2025-10-22 (but will grow)
-                    error_msg=lambda name, value: f"Expected at least 52 unique vllm:* metrics, but found only {len(set(value))}",
-                    success_msg=lambda name, value: f"SUCCESS: Found {len(set(value))} unique vllm:* metrics (minimum required: 52)",
-                    multiline=True,
-                )
-            )
-        elif backend == "lmcache":
-            metrics_to_check.append(
-                MetricCheck(
-                    # Check: Minimum count of unique lmcache:* metrics
-                    name="lmcache:*",
-                    pattern=lambda name: r"^lmcache:\w+",
-                    validator=lambda value: len(set(value))
-                    >= 1,  # At least 1 lmcache metric
-                    error_msg=lambda name, value: f"Expected at least 1 lmcache:* metric, but found only {len(set(value))}",
-                    success_msg=lambda name, value: f"SUCCESS: Found {len(set(value))} lmcache:* metrics",
-                    multiline=True,
-                )
-            )
-        elif backend == "sglang":
-            metrics_to_check.append(
-                MetricCheck(
-                    # Check: Minimum count of unique sglang:* metrics
-                    name="sglang:*",
-                    pattern=lambda name: r"^sglang:\w+",
-                    validator=lambda value: len(set(value))
-                    >= 20,  # 80% of typical ~25 sglang metrics (excluding _bucket) as of 2025-10-22 (but will grow)
-                    error_msg=lambda name, value: f"Expected at least 20 unique sglang:* metrics, but found only {len(set(value))}",
-                    success_msg=lambda name, value: f"SUCCESS: Found {len(set(value))} unique sglang:* metrics (minimum required: 20)",
-                    multiline=True,
-                )
-            )
-        elif backend == "trtllm":
-            metrics_to_check.append(
-                MetricCheck(
-                    # Check: Minimum count of unique trtllm_* metrics
-                    name="trtllm_*",
-                    pattern=lambda name: r"^trtllm_\w+",
-                    validator=lambda value: len(set(value))
-                    >= 4,  # 80% of typical ~5 trtllm metrics (excluding _bucket) as of 2025-10-22 (but will grow)
-                    error_msg=lambda name, value: f"Expected at least 4 unique trtllm_* metrics, but found only {len(set(value))}",
-                    success_msg=lambda name, value: f"SUCCESS: Found {len(set(value))} unique trtllm_* metrics (minimum required: 4)",
-                    multiline=True,
-                )
-            )
+    def _get_backend_specific_checks(self) -> list[MetricCheck]:
+        """Get backend-specific metric checks. Override in subclasses."""
+        return []
 
-        # Check all metrics
+    def _validate_metric_checks(
+        self, metrics_to_check: list[MetricCheck], content: str
+    ) -> None:
+        """Run all metric checks and raise AssertionError if any fail"""
         for metric in metrics_to_check:
             # Special handling for multiline patterns (like counting unique metrics)
             if metric.multiline:
@@ -726,6 +680,163 @@ class MetricsPayload(BasePayload):
                             metric.name, last_value if last_value else "N/A"
                         )
                     )
+
+    def validate(self, response: Any, content: str) -> None:
+        """Validate Prometheus metrics output"""
+        content = self._filter_bucket_metrics(content)
+
+        # Collect all checks: common + backend-specific
+        metrics_to_check = self._get_common_metric_checks()
+        metrics_to_check.extend(self._get_backend_specific_checks())
+
+        # Run all validations
+        self._validate_metric_checks(metrics_to_check, content)
+
+
+@dataclass
+class VLLMMetricsPayload(MetricsPayload):
+    """Metrics validation for vLLM backend with auto-label checks"""
+
+    def _get_backend_specific_checks(self) -> list[MetricCheck]:
+        """vLLM-specific metric checks"""
+        checks = [
+            MetricCheck(
+                # Check: Minimum count of unique vllm:* metrics
+                name="vllm:*",
+                pattern=lambda name: r"^vllm:\w+",
+                validator=lambda value: len(set(value))
+                >= 56,  # 80% of typical ~70 vllm metrics (excluding _bucket) as of 2026-02-05 (but will grow)
+                error_msg=lambda name, value: f"Expected at least 56 unique vllm:* metrics, but found only {len(set(value))}",
+                success_msg=lambda name, value: f"SUCCESS: Found {len(set(value))} unique vllm:* metrics (minimum required: 56)",
+                multiline=True,
+            )
+        ]
+
+        # Check required labels: auto-injected (from prometheus_names.labels) + injected by backend
+        required_labels = [
+            prometheus_names.labels.NAMESPACE,
+            prometheus_names.labels.COMPONENT,
+            prometheus_names.labels.ENDPOINT,
+            prometheus_names.labels.MODEL,  # OpenAI standard (injected by all backends)
+            prometheus_names.labels.MODEL_NAME,  # Alternative label (injected for compatibility)
+        ]
+        for label_name in required_labels:
+            checks.append(
+                MetricCheck(
+                    name=f"vllm:* with {label_name}",
+                    pattern=lambda name, lbl=label_name: rf'vllm:\w+\{{[^}}]*{lbl}="[^"]+"',
+                    validator=lambda value: len(value) > 0,
+                    error_msg=lambda name, value, lbl=label_name: f"vLLM metrics missing label: {lbl}",
+                    success_msg=lambda name, value, lbl=label_name: f"SUCCESS: vLLM metrics include {lbl} label (found {len(value)} metrics)",
+                    multiline=True,
+                )
+            )
+
+        return checks
+
+
+@dataclass
+class LMCacheMetricsPayload(MetricsPayload):
+    """Metrics validation for lmcache"""
+
+    def _get_backend_specific_checks(self) -> list[MetricCheck]:
+        """lmcache-specific metric checks"""
+        return [
+            MetricCheck(
+                # Check: Minimum count of unique lmcache:* metrics
+                name="lmcache:*",
+                pattern=lambda name: r"^lmcache:\w+",
+                validator=lambda value: len(set(value))
+                >= 26,  # 80% of typical ~33 lmcache metrics (excluding _bucket) as of 2026-02-05 (but will grow)
+                error_msg=lambda name, value: f"Expected at least 26 unique lmcache:* metrics, but found only {len(set(value))}",
+                success_msg=lambda name, value: f"SUCCESS: Found {len(set(value))} lmcache:* metrics (minimum required: 26)",
+                multiline=True,
+            )
+        ]
+
+
+@dataclass
+class SGLangMetricsPayload(MetricsPayload):
+    """Metrics validation for SGLang backend with auto-label checks"""
+
+    def _get_backend_specific_checks(self) -> list[MetricCheck]:
+        """SGLang-specific metric checks"""
+        checks = [
+            MetricCheck(
+                # Check: Minimum count of unique sglang:* metrics
+                name="sglang:*",
+                pattern=lambda name: r"^sglang:\w+",
+                validator=lambda value: len(set(value))
+                >= 20,  # 80% of typical ~25 sglang metrics (excluding _bucket) as of 2025-10-22 (but will grow)
+                error_msg=lambda name, value: f"Expected at least 20 unique sglang:* metrics, but found only {len(set(value))}",
+                success_msg=lambda name, value: f"SUCCESS: Found {len(set(value))} unique sglang:* metrics (minimum required: 20)",
+                multiline=True,
+            )
+        ]
+
+        # Check required labels: auto-injected (from prometheus_names.labels) + injected by backend
+        required_labels = [
+            prometheus_names.labels.NAMESPACE,
+            prometheus_names.labels.COMPONENT,
+            prometheus_names.labels.ENDPOINT,
+            prometheus_names.labels.MODEL,  # OpenAI standard (injected by all backends)
+            prometheus_names.labels.MODEL_NAME,  # Alternative label (injected for compatibility)
+        ]
+        for label_name in required_labels:
+            checks.append(
+                MetricCheck(
+                    name=f"sglang:* with {label_name}",
+                    pattern=lambda name, lbl=label_name: rf'sglang:\w+\{{[^}}]*{lbl}="[^"]+"',
+                    validator=lambda value: len(value) > 0,
+                    error_msg=lambda name, value, lbl=label_name: f"sglang metrics missing label: {lbl}",
+                    success_msg=lambda name, value, lbl=label_name: f"SUCCESS: sglang metrics include {lbl} label (found {len(value)} metrics)",
+                    multiline=True,
+                )
+            )
+
+        return checks
+
+
+@dataclass
+class TRTLLMMetricsPayload(MetricsPayload):
+    """Metrics validation for TensorRT-LLM backend"""
+
+    def _get_backend_specific_checks(self) -> list[MetricCheck]:
+        """TRT-LLM-specific metric checks"""
+        checks = [
+            MetricCheck(
+                # Check: Minimum count of unique trtllm_* metrics
+                name="trtllm_*",
+                pattern=lambda name: r"^trtllm_\w+",
+                validator=lambda value: len(set(value))
+                >= 4,  # 80% of typical ~5 trtllm metrics (excluding _bucket) as of 2025-10-22 (but will grow)
+                error_msg=lambda name, value: f"Expected at least 4 unique trtllm_* metrics, but found only {len(set(value))}",
+                success_msg=lambda name, value: f"SUCCESS: Found {len(set(value))} unique trtllm_* metrics (minimum required: 4)",
+                multiline=True,
+            )
+        ]
+
+        # Check required labels: auto-injected (from prometheus_names.labels) + injected by backend
+        required_labels = [
+            prometheus_names.labels.NAMESPACE,
+            prometheus_names.labels.COMPONENT,
+            prometheus_names.labels.ENDPOINT,
+            prometheus_names.labels.MODEL,  # OpenAI standard (injected by all backends)
+            prometheus_names.labels.MODEL_NAME,  # Alternative label (injected for compatibility)
+        ]
+        for label_name in required_labels:
+            checks.append(
+                MetricCheck(
+                    name=f"trtllm_* with {label_name}",
+                    pattern=lambda name, lbl=label_name: rf'trtllm_\w+\{{[^}}]*{lbl}="[^"]+"',
+                    validator=lambda value: len(value) > 0,
+                    error_msg=lambda name, value, lbl=label_name: f"TRT-LLM metrics missing label: {lbl}",
+                    success_msg=lambda name, value, lbl=label_name: f"SUCCESS: TRT-LLM metrics include {lbl} label (found {len(value)} metrics)",
+                    multiline=True,
+                )
+            )
+
+        return checks
 
 
 def check_models_api(response):


### PR DESCRIPTION
#### Overview:

Implements auto-injection and custom-injection of labels into Prometheus metrics from engine backends (vLLM, SGLang, TensorRT-LLM). 


#### Details:

- Auto-injection adds hierarchy labels and model labels automatically when USE_AUTO_LABELS is enabled
- Both `model` and `model_name` labels are injected for compatibility since different engines use different conventions
- Custom-injection via inject_custom_labels parameter allows users to add labels
- Label precedence enforced: existing labels (never changed), auto-injected labels, then custom labels
- Conflicts between auto-injected and custom labels log warnings
- Refactored MetricsPayload into backend-specific subclasses for cleaner validation
- New LabelInjectingCollector class implements prometheus_client.Collector for label injection
- All framework call sites (vLLM, SGLang, TRT-LLM) updated to pass model_name parameter
- Tests updated to use prometheus_names constants for label names
- Comprehensive unit and integration tests with gpu_0 marker

#### Where should the reviewer start?

- components/src/dynamo/common/utils/prometheus.py - Core auto-injection and custom-injection logic
- tests/utils/payloads.py - Refactored backend-specific validation classes
- components/src/dynamo/vllm/main.py - Example of model_name parameter usage (4 call sites)
- lib/runtime/src/metrics/prometheus_names.rs - New label constants

#### Related Issues:

Relates to DIS-1283

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Metrics now automatically include namespace, component, endpoint, and model labels across vLLM, SGLang, and TRT-LLM backends.

* **Tests**
  * Added comprehensive test coverage for metrics label injection and validation across supported backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->