### PR TITLE
fix: add watchdog timeout for sglang dsr1 recipe

### DIFF
--- a/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-16gpu/deploy.yaml
@@ -67,6 +67,8 @@ spec:
             - --host
             - 0.0.0.0
             - --prefill-round-robin-balance
+            - --watchdog-timeout
+            - "3600"
     prefill:
       componentType: worker
       subComponentType: prefill
@@ -110,3 +112,5 @@ spec:
             - 0.0.0.0
             - --load-balance-method
             - round_robin
+            - --watchdog-timeout
+            - "3600"

--- a/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
+++ b/recipes/deepseek-r1/sglang/disagg-8gpu/deploy.yaml
@@ -64,6 +64,8 @@ spec:
             - --host
             - 0.0.0.0
             - --prefill-round-robin-balance
+            - --watchdog-timeout
+            - "3600"
     prefill:
       componentType: worker
       subComponentType: prefill
@@ -104,3 +106,5 @@ spec:
             - 0.0.0.0
             - --load-balance-method
             - round_robin
+            - --watchdog-timeout
+            - "3600"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added watchdog timeout configuration to DeepSeek-R1 deployment setups for both 8-GPU and 16-GPU environments. This setting applies to decode and prefill container configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->