### PR TITLE
docs: add notes and instruction for latest trtllm kvbm disagg

### DIFF
--- a/docs/components/kvbm/kvbm_guide.md
+++ b/docs/components/kvbm/kvbm_guide.md
@@ -194,6 +194,29 @@ curl localhost:8000/v1/chat/completions \
 
 ## Disaggregated Serving with KVBM
 
+> [!NOTE]
+> The latest TensorRT-LLM release (1.3.0rc1) is currently experiencing a request hang when running disaggregated serving with KVBM.
+> Please include the TensorRT-LLM commit id `18e611da773026a55d187870ebcfa95ff00c8482` when building the Dynamo TensorRT-LLM runtime image to test the KVBM + disaggregated serving feature.
+
+```bash
+# Build a dynamo TensorRT-LLM container with commit-id 18e611da773026a55d187870ebcfa95ff00c8482
+./container/build.sh --framework trtllm --tensorrtllm-commit 18e611da773026a55d187870ebcfa95ff00c8482 --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git
+
+# Launch the container
+./container/run.sh --framework trtllm -it --mount-workspace --use-nixl-gds
+```
+> Important: After logging into the Dynamo TensorRT-LLM runtime container, copy the Triton kernels into the container’s virtual environment as a separate Python module.
+
+```bash
+# Clone the TensorRT-LLM repo and copy the triton_kernels folder into the container as a Python module.
+git clone https://github.com/NVIDIA/TensorRT-LLM.git /tmp/TensorRT-LLM && \
+cd /tmp/TensorRT-LLM && \
+git checkout 18e611da773026a55d187870ebcfa95ff00c8482 && \
+cp -r triton_kernels /opt/dynamo/venv/lib/python3.12/site-packages/ && \
+cd /workspace && \
+rm -rf /tmp/TensorRT-LLM
+```
+
 KVBM supports disaggregated serving where prefill and decode operations run on separate workers. KVBM is enabled on the prefill worker to offload KV cache.
 
 ### Disaggregated Serving with vLLM

--- a/docs/components/kvbm/kvbm_guide.md
+++ b/docs/components/kvbm/kvbm_guide.md
@@ -194,6 +194,24 @@ curl localhost:8000/v1/chat/completions \
 
 ## Disaggregated Serving with KVBM
 
+KVBM supports disaggregated serving where prefill and decode operations run on separate workers. KVBM is enabled on the prefill worker to offload KV cache.
+
+### Disaggregated Serving with vLLM
+
+```bash
+# 1P1D - one prefill worker and one decode worker
+# NOTE: requires at least 2 GPUs
+cd $DYNAMO_HOME/examples/backends/vllm
+./launch/disagg_kvbm.sh
+
+# 2P2D - two prefill workers and two decode workers
+# NOTE: requires at least 4 GPUs
+cd $DYNAMO_HOME/examples/backends/vllm
+./launch/disagg_kvbm_2p2d.sh
+```
+
+### Disaggregated Serving with TRT-LLM
+
 > [!NOTE]
 > The latest TensorRT-LLM release (1.3.0rc1) is currently experiencing a request hang when running disaggregated serving with KVBM.
 > Please include the TensorRT-LLM commit id `18e611da773026a55d187870ebcfa95ff00c8482` when building the Dynamo TensorRT-LLM runtime image to test the KVBM + disaggregated serving feature.
@@ -216,24 +234,6 @@ cp -r triton_kernels /opt/dynamo/venv/lib/python3.12/site-packages/ && \
 cd /workspace && \
 rm -rf /tmp/TensorRT-LLM
 ```
-
-KVBM supports disaggregated serving where prefill and decode operations run on separate workers. KVBM is enabled on the prefill worker to offload KV cache.
-
-### Disaggregated Serving with vLLM
-
-```bash
-# 1P1D - one prefill worker and one decode worker
-# NOTE: requires at least 2 GPUs
-cd $DYNAMO_HOME/examples/backends/vllm
-./launch/disagg_kvbm.sh
-
-# 2P2D - two prefill workers and two decode workers
-# NOTE: requires at least 4 GPUs
-cd $DYNAMO_HOME/examples/backends/vllm
-./launch/disagg_kvbm_2p2d.sh
-```
-
-### Disaggregated Serving with TRT-LLM
 
 ```bash
 # Launch prefill worker with KVBM

--- a/docs/components/kvbm/kvbm_guide.md
+++ b/docs/components/kvbm/kvbm_guide.md
@@ -223,6 +223,7 @@ cd $DYNAMO_HOME/examples/backends/vllm
 # Launch the container
 ./container/run.sh --framework trtllm -it --mount-workspace --use-nixl-gds
 ```
+> [!NOTE]
 > Important: After logging into the Dynamo TensorRT-LLM runtime container, copy the Triton kernels into the container’s virtual environment as a separate Python module.
 
 ```bash

--- a/docs/components/kvbm/kvbm_guide.md
+++ b/docs/components/kvbm/kvbm_guide.md
@@ -217,7 +217,7 @@ cd $DYNAMO_HOME/examples/backends/vllm
 > Please include the TensorRT-LLM commit id `18e611da773026a55d187870ebcfa95ff00c8482` when building the Dynamo TensorRT-LLM runtime image to test the KVBM + disaggregated serving feature.
 
 ```bash
-# Build a dynamo TensorRT-LLM container with commit-id 18e611da773026a55d187870ebcfa95ff00c8482
+# Build the Dynamo TensorRT-LLM container using commit ID 18e611da773026a55d187870ebcfa95ff00c8482. Note: This build can take a long time.
 ./container/build.sh --framework trtllm --tensorrtllm-commit 18e611da773026a55d187870ebcfa95ff00c8482 --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git
 
 # Launch the container


### PR DESCRIPTION
#### Overview:

TRTLLM team fix the TRTLLM disagg hang bug on 1.3.0 today: https://github.com/NVIDIA/TensorRT-LLM/pull/11247

Instruct the users to build from certain commit from TRTLLM

There is also an issue with integrating the TRTLLM's vendored triton kernels in the site-packages, adding a instruction to add the triton kernels python module. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated KVBM guide with detailed setup instructions for disaggregated serving, including container build commands, runtime configuration, and kernel module installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->