### PR TITLE
docs: sync fern/ with local indexer default changes from #5941

### DIFF
--- a/fern/pages/design-docs/router-design.md
+++ b/fern/pages/design-docs/router-design.md
@@ -146,16 +146,20 @@ Each event carries a unique router ID to prevent self-event processing. This asy
 
 The router supports two event transport modes for KV cache state synchronization:
 
-- **JetStream (default)**: Persistent event stream with durable consumers. State persists across router restarts via snapshots in NATS object store. Best for production with multi-replica consistency.
+- **NATS Core / Event Plane with Local Indexer (default)**: Fire-and-forget pub/sub where workers maintain local radix trees (enabled by default). Router rebuilds state by querying workers on startup. Lower latency, simpler setup. Works with both NATS Core and ZMQ event planes.
 
-- **NATS Core with Local Indexer** (`--enable-local-indexer` on workers): Fire-and-forget pub/sub where workers maintain local radix trees. Router rebuilds state by querying workers on startup. Lower latency, simpler setup.
+- **JetStream** (`--durable-kv-events` on **both** frontend **and** workers): Persistent event stream with durable consumers. State persists across router restarts via snapshots in NATS object store. Best for production with multi-replica consistency. **Important:** Both the frontend and all workers must specify `--durable-kv-events` for JetStream mode to work correctly.
 
-### JetStream Mode
+### JetStream Mode (Opt-in)
 
 KV events are sent to a persistent NATS JetStream. Each KV router/indexer replica acts as a durable consumer, pulling messages from this shared stream. This architecture ensures consistency across router replicas and persistence across restarts.
 
 - **Best for**: Production deployments requiring durability and multi-replica router consistency
 - **Tradeoffs**: Requires JetStream setup; slightly higher latency due to persistence guarantees
+- **Enable with**: `--durable-kv-events` flag on **both** the frontend **and** all workers
+
+> [!Note]
+> **Both frontend and workers must specify `--durable-kv-events`** for JetStream mode to work correctly. The frontend uses this flag to consume from JetStream, while workers use it to publish to JetStream instead of the local indexer.
 
 ```mermaid
 graph TD
@@ -197,13 +201,13 @@ graph TD
     linkStyle 0,1,2,3,4,5 stroke:#2196f3,stroke-width:2px
 ```
 
-### NATS Core with Local Indexer
+### NATS Core / Event Plane with Local Indexer (Default)
 
-When workers are started with `--enable-local-indexer`, each worker maintains its own local radix tree (local indexer) and publishes events over NATS Core (fire-and-forget pub/sub) instead of JetStream. Each worker assigns monotonically increasing event IDs to its events. The router detects gaps in event sequences and recovers missed events by querying the worker's local indexer directly.
+By default, workers have local indexer enabled. Each worker maintains its own local radix tree (local indexer) and publishes events over the generic event plane (NATS Core or ZMQ, depending on `--event-plane`). Each worker assigns monotonically increasing event IDs to its events. The router detects gaps in event sequences and recovers missed events by querying the worker's local indexer directly.
 
-- **Best for**: Lower-latency setups; simpler deployments without JetStream; single-router scenarios
+- **Best for**: Lower-latency setups; simpler deployments without JetStream; single-router scenarios; deployments without NATS (using ZMQ event plane)
 - **Tradeoffs**: State persists on workers (not centralized); recovery depends on workers being available
-- **Enable with**: `--enable-local-indexer` flag on workers (vLLM, mocker)
+- **Switch to JetStream**: Use `--durable-kv-events` flag on **both** workers (vLLM, SGLang, TRT-LLM, mocker) **and** frontend
 
 ```mermaid
 graph TD
@@ -251,7 +255,7 @@ graph TD
 - When a worker is removed, the router removes all its blocks from the global radix tree
 
 >[!Note]
-> The router automatically selects the transport mode based on worker configuration. If all connected workers have `enable_local_indexer=true`, the router uses NATS Core mode. Otherwise, it uses JetStream mode.
+> By default, all workers have `enable_local_indexer=true`, so the router uses NATS Core / Event Plane mode with local indexer. To use JetStream mode instead, specify `--durable-kv-events` on **both** the frontend and all workers.
 
 ### Local Active Block Management with Replica Sync
 

--- a/fern/pages/integrations/kv-events-custom-engines.md
+++ b/fern/pages/integrations/kv-events-custom-engines.md
@@ -89,7 +89,6 @@ class CustomEnginePublisher:
             worker_id=worker_id,
             kv_block_size=block_size,
             dp_rank=dp_rank,
-            enable_local_indexer=False,
         )
 
     def on_blocks_stored(self, token_ids: list[int], block_hashes: list[int],
@@ -196,7 +195,6 @@ config = ZmqKvEventPublisherConfig(
     kv_block_size=block_size,
     zmq_endpoint="tcp://127.0.0.1:5557",  # Where your engine publishes
     zmq_topic="",                          # Subscribe to all topics
-    enable_local_indexer=False,
 )
 
 # Create publisher - it automatically subscribes to ZMQ and forwards to NATS


### PR DESCRIPTION
## Summary
- Sync 2 fern files that were missed when PR #5941 updated `docs/` to make local indexers the default event transport mode
- `fern/pages/design-docs/router-design.md`: flip default from JetStream to local indexer, update `--enable-local-indexer` references to `--durable-kv-events`, add ZMQ event plane mention
- `fern/pages/integrations/kv-events-custom-engines.md`: remove deprecated `enable_local_indexer=False` parameter from code examples

## Details
PR #5941 changed the default event transport from JetStream to local indexer mode and renamed `--enable-local-indexer` to `--durable-kv-events` (inverted semantics). The `docs/` files were updated in that PR, but these two `fern/` files were not synced:

1. **`fern/pages/design-docs/router-design.md`** — mirrors changes from `docs/design_docs/router_design.md`:
   - Reorders transport modes to list local indexer first (as default)
   - Renames JetStream section to "JetStream Mode (Opt-in)"
   - Updates flag references from `--enable-local-indexer` to `--durable-kv-events`
   - Adds note about ZMQ event plane support
   - Adds important note that both frontend and workers must specify `--durable-kv-events`

2. **`fern/pages/integrations/kv-events-custom-engines.md`** — mirrors changes from `docs/integrations/kv_events_custom_engines.md`:
   - Removes `enable_local_indexer=False` from `KvEventPublisher` constructor example
   - Removes `enable_local_indexer=False` from `ZmqKvEventPublisherConfig` example

## Where should the reviewer start?
`fern/pages/design-docs/router-design.md` has the bulk of the changes.

## Related Issues
Follow-up to #5941

## Test Plan
- [ ] CI passes
- [ ] Fern files match corresponding `docs/` content

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated default transport mode configuration: NATS Core with Local Indexer is now enabled by default
  * JetStream is now opt-in; requires explicit flag configuration on both frontend and workers
  * Added comprehensive configuration guidance for transport mode setup and switching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->