### PR TITLE
fix(sglang): remove apt-installed python3-blinker

### DIFF
--- a/container/Dockerfile.sglang
+++ b/container/Dockerfile.sglang
@@ -473,8 +473,8 @@ RUN if [ "$ENABLE_GPU_MEMORY_SERVICE" = "true" ]; then \
 
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
 
-# cleanup unnecessary libs
-RUN apt remove -y python3-apt &&\
+# cleanup unnecessary libs (python3-blinker conflicts with pip-installed blinker from Flask/dash)
+RUN apt remove -y python3-apt python3-blinker &&\
     pip uninstall -y termplotlib
 
 # This ARG is still utilized for SGLANG Version extraction


### PR DESCRIPTION
#### Overview:

  Fix SGLang container build failure (cuda12.9/cuda13) caused by apt/pip blinker package conflict.

  #### Details:

  The `lmsysorg/sglang:v0.5.8-runtime` base image has `python3-blinker 1.7.0` installed via apt. When pip resolves to
  `Flask 3.1.x` (which requires `blinker>=1.9.0`), it cannot uninstall the apt-installed blinker due to missing `RECORD`
  file.

  **Dependency chain:** `aiperf` → `dash` → `Flask` → `blinker`

  **Fix:** Add `python3-blinker` to existing `apt remove` command in runtime stage.

  **Failure logs (step 15/22 - runtime stage):**
```
Attempting uninstall: blinker
  Found existing installation: blinker 1.7.0
error: uninstall-no-record-file

× Cannot uninstall blinker 1.7.0
╰─> The package's contents are unknown: no RECORD file was found for blinker.

hint: The package was installed by debian. You should check if it can uninstall the package.
```

  **Repro:**
  ```bash
# Fails
docker run --rm lmsysorg/sglang:v0.5.8-runtime \
  pip install --break-system-packages "Flask>=3.1.0"

# Succeeds with fix
docker run --rm lmsysorg/sglang:v0.5.8-runtime \
  bash -c "apt remove -y python3-blinker && pip install --break-system-packages Flask>=3.1.0"
```

  Where should the reviewer start?

  - `container/Dockerfile.sglang` line 477 - single line change adding `python3-blinker` to apt remove

  Related Issues:

  - Fixes failing CI runs:
    - https://github.com/ai-dynamo/dynamo/actions/runs/21698359048/job/62573326024
    - https://github.com/ai-dynamo/dynamo/actions/runs/21696106171/job/62566553574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container runtime stability by resolving potential package conflicts in the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->