### PR TITLE
fix: Correctly pass DP rank from Dynamo router into vLLM engine

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1350,8 +1350,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             logger.debug(
                 f"Decode request {request_id} has no LoRA specified (model: {model_name})"
             )
-
-        dp_rank = request.get("dp_rank", None)
+        dp_rank = request.get("routing", {}).get("dp_rank")
 
         trace_headers = build_trace_headers(context)
 
@@ -1395,7 +1394,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             request, self.default_sampling_params
         )
 
-        dp_rank = request.get("dp_rank", None)
+        dp_rank = request.get("routing", {}).get("dp_rank")
         openai_request_id = request.get("id") or request.get("request_id", request_id)
         previous_text = ""
 
@@ -1565,7 +1564,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 f"Prefill request {request_id} has no LoRA specified (model: {model_name})"
             )
 
-        dp_rank = request.get("dp_rank", None)
+        dp_rank = request.get("routing", {}).get("dp_rank")
 
         trace_headers = build_trace_headers(context)
 


### PR DESCRIPTION
#### Overview:

https://github.com/ai-dynamo/dynamo/pull/5040 moved the "dp_rank" field of request (from router) into a nested level in `{"routing": {"dp_rank"}}`, but the vLLM handler hasn't been updated to reflect this. 
This means that we were passing `dp_rank=None` into the vLLM engine, ignoring the router. The `tests/router/test_router_e2e_with_vllm.py::test_router_decisions_vllm_dp` is failing (but went undetected because it's a gitlab 2GPU test 😞 ).

#### Details:

Modifies vLLM handler `components/src/dynamo/vllm/handlers.py` to retrieve dp rank correctly from nested dict.

#### Where should the reviewer start?
`components/src/dynamo/vllm/handlers.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Found this issue while implementing TRTLLM DP routing: https://github.com/ai-dynamo/dynamo/pull/5936 
- SGLang handler is already correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed processing rank retrieval in token generation and inference operations for enhanced reliability in distributed inference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->