### PR TITLE
docs: alphabetize backends (SGLang, TensorRT-LLM, vLLM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ High-throughput, low-latency inference framework designed for serving generative
 
 Large language models exceed single-GPU capacity. Tensor parallelism spreads layers across GPUs but creates coordination challenges. Dynamo closes this orchestration gap.
 
-Dynamo is inference engine agnostic (supports TRT-LLM, vLLM, SGLang) and provides:
+Dynamo is inference engine agnostic (supports SGLang, TRT-LLM, vLLM) and provides:
 
 - **Disaggregated Prefill & Decode** – Maximizes GPU throughput with latency/throughput trade-offs
 - **Dynamic GPU Scheduling** – Optimizes performance based on fluctuating demand

--- a/docs/components/profiler/profiler_guide.md
+++ b/docs/components/profiler/profiler_guide.md
@@ -14,7 +14,7 @@ A **DynamoGraphDeploymentRequest (DGDR)** is a Kubernetes Custom Resource that s
 - **What** model you want to deploy (`model`)
 - **How** it should perform (SLA targets: `ttft`, `itl`)
 - **Where** it should run (optional GPU preferences)
-- **Which** backend to use (`backend`: vllm, sglang, or trtllm)
+- **Which** backend to use (`backend`: sglang, trtllm, or vllm)
 - **Which** images to use (`profilingConfig.profilerImage`, `deploymentOverrides.workersImage`)
 
 The Dynamo Operator watches for DGDRs and automatically:
@@ -186,7 +186,7 @@ Profiles your model by creating real test deployments in Kubernetes and measurin
 - **Duration**: 2-4 hours
 - **Accuracy**: Highest (real measurements)
 - **GPU Requirements**: Full access to test different parallelization mappings
-- **Backends**: vLLM, SGLang, TensorRT-LLM
+- **Backends**: SGLang, TensorRT-LLM, vLLM
 
 ```yaml
 profilingConfig:
@@ -202,7 +202,7 @@ Uses performance simulation to rapidly estimate optimal configurations without r
 - **Duration**: 20-30 seconds
 - **Accuracy**: Estimated (may have errors for unusual configurations)
 - **GPU Requirements**: None
-- **Backends**: TensorRT-LLM only (vLLM/SGLang coming soon)
+- **Backends**: TensorRT-LLM only (SGLang/vLLM coming soon)
 
 ```yaml
 profilingConfig:
@@ -401,7 +401,7 @@ The profiler uses the DGD config as a **base template**, then optimizes it based
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
-| `--backend` | string | - | Inference backend: vllm, sglang, trtllm |
+| `--backend` | string | - | Inference backend: sglang, trtllm, vllm |
 | `--config` | string | - | Path to DGD YAML config file |
 | `--model` | string | - | HuggingFace model ID |
 | `--ttft` | float | - | Target TTFT in milliseconds |

--- a/docs/pages/agents/tool-calling.md
+++ b/docs/pages/agents/tool-calling.md
@@ -18,7 +18,7 @@ To enable this feature, you should set the following flag while launching the ba
 - `--dyn-tool-call-parser` : select the parser from the available parsers list using the below command
 
 ```bash
-# <backend> can be vllm, sglang, trtllm, etc. based on your installation
+# <backend> can be sglang, trtllm, vllm, etc. based on your installation
 python -m dynamo.<backend> --help"
 ```
 

--- a/docs/pages/benchmarks/benchmarking.md
+++ b/docs/pages/benchmarks/benchmarking.md
@@ -139,7 +139,7 @@ python3 -m benchmarks.utils.plot --data-dir ./benchmarks/results --benchmark-nam
 The benchmarking framework supports various comparative analysis scenarios:
 
 - **Compare multiple DynamoGraphDeployments of a single backend** (e.g., aggregated vs disaggregated configurations)
-- **Compare different backends** (e.g., vLLM vs TensorRT-LLM vs SGLang)
+- **Compare different backends** (e.g., SGLang vs TensorRT-LLM vs vLLM)
 - **Compare Dynamo vs other platforms** (e.g., Dynamo vs llm-d vs AIBrix)
 - **Compare different models** (e.g., Llama-3-8B vs Llama-3-70B vs Qwen-3-0.6B)
 - **Compare different hardware configurations** (e.g., H100 vs A100 vs H200)
@@ -529,6 +529,6 @@ For development and testing purposes, Dynamo provides a [mocker backend](https:/
 - **CI/CD pipelines** that need to validate infrastructure without model execution
 - **Benchmarking framework validation** to ensure your setup works before using real backends
 
-The mocker backend mimics the API and behavior of real backends (vLLM, SGLang, TensorRT-LLM) but generates mock responses instead of running actual inference.
+The mocker backend mimics the API and behavior of real backends (SGLang, TensorRT-LLM, vLLM) but generates mock responses instead of running actual inference.
 
 See the [mocker directory](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/mocker) for usage examples and configuration options.

--- a/docs/pages/components/frontend/frontend-guide.md
+++ b/docs/pages/components/frontend/frontend-guide.md
@@ -60,7 +60,7 @@ Tune these values based on your workload. Connection window should accommodate `
 Similar to HTTP frontend, the registered backend will be auto-discovered and added to the frontend list of serving model. To register a backend, the same `register_model()` API will be used. Currently the frontend support serving of the following model type and model input combination:
 
 * `ModelType::Completions` and `ModelInput::Text`: Combination for LLM backend that uses custom preprocessor
-* `ModelType::Completions` and `ModelInput::Token`: Combination for LLM backend that uses Dynamo preprocessor (i.e. Dynamo vLLM / SGLang / TRTLLM backend)
+* `ModelType::Completions` and `ModelInput::Token`: Combination for LLM backend that uses Dynamo preprocessor (i.e. Dynamo SGLang / TRTLLM / vLLM backend)
 * `ModelType::TensorBased` and `ModelInput::Tensor`: Combination for backend that is used for generic tensor-based inference
 
 The first two combinations are backed by OpenAI Completions API, see [OpenAI Completions section](#openai-completions) for more detail. Whereas the last combination is most aligned with KServe API and the users can replace existing deployment with Dynamo once their backends implements adaptor for `NvCreateTensorRequest/NvCreateTensorResponse`, see [Tensor section](#tensor) for more detail:

--- a/docs/pages/components/frontend/nvext.md
+++ b/docs/pages/components/frontend/nvext.md
@@ -121,10 +121,10 @@ Backend engine scheduling priority forwarded to the engine's `generate` call. In
 
 The semantics of the priority value differ between backends:
 
-- **vLLM**: Smaller values = higher priority. A request with `priority: 0` is scheduled before `priority: 10`. Ties are broken by arrival time. Requires `--scheduling-policy priority` on the engine.
 - **SGLang**: By default, larger values = higher priority. This can be inverted with `--schedule-low-priority-values-first` to match vLLM's convention. Requires `--enable-priority-scheduling` on the engine.
+- **vLLM**: Smaller values = higher priority. A request with `priority: 0` is scheduled before `priority: 10`. Ties are broken by arrival time. Requires `--scheduling-policy priority` on the engine.
 
-When omitted, vLLM defaults to `0`; SGLang defaults to `None` (engine default). TensorRT-LLM does not currently support per-request priority.
+When omitted, SGLang defaults to `None` (engine default); vLLM defaults to `0`. TensorRT-LLM does not currently support per-request priority.
 
 ```json
 {

--- a/docs/pages/components/kvbm/README.md
+++ b/docs/pages/components/kvbm/README.md
@@ -6,7 +6,7 @@ title: KVBM
 
 # KV Block Manager (KVBM)
 
-The Dynamo KV Block Manager (KVBM) is a scalable runtime component designed to handle memory allocation, management, and remote sharing of Key-Value (KV) blocks for inference tasks across heterogeneous and distributed environments. It acts as a unified memory layer for frameworks like vLLM and TensorRT-LLM.
+The Dynamo KV Block Manager (KVBM) is a scalable runtime component designed to handle memory allocation, management, and remote sharing of Key-Value (KV) blocks for inference tasks across heterogeneous and distributed environments. It acts as a unified memory layer for frameworks like TensorRT-LLM and vLLM.
 
 KVBM offers:
 - A **unified memory API** spanning GPU memory, pinned host memory, remote RDMA-accessible memory, local/distributed SSDs, and remote file/object/cloud storage systems

--- a/docs/pages/components/kvbm/kvbm-guide.md
+++ b/docs/pages/components/kvbm/kvbm-guide.md
@@ -6,7 +6,7 @@ subtitle: Enable KV offloading using KV Block Manager (KVBM) for Dynamo deployme
 ---
 
 # KVBM Guide
-The Dynamo KV Block Manager (KVBM) is a scalable runtime component designed to handle memory allocation, management, and remote sharing of Key-Value (KV) blocks for inference tasks across heterogeneous and distributed environments. It acts as a unified memory layer for frameworks like vLLM and TensorRT-LLM.
+The Dynamo KV Block Manager (KVBM) is a scalable runtime component designed to handle memory allocation, management, and remote sharing of Key-Value (KV) blocks for inference tasks across heterogeneous and distributed environments. It acts as a unified memory layer for frameworks like TensorRT-LLM and vLLM.
 
 KVBM is modular and can be used standalone via `pip install kvbm` or as the memory management component in the full Dynamo stack. This guide covers installation, configuration, and deployment of the Dynamo KV Block Manager (KVBM) and other KV cache management systems.
 

--- a/docs/pages/components/planner/README.md
+++ b/docs/pages/components/planner/README.md
@@ -25,9 +25,9 @@ When both modes are enabled, throughput-based scaling provides a lower bound on 
 | Disaggregated | Supported | Supported |
 | Aggregated | Unsupported | Supported |
 | **LLM Framework** | | |
-| vLLM | Supported | Supported |
-| TensorRT-LLM | Supported | Supported |
 | SGLang | Supported | Supported |
+| TensorRT-LLM | Supported | Supported |
+| vLLM | Supported | Supported |
 | **Requires Profiling Data** | Yes | No |
 | **Load Predictors** | ARIMA, Prophet, Kalman, Constant | N/A |
 | **Connectors** | | |
@@ -98,7 +98,7 @@ kubectl apply -f examples/backends/vllm/deploy/disagg_planner.yaml -n $NAMESPACE
 |----------|---------|-------------|
 | **Common** | | |
 | `--namespace` | `$DYN_NAMESPACE` or `dynamo` | Dynamo logical namespace |
-| `--backend` | `vllm` | Backend framework (`vllm`, `sglang`, `trtllm`) |
+| `--backend` | `vllm` | Backend framework (`sglang`, `trtllm`, `vllm`) |
 | `--mode` | `disagg` | Planner mode (`disagg`, `prefill`, `decode`, `agg`) |
 | `--environment` | `kubernetes` | Deployment environment |
 | `--ttft` | `500.0` | Target Time To First Token (ms) |

--- a/docs/pages/components/planner/planner-guide.md
+++ b/docs/pages/components/planner/planner-guide.md
@@ -71,7 +71,7 @@ A **DGDR** is a Kubernetes Custom Resource that serves as the primary interface 
 - **What** model to deploy (`model`)
 - **How** it should perform (SLA targets: `ttft`, `itl`)
 - **Where** it should run (optional GPU preferences)
-- **Which** backend to use (`backend`: vllm, sglang, or trtllm)
+- **Which** backend to use (`backend`: sglang, trtllm, or vllm)
 - **Which** images to use (`profilingConfig.profilerImage`, `deploymentOverrides.workersImage`)
 
 The Dynamo Operator watches for DGDRs and automatically:
@@ -161,7 +161,7 @@ metadata:
 | Field | Type | Description |
 |-------|------|-------------|
 | `spec.model` | string | Model identifier (e.g., `meta-llama/Llama-3-70b`) |
-| `spec.backend` | enum | Inference backend: `vllm`, `sglang`, or `trtllm` |
+| `spec.backend` | enum | Inference backend: `sglang`, `trtllm`, or `vllm` |
 | `spec.profilingConfig.profilerImage` | string | Container image for profiling job |
 | `spec.profilingConfig.config.sla` | object | SLA targets (isl, osl, ttft, itl) |
 

--- a/docs/pages/components/profiler/README.md
+++ b/docs/pages/components/profiler/README.md
@@ -10,14 +10,14 @@ The Dynamo Profiler is an automated performance analysis tool that measures mode
 
 ## Feature Matrix
 
-| Feature | vLLM | SGLang | TensorRT-LLM |
-|---------|------|--------|--------------|
+| Feature | SGLang | TensorRT-LLM | vLLM |
+|---------|--------|--------------|------|
 | Dense Model Profiling | ✅ | ✅ | ✅ |
-| MoE Model Profiling | 🚧 | ✅ | 🚧 |
-| AI Configurator (Offline) | ❌ | ❌ | ✅ |
+| MoE Model Profiling | ✅ | 🚧 | 🚧 |
+| AI Configurator (Offline) | ❌ | ✅ | ❌ |
 | Online Profiling (AIPerf) | ✅ | ✅ | ✅ |
 | Interactive WebUI | ✅ | ✅ | ✅ |
-| Runtime Profiling Endpoints | ❌ | ✅ | ❌ |
+| Runtime Profiling Endpoints | ✅ | ❌ | ❌ |
 
 ## Quick Start
 

--- a/docs/pages/components/profiler/profiler-guide.md
+++ b/docs/pages/components/profiler/profiler-guide.md
@@ -15,7 +15,7 @@ A **DynamoGraphDeploymentRequest (DGDR)** is a Kubernetes Custom Resource that s
 - **What** model you want to deploy (`model`)
 - **How** it should perform (SLA targets: `ttft`, `itl`)
 - **Where** it should run (optional GPU preferences)
-- **Which** backend to use (`backend`: vllm, sglang, or trtllm)
+- **Which** backend to use (`backend`: sglang, trtllm, or vllm)
 - **Which** images to use (`profilingConfig.profilerImage`, `deploymentOverrides.workersImage`)
 
 The Dynamo Operator watches for DGDRs and automatically:
@@ -187,7 +187,7 @@ Profiles your model by creating real test deployments in Kubernetes and measurin
 - **Duration**: 2-4 hours
 - **Accuracy**: Highest (real measurements)
 - **GPU Requirements**: Full access to test different parallelization mappings
-- **Backends**: vLLM, SGLang, TensorRT-LLM
+- **Backends**: SGLang, TensorRT-LLM, vLLM
 
 ```yaml
 profilingConfig:
@@ -203,7 +203,7 @@ Uses performance simulation to rapidly estimate optimal configurations without r
 - **Duration**: 20-30 seconds
 - **Accuracy**: Estimated (may have errors for unusual configurations)
 - **GPU Requirements**: None
-- **Backends**: TensorRT-LLM only (vLLM/SGLang coming soon)
+- **Backends**: TensorRT-LLM only (SGLang/vLLM coming soon)
 
 ```yaml
 profilingConfig:
@@ -422,7 +422,7 @@ The profiler uses the DGD config as a **base template**, then optimizes it based
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
-| `--backend` | string | - | Inference backend: vllm, sglang, trtllm |
+| `--backend` | string | - | Inference backend: sglang, trtllm, vllm |
 | `--config` | string | - | Path to DGD YAML config file |
 | `--model` | string | - | HuggingFace model ID |
 | `--ttft` | float | - | Target TTFT in milliseconds |

--- a/docs/pages/components/router/README.md
+++ b/docs/pages/components/router/README.md
@@ -88,7 +88,7 @@ For more configuration options and tuning guidelines, see the [Router Guide](rou
 - You cannot use `--static-endpoint` mode with KV routing (use dynamic discovery instead)
 
 **Multimodal Support:**
-- **vLLM and TRT-LLM**: Multimodal routing supported for images via multimodal hashes
+- **TRT-LLM and vLLM**: Multimodal routing supported for images via multimodal hashes
 - **SGLang**: Image routing not yet supported
 - **Other modalities** (audio, video, etc.): Not yet supported
 

--- a/docs/pages/components/router/router-examples.md
+++ b/docs/pages/components/router/router-examples.md
@@ -279,7 +279,7 @@ See [Router Design](../../design-docs/router-design.md) for architecture details
 For full documentation on implementing KV event publishing for custom inference engines, see the dedicated [KV Event Publishing for Custom Engines](../../integrations/kv-events-custom-engines.md) guide. It covers:
 
 - **Direct publishing**: Call `publish_stored()` / `publish_removed()` to push events over the Dynamo event plane
-- **ZMQ relay**: For engines that emit raw KV events over ZMQ (like vLLM and SGLang), the same `KvEventPublisher` subscribes to the ZMQ socket and relays events automatically
+- **ZMQ relay**: For engines that emit raw KV events over ZMQ (like SGLang and vLLM), the same `KvEventPublisher` subscribes to the ZMQ socket and relays events automatically
 - API reference, event structure, ZMQ wire format, and best practices
 
 ## Global Router (Hierarchical Routing)

--- a/docs/pages/design-docs/architecture.md
+++ b/docs/pages/design-docs/architecture.md
@@ -6,7 +6,7 @@ title: Overall Architecture
 
 # High Level Architecture
 
-Dynamo is NVIDIA's high-throughput, low-latency inference framework that's designed to serve generative AI and reasoning models in multi-node distributed environments. It's inference engine agnostic, supporting TRT-LLM, vLLM, SGLang and others, while capturing essential LLM capabilities:
+Dynamo is NVIDIA's high-throughput, low-latency inference framework that's designed to serve generative AI and reasoning models in multi-node distributed environments. It's inference engine agnostic, supporting SGLang, TRT-LLM, vLLM and others, while capturing essential LLM capabilities:
 
 - **Disaggregated prefill & decode inference**: Maximizes GPU throughput and helps you balance throughput and latency
 - **Dynamic GPU scheduling**: Optimizes performance based on real-time demand

--- a/docs/pages/design-docs/distributed-runtime.md
+++ b/docs/pages/design-docs/distributed-runtime.md
@@ -20,7 +20,7 @@ While theoretically each `DistributedRuntime` can have multiple `Namespace`s as 
 For example, a typical deployment configuration (like `examples/backends/vllm/deploy/agg.yaml` or `examples/backends/sglang/deploy/agg.yaml`) has multiple components:
 
 - `Frontend`: Starts an HTTP server (OpenAI-compatible API on port 8000), handles incoming requests, applies chat templates, performs tokenization, and routes requests to workers. The `make_engine` function encapsulates this functionality.
-- `Worker` components (e.g., `VllmDecodeWorker`, `VllmPrefillWorker`, `SGLangDecodeWorker`, `TRTLLMWorker`): Perform the actual inference computation using their respective engines (vLLM, SGLang, TensorRT-LLM).
+- `Worker` components (e.g., `VllmDecodeWorker`, `VllmPrefillWorker`, `SGLangDecodeWorker`, `TRTLLMWorker`): Perform the actual inference computation using their respective engines (SGLang, TensorRT-LLM, vLLM).
 
 Since these components are deployed in different processes, each has its own `DistributedRuntime`. Within their own `DistributedRuntime`, they all share the same `Namespace` (e.g., `vllm-agg`, `sglang-disagg`). Under their namespace, each has its own `Component`:
 

--- a/docs/pages/design-docs/dynamo-flow.md
+++ b/docs/pages/design-docs/dynamo-flow.md
@@ -61,7 +61,7 @@ Coordination and messaging support:
 ### NIXL (NVIDIA Interchange Library):
 - Enables high-speed GPU-to-GPU data transfers using NVLink, InfiniBand/UCX, or PCIe
 - Transfer metadata exchanged via `disaggregated_params` in prefill response
-- Backend-specific coordination: SGLang uses bootstrap connections, vLLM uses block IDs, TRTLLM uses opaque state
+- Backend-specific coordination: SGLang uses bootstrap connections, TRTLLM uses opaque state, vLLM uses block IDs
 
 ### Disaggregated KV Cache:
 - Each worker maintains local KV cache in its GPU memory

--- a/docs/pages/design-docs/event-plane.md
+++ b/docs/pages/design-docs/event-plane.md
@@ -45,11 +45,11 @@ export DYN_EVENT_PLANE=zmq
 Python components also accept this as a CLI flag:
 
 ```bash
-# vLLM backend
-python3 -m dynamo.vllm --event-plane zmq --model Qwen/Qwen3-0.6B
-
 # SGLang backend
 python3 -m dynamo.sglang --event-plane zmq --model Qwen/Qwen3-0.6B
+
+# vLLM backend
+python3 -m dynamo.vllm --event-plane zmq --model Qwen/Qwen3-0.6B
 ```
 
 ### Environment Variables

--- a/docs/pages/design-docs/kvbm-design.md
+++ b/docs/pages/design-docs/kvbm-design.md
@@ -6,7 +6,7 @@ title: KVBM Design
 
 # KVBM Design
 
-This document provides an in-depth look at the architecture, components, framework integrations via the connector API, and the detailed workings of the Dynamo KV Block Manager (KVBM). The design of KVBM takes inspiration from the KV block managers used in vLLM and SGLang, with added influence from historical memory tiering strategies common in general GPU programming. For more details, see [Further Reading](#further-reading).
+This document provides an in-depth look at the architecture, components, framework integrations via the connector API, and the detailed workings of the Dynamo KV Block Manager (KVBM). The design of KVBM takes inspiration from the KV block managers used in SGLang and vLLM, with added influence from historical memory tiering strategies common in general GPU programming. For more details, see [Further Reading](#further-reading).
 
 ## KVBM Components
 
@@ -313,7 +313,7 @@ This design ensures that performance, resilience, and extensibility scale indepe
 
 ## Framework Integrations
 
-KVBM integrates with inference frameworks (vLLM, TensorRT-LLM, SGLang) via Connector APIs to influence KV caching behavior, scheduling, and forward pass execution.
+KVBM integrates with inference frameworks (SGLang, TensorRT-LLM, vLLM) via Connector APIs to influence KV caching behavior, scheduling, and forward pass execution.
 
 ### Connector Architecture
 

--- a/docs/pages/design-docs/router-design.md
+++ b/docs/pages/design-docs/router-design.md
@@ -107,7 +107,7 @@ To get a feel for how KV Cache management works on a single worker with KV Cache
     - These tensors are stored in the newly allocated cache blocks
     - **KVPublisher emits a kv stored event notifying KVIndexer about newly stored blocks**.
 
-Further details can be found for: [TRT-LLM](https://developer.nvidia.com/blog/introducing-new-kv-cache-reuse-optimizations-in-nvidia-tensorrt-llm/), [vLLM](https://docs.vllm.ai/en/latest/design/automatic_prefix_caching.html#design-automatic-prefix-caching) and [SGLang](https://lmsys.org/blog/2024-01-17-sglang/).
+Further details can be found for: [SGLang](https://lmsys.org/blog/2024-01-17-sglang/), [TRT-LLM](https://developer.nvidia.com/blog/introducing-new-kv-cache-reuse-optimizations-in-nvidia-tensorrt-llm/) and [vLLM](https://docs.vllm.ai/en/latest/design/automatic_prefix_caching.html#design-automatic-prefix-caching).
 
 ## Events
 
@@ -214,7 +214,7 @@ By default, workers have local indexer enabled. Each worker maintains its own lo
 
 - **Best for**: Lower-latency setups; simpler deployments without JetStream; single-router scenarios; deployments without NATS (using ZMQ event plane)
 - **Tradeoffs**: State persists on workers (not centralized); recovery depends on workers being available
-- **Switch to JetStream**: Use `--durable-kv-events` flag on **both** workers (vLLM, SGLang, TRT-LLM, mocker) **and** frontend
+- **Switch to JetStream**: Use `--durable-kv-events` flag on **both** workers (SGLang, TRT-LLM, vLLM, mocker) **and** frontend
 
 ```mermaid
 graph TD

--- a/docs/pages/features/disaggregated-serving/README.md
+++ b/docs/pages/features/disaggregated-serving/README.md
@@ -86,7 +86,7 @@ aiconfigurator cli default \
 - `--total_gpus`: Number of GPUs available for deployment
 - `--isl` / `--osl`: Input/Output sequence lengths in tokens
 - `--ttft` / `--tpot`: SLA targets - Time To First Token (ms) and Time Per Output Token (ms)
-- `--backend`: Inference backend (`vllm`, `trtllm`, or `sglang`)
+- `--backend`: Inference backend (`sglang`, `trtllm`, or `vllm`)
 - `--backend_version`: Backend version (e.g., `0.12.0` for vLLM)
 - `--save_dir`: Directory to save generated deployment configs
 
@@ -623,13 +623,13 @@ AIConfigurator's default predictions assume no prefix caching. Enable it post-de
 
 ### Systems
 
-| GPU System | TensorRT-LLM | vLLM | SGLang |
-|------------|--------------|------|--------|
+| GPU System | SGLang | TensorRT-LLM | vLLM |
+|------------|--------|--------------|------|
 | H200 SXM | Yes | Yes | Yes |
 | H100 SXM | Yes | Yes | Yes |
-| A100 SXM | Yes | Yes | -- |
-| B200 SXM | Yes | -- | Yes |
-| GB200 SXM | Yes | -- | -- |
+| A100 SXM | -- | Yes | Yes |
+| B200 SXM | Yes | Yes | -- |
+| GB200 SXM | -- | Yes | -- |
 
 ### Models
 

--- a/docs/pages/features/multimodal/README.md
+++ b/docs/pages/features/multimodal/README.md
@@ -39,10 +39,10 @@ Dynamo supports multimodal inference across multiple LLM backends, enabling mode
 
 ### Input Format Support
 
-| Format | vLLM | TRT-LLM | SGLang |
-|--------|------|---------|--------|
+| Format | SGLang | TRT-LLM | vLLM |
+|--------|--------|---------|------|
 | HTTP/HTTPS URL | ✅ | ✅ | ✅ |
-| Data URL (Base64) | ✅ | ❌ | ❌ |
+| Data URL (Base64) | ❌ | ❌ | ✅ |
 | Pre-computed Embeddings (.pt) | ❌ | ✅ | ❌ |
 
 ## Architecture Patterns

--- a/docs/pages/integrations/flexkv-integration.md
+++ b/docs/pages/integrations/flexkv-integration.md
@@ -8,7 +8,7 @@ title: FlexKV
 
 ## Introduction
 
-[FlexKV](https://github.com/taco-project/FlexKV) is a scalable, distributed runtime for KV cache offloading developed by Tencent Cloud's TACO team in collaboration with the community. It acts as a unified KV caching layer for inference engines like vLLM, TensorRT-LLM, and SGLang.
+[FlexKV](https://github.com/taco-project/FlexKV) is a scalable, distributed runtime for KV cache offloading developed by Tencent Cloud's TACO team in collaboration with the community. It acts as a unified KV caching layer for inference engines like SGLang, TensorRT-LLM, and vLLM.
 
 ### Key Features
 

--- a/docs/pages/integrations/kv-events-custom-engines.md
+++ b/docs/pages/integrations/kv-events-custom-engines.md
@@ -17,7 +17,7 @@ Events are published over the **Dynamo event plane**, a transport-agnostic pub/s
 `KvEventPublisher` supports two publishing modes:
 
 1. **Direct publishing** — Your engine calls `publish_stored()` / `publish_removed()` to push events directly over the event plane. Simplest approach for custom engines.
-2. **ZMQ relay** — For engines that emit raw KV events over a ZMQ socket (like vLLM and SGLang). The publisher subscribes to the ZMQ endpoint and relays events to the event plane automatically.
+2. **ZMQ relay** — For engines that emit raw KV events over a ZMQ socket (like SGLang and vLLM). The publisher subscribes to the ZMQ endpoint and relays events to the event plane automatically.
 
 ## Event Types
 
@@ -137,11 +137,11 @@ async def main():
 
 ## ZMQ Relay (For Engines with Raw KV Events)
 
-For engines that already publish raw KV events over a ZMQ socket (like vLLM and SGLang), use the same `KvEventPublisher` with a `zmq_endpoint`. The publisher subscribes to the ZMQ socket and relays events to the event plane automatically.
+For engines that already publish raw KV events over a ZMQ socket (like SGLang and vLLM), use the same `KvEventPublisher` with a `zmq_endpoint`. The publisher subscribes to the ZMQ socket and relays events to the event plane automatically.
 
 ```mermaid
 flowchart LR
-    subgraph Engine["Custom Engine / vLLM / SGLang"]
+    subgraph Engine["Custom Engine / SGLang / vLLM"]
         cache["KV Cache Manager"]
         zmq_pub["ZMQ Publisher"]
     end
@@ -170,7 +170,7 @@ flowchart LR
 ```
 
 **When to use:**
-- Your engine already publishes KV events via ZMQ (like vLLM or SGLang)
+- Your engine already publishes KV events via ZMQ (like SGLang or vLLM)
 - You want to decouple event publishing from your engine's main loop
 
 ### Setup
@@ -192,7 +192,7 @@ No further calls to `publish_stored()` / `publish_removed()` are needed — the 
 
 ### ZMQ Wire Format
 
-The ZMQ message format (compatible with vLLM / SGLang):
+The ZMQ message format (compatible with SGLang / vLLM):
 
 | Frame | Description |
 |-------|-------------|

--- a/docs/pages/kubernetes/api-reference.md
+++ b/docs/pages/kubernetes/api-reference.md
@@ -239,7 +239,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `model` _string_ | Model is the model identifier (e.g., "meta-llama/Llama-3-70B") |  | Required: \{\} <br /> |
-| `backendFramework` _string_ | BackendFramework is the runtime framework (vllm, sglang, trtllm) |  | Enum: [vllm sglang trtllm] <br />Required: \{\} <br /> |
+| `backendFramework` _string_ | BackendFramework is the runtime framework (sglang, trtllm, vllm) |  | Enum: [sglang trtllm vllm] <br />Required: \{\} <br /> |
 | `dynamoVersion` _string_ | DynamoVersion is the Dynamo platform version (optional)<br />If not specified, version is not included in identity hash<br />This ensures checkpoint compatibility across Dynamo releases |  | Optional: \{\} <br /> |
 | `tensorParallelSize` _integer_ | TensorParallelSize is the tensor parallel configuration | 1 | Minimum: 1 <br />Optional: \{\} <br /> |
 | `pipelineParallelSize` _integer_ | PipelineParallelSize is the pipeline parallel configuration | 1 | Minimum: 1 <br />Optional: \{\} <br /> |
@@ -412,7 +412,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `backendFramework` _string_ | BackendFramework specifies the backend framework (e.g., "sglang", "vllm", "trtllm") |  | Enum: [sglang vllm trtllm] <br /> |
+| `backendFramework` _string_ | BackendFramework specifies the backend framework (e.g., "sglang", "trtllm", "vllm") |  | Enum: [sglang trtllm vllm] <br /> |
 | `annotations` _object (keys:string, values:string)_ | Annotations to add to generated Kubernetes resources for this component<br />(such as Pod, Service, and Ingress when applicable). |  |  |
 | `labels` _object (keys:string, values:string)_ | Labels to add to generated Kubernetes resources for this component. |  |  |
 | `serviceName` _string_ | The name of the component |  |  |
@@ -510,7 +510,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `model` _string_ | Model specifies the model to deploy (e.g., "Qwen/Qwen3-0.6B", "meta-llama/Llama-3-70b").<br />This is a high-level identifier for easy reference in kubectl output and logs.<br />The controller automatically sets this value in profilingConfig.config.deployment.model. |  | Required: \{\} <br /> |
-| `backend` _string_ | Backend specifies the inference backend for profiling.<br />The controller automatically sets this value in profilingConfig.config.engine.backend.<br />Profiling runs on real GPUs or via AIC simulation to collect performance data. |  | Enum: [vllm sglang trtllm] <br />Required: \{\} <br /> |
+| `backend` _string_ | Backend specifies the inference backend for profiling.<br />The controller automatically sets this value in profilingConfig.config.engine.backend.<br />Profiling runs on real GPUs or via AIC simulation to collect performance data. |  | Enum: [sglang trtllm vllm] <br />Required: \{\} <br /> |
 | `useMocker` _boolean_ | UseMocker indicates whether to deploy a mocker DynamoGraphDeployment instead of<br />a real backend deployment. When true, the deployment uses simulated engines that<br />don't require GPUs, using the profiling data to simulate realistic timing behavior.<br />Mocker is available in all backend images and useful for large-scale experiments.<br />Profiling still runs against the real backend (specified above) to collect performance data. | false |  |
 | `profilingConfig` _[ProfilingConfigSpec](#profilingconfigspec)_ | ProfilingConfig provides the complete configuration for the profiling job.<br />Note: GPU discovery is automatically attempted to detect GPU resources from Kubernetes<br />cluster nodes. If the operator has node read permissions (cluster-wide or explicitly granted),<br />discovered GPU configuration is used as defaults when hardware configuration is not manually<br />specified (minNumGpusPerEngine, maxNumGpusPerEngine, numGpusPerNode). User-specified values<br />always take precedence over auto-discovered values. If GPU discovery fails (e.g.,<br />namespace-restricted operator without node permissions), manual hardware config is required.<br />This configuration is passed directly to the profiler.<br />The structure matches the profile_sla config format exactly (see ProfilingConfigSpec for schema).<br />Note: deployment.model and engine.backend are automatically set from the high-level<br />modelName and backend fields and should not be specified in this config. |  | Required: \{\} <br /> |
 | `enableGpuDiscovery` _boolean_ | EnableGPUDiscovery controls whether the operator attempts to discover GPU hardware from cluster nodes.<br />DEPRECATED: This field is deprecated and will be removed in v1beta1. GPU discovery is now always<br />attempted automatically. Setting this field has no effect - the operator will always try to discover<br />GPU hardware when node read permissions are available. If discovery is unavailable (e.g., namespace-scoped<br />operator without permissions), manual hardware configuration is required regardless of this setting. | true | Optional: \{\} <br /> |
@@ -634,7 +634,7 @@ _Appears in:_
 | `pvcs` _[PVC](#pvc) array_ | PVCs defines a list of persistent volume claims that can be referenced by components.<br />Each PVC must have a unique name that can be referenced in component specifications. |  | MaxItems: 100 <br />Optional: \{\} <br /> |
 | `services` _object (keys:string, values:[DynamoComponentDeploymentSharedSpec](#dynamocomponentdeploymentsharedspec))_ | Services are the services to deploy as part of this deployment. |  | MaxProperties: 25 <br />Optional: \{\} <br /> |
 | `envs` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Envs are environment variables applied to all services in the deployment unless<br />overridden by service-specific configuration. |  | Optional: \{\} <br /> |
-| `backendFramework` _string_ | BackendFramework specifies the backend framework (e.g., "sglang", "vllm", "trtllm"). |  | Enum: [sglang vllm trtllm] <br /> |
+| `backendFramework` _string_ | BackendFramework specifies the backend framework (e.g., "sglang", "trtllm", "vllm"). |  | Enum: [sglang trtllm vllm] <br /> |
 | `restart` _[Restart](#restart)_ | Restart specifies the restart policy for the graph deployment. |  | Optional: \{\} <br /> |
 
 
@@ -2075,7 +2075,7 @@ The Dynamo operator automatically applies default values to various fields when 
 
 - **Autoscaling**: When enabled without explicit metrics, defaults to CPU-based autoscaling with 80% target utilization.
 
-- **Backend-Specific Behavior**: For multinode deployments, probes are automatically modified or removed for worker nodes depending on the backend framework (VLLM, SGLang, or TensorRT-LLM).
+- **Backend-Specific Behavior**: For multinode deployments, probes are automatically modified or removed for worker nodes depending on the backend framework (SGLang, TensorRT-LLM, or vLLM).
 
 ## Pod Specification Defaults
 

--- a/docs/pages/kubernetes/chrek/dynamo.md
+++ b/docs/pages/kubernetes/chrek/dynamo.md
@@ -212,7 +212,7 @@ Checkpoints are uniquely identified by a **16-character SHA256 hash** (64 bits) 
 | Field | Required | Affects Hash | Example |
 |-------|----------|-------------|---------|
 | `model` | ✓ | ✓ | `meta-llama/Llama-3-8B` |
-| `framework` | ✓ | ✓ | `vllm`, `sglang`, `trtllm` |
+| `framework` | ✓ | ✓ | `sglang`, `trtllm`, `vllm` |
 | `dynamoVersion` | | ✓ | `0.9.0`, `1.0.0` |
 | `tensorParallelSize` | | ✓ | `1`, `2`, `4`, `8` (default: 1) |
 | `pipelineParallelSize` | | ✓ | `1`, `2` (default: 1) |

--- a/docs/pages/kubernetes/deployment/dynamomodel-guide.md
+++ b/docs/pages/kubernetes/deployment/dynamomodel-guide.md
@@ -437,7 +437,7 @@ status:
    - For HuggingFace: Verify token is valid, repo exists and is accessible
 
 2. **Invalid LoRA format**
-   **Solution:** Ensure your LoRA weights are in the format expected by your backend framework (vLLM, SGLang, etc.)
+   **Solution:** Ensure your LoRA weights are in the format expected by your backend framework (SGLang, vLLM, etc.)
 
 3. **Endpoint API errors**
    ```bash

--- a/docs/pages/observability/metrics.md
+++ b/docs/pages/observability/metrics.md
@@ -86,7 +86,7 @@ Dynamo exposes several categories of metrics:
 - **Frontend Metrics** (`dynamo_frontend_*`) - Request handling, token processing, and latency measurements
 - **Component Metrics** (`dynamo_component_*`) - Request counts, processing times, byte transfers, and system uptime
 - **Specialized Component Metrics** (e.g., `dynamo_preprocessor_*`) - Component-specific metrics
-- **Engine Metrics** (Pass-through) - Backend engines expose their own metrics: [vLLM](../backends/vllm/prometheus.md) (`vllm:*`), [SGLang](../backends/sglang/prometheus.md) (`sglang:*`), [TensorRT-LLM](../backends/trtllm/prometheus.md) (`trtllm_*`)
+- **Engine Metrics** (Pass-through) - Backend engines expose their own metrics: [SGLang](../backends/sglang/prometheus.md) (`sglang:*`), [TensorRT-LLM](../backends/trtllm/prometheus.md) (`trtllm_*`), [vLLM](../backends/vllm/prometheus.md) (`vllm:*`)
 
 ## Runtime Hierarchy
 
@@ -194,7 +194,7 @@ curl -s localhost:8000/v1/completions -H "Content-Type: application/json" -d '{
 **Timeline:**
 ```
 Timeline:    0, 1, ...
-Client ────> Frontend:8000 ────────────────────> Dynamo component/backend (vLLM, SGLang, TRT)
+Client ────> Frontend:8000 ────────────────────> Dynamo component/backend (SGLang, TRT, vLLM)
              │request start                     │received                              │
              |                                  |                                      |
              │                                  ├──> start prefill ──> first token ──> |last token

--- a/docs/pages/reference/feature-matrix.md
+++ b/docs/pages/reference/feature-matrix.md
@@ -16,20 +16,20 @@ This document provides a comprehensive compatibility matrix for key Dynamo featu
 
 ## Quick Comparison
 
-| Feature | vLLM | TensorRT-LLM | SGLang | Source |
+| Feature | SGLang | TensorRT-LLM | vLLM | Source |
 | :--- | :---: | :---: | :---: | :--- |
 | **Disaggregated Serving** | ✅ | ✅ | ✅ | [Design Doc][disagg] |
 | **KV-Aware Routing** | ✅ | ✅ | ✅ | [Router Doc][kv-routing] |
 | **SLA-Based Planner** | ✅ | ✅ | ✅ | [Planner Doc][planner] |
-| **KV Block Manager** | ✅ | ✅ | 🚧 | [KVBM Doc][kvbm] |
+| **KV Block Manager** | 🚧 | ✅ | ✅ | [KVBM Doc][kvbm] |
 | **Multimodal (Image)** | ✅ | ✅ | ✅ | [Multimodal Doc][mm] |
-| **Multimodal (Video)** | ✅ | | | [Multimodal Doc][mm] |
-| **Multimodal (Audio)** | 🚧 | | | [Multimodal Doc][mm] |
+| **Multimodal (Video)** | | | ✅ | [Multimodal Doc][mm] |
+| **Multimodal (Audio)** | | | 🚧 | [Multimodal Doc][mm] |
 | **Request Migration** | ✅ | 🚧 | ✅ | [Migration Doc][migration] |
-| **Request Cancellation** | ✅ | ✅ | 🚧 | Backend READMEs |
-| **LoRA** | ✅ | | | [K8s Guide][lora] |
+| **Request Cancellation** | 🚧 | ✅ | ✅ | Backend READMEs |
+| **LoRA** | | | ✅ | [K8s Guide][lora] |
 | **Tool Calling** | ✅ | ✅ | ✅ | [Tool Calling Doc][tools] |
-| **Speculative Decoding** | ✅ | ✅ | 🚧 | Backend READMEs |
+| **Speculative Decoding** | 🚧 | ✅ | ✅ | Backend READMEs |
 
 ## 1. vLLM Backend
 

--- a/docs/pages/reference/release-artifacts.md
+++ b/docs/pages/reference/release-artifacts.md
@@ -48,7 +48,7 @@ We recommend using the TensorRT-LLM NGC container instead of the `ai-dynamo[trtl
 
 | Package | Description | Python | Platform | PyPI |
 |---------|-------------|--------|----------|------|
-| `ai-dynamo==0.8.1` | Main package with backend integrations (vLLM, SGLang, TRT-LLM) | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo/0.8.1/) |
+| `ai-dynamo==0.8.1` | Main package with backend integrations (SGLang, TRT-LLM, vLLM) | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo/0.8.1/) |
 | `ai-dynamo-runtime==0.8.1` | Core Python bindings for Dynamo runtime | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo-runtime/0.8.1/) |
 | `kvbm==0.8.1` | KV Block Manager for disaggregated KV cache | `3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/kvbm/0.8.1/) |
 
@@ -75,7 +75,7 @@ We recommend using the TensorRT-LLM NGC container instead of the `ai-dynamo[trtl
 
 ### Container Images (NGC)
 
-> For detailed run instructions, see the [Container README](https://github.com/ai-dynamo/dynamo/tree/main/container/README.md) or backend-specific guides: [vLLM](../backends/vllm/README.md) | [SGLang](../backends/sglang/README.md) | [TensorRT-LLM](../backends/trtllm/README.md)
+> For detailed run instructions, see the [Container README](https://github.com/ai-dynamo/dynamo/tree/main/container/README.md) or backend-specific guides: [SGLang](../backends/sglang/README.md) | [TensorRT-LLM](../backends/trtllm/README.md) | [vLLM](../backends/vllm/README.md)
 
 ```bash
 # Runtime containers
@@ -158,7 +158,7 @@ For a complete list of known issues, refer to the release notes for each patch:
 
 - **v0.8.1.post1 Patch**: Updated TRT-LLM to `v1.2.0rc6.post2` (PyPI wheels and TRT-LLM container only)
 - **Standalone Frontend Container**: `dynamo-frontend` added in v0.8.0
-- **CUDA 13 Runtimes**: Experimental CUDA 13 runtime for vLLM and SGLang in v0.8.0
+- **CUDA 13 Runtimes**: Experimental CUDA 13 runtime for SGLang and vLLM in v0.8.0
 - **New Rust Crates**: `dynamo-memory` and `dynamo-config` added in v0.8.0
 
 ### GitHub Releases

--- a/docs/pages/reference/support-matrix.md
+++ b/docs/pages/reference/support-matrix.md
@@ -14,23 +14,23 @@ This document provides the support matrix for Dynamo, including hardware, softwa
 
 The following table shows the backend framework versions included with each Dynamo release:
 
-| **Dynamo** | **vLLM** | **SGLang** | **TensorRT-LLM** | **NIXL** |
+| **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.15.1` | `0.5.8` | `1.3.0rc3` | `0.9.0` |
-| **v1.0.0** *(planned)* | `0.15.0` | *Latest as of 2/17* | *Latest as of 2/17* | `0.10.0` |
-| **v0.9.1** *(in progress)* | `0.14.1` | `0.5.8` | `1.3.0rc3` | `0.9.0` |
-| **v0.9.0** *(in progress)* | `0.14.1` | `0.5.8` | `1.3.0rc1` | `0.9.0` |
-| **v0.8.1.post3** *(in progress)* | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post3` | `0.8.0` |
-| **v0.8.1.post2** | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post2` | `0.8.0` |
-| **v0.8.1.post1** | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post1` | `0.8.0` |
-| **v0.8.1** | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post1` | `0.8.0` |
-| **v0.8.0** | `0.12.0` | `0.5.6.post2` | `1.2.0rc6.post1` | `0.8.0` |
-| **v0.7.1** | `0.11.0` | `0.5.4.post3` | `1.2.0rc3` | `0.8.0` |
-| **v0.7.0.post1** | `0.11.0` | `0.5.4.post3` | `1.2.0rc3` | `0.8.0` |
-| **v0.7.0** | `0.11.0` | `0.5.4.post3` | `1.2.0rc2` | `0.8.0` |
-| **v0.6.1.post1** | `0.11.0` | `0.5.3.post2` | `1.1.0rc5` | `0.6.0` |
-| **v0.6.1** | `0.11.0` | `0.5.3.post2` | `1.1.0rc5` | `0.6.0` |
-| **v0.6.0** | `0.11.0` | `0.5.3.post2` | `1.1.0rc5` | `0.6.0` |
+| **main (ToT)** | `0.5.8` | `1.3.0rc3` | `0.15.1` | `0.9.0` |
+| **v1.0.0** *(planned)* | *Latest as of 2/17* | *Latest as of 2/17* | `0.15.0` | `0.10.0` |
+| **v0.9.1** *(in progress)* | `0.5.8` | `1.3.0rc3` | `0.14.1` | `0.9.0` |
+| **v0.9.0** *(in progress)* | `0.5.8` | `1.3.0rc1` | `0.14.1` | `0.9.0` |
+| **v0.8.1.post3** *(in progress)* | `0.5.6.post2` | `1.2.0rc6.post3` | `0.12.0` | `0.8.0` |
+| **v0.8.1.post2** | `0.5.6.post2` | `1.2.0rc6.post2` | `0.12.0` | `0.8.0` |
+| **v0.8.1.post1** | `0.5.6.post2` | `1.2.0rc6.post1` | `0.12.0` | `0.8.0` |
+| **v0.8.1** | `0.5.6.post2` | `1.2.0rc6.post1` | `0.12.0` | `0.8.0` |
+| **v0.8.0** | `0.5.6.post2` | `1.2.0rc6.post1` | `0.12.0` | `0.8.0` |
+| **v0.7.1** | `0.5.4.post3` | `1.2.0rc3` | `0.11.0` | `0.8.0` |
+| **v0.7.0.post1** | `0.5.4.post3` | `1.2.0rc3` | `0.11.0` | `0.8.0` |
+| **v0.7.0** | `0.5.4.post3` | `1.2.0rc2` | `0.11.0` | `0.8.0` |
+| **v0.6.1.post1** | `0.5.3.post2` | `1.1.0rc5` | `0.11.0` | `0.6.0` |
+| **v0.6.1** | `0.5.3.post2` | `1.1.0rc5` | `0.11.0` | `0.6.0` |
+| **v0.6.0** | `0.5.3.post2` | `1.1.0rc5` | `0.11.0` | `0.6.0` |
 
 ### Version Labels
 
@@ -44,14 +44,14 @@ The following table shows the backend framework versions included with each Dyna
 
 ### CUDA Versions by Backend
 
-| **Dynamo** | **vLLM** | **SGLang** | **TensorRT-LLM** | **Notes** |
+| **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **Notes** |
 | :--- | :--- | :--- | :--- | :--- |
-| **v0.8.1** | `12.9`, `13.0` | `12.9`, `13.0` | `13.0` | Experimental vLLM/SGLang CUDA 13 support |
-| **v0.8.0** | `12.9`, `13.0` | `12.9`, `13.0` | `13.0` | Experimental vLLM/SGLang CUDA 13 support |
-| **v0.7.1** | `12.9` | `12.8` | `13.0` | |
-| **v0.7.0** | `12.8` | `12.9` | `13.0` | TensorRT-LLM CUDA 13 support - CUDA 12.9 deprecated |
-| **v0.6.1** | `12.8` | `12.9` | `12.9` | |
-| **v0.6.0** | `12.8` | `12.8` | `12.9` | |
+| **v0.8.1** | `12.9`, `13.0` | `13.0` | `12.9`, `13.0` | Experimental SGLang/vLLM CUDA 13 support |
+| **v0.8.0** | `12.9`, `13.0` | `13.0` | `12.9`, `13.0` | Experimental SGLang/vLLM CUDA 13 support |
+| **v0.7.1** | `12.8` | `13.0` | `12.9` | |
+| **v0.7.0** | `12.9` | `13.0` | `12.8` | TensorRT-LLM CUDA 13 support - CUDA 12.9 deprecated |
+| **v0.6.1** | `12.9` | `12.9` | `12.8` | |
+| **v0.6.0** | `12.8` | `12.9` | `12.8` | |
 
 Patch versions (e.g., v0.8.1.post1, v0.7.0.post1) have the same CUDA support as their base version.
 
@@ -101,22 +101,22 @@ Dynamo container images include CUDA toolkit libraries. The host machine must ha
 
 | Dynamo Version | Backend | CUDA Toolkit | Min Driver (Linux) | Min Driver (Windows) | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| **0.8.1** | **vLLM** | 12.9 | 575.xx+ | 576.xx+ | |
-| | | 13.0 | 580.xx+ | 581.xx+ | Experimental |
-| | **SGLang** | 12.9 | 575.xx+ | 576.xx+ | |
+| **0.8.1** | **SGLang** | 12.9 | 575.xx+ | 576.xx+ | |
 | | | 13.0 | 580.xx+ | 581.xx+ | Experimental |
 | | **TensorRT-LLM** | 13.0 | 580.xx+ | 581.xx+ | |
-| **0.8.0** | **vLLM** | 12.9 | 575.xx+ | 576.xx+ | |
+| | **vLLM** | 12.9 | 575.xx+ | 576.xx+ | |
 | | | 13.0 | 580.xx+ | 581.xx+ | Experimental |
-| | **SGLang** | 12.9 | 575.xx+ | 576.xx+ | |
+| **0.8.0** | **SGLang** | 12.9 | 575.xx+ | 576.xx+ | |
 | | | 13.0 | 580.xx+ | 581.xx+ | Experimental |
 | | **TensorRT-LLM** | 13.0 | 580.xx+ | 581.xx+ | |
-| **0.7.1** | **vLLM** | 12.9 | 575.xx+ | 576.xx+ | |
-| | **SGLang** | 12.8 | 570.xx+ | 571.xx+ | |
+| | **vLLM** | 12.9 | 575.xx+ | 576.xx+ | |
+| | | 13.0 | 580.xx+ | 581.xx+ | Experimental |
+| **0.7.1** | **SGLang** | 12.8 | 570.xx+ | 571.xx+ | |
 | | **TensorRT-LLM** | 13.0 | 580.xx+ | 581.xx+ | |
-| **0.7.0** | **vLLM** | 12.8 | 570.xx+ | 571.xx+ | |
-| | **SGLang** | 12.9 | 575.xx+ | 576.xx+ | |
+| | **vLLM** | 12.9 | 575.xx+ | 576.xx+ | |
+| **0.7.0** | **SGLang** | 12.9 | 575.xx+ | 576.xx+ | |
 | | **TensorRT-LLM** | 13.0 | 580.xx+ | 581.xx+ | |
+| | **vLLM** | 12.8 | 570.xx+ | 571.xx+ | |
 
 Experimental CUDA 13 images are not published for all versions. Check [Release Artifacts](release-artifacts.md) for availability.
 

--- a/docs/pages/templates/README.md
+++ b/docs/pages/templates/README.md
@@ -30,7 +30,7 @@ Templates for creating consistent Dynamo documentation.
 └──────────────────────────────────────────────────────────────┘
 ```
 
-### Backends (vLLM, SGLang, TRT-LLM)
+### Backends (SGLang, TRT-LLM, vLLM)
 
 ```
 ┌─────────────────────────────────────────────────────┐

--- a/lib/kv-router/README.md
+++ b/lib/kv-router/README.md
@@ -38,7 +38,7 @@ block2 in B: seq_hash = hash(hash(hash(block0') || block1') || block2) = 0x2222
 
 > **Important: Engine-Provided Hashes**
 >
-> In practice, the `ExternalSequenceBlockHash` may come directly from the inference engine (e.g., vLLM, TensorRT-LLM) using a rolling hash algorithm that we don't know or control. The engine computes these hashes internally and reports them via KV cache events.
+> In practice, the `ExternalSequenceBlockHash` may come directly from the inference engine (e.g., TensorRT-LLM, vLLM) using a rolling hash algorithm that we don't know or control. The engine computes these hashes internally and reports them via KV cache events.
 >
 > **LoRA identity**: The engine is responsible for incorporating the LoRA adapter identity into the `ExternalSequenceBlockHash` before emitting KV events. Dynamo does not add LoRA information at the router layer. For example, vLLM does this via `_gen_lora_extra_hash_keys`, which appends the LoRA ID as extra keys when calling `hash_block_tokens(..., extra_keys)`. Any engine integrating with the KV router must follow the same convention to ensure correct cache isolation between LoRA adapters.
 >


### PR DESCRIPTION
## Summary
- Standardize backend ordering to alphabetical (SGLang, TensorRT-LLM, vLLM) across all user-facing documentation
- Applies to inline text, table columns (with row data swapped), enum listings, and CLI help strings
- Covers `docs/`, `fern/pages/`, root `README.md`, `container/README.md`, and `recipes/`

## Changes by category

**Inline text (prose, lists, help strings):** ~45 files  
Reorder backend names wherever they appear together — e.g. "vLLM, SGLang, TRT-LLM" becomes "SGLang, TRT-LLM, vLLM"

**Table column reordering (headers + all row data):** ~14 files  
- `docs/reference/feature-matrix.md` and fern mirror — Quick Comparison table
- `docs/reference/support-matrix.md` and fern mirror — Backend Dependencies + CUDA Versions tables
- `docs/features/disaggregated_serving/README.md` and fern mirror — GPU Systems table
- `docs/components/profiler/README.md` and fern mirror — Feature Matrix table
- `docs/features/multimodal/README.md` and fern mirror — Input Format Support table

## Test plan
- [ ] Verify rendered docs site shows correct data in reordered tables
- [ ] Spot-check feature-matrix and support-matrix tables for correct checkmark/version alignment

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Standardized the ordering of supported inference engines across documentation and reference materials to consistently present them as: SGLang, TensorRT-LLM, and vLLM.

* **Chores**
  * Updated Kubernetes CRD field enumerations for backend framework selection to reflect the new canonical backend order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->