### PR TITLE
fix: Fix clashing labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -74,12 +74,12 @@ deployment::k8s:
           - deploy/operator/**
 
 # Misc labels
-build:
+container:
   - changed-files:
       - any-glob-to-any-file:
           - container/**
 
-ci:
+actions:
   - changed-files:
       - any-glob-to-any-file:
           - .github/workflows/**


### PR DESCRIPTION
#### Overview:

These two labels clashed with another workflow that labeled based on PR title: https://github.com/ai-dynamo/dynamo/blob/main/.github/workflows/lint-pr-title.yaml#L18

This fixes that issue. Without this there is a lot of PR label spam between commits for CI/build changes. These two workflows would fight over removing and adding the label for changes :joy: 
