### PR TITLE
feat: enable go-to-definition for dynamo.runtime, dynamo.nixl and external dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,15 @@ indent-width = 4
 "icp/tests/**/test_*.py" = ["F811", "F401"]
 "*_inc.py" = ["F821"]
 
+# This is IDE (e.g. Cursor's default Python language server)
+# Configure it so that developers can use "go-to-definition", "hover types" and other
+# features.
+[tool.basedpyright]
+extraPaths = ["components/src", "lib/bindings/python/src"]
+# This is for external dependencies.
+venvPath = "."
+venv = ".venv"
+
 [tool.mypy]
 
 # --disable-error-code: WAR large set of errors due to mypy not being run


### PR DESCRIPTION
## Why

IDE features like go-to-definition and hover types didn't work for `dynamo.runtime`, `dynamo.nixl_connect`, or third-party packages because Cursor's built-in type checker (basedpyright) had no configuration for source roots or venv.

## What

Added `[tool.basedpyright]` to `pyproject.toml` with `extraPaths` for `components/src` and `lib/bindings/python/src`, plus `venvPath`/`venv` pointing to `.venv`.

## Test plan

Open any file importing `dynamo.runtime` (e.g. `components/src/dynamo/vllm/multimodal_handlers/worker_handler.py`), Ctrl+click an import — should jump to definition.

Before

<img width="1010" height="561" alt="Screenshot 2026-02-05 at 8 57 25 PM" src="https://github.com/user-attachments/assets/cbe024ba-5376-4784-87f4-e69ba26eb118" />

After

<img width="752" height="632" alt="Screenshot 2026-02-05 at 8 57 00 PM" src="https://github.com/user-attachments/assets/e0a1c148-7de1-4b90-acb3-7b5b33c46da4" />
