### PR TITLE
fix: remove envsubst for logging-dashboard.yaml to preserve Grafana template variables

### DIFF
--- a/docs/kubernetes/observability/logging.md
+++ b/docs/kubernetes/observability/logging.md
@@ -123,7 +123,7 @@ Since we are using Grafana with the Prometheus Operator, we can simply apply the
 envsubst < deploy/observability/k8s/logging/grafana/loki-datasource.yaml | kubectl apply -n $MONITORING_NAMESPACE -f -
 
 # Configure Grafana with the Dynamo Logs dashboard
-envsubst < deploy/observability/k8s/logging/grafana/logging-dashboard.yaml | kubectl apply -n $MONITORING_NAMESPACE -f -
+kubectl apply -f deploy/observability/k8s/logging/grafana/logging-dashboard.yaml -n $MONITORING_NAMESPACE
 ```
 
 > [!Note]

--- a/fern/pages/kubernetes/observability/logging.md
+++ b/fern/pages/kubernetes/observability/logging.md
@@ -128,7 +128,7 @@ Since we are using Grafana with the Prometheus Operator, we can simply apply the
 envsubst < deploy/observability/k8s/logging/grafana/loki-datasource.yaml | kubectl apply -n $MONITORING_NAMESPACE -f -
 
 # Configure Grafana with the Dynamo Logs dashboard
-envsubst < deploy/observability/k8s/logging/grafana/logging-dashboard.yaml | kubectl apply -n $MONITORING_NAMESPACE -f -
+kubectl apply -f deploy/observability/k8s/logging/grafana/logging-dashboard.yaml -n $MONITORING_NAMESPACE
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The logging setup docs pipe logging-dashboard.yaml through envsubst, which replaces Grafana template variables ($namespace, $dynamographdeployment, $component, $search, $trace_id, etc.) with empty strings since they are not set as shell environment variables. Unlike loki-datasource.yaml, this file contains no shell variables that need substitution, so the fix replaces the envsubst pipe with a direct kubectl apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Kubernetes logging setup instructions to simplify the configuration deployment process.
  * Modified command syntax for applying observability configurations, streamlining the setup workflow for Grafana dashboard and logging components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->