### PR TITLE
fix: stabilize router tie handling and keep pytest logs out of repo

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,10 +191,17 @@ def predownload_tokenizers(pytestconfig):
 
 @pytest.fixture(autouse=True)
 def logger(request):
-    log_path = os.path.join(request.node.name, "test.log.txt")
+    # If DYN_TEST_OUTPUT_PATH is set, write logs there to keep them out of the git working tree
+    # Otherwise, use the old behavior of writing to CWD/request.node.name
+    log_root = os.environ.get("DYN_TEST_OUTPUT_PATH")
+    if log_root:
+        log_dir = os.path.join(log_root, request.node.name)
+    else:
+        log_dir = request.node.name
+    log_path = os.path.join(log_dir, "test.log.txt")
     logger = logging.getLogger()
-    shutil.rmtree(request.node.name, ignore_errors=True)
-    os.makedirs(request.node.name, exist_ok=True)
+    shutil.rmtree(log_dir, ignore_errors=True)
+    os.makedirs(log_dir, exist_ok=True)
     handler = logging.FileHandler(log_path, mode="w")
     formatter = logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT)
     handler.setFormatter(formatter)


### PR DESCRIPTION
#### Overview:

This PR fixes an intermittent router-decision flake in `test_router_decisions[...]` caused by non-deterministic tie handling in the KV router worker selector. It also makes pytest runs stop writing per-test logs into the git working tree by allowing log redirection via `DYN_TEST_OUTPUT_PATH`.

Before vs after (for the specific issue this PR addresses): **~3% failures → 0% failures**.

#### Details:

- Fix router decision flake: when multiple workers are tied, prefer **larger `tree_size`** (more prefix reuse) and use a deterministic secondary key.
  - Exact failure message seen before:
    - `AssertionError: Expected exactly 1 (worker_id, dp_rank) to have events (due to prefix reuse), but found 3 with events: [(0, 0), (0, 1), (0, 2)]`
  - Before: **2 / 75** serial iterations failed (**~3%**) of `test_router_decisions[jetstream-nats]`
  - After: **0 occurrences** in **1..50** serial container iterations (**0%**) (validated by absence of the A1 assertion signatures in run logs)

- Make test logging non-polluting: allow tests to write their logs under `DYN_TEST_OUTPUT_PATH` (instead of creating `request.node.name/` directories in the repo root).

- Important scope note: this PR does NOT fix the other intermittent failures we’ve seen in router E2E stress runs, including:
  - Event sync mismatch:
    - `AssertionError: Router states have different numbers of events`
    - Example: `Router 1 has 100 events, Router 2 has 50 events`
    - Observed frequency in recent runs: **13 / 50 (26%)**
  - Timeouts:
    - `E           Failed: Timeout (>90.0s) from pytest-timeout.`
    - Observed frequency in recent runs: **2 / 100 (2%)**
  - Indefinite hang creating the second router:
    - Last log line: `[TEST] INFO tests.router.common: Creating second KV router with its own runtime`
  - xdist crash / SIGABRT:
    - `Fatal Python error: Aborted`
    - `[gwX] node down: Not properly terminated`
    - Example: `worker 'gw6' crashed while running 'tests/router/test_router_e2e_with_mockers.py::test_kv_push_router_bindings[True-tcp]'`
    - Observed frequency in recent runs: **5 / 10 (50%)** at `-n 4`

#### Where should the reviewer start?

- `lib/llm/src/kv_router/scheduler.rs` (tie handling + deterministic tie-breaker)
- `tests/conftest.py` and `tests/utils/managed_process.py` (log redirection via `DYN_TEST_OUTPUT_PATH`)

#### Related Issues: (use Closes / Fixes / Resolves / Relates to)

Relates to DIS-1406

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refined worker selection algorithm to improve fairness in request routing through enhanced tie-breaking logic when multiple workers are equally suitable.

* **Tests**
  * Improved test logging infrastructure with support for dynamic output path configuration.
  * Enhanced test code documentation and process management utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->