### PR TITLE
ci: add doc exclusions to all CI-triggering filter groups

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -98,11 +98,11 @@ operator:
   - 'docs/kubernetes/api_reference.md'
 
 deploy:
+  - '!**/*.md'
+  - '!**/*.rst'
   - 'deploy/helm/**'
   - 'deploy/utils/**'
   - 'deploy/chrek/**'
-  - '!**/*.md'
-  - '!**/*.rst'
 
 planner:
   - 'components/src/dynamo/planner/**'
@@ -110,31 +110,33 @@ planner:
   - 'components/src/dynamo/global_router/**'
 
 vllm:
+  - '!**/*.md'
+  - '!**/*.rst'
   - 'container/Dockerfile.vllm'
   - 'container/deps/requirements.vllm.txt'
   - 'container/deps/vllm/**'
   - 'examples/backends/vllm/**'
   - 'components/src/dynamo/vllm/**'
-  - '!**/*.md'
-  - '!**/*.rst'
 
 sglang:
+  - '!**/*.md'
+  - '!**/*.rst'
   - 'container/Dockerfile.sglang'
   - 'examples/backends/sglang/**'
   - 'components/src/dynamo/sglang/**'
-  - '!**/*.md'
-  - '!**/*.rst'
 
 trtllm:
+  - '!**/*.md'
+  - '!**/*.rst'
   - 'container/Dockerfile.trtllm'
   - 'container/deps/trtllm/**'
   - 'examples/backends/trtllm/**'
   - 'components/src/dynamo/trtllm/**'
   - 'container/build_trtllm_wheel.sh'
-  - '!**/*.md'
-  - '!**/*.rst'
 
 frontend:
+  - '!**/*.md'
+  - '!**/*.rst'
   - *ci
   - '.cargo/config.toml'
   - 'lib/**'
@@ -148,8 +150,6 @@ frontend:
   - 'components/src/dynamo/frontend/**'
   - 'components/src/dynamo/common/**'
   - 'deploy/inference-gateway/**'
-  - '!**/*.md'
-  - '!**/*.rst'
 
 rust:
   - '.github/workflows/pre-merge.yml'

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -101,6 +101,8 @@ deploy:
   - 'deploy/helm/**'
   - 'deploy/utils/**'
   - 'deploy/chrek/**'
+  - '!**/*.md'
+  - '!**/*.rst'
 
 planner:
   - 'components/src/dynamo/planner/**'
@@ -113,11 +115,15 @@ vllm:
   - 'container/deps/vllm/**'
   - 'examples/backends/vllm/**'
   - 'components/src/dynamo/vllm/**'
+  - '!**/*.md'
+  - '!**/*.rst'
 
 sglang:
   - 'container/Dockerfile.sglang'
   - 'examples/backends/sglang/**'
   - 'components/src/dynamo/sglang/**'
+  - '!**/*.md'
+  - '!**/*.rst'
 
 trtllm:
   - 'container/Dockerfile.trtllm'
@@ -125,6 +131,8 @@ trtllm:
   - 'examples/backends/trtllm/**'
   - 'components/src/dynamo/trtllm/**'
   - 'container/build_trtllm_wheel.sh'
+  - '!**/*.md'
+  - '!**/*.rst'
 
 frontend:
   - *ci
@@ -140,6 +148,8 @@ frontend:
   - 'components/src/dynamo/frontend/**'
   - 'components/src/dynamo/common/**'
   - 'deploy/inference-gateway/**'
+  - '!**/*.md'
+  - '!**/*.rst'
 
 rust:
   - '.github/workflows/pre-merge.yml'


### PR DESCRIPTION
## Summary
- Add `!**/*.md` and `!**/*.rst` exclusions to 5 CI-triggering filter groups that were missing them: `deploy`, `vllm`, `sglang`, `trtllm`, and `frontend`
- Prevents docs-only changes (e.g. editing a README.md) from unnecessarily triggering container builds and test suites
- Consistent with `core` filter which already had these exclusions
- Intentionally omits `!**/*.txt` to avoid excluding dependency files like `requirements.txt` that should trigger CI

## Details
The `core` filter correctly excluded documentation files from triggering CI builds, but five other CI-triggering filter groups were missing these exclusions. For example, editing `lib/runtime/README.md` would trigger the `frontend` EPP image build because `lib/**` matched without any doc exclusion.

**Affected filters and the CI they unnecessarily triggered:**
| Filter | CI Job | Example doc files in paths |
|--------|--------|---------------------------|
| `frontend` | EPP image build | `lib/runtime/README.md`, `components/src/dynamo/router/README.md` |
| `deploy` | deploy-test-vllm-disagg-router | `deploy/helm/README.md`, `deploy/utils/README.md` |
| `vllm` | vLLM build & test | `examples/backends/vllm/deploy/README.md` |
| `sglang` | SGLang build & test | `examples/backends/sglang/deploy/README.md` |
| `trtllm` | TRT-LLM build & test | `examples/backends/trtllm/deploy/README.md` |

**Note:** The `operator` filter was intentionally left unchanged because it explicitly includes `docs/kubernetes/api_reference.md` to trigger operator CI when the API reference changes.

## Where should the reviewer start?
`.github/filters.yaml` — single file, 10 lines added (2 exclusion lines per filter group)

## Test Plan
- [ ] CI passes (this PR changes `filters.yaml` which is in the `ci` anchor, so it will trigger all CI jobs)
- [ ] Verify no regressions by checking that code-only changes in affected paths still trigger their respective CI jobs