### PR TITLE
test: router mocker E2E tests to run serially for stability

### DIFF
--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -43,7 +43,6 @@ pytestmark = [
     pytest.mark.pre_merge,
     pytest.mark.gpu_0,
     pytest.mark.integration,
-    pytest.mark.parallel,
     pytest.mark.model(MODEL_NAME),
 ]
 NUM_MOCKERS = 2


### PR DESCRIPTION
#### Overview:

Remove parallel marker from router mocker E2E tests for stability.

#### Details:

- Remove `pytest.mark.parallel` from `tests/router/test_router_e2e_with_mockers.py`
- Tests spawn multiple subprocesses and flake when run concurrently due to resource contention

#### Where should the reviewer start?

Single-line change in `tests/router/test_router_e2e_with_mockers.py`

#### Related Issues:

Relates to DIS-1406

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test execution configuration for the router test suite.

---

*Note: This change is internal to the testing infrastructure and does not affect end-user functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->