### PR TITLE
ci: apply static type check to vllm multimodal handlers

### DIFF
--- a/components/src/dynamo/common/memory/__init__.py
+++ b/components/src/dynamo/common/memory/__init__.py
@@ -3,6 +3,8 @@
 
 """Memory management utilities for Dynamo components."""
 
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 
-__all__ = ["EncoderCacheManager"]
+__all__ = ["MultimodalEmbeddingCacheManager"]

--- a/components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py
+++ b/components/src/dynamo/common/memory/multimodal_embedding_cache_manager.py
@@ -8,7 +8,7 @@ A simple LRU cache for encoder embeddings (tensors).
 Maps content hash keys to tensors with capacity-based eviction.
 
 Usage:
-    cache = EncoderCacheManager(capacity_bytes=4 * 1024**3)  # 4GB
+    cache = MultimodalEmbeddingCacheManager(capacity_bytes=4 * 1024**3)  # 4GB
 
     # Store embedding
     cache.set("abc123", embedding_tensor)
@@ -26,7 +26,7 @@ import torch
 logger = logging.getLogger(__name__)
 
 
-class EncoderCacheManager:
+class MultimodalEmbeddingCacheManager:
     """
     LRU cache for encoder embeddings.
 
@@ -56,7 +56,7 @@ class EncoderCacheManager:
         self._misses = 0
 
         logger.info(
-            f"EncoderCacheManager initialized: capacity={capacity_bytes / 1024**3:.2f}GB"
+            f"MultimodalEmbeddingCacheManager initialized: capacity={capacity_bytes / 1024**3:.2f}GB"
         )
 
     @staticmethod

--- a/components/src/dynamo/common/multimodal/async_encoder_cache.py
+++ b/components/src/dynamo/common/multimodal/async_encoder_cache.py
@@ -4,11 +4,11 @@
 """
 Async Encoder Cache
 
-Async wrapper over EncoderCacheManager with request coalescing.
+Async wrapper over MultimodalEmbeddingCacheManager with request coalescing.
 Prevents duplicate encoding when multiple requests arrive for the same content.
 
 Usage:
-    cache = EncoderCacheManager(capacity_bytes=4 * 1024**3)
+    cache = MultimodalEmbeddingCacheManager(capacity_bytes=4 * 1024**3)
     async_cache = AsyncEncoderCache(cache)
 
     # Get from cache or compute with coalescing
@@ -21,7 +21,9 @@ from typing import Awaitable, Callable, Dict, Optional
 
 import torch
 
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +45,7 @@ def _suppress_unhandled_future_exception(future: asyncio.Future) -> None:
 
 class AsyncEncoderCache:
     """
-    Async wrapper with request coalescing over EncoderCacheManager.
+    Async wrapper with request coalescing over MultimodalEmbeddingCacheManager.
 
     Provides async get_or_compute that deduplicates concurrent requests
     for the same key, ensuring only one encoding runs at a time per key.
@@ -53,12 +55,12 @@ class AsyncEncoderCache:
         asyncio event loop. All access must be from the same thread.
     """
 
-    def __init__(self, cache: EncoderCacheManager):
+    def __init__(self, cache: MultimodalEmbeddingCacheManager):
         """
         Initialize the async encoder cache.
 
         Args:
-            cache: Underlying EncoderCacheManager for storage.
+            cache: Underlying MultimodalEmbeddingCacheManager for storage.
         """
         self._cache = cache
         self._in_flight: Dict[str, asyncio.Future[torch.Tensor]] = {}

--- a/components/src/dynamo/common/tests/multimodal/test_async_encoder_cache.py
+++ b/components/src/dynamo/common/tests/multimodal/test_async_encoder_cache.py
@@ -8,7 +8,9 @@ import asyncio
 import pytest
 import torch
 
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.common.multimodal.async_encoder_cache import AsyncEncoderCache
 
 
@@ -18,7 +20,7 @@ class TestAsyncEncoderCacheBasicOperations:
     @pytest.fixture
     def cache(self):
         """Create a cache for testing."""
-        ecm = EncoderCacheManager(capacity_bytes=1024 * 1024)
+        ecm = MultimodalEmbeddingCacheManager(capacity_bytes=1024 * 1024)
         return AsyncEncoderCache(ecm)
 
     def test_sync_get_returns_none_for_missing_key(self, cache):
@@ -74,7 +76,7 @@ class TestAsyncEncoderCacheRequestCoalescing:
     @pytest.fixture
     def cache(self):
         """Create a cache for testing."""
-        ecm = EncoderCacheManager(capacity_bytes=1024 * 1024)
+        ecm = MultimodalEmbeddingCacheManager(capacity_bytes=1024 * 1024)
         return AsyncEncoderCache(ecm)
 
     @pytest.mark.asyncio
@@ -137,7 +139,7 @@ class TestAsyncEncoderCacheExceptionHandling:
     @pytest.fixture
     def cache(self):
         """Create a cache for testing."""
-        ecm = EncoderCacheManager(capacity_bytes=1024 * 1024)
+        ecm = MultimodalEmbeddingCacheManager(capacity_bytes=1024 * 1024)
         return AsyncEncoderCache(ecm)
 
     @pytest.mark.asyncio
@@ -209,7 +211,7 @@ class TestAsyncEncoderCacheStats:
     @pytest.fixture
     def cache(self):
         """Create a cache for testing."""
-        ecm = EncoderCacheManager(capacity_bytes=1024 * 1024)
+        ecm = MultimodalEmbeddingCacheManager(capacity_bytes=1024 * 1024)
         return AsyncEncoderCache(ecm)
 
     def test_stats_includes_in_flight(self, cache):

--- a/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
+++ b/components/src/dynamo/trtllm/multimodal/embedding_fetcher.py
@@ -14,7 +14,9 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from tensorrt_llm.llmapi import DisaggregatedParams
 
-from dynamo.common.multimodal.async_encoder_cache import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.trtllm.multimodal.cuda_ipc import extract_embeddings_from_handles
 from dynamo.trtllm.multimodal.hasher import MultimodalHasher
 
@@ -25,7 +27,7 @@ async def fetch_embeddings_from_encoder(
     image_urls: List[str],
     request: Dict[str, Any],
     encode_client: Any,
-    encoder_cache: Optional[EncoderCacheManager] = None,
+    encoder_cache: Optional[MultimodalEmbeddingCacheManager] = None,
 ) -> Union[List[torch.Tensor], DisaggregatedParams]:
     """
     Fetch embeddings from remote encode worker.
@@ -112,7 +114,7 @@ async def _remote_encode_full_epd(
 async def _fetch_embeddings_with_cache(
     image_urls: List[str],
     request: Dict[str, Any],
-    cache: EncoderCacheManager,
+    cache: MultimodalEmbeddingCacheManager,
     encode_fn: Callable[[Dict[str, Any]], DisaggregatedParams],
 ) -> List[torch.Tensor]:
     """

--- a/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
@@ -7,7 +7,9 @@ import logging
 from typing import Optional
 
 from dynamo._core import Context
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.trtllm.multimodal.embedding_fetcher import fetch_embeddings_from_encoder
 from dynamo.trtllm.request_handlers.handler_base import (
     HandlerBase,
@@ -26,7 +28,7 @@ class AggregatedHandler(HandlerBase):
     def __init__(
         self,
         config: RequestHandlerConfig,
-        encoder_cache: Optional[EncoderCacheManager] = None,
+        encoder_cache: Optional[MultimodalEmbeddingCacheManager] = None,
     ):
         super().__init__(config)
         self._encoder_cache = encoder_cache

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -5,7 +5,9 @@ import logging
 from typing import Optional
 
 from dynamo._core import Context
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.trtllm.encode_helper import EncodeHelper
 from dynamo.trtllm.multimodal.embedding_fetcher import fetch_embeddings_from_encoder
@@ -35,7 +37,7 @@ class RequestHandlerFactory:
         encoder_cache = None
         if config.encoder_cache_capacity_gb > 0:
             capacity_bytes = int(config.encoder_cache_capacity_gb * 1024**3)
-            encoder_cache = EncoderCacheManager(capacity_bytes)
+            encoder_cache = MultimodalEmbeddingCacheManager(capacity_bytes)
         if config.disaggregation_mode.value == "prefill":
             return PrefillHandler(config, encoder_cache=encoder_cache)
         if config.disaggregation_mode.value == "prefill_and_decode":
@@ -90,7 +92,7 @@ class PrefillHandler(HandlerBase):
     def __init__(
         self,
         config: RequestHandlerConfig,
-        encoder_cache: Optional[EncoderCacheManager] = None,
+        encoder_cache: Optional[MultimodalEmbeddingCacheManager] = None,
     ):
         super().__init__(config)
         self._encoder_cache = encoder_cache

--- a/components/src/dynamo/trtllm/tests/multimodal/test_trtllm_embedding_fetcher.py
+++ b/components/src/dynamo/trtllm/tests/multimodal/test_trtllm_embedding_fetcher.py
@@ -10,7 +10,9 @@ import pytest
 import torch
 from tensorrt_llm.llmapi import DisaggregatedParams
 
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.trtllm.multimodal.embedding_fetcher import fetch_embeddings_from_encoder
 from dynamo.trtllm.multimodal.hasher import MultimodalHasher
 
@@ -53,9 +55,9 @@ def create_mock_encode_client(
 
 
 @pytest.fixture
-def encoder_cache() -> EncoderCacheManager:
+def encoder_cache() -> MultimodalEmbeddingCacheManager:
     """Create encoder cache with 10MB capacity."""
-    return EncoderCacheManager(capacity_bytes=10 * 1024 * 1024)
+    return MultimodalEmbeddingCacheManager(capacity_bytes=10 * 1024 * 1024)
 
 
 class TestFetchEmbeddingsFromEncoder:

--- a/components/src/dynamo/trtllm/tests/request_handlers/test_trtllm_request_handler_factory.py
+++ b/components/src/dynamo/trtllm/tests/request_handlers/test_trtllm_request_handler_factory.py
@@ -5,7 +5,9 @@
 
 import pytest
 
-from dynamo.common.memory.encoder_cache_manager import EncoderCacheManager
+from dynamo.common.memory.multimodal_embedding_cache_manager import (
+    MultimodalEmbeddingCacheManager,
+)
 from dynamo.trtllm.request_handlers.handlers import (
     AggregatedHandler,
     PrefillHandler,
@@ -53,7 +55,7 @@ class TestRequestHandlerFactory:
         assert isinstance(handler, PrefillHandler)
 
     def test_prefill_handler_with_encoder_cache(self):
-        """Test factory creates PrefillHandler with EncoderCacheManager when capacity > 0."""
+        """Test factory creates PrefillHandler with MultimodalEmbeddingCacheManager when capacity > 0."""
         mock_config = create_mock_request_handler_config(
             disaggregation_mode="prefill",
             encoder_cache_capacity_gb=1.0,
@@ -62,7 +64,7 @@ class TestRequestHandlerFactory:
         handler = factory.get_request_handler(mock_config)
 
         assert isinstance(handler, PrefillHandler)
-        assert isinstance(handler._encoder_cache, EncoderCacheManager)
+        assert isinstance(handler._encoder_cache, MultimodalEmbeddingCacheManager)
 
     def test_prefill_handler_without_encoder_cache(self):
         """Test factory creates PrefillHandler with no cache when capacity is 0."""

--- a/components/src/dynamo/trtllm/tests/request_handlers/utils.py
+++ b/components/src/dynamo/trtllm/tests/request_handlers/utils.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 
 def create_mock_encoder_cache() -> MagicMock:
-    """Create mock EncoderCacheManager."""
+    """Create mock MultimodalEmbeddingCacheManager."""
     cache = MagicMock()
     cache.get = MagicMock(return_value=None)
     cache.set = MagicMock(return_value=True)

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -81,7 +81,7 @@ class EncodeWorkerHandler:
         self.vision_encoder, self.projector = get_encoder_components(
             self.model, self.vision_model
         )
-        self._connector = None
+        self._connector: connect.Connector | None = None
         self._accumulated_time = 0.0
         self._processed_requests = 0
         self.readables = []
@@ -253,6 +253,9 @@ class EncodeWorkerHandler:
                     request.multimodal_inputs[idx].serialized_request = cache_path
                 else:
                     descriptor = connect.Descriptor(embedding_item.embeddings_cpu)
+                    assert (
+                        self._connector is not None
+                    ), "Connector not initialized; call async_init() first"
                     self.readables.append(
                         await self._connector.create_readable(descriptor)
                     )

--- a/components/src/dynamo/vllm/multimodal_handlers/preprocessed_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/preprocessed_handler.py
@@ -158,10 +158,10 @@ class PreprocessedHandler(ProcessMixIn):
         for encode_res in encode_res_gen:
             async for response in encode_res:
                 logger.debug(f"Received response from encode worker: {response}")
-                output = vLLMMultimodalRequest.model_validate_json(response.data())
+                output = vLLMMultimodalRequest.model_validate_json(response.data())  # type: ignore[attr-defined]
                 worker_request.multimodal_inputs.extend(output.multimodal_inputs)
 
-        response_generator = await self.pd_worker_client.round_robin(
+        response_generator = await self.pd_worker_client.round_robin(  # type: ignore[call-arg]
             worker_request.model_dump_json(), context=context
         )
 
@@ -180,7 +180,7 @@ class PreprocessedHandler(ProcessMixIn):
             async for resp in response_generator:
                 # Deserialize the response from the engine
                 # Creates correct vLLM objects for each field
-                output = MyRequestOutput.model_validate_json(resp.data())
+                output = MyRequestOutput.model_validate_json(resp.data())  # type: ignore[attr-defined]
 
                 # OpenAIServingChat.chat_completion_stream_generator() method expects a RequestOutput object
                 res = RequestOutput(
@@ -287,7 +287,7 @@ class ECProcessorHandler(PreprocessedHandler):
         engine_args: AsyncEngineArgs,
         encoder_worker_client: Client,
         pd_worker_client: Client,
-        prompt_template: str = None,
+        prompt_template: str | None = None,
     ):
         """
         Initialize the ECConnector processor.
@@ -398,7 +398,7 @@ class ECProcessorHandler(PreprocessedHandler):
         )
 
         # Send single request to PD worker with ALL images
-        response_generator = await self.pd_worker_client.round_robin(
+        response_generator = await self.pd_worker_client.round_robin(  # type: ignore[call-arg]
             worker_request.model_dump_json(), context=context
         )
 

--- a/components/src/dynamo/vllm/multimodal_handlers/worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/worker_handler.py
@@ -122,7 +122,7 @@ class MultimodalPDWorkerHandler(BaseWorkerHandler):
         component: Component,
         engine_client: AsyncLLM,
         config,
-        decode_worker_client: Client = None,
+        decode_worker_client: Client | None = None,
         shutdown_event=None,
     ):
         # Get default_sampling_params from config
@@ -157,7 +157,9 @@ class MultimodalPDWorkerHandler(BaseWorkerHandler):
         # Create and initialize a dynamo connector for this worker.
         # We'll need this to move data between this worker and remote workers efficiently.
         # Note: This is synchronous initialization, async initialization happens in async_init
-        self._connector = None  # Will be initialized in async_init
+        self._connector: connect.Connector | None = (
+            None  # Will be initialized in async_init
+        )
         self.image_loader = ImageLoader()
 
         logger.info("Multimodal PD Worker has been initialized")
@@ -279,7 +281,7 @@ class MultimodalPDWorkerHandler(BaseWorkerHandler):
                 ) in await self.decode_worker_client.round_robin(
                     decode_request.model_dump_json()
                 ):
-                    output = MyRequestOutput.model_validate_json(decode_response.data())
+                    output = MyRequestOutput.model_validate_json(decode_response.data())  # type: ignore[attr-defined]
                     yield MyRequestOutput(
                         request_id=output.request_id,
                         prompt=output.prompt,

--- a/components/src/dynamo/vllm/multimodal_handlers/worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/worker_handler.py
@@ -3,10 +3,9 @@
 
 import copy
 import logging
-import os
 from collections import defaultdict
+from typing import Any
 
-import safetensors
 import torch
 from vllm.inputs.data import TokensPrompt
 from vllm.v1.engine.async_llm import AsyncLLM
@@ -15,17 +14,14 @@ import dynamo.nixl_connect as connect
 from dynamo.runtime import Client, Component, DistributedRuntime
 
 from ..handlers import BaseWorkerHandler
-from ..multimodal_utils import (
-    ImageLoader,
-    MyRequestOutput,
-    construct_mm_data,
-    vLLMMultimodalRequest,
-)
+from ..multimodal_utils import ImageLoader, MyRequestOutput, vLLMMultimodalRequest
 from ..multimodal_utils.model import construct_qwen_decode_mm_data, is_qwen_vl_model
+from ..multimodal_utils.prefill_worker_utils import (
+    accumulate_embeddings,
+    load_embeddings,
+)
 
 logger = logging.getLogger(__name__)
-
-TRANSFER_LOCAL = int(os.getenv("TRANSFER_LOCAL", 1))
 
 
 class MultimodalDecodeWorkerHandler(BaseWorkerHandler):
@@ -181,108 +177,29 @@ class MultimodalPDWorkerHandler(BaseWorkerHandler):
                 request = vLLMMultimodalRequest.model_validate(request)
         logger.debug(f"Received PD request: {{ id: {request.request_id} }}.")
 
-        multi_modal_data = defaultdict(list)
+        multi_modal_data: dict[str, Any] = defaultdict(list)
         for mi in request.multimodal_inputs:
-            # ECConnector consumer mode: vLLM loads embeddings automatically from disk
-            # We need to pass multimodal_input so vLLM can generate mm_hash and look up cache
-            if self.config.ec_consumer_mode:
-                logger.debug(
-                    f"[{request.request_id}] ECConnector consumer mode: "
-                    f"vLLM will load embeddings from cache using mm_hash"
-                )
-                # Use PIL image loading - vLLM will detect it's already in EC cache
-                # and load from disk instead of reprocessing
-                if mi.multimodal_input.image_url:
-                    multi_modal_data["image"].append(
-                        await self.image_loader.load_image(
-                            mi.multimodal_input.image_url
-                        )
-                    )
-                elif mi.multimodal_input.video_url:
-                    # For video, load as image placeholder (vLLM will use EC cache)
-                    multi_modal_data["image"].append(
-                        await self.image_loader.load_image(
-                            request.multimodal_input.video_url
-                        )
-                    )
-                else:
-                    raise ValueError(
-                        "ECConnector mode requires multimodal_input with image/video URL"
-                    )
-            elif (
-                mi.multimodal_input.image_url is None
-                and mi.multimodal_input.video_url is None
-            ):
-                # Process embeddings using the connector
-                # Create a descriptor based on the embedding shape.
-                if TRANSFER_LOCAL:
-                    logger.info("PD: Loading local safetensors file")
-                    embeddings = safetensors.torch.load_file(mi.serialized_request)[
-                        "ec_cache"
-                    ]
-                else:
-                    embeddings = torch.empty(
-                        mi.embeddings_shape,
-                        dtype=self.EMBEDDINGS_DTYPE,
-                        device=self.EMBEDDINGS_DEVICE,
-                    )
-                    descriptor = connect.Descriptor(embeddings)
-
-                    if descriptor is None:
-                        raise RuntimeError(
-                            "Descriptor is None in PD worker - cannot process embeddings"
-                        )
-
-                    read_op = await self._connector.begin_read(
-                        mi.serialized_request, descriptor
-                    )
-                    await read_op.wait_for_completion()
-                if "video" in self.config.model.lower():
-                    video_numpy = embeddings.numpy()
-                    mm_data = construct_mm_data(
-                        self.config.model,
-                        self.EMBEDDINGS_DTYPE,
-                        video_numpy=video_numpy,
-                    )
-                    multi_modal_data["video"].append(mm_data["video"])
-                else:
-                    mm_data = construct_mm_data(
-                        self.config.model,
-                        self.EMBEDDINGS_DTYPE,
-                        image_embeds=embeddings,
-                        image_grid_thw=mi.image_grid_thw,
-                    )
-                    if isinstance(mm_data["image"], dict):
-                        if multi_modal_data["image"] == []:
-                            multi_modal_data["image"] = mm_data["image"]
-                        else:
-                            # [gluo FIXME] need to understand how Qwen consumes multi-image embeddings
-                            # Merging tensors
-                            multi_modal_data["image"]["image_embeds"] = torch.cat(
-                                (
-                                    multi_modal_data["image"]["image_embeds"],
-                                    mm_data["image"]["image_embeds"],
-                                )
-                            )
-                            multi_modal_data["image"]["image_grid_thw"] = torch.cat(
-                                (
-                                    multi_modal_data["image"]["image_grid_thw"],
-                                    mm_data["image"]["image_grid_thw"],
-                                )
-                            )
-                    else:
-                        logger.info(f"Get embedding of shape {mm_data['image'].shape}")
-                        # [gluo FIXME] embedding with multiple images?
-                        if multi_modal_data["image"] == []:
-                            multi_modal_data["image"] = mm_data["image"]
-                        else:
-                            multi_modal_data["image"] = torch.cat(
-                                (multi_modal_data["image"], mm_data["image"])
-                            )
-            else:
-                # Use PIL image instead of image embeddings
+            if mi.multimodal_input.image_url:
+                # PIL image path — used by both EC consumer mode
+                # (vLLM looks up cached embeddings via mm_hash) and
+                # non-disaggregated mode (vLLM encodes inline).
                 multi_modal_data["image"].append(
                     await self.image_loader.load_image(mi.multimodal_input.image_url)
+                )
+            else:
+                # Pre-computed embeddings via NIXL RDMA or local safetensors
+                embeddings = await load_embeddings(
+                    mi,
+                    self.EMBEDDINGS_DTYPE,
+                    self.EMBEDDINGS_DEVICE,
+                    self._connector,
+                )
+                accumulate_embeddings(
+                    multi_modal_data,
+                    self.config.model,
+                    self.EMBEDDINGS_DTYPE,
+                    embeddings,
+                    mi.image_grid_thw,
                 )
 
         # For Qwen VL (mRoPE), capture the accumulated image grid + embedding shape

--- a/components/src/dynamo/vllm/multimodal_utils/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/__init__.py
@@ -19,6 +19,10 @@ from dynamo.vllm.multimodal_utils.model import (
     construct_mm_data,
     load_vision_model,
 )
+from dynamo.vllm.multimodal_utils.prefill_worker_utils import (
+    accumulate_embeddings,
+    load_embeddings,
+)
 from dynamo.vllm.multimodal_utils.protocol import (
     MultiModalGroup,
     MultiModalInput,
@@ -51,4 +55,6 @@ __all__ = [
     "vLLMMultimodalRequest",
     "VLLMNativeEncoderRequest",
     "VLLMNativeEncoderResponse",
+    "accumulate_embeddings",
+    "load_embeddings",
 ]

--- a/components/src/dynamo/vllm/multimodal_utils/prefill_worker_utils.py
+++ b/components/src/dynamo/vllm/multimodal_utils/prefill_worker_utils.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+from typing import Any, Dict
+
+import safetensors
+import torch
+
+import dynamo.nixl_connect as connect
+
+from .model import construct_mm_data
+from .protocol import MultiModalGroup
+
+logger = logging.getLogger(__name__)
+
+TRANSFER_LOCAL = int(os.getenv("TRANSFER_LOCAL", 1))
+
+
+async def load_embeddings(
+    mi: MultiModalGroup,
+    embeddings_dtype: torch.dtype,
+    embeddings_device: str,
+    connector: connect.Connector | None,
+) -> torch.Tensor:
+    """Load pre-computed embedding tensor via local safetensors or NIXL RDMA.
+
+    Args:
+        mi: A single MultiModalGroup whose ``serialized_request`` field
+            contains either a local file path or NIXL RDMA metadata.
+        embeddings_dtype: Torch dtype for the tensor (used for RDMA path).
+        embeddings_device: Device string for the tensor (used for RDMA path).
+        connector: NIXL Connector for RDMA reads (required when TRANSFER_LOCAL=0).
+
+    Returns:
+        The embedding tensor loaded into CPU memory.
+    """
+    if TRANSFER_LOCAL:
+        logger.info("PD: Loading local safetensors file")
+        return safetensors.torch.load_file(mi.serialized_request)["ec_cache"]
+
+    embeddings = torch.empty(
+        mi.embeddings_shape,
+        dtype=embeddings_dtype,
+        device=embeddings_device,
+    )
+    descriptor = connect.Descriptor(embeddings)
+
+    if descriptor is None:
+        raise RuntimeError(
+            "Descriptor is None in PD worker - cannot process embeddings"
+        )
+
+    read_op = await connector.begin_read(mi.serialized_request, descriptor)
+    await read_op.wait_for_completion()
+    return embeddings
+
+
+def accumulate_embeddings(
+    multi_modal_data: Dict[str, Any],
+    model: str,
+    embeddings_dtype: torch.dtype,
+    embeddings: torch.Tensor,
+    image_grid_thw,
+) -> None:
+    """Construct model-specific mm_data from embeddings and merge into the
+    accumulated ``multi_modal_data`` dict (mutated in-place).
+
+    Handles both video (numpy conversion) and image modalities, including
+    the Qwen-VL dict-style embeddings with ``image_embeds`` + ``image_grid_thw``.
+    """
+    if "video" in model.lower():
+        video_numpy = embeddings.numpy()
+        mm_data = construct_mm_data(
+            model,
+            embeddings_dtype,
+            video_numpy=video_numpy,
+        )
+        multi_modal_data["video"].append(mm_data["video"])
+        return
+
+    mm_data = construct_mm_data(
+        model,
+        embeddings_dtype,
+        image_embeds=embeddings,
+        image_grid_thw=image_grid_thw,
+    )
+
+    if isinstance(mm_data["image"], dict):
+        # Qwen-VL style: dict with image_embeds + image_grid_thw tensors
+        if multi_modal_data["image"] == []:
+            multi_modal_data["image"] = mm_data["image"]
+        else:
+            # [gluo FIXME] need to understand how Qwen consumes multi-image embeddings
+            multi_modal_data["image"]["image_embeds"] = torch.cat(
+                (
+                    multi_modal_data["image"]["image_embeds"],
+                    mm_data["image"]["image_embeds"],
+                )
+            )
+            multi_modal_data["image"]["image_grid_thw"] = torch.cat(
+                (
+                    multi_modal_data["image"]["image_grid_thw"],
+                    mm_data["image"]["image_grid_thw"],
+                )
+            )
+    else:
+        # Plain tensor embeddings
+        logger.info(f"Get embedding of shape {mm_data['image'].shape}")
+        # [gluo FIXME] embedding with multiple images?
+        if multi_modal_data["image"] == []:
+            multi_modal_data["image"] = mm_data["image"]
+        else:
+            multi_modal_data["image"] = torch.cat(
+                (multi_modal_data["image"], mm_data["image"])
+            )

--- a/examples/backends/trtllm/launch/e_pd_disagg.sh
+++ b/examples/backends/trtllm/launch/e_pd_disagg.sh
@@ -53,6 +53,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.trtllm \
   --modality "$MODALITY" \
   --custom-jinja-template "$CUSTOM_TEMPLATE" \
   --encode-endpoint "$ENCODE_ENDPOINT" \
+  --disaggregation-mode prefill_and_decode \
   --dyn-encoder-cache-capacity-gb "$DYN_ENCODER_CACHE_CAPACITY_GB" &
 PD_PID_1=$!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,6 @@ addopts = [
     "--ignore-glob=components/src/dynamo/sglang/request_handlers/*",
     "--ignore-glob=components/src/dynamo/sglang/multimodal_utils/*",
     "--ignore-glob=components/src/dynamo/vllm/multimodal_utils/*",
-    "--ignore-glob=components/src/dynamo/vllm/multimodal_handlers/*",
     "--ignore-glob=examples/backends/sglang/slurm_jobs/*",
     # FIXME: Get relative/generic blob paths to work here
 ]
@@ -188,6 +187,12 @@ filterwarnings = [
     'ignore:Field name "schema" in "ResponseFormat" shadows an attribute in parent:UserWarning',
     # pytest-benchmark automatically disables when xdist is active, ignore the warning
     "ignore:.*Benchmarks are automatically disabled.*:pytest_benchmark.logger.PytestBenchmarkWarning",
+
+    ################################################################################################
+    # vLLM
+    ################################################################################################
+    # vLLM tokenizer deprecation warning (AnyTokenizer moved to vllm.tokenizers.TokenizerLike)
+    "ignore:.*vllm\\.transformers_utils\\.tokenizer\\.AnyTokenizer.*has been moved.*:DeprecationWarning",
 
     ################################################################################################
     # TRT-LLM


### PR DESCRIPTION
## Why

mypy was completely skipped on `vllm/multimodal_handlers/` via `--ignore-glob`, meaning type errors (missing annotations, `None`-unsafe access, wrong default types) accumulated silently and could cause runtime bugs that static analysis would normally catch.

## What

Removed the mypy exclusion and fixed all resulting type errors across 3 handler files.

## Test plan

pytest --mypy components/src/dynamo/vllm/multimodal_handlers/ --co
