### PR TITLE
fix: add ephemeral-storage resource limits to EPP deployment

### DIFF
--- a/recipes/llama-3-70b/vllm/agg/gaie/k8s-manifests/epp/deployment.yaml
+++ b/recipes/llama-3-70b/vllm/agg/gaie/k8s-manifests/epp/deployment.yaml
@@ -44,9 +44,11 @@ spec:
             requests:
               memory: "1Gi"
               cpu: "1"
+              ephemeral-storage: "256Mi"
             limits:
               memory: "2Gi"
               cpu: "2"
+              ephemeral-storage: "1Gi"
           args:
             - -pool-name
             - "llama3-70b-agg-pool"


### PR DESCRIPTION
## Summary
- Add ephemeral-storage requests (256Mi) and limits (1Gi) to EPP deployment
- Prevents unbounded ephemeral storage consumption on cluster nodes

## Test plan
- [ ] Verify EPP pod starts successfully with new resource constraints
- [ ] Confirm no OOMKilled or storage eviction issues under normal operation


Made with [Cursor](https://cursor.com)