### PR TITLE
feat(runtime): add hierarchical Model/WorkerSet architecture for multi-namespace support

### DIFF
--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -3,13 +3,13 @@
 
 """Dynamo runtime configuration ArgGroup."""
 
-import os
 from typing import List, Optional
 
 from dynamo._core import get_reasoning_parser_names, get_tool_parser_names
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
 from dynamo.common.configuration.utils import add_argument, add_negatable_bool_argument
+from dynamo.common.utils.namespace import get_worker_namespace
 from dynamo.common.utils.output_modalities import OutputModality
 
 
@@ -36,12 +36,7 @@ class DynamoRuntimeConfig(ConfigBase):
     media_output_http_url: Optional[str] = None
 
     def validate(self) -> None:
-        # Apply DYN_NAMESPACE_WORKER_SUFFIX to the namespace if set.
-        # This enables multiple sets of workers for the same model by giving
-        # each set a distinct namespace (e.g., "dynamo-pool1", "dynamo-pool2").
-        suffix = os.environ.get("DYN_NAMESPACE_WORKER_SUFFIX")
-        if suffix:
-            self.namespace = f"{self.namespace}-{suffix}"
+        self.namespace = get_worker_namespace(self.namespace)
 
         # TODO  get a better way for spot fixes like this.
         self.enable_local_indexer = not self.durable_kv_events

--- a/components/src/dynamo/common/utils/__init__.py
+++ b/components/src/dynamo/common/utils/__init__.py
@@ -17,6 +17,7 @@ Submodules:
 from dynamo.common.utils import (
     endpoint_types,
     engine_response,
+    namespace,
     otel_tracing,
     paths,
     prometheus,
@@ -26,6 +27,7 @@ from dynamo.common.utils import (
 __all__ = [
     "endpoint_types",
     "engine_response",
+    "namespace",
     "otel_tracing",
     "paths",
     "prometheus",

--- a/components/src/dynamo/common/utils/namespace.py
+++ b/components/src/dynamo/common/utils/namespace.py
@@ -4,7 +4,7 @@
 import os
 
 
-def get_namespace(default="dynamo"):
+def get_worker_namespace(default="dynamo"):
     """Get the Dynamo namespace for a worker.
 
     If DYN_NAMESPACE_WORKER_SUFFIX is set, the namespace becomes

--- a/components/src/dynamo/common/utils/namespace.py
+++ b/components/src/dynamo/common/utils/namespace.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+
+def get_namespace(default="dynamo"):
+    """Get the effective Dynamo namespace for a worker.
+
+    If DYN_NAMESPACE_WORKER_SUFFIX is set, the effective namespace becomes
+    "{DYN_NAMESPACE}-{suffix}". This enables rolling updates where different
+    worker versions register in different namespaces.
+    """
+    namespace = os.environ.get("DYN_NAMESPACE", default)
+    suffix = os.environ.get("DYN_NAMESPACE_WORKER_SUFFIX")
+    if suffix:
+        namespace = f"{namespace}-{suffix}"
+    return namespace

--- a/components/src/dynamo/common/utils/namespace.py
+++ b/components/src/dynamo/common/utils/namespace.py
@@ -5,11 +5,11 @@ import os
 
 
 def get_namespace(default="dynamo"):
-    """Get the effective Dynamo namespace for a worker.
+    """Get the Dynamo namespace for a worker.
 
-    If DYN_NAMESPACE_WORKER_SUFFIX is set, the effective namespace becomes
-    "{DYN_NAMESPACE}-{suffix}". This enables rolling updates where different
-    worker versions register in different namespaces.
+    If DYN_NAMESPACE_WORKER_SUFFIX is set, the namespace becomes
+    "{DYN_NAMESPACE}-{DYN_NAMESPACE_WORKER_SUFFIX}". This enables supporting
+    multiple sets of workers for the same model.
     """
     namespace = os.environ.get("DYN_NAMESPACE", default)
     suffix = os.environ.get("DYN_NAMESPACE_WORKER_SUFFIX")

--- a/components/src/dynamo/common/utils/namespace.py
+++ b/components/src/dynamo/common/utils/namespace.py
@@ -2,16 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from typing import Optional
 
 
-def get_worker_namespace(default="dynamo"):
+def get_worker_namespace(namespace: Optional[str] = None) -> str:
     """Get the Dynamo namespace for a worker.
 
-    If DYN_NAMESPACE_WORKER_SUFFIX is set, the namespace becomes
-    "{DYN_NAMESPACE}-{DYN_NAMESPACE_WORKER_SUFFIX}". This enables supporting
-    multiple sets of workers for the same model.
+    Uses the provided namespace, or falls back to the DYN_NAMESPACE environment
+    variable (defaulting to "dynamo"). If DYN_NAMESPACE_WORKER_SUFFIX is set,
+    it is appended as "{namespace}-{suffix}" to support multiple sets of workers
+    for the same model.
     """
-    namespace = os.environ.get("DYN_NAMESPACE", default)
+    if not namespace:
+        namespace = os.environ.get("DYN_NAMESPACE", "dynamo")
+
     suffix = os.environ.get("DYN_NAMESPACE_WORKER_SUFFIX")
     if suffix:
         namespace = f"{namespace}-{suffix}"

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -54,6 +54,7 @@ class FrontendConfig(ConfigBase):
     router_max_tree_size: int
     router_prune_target_ratio: float
     namespace: Optional[str] = None
+    namespace_prefix: Optional[str] = None
     router_replica_sync: bool
     router_snapshot_threshold: int
     router_reset_states: bool
@@ -128,9 +129,8 @@ class FrontendArgGroup(ArgGroup):
             env_var="DYN_NAMESPACE",
             default=None,
             help=(
-                "Dynamo namespace for model discovery scoping. If specified, models will "
-                "only be discovered from this namespace. If not specified, discovers models "
-                "from all namespaces (global discovery)."
+                "Dynamo namespace for model discovery scoping. Use for exact namespace matching. "
+                "If --namespace-prefix is also specified, prefix takes precedence."
             ),
         )
 
@@ -254,6 +254,18 @@ class FrontendArgGroup(ArgGroup):
                 "Only used when --no-router-kv-events is set."
             ),
             arg_type=float,
+        )
+
+        add_argument(
+            g,
+            flag_name="--namespace-prefix",
+            env_var="DYN_NAMESPACE_PREFIX",
+            default=None,
+            help=(
+                "Dynamo namespace prefix for model discovery scoping. Discovers models from "
+                "namespaces starting with this prefix (e.g., 'ns' matches 'ns', 'ns-abc123', "
+                "'ns-def456'). Takes precedence over --namespace if both are specified."
+            ),
         )
 
         add_negatable_bool_argument(

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -230,6 +230,8 @@ async def async_main():
         kwargs["tls_key_path"] = config.tls_key_path
     if config.namespace:
         kwargs["namespace"] = config.namespace
+    if config.namespace_prefix:
+        kwargs["namespace_prefix"] = config.namespace_prefix
     if config.kserve_grpc_server and config.grpc_metrics_port:
         kwargs["http_metrics_port"] = config.grpc_metrics_port
 

--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -8,6 +8,8 @@ import os
 import tempfile
 from pathlib import Path
 
+from dynamo.common.utils.namespace import get_namespace
+
 from . import __version__
 from .utils.planner_profiler_perf_data_converter import (
     convert_profile_results_to_npz,
@@ -15,7 +17,7 @@ from .utils.planner_profiler_perf_data_converter import (
     is_profile_results_dir,
 )
 
-DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+DYN_NAMESPACE = get_namespace()
 DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
 DEFAULT_PREFILL_ENDPOINT = f"dyn://{DYN_NAMESPACE}.prefill.generate"
 

--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 from pathlib import Path
 
-from dynamo.common.utils.namespace import get_namespace
+from dynamo.common.utils.namespace import get_worker_namespace
 
 from . import __version__
 from .utils.planner_profiler_perf_data_converter import (
@@ -17,7 +17,7 @@ from .utils.planner_profiler_perf_data_converter import (
     is_profile_results_dir,
 )
 
-DYN_NAMESPACE = get_namespace()
+DYN_NAMESPACE = get_worker_namespace()
 DEFAULT_ENDPOINT = f"dyn://{DYN_NAMESPACE}.backend.generate"
 DEFAULT_PREFILL_ENDPOINT = f"dyn://{DYN_NAMESPACE}.prefill.generate"
 

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -20,13 +20,13 @@ from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 from dynamo.common.config_dump import register_encoder
 from dynamo.common.configuration.groups import DynamoRuntimeConfig
 from dynamo.common.configuration.groups.runtime_args import DynamoRuntimeArgGroup
+from dynamo.common.utils.namespace import get_namespace
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.llm import fetch_model
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 
 configure_dynamo_logging()
-
 
 class DisaggregationMode(Enum):
     AGGREGATED = "agg"
@@ -269,7 +269,7 @@ async def parse_args(args: list[str]) -> Config:
     # Dynamo argument processing
     # If an endpoint is provided, validate and use it
     # otherwise fall back to default endpoints
-    namespace = dynamo_config.namespace
+    namespace = get_namespace()
 
     # If --embedding-worker is set, also set SGLang's --is-embedding flag
     if dynamo_config.embedding_worker:

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -20,7 +20,7 @@ from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 from dynamo.common.config_dump import register_encoder
 from dynamo.common.configuration.groups import DynamoRuntimeConfig
 from dynamo.common.configuration.groups.runtime_args import DynamoRuntimeArgGroup
-from dynamo.common.utils.namespace import get_namespace
+from dynamo.common.utils.namespace import get_worker_namespace
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.llm import fetch_model
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -269,7 +269,7 @@ async def parse_args(args: list[str]) -> Config:
     # Dynamo argument processing
     # If an endpoint is provided, validate and use it
     # otherwise fall back to default endpoints
-    namespace = get_namespace()
+    namespace = get_worker_namespace()
 
     # If --embedding-worker is set, also set SGLang's --is-embedding flag
     if dynamo_config.embedding_worker:

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -20,13 +20,13 @@ from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 from dynamo.common.config_dump import register_encoder
 from dynamo.common.configuration.groups import DynamoRuntimeConfig
 from dynamo.common.configuration.groups.runtime_args import DynamoRuntimeArgGroup
-from dynamo.common.utils.namespace import get_worker_namespace
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.llm import fetch_model
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 
 configure_dynamo_logging()
+
 
 class DisaggregationMode(Enum):
     AGGREGATED = "agg"
@@ -269,7 +269,7 @@ async def parse_args(args: list[str]) -> Config:
     # Dynamo argument processing
     # If an endpoint is provided, validate and use it
     # otherwise fall back to default endpoints
-    namespace = get_worker_namespace()
+    namespace = dynamo_config.namespace
 
     # If --embedding-worker is set, also set SGLang's --is-embedding flag
     if dynamo_config.embedding_worker:

--- a/components/src/dynamo/trtllm/configs/diffusion_config.py
+++ b/components/src/dynamo/trtllm/configs/diffusion_config.py
@@ -7,11 +7,12 @@ This module defines the DiffusionConfig dataclass used for configuring
 video and image diffusion workers.
 """
 
-import os
 from dataclasses import dataclass
 from typing import Optional
 
-DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
+from dynamo.common.utils.namespace import get_worker_namespace
+
+DYN_NAMESPACE = get_worker_namespace()
 
 # Default model paths
 DEFAULT_VIDEO_MODEL_PATH = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -704,6 +704,7 @@ pub unsafe extern "C" fn create_routers(
                     Some(prefill_config),
                     enforce_disagg,
                     model_name.clone(),
+                    namespace_str.clone(),
                 )
             }
             None if enforce_disagg => {

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -182,6 +182,7 @@ pub(crate) struct EntrypointArgs {
     tls_key_path: Option<PathBuf>,
     extra_engine_args: Option<PathBuf>,
     namespace: Option<String>,
+    namespace_prefix: Option<String>,
     is_prefill: bool,
     migration_limit: u32,
     chat_engine_factory: Option<PyEngineFactory>,
@@ -191,7 +192,7 @@ pub(crate) struct EntrypointArgs {
 impl EntrypointArgs {
     #[allow(clippy::too_many_arguments)]
     #[new]
-    #[pyo3(signature = (engine_type, model_path=None, model_name=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, http_metrics_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, namespace=None, is_prefill=false, migration_limit=0, chat_engine_factory=None))]
+    #[pyo3(signature = (engine_type, model_path=None, model_name=None, endpoint_id=None, context_length=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, http_metrics_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, namespace=None, namespace_prefix=None, is_prefill=false, migration_limit=0, chat_engine_factory=None))]
     pub fn new(
         py: Python<'_>,
         engine_type: EngineType,
@@ -209,6 +210,7 @@ impl EntrypointArgs {
         tls_key_path: Option<PathBuf>,
         extra_engine_args: Option<PathBuf>,
         namespace: Option<String>,
+        namespace_prefix: Option<String>,
         is_prefill: bool,
         migration_limit: u32,
         chat_engine_factory: Option<PyObject>,
@@ -254,6 +256,7 @@ impl EntrypointArgs {
             tls_key_path,
             extra_engine_args,
             namespace,
+            namespace_prefix,
             is_prefill,
             migration_limit,
             chat_engine_factory,
@@ -296,7 +299,8 @@ pub fn make_engine<'p>(
         .tls_key_path(args.tls_key_path.clone())
         .is_mocker(matches!(args.engine_type, EngineType::Mocker))
         .extra_engine_args(args.extra_engine_args.clone())
-        .namespace(args.namespace.clone());
+        .namespace(args.namespace.clone())
+        .namespace_prefix(args.namespace_prefix.clone());
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
         if let Some(model_path) = args.model_path.clone() {
             let local_path = if model_path.exists() {

--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -1,8 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod model;
+pub use model::Model;
+
 mod model_manager;
 pub use model_manager::{ModelManager, ModelManagerError};
+
+mod worker_set;
+pub use worker_set::WorkerSet;
 
 pub(crate) mod runtime_configs;
 pub use runtime_configs::{RuntimeConfigWatch, runtime_config_watch};

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! A Model represents a named model (e.g., "llama-3-70b") that may be served by
-//! one or more WorkerSets. Each WorkerSet corresponds to a namespace (deployment version).
+//! one or more WorkerSets. Each WorkerSet corresponds to a namespace.
 //!
-//! During steady state, a Model has exactly one WorkerSet. During rolling updates,
-//! it may have multiple WorkerSets with different configurations. Requests are routed
-//! to a WorkerSet selected by weighted random (proportional to worker count).
+//! Requests are routed to a WorkerSet selected by weighted random (proportional to worker count).
 
 use std::sync::Arc;
 

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -21,8 +21,7 @@ use crate::types::{
     openai::{
         chat_completions::OpenAIChatCompletionsStreamingEngine,
         completions::OpenAICompletionsStreamingEngine, embeddings::OpenAIEmbeddingsStreamingEngine,
-        images::OpenAIImagesStreamingEngine,
-        videos::OpenAIVideosStreamingEngine,
+        images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
     },
 };
 
@@ -135,7 +134,9 @@ impl Model {
 
     /// Check if any WorkerSet has a videos engine.
     pub fn has_videos_engine(&self) -> bool {
-        self.worker_sets.iter().any(|entry| entry.value().has_videos_engine())
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_videos_engine())
     }
 
     /// Get the MDC checksum for a specific namespace's WorkerSet, if it exists.

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -231,7 +231,7 @@ impl Model {
     /// Select a WorkerSet and extract a value from it.
     ///
     /// When there's only one set (steady state), returns from that set directly.
-    /// With multiple sets (rollout), uses weighted random selection proportional
+    /// With multiple sets, uses weighted random selection proportional
     /// to worker count, filtering to sets that have the requested engine.
     ///
     /// The `extract` closure should return `Some(value)` if the WorkerSet has the

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -211,11 +211,11 @@ impl Model {
         result
     }
 
-    /// Get a worker monitor from the first WorkerSet that has one.
-    pub fn get_worker_monitor(&self) -> Option<KvWorkerMonitor> {
+    /// Get the worker monitor for a specific namespace's WorkerSet.
+    pub fn get_worker_monitor_for_namespace(&self, namespace: &str) -> Option<KvWorkerMonitor> {
         self.worker_sets
-            .iter()
-            .find_map(|entry| entry.value().worker_monitor.clone())
+            .get(namespace)
+            .and_then(|entry| entry.value().worker_monitor.clone())
     }
 
     /// Total worker count across all WorkerSets.

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -246,7 +246,9 @@ impl Model {
                 .and_then(|entry| extract(entry.value()));
         }
 
-        // Collect eligible sets with their worker counts, skipping sets with no workers
+        // Collect eligible sets with their worker counts, skipping sets with no workers.
+        // In-process models (no discovery watcher) return count=1, so they always participate.
+        // Discovery models with count=0 have no available workers and are skipped.
         let eligible: Vec<(T, usize)> = self
             .worker_sets
             .iter()

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -291,18 +291,6 @@ mod tests {
         ))
     }
 
-    fn make_worker_set_with_count(namespace: &str, mdcsum: &str, count: usize) -> Arc<WorkerSet> {
-        let ws = Arc::new(WorkerSet::new(
-            namespace.to_string(),
-            mdcsum.to_string(),
-            ModelDeploymentCard::default(),
-        ));
-        for _ in 0..count {
-            ws.increment_workers();
-        }
-        ws
-    }
-
     #[test]
     fn test_model_new() {
         let model = Model::new("llama".to_string());
@@ -395,32 +383,6 @@ mod tests {
         assert!(model.get_embeddings_engine().is_err());
         assert!(model.get_images_engine().is_err());
         assert!(model.get_tensor_engine().is_err());
-    }
-
-    #[test]
-    fn test_total_workers() {
-        let model = Model::new("llama".to_string());
-        model.add_worker_set("ns1".to_string(), make_worker_set_with_count("ns1", "abc", 5));
-        model.add_worker_set("ns2".to_string(), make_worker_set_with_count("ns2", "def", 3));
-
-        assert_eq!(model.total_workers(), 8);
-    }
-
-    #[test]
-    fn test_worker_count_updates_through_model() {
-        let model = Model::new("llama".to_string());
-        let ws = make_worker_set("ns1", "abc");
-        model.add_worker_set("ns1".to_string(), ws);
-
-        // Get the worker set and modify its count
-        let ws_ref = model.get_worker_set("ns1").unwrap();
-        ws_ref.increment_workers();
-        ws_ref.increment_workers();
-
-        assert_eq!(model.total_workers(), 2);
-
-        ws_ref.decrement_workers();
-        assert_eq!(model.total_workers(), 1);
     }
 
     #[test]

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -20,8 +20,7 @@ use crate::types::{
     generic::tensor::TensorStreamingEngine,
     openai::{
         chat_completions::OpenAIChatCompletionsStreamingEngine,
-        completions::OpenAICompletionsStreamingEngine,
-        embeddings::OpenAIEmbeddingsStreamingEngine,
+        completions::OpenAICompletionsStreamingEngine, embeddings::OpenAIEmbeddingsStreamingEngine,
         images::OpenAIImagesStreamingEngine,
         videos::OpenAIVideosStreamingEngine,
     },
@@ -72,7 +71,9 @@ impl Model {
     }
 
     pub fn get_worker_set(&self, namespace: &str) -> Option<Arc<WorkerSet>> {
-        self.worker_sets.get(namespace).map(|entry| entry.value().clone())
+        self.worker_sets
+            .get(namespace)
+            .map(|entry| entry.value().clone())
     }
 
     pub fn is_empty(&self) -> bool {
@@ -85,37 +86,51 @@ impl Model {
 
     /// Check if this model has any decode engine (chat or completions) across any WorkerSet.
     pub fn has_decode_engine(&self) -> bool {
-        self.worker_sets.iter().any(|entry| entry.value().has_decode_engine())
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_decode_engine())
     }
 
     /// Check if this model tracks prefill (any WorkerSet is a prefill set).
     pub fn has_prefill(&self) -> bool {
-        self.worker_sets.iter().any(|entry| entry.value().is_prefill_set())
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().is_prefill_set())
     }
 
     /// Check if any WorkerSet has a chat engine.
     pub fn has_chat_engine(&self) -> bool {
-        self.worker_sets.iter().any(|entry| entry.value().has_chat_engine())
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_chat_engine())
     }
 
     /// Check if any WorkerSet has a completions engine.
     pub fn has_completions_engine(&self) -> bool {
-        self.worker_sets.iter().any(|entry| entry.value().has_completions_engine())
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_completions_engine())
     }
 
     /// Check if any WorkerSet has an embeddings engine.
     pub fn has_embeddings_engine(&self) -> bool {
-        self.worker_sets.iter().any(|entry| entry.value().has_embeddings_engine())
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_embeddings_engine())
     }
 
     /// Check if any WorkerSet has a tensor engine.
     pub fn has_tensor_engine(&self) -> bool {
-        self.worker_sets.iter().any(|entry| entry.value().has_tensor_engine())
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_tensor_engine())
     }
 
     /// Check if any WorkerSet has an images engine.
     pub fn has_images_engine(&self) -> bool {
-        self.worker_sets.iter().any(|entry| entry.value().has_images_engine())
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_images_engine())
     }
 
     /// Check if any WorkerSet has a videos engine.
@@ -133,7 +148,9 @@ impl Model {
 
     // -- Engine accessors: select a WorkerSet, return its engine --
 
-    pub fn get_chat_engine(&self) -> Result<OpenAIChatCompletionsStreamingEngine, ModelManagerError> {
+    pub fn get_chat_engine(
+        &self,
+    ) -> Result<OpenAIChatCompletionsStreamingEngine, ModelManagerError> {
         self.select_worker_set_with(|ws| ws.chat_engine.clone())
             .ok_or_else(|| ModelManagerError::ModelNotFound(self.name.clone()))
     }
@@ -172,10 +189,8 @@ impl Model {
     pub fn get_chat_engine_with_parsing(
         &self,
     ) -> Result<(OpenAIChatCompletionsStreamingEngine, ParsingOptions), ModelManagerError> {
-        self.select_worker_set_with(|ws| {
-            ws.chat_engine.clone().map(|e| (e, ws.parsing_options()))
-        })
-        .ok_or_else(|| ModelManagerError::ModelNotFound(self.name.clone()))
+        self.select_worker_set_with(|ws| ws.chat_engine.clone().map(|e| (e, ws.parsing_options())))
+            .ok_or_else(|| ModelManagerError::ModelNotFound(self.name.clone()))
     }
 
     pub fn get_completions_engine_with_parsing(
@@ -244,17 +259,13 @@ impl Model {
         // TODO: When the single set has 0 workers, this returns None which maps to
         // ModelNotFound (404). Ideally should be 503 "no available workers" — see follow-up.
         if self.worker_sets.len() == 1 {
-            return self
-                .worker_sets
-                .iter()
-                .next()
-                .and_then(|entry| {
-                    let ws = entry.value();
-                    if ws.worker_count() == 0 {
-                        return None;
-                    }
-                    extract(ws)
-                });
+            return self.worker_sets.iter().next().and_then(|entry| {
+                let ws = entry.value();
+                if ws.worker_count() == 0 {
+                    return None;
+                }
+                extract(ws)
+            });
         }
 
         // Collect eligible sets with their worker counts, skipping sets with no workers.
@@ -298,8 +309,8 @@ impl Model {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio::sync::watch;
     use crate::model_card::ModelDeploymentCard;
+    use tokio::sync::watch;
 
     fn make_worker_set(namespace: &str, mdcsum: &str) -> Arc<WorkerSet> {
         Arc::new(WorkerSet::new(
@@ -387,8 +398,14 @@ mod tests {
         model.add_worker_set("ns1".to_string(), make_worker_set("ns1", "abc123"));
         model.add_worker_set("ns2".to_string(), make_worker_set("ns2", "def456"));
 
-        assert_eq!(model.checksum_for_namespace("ns1"), Some("abc123".to_string()));
-        assert_eq!(model.checksum_for_namespace("ns2"), Some("def456".to_string()));
+        assert_eq!(
+            model.checksum_for_namespace("ns1"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            model.checksum_for_namespace("ns2"),
+            Some("def456".to_string())
+        );
         assert_eq!(model.checksum_for_namespace("ns3"), None);
     }
 

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -246,13 +246,17 @@ impl Model {
                 .and_then(|entry| extract(entry.value()));
         }
 
-        // Collect eligible sets with their worker counts
+        // Collect eligible sets with their worker counts, skipping sets with no workers
         let eligible: Vec<(T, usize)> = self
             .worker_sets
             .iter()
             .filter_map(|entry| {
                 let ws = entry.value();
-                extract(ws).map(|val| (val, ws.worker_count().max(1)))
+                let count = ws.worker_count();
+                if count == 0 {
+                    return None;
+                }
+                extract(ws).map(|val| (val, count))
             })
             .collect();
 

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -651,6 +651,7 @@ impl ModelManager {
         let key = Self::prefill_key(&model_name, namespace);
         match self.prefill_router_activators.remove(&key) {
             Some((_, PrefillActivationState::PrefillReady(rx))) => {
+                // Prefill endpoint already arrived - rx will immediately resolve
                 tracing::debug!(
                     model_name = %model_name,
                     namespace = %namespace,
@@ -659,6 +660,7 @@ impl ModelManager {
                 Some(rx)
             }
             Some((key, PrefillActivationState::DecodeWaiting(tx))) => {
+                // Decode already registered - this shouldn't happen, restore state and return None
                 tracing::error!(
                     model_name = %model_name,
                     namespace = %namespace,
@@ -669,6 +671,7 @@ impl ModelManager {
                 None
             }
             None => {
+                // New registration: create tx/rx pair, store sender and return receiver
                 let (tx, rx) = oneshot::channel();
                 self.prefill_router_activators.insert(
                     key,

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -636,7 +636,9 @@ impl ModelManager {
     // Keyed by "model_name:namespace" so each namespace's decode WorkerSet gets its own
     // prefill router activated by same-namespace prefill workers.
 
-    fn prefill_key(model_name: &str, namespace: &str) -> String {
+    /// Build a key for a (model, namespace) pair. Used for prefill router activators
+    /// and registration guards.
+    pub(crate) fn model_namespace_key(model_name: &str, namespace: &str) -> String {
         format!("{}:{}", model_name, namespace)
     }
 
@@ -648,7 +650,7 @@ impl ModelManager {
         model_name: String,
         namespace: &str,
     ) -> Option<oneshot::Receiver<Endpoint>> {
-        let key = Self::prefill_key(&model_name, namespace);
+        let key = Self::model_namespace_key(&model_name, namespace);
         match self.prefill_router_activators.remove(&key) {
             Some((_, PrefillActivationState::PrefillReady(rx))) => {
                 // Prefill endpoint already arrived - rx will immediately resolve
@@ -695,7 +697,7 @@ impl ModelManager {
         namespace: &str,
         endpoint: Endpoint,
     ) -> anyhow::Result<()> {
-        let key = Self::prefill_key(model_name, namespace);
+        let key = Self::model_namespace_key(model_name, namespace);
         match self.prefill_router_activators.remove(&key) {
             Some((_, PrefillActivationState::DecodeWaiting(sender))) => {
                 sender.send(endpoint).map_err(|_| {
@@ -745,7 +747,7 @@ impl ModelManager {
     /// Remove the prefill router activator for a (model, namespace) pair.
     /// Called when a WorkerSet is removed to prevent stale activators.
     pub fn remove_prefill_activator(&self, model_name: &str, namespace: &str) {
-        let key = Self::prefill_key(model_name, namespace);
+        let key = Self::model_namespace_key(model_name, namespace);
         if self.prefill_router_activators.remove(&key).is_some() {
             tracing::debug!(
                 model_name = %model_name,

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -1,17 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
 use dashmap::{DashMap, mapref::entry::Entry};
-use parking_lot::RwLock;
 use tokio::sync::oneshot;
 
 use super::worker_monitor::LoadThresholdConfig;
-use super::{KvWorkerMonitor, RuntimeConfigWatch, runtime_config_watch};
+use super::{KvWorkerMonitor, Model, RuntimeConfigWatch, WorkerSet, runtime_config_watch};
 
 use dynamo_runtime::{
     component::{Client, Endpoint, build_transport_type},
@@ -27,7 +23,6 @@ use crate::{
     },
     local_model::runtime_config::DisaggregatedEndpoint,
     model_card::ModelDeploymentCard,
-    model_type::ModelType,
     types::{
         generic::tensor::TensorStreamingEngine,
         openai::{
@@ -58,27 +53,21 @@ pub enum ModelManagerError {
 
 /// Central manager for model engines, routing, and configuration.
 ///
-/// Manages model lifecycle including engines, KV routers, prefill coordination,
-/// and per-model busy thresholds for load-based request rejection.
+/// Models are stored hierarchically: ModelManager → Model → WorkerSet.
+/// Each WorkerSet owns a complete pipeline built from its specific configuration.
 ///
 /// Note: Don't implement Clone for this, put it in an Arc instead.
 pub struct ModelManager {
-    // We read a lot and write rarely, so these three are RwLock
-    completion_engines: RwLock<ModelEngines<OpenAICompletionsStreamingEngine>>,
-    chat_completion_engines: RwLock<ModelEngines<OpenAIChatCompletionsStreamingEngine>>,
-    embeddings_engines: RwLock<ModelEngines<OpenAIEmbeddingsStreamingEngine>>,
-    images_engines: RwLock<ModelEngines<OpenAIImagesStreamingEngine>>,
-    videos_engines: RwLock<ModelEngines<OpenAIVideosStreamingEngine>>,
-    tensor_engines: RwLock<ModelEngines<TensorStreamingEngine>>,
-    // Prefill models don't have engines - they're only tracked for discovery/lifecycle
-    prefill_engines: RwLock<ModelEngines<()>>,
+    /// Model name → Model (which contains WorkerSets with engines)
+    models: DashMap<String, Arc<Model>>,
 
+    /// Per-instance model cards, keyed by instance path. Used for cleanup on worker removal.
     cards: DashMap<String, ModelDeploymentCard>,
-    kv_choosers: DashMap<EndpointId, Arc<KvRouter>>,
+
+    /// Prefill router activation rendezvous, keyed by model name.
     prefill_router_activators: DashMap<String, PrefillActivationState>,
 
-    // Per-model monitoring: worker_monitors for load-based rejection, runtime_configs for KvScheduler
-    worker_monitors: DashMap<String, KvWorkerMonitor>,
+    /// Per-endpoint runtime config watchers. Keyed by EndpointId (includes namespace).
     runtime_configs: DashMap<EndpointId, RuntimeConfigWatch>,
 }
 
@@ -91,290 +80,92 @@ impl Default for ModelManager {
 impl ModelManager {
     pub fn new() -> Self {
         Self {
-            completion_engines: RwLock::new(ModelEngines::default()),
-            chat_completion_engines: RwLock::new(ModelEngines::default()),
-            embeddings_engines: RwLock::new(ModelEngines::default()),
-            images_engines: RwLock::new(ModelEngines::default()),
-            videos_engines: RwLock::new(ModelEngines::default()),
-            tensor_engines: RwLock::new(ModelEngines::default()),
-            prefill_engines: RwLock::new(ModelEngines::default()),
+            models: DashMap::new(),
             cards: DashMap::new(),
-            kv_choosers: DashMap::new(),
             prefill_router_activators: DashMap::new(),
-            worker_monitors: DashMap::new(),
             runtime_configs: DashMap::new(),
         }
     }
 
-    pub fn is_valid_checksum(
-        &self,
-        model_type: ModelType,
-        model_name: &str,
-        candidate_checksum: &str,
-    ) -> Option<bool> {
-        let mut results = vec![];
-        for unit in model_type.units() {
-            let maybe_valid_checksum = match unit {
-                ModelType::Chat => self.chat_completion_engines.read().checksum(model_name),
-                ModelType::Completions => self.completion_engines.read().checksum(model_name),
-                ModelType::Embedding => self.embeddings_engines.read().checksum(model_name),
-                ModelType::TensorBased => self.tensor_engines.read().checksum(model_name),
-                ModelType::Images => self.images_engines.read().checksum(model_name),
-                ModelType::Videos => self.videos_engines.read().checksum(model_name),
-                ModelType::Prefill => self.prefill_engines.read().checksum(model_name),
-                _ => {
-                    continue;
-                }
-            };
-            if let Some(is_valid) = maybe_valid_checksum.map(|valid_checksum| {
-                tracing::debug!(
-                    model_name,
-                    valid_checksum,
-                    candidate_checksum,
-                    "is_valid_checksum: check case"
-                );
-                valid_checksum == candidate_checksum
-            }) {
-                results.push(is_valid)
+    // -- Model access --
+
+    /// Get or create a Model for the given name.
+    pub fn get_or_create_model(&self, model_name: &str) -> Arc<Model> {
+        self.models
+            .entry(model_name.to_string())
+            .or_insert_with(|| Arc::new(Model::new(model_name.to_string())))
+            .clone()
+    }
+
+    /// Get an existing Model, if it exists.
+    pub fn get_model(&self, model_name: &str) -> Option<Arc<Model>> {
+        self.models.get(model_name).map(|entry| entry.value().clone())
+    }
+
+    /// Remove a Model if it has no remaining WorkerSets.
+    pub fn remove_model_if_empty(&self, model_name: &str) {
+        // Only remove if the model is empty (no worker sets)
+        if let Some(model) = self.models.get(model_name) {
+            if model.is_empty() {
+                drop(model); // Release the read reference before removing
+                self.models.remove(model_name);
+                tracing::info!(model_name, "Removed empty model from manager");
             }
         }
-        if results.is_empty() {
-            None
-        } else {
-            // The checksum is valid if it is correct for all the ModelType in the bitflag.
-            Some(results.into_iter().all(|x| x))
-        }
     }
+
+    /// Add a WorkerSet to a Model. Creates the Model if it doesn't exist.
+    pub fn add_worker_set(
+        &self,
+        model_name: &str,
+        namespace: &str,
+        worker_set: WorkerSet,
+    ) {
+        let model = self.get_or_create_model(model_name);
+        model.add_worker_set(namespace.to_string(), Arc::new(worker_set));
+    }
+
+    /// Remove a WorkerSet from a Model. Removes the Model if it becomes empty.
+    pub fn remove_worker_set(
+        &self,
+        model_name: &str,
+        namespace: &str,
+    ) -> Option<Arc<WorkerSet>> {
+        let model = self.models.get(model_name)?;
+        let removed = model.remove_worker_set(namespace);
+        drop(model);
+        self.remove_model_if_empty(model_name);
+        removed
+    }
+
+    // -- Checksum validation --
+
+    /// Check if a candidate checksum is valid for a model in a specific namespace.
+    /// Returns Some(true) if valid, Some(false) if mismatches existing WorkerSet in same namespace,
+    /// None if model doesn't exist or no WorkerSet exists for this namespace (new namespace is OK).
+    pub fn is_valid_checksum(
+        &self,
+        _model_type: crate::model_type::ModelType,
+        model_name: &str,
+        namespace: &str,
+        candidate_checksum: &str,
+    ) -> Option<bool> {
+        let model = self.models.get(model_name)?;
+        let existing_checksum = model.checksum_for_namespace(namespace)?;
+        tracing::debug!(
+            model_name,
+            namespace,
+            existing_checksum,
+            candidate_checksum,
+            "is_valid_checksum: checking against same-namespace WorkerSet"
+        );
+        Some(existing_checksum == candidate_checksum)
+    }
+
+    // -- Model cards --
 
     pub fn get_model_cards(&self) -> Vec<ModelDeploymentCard> {
         self.cards.iter().map(|r| r.value().clone()).collect()
-    }
-
-    /// Check if a decode model (chat or completions) is registered
-    pub fn has_decode_model(&self, model: &str) -> bool {
-        self.chat_completion_engines.read().contains(model)
-            || self.completion_engines.read().contains(model)
-    }
-
-    /// Check if a prefill model is registered
-    pub fn has_prefill_model(&self, model: &str) -> bool {
-        self.prefill_engines.read().contains(model)
-    }
-
-    /// Check if any model (decode or prefill) is registered.
-    /// Note: For registration skip-checks, use has_decode_model() or has_prefill_model() instead.
-    pub fn has_model_any(&self, model: &str) -> bool {
-        self.has_decode_model(model) || self.has_prefill_model(model)
-    }
-
-    pub fn model_display_names(&self) -> HashSet<String> {
-        self.list_chat_completions_models()
-            .into_iter()
-            .chain(self.list_completions_models())
-            .chain(self.list_embeddings_models())
-            .chain(self.list_images_models())
-            .chain(self.list_videos_models())
-            .chain(self.list_tensor_models())
-            .chain(self.list_prefill_models())
-            .collect()
-    }
-
-    pub fn list_chat_completions_models(&self) -> Vec<String> {
-        self.chat_completion_engines.read().list()
-    }
-
-    pub fn list_completions_models(&self) -> Vec<String> {
-        self.completion_engines.read().list()
-    }
-
-    pub fn list_embeddings_models(&self) -> Vec<String> {
-        self.embeddings_engines.read().list()
-    }
-
-    pub fn list_tensor_models(&self) -> Vec<String> {
-        self.tensor_engines.read().list()
-    }
-
-    pub fn list_prefill_models(&self) -> Vec<String> {
-        self.prefill_engines.read().list()
-    }
-
-    pub fn list_images_models(&self) -> Vec<String> {
-        self.images_engines.read().list()
-    }
-
-    pub fn list_videos_models(&self) -> Vec<String> {
-        self.videos_engines.read().list()
-    }
-
-    pub fn add_completions_model(
-        &self,
-        model: &str,
-        card_checksum: &str,
-        engine: OpenAICompletionsStreamingEngine,
-    ) -> Result<(), ModelManagerError> {
-        let mut clients = self.completion_engines.write();
-        clients.add(model, card_checksum, engine)
-    }
-
-    pub fn add_chat_completions_model(
-        &self,
-        model: &str,
-        card_checksum: &str,
-        engine: OpenAIChatCompletionsStreamingEngine,
-    ) -> Result<(), ModelManagerError> {
-        let mut clients = self.chat_completion_engines.write();
-        clients.add(model, card_checksum, engine)
-    }
-
-    pub fn add_embeddings_model(
-        &self,
-        model: &str,
-        card_checksum: &str,
-        engine: OpenAIEmbeddingsStreamingEngine,
-    ) -> Result<(), ModelManagerError> {
-        let mut clients = self.embeddings_engines.write();
-        clients.add(model, card_checksum, engine)
-    }
-
-    pub fn add_tensor_model(
-        &self,
-        model: &str,
-        card_checksum: &str,
-        engine: TensorStreamingEngine,
-    ) -> Result<(), ModelManagerError> {
-        let mut clients = self.tensor_engines.write();
-        clients.add(model, card_checksum, engine)
-    }
-
-    pub fn add_images_model(
-        &self,
-        model: &str,
-        card_checksum: &str,
-        engine: OpenAIImagesStreamingEngine,
-    ) -> Result<(), ModelManagerError> {
-        let mut clients = self.images_engines.write();
-        clients.add(model, card_checksum, engine)
-    }
-
-    pub fn add_videos_model(
-        &self,
-        model: &str,
-        card_checksum: &str,
-        engine: OpenAIVideosStreamingEngine,
-    ) -> Result<(), ModelManagerError> {
-        let mut clients = self.videos_engines.write();
-        clients.add(model, card_checksum, engine)
-    }
-
-    pub fn add_prefill_model(
-        &self,
-        model: &str,
-        card_checksum: &str,
-    ) -> Result<(), ModelManagerError> {
-        let mut clients = self.prefill_engines.write();
-        clients.add(model, card_checksum, ())
-    }
-
-    pub fn remove_completions_model(&self, model: &str) -> Result<(), ModelManagerError> {
-        let mut clients = self.completion_engines.write();
-        clients.remove(model)
-    }
-
-    pub fn remove_chat_completions_model(&self, model: &str) -> Result<(), ModelManagerError> {
-        let mut clients = self.chat_completion_engines.write();
-        clients.remove(model)
-    }
-
-    pub fn remove_embeddings_model(&self, model: &str) -> Result<(), ModelManagerError> {
-        let mut clients = self.embeddings_engines.write();
-        clients.remove(model)
-    }
-
-    pub fn remove_tensor_model(&self, model: &str) -> Result<(), ModelManagerError> {
-        let mut clients = self.tensor_engines.write();
-        clients.remove(model)
-    }
-
-    pub fn remove_images_model(&self, model: &str) -> Result<(), ModelManagerError> {
-        let mut clients = self.images_engines.write();
-        clients.remove(model)
-    }
-
-    pub fn remove_videos_model(&self, model: &str) -> Result<(), ModelManagerError> {
-        let mut clients = self.videos_engines.write();
-        clients.remove(model)
-    }
-
-    pub fn remove_prefill_model(&self, model: &str) -> Result<(), ModelManagerError> {
-        let mut clients = self.prefill_engines.write();
-        clients.remove(model)
-    }
-
-    pub fn get_embeddings_engine(
-        &self,
-        model: &str,
-    ) -> Result<OpenAIEmbeddingsStreamingEngine, ModelManagerError> {
-        self.embeddings_engines
-            .read()
-            .get(model)
-            .cloned()
-            .ok_or(ModelManagerError::ModelNotFound(model.to_string()))
-    }
-
-    pub fn get_completions_engine(
-        &self,
-        model: &str,
-    ) -> Result<OpenAICompletionsStreamingEngine, ModelManagerError> {
-        self.completion_engines
-            .read()
-            .get(model)
-            .cloned()
-            .ok_or(ModelManagerError::ModelNotFound(model.to_string()))
-    }
-
-    pub fn get_chat_completions_engine(
-        &self,
-        model: &str,
-    ) -> Result<OpenAIChatCompletionsStreamingEngine, ModelManagerError> {
-        self.chat_completion_engines
-            .read()
-            .get(model)
-            .cloned()
-            .ok_or(ModelManagerError::ModelNotFound(model.to_string()))
-    }
-
-    pub fn get_tensor_engine(
-        &self,
-        model: &str,
-    ) -> Result<TensorStreamingEngine, ModelManagerError> {
-        self.tensor_engines
-            .read()
-            .get(model)
-            .cloned()
-            .ok_or(ModelManagerError::ModelNotFound(model.to_string()))
-    }
-
-    pub fn get_images_engine(
-        &self,
-        model: &str,
-    ) -> Result<OpenAIImagesStreamingEngine, ModelManagerError> {
-        self.images_engines
-            .read()
-            .get(model)
-            .cloned()
-            .ok_or(ModelManagerError::ModelNotFound(model.to_string()))
-    }
-
-    pub fn get_videos_engine(
-        &self,
-        model: &str,
-    ) -> Result<OpenAIVideosStreamingEngine, ModelManagerError> {
-        self.videos_engines
-            .read()
-            .get(model)
-            .cloned()
-            .ok_or(ModelManagerError::ModelNotFound(model.to_string()))
     }
 
     /// Save a ModelDeploymentCard from an instance's key so we can fetch it later when the key is
@@ -389,6 +180,398 @@ impl ModelManager {
         self.cards.remove(key).map(|(_, v)| v)
     }
 
+    // -- Engine accessors (delegate through Model → WorkerSet) --
+
+    /// Check if a decode model (chat or completions) is registered
+    pub fn has_decode_model(&self, model: &str) -> bool {
+        self.models
+            .get(model)
+            .is_some_and(|m| m.has_decode_engine())
+    }
+
+    /// Check if a prefill model is registered
+    pub fn has_prefill_model(&self, model: &str) -> bool {
+        self.models
+            .get(model)
+            .is_some_and(|m| m.has_prefill())
+    }
+
+    /// Check if any model (decode or prefill) is registered.
+    pub fn has_model_any(&self, model: &str) -> bool {
+        self.has_decode_model(model) || self.has_prefill_model(model)
+    }
+
+    pub fn model_display_names(&self) -> HashSet<String> {
+        let mut names = HashSet::new();
+        for entry in self.models.iter() {
+            let model = entry.value();
+            if model.has_chat_engine()
+                || model.has_completions_engine()
+                || model.has_embeddings_engine()
+                || model.has_tensor_engine()
+                || model.has_images_engine()
+                || model.has_videos_engine()
+                || model.has_prefill()
+            {
+                names.insert(entry.key().clone());
+            }
+        }
+        names
+    }
+
+    pub fn list_chat_completions_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_chat_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    pub fn list_completions_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_completions_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    pub fn list_embeddings_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_embeddings_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    pub fn list_tensor_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_tensor_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    pub fn list_images_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_images_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    pub fn list_videos_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_videos_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    pub fn list_prefill_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_prefill())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    pub fn get_embeddings_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAIEmbeddingsStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_embeddings_engine()
+    }
+
+    pub fn get_completions_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAICompletionsStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_completions_engine()
+    }
+
+    pub fn get_chat_completions_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAIChatCompletionsStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_chat_engine()
+    }
+
+    pub fn get_tensor_engine(
+        &self,
+        model: &str,
+    ) -> Result<TensorStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_tensor_engine()
+    }
+
+    pub fn get_images_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAIImagesStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_images_engine()
+    }
+
+    pub fn get_videos_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAIVideosStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_videos_engine()
+    }
+
+    // -- Combined engine + parsing options (atomically from one WorkerSet) --
+
+    pub fn get_chat_completions_engine_with_parsing(
+        &self,
+        model: &str,
+    ) -> Result<
+        (
+            OpenAIChatCompletionsStreamingEngine,
+            crate::protocols::openai::ParsingOptions,
+        ),
+        ModelManagerError,
+    > {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_chat_engine_with_parsing()
+    }
+
+    pub fn get_completions_engine_with_parsing(
+        &self,
+        model: &str,
+    ) -> Result<
+        (
+            OpenAICompletionsStreamingEngine,
+            crate::protocols::openai::ParsingOptions,
+        ),
+        ModelManagerError,
+    > {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_completions_engine_with_parsing()
+    }
+
+    // -- Convenience methods for in-process models (http.rs, grpc.rs) --
+    // These create a WorkerSet with a default namespace for local models.
+
+    pub fn add_chat_completions_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAIChatCompletionsStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_chat_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_chat_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            ModelDeploymentCard::default(),
+        );
+        ws.chat_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
+    pub fn add_completions_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAICompletionsStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_completions_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_completions_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            ModelDeploymentCard::default(),
+        );
+        ws.completions_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
+    pub fn add_embeddings_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAIEmbeddingsStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_embeddings_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_embeddings_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            ModelDeploymentCard::default(),
+        );
+        ws.embeddings_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
+    pub fn add_tensor_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: TensorStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_tensor_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_tensor_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            ModelDeploymentCard::default(),
+        );
+        ws.tensor_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
+    pub fn add_images_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAIImagesStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_images_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_images_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            ModelDeploymentCard::default(),
+        );
+        ws.images_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
+    pub fn add_videos_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAIVideosStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_videos_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_videos_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            ModelDeploymentCard::default(),
+        );
+        ws.videos_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
+    pub fn add_prefill_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_prefill() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_prefill_{}", model);
+        let ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            ModelDeploymentCard::default(),
+        );
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
+    // -- Model removal --
+
+    /// Remove a model entirely (all its WorkerSets).
+    /// Returns the removed Model, or None if not found.
+    pub fn remove_model(&self, model: &str) -> Option<Arc<Model>> {
+        self.models.remove(model).map(|(_, m)| m)
+    }
+
+    // Per-type remove methods for in-process models (used by Python bindings).
+    // These remove the specific synthetic WorkerSet created by the corresponding add_*_model method.
+
+    pub fn remove_chat_completions_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_chat_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_completions_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_completions_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_tensor_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_tensor_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_embeddings_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_embeddings_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_images_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_images_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_videos_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_videos_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    // -- KV Router creation --
+
     pub async fn kv_chooser_for(
         &self,
         endpoint: &Endpoint,
@@ -396,25 +579,8 @@ impl ModelManager {
         kv_router_config: Option<KvRouterConfig>,
         worker_type: &'static str,
     ) -> anyhow::Result<Arc<KvRouter>> {
-        let endpoint_id = endpoint.id();
-
-        if let Some(kv_chooser) = self.get_kv_chooser(&endpoint_id) {
-            // Check if the existing router has a different block size
-            if kv_chooser.block_size() != kv_cache_block_size {
-                tracing::warn!(
-                    endpoint = %endpoint_id,
-                    existing_block_size = %kv_chooser.block_size(),
-                    requested_block_size = %kv_cache_block_size,
-                    "KV Router block size mismatch! Endpoint is requesting a different kv_cache_block_size than the existing router. \
-                     This will cause routing to fail silently. Consider using the same block size or restarting the router."
-                );
-            }
-            return Ok(kv_chooser);
-        }
-
         let client = endpoint.client().await?;
 
-        // Register router via discovery mechanism
         let discovery = endpoint.component().drt().discovery();
         let instance_id = discovery.instance_id();
 
@@ -433,7 +599,6 @@ impl ModelManager {
 
         discovery.register(discovery_spec).await?;
 
-        // Get or create runtime config watcher for this endpoint
         let workers_with_configs = self.get_or_create_runtime_config_watcher(endpoint).await?;
 
         let selector = Box::new(DefaultWorkerSelector::new(kv_router_config));
@@ -447,51 +612,72 @@ impl ModelManager {
             worker_type,
         )
         .await?;
-        let new_kv_chooser = Arc::new(chooser);
-        self.kv_choosers.insert(endpoint_id, new_kv_chooser.clone());
-        Ok(new_kv_chooser)
+        Ok(Arc::new(chooser))
     }
 
-    fn get_kv_chooser(&self, id: &EndpointId) -> Option<Arc<KvRouter>> {
-        self.kv_choosers.get(id).map(|r| r.value().clone())
+    // -- Worker monitor creation --
+
+    pub fn get_or_create_worker_monitor(
+        &self,
+        model: &str,
+        client: Client,
+        config: LoadThresholdConfig,
+    ) -> KvWorkerMonitor {
+        // Check if any existing WorkerSet for this model has a monitor
+        if let Some(existing) = self.get_worker_monitor(model) {
+            existing.set_load_threshold_config(&config);
+            return existing;
+        }
+        // Create new monitor
+        KvWorkerMonitor::new(client, config)
     }
 
-    /// Register a prefill router for a decode model. Returns a receiver that will be
-    /// activated when the corresponding prefill model is discovered.
-    /// Returns None if the decode model was already registered.
+    // -- Prefill router coordination --
+    // Keyed by "model_name:namespace" so each namespace's decode WorkerSet gets its own
+    // prefill router activated by same-namespace prefill workers.
+
+    fn prefill_key(model_name: &str, namespace: &str) -> String {
+        format!("{}:{}", model_name, namespace)
+    }
+
+    /// Register a prefill router for a decode WorkerSet. Returns a receiver that will be
+    /// activated when the corresponding prefill model in the same namespace is discovered.
+    /// Returns None if a decode WorkerSet in this namespace was already registered.
     pub fn register_prefill_router(
         &self,
         model_name: String,
+        namespace: &str,
     ) -> Option<oneshot::Receiver<Endpoint>> {
-        match self.prefill_router_activators.remove(&model_name) {
+        let key = Self::prefill_key(&model_name, namespace);
+        match self.prefill_router_activators.remove(&key) {
             Some((_, PrefillActivationState::PrefillReady(rx))) => {
-                // Prefill endpoint already arrived - rx will immediately resolve
                 tracing::debug!(
                     model_name = %model_name,
-                    "Prefill endpoint already available, returning receiver with endpoint"
+                    namespace = %namespace,
+                    "Prefill endpoint already available for namespace, returning receiver"
                 );
                 Some(rx)
             }
             Some((key, PrefillActivationState::DecodeWaiting(tx))) => {
-                // Decode already registered - this shouldn't happen, restore state and return None
                 tracing::error!(
                     model_name = %model_name,
-                    "Decode model already registered for this prefill router"
+                    namespace = %namespace,
+                    "Decode WorkerSet already registered for this prefill router"
                 );
                 self.prefill_router_activators
                     .insert(key, PrefillActivationState::DecodeWaiting(tx));
                 None
             }
             None => {
-                // New registration: create tx/rx pair, store sender and return receiver
                 let (tx, rx) = oneshot::channel();
                 self.prefill_router_activators.insert(
-                    model_name.clone(),
+                    key,
                     PrefillActivationState::DecodeWaiting(tx),
                 );
                 tracing::debug!(
                     model_name = %model_name,
-                    "No prefill endpoint available yet, storing sender for future activation"
+                    namespace = %namespace,
+                    "No prefill endpoint for namespace yet, storing sender for future activation"
                 );
                 Some(rx)
             }
@@ -499,114 +685,104 @@ impl ModelManager {
     }
 
     /// Activate a prefill router by sending the endpoint through the oneshot channel.
-    /// If no decode model has registered yet, stores the endpoint for future retrieval.
+    /// The namespace must match the decode WorkerSet's namespace.
     pub fn activate_prefill_router(
         &self,
         model_name: &str,
+        namespace: &str,
         endpoint: Endpoint,
     ) -> anyhow::Result<()> {
-        match self.prefill_router_activators.remove(model_name) {
+        let key = Self::prefill_key(model_name, namespace);
+        match self.prefill_router_activators.remove(&key) {
             Some((_, PrefillActivationState::DecodeWaiting(sender))) => {
-                // Decode model already registered
                 sender.send(endpoint).map_err(|_| {
                     anyhow::anyhow!(
-                        "Failed to send endpoint to prefill router activator for model: {}",
-                        model_name
+                        "Failed to send endpoint to prefill router activator for {}:{}",
+                        model_name,
+                        namespace
                     )
                 })?;
-
                 tracing::info!(
                     model_name = %model_name,
-                    "Activated prefill router for already-registered decode model"
+                    namespace = %namespace,
+                    "Activated prefill router for decode WorkerSet"
                 );
-
                 Ok(())
             }
             Some((_, PrefillActivationState::PrefillReady(_))) => {
-                // Prefill already activated - this shouldn't happen
-                anyhow::bail!("Prefill router for model {} already activated", model_name);
+                anyhow::bail!(
+                    "Prefill router for {}:{} already activated",
+                    model_name,
+                    namespace
+                );
             }
             None => {
-                // Decode model not registered yet - create pair and immediately send endpoint
                 let (tx, rx) = oneshot::channel();
-
                 tx.send(endpoint).map_err(|_| {
-                    anyhow::anyhow!("Failed to send endpoint for prefill model: {}", model_name)
+                    anyhow::anyhow!(
+                        "Failed to send endpoint for prefill model {}:{}",
+                        model_name,
+                        namespace
+                    )
                 })?;
-
-                // Store the receiver for when decode model registers
                 self.prefill_router_activators.insert(
-                    model_name.to_string(),
+                    key,
                     PrefillActivationState::PrefillReady(rx),
                 );
-
                 tracing::info!(
                     model_name = %model_name,
-                    "Stored prefill endpoint for future decode model registration"
+                    namespace = %namespace,
+                    "Stored prefill endpoint for future decode WorkerSet registration"
                 );
-
                 Ok(())
             }
         }
     }
 
-    pub fn get_model_tool_call_parser(&self, model: &str) -> Option<String> {
-        self.cards
-            .iter()
-            .find(|r| r.value().display_name == model)
-            .and_then(|r| r.value().runtime_config.tool_call_parser.clone())
+    /// Remove the prefill router activator for a (model, namespace) pair.
+    /// Called when a WorkerSet is removed to prevent stale activators.
+    pub fn remove_prefill_activator(&self, model_name: &str, namespace: &str) {
+        let key = Self::prefill_key(model_name, namespace);
+        if self.prefill_router_activators.remove(&key).is_some() {
+            tracing::debug!(
+                model_name = %model_name,
+                namespace = %namespace,
+                "Cleaned up prefill router activator for removed WorkerSet"
+            );
+        }
     }
 
-    pub fn get_model_reasoning_parser(&self, model: &str) -> Option<String> {
-        self.cards
-            .iter()
-            .find(|r| r.value().display_name == model)
-            .and_then(|r| r.value().runtime_config.reasoning_parser.clone())
-    }
-
-    /// Creates parsing options with tool call parser and reasoning parser for the specified model.
-    pub fn get_parsing_options(&self, model: &str) -> crate::protocols::openai::ParsingOptions {
-        let tool_call_parser = self.get_model_tool_call_parser(model);
-        let reasoning_parser = self.get_model_reasoning_parser(model);
-
-        crate::protocols::openai::ParsingOptions::new(tool_call_parser, reasoning_parser)
-    }
+    // -- Worker monitoring --
 
     /// Gets or sets the load threshold config for a model's worker monitor.
-    /// Pass `Some(config)` to update, `None` to get. Returns `None` if no monitor exists.
+    /// Checks across all WorkerSets for the model.
     pub fn load_threshold_config(
         &self,
         model: &str,
         config: Option<&LoadThresholdConfig>,
     ) -> Option<LoadThresholdConfig> {
-        let monitor = self.worker_monitors.get(model)?;
-        if let Some(cfg) = config {
-            monitor.set_load_threshold_config(cfg);
-        }
-        Some(monitor.load_threshold_config())
+        let model_entry = self.models.get(model)?;
+        model_entry.load_threshold_config(config)
     }
 
     /// Gets an existing worker monitor for a model, if one exists.
     pub fn get_worker_monitor(&self, model: &str) -> Option<KvWorkerMonitor> {
-        self.worker_monitors.get(model).map(|m| m.clone())
+        let model_entry = self.models.get(model)?;
+        model_entry.get_worker_monitor()
     }
 
-    /// Gets or creates a worker monitor for a model. Updates thresholds if monitor exists.
-    pub fn get_or_create_worker_monitor(
-        &self,
-        model: &str,
-        client: Client,
-        config: LoadThresholdConfig,
-    ) -> KvWorkerMonitor {
-        if let Some(existing) = self.worker_monitors.get(model) {
-            existing.set_load_threshold_config(&config);
-            return existing.clone();
+    /// Lists all models with worker monitors configured.
+    pub fn list_busy_thresholds(&self) -> Vec<(String, LoadThresholdConfig)> {
+        let mut result = Vec::new();
+        for entry in self.models.iter() {
+            if let Some(config) = entry.value().load_threshold_config(None) {
+                result.push((entry.key().clone(), config));
+            }
         }
-        let monitor = KvWorkerMonitor::new(client, config);
-        self.worker_monitors
-            .insert(model.to_string(), monitor.clone());
-        monitor
+        result
     }
+
+    // -- Runtime configs --
 
     /// Get or create a runtime config watcher for an endpoint.
     /// Spawns a background task that joins instance availability and config discovery.
@@ -617,7 +793,6 @@ impl ModelManager {
     ) -> anyhow::Result<RuntimeConfigWatch> {
         let endpoint_id = endpoint.id();
 
-        // Fast path: return existing if present
         if let Some(existing) = self.runtime_configs.get(&endpoint_id) {
             return Ok(existing.clone());
         }
@@ -638,7 +813,6 @@ impl ModelManager {
     }
 
     /// Get disaggregated endpoint for a specific worker.
-    /// Used by PrefillRouter for bootstrap info - works for ANY routing mode.
     pub fn get_disaggregated_endpoint(
         &self,
         endpoint_id: &EndpointId,
@@ -647,80 +821,5 @@ impl ModelManager {
         let rx = self.runtime_configs.get(endpoint_id)?;
         let configs = rx.borrow();
         configs.get(&worker_id)?.disaggregated_endpoint.clone()
-    }
-
-    /// Lists all models with worker monitors configured.
-    pub fn list_busy_thresholds(&self) -> Vec<(String, LoadThresholdConfig)> {
-        self.worker_monitors
-            .iter()
-            .map(|entry| (entry.key().clone(), entry.value().load_threshold_config()))
-            .collect()
-    }
-}
-
-pub struct ModelEngines<E> {
-    /// Optional default model name
-    default: Option<String>,
-    engines: HashMap<String, E>,
-    /// Key: Model name, value: Checksum of the ModelDeploymentCard. New instances must have the
-    /// same card.
-    checksums: HashMap<String, String>,
-}
-
-impl<E> Default for ModelEngines<E> {
-    fn default() -> Self {
-        Self {
-            default: None,
-            engines: HashMap::new(),
-            checksums: HashMap::new(),
-        }
-    }
-}
-
-impl<E> ModelEngines<E> {
-    #[allow(dead_code)]
-    fn set_default(&mut self, model: &str) {
-        self.default = Some(model.to_string());
-    }
-
-    #[allow(dead_code)]
-    fn clear_default(&mut self) {
-        self.default = None;
-    }
-
-    fn add(&mut self, model: &str, checksum: &str, engine: E) -> Result<(), ModelManagerError> {
-        if self.engines.contains_key(model) {
-            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
-        }
-        self.engines.insert(model.to_string(), engine);
-        self.checksums
-            .insert(model.to_string(), checksum.to_string());
-        Ok(())
-    }
-
-    fn remove(&mut self, model: &str) -> Result<(), ModelManagerError> {
-        if self.engines.remove(model).is_none() {
-            return Err(ModelManagerError::ModelNotFound(model.to_string()));
-        }
-        let _ = self.checksums.remove(model);
-        Ok(())
-    }
-
-    fn get(&self, model: &str) -> Option<&E> {
-        self.engines.get(model)
-    }
-
-    fn contains(&self, model: &str) -> bool {
-        self.engines.contains_key(model)
-    }
-
-    pub fn list(&self) -> Vec<String> {
-        self.engines.keys().map(|k| k.to_owned()).collect()
-    }
-
-    /// Returns a newly allocated String for called convenience. All the places I use
-    /// this I need a String.
-    pub fn checksum(&self, model: &str) -> Option<String> {
-        self.checksums.get(model).map(|s| s.to_string())
     }
 }

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -209,7 +209,6 @@ impl ModelManager {
                 || model.has_embeddings_engine()
                 || model.has_images_engine()
                 || model.has_tensor_engine()
-                || model.has_images_engine()
                 || model.has_videos_engine()
                 || model.has_prefill()
             {

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -581,6 +581,7 @@ impl ModelManager {
     ) -> anyhow::Result<Arc<KvRouter>> {
         let client = endpoint.client().await?;
 
+        // Register router via discovery mechanism.
         let discovery = endpoint.component().drt().discovery();
         let instance_id = discovery.instance_id();
 
@@ -599,6 +600,7 @@ impl ModelManager {
 
         discovery.register(discovery_spec).await?;
 
+        // Get of create runtime config watcher for this endpoint
         let workers_with_configs = self.get_or_create_runtime_config_watcher(endpoint).await?;
 
         let selector = Box::new(DefaultWorkerSelector::new(kv_router_config));

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -758,10 +758,10 @@ impl ModelManager {
         model_entry.load_threshold_config(config)
     }
 
-    /// Gets an existing worker monitor for a model, if one exists.
-    pub fn get_worker_monitor(&self, model: &str) -> Option<KvWorkerMonitor> {
+    /// Gets an existing worker monitor for a specific namespace of a model.
+    pub fn get_worker_monitor_for_namespace(&self, model: &str, namespace: &str) -> Option<KvWorkerMonitor> {
         let model_entry = self.models.get(model)?;
-        model_entry.get_worker_monitor()
+        model_entry.get_worker_monitor_for_namespace(namespace)
     }
 
     /// Lists all models with worker monitors configured.

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -50,7 +50,9 @@ pub enum ModelManagerError {
     #[error("Model already exists: {0}")]
     ModelAlreadyExists(String),
 
-    #[error("Checksum mismatch for model {model}: expected {expected}, got {got}. All WorkerSets of a model must share the same checksum. Drain all old workers before deploying a new version.")]
+    #[error(
+        "Checksum mismatch for model {model}: expected {expected}, got {got}. All WorkerSets of a model must share the same checksum. Drain all old workers before deploying a new version."
+    )]
     ChecksumMismatch {
         model: String,
         expected: String,
@@ -149,11 +151,7 @@ impl ModelManager {
     /// Check if a candidate checksum is valid for a model.
     /// Returns `Some(true)` if it matches the model's canonical checksum, `Some(false)` if it
     /// doesn't match, or `None` if the model doesn't exist or has no canonical checksum yet.
-    pub fn is_valid_checksum(
-        &self,
-        model_name: &str,
-        candidate_checksum: &str,
-    ) -> Option<bool> {
+    pub fn is_valid_checksum(&self, model_name: &str, candidate_checksum: &str) -> Option<bool> {
         let model = self.models.get(model_name)?;
         model.is_valid_checksum(candidate_checksum)
     }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -49,6 +49,16 @@ use crate::{
 use super::ModelManager;
 use crate::namespace::NamespaceFilter;
 
+/// Constructs the WorkerSet storage key. Prefill and decode workers in the same
+/// namespace get different keys so they don't block each other's registration.
+fn worker_set_key(namespace: &str, model_type: ModelType) -> String {
+    if model_type.supports_prefill() {
+        format!("{}:prefill", namespace)
+    } else {
+        namespace.to_string()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum ModelUpdate {
     Added(ModelDeploymentCard),
@@ -180,9 +190,10 @@ impl ModelWatcher {
                     // If we already have a WorkerSet for this (model, namespace) and the
                     // checksums don't match, reject the new worker. Different namespaces
                     // may legitimately have different checksums.
+                    let ws_key = worker_set_key(&mcid.namespace, card.model_type);
                     let can_add = self.manager.is_valid_checksum(
                         card.name(),
-                        &mcid.namespace,
+                        &ws_key,
                         card.mdcsum(),
                     );
                     if can_add.is_some_and(|is_valid| !is_valid) {
@@ -268,6 +279,8 @@ impl ModelWatcher {
         };
         let model_name = card.name().to_string();
         let worker_namespace = &mcid.namespace;
+        let worker_component = &mcid.component;
+        let ws_key = worker_set_key(&mcid.namespace, card.model_type);
 
         // Query discovery for all remaining instances of this model
         let active_instances = self
@@ -275,14 +288,18 @@ impl ModelWatcher {
             .await
             .with_context(|| model_name.clone())?;
 
-        // Check if any instances remain in this worker's specific namespace
-        let ns_has_instances = active_instances
+        // Check if instances of the SAME component remain in this namespace.
+        // In disaggregated deployments, prefill and decode are different components
+        // in the same namespace, so we must check at the component level to avoid
+        // removing one type's WorkerSet while the other still has workers.
+        let component_has_instances = active_instances
             .iter()
-            .any(|(eid, _)| eid.namespace == *worker_namespace);
+            .any(|(eid, _)| eid.namespace == *worker_namespace && eid.component == *worker_component);
 
-        if !ns_has_instances {
-            // No more workers in this namespace — remove its WorkerSet and associated state
-            if let Some(_removed_ws) = self.manager.remove_worker_set(&model_name, worker_namespace) {
+        if !component_has_instances {
+            // No more workers of this component in this namespace — remove its WorkerSet
+            if let Some(_removed_ws) = self.manager.remove_worker_set(&model_name, &ws_key) {
+                // remove_prefill_activator uses deployment namespace (not ws_key)
                 self.manager.remove_prefill_activator(&model_name, worker_namespace);
                 tracing::info!(
                     model_name,
@@ -323,13 +340,14 @@ impl ModelWatcher {
         mcid: &ModelCardInstanceId,
         card: &mut ModelDeploymentCard,
     ) -> anyhow::Result<()> {
-        // Check if this specific (model, namespace) WorkerSet already exists.
+        // Check if this specific (model, namespace, type) WorkerSet already exists.
         // If so, this is just another worker joining an existing set — no pipeline build needed.
         let model_name = card.name().to_string();
         let namespace = mcid.namespace.clone();
+        let ws_key = worker_set_key(&namespace, card.model_type);
 
         if let Some(model) = self.manager.get_model(&model_name) {
-            if model.has_worker_set(&namespace) {
+            if model.has_worker_set(&ws_key) {
                 self.manager
                     .save_model_card(&mcid.to_path(), card.clone())?;
                 tracing::debug!(
@@ -341,8 +359,8 @@ impl ModelWatcher {
             }
         }
 
-        // Guard against concurrent pipeline construction for the same (model, namespace)
-        let registration_key = ModelManager::model_namespace_key(&model_name, &namespace);
+        // Guard against concurrent pipeline construction for the same (model, namespace, type)
+        let registration_key = ModelManager::model_namespace_key(&model_name, &ws_key);
         if !self.registering_worker_sets.insert(registration_key.clone()) {
             self.manager
                 .save_model_card(&mcid.to_path(), card.clone())?;
@@ -388,6 +406,7 @@ impl ModelWatcher {
 
         let checksum = card.mdcsum();
         let namespace = mcid.namespace.clone();
+        let ws_key = worker_set_key(&namespace, card.model_type);
 
         // Build the WorkerSet with all applicable engines
         let mut worker_set = WorkerSet::new(
@@ -674,7 +693,7 @@ impl ModelWatcher {
 
             // Prefill sets have no engines — we add the WorkerSet first for tracking,
             // then activate the prefill router.
-            self.manager.add_worker_set(card.name(), &namespace, worker_set);
+            self.manager.add_worker_set(card.name(), &ws_key, worker_set);
 
             let Ok(()) = self.manager.activate_prefill_router(card.name(), &namespace, endpoint) else {
                 tracing::warn!(
@@ -701,7 +720,7 @@ impl ModelWatcher {
         }
 
         // Add the completed WorkerSet to the Model
-        self.manager.add_worker_set(card.name(), &namespace, worker_set);
+        self.manager.add_worker_set(card.name(), &ws_key, worker_set);
 
         Ok(())
     }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -24,7 +24,7 @@ use dynamo_runtime::{
 
 use crate::{
     backend::Backend,
-    discovery::{WORKER_TYPE_DECODE, WorkerSet},
+    discovery::{KvWorkerMonitor, WORKER_TYPE_DECODE, WorkerSet},
     entrypoint::{self, ChatEngineFactoryCallback, RouterConfig},
     http::service::metrics::Metrics,
     kv_router::PrefillRouter,
@@ -181,7 +181,6 @@ impl ModelWatcher {
                     // checksums don't match, reject the new worker. Different namespaces
                     // may legitimately have different checksums.
                     let can_add = self.manager.is_valid_checksum(
-                        card.model_type,
                         card.name(),
                         &mcid.namespace,
                         card.mdcsum(),
@@ -437,7 +436,7 @@ impl ModelWatcher {
             let model_name = card.name().to_string();
             let prefill_chooser = self
                 .manager
-                .register_prefill_router(model_name.clone(), &namespace)
+                .register_prefill_router(&model_name, &namespace)
                 .map(|rx| {
                     // Create prefill-specific config with track_active_blocks disabled
                     let mut prefill_config = self.router_config.kv_router_config;
@@ -454,12 +453,11 @@ impl ModelWatcher {
                     )
                 });
 
-            // Get or create the worker monitor for this model.
-            // Always create the monitor for Prometheus metrics (active_decode_blocks, active_prefill_tokens,
+            // Create a new worker monitor for this WorkerSet. Each WorkerSet gets its own
+            // monitor (1-to-1) since each monitor is scoped to this WorkerSet's Client/namespace.
+            // The monitor tracks Prometheus metrics (active_decode_blocks, active_prefill_tokens,
             // worker TTFT/ITL cleanup). The thresholds control busy detection behavior only.
-            // LoadThresholdConfig allows dynamic threshold updates via the ModelManager.
-            let worker_monitor = Some(self.manager.get_or_create_worker_monitor(
-                card.name(),
+            let worker_monitor = Some(KvWorkerMonitor::new(
                 client.clone(),
                 self.router_config.load_threshold_config.clone(),
             ));

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -47,7 +47,7 @@ use crate::{
 };
 
 use super::ModelManager;
-use crate::namespace::is_global_namespace;
+use crate::namespace::{is_global_namespace, NamespaceFilter};
 
 #[derive(Debug, Clone)]
 pub enum ModelUpdate {
@@ -120,10 +120,8 @@ impl ModelWatcher {
     pub async fn watch(
         &self,
         mut discovery_stream: DiscoveryStream,
-        target_namespace: Option<&str>,
+        namespace_filter: NamespaceFilter,
     ) {
-        let global_namespace = target_namespace.is_none_or(is_global_namespace);
-
         while let Some(result) = discovery_stream.next().await {
             let event = match result {
                 Ok(event) => event,
@@ -169,15 +167,12 @@ impl ModelWatcher {
                         }
                     };
 
-                    // Filter by namespace if target_namespace is specified
-                    if !global_namespace
-                        && let Some(target_ns) = target_namespace
-                        && mcid.namespace != target_ns
-                    {
+                    // Filter by namespace using the configured filter
+                    if !namespace_filter.matches(&mcid.namespace) {
                         tracing::debug!(
                             model_namespace = mcid.namespace,
-                            target_namespace = target_ns,
-                            "Skipping model from different namespace"
+                            namespace_filter = ?namespace_filter,
+                            "Skipping model due to namespace filter"
                         );
                         continue;
                     }
@@ -234,7 +229,7 @@ impl ModelWatcher {
                     };
 
                     match self
-                        .handle_delete(model_card_instance_id, target_namespace, global_namespace)
+                        .handle_delete(model_card_instance_id, &namespace_filter)
                         .await
                     {
                         Ok(Some(model_name)) => {
@@ -257,8 +252,7 @@ impl ModelWatcher {
     async fn handle_delete(
         &self,
         mcid: &ModelCardInstanceId,
-        target_namespace: Option<&str>,
-        is_global_namespace: bool,
+        namespace_filter: &NamespaceFilter,
     ) -> anyhow::Result<Option<String>> {
         let key = mcid.to_path();
         let card = match self.manager.remove_model_card(&key) {
@@ -285,7 +279,7 @@ impl ModelWatcher {
 
         // Query discovery for all remaining instances of this model
         let active_instances = self
-            .cards_for_model_with_endpoints(&model_name, target_namespace, is_global_namespace)
+            .cards_for_model_with_endpoints(&model_name, namespace_filter)
             .await
             .with_context(|| model_name.clone())?;
 
@@ -745,11 +739,10 @@ impl ModelWatcher {
     pub async fn cards_for_model(
         &self,
         model_name: &str,
-        target_namespace: Option<&str>,
-        is_global_namespace: bool,
+        namespace_filter: &NamespaceFilter,
     ) -> anyhow::Result<Vec<ModelDeploymentCard>> {
         Ok(self
-            .cards_for_model_with_endpoints(model_name, target_namespace, is_global_namespace)
+            .cards_for_model_with_endpoints(model_name, namespace_filter)
             .await?
             .into_iter()
             .map(|(_, card)| card)
@@ -761,17 +754,12 @@ impl ModelWatcher {
     async fn cards_for_model_with_endpoints(
         &self,
         model_name: &str,
-        target_namespace: Option<&str>,
-        is_global_namespace: bool,
+        namespace_filter: &NamespaceFilter,
     ) -> anyhow::Result<Vec<(EndpointId, ModelDeploymentCard)>> {
         let mut all = self.all_cards().await?;
         all.retain(|(endpoint_id, card)| {
             let matches_name = card.name() == model_name;
-            let matches_namespace = match (is_global_namespace, target_namespace) {
-                (true, _) => true,
-                (false, None) => true,
-                (false, Some(target_ns)) => endpoint_id.namespace == target_ns,
-            };
+            let matches_namespace = namespace_filter.matches(&endpoint_id.namespace);
             matches_name && matches_namespace
         });
         Ok(all)

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -24,7 +24,7 @@ use dynamo_runtime::{
 
 use crate::{
     backend::Backend,
-    discovery::WORKER_TYPE_DECODE,
+    discovery::{WORKER_TYPE_DECODE, WorkerSet},
     entrypoint::{self, ChatEngineFactoryCallback, RouterConfig},
     http::service::metrics::Metrics,
     kv_router::PrefillRouter,
@@ -64,7 +64,8 @@ pub struct ModelWatcher {
     model_update_tx: Option<Sender<ModelUpdate>>,
     chat_engine_factory: Option<ChatEngineFactoryCallback>,
     metrics: Arc<Metrics>,
-    registering_models: DashSet<String>,
+    /// Guards against concurrent pipeline construction for the same (model, namespace).
+    registering_worker_sets: DashSet<String>,
 }
 
 const ALL_MODEL_TYPES: &[ModelType] = &[
@@ -96,7 +97,7 @@ impl ModelWatcher {
             model_update_tx: None,
             chat_engine_factory,
             metrics,
-            registering_models: DashSet::new(),
+            registering_worker_sets: DashSet::new(),
         }
     }
 
@@ -181,25 +182,23 @@ impl ModelWatcher {
                         continue;
                     }
 
-                    // If we already have a worker for this model, and the ModelDeploymentCard
-                    // cards don't match, alert, and don't add the new instance
-                    let can_add =
-                        self.manager
-                            .is_valid_checksum(card.model_type, card.name(), card.mdcsum());
+                    // If we already have a WorkerSet for this (model, namespace) and the
+                    // checksums don't match, reject the new worker. Different namespaces
+                    // may legitimately have different checksums (rolling updates).
+                    let can_add = self.manager.is_valid_checksum(
+                        card.model_type,
+                        card.name(),
+                        &mcid.namespace,
+                        card.mdcsum(),
+                    );
                     if can_add.is_some_and(|is_valid| !is_valid) {
                         tracing::error!(
                             model_name = card.name(),
-                            "Checksum for new model does not match existing model."
+                            namespace = mcid.namespace,
+                            "Checksum for new worker does not match existing WorkerSet in same namespace."
                         );
 
                         // TODO: mark that instance down in clients
-                        // Not obvious how to do that given the current design
-                        // Instances come from an `InstanceSource` in a `Client` in a `PushRouter`.
-                        // Calling `report_instance_down` on the Client should do it (although
-                        // needs more testing).
-                        // The `PushRouter` is in `ModelMananger` (`self.manager` here), but inside
-                        // interface `AsyncEngine` which only has a `generate` method.
-
                         continue;
                     }
 
@@ -253,8 +252,8 @@ impl ModelWatcher {
         }
     }
 
-    /// If the last instance running this model has gone delete it.
-    /// Returns the name of the model we just deleted, if any.
+    /// Handle a worker removal. Cleans up per-namespace WorkerSets and the Model itself
+    /// when no instances remain. Returns the model name if the entire Model was removed.
     async fn handle_delete(
         &self,
         mcid: &ModelCardInstanceId,
@@ -269,90 +268,60 @@ impl ModelWatcher {
             }
         };
         let model_name = card.name().to_string();
+        let worker_namespace = &mcid.namespace;
+
+        // Decrement worker count for this namespace's WorkerSet
+        if let Some(model) = self.manager.get_model(&model_name) {
+            if let Some(ws) = model.get_worker_set(worker_namespace) {
+                let remaining = ws.decrement_workers();
+                tracing::debug!(
+                    model_name,
+                    namespace = %worker_namespace,
+                    remaining_workers = remaining,
+                    "Decremented worker count for WorkerSet"
+                );
+            }
+        }
+
+        // Query discovery for all remaining instances of this model
         let active_instances = self
-            .cards_for_model(&model_name, target_namespace, is_global_namespace)
+            .cards_for_model_with_endpoints(&model_name, target_namespace, is_global_namespace)
             .await
             .with_context(|| model_name.clone())?;
+
+        // Check if any instances remain in this worker's specific namespace
+        let ns_has_instances = active_instances
+            .iter()
+            .any(|(eid, _)| eid.namespace == *worker_namespace);
+
+        if !ns_has_instances {
+            // No more workers in this namespace — remove its WorkerSet and associated state
+            if let Some(_removed_ws) = self.manager.remove_worker_set(&model_name, worker_namespace) {
+                self.manager.remove_prefill_activator(&model_name, worker_namespace);
+                tracing::info!(
+                    model_name,
+                    namespace = %worker_namespace,
+                    "Removed WorkerSet (no remaining instances in namespace)"
+                );
+            }
+        }
+
+        // Check if the Model still has instances in any namespace
         if !active_instances.is_empty() {
             tracing::debug!(
                 model_name,
-                target_namespace = ?target_namespace,
                 active_instance_count = active_instances.len(),
-                "Model has other active instances, not removing"
+                "Model has other active instances in other namespaces"
             );
             return Ok(None);
         }
 
-        // Ignore the errors because model could be either type
-        let chat_model_remove_err = self.manager.remove_chat_completions_model(&model_name);
-        let completions_model_remove_err = self.manager.remove_completions_model(&model_name);
-        let embeddings_model_remove_err = self.manager.remove_embeddings_model(&model_name);
-        let images_model_remove_err = self.manager.remove_images_model(&model_name);
-        let videos_model_remove_err = self.manager.remove_videos_model(&model_name);
-        let tensor_model_remove_err = self.manager.remove_tensor_model(&model_name);
-        let prefill_model_remove_err = self.manager.remove_prefill_model(&model_name);
+        // No instances remain anywhere — remove the entire Model
+        let _ = self.manager.remove_model(&model_name);
 
-        let mut chat_model_removed = false;
-        let mut completions_model_removed = false;
-        let mut embeddings_model_removed = false;
-        let mut images_model_removed = false;
-        let mut videos_model_removed = false;
-        let mut tensor_model_removed = false;
-        let mut prefill_model_removed = false;
-
-        if chat_model_remove_err.is_ok() && self.manager.list_chat_completions_models().is_empty() {
-            chat_model_removed = true;
-        }
-        if completions_model_remove_err.is_ok() && self.manager.list_completions_models().is_empty()
-        {
-            completions_model_removed = true;
-        }
-        if embeddings_model_remove_err.is_ok() && self.manager.list_embeddings_models().is_empty() {
-            embeddings_model_removed = true;
-        }
-        if images_model_remove_err.is_ok() && self.manager.list_images_models().is_empty() {
-            images_model_removed = true;
-        }
-        if videos_model_remove_err.is_ok() && self.manager.list_videos_models().is_empty() {
-            videos_model_removed = true;
-        }
-        if tensor_model_remove_err.is_ok() && self.manager.list_tensor_models().is_empty() {
-            tensor_model_removed = true;
-        }
-        if prefill_model_remove_err.is_ok() && self.manager.list_prefill_models().is_empty() {
-            prefill_model_removed = true;
-        }
-
-        if !chat_model_removed
-            && !completions_model_removed
-            && !embeddings_model_removed
-            && !images_model_removed
-            && !videos_model_removed
-            && !tensor_model_removed
-            && !prefill_model_removed
-        {
-            tracing::debug!(
-                "No updates to send for model {}: chat_model_removed: {}, completions_model_removed: {}, embeddings_model_removed: {}, images_model_removed: {}, videos_model_removed: {}, tensor_model_removed: {}, prefill_model_removed: {}",
-                model_name,
-                chat_model_removed,
-                completions_model_removed,
-                embeddings_model_removed,
-                images_model_removed,
-                videos_model_removed,
-                tensor_model_removed,
-                prefill_model_removed
-            );
-        } else {
+        if let Some(tx) = &self.model_update_tx {
             for model_type in ALL_MODEL_TYPES {
-                if ((chat_model_removed && *model_type == ModelType::Chat)
-                    || (completions_model_removed && *model_type == ModelType::Completions)
-                    || (embeddings_model_removed && *model_type == ModelType::Embedding)
-                    || (images_model_removed && *model_type == ModelType::Images)
-                    || (videos_model_removed && *model_type == ModelType::Videos)
-                    || (tensor_model_removed && *model_type == ModelType::TensorBased)
-                    || (prefill_model_removed && *model_type == ModelType::Prefill))
-                    && let Some(tx) = &self.model_update_tx
-                {
+                if card.model_type.intersects(*model_type) {
                     tx.send(ModelUpdate::Removed(card.clone())).await.ok();
                 }
             }
@@ -368,54 +337,50 @@ impl ModelWatcher {
         mcid: &ModelCardInstanceId,
         card: &mut ModelDeploymentCard,
     ) -> anyhow::Result<()> {
-        // Check if model is already registered before downloading config.
-        // This prevents duplicate HuggingFace API calls when multiple workers register
-        // the same model.
-        // Prefill and decode models are tracked separately, so registering one
-        // doesn't block the other (they can arrive in any order).
-        let already_registered = if card.model_type.supports_prefill() {
-            self.manager.has_prefill_model(card.name())
-        } else {
-            self.manager.has_decode_model(card.name())
-        };
+        // Check if this specific (model, namespace) WorkerSet already exists.
+        // If so, this is just another worker joining an existing set — no pipeline build needed.
+        let model_name = card.name().to_string();
+        let namespace = mcid.namespace.clone();
 
-        if already_registered {
+        if let Some(model) = self.manager.get_model(&model_name) {
+            if let Some(ws) = model.get_worker_set(&namespace) {
+                self.manager
+                    .save_model_card(&mcid.to_path(), card.clone())?;
+                let count = ws.increment_workers();
+                tracing::debug!(
+                    model_name = card.name(),
+                    namespace = namespace,
+                    worker_count = count,
+                    "Worker joined existing WorkerSet, skipping pipeline build"
+                );
+                return Ok(());
+            }
+        }
+
+        // Guard against concurrent pipeline construction for the same (model, namespace)
+        let registration_key = format!("{}:{}", model_name, namespace);
+        if !self.registering_worker_sets.insert(registration_key.clone()) {
             self.manager
                 .save_model_card(&mcid.to_path(), card.clone())?;
             tracing::debug!(
                 model_name = card.name(),
-                namespace = mcid.namespace,
-                model_type = %card.model_type,
-                "Model already registered, skipping config download"
+                namespace = namespace,
+                "WorkerSet registration in progress, skipping"
             );
             return Ok(());
         }
 
-        // Use registering_models set to prevent concurrent registrations.
-        let model_key = card.name().to_string();
-        if !self.registering_models.insert(model_key.clone()) {
-            self.manager
-                .save_model_card(&mcid.to_path(), card.clone())?;
-            tracing::debug!(
-                model_name = card.name(),
-                namespace = mcid.namespace,
-                "Model registration in progress by another worker, skipping"
-            );
-            return Ok(());
-        }
+        let result = self.do_worker_set_registration(mcid, card).await;
 
-        // We acquired the registration lock. Use a helper to ensure cleanup on all exit paths.
-        let result = self.do_model_registration(mcid, card).await;
-
-        // Always remove from registering set, whether success or failure
-        self.registering_models.remove(&model_key);
+        // Always remove from registering set
+        self.registering_worker_sets.remove(&registration_key);
 
         result
     }
 
-    /// Inner function that performs the actual model registration.
-    /// Called by handle_put after acquiring the registration lock.
-    async fn do_model_registration(
+    /// Build a complete WorkerSet with all engines for this (model, namespace)
+    /// and add it to the Model.
+    async fn do_worker_set_registration(
         &self,
         mcid: &ModelCardInstanceId,
         card: &mut ModelDeploymentCard,
@@ -428,7 +393,7 @@ impl ModelWatcher {
             .component(&mcid.component)?;
         let endpoint = component.endpoint(&mcid.endpoint);
         let client = endpoint.client().await?;
-        tracing::debug!(model_name = card.name(), "adding model");
+        tracing::debug!(model_name = card.name(), namespace = mcid.namespace, "building worker set pipeline");
         self.manager
             .save_model_card(&mcid.to_path(), card.clone())?;
 
@@ -437,14 +402,19 @@ impl ModelWatcher {
         }
 
         let checksum = card.mdcsum();
+        let namespace = mcid.namespace.clone();
+
+        // Build the WorkerSet with all applicable engines
+        let mut worker_set = WorkerSet::new(
+            namespace.clone(),
+            checksum.to_string(),
+            card.clone(),
+        );
 
         if card.model_input == ModelInput::Tokens
             && (card.model_type.supports_chat() || card.model_type.supports_completions())
         {
             // Case 1: Tokens + (Chat OR Completions OR Both)
-            // A model that expects pre-processed requests meaning it's up to us whether we
-            // handle Chat or Completions requests, so handle whatever the model supports.
-
             let endpoint = component.endpoint(&mcid.endpoint);
             // Create the KV router whenever any local routed pipeline will be built.
             // The chat factory builds its own router, but completions currently always
@@ -461,7 +431,7 @@ impl ModelWatcher {
                             &endpoint,
                             card.kv_cache_block_size,
                             Some(self.router_config.kv_router_config),
-                            WORKER_TYPE_DECODE, // This is the decode router
+                            WORKER_TYPE_DECODE,
                         )
                         .await?,
                 )
@@ -469,17 +439,13 @@ impl ModelWatcher {
                 None
             };
 
-            // This is expensive, we are loading ~10MiB JSON, so only do it once
             let tokenizer_hf = card.tokenizer_hf().context("tokenizer_hf")?;
 
-            // Create prefill chooser once if we're building pipelines
-            // Both chat and completions will share the same prefill chooser instance
             let model_name = card.name().to_string();
             let prefill_chooser = self
                 .manager
-                .register_prefill_router(model_name.clone())
+                .register_prefill_router(model_name.clone(), &namespace)
                 .map(|rx| {
-                    // Create prefill-specific config with track_active_blocks disabled
                     let mut prefill_config = self.router_config.kv_router_config;
                     prefill_config.router_track_active_blocks = false;
 
@@ -490,21 +456,20 @@ impl ModelWatcher {
                         card.kv_cache_block_size,
                         Some(prefill_config),
                         self.router_config.enforce_disagg,
-                        model_name.clone(), // Pass model name for worker monitor lookup
+                        model_name.clone(),
                     )
                 });
 
-            // Get or create the worker monitor for this model.
-            // Always create the monitor for Prometheus metrics (active_decode_blocks, active_prefill_tokens,
-            // worker TTFT/ITL cleanup). The thresholds control busy detection behavior only.
-            // LoadThresholdConfig allows dynamic threshold updates via the ModelManager.
             let worker_monitor = Some(self.manager.get_or_create_worker_monitor(
                 card.name(),
                 client.clone(),
                 self.router_config.load_threshold_config.clone(),
             ));
 
-            // Add chat engine only if the model supports chat
+            // Store KV router and worker monitor on the WorkerSet
+            worker_set.kv_router = kv_chooser.clone();
+            worker_set.worker_monitor = worker_monitor.clone();
+
             if card.model_type.supports_chat() {
                 let factory_engine = if let Some(ref factory) = self.chat_engine_factory {
                     match factory(mcid.clone(), card.clone()).await {
@@ -537,9 +502,7 @@ impl ModelWatcher {
                     .await
                     .context("build_routed_pipeline")?
                 };
-                self.manager
-                    .add_chat_completions_model(card.name(), checksum, chat_engine)
-                    .context("add_chat_completions_model")?;
+                worker_set.chat_engine = Some(chat_engine);
                 tracing::info!("Chat completions is ready");
             }
 
@@ -572,13 +535,10 @@ impl ModelWatcher {
                 )
                 .await
                 .context("build_routed_pipeline_with_preprocessor")?;
-                self.manager
-                    .add_completions_model(card.name(), checksum, completions_engine)
-                    .context("add_completions_model")?;
+                worker_set.completions_engine = Some(completions_engine);
                 tracing::info!("Completions is ready");
             }
         } else if card.model_input == ModelInput::Text && card.model_type.supports_embedding() {
-            // Case: Text + Embeddings
             let push_router = PushRouter::<
                 NvCreateEmbeddingRequest,
                 Annotated<NvCreateEmbeddingResponse>,
@@ -586,9 +546,7 @@ impl ModelWatcher {
                 client, self.router_config.router_mode, None, None
             )
             .await?;
-            let engine = Arc::new(push_router);
-            self.manager
-                .add_embeddings_model(card.name(), checksum, engine)?;
+            worker_set.embeddings_engine = Some(Arc::new(push_router));
         }
         // Case: Text + (Images, Audio, Videos)
         // Must come before the plain Text+Chat / Text+Completions branches because
@@ -599,8 +557,7 @@ impl ModelWatcher {
                 || card.model_type.supports_audios()
                 || card.model_type.supports_videos())
         {
-            // Image Models can support chat completions (vllm omni way)
-            // So register chat_completions model as well
+            // Image/Audio/Video models can also support chat completions (vLLM omni way)
             if card.model_type.supports_chat() {
                 let chat_router = PushRouter::<
                     NvCreateChatCompletionRequest,
@@ -612,14 +569,9 @@ impl ModelWatcher {
                     None,
                 )
                 .await?;
-                self.manager.add_chat_completions_model(
-                    card.name(),
-                    checksum,
-                    Arc::new(chat_router),
-                )?;
+                worker_set.chat_engine = Some(Arc::new(chat_router));
             }
 
-            // This is ModelType::Images : registers /v1/images/* endpoints
             if card.model_type.supports_images() {
                 let images_router = PushRouter::<
                     NvCreateImageRequest,
@@ -628,11 +580,9 @@ impl ModelWatcher {
                     client.clone(), self.router_config.router_mode, None, None
                 )
                 .await?;
-                self.manager
-                    .add_images_model(card.name(), checksum, Arc::new(images_router))?;
+                worker_set.images_engine = Some(Arc::new(images_router));
             }
 
-            // This is ModelType::Videos : registers /v1/videos/* endpoints
             if card.model_type.supports_videos() {
                 let videos_router = PushRouter::<
                     NvCreateVideoRequest,
@@ -641,8 +591,7 @@ impl ModelWatcher {
                     client.clone(), self.router_config.router_mode, None, None
                 )
                 .await?;
-                self.manager
-                    .add_videos_model(card.name(), checksum, Arc::new(videos_router))?;
+                worker_set.videos_engine = Some(Arc::new(videos_router));
             }
 
             // TODO: add audio models support
@@ -655,9 +604,7 @@ impl ModelWatcher {
                 client, self.router_config.router_mode, None, None
             )
             .await?;
-            let engine = Arc::new(push_router);
-            self.manager
-                .add_chat_completions_model(card.name(), checksum, engine)?;
+            worker_set.chat_engine = Some(Arc::new(push_router));
         } else if card.model_input == ModelInput::Text && card.model_type.supports_completions() {
             // Case: Text + Completions
             let push_router = PushRouter::<
@@ -667,13 +614,8 @@ impl ModelWatcher {
                 client, self.router_config.router_mode, None, None
             )
             .await?;
-            let engine = Arc::new(push_router);
-            self.manager
-                .add_completions_model(card.name(), checksum, engine)?;
+            worker_set.completions_engine = Some(Arc::new(push_router));
         } else if card.model_input == ModelInput::Tokens && card.model_type.supports_embedding() {
-            // Case 4: Tokens + Embeddings
-
-            // Create preprocessing pipeline similar to Backend
             let frontend = SegmentSource::<
                 SingleIn<NvCreateEmbeddingRequest>,
                 ManyOut<Annotated<NvCreateEmbeddingResponse>>,
@@ -690,10 +632,8 @@ impl ModelWatcher {
             )
             .await?;
 
-            // Note: Embeddings don't need KV routing complexity or load monitoring
             let service_backend = ServiceBackend::from_engine(Arc::new(router));
 
-            // Link the pipeline: frontend -> preprocessor -> backend -> service_backend -> backend -> preprocessor -> frontend
             let embedding_engine = frontend
                 .link(preprocessor.forward_edge())?
                 .link(backend.forward_edge())?
@@ -702,8 +642,7 @@ impl ModelWatcher {
                 .link(preprocessor.backward_edge())?
                 .link(frontend)?;
 
-            self.manager
-                .add_embeddings_model(card.name(), checksum, embedding_engine)?;
+            worker_set.embeddings_engine = Some(embedding_engine);
         } else if card.model_input == ModelInput::Tensor && card.model_type.supports_tensor() {
             // Case 6: Tensor + TensorBased (non-LLM)
             // No KV cache concepts - not an LLM model
@@ -714,12 +653,8 @@ impl ModelWatcher {
                 client, self.router_config.router_mode, None, None
             )
             .await?;
-            let engine = Arc::new(push_router);
-            self.manager
-                .add_tensor_model(card.name(), checksum, engine)?;
+            worker_set.tensor_engine = Some(Arc::new(push_router));
         } else if card.model_type.supports_prefill() {
-            // Case 6: Prefill
-            // Guardrail: Verify model_input is Tokens
             if card.model_input != ModelInput::Tokens {
                 anyhow::bail!(
                     "Prefill models must use ModelInput::Tokens, got {}",
@@ -732,13 +667,12 @@ impl ModelWatcher {
                 "Prefill model detected, registering and activating prefill router"
             );
 
-            // Register prefill model for tracking (no engine needed, just lifecycle)
-            self.manager
-                .add_prefill_model(card.name(), checksum)
-                .context("add_prefill_model")?;
+            // Prefill sets have no engines — we add the WorkerSet first for tracking,
+            // then activate the prefill router.
+            worker_set.increment_workers();
+            self.manager.add_worker_set(card.name(), &namespace, worker_set);
 
-            // Activate the prefill router with the endpoint for this prefill model
-            let Ok(()) = self.manager.activate_prefill_router(card.name(), endpoint) else {
+            let Ok(()) = self.manager.activate_prefill_router(card.name(), &namespace, endpoint) else {
                 tracing::warn!(
                     model_name = card.name(),
                     "Failed to activate prefill router - prefill model may already be activated"
@@ -750,8 +684,9 @@ impl ModelWatcher {
                 model_name = card.name(),
                 "Prefill model registered and router activated successfully"
             );
+
+            return Ok(());
         } else {
-            // Reject unsupported combinations
             anyhow::bail!(
                 "Unsupported model configuration: {} with {} input. Supported combinations: \
                 Tokens+(Chat|Completions|Prefill), Text+(Chat|Completions|Images), Tokens+Embeddings, Tensor+TensorBased",
@@ -759,6 +694,12 @@ impl ModelWatcher {
                 card.model_input.as_str()
             );
         }
+
+        // Count the first worker that triggered this registration
+        worker_set.increment_workers();
+
+        // Add the completed WorkerSet to the Model
+        self.manager.add_worker_set(card.name(), &namespace, worker_set);
 
         Ok(())
     }
@@ -772,7 +713,6 @@ impl ModelWatcher {
         for instance in instances {
             match instance.deserialize_model::<ModelDeploymentCard>() {
                 Ok(card) => {
-                    // Extract EndpointId from the instance
                     let endpoint_id = match &instance {
                         dynamo_runtime::discovery::DiscoveryInstance::Model {
                             namespace,
@@ -808,6 +748,22 @@ impl ModelWatcher {
         target_namespace: Option<&str>,
         is_global_namespace: bool,
     ) -> anyhow::Result<Vec<ModelDeploymentCard>> {
+        Ok(self
+            .cards_for_model_with_endpoints(model_name, target_namespace, is_global_namespace)
+            .await?
+            .into_iter()
+            .map(|(_, card)| card)
+            .collect())
+    }
+
+    /// Like `cards_for_model` but also returns the EndpointId for each card,
+    /// allowing callers to filter by namespace.
+    async fn cards_for_model_with_endpoints(
+        &self,
+        model_name: &str,
+        target_namespace: Option<&str>,
+        is_global_namespace: bool,
+    ) -> anyhow::Result<Vec<(EndpointId, ModelDeploymentCard)>> {
         let mut all = self.all_cards().await?;
         all.retain(|(endpoint_id, card)| {
             let matches_name = card.name() == model_name;
@@ -818,6 +774,6 @@ impl ModelWatcher {
             };
             matches_name && matches_namespace
         });
-        Ok(all.into_iter().map(|(_eid, card)| card).collect())
+        Ok(all)
     }
 }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -191,11 +191,9 @@ impl ModelWatcher {
                     // checksums don't match, reject the new worker. Different namespaces
                     // may legitimately have different checksums.
                     let ws_key = worker_set_key(&mcid.namespace, card.model_type);
-                    let can_add = self.manager.is_valid_checksum(
-                        card.name(),
-                        &ws_key,
-                        card.mdcsum(),
-                    );
+                    let can_add =
+                        self.manager
+                            .is_valid_checksum(card.name(), &ws_key, card.mdcsum());
                     if can_add.is_some_and(|is_valid| !is_valid) {
                         tracing::error!(
                             model_name = card.name(),
@@ -292,15 +290,16 @@ impl ModelWatcher {
         // In disaggregated deployments, prefill and decode are different components
         // in the same namespace, so we must check at the component level to avoid
         // removing one type's WorkerSet while the other still has workers.
-        let component_has_instances = active_instances
-            .iter()
-            .any(|(eid, _)| eid.namespace == *worker_namespace && eid.component == *worker_component);
+        let component_has_instances = active_instances.iter().any(|(eid, _)| {
+            eid.namespace == *worker_namespace && eid.component == *worker_component
+        });
 
         if !component_has_instances {
             // No more workers of this component in this namespace — remove its WorkerSet
             if let Some(_removed_ws) = self.manager.remove_worker_set(&model_name, &ws_key) {
                 // remove_prefill_activator uses deployment namespace (not ws_key)
-                self.manager.remove_prefill_activator(&model_name, worker_namespace);
+                self.manager
+                    .remove_prefill_activator(&model_name, worker_namespace);
                 tracing::info!(
                     model_name,
                     namespace = %worker_namespace,
@@ -346,22 +345,25 @@ impl ModelWatcher {
         let namespace = mcid.namespace.clone();
         let ws_key = worker_set_key(&namespace, card.model_type);
 
-        if let Some(model) = self.manager.get_model(&model_name) {
-            if model.has_worker_set(&ws_key) {
-                self.manager
-                    .save_model_card(&mcid.to_path(), card.clone())?;
-                tracing::debug!(
-                    model_name = card.name(),
-                    namespace = namespace,
-                    "Worker joined existing WorkerSet, skipping pipeline build"
-                );
-                return Ok(());
-            }
+        if let Some(model) = self.manager.get_model(&model_name)
+            && model.has_worker_set(&ws_key)
+        {
+            self.manager
+                .save_model_card(&mcid.to_path(), card.clone())?;
+            tracing::debug!(
+                model_name = card.name(),
+                namespace = namespace,
+                "Worker joined existing WorkerSet, skipping pipeline build"
+            );
+            return Ok(());
         }
 
         // Guard against concurrent pipeline construction for the same (model, namespace, type)
         let registration_key = ModelManager::model_namespace_key(&model_name, &ws_key);
-        if !self.registering_worker_sets.insert(registration_key.clone()) {
+        if !self
+            .registering_worker_sets
+            .insert(registration_key.clone())
+        {
             self.manager
                 .save_model_card(&mcid.to_path(), card.clone())?;
             tracing::debug!(
@@ -396,7 +398,11 @@ impl ModelWatcher {
         let endpoint = component.endpoint(&mcid.endpoint);
         let client = endpoint.client().await?;
         let instance_watcher = client.instance_avail_watcher();
-        tracing::debug!(model_name = card.name(), namespace = mcid.namespace, "building worker set pipeline");
+        tracing::debug!(
+            model_name = card.name(),
+            namespace = mcid.namespace,
+            "building worker set pipeline"
+        );
         self.manager
             .save_model_card(&mcid.to_path(), card.clone())?;
 
@@ -409,11 +415,7 @@ impl ModelWatcher {
         let ws_key = worker_set_key(&namespace, card.model_type);
 
         // Build the WorkerSet with all applicable engines
-        let mut worker_set = WorkerSet::new(
-            namespace.clone(),
-            checksum.to_string(),
-            card.clone(),
-        );
+        let mut worker_set = WorkerSet::new(namespace.clone(), checksum.to_string(), card.clone());
         worker_set.set_instance_watcher(instance_watcher);
 
         if card.model_input == ModelInput::Tokens
@@ -693,12 +695,16 @@ impl ModelWatcher {
 
             // Prefill sets have no engines — we add the WorkerSet first for tracking,
             // then activate the prefill router.
-            self.manager.add_worker_set(card.name(), &ws_key, worker_set);
+            self.manager
+                .add_worker_set(card.name(), &ws_key, worker_set);
 
             // Note: activate_prefill_router is keyed by deployment namespace (not ws_key)
             // because it coordinates between decode and prefill WorkerSets that share
             // the same deployment namespace but have different ws_keys ("ns" vs "ns:prefill").
-            let Ok(()) = self.manager.activate_prefill_router(card.name(), &namespace, endpoint) else {
+            let Ok(()) = self
+                .manager
+                .activate_prefill_router(card.name(), &namespace, endpoint)
+            else {
                 tracing::warn!(
                     model_name = card.name(),
                     "Failed to activate prefill router - prefill model may already be activated"
@@ -723,7 +729,8 @@ impl ModelWatcher {
         }
 
         // Add the completed WorkerSet to the Model
-        self.manager.add_worker_set(card.name(), &ws_key, worker_set);
+        self.manager
+            .add_worker_set(card.name(), &ws_key, worker_set);
 
         Ok(())
     }

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -695,6 +695,9 @@ impl ModelWatcher {
             // then activate the prefill router.
             self.manager.add_worker_set(card.name(), &ws_key, worker_set);
 
+            // Note: activate_prefill_router is keyed by deployment namespace (not ws_key)
+            // because it coordinates between decode and prefill WorkerSets that share
+            // the same deployment namespace but have different ws_keys ("ns" vs "ns:prefill").
             let Ok(()) = self.manager.activate_prefill_router(card.name(), &namespace, endpoint) else {
                 tracing::warn!(
                     model_name = card.name(),

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -352,7 +352,7 @@ impl ModelWatcher {
         }
 
         // Guard against concurrent pipeline construction for the same (model, namespace)
-        let registration_key = format!("{}:{}", model_name, namespace);
+        let registration_key = ModelManager::model_namespace_key(&model_name, &namespace);
         if !self.registering_worker_sets.insert(registration_key.clone()) {
             self.manager
                 .save_model_card(&mcid.to_path(), card.clone())?;

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -449,7 +449,8 @@ impl ModelWatcher {
                         card.kv_cache_block_size,
                         Some(prefill_config),
                         self.router_config.enforce_disagg,
-                        model_name.clone(), // Pass model name for worker monitor lookup
+                        model_name.clone(),
+                        namespace.clone(),
                     )
                 });
 

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -47,7 +47,7 @@ use crate::{
 };
 
 use super::ModelManager;
-use crate::namespace::{is_global_namespace, NamespaceFilter};
+use crate::namespace::NamespaceFilter;
 
 #[derive(Debug, Clone)]
 pub enum ModelUpdate {

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -179,7 +179,7 @@ impl ModelWatcher {
 
                     // If we already have a WorkerSet for this (model, namespace) and the
                     // checksums don't match, reject the new worker. Different namespaces
-                    // may legitimately have different checksums (rolling updates).
+                    // may legitimately have different checksums.
                     let can_add = self.manager.is_valid_checksum(
                         card.model_type,
                         card.name(),
@@ -194,6 +194,12 @@ impl ModelWatcher {
                         );
 
                         // TODO: mark that instance down in clients
+                        // Not obvious how to do that given the current design
+                        // Instances come from an `InstanceSource` in a `Client` in a `PushRouter`.
+                        // Calling `report_instance_down` on the Client should do it (although
+                        // needs more testing).
+                        // The `PushRouter` is in `ModelMananger` (`self.manager` here), but inside
+                        // interface `AsyncEngine` which only has a `generate` method.
                         continue;
                     }
 
@@ -396,6 +402,9 @@ impl ModelWatcher {
             && (card.model_type.supports_chat() || card.model_type.supports_completions())
         {
             // Case 1: Tokens + (Chat OR Completions OR Both)
+            // A model that expects pre-processed requests meaning it's up to us whether we
+            // handle Chat or Completions requests, so handle whatever the model supports.
+
             let endpoint = component.endpoint(&mcid.endpoint);
             // Create the KV router whenever any local routed pipeline will be built.
             // The chat factory builds its own router, but completions currently always
@@ -412,7 +421,7 @@ impl ModelWatcher {
                             &endpoint,
                             card.kv_cache_block_size,
                             Some(self.router_config.kv_router_config),
-                            WORKER_TYPE_DECODE,
+                            WORKER_TYPE_DECODE, // This is the decode router
                         )
                         .await?,
                 )
@@ -420,13 +429,17 @@ impl ModelWatcher {
                 None
             };
 
+            // This is expensive, we are loading ~10MiB JSON, so only do it once
             let tokenizer_hf = card.tokenizer_hf().context("tokenizer_hf")?;
 
+            // Create prefill chooser once if we're building pipelines
+            // Both chat and completions will share the same prefill chooser instance
             let model_name = card.name().to_string();
             let prefill_chooser = self
                 .manager
                 .register_prefill_router(model_name.clone(), &namespace)
                 .map(|rx| {
+                    // Create prefill-specific config with track_active_blocks disabled
                     let mut prefill_config = self.router_config.kv_router_config;
                     prefill_config.router_track_active_blocks = false;
 
@@ -437,10 +450,14 @@ impl ModelWatcher {
                         card.kv_cache_block_size,
                         Some(prefill_config),
                         self.router_config.enforce_disagg,
-                        model_name.clone(),
+                        model_name.clone(), // Pass model name for worker monitor lookup
                     )
                 });
 
+            // Get or create the worker monitor for this model.
+            // Always create the monitor for Prometheus metrics (active_decode_blocks, active_prefill_tokens,
+            // worker TTFT/ITL cleanup). The thresholds control busy detection behavior only.
+            // LoadThresholdConfig allows dynamic threshold updates via the ModelManager.
             let worker_monitor = Some(self.manager.get_or_create_worker_monitor(
                 card.name(),
                 client.clone(),
@@ -451,6 +468,7 @@ impl ModelWatcher {
             worker_set.kv_router = kv_chooser.clone();
             worker_set.worker_monitor = worker_monitor.clone();
 
+            // Add chat engine only if the model supports chat
             if card.model_type.supports_chat() {
                 let factory_engine = if let Some(ref factory) = self.chat_engine_factory {
                     match factory(mcid.clone(), card.clone()).await {
@@ -520,6 +538,7 @@ impl ModelWatcher {
                 tracing::info!("Completions is ready");
             }
         } else if card.model_input == ModelInput::Text && card.model_type.supports_embedding() {
+            // Case: Text + Embeddings
             let push_router = PushRouter::<
                 NvCreateEmbeddingRequest,
                 Annotated<NvCreateEmbeddingResponse>,
@@ -597,6 +616,8 @@ impl ModelWatcher {
             .await?;
             worker_set.completions_engine = Some(Arc::new(push_router));
         } else if card.model_input == ModelInput::Tokens && card.model_type.supports_embedding() {
+            // Case 4: Tokens + Embeddings
+            // Create preprocessing pipeline similar to Backend
             let frontend = SegmentSource::<
                 SingleIn<NvCreateEmbeddingRequest>,
                 ManyOut<Annotated<NvCreateEmbeddingResponse>>,
@@ -613,8 +634,10 @@ impl ModelWatcher {
             )
             .await?;
 
+            // Note: Embeddings don't need KV routing complexity or load monitoring
             let service_backend = ServiceBackend::from_engine(Arc::new(router));
 
+            // Link the pipeline: frontend -> preprocessor -> backend -> service_backend -> backend -> preprocessor -> frontend
             let embedding_engine = frontend
                 .link(preprocessor.forward_edge())?
                 .link(backend.forward_edge())?
@@ -636,6 +659,8 @@ impl ModelWatcher {
             .await?;
             worker_set.tensor_engine = Some(Arc::new(push_router));
         } else if card.model_type.supports_prefill() {
+            // Case 6: Prefill
+            // Guardrail: Verify model_input is Tokens
             if card.model_input != ModelInput::Tokens {
                 anyhow::bail!(
                     "Prefill models must use ModelInput::Tokens, got {}",
@@ -667,6 +692,7 @@ impl ModelWatcher {
 
             return Ok(());
         } else {
+            // Reject unsupported combinations
             anyhow::bail!(
                 "Unsupported model configuration: {} with {} input. Supported combinations: \
                 Tokens+(Chat|Completions|Prefill), Text+(Chat|Completions|Images), Tokens+Embeddings, Tensor+TensorBased",

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -211,9 +211,7 @@ impl ModelWatcher {
                     // If we already have a WorkerSet for this model and the checksums
                     // don't match, reject the new worker. All WorkerSets of a model
                     // must share the same checksum.
-                    let can_add =
-                        self.manager
-                            .is_valid_checksum(card.name(), card.mdcsum());
+                    let can_add = self.manager.is_valid_checksum(card.name(), card.mdcsum());
                     if can_add.is_some_and(|is_valid| !is_valid) {
                         tracing::error!(
                             model_name = card.name(),

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -18,8 +18,7 @@ use crate::{
         openai::{
             chat_completions::OpenAIChatCompletionsStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
-            embeddings::OpenAIEmbeddingsStreamingEngine,
-            images::OpenAIImagesStreamingEngine,
+            embeddings::OpenAIEmbeddingsStreamingEngine, images::OpenAIImagesStreamingEngine,
             videos::OpenAIVideosStreamingEngine,
         },
     },

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -27,7 +27,7 @@ use crate::{
 
 /// A set of workers from the same namespace/configuration with their own pipeline.
 pub struct WorkerSet {
-    /// Full namespace (e.g., "default-myapp-abc12345")
+    /// Full namespace (e.g., "ns-abc12345")
     namespace: String,
 
     /// MDC checksum for this set's configuration

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -47,9 +47,6 @@ pub struct WorkerSet {
     /// KV router for this set's workers (if KV mode)
     pub(crate) kv_router: Option<Arc<KvRouter>>,
 
-    /// Prefill router for this set's prefill workers (if disaggregated)
-    pub(crate) prefill_router: Option<Arc<PrefillRouter>>,
-
     /// Worker monitor for load-based rejection
     pub(crate) worker_monitor: Option<KvWorkerMonitor>,
 
@@ -59,11 +56,7 @@ pub struct WorkerSet {
 }
 
 impl WorkerSet {
-    pub fn new(
-        namespace: String,
-        mdcsum: String,
-        card: ModelDeploymentCard,
-    ) -> Self {
+    pub fn new(namespace: String, mdcsum: String, card: ModelDeploymentCard) -> Self {
         Self {
             namespace,
             mdcsum,
@@ -75,7 +68,6 @@ impl WorkerSet {
             videos_engine: None,
             tensor_engine: None,
             kv_router: None,
-            prefill_router: None,
             worker_monitor: None,
             instance_count_rx: None,
         }

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -4,9 +4,6 @@
 //! A WorkerSet represents a group of workers deployed from the same configuration,
 //! identified by their shared namespace. Each WorkerSet owns a complete pipeline
 //! (engines, KV router, prefill router) built from its specific ModelDeploymentCard.
-//!
-//! During rolling updates, multiple WorkerSets coexist under the same Model, each
-//! serving traffic proportional to its worker count.
 
 use std::sync::Arc;
 
@@ -143,12 +140,12 @@ impl WorkerSet {
     }
 
     /// Number of active workers in this set, derived from the Client's discovery watcher.
-    /// Returns 0 for in-process models (no watcher).
+    /// Returns 1 for in-process models (no watcher) since they always have one local worker.
     pub fn worker_count(&self) -> usize {
-        self.instance_count_rx
-            .as_ref()
-            .map(|rx| rx.borrow().len())
-            .unwrap_or(0)
+        match &self.instance_count_rx {
+            Some(rx) => rx.borrow().len(),
+            None => 1,
+        }
     }
 
     /// Store the instance watcher from the Client's discovery system.

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A WorkerSet represents a group of workers deployed from the same configuration,
+//! identified by their shared namespace. Each WorkerSet owns a complete pipeline
+//! (engines, KV router, prefill router) built from its specific ModelDeploymentCard.
+//!
+//! During rolling updates, multiple WorkerSets coexist under the same Model, each
+//! serving traffic proportional to its worker count.
+
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+
+use crate::{
+    discovery::KvWorkerMonitor,
+    kv_router::{KvRouter, PrefillRouter},
+    model_card::ModelDeploymentCard,
+    types::{
+        generic::tensor::TensorStreamingEngine,
+        openai::{
+            chat_completions::OpenAIChatCompletionsStreamingEngine,
+            completions::OpenAICompletionsStreamingEngine,
+            embeddings::OpenAIEmbeddingsStreamingEngine,
+            images::OpenAIImagesStreamingEngine,
+            videos::OpenAIVideosStreamingEngine,
+        },
+    },
+};
+
+/// A set of workers from the same namespace/configuration with their own pipeline.
+pub struct WorkerSet {
+    /// Full namespace (e.g., "default-myapp-abc12345")
+    namespace: String,
+
+    /// MDC checksum for this set's configuration
+    mdcsum: String,
+
+    /// The model deployment card used to build this set's pipeline
+    card: ModelDeploymentCard,
+
+    // Engines — each WorkerSet owns its own pipelines
+    pub(crate) chat_engine: Option<OpenAIChatCompletionsStreamingEngine>,
+    pub(crate) completions_engine: Option<OpenAICompletionsStreamingEngine>,
+    pub(crate) embeddings_engine: Option<OpenAIEmbeddingsStreamingEngine>,
+    pub(crate) images_engine: Option<OpenAIImagesStreamingEngine>,
+    pub(crate) videos_engine: Option<OpenAIVideosStreamingEngine>,
+    pub(crate) tensor_engine: Option<TensorStreamingEngine>,
+
+    /// KV router for this set's workers (if KV mode)
+    pub(crate) kv_router: Option<Arc<KvRouter>>,
+
+    /// Prefill router for this set's prefill workers (if disaggregated)
+    pub(crate) prefill_router: Option<Arc<PrefillRouter>>,
+
+    /// Worker monitor for load-based rejection
+    pub(crate) worker_monitor: Option<KvWorkerMonitor>,
+
+    /// Number of active workers in this set (for weighted selection)
+    worker_count: AtomicUsize,
+}
+
+impl WorkerSet {
+    pub fn new(
+        namespace: String,
+        mdcsum: String,
+        card: ModelDeploymentCard,
+    ) -> Self {
+        Self {
+            namespace,
+            mdcsum,
+            card,
+            chat_engine: None,
+            completions_engine: None,
+            embeddings_engine: None,
+            images_engine: None,
+            videos_engine: None,
+            tensor_engine: None,
+            kv_router: None,
+            prefill_router: None,
+            worker_monitor: None,
+            worker_count: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    pub fn mdcsum(&self) -> &str {
+        &self.mdcsum
+    }
+
+    pub fn card(&self) -> &ModelDeploymentCard {
+        &self.card
+    }
+
+    pub fn has_chat_engine(&self) -> bool {
+        self.chat_engine.is_some()
+    }
+
+    pub fn has_completions_engine(&self) -> bool {
+        self.completions_engine.is_some()
+    }
+
+    pub fn has_embeddings_engine(&self) -> bool {
+        self.embeddings_engine.is_some()
+    }
+
+    pub fn has_images_engine(&self) -> bool {
+        self.images_engine.is_some()
+    }
+
+    pub fn has_videos_engine(&self) -> bool {
+        self.videos_engine.is_some()
+    }
+
+    pub fn has_tensor_engine(&self) -> bool {
+        self.tensor_engine.is_some()
+    }
+
+    /// Whether this set has any decode engine (chat or completions)
+    pub fn has_decode_engine(&self) -> bool {
+        self.has_chat_engine() || self.has_completions_engine()
+    }
+
+    /// Whether this set tracks a prefill model (no engine, just lifecycle)
+    pub fn is_prefill_set(&self) -> bool {
+        !self.has_decode_engine()
+            && !self.has_embeddings_engine()
+            && !self.has_images_engine()
+            && !self.has_videos_engine()
+            && !self.has_tensor_engine()
+    }
+
+    /// Build ParsingOptions from this WorkerSet's card configuration.
+    pub fn parsing_options(&self) -> crate::protocols::openai::ParsingOptions {
+        crate::protocols::openai::ParsingOptions::new(
+            self.card.runtime_config.tool_call_parser.clone(),
+            self.card.runtime_config.reasoning_parser.clone(),
+        )
+    }
+
+    /// Number of active workers in this set.
+    pub fn worker_count(&self) -> usize {
+        self.worker_count.load(Ordering::Relaxed)
+    }
+
+    /// Increment worker count (worker joined this set).
+    pub fn increment_workers(&self) -> usize {
+        self.worker_count.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Decrement worker count (worker left this set). Returns new count.
+    pub fn decrement_workers(&self) -> usize {
+        loop {
+            let current = self.worker_count.load(Ordering::Relaxed);
+            if current == 0 {
+                return 0;
+            }
+            match self.worker_count.compare_exchange_weak(
+                current,
+                current - 1,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return current - 1,
+                Err(_) => continue,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_card::ModelDeploymentCard;
+
+    fn make_worker_set(namespace: &str, mdcsum: &str) -> WorkerSet {
+        WorkerSet::new(
+            namespace.to_string(),
+            mdcsum.to_string(),
+            ModelDeploymentCard::default(),
+        )
+    }
+
+    #[test]
+    fn test_worker_set_basics() {
+        let ws = make_worker_set("ns1", "abc123");
+        assert_eq!(ws.namespace(), "ns1");
+        assert_eq!(ws.mdcsum(), "abc123");
+    }
+
+    #[test]
+    fn test_no_engines_by_default() {
+        let ws = make_worker_set("ns1", "abc123");
+        assert!(!ws.has_chat_engine());
+        assert!(!ws.has_completions_engine());
+        assert!(!ws.has_embeddings_engine());
+        assert!(!ws.has_images_engine());
+        assert!(!ws.has_tensor_engine());
+        assert!(!ws.has_decode_engine());
+        assert!(ws.is_prefill_set());
+    }
+
+    #[test]
+    fn test_worker_count_increment() {
+        let ws = make_worker_set("ns1", "abc123");
+        assert_eq!(ws.worker_count(), 0);
+        assert_eq!(ws.increment_workers(), 1);
+        assert_eq!(ws.increment_workers(), 2);
+        assert_eq!(ws.increment_workers(), 3);
+        assert_eq!(ws.worker_count(), 3);
+    }
+
+    #[test]
+    fn test_worker_count_decrement() {
+        let ws = make_worker_set("ns1", "abc123");
+        ws.increment_workers();
+        ws.increment_workers();
+        ws.increment_workers();
+        assert_eq!(ws.decrement_workers(), 2);
+        assert_eq!(ws.decrement_workers(), 1);
+        assert_eq!(ws.decrement_workers(), 0);
+        assert_eq!(ws.worker_count(), 0);
+    }
+
+    #[test]
+    fn test_worker_count_decrement_at_zero() {
+        let ws = make_worker_set("ns1", "abc123");
+        assert_eq!(ws.decrement_workers(), 0);
+        assert_eq!(ws.decrement_workers(), 0);
+        assert_eq!(ws.worker_count(), 0);
+    }
+}

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -11,7 +11,7 @@ use tokio::sync::watch;
 
 use crate::{
     discovery::KvWorkerMonitor,
-    kv_router::{KvRouter},
+    kv_router::KvRouter,
     model_card::ModelDeploymentCard,
     types::{
         generic::tensor::TensorStreamingEngine,

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -11,7 +11,7 @@ use tokio::sync::watch;
 
 use crate::{
     discovery::KvWorkerMonitor,
-    kv_router::{KvRouter, PrefillRouter},
+    kv_router::{KvRouter},
     model_card::ModelDeploymentCard,
     types::{
         generic::tensor::TensorStreamingEngine,

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -11,6 +11,7 @@ use crate::{
     http::service::metrics::Metrics,
     kv_router::{DirectRoutingRouter, KvPushRouter, KvRouter, PrefillRouter},
     migration::Migration,
+    namespace::NamespaceFilter,
     model_card::ModelDeploymentCard,
     preprocessor::{OpenAIPreprocessor, prompt::PromptFormatter},
     protocols::common::llm_backend::{BackendOutput, LLMEngineOutput, PreprocessedRequest},
@@ -82,8 +83,12 @@ pub async fn prepare_engine(
                 )
                 .await?;
             let inner_watch_obj = watch_obj.clone();
+            let namespace_filter = NamespaceFilter::from_namespace_and_prefix(
+                local_model.namespace(),
+                local_model.namespace_prefix(),
+            );
             let _watcher_task = tokio::spawn(async move {
-                inner_watch_obj.watch(discovery_stream, crate::namespace::NamespaceFilter::Global).await;
+                inner_watch_obj.watch(discovery_stream, namespace_filter).await;
             });
             tracing::info!("Waiting for remote model..");
 

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -11,8 +11,8 @@ use crate::{
     http::service::metrics::Metrics,
     kv_router::{DirectRoutingRouter, KvPushRouter, KvRouter, PrefillRouter},
     migration::Migration,
-    namespace::NamespaceFilter,
     model_card::ModelDeploymentCard,
+    namespace::NamespaceFilter,
     preprocessor::{OpenAIPreprocessor, prompt::PromptFormatter},
     protocols::common::llm_backend::{BackendOutput, LLMEngineOutput, PreprocessedRequest},
     request_template::RequestTemplate,
@@ -88,7 +88,9 @@ pub async fn prepare_engine(
                 local_model.namespace_prefix(),
             );
             let _watcher_task = tokio::spawn(async move {
-                inner_watch_obj.watch(discovery_stream, namespace_filter).await;
+                inner_watch_obj
+                    .watch(discovery_stream, namespace_filter)
+                    .await;
             });
             tracing::info!("Waiting for remote model..");
 

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -83,7 +83,7 @@ pub async fn prepare_engine(
                 .await?;
             let inner_watch_obj = watch_obj.clone();
             let _watcher_task = tokio::spawn(async move {
-                inner_watch_obj.watch(discovery_stream, None).await;
+                inner_watch_obj.watch(discovery_stream, crate::namespace::NamespaceFilter::Global).await;
             });
             tracing::info!("Waiting for remote model..");
 

--- a/lib/llm/src/entrypoint/input/grpc.rs
+++ b/lib/llm/src/entrypoint/input/grpc.rs
@@ -9,7 +9,7 @@ use crate::{
     entrypoint::{EngineConfig, RouterConfig, input::common},
     grpc::service::kserve,
     http::service::metrics::Metrics,
-    namespace::is_global_namespace,
+    namespace::NamespaceFilter,
     types::openai::{
         chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
         completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
@@ -38,18 +38,16 @@ pub async fn run(
             let router_config = model.router_config();
             let migration_limit = model.migration_limit();
             // Listen for models registering themselves, add them to gRPC service
-            let namespace = model.namespace().unwrap_or("");
-            let target_namespace = if is_global_namespace(namespace) {
-                None
-            } else {
-                Some(namespace.to_string())
-            };
+            let namespace_filter = NamespaceFilter::from_namespace_and_prefix(
+                model.namespace(),
+                model.namespace_prefix(),
+            );
             run_watcher(
                 distributed_runtime.clone(),
                 grpc_service.state().manager_clone(),
                 router_config.clone(),
                 migration_limit,
-                target_namespace,
+                namespace_filter,
             )
             .await?;
             grpc_service
@@ -113,7 +111,7 @@ async fn run_watcher(
     model_manager: Arc<ModelManager>,
     router_config: RouterConfig,
     migration_limit: u32,
-    target_namespace: Option<String>,
+    namespace_filter: NamespaceFilter,
 ) -> anyhow::Result<()> {
     // Create metrics for migration tracking (not exposed via /metrics in gRPC mode)
     let metrics = Arc::new(Metrics::new());
@@ -141,7 +139,7 @@ async fn run_watcher(
     // Pass the discovery stream to the watcher
     let _watcher_task = tokio::spawn(async move {
         watch_obj
-            .watch(discovery_stream, target_namespace.as_deref())
+            .watch(discovery_stream, namespace_filter)
             .await;
     });
 

--- a/lib/llm/src/entrypoint/input/grpc.rs
+++ b/lib/llm/src/entrypoint/input/grpc.rs
@@ -138,9 +138,7 @@ async fn run_watcher(
 
     // Pass the discovery stream to the watcher
     let _watcher_task = tokio::spawn(async move {
-        watch_obj
-            .watch(discovery_stream, namespace_filter)
-            .await;
+        watch_obj.watch(discovery_stream, namespace_filter).await;
     });
 
     Ok(())

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -9,7 +9,7 @@ use crate::{
     engines::StreamingEngineAdapter,
     entrypoint::{ChatEngineFactoryCallback, EngineConfig, RouterConfig, input::common},
     http::service::service_v2::{self, HttpService},
-    namespace::is_global_namespace,
+    namespace::NamespaceFilter,
     types::openai::{
         chat_completions::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse},
         completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
@@ -66,20 +66,17 @@ pub async fn run(
             let router_config = model.router_config();
             let migration_limit = model.migration_limit();
             // Listen for models registering themselves, add them to HTTP service
-            // Check if we should filter by namespace (based on the local model's namespace)
-            // Get namespace from the model, fallback to endpoint_id namespace if not set
-            let namespace = model.namespace().unwrap_or("");
-            let target_namespace = if is_global_namespace(namespace) {
-                None
-            } else {
-                Some(namespace.to_string())
-            };
+            // Create namespace filter from model configuration
+            let namespace_filter = NamespaceFilter::from_namespace_and_prefix(
+                model.namespace(),
+                model.namespace_prefix(),
+            );
             run_watcher(
                 distributed_runtime.clone(),
                 http_service.state().manager_clone(),
                 router_config.clone(),
                 migration_limit,
-                target_namespace,
+                namespace_filter,
                 Arc::new(http_service.clone()),
                 http_service.state().metrics_clone(),
                 chat_engine_factory.clone(),
@@ -157,7 +154,7 @@ async fn run_watcher(
     model_manager: Arc<ModelManager>,
     router_config: RouterConfig,
     migration_limit: u32,
-    target_namespace: Option<String>,
+    namespace_filter: NamespaceFilter,
     http_service: Arc<HttpService>,
     metrics: Arc<crate::http::service::metrics::Metrics>,
     chat_engine_factory: Option<ChatEngineFactoryCallback>,
@@ -194,7 +191,7 @@ async fn run_watcher(
     // Pass the discovery stream to the watcher
     let _watcher_task = tokio::spawn(async move {
         watch_obj
-            .watch(discovery_stream, target_namespace.as_deref())
+            .watch(discovery_stream, namespace_filter)
             .await;
     });
 

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -190,9 +190,7 @@ async fn run_watcher(
 
     // Pass the discovery stream to the watcher
     let _watcher_task = tokio::spawn(async move {
-        watch_obj
-            .watch(discovery_stream, namespace_filter)
-            .await;
+        watch_obj.watch(discovery_stream, namespace_filter).await;
     });
 
     Ok(())

--- a/lib/llm/src/grpc/service/kserve.rs
+++ b/lib/llm/src/grpc/service/kserve.rs
@@ -377,10 +377,8 @@ impl GrpcInferenceService for KserveService {
             }
         }
 
-        let model = completion_request.inner.model.clone();
-        let parsing_options = self.state.manager.get_parsing_options(&model);
-
-        let stream = completion_response_stream(self.state_clone(), completion_request).await?;
+        let (stream, parsing_options) =
+            completion_response_stream(self.state_clone(), completion_request).await?;
 
         let completion_response =
             NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
@@ -494,12 +492,9 @@ impl GrpcInferenceService for KserveService {
                     }
                 }
 
-                let model = completion_request.inner.model.clone();
-                let parsing_options = state.manager.get_parsing_options(&model);
-
                 let streaming = completion_request.inner.stream.unwrap_or(false);
 
-                let stream = completion_response_stream(state.clone(), completion_request).await?;
+                let (stream, parsing_options) = completion_response_stream(state.clone(), completion_request).await?;
 
                 if streaming {
                     pin_mut!(stream);

--- a/lib/llm/src/grpc/service/openai.rs
+++ b/lib/llm/src/grpc/service/openai.rs
@@ -9,10 +9,10 @@ use dynamo_runtime::{
 use futures::{Stream, StreamExt, stream};
 use std::sync::Arc;
 
+use crate::protocols::openai::ParsingOptions;
 use crate::protocols::openai::completions::{
     NvCreateCompletionRequest, NvCreateCompletionResponse,
 };
-use crate::protocols::openai::ParsingOptions;
 use crate::types::Annotated;
 
 use super::kserve;
@@ -44,7 +44,13 @@ pub const ANNOTATION_REQUEST_ID: &str = "request_id";
 pub async fn completion_response_stream(
     state: Arc<kserve::State>,
     request: NvCreateCompletionRequest,
-) -> Result<(impl Stream<Item = Annotated<NvCreateCompletionResponse>>, ParsingOptions), Status> {
+) -> Result<
+    (
+        impl Stream<Item = Annotated<NvCreateCompletionResponse>>,
+        ParsingOptions,
+    ),
+    Status,
+> {
     // create the context for the request
     // [WIP] from request id.
     let request_id = get_or_create_request_id(request.inner.user.as_deref());

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -194,9 +194,9 @@ async fn anthropic_messages(
 
     tracing::trace!("Getting chat completions engine for model: {}", model);
 
-    let engine = state
+    let (engine, parsing_options) = state
         .manager()
-        .get_chat_completions_engine(&model)
+        .get_chat_completions_engine_with_parsing(&model)
         .map_err(|_| {
             anthropic_error(
                 StatusCode::NOT_FOUND,
@@ -204,8 +204,6 @@ async fn anthropic_messages(
                 &format!("Model '{}' not found", model),
             )
         })?;
-
-    let parsing_options = state.manager().get_parsing_options(&model);
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -372,12 +372,10 @@ async fn completions_single(
     let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
 
     // todo - error handling should be more robust
-    let engine = state
+    let (engine, parsing_options) = state
         .manager()
-        .get_completions_engine(&model)
+        .get_completions_engine_with_parsing(&model)
         .map_err(|_| ErrorMessage::model_not_found())?;
-
-    let parsing_options = state.manager().get_parsing_options(&model);
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
@@ -495,12 +493,10 @@ async fn completions_batch(
     // Create http_queue_guard early - tracks time waiting to be processed
     let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
 
-    let engine = state
+    let (engine, parsing_options) = state
         .manager()
-        .get_completions_engine(&model)
+        .get_completions_engine_with_parsing(&model)
         .map_err(|_| ErrorMessage::model_not_found())?;
-
-    let parsing_options = state.manager().get_parsing_options(&model);
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
@@ -916,12 +912,10 @@ async fn chat_completions(
 
     tracing::trace!("Getting chat completions engine for model: {}", model);
 
-    let engine = state
+    let (engine, parsing_options) = state
         .manager()
-        .get_chat_completions_engine(&model)
+        .get_chat_completions_engine_with_parsing(&model)
         .map_err(|_| ErrorMessage::model_not_found())?;
-
-    let parsing_options = state.manager().get_parsing_options(&model);
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
@@ -1260,12 +1254,10 @@ async fn responses(
 
     tracing::trace!("Getting chat completions engine for model: {}", model);
 
-    let engine = state
+    let (engine, parsing_options) = state
         .manager()
-        .get_chat_completions_engine(&model)
+        .get_chat_completions_engine_with_parsing(&model)
         .map_err(|_| ErrorMessage::model_not_found())?;
-
-    let parsing_options = state.manager().get_parsing_options(&model);
 
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 

--- a/lib/llm/src/kv_router/prefill_router.rs
+++ b/lib/llm/src/kv_router/prefill_router.rs
@@ -123,6 +123,7 @@ impl PrefillRouter {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         activation_rx: oneshot::Receiver<Endpoint>,
         model_manager: Arc<ModelManager>,
@@ -212,7 +213,9 @@ impl PrefillRouter {
             let client = kv_chooser.client().clone();
 
             // Register prefill client with worker monitor for TTFT metric cleanup in disaggregated mode
-            if let Some(monitor) = model_manager.get_worker_monitor_for_namespace(&self.model_name, &self.namespace) {
+            if let Some(monitor) =
+                model_manager.get_worker_monitor_for_namespace(&self.model_name, &self.namespace)
+            {
                 monitor.set_prefill_client(client.clone());
             }
 
@@ -232,7 +235,9 @@ impl PrefillRouter {
             let client = endpoint.client().await?;
 
             // Register prefill client with worker monitor for TTFT metric cleanup in disaggregated mode
-            if let Some(monitor) = model_manager.get_worker_monitor_for_namespace(&self.model_name, &self.namespace) {
+            if let Some(monitor) =
+                model_manager.get_worker_monitor_for_namespace(&self.model_name, &self.namespace)
+            {
                 monitor.set_prefill_client(client.clone());
             }
 

--- a/lib/llm/src/kv_router/prefill_router.rs
+++ b/lib/llm/src/kv_router/prefill_router.rs
@@ -100,6 +100,8 @@ pub struct PrefillRouter {
     enforce_disagg: bool,
     /// Model name used to look up the worker monitor for prefill client registration
     model_name: String,
+    /// Namespace used to look up the correct WorkerSet's worker monitor
+    namespace: String,
 }
 
 impl PrefillRouter {
@@ -117,6 +119,7 @@ impl PrefillRouter {
             router_mode,
             enforce_disagg,
             model_name: String::new(), // Not used for disabled router
+            namespace: String::new(),  // Not used for disabled router
         })
     }
 
@@ -128,6 +131,7 @@ impl PrefillRouter {
         kv_router_config: Option<KvRouterConfig>,
         enforce_disagg: bool,
         model_name: String,
+        namespace: String,
     ) -> Arc<Self> {
         let prefill_router = OnceLock::new();
         let cancel_token = CancellationToken::new();
@@ -140,6 +144,7 @@ impl PrefillRouter {
             router_mode,
             enforce_disagg,
             model_name,
+            namespace,
         });
 
         // Spawn background task to wait for activation
@@ -207,7 +212,7 @@ impl PrefillRouter {
             let client = kv_chooser.client().clone();
 
             // Register prefill client with worker monitor for TTFT metric cleanup in disaggregated mode
-            if let Some(monitor) = model_manager.get_worker_monitor(&self.model_name) {
+            if let Some(monitor) = model_manager.get_worker_monitor_for_namespace(&self.model_name, &self.namespace) {
                 monitor.set_prefill_client(client.clone());
             }
 
@@ -227,7 +232,7 @@ impl PrefillRouter {
             let client = endpoint.client().await?;
 
             // Register prefill client with worker monitor for TTFT metric cleanup in disaggregated mode
-            if let Some(monitor) = model_manager.get_worker_monitor(&self.model_name) {
+            if let Some(monitor) = model_manager.get_worker_monitor_for_namespace(&self.model_name, &self.namespace) {
                 monitor.set_prefill_client(client.clone());
             }
 

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -295,6 +295,7 @@ impl LocalModelBuilder {
                 router_config: self.router_config.take().unwrap_or_default(),
                 runtime_config: self.runtime_config.clone(),
                 namespace: self.namespace.clone(),
+                namespace_prefix: self.namespace_prefix.clone(),
                 migration_limit: self.migration_limit,
             });
         }
@@ -347,6 +348,7 @@ impl LocalModelBuilder {
             router_config: self.router_config.take().unwrap_or_default(),
             runtime_config: self.runtime_config.clone(),
             namespace: self.namespace.clone(),
+            namespace_prefix: self.namespace_prefix.clone(),
             migration_limit: self.migration_limit,
         })
     }

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -56,6 +56,7 @@ pub struct LocalModelBuilder {
     user_data: Option<serde_json::Value>,
     custom_template_path: Option<PathBuf>,
     namespace: Option<String>,
+    namespace_prefix: Option<String>,
     media_decoder: Option<MediaDecoder>,
     media_fetcher: Option<MediaFetcher>,
 }
@@ -83,6 +84,7 @@ impl Default for LocalModelBuilder {
             user_data: Default::default(),
             custom_template_path: Default::default(),
             namespace: Default::default(),
+            namespace_prefix: Default::default(),
             media_decoder: Default::default(),
             media_fetcher: Default::default(),
         }
@@ -157,6 +159,11 @@ impl LocalModelBuilder {
 
     pub fn namespace(&mut self, namespace: Option<String>) -> &mut Self {
         self.namespace = namespace;
+        self
+    }
+
+    pub fn namespace_prefix(&mut self, namespace_prefix: Option<String>) -> &mut Self {
+        self.namespace_prefix = namespace_prefix;
         self
     }
 
@@ -359,6 +366,7 @@ pub struct LocalModel {
     router_config: RouterConfig,
     runtime_config: ModelRuntimeConfig,
     namespace: Option<String>,
+    namespace_prefix: Option<String>,
     migration_limit: u32,
 }
 
@@ -429,6 +437,10 @@ impl LocalModel {
 
     pub fn namespace(&self) -> Option<&str> {
         self.namespace.as_deref()
+    }
+
+    pub fn namespace_prefix(&self) -> Option<&str> {
+        self.namespace_prefix.as_deref()
     }
 
     /// An endpoint to identify this model by.

--- a/lib/llm/src/namespace.rs
+++ b/lib/llm/src/namespace.rs
@@ -78,7 +78,7 @@ mod tests {
             NamespaceFilter::Global
         );
         assert_eq!(
-            NamespaceFilter::from_namespace_and_prefix(Some("default"), None),
+            NamespaceFilter::from_namespace_and_prefix(Some(GLOBAL_NAMESPACE), None),
             NamespaceFilter::Global
         );
     }

--- a/lib/llm/src/namespace.rs
+++ b/lib/llm/src/namespace.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-pub const GLOBAL_NAMESPACE: &str = "default";
+pub const GLOBAL_NAMESPACE: &str = "dynamo";
 
 /// Determines how namespaces are filtered during model discovery.
 ///

--- a/lib/llm/src/namespace.rs
+++ b/lib/llm/src/namespace.rs
@@ -1,9 +1,136 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// The global namespace for all models
-pub const GLOBAL_NAMESPACE: &str = "dynamo";
+pub const GLOBAL_NAMESPACE: &str = "default";
+
+/// Determines how namespaces are filtered during model discovery.
+///
+/// This supports the hierarchical model architecture where multiple WorkerSets
+/// with different namespaces (e.g., during rolling updates) should be discovered
+/// together under the same Model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamespaceFilter {
+    /// Discover models from all namespaces (no filtering)
+    Global,
+    /// Discover models only from an exact namespace match
+    Exact(String),
+    /// Discover models from namespaces starting with the given prefix
+    /// (e.g., prefix "ns" matches "ns", "ns-abc123", "ns-def456")
+    Prefix(String),
+}
+
+impl NamespaceFilter {
+    /// Create a NamespaceFilter from optional namespace and namespace_prefix.
+    /// If prefix is provided, it takes precedence over exact namespace.
+    pub fn from_namespace_and_prefix(
+        namespace: Option<&str>,
+        namespace_prefix: Option<&str>,
+    ) -> Self {
+        // Prefix takes precedence if both are specified
+        if let Some(prefix) = namespace_prefix {
+            if prefix.is_empty() || is_global_namespace(prefix) {
+                return NamespaceFilter::Global;
+            }
+            return NamespaceFilter::Prefix(prefix.to_string());
+        }
+
+        if let Some(ns) = namespace {
+            if ns.is_empty() || is_global_namespace(ns) {
+                return NamespaceFilter::Global;
+            }
+            return NamespaceFilter::Exact(ns.to_string());
+        }
+
+        NamespaceFilter::Global
+    }
+
+    /// Check if a given namespace matches this filter.
+    pub fn matches(&self, namespace: &str) -> bool {
+        match self {
+            NamespaceFilter::Global => true,
+            NamespaceFilter::Exact(target) => namespace == target,
+            NamespaceFilter::Prefix(prefix) => namespace.starts_with(prefix),
+        }
+    }
+
+    /// Returns true if this is global namespace filtering (no filtering).
+    pub fn is_global(&self) -> bool {
+        matches!(self, NamespaceFilter::Global)
+    }
+}
 
 pub fn is_global_namespace(namespace: &str) -> bool {
     namespace == GLOBAL_NAMESPACE || namespace.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_namespace_and_prefix_global() {
+        assert_eq!(
+            NamespaceFilter::from_namespace_and_prefix(None, None),
+            NamespaceFilter::Global
+        );
+        assert_eq!(
+            NamespaceFilter::from_namespace_and_prefix(Some(""), None),
+            NamespaceFilter::Global
+        );
+        assert_eq!(
+            NamespaceFilter::from_namespace_and_prefix(Some("default"), None),
+            NamespaceFilter::Global
+        );
+    }
+
+    #[test]
+    fn test_from_namespace_and_prefix_exact() {
+        assert_eq!(
+            NamespaceFilter::from_namespace_and_prefix(Some("my-namespace"), None),
+            NamespaceFilter::Exact("my-namespace".to_string())
+        );
+    }
+
+    #[test]
+    fn test_from_namespace_and_prefix_prefix_takes_precedence() {
+        assert_eq!(
+            NamespaceFilter::from_namespace_and_prefix(Some("exact"), Some("prefix")),
+            NamespaceFilter::Prefix("prefix".to_string())
+        );
+    }
+
+    #[test]
+    fn test_matches_global() {
+        let filter = NamespaceFilter::Global;
+        assert!(filter.matches("anything"));
+        assert!(filter.matches(""));
+        assert!(filter.matches("default"));
+        assert!(filter.matches("ns-abc123"));
+    }
+
+    #[test]
+    fn test_matches_exact() {
+        let filter = NamespaceFilter::Exact("my-namespace".to_string());
+        assert!(filter.matches("my-namespace"));
+        assert!(!filter.matches("my-namespace-abc123"));
+        assert!(!filter.matches("other"));
+        assert!(!filter.matches(""));
+    }
+
+    #[test]
+    fn test_matches_prefix() {
+        let filter = NamespaceFilter::Prefix("ns".to_string());
+        assert!(filter.matches("ns"));
+        assert!(filter.matches("ns-abc123"));
+        assert!(filter.matches("ns-def456"));
+        assert!(!filter.matches("other-ns"));
+        assert!(!filter.matches(""));
+    }
+
+    #[test]
+    fn test_is_global() {
+        assert!(NamespaceFilter::Global.is_global());
+        assert!(!NamespaceFilter::Exact("ns".to_string()).is_global());
+        assert!(!NamespaceFilter::Prefix("ns".to_string()).is_global());
+    }
 }

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -6,6 +6,7 @@ use async_stream::stream;
 use dynamo_llm::{
     http::service::{metrics::Endpoint, service_v2::HttpService},
     model_card::ModelDeploymentCard,
+    namespace::NamespaceFilter,
     protocols::{
         Annotated,
         openai::chat_completions::{
@@ -355,7 +356,7 @@ mod integration_tests {
 
         // Spawn watcher task to discover models
         let _watcher_task = tokio::spawn(async move {
-            model_watcher.watch(discovery_stream, None).await;
+            model_watcher.watch(discovery_stream, NamespaceFilter::Global).await;
         });
 
         let EngineConfig::InProcessText { engine, model, .. } = engine_config else {

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -553,13 +553,8 @@ mod integration_tests {
                     if let Some(key) = key {
                         // Remove from ModelManager first (this returns the ModelEntry)
                         if let Some(_removed_card) = manager.remove_model_card(&key) {
-                            // Remove engines (following ModelWatcher::handle_delete pattern)
-                            manager
-                                .remove_chat_completions_model(&model_entry.name)
-                                .ok();
-                            manager.remove_completions_model(&model_entry.name).ok();
-                            manager.remove_embeddings_model(&model_entry.name).ok();
-                            manager.remove_tensor_model(&model_entry.name).ok();
+                            // Remove entire model (following ModelWatcher::handle_delete pattern)
+                            manager.remove_model(&model_entry.name);
 
                             // Then delete from etcd
                             etcd_client.kv_delete(key.as_str(), None).await.unwrap();

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -6,7 +6,6 @@ use async_stream::stream;
 use dynamo_llm::{
     http::service::{metrics::Endpoint, service_v2::HttpService},
     model_card::ModelDeploymentCard,
-    namespace::NamespaceFilter,
     protocols::{
         Annotated,
         openai::chat_completions::{
@@ -296,7 +295,7 @@ mod integration_tests {
     use super::*;
     use dynamo_llm::{
         discovery::ModelWatcher, engines::make_echo_engine, entrypoint::EngineConfig,
-        local_model::LocalModelBuilder,
+        local_model::LocalModelBuilder, namespace::NamespaceFilter,
     };
     use dynamo_runtime::DistributedRuntime;
     use dynamo_runtime::discovery::DiscoveryQuery;
@@ -356,7 +355,9 @@ mod integration_tests {
 
         // Spawn watcher task to discover models
         let _watcher_task = tokio::spawn(async move {
-            model_watcher.watch(discovery_stream, NamespaceFilter::Global).await;
+            model_watcher
+                .watch(discovery_stream, NamespaceFilter::Global)
+                .await;
         });
 
         let EngineConfig::InProcessText { engine, model, .. } = engine_config else {


### PR DESCRIPTION
## Summary

- Introduces a hierarchical `Model → WorkerSet` architecture in the frontend's `ModelManager`, replacing the previous flat engine map design
- Each `Model` holds a `DashMap<namespace, Arc<WorkerSet>>` where each `WorkerSet` owns its own complete pipeline (engines, KV router, prefill router, worker monitor)
- Requests are routed to WorkerSets via weighted random selection based on worker count, providing proportional load distribution
- Workers register into namespaces derived from `DYN_NAMESPACE` + optional `DYN_NAMESPACE_WORKER_SUFFIX` environment variable

## Motivation

This change enables **rolling upgrades** with full isolation between old and new workers. During a rolling update:

1. New workers register under a different namespace suffix (e.g., `dynamo-v2`) while old workers remain under the original namespace (`dynamo`)
2. Each namespace gets its own independent `WorkerSet` with a dedicated pipeline — KV router, prefill router, and worker monitor are all isolated
3. The frontend routes traffic proportionally: as new workers come up and old workers drain, traffic naturally shifts to the new version
4. Once old workers are fully drained, their `WorkerSet` is cleaned up automatically

Without this isolation, old and new workers would share a single KV cache router and prefill router, leading to compatibility issues during transitions (e.g., KV cache blocks being routed between incompatible model versions).

## Key Changes

- **`Model` struct** (`discovery/model.rs`): Manages multiple `WorkerSet`s per model, weighted selection, aggregated engine views
- **`WorkerSet` struct** (`discovery/worker_set.rs`): Owns a complete pipeline with atomic worker counting
- **`ModelManager`** (`discovery/model_manager.rs`): Delegates through the `Model` layer; handles per-namespace checksum validation
- **`ModelWatcher`** (`discovery/watcher.rs`): Builds per-WorkerSet pipelines, cleans up empty namespaces/models on worker departure
- **Namespace utilities** (Python + Rust): `DYN_NAMESPACE_WORKER_SUFFIX` support for worker-side namespace configuration
- **In-process model support** (`http.rs`, `grpc.rs`): Convenience methods that create synthetic single-namespace WorkerSets

## Test plan

- [x] Unit tests for `Model` weighted selection, worker counting, and engine aggregation
- [x] Unit tests for `WorkerSet` lifecycle
- [ ] Existing integration tests pass (`http_metrics.rs` updated for new API)
- [ ] End-to-end rolling update test with two namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --namespace-prefix CLI flag and NamespaceFilter (Global/Exact/Prefix) for refined discovery
  * Introduced namespace-scoped WorkerSets and model-centric orchestration for multi-namespace deployments
  * Engines now return parsing options alongside streams/clients
  * Exposed optional namespace_prefix on local models and a utility to compute worker namespaces

* **Improvements**
  * Consolidated model lifecycle and removal semantics (single remove_model)
  * Prefill/router activation and watcher flows are now namespace-scoped
<!-- end of auto-generated comment: release notes by coderabbit.ai -->