### PR TITLE
docs(responses): add design documentation for stateful responses

### DIFF
--- a/docs/design_docs/stateful_responses_custom_providers.md
+++ b/docs/design_docs/stateful_responses_custom_providers.md
@@ -1,0 +1,806 @@
+# Custom Auth and Storage Providers for Stateful Responses
+
+**Quick Start Guide for Bringing Your Own Implementation**
+
+This guide shows how to implement custom authentication and storage backends for Dynamo's stateful Responses API.
+
+---
+
+## Overview
+
+Dynamo provides **trait-based interfaces** for both authentication and storage, allowing you to plug in your existing infrastructure:
+
+```
+┌─────────────────────────────────────────────┐
+│          Your Custom Systems                │
+│  ┌──────────────┐      ┌──────────────┐    │
+│  │ Your Auth    │      │ Your Storage │    │
+│  │ (LDAP, SSO)  │      │ (DB, S3)     │    │
+│  └──────────────┘      └──────────────┘    │
+│         │                       │           │
+│         v                       v           │
+│  ┌──────────────┐      ┌──────────────┐    │
+│  │ AuthProvider │      │ResponseStorage│   │
+│  │   Trait      │      │    Trait      │    │
+│  └──────────────┘      └──────────────┘    │
+└─────────────────────────────────────────────┘
+                    │
+                    v
+            ┌──────────────┐
+            │    Dynamo    │
+            │  HTTP Server │
+            └──────────────┘
+```
+
+---
+
+## Custom Authentication Provider
+
+### Step 1: Implement the `AuthProvider` Trait
+
+Create `lib/custom_auth/src/lib.rs`:
+
+```rust
+use dynamo_llm::http::auth::{AuthProvider, AuthContext, AuthError, Role};
+use async_trait::async_trait;
+use axum::http::HeaderMap;
+use std::collections::HashMap;
+
+pub struct MyAuthProvider {
+    // Your auth system config
+    ldap_server: String,
+    oauth_client_id: String,
+    // etc.
+}
+
+impl MyAuthProvider {
+    pub fn new(config: MyAuthConfig) -> Self {
+        Self {
+            ldap_server: config.ldap_server,
+            oauth_client_id: config.oauth_client_id,
+        }
+    }
+}
+
+#[async_trait]
+impl AuthProvider for MyAuthProvider {
+    async fn authenticate(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthContext, AuthError> {
+        // 1. Extract credentials from headers
+        let token = headers
+            .get("Authorization")
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.strip_prefix("Bearer "))
+            .ok_or(AuthError::MissingCredentials)?;
+
+        // 2. Validate with your auth system (LDAP, OAuth, etc.)
+        let user_info = self.validate_token(token).await
+            .map_err(|e| AuthError::InvalidCredentials)?;
+
+        // 3. Return auth context
+        Ok(AuthContext {
+            tenant_id: user_info.organization_id,
+            user_id: user_info.user_id,
+            role: match user_info.role.as_str() {
+                "admin" => Role::Admin,
+                "service" => Role::ServiceAccount,
+                _ => Role::User,
+            },
+            permissions: vec![],  // Optional: map from your permissions
+            metadata: HashMap::new(),
+        })
+    }
+
+    async fn authorize(
+        &self,
+        context: &AuthContext,
+        resource: &str,
+        action: &str,
+    ) -> Result<bool, AuthError> {
+        // Optional: Implement fine-grained authorization
+        // For example, check if user can delete a specific response
+        Ok(true)
+    }
+}
+
+impl MyAuthProvider {
+    async fn validate_token(&self, token: &str) -> Result<UserInfo, MyAuthError> {
+        // Your validation logic:
+        // - LDAP bind
+        // - OAuth token introspection
+        // - JWT verification
+        // - Database lookup
+        // - etc.
+        todo!()
+    }
+}
+
+struct UserInfo {
+    user_id: String,
+    organization_id: String,
+    role: String,
+}
+```
+
+### Step 2: Register Your Provider
+
+In your main.rs or entrypoint:
+
+```rust
+use std::sync::Arc;
+use dynamo_llm::http::service::service_v2::State;
+use my_auth_provider::MyAuthProvider;
+
+#[tokio::main]
+async fn main() {
+    // 1. Load config
+    let auth_config = MyAuthConfig::from_env();
+
+    // 2. Create your auth provider
+    let auth_provider: Arc<dyn AuthProvider> = Arc::new(
+        MyAuthProvider::new(auth_config)
+    );
+
+    // 3. Pass to Dynamo state
+    let state = State::builder()
+        .auth_provider(auth_provider)
+        .build();
+
+    // 4. Start server
+    dynamo_llm::entrypoint::run(state).await;
+}
+```
+
+---
+
+## Custom Storage Backend
+
+### Step 1: Implement the `ResponseStorage` Trait
+
+Create `lib/custom_storage/src/lib.rs`:
+
+```rust
+use dynamo_llm::storage::{
+    ResponseStorage, StoredResponse, ResponseQuery, StorageError
+};
+use dynamo_llm::http::auth::AuthContext;
+use async_trait::async_trait;
+use std::time::Duration;
+
+pub struct MyStorageBackend {
+    // Your storage config
+    db_pool: sqlx::PgPool,
+    s3_client: aws_sdk_s3::Client,
+}
+
+impl MyStorageBackend {
+    pub fn new(db_pool: sqlx::PgPool, s3_client: aws_sdk_s3::Client) -> Self {
+        Self { db_pool, s3_client }
+    }
+}
+
+#[async_trait]
+impl ResponseStorage for MyStorageBackend {
+    async fn store_response(
+        &self,
+        response: Response,
+        auth: &AuthContext,
+        ttl: Option<Duration>,
+    ) -> Result<String, StorageError> {
+        // 1. Create stored response with metadata
+        let stored = StoredResponse {
+            response_id: response.id.clone(),
+            tenant_id: auth.tenant_id.clone(),
+            user_id: auth.user_id.clone(),
+            response,
+            created_at: unix_timestamp(),
+            updated_at: unix_timestamp(),
+            accessed_at: unix_timestamp(),
+            expires_at: ttl.map(|d| unix_timestamp() + d.as_secs()),
+            permissions: None,
+        };
+
+        // 2. Serialize response
+        let data = serde_json::to_vec(&stored)
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+        let size_bytes = data.len();
+        let mut s3_key: Option<String> = None;
+
+        // 3. Store in your backend
+        // Option A: Store in S3 for large responses
+        if size_bytes > 1_000_000 {  // 1MB threshold
+            let key = format!(
+                "{}/responses/{}.json",
+                auth.tenant_id,
+                stored.response_id
+            );
+            self.s3_client
+                .put_object()
+                .bucket("dynamo-responses")
+                .key(&key)
+                .body(data.clone().into())
+                .send()
+                .await
+                .map_err(|e| StorageError::BackendError(e.to_string()))?;
+            s3_key = Some(key);
+        }
+
+        // Option B: Store metadata in Postgres for fast queries
+        sqlx::query(
+            r#"
+            INSERT INTO responses (
+                response_id, tenant_id, user_id,
+                s3_key, size_bytes, created_at, expires_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            "#
+        )
+        .bind(&stored.response_id)
+        .bind(&auth.tenant_id)
+        .bind(&auth.user_id)
+        .bind(s3_key.as_deref())
+        .bind(size_bytes as i64)
+        .bind(stored.created_at as i64)
+        .bind(stored.expires_at.map(|e| e as i64))
+        .execute(&self.db_pool)
+        .await
+        .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        Ok(stored.response_id)
+    }
+
+    async fn get_response(
+        &self,
+        response_id: &str,
+        auth: &AuthContext,
+    ) -> Result<StoredResponse, StorageError> {
+        // 1. Query metadata from Postgres
+        let row = sqlx::query_as::<_, ResponseMetadata>(
+            r#"
+            SELECT response_id, tenant_id, user_id, s3_key,
+                   created_at, accessed_at, expires_at
+            FROM responses
+            WHERE response_id = $1 AND tenant_id = $2
+            "#
+        )
+        .bind(response_id)
+        .bind(&auth.tenant_id)
+        .fetch_optional(&self.db_pool)
+        .await
+        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .ok_or_else(|| StorageError::NotFound(response_id.to_string()))?;
+
+        // 2. Verify access (tenant isolation)
+        if row.tenant_id != auth.tenant_id {
+            return Err(StorageError::AccessDenied("Tenant mismatch".to_string()));
+        }
+
+        // 3. Check if expired
+        if let Some(expires_at) = row.expires_at {
+            if expires_at < unix_timestamp() {
+                return Err(StorageError::NotFound("Response expired".to_string()));
+            }
+        }
+
+        // 4. Fetch from S3
+        let obj = self.s3_client
+            .get_object()
+            .bucket("dynamo-responses")
+            .key(&row.s3_key)
+            .send()
+            .await
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        let data = obj.body.collect().await
+            .map_err(|e| StorageError::BackendError(e.to_string()))?
+            .into_bytes();
+
+        // 5. Deserialize
+        let stored: StoredResponse = serde_json::from_slice(&data)
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        Ok(stored)
+    }
+
+    async fn delete_response(
+        &self,
+        response_id: &str,
+        auth: &AuthContext,
+    ) -> Result<(), StorageError> {
+        // Get metadata to verify ownership and get S3 key
+        let row = sqlx::query_as::<_, ResponseMetadata>(
+            "SELECT * FROM responses WHERE response_id = $1 AND tenant_id = $2"
+        )
+        .bind(response_id)
+        .bind(&auth.tenant_id)
+        .fetch_optional(&self.db_pool)
+        .await
+        .map_err(|e| StorageError::BackendError(e.to_string()))?
+        .ok_or_else(|| StorageError::NotFound(response_id.to_string()))?;
+
+        // Verify user is owner (or admin)
+        if row.user_id != auth.user_id && auth.role != Role::Admin {
+            return Err(StorageError::AccessDenied("Not owner".to_string()));
+        }
+
+        // Delete from S3
+        self.s3_client
+            .delete_object()
+            .bucket("dynamo-responses")
+            .key(&row.s3_key)
+            .send()
+            .await
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        // Delete from Postgres
+        sqlx::query("DELETE FROM responses WHERE response_id = $1")
+            .bind(response_id)
+            .execute(&self.db_pool)
+            .await
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn list_responses(
+        &self,
+        query: ResponseQuery,
+        auth: &AuthContext,
+    ) -> Result<Vec<StoredResponse>, StorageError> {
+        // Build dynamic query based on filters
+        let mut sql = String::from(
+            "SELECT response_id FROM responses WHERE tenant_id = $1"
+        );
+
+        if let Some(user_id) = &query.user_id {
+            sql.push_str(" AND user_id = $2");
+        }
+
+        if let Some(created_after) = query.created_after {
+            sql.push_str(" AND created_at > $3");
+        }
+
+        sql.push_str(" ORDER BY created_at DESC");
+
+        if let Some(limit) = query.limit {
+            sql.push_str(&format!(" LIMIT {}", limit));
+        }
+
+        // Execute query
+        let rows = sqlx::query_as::<_, (String,)>(&sql)
+            .bind(&auth.tenant_id)
+            .fetch_all(&self.db_pool)
+            .await
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        // Fetch full responses (or just return IDs for efficiency)
+        let mut responses = Vec::new();
+        for (response_id,) in rows {
+            if let Ok(stored) = self.get_response(&response_id, auth).await {
+                responses.push(stored);
+            }
+        }
+
+        Ok(responses)
+    }
+
+    async fn touch_response(
+        &self,
+        response_id: &str,
+        auth: &AuthContext,
+    ) -> Result<(), StorageError> {
+        sqlx::query(
+            "UPDATE responses SET accessed_at = $1
+             WHERE response_id = $2 AND tenant_id = $3"
+        )
+        .bind(unix_timestamp() as i64)
+        .bind(response_id)
+        .bind(&auth.tenant_id)
+        .execute(&self.db_pool)
+        .await
+        .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct ResponseMetadata {
+    response_id: String,
+    tenant_id: String,
+    user_id: String,
+    s3_key: String,
+    created_at: i64,
+    accessed_at: i64,
+    expires_at: Option<i64>,
+}
+```
+
+### Step 2: Register Your Storage Backend
+
+```rust
+use my_storage_backend::MyStorageBackend;
+
+#[tokio::main]
+async fn main() {
+    // 1. Setup your storage
+    let db_pool = sqlx::PgPool::connect(&config.database_url).await?;
+    let s3_client = aws_sdk_s3::Client::new(&aws_config);
+
+    // 2. Create storage backend
+    let storage: Arc<dyn ResponseStorage> = Arc::new(
+        MyStorageBackend::new(db_pool, s3_client)
+    );
+
+    // 3. Pass to Dynamo state
+    let state = State::builder()
+        .auth_provider(auth_provider)
+        .response_storage(storage)
+        .build();
+
+    dynamo_llm::entrypoint::run(state).await;
+}
+```
+
+---
+
+## Example: LDAP Auth + PostgreSQL Storage
+
+Complete example combining custom auth and storage:
+
+```rust
+// main.rs
+use std::sync::Arc;
+
+mod ldap_auth;
+mod postgres_storage;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Load config
+    let config = load_config()?;
+
+    // Setup LDAP auth
+    let auth: Arc<dyn AuthProvider> = Arc::new(
+        ldap_auth::LdapAuthProvider::new(
+            config.ldap_server,
+            config.ldap_bind_dn,
+            config.ldap_bind_password,
+        )
+    );
+
+    // Setup PostgreSQL storage
+    let db_pool = sqlx::PgPool::connect(&config.database_url).await?;
+    let storage: Arc<dyn ResponseStorage> = Arc::new(
+        postgres_storage::PostgresStorage::new(db_pool)
+    );
+
+    // Build Dynamo state with custom providers
+    let state = dynamo_llm::http::service::service_v2::State::builder()
+        .auth_provider(auth)
+        .response_storage(storage)
+        .conversation_storage(storage.clone())  // Can reuse same backend
+        .build();
+
+    // Start server
+    dynamo_llm::entrypoint::run(state).await
+}
+```
+
+---
+
+## Testing Your Custom Providers
+
+### Unit Tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_auth_valid_token() {
+        let provider = MyAuthProvider::new(test_config());
+        let headers = make_headers("Bearer valid_token");
+
+        let result = provider.authenticate(&headers).await;
+        assert!(result.is_ok());
+
+        let context = result.unwrap();
+        assert_eq!(context.tenant_id, "test-tenant");
+    }
+
+    #[tokio::test]
+    async fn test_auth_invalid_token() {
+        let provider = MyAuthProvider::new(test_config());
+        let headers = make_headers("Bearer invalid_token");
+
+        let result = provider.authenticate(&headers).await;
+        assert!(matches!(result, Err(AuthError::InvalidCredentials)));
+    }
+
+    #[tokio::test]
+    async fn test_storage_store_and_retrieve() {
+        let storage = MyStorageBackend::new(test_db_pool()).await;
+        let auth = test_auth_context();
+        let response = test_response();
+
+        // Store
+        let id = storage.store_response(response.clone(), &auth, None).await?;
+
+        // Retrieve
+        let stored = storage.get_response(&id, &auth).await?;
+        assert_eq!(stored.response.id, response.id);
+    }
+
+    #[tokio::test]
+    async fn test_storage_tenant_isolation() {
+        let storage = MyStorageBackend::new(test_db_pool()).await;
+
+        // User A stores response
+        let auth_a = AuthContext { tenant_id: "tenant-a", user_id: "user-1", .. };
+        let id = storage.store_response(test_response(), &auth_a, None).await?;
+
+        // User B from different tenant tries to access
+        let auth_b = AuthContext { tenant_id: "tenant-b", user_id: "user-2", .. };
+        let result = storage.get_response(&id, &auth_b).await;
+
+        assert!(matches!(result, Err(StorageError::NotFound(_))));
+    }
+}
+```
+
+### Integration Tests
+
+```rust
+#[tokio::test]
+async fn test_end_to_end_stateful_request() {
+    // 1. Setup server with custom providers
+    let server = test_server_with_providers(my_auth(), my_storage());
+
+    // 2. First request
+    let response1 = server
+        .post("/v1/responses")
+        .header("Authorization", "Bearer valid_token")
+        .json(&json!({
+            "model": "gpt-4",
+            "input": "What is 2+2?",
+            "store": true
+        }))
+        .await;
+
+    assert_eq!(response1.status(), 200);
+    let resp_id = response1.json::<Response>().await.id;
+
+    // 3. Second request using previous_response_id
+    let response2 = server
+        .post("/v1/responses")
+        .header("Authorization", "Bearer valid_token")
+        .json(&json!({
+            "model": "gpt-4",
+            "previous_response_id": resp_id,
+            "input": "Times 3?"
+        }))
+        .await;
+
+    assert_eq!(response2.status(), 200);
+}
+```
+
+---
+
+## Configuration Options
+
+Environment variables for custom providers:
+
+```bash
+# Tell Dynamo to use custom providers
+DYN_AUTH_PROVIDER=custom
+DYN_STORAGE_PROVIDER=custom
+
+# Your provider-specific config
+MY_LDAP_SERVER=ldap://ldap.example.com
+MY_LDAP_BIND_DN=cn=admin,dc=example,dc=com
+MY_LDAP_BIND_PASSWORD=secret
+
+MY_DB_URL=postgres://user:pass@localhost/dynamo
+MY_S3_BUCKET=dynamo-responses
+MY_S3_REGION=us-west-2
+```
+
+---
+
+## Common Patterns
+
+### 1. Database Schema for Responses
+
+```sql
+-- Postgres example
+CREATE TABLE responses (
+    response_id VARCHAR(64) PRIMARY KEY,
+    tenant_id VARCHAR(64) NOT NULL,
+    user_id VARCHAR(64) NOT NULL,
+
+    -- Store full response or S3 reference
+    response_data JSONB,
+    s3_key VARCHAR(255),
+
+    -- Metadata
+    size_bytes BIGINT,
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL,
+    accessed_at BIGINT NOT NULL,
+    expires_at BIGINT,
+
+    -- Indexes
+    INDEX idx_tenant_user_created (tenant_id, user_id, created_at DESC),
+    INDEX idx_expires (expires_at) WHERE expires_at IS NOT NULL
+);
+
+-- Cleanup job
+CREATE INDEX idx_expired ON responses (expires_at)
+WHERE expires_at < EXTRACT(EPOCH FROM NOW());
+```
+
+### 2. Hybrid Storage (Metadata + Blob)
+
+- **Small responses** (< 1MB): Store in database
+- **Large responses** (> 1MB): Store in S3/blob storage
+- **Metadata**: Always in database for fast queries
+
+### 3. Multi-Region Replication
+
+```rust
+pub struct MultiRegionStorage {
+    primary: Arc<dyn ResponseStorage>,
+    replicas: Vec<Arc<dyn ResponseStorage>>,
+}
+
+#[async_trait]
+impl ResponseStorage for MultiRegionStorage {
+    async fn store_response(...) -> Result<String, StorageError> {
+        // Write to primary
+        let id = self.primary.store_response(...).await?;
+
+        // Async replicate to other regions (fire and forget)
+        for replica in &self.replicas {
+            tokio::spawn(async move {
+                replica.store_response(...).await.ok();
+            });
+        }
+
+        Ok(id)
+    }
+}
+```
+
+---
+
+## Migration Examples
+
+### From Redis to Your Database
+
+```rust
+pub async fn migrate_from_redis_to_postgres(
+    redis: &RedisResponseStorage,
+    postgres: &PostgresStorage,
+) -> Result<usize, MigrationError> {
+    let mut migrated = 0;
+
+    // Scan all Redis keys
+    let keys: Vec<String> = redis.scan("*:responses:*").await?;
+
+    for key in keys {
+        // Get from Redis
+        if let Ok(data) = redis.client.get::<Vec<u8>>(&key).await {
+            // Parse
+            let stored: StoredResponse = serde_json::from_slice(&data)?;
+
+            // Store in Postgres
+            postgres.store_raw(stored).await?;
+
+            migrated += 1;
+        }
+    }
+
+    Ok(migrated)
+}
+```
+
+---
+
+## Performance Tips
+
+### 1. Connection Pooling
+
+```rust
+// Use connection pools for databases
+let db_pool = sqlx::PgPool::builder()
+    .max_connections(100)
+    .min_connections(10)
+    .connect(&db_url)
+    .await?;
+```
+
+### 2. Caching
+
+```rust
+pub struct CachedStorage {
+    backend: Arc<dyn ResponseStorage>,
+    cache: Arc<Cache<String, StoredResponse>>,
+}
+
+#[async_trait]
+impl ResponseStorage for CachedStorage {
+    async fn get_response(...) -> Result<StoredResponse, StorageError> {
+        // Check cache first
+        if let Some(cached) = self.cache.get(response_id) {
+            return Ok(cached);
+        }
+
+        // Fallback to backend
+        let stored = self.backend.get_response(...).await?;
+
+        // Cache for next time
+        self.cache.insert(response_id, stored.clone());
+
+        Ok(stored)
+    }
+}
+```
+
+### 3. Batch Operations
+
+```rust
+async fn list_responses_batch(
+    &self,
+    ids: &[String],
+    auth: &AuthContext,
+) -> Result<Vec<StoredResponse>, StorageError> {
+    // Fetch all in parallel
+    let futures: Vec<_> = ids.iter()
+        .map(|id| self.get_response(id, auth))
+        .collect();
+
+    let results = futures::future::join_all(futures).await;
+
+    // Filter out errors
+    Ok(results.into_iter().filter_map(|r| r.ok()).collect())
+}
+```
+
+---
+
+## Support & Troubleshooting
+
+### Common Issues
+
+1. **"Access Denied" errors**: Check tenant_id matching in auth and storage
+2. **"Not Found" on valid IDs**: Verify tenant isolation isn't blocking access
+3. **Slow queries**: Add database indexes on tenant_id + created_at
+4. **Memory issues**: Use streaming for large responses, store in blob storage
+
+### Debug Logging
+
+Enable verbose logging:
+```bash
+RUST_LOG=dynamo_llm::http::auth=debug,dynamo_llm::storage=debug
+```
+
+### Metrics to Monitor
+
+- Auth failures / success rate
+- Storage latency (p50, p95, p99)
+- Storage errors
+- Tenant isolation violations (should be 0!)
+
+---
+
+## Next Steps
+
+1. **Review the main plan**: [stateful_responses_plan.md](./stateful_responses_plan.md)
+2. **Check existing traits**: Look at `lib/llm/src/http/auth/mod.rs` (once implemented)
+3. **Run examples**: See `examples/custom_providers/` (once added)
+4. **Join discussion**: Linear issue [DYN-2045](https://linear.app/nvidia/issue/DYN-2045)

--- a/docs/design_docs/stateful_responses_plan.md
+++ b/docs/design_docs/stateful_responses_plan.md
@@ -1,0 +1,1032 @@
+# Stateful Responses API Implementation Plan
+
+**Status**: Planning
+**Assignee**: TBD
+**Linear**: [DYN-2045](https://linear.app/nvidia/issue/DYN-2045/investigate-v1responses-being-stateful)
+**Priority**: Medium (requires security architecture first)
+
+## Executive Summary
+
+This document outlines the implementation plan for adding **stateful conversation management** to Dynamo's Responses API. The current implementation (PR #5854) provides a fully functional **stateless** Responses API. This plan adds server-side state management via `previous_response_id`, `conversation` references, and the Conversation API endpoints.
+
+**Key Design Principle**: **Pluggable Architecture** - Allow users to bring their own authentication and storage backends while providing secure defaults.
+
+---
+
+## Background
+
+### Current State (Stateless Mode) ✅
+
+Clients manage conversation history by sending all previous messages in each request:
+
+```json
+{
+  "model": "gpt-4",
+  "input": [
+    {"type": "message", "role": "user", "content": "What's 2+2?"},
+    {"type": "message", "role": "assistant", "content": "4"},
+    {"type": "message", "role": "user", "content": "Times 3?"}
+  ]
+}
+```
+
+**Benefits**: Simple, no server-side state, works today
+**Drawbacks**: High bandwidth, client complexity, no server-side caching optimization
+
+### Target State (Stateful Mode) 🎯
+
+Server manages conversation state; clients send only deltas:
+
+```json
+{
+  "model": "gpt-4",
+  "previous_response_id": "resp_abc123",
+  "input": "Times 3?"
+}
+```
+
+**Benefits**: Lower bandwidth, simplified clients, server-side caching, conversation analytics
+**Drawbacks**: Requires storage, security, and distributed state management
+
+---
+
+## Architecture Overview
+
+### Core Components
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                     HTTP Request                             │
+│                 (with Auth Headers)                          │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+                       v
+┌─────────────────────────────────────────────────────────────┐
+│                 Auth Middleware (Pluggable)                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
+│  │  API Key     │  │     JWT      │  │    mTLS      │      │
+│  │  Provider    │  │   Provider   │  │   Provider   │      │
+│  └──────────────┘  └──────────────┘  └──────────────┘      │
+│                          │                                   │
+│                          v                                   │
+│                   AuthContext { user_id, tenant_id }        │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+                       v
+┌─────────────────────────────────────────────────────────────┐
+│              Response Handler (openai.rs)                    │
+│  - Validate previous_response_id / conversation             │
+│  - Authorize access (tenant + user checks)                  │
+│  - Retrieve stored context from Storage Backend             │
+│  - Merge with new input                                     │
+│  - Process via Chat Completions Engine                      │
+│  - Store response if store=true                             │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+                       v
+┌─────────────────────────────────────────────────────────────┐
+│              Storage Backend (Pluggable)                     │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
+│  │    Redis     │  │   Postgres   │  │   S3 + DDB   │      │
+│  │  (Default)   │  │   (Custom)   │  │   (Custom)   │      │
+│  └──────────────┘  └──────────────┘  └──────────────┘      │
+│                                                              │
+│  Common Interface: ResponseStorage trait                    │
+│  - store_response(response, auth)                           │
+│  - get_response(id, auth)                                   │
+│  - delete_response(id, auth)                                │
+│  - list_responses(filters, auth)                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Phase 1: Pluggable Auth Framework (4 weeks)
+
+### 1.1 Auth Trait Definition (1 week)
+
+**File**: `lib/llm/src/http/auth/mod.rs`
+
+```rust
+/// Authentication context extracted from request
+#[derive(Debug, Clone)]
+pub struct AuthContext {
+    /// Unique tenant identifier for multi-tenancy isolation
+    pub tenant_id: String,
+
+    /// Unique user identifier within the tenant
+    pub user_id: String,
+
+    /// User's role (admin, user, service_account)
+    pub role: Role,
+
+    /// Optional: Fine-grained permissions
+    pub permissions: Vec<Permission>,
+
+    /// Optional: Metadata (IP, user-agent, etc.)
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Role {
+    Admin,
+    User,
+    ServiceAccount,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Permission {
+    ReadResponses,
+    WriteResponses,
+    DeleteResponses,
+    ReadConversations,
+    WriteConversations,
+    DeleteConversations,
+}
+
+/// Trait for authentication providers
+#[async_trait]
+pub trait AuthProvider: Send + Sync {
+    /// Authenticate a request and extract context
+    async fn authenticate(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthContext, AuthError>;
+
+    /// Optional: Validate a specific permission
+    async fn authorize(
+        &self,
+        context: &AuthContext,
+        resource: &str,
+        action: &str,
+    ) -> Result<bool, AuthError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    #[error("Missing authentication credentials")]
+    MissingCredentials,
+
+    #[error("Invalid credentials")]
+    InvalidCredentials,
+
+    #[error("Insufficient permissions: {0}")]
+    Forbidden(String),
+
+    #[error("Authentication provider error: {0}")]
+    ProviderError(String),
+}
+```
+
+### 1.2 Built-in Auth Providers (2 weeks)
+
+#### Option A: API Key Provider (Default)
+
+**File**: `lib/llm/src/http/auth/api_key.rs`
+
+```rust
+pub struct ApiKeyAuthProvider {
+    key_store: Arc<dyn KeyStore>,
+}
+
+#[async_trait]
+pub trait KeyStore: Send + Sync {
+    /// Look up API key and return associated context
+    async fn validate_key(&self, key: &str) -> Result<AuthContext, AuthError>;
+}
+
+/// In-memory key store for testing/development
+pub struct InMemoryKeyStore {
+    keys: HashMap<String, AuthContext>,
+}
+
+/// Redis-backed key store for production
+pub struct RedisKeyStore {
+    client: RedisClient,
+}
+```
+
+**Configuration** (environment variables):
+```bash
+DYN_AUTH_PROVIDER=api_key
+DYN_AUTH_API_KEY_STORE=redis  # or "in_memory" for dev
+DYN_AUTH_REDIS_URL=redis://localhost:6379
+```
+
+#### Option B: JWT Provider
+
+**File**: `lib/llm/src/http/auth/jwt.rs`
+
+```rust
+pub struct JwtAuthProvider {
+    /// Public key for verification (RS256, ES256)
+    public_key: DecodingKey,
+
+    /// Algorithm
+    algorithm: Algorithm,
+
+    /// Expected issuer
+    issuer: String,
+}
+
+impl JwtAuthProvider {
+    /// Extract tenant_id and user_id from JWT claims
+    fn extract_context(&self, claims: &Claims) -> AuthContext {
+        AuthContext {
+            tenant_id: claims.custom.get("tenant_id").unwrap().clone(),
+            user_id: claims.sub.clone(),
+            role: self.parse_role(&claims.custom.get("role")),
+            permissions: self.parse_permissions(&claims.custom),
+            metadata: HashMap::new(),
+        }
+    }
+}
+```
+
+**Configuration**:
+```bash
+DYN_AUTH_PROVIDER=jwt
+DYN_AUTH_JWT_PUBLIC_KEY_PATH=/path/to/public.pem
+DYN_AUTH_JWT_ALGORITHM=RS256
+DYN_AUTH_JWT_ISSUER=https://auth.example.com
+```
+
+#### Option C: Custom Provider (User-Provided)
+
+Allow users to implement their own auth:
+
+```rust
+// User creates lib/custom_auth/my_auth.rs
+pub struct MyCustomAuth {
+    // Custom fields
+}
+
+#[async_trait]
+impl AuthProvider for MyCustomAuth {
+    async fn authenticate(&self, headers: &HeaderMap) -> Result<AuthContext, AuthError> {
+        // Custom logic: LDAP, OAuth, SSO, etc.
+    }
+}
+
+// Register in main.rs
+let auth_provider = Arc::new(MyCustomAuth::new());
+let state = State::new(auth_provider);
+```
+
+### 1.3 Auth Middleware (1 week)
+
+**File**: `lib/llm/src/http/middleware/auth.rs`
+
+```rust
+pub async fn auth_middleware(
+    State(auth_provider): State<Arc<dyn AuthProvider>>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Result<Response, ErrorResponse> {
+    // Extract headers
+    let headers = request.headers();
+
+    // Authenticate
+    let auth_context = auth_provider
+        .authenticate(headers)
+        .await
+        .map_err(|e| match e {
+            AuthError::MissingCredentials | AuthError::InvalidCredentials => {
+                ErrorMessage::unauthorized(e.to_string())
+            }
+            AuthError::Forbidden(msg) => ErrorMessage::forbidden(msg),
+            AuthError::ProviderError(msg) => ErrorMessage::internal_server_error(&msg),
+        })?;
+
+    // Store in request extensions for downstream handlers
+    request.extensions_mut().insert(auth_context);
+
+    Ok(next.run(request).await)
+}
+```
+
+**Apply to routes**:
+```rust
+// In openai.rs
+pub fn responses_router(
+    state: Arc<service_v2::State>,
+    auth_provider: Arc<dyn AuthProvider>,
+) -> Router {
+    Router::new()
+        .route("/v1/responses", post(handler_responses))
+        .layer(middleware::from_fn_state(auth_provider.clone(), auth_middleware))
+        .with_state(state)
+}
+```
+
+---
+
+## Phase 2: Pluggable Storage Backend (4 weeks)
+
+### 2.1 Storage Trait Definition (1 week)
+
+**File**: `lib/llm/src/storage/mod.rs`
+
+```rust
+/// Stored response with metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredResponse {
+    // Identity
+    pub response_id: String,
+    pub tenant_id: String,
+    pub user_id: String,
+
+    // Response data
+    pub response: Response,
+
+    // Timestamps
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub accessed_at: u64,
+    pub expires_at: Option<u64>,
+
+    // Access control (optional)
+    pub permissions: Option<Vec<StoredPermission>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum StoredPermission {
+    Owner,
+    SharedReadOnly { users: Vec<String> },
+    SharedReadWrite { users: Vec<String> },
+}
+
+/// Query filters for listing responses
+#[derive(Debug, Default)]
+pub struct ResponseQuery {
+    pub tenant_id: String,
+    pub user_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub created_after: Option<u64>,
+    pub created_before: Option<u64>,
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+
+/// Trait for response storage backends
+#[async_trait]
+pub trait ResponseStorage: Send + Sync {
+    /// Store a response with auth context
+    async fn store_response(
+        &self,
+        response: Response,
+        auth: &AuthContext,
+        ttl: Option<Duration>,
+    ) -> Result<String, StorageError>;
+
+    /// Retrieve a response by ID
+    async fn get_response(
+        &self,
+        response_id: &str,
+        auth: &AuthContext,
+    ) -> Result<StoredResponse, StorageError>;
+
+    /// Delete a response
+    async fn delete_response(
+        &self,
+        response_id: &str,
+        auth: &AuthContext,
+    ) -> Result<(), StorageError>;
+
+    /// List responses matching filters
+    async fn list_responses(
+        &self,
+        query: ResponseQuery,
+        auth: &AuthContext,
+    ) -> Result<Vec<StoredResponse>, StorageError>;
+
+    /// Update last accessed timestamp
+    async fn touch_response(
+        &self,
+        response_id: &str,
+        auth: &AuthContext,
+    ) -> Result<(), StorageError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("Response not found: {0}")]
+    NotFound(String),
+
+    #[error("Access denied: {0}")]
+    AccessDenied(String),
+
+    #[error("Storage quota exceeded")]
+    QuotaExceeded,
+
+    #[error("Storage backend error: {0}")]
+    BackendError(String),
+}
+```
+
+### 2.2 Built-in Storage Providers (2 weeks)
+
+#### Option A: Redis Storage (Default)
+
+**File**: `lib/llm/src/storage/redis.rs`
+
+```rust
+pub struct RedisResponseStorage {
+    client: RedisClient,
+    encryption: Option<Arc<dyn EncryptionProvider>>,
+    max_response_size: usize,
+}
+
+impl RedisResponseStorage {
+    /// Key format: {tenant_id}:responses:{response_id}
+    fn make_key(&self, tenant_id: &str, response_id: &str) -> String {
+        format!("{}:responses:{}", tenant_id, response_id)
+    }
+
+    /// Secondary index: {tenant_id}:responses:user:{user_id}:list
+    fn make_user_index_key(&self, tenant_id: &str, user_id: &str) -> String {
+        format!("{}:responses:user:{}:list", tenant_id, user_id)
+    }
+}
+
+#[async_trait]
+impl ResponseStorage for RedisResponseStorage {
+    async fn store_response(
+        &self,
+        response: Response,
+        auth: &AuthContext,
+        ttl: Option<Duration>,
+    ) -> Result<String, StorageError> {
+        // Create StoredResponse
+        let stored = StoredResponse {
+            response_id: response.id.clone(),
+            tenant_id: auth.tenant_id.clone(),
+            user_id: auth.user_id.clone(),
+            response,
+            created_at: unix_timestamp(),
+            updated_at: unix_timestamp(),
+            accessed_at: unix_timestamp(),
+            expires_at: ttl.map(|d| unix_timestamp() + d.as_secs()),
+            permissions: None,
+        };
+
+        // Serialize
+        let data = serde_json::to_vec(&stored)
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        // Check size limit
+        if data.len() > self.max_response_size {
+            return Err(StorageError::QuotaExceeded);
+        }
+
+        // Encrypt if provider is configured
+        let final_data = if let Some(enc) = &self.encryption {
+            enc.encrypt(&data, &auth.tenant_id).await?
+        } else {
+            data
+        };
+
+        // Store in Redis
+        let key = self.make_key(&auth.tenant_id, &stored.response_id);
+        let ttl_secs = ttl.map(|d| d.as_secs()).unwrap_or(86400); // 24h default
+
+        self.client.set_ex(&key, final_data, ttl_secs).await
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        // Add to user index
+        let index_key = self.make_user_index_key(&auth.tenant_id, &auth.user_id);
+        self.client.zadd(&index_key, &stored.response_id, unix_timestamp() as f64).await
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        Ok(stored.response_id)
+    }
+
+    async fn get_response(
+        &self,
+        response_id: &str,
+        auth: &AuthContext,
+    ) -> Result<StoredResponse, StorageError> {
+        let key = self.make_key(&auth.tenant_id, response_id);
+
+        // Get from Redis
+        let data: Vec<u8> = self.client.get(&key).await
+            .map_err(|_| StorageError::NotFound(response_id.to_string()))?;
+
+        // Decrypt if needed
+        let decrypted = if let Some(enc) = &self.encryption {
+            enc.decrypt(&data, &auth.tenant_id).await?
+        } else {
+            data
+        };
+
+        // Deserialize
+        let stored: StoredResponse = serde_json::from_slice(&decrypted)
+            .map_err(|e| StorageError::BackendError(e.to_string()))?;
+
+        // Verify tenant isolation (defense in depth)
+        if stored.tenant_id != auth.tenant_id {
+            return Err(StorageError::AccessDenied("Tenant mismatch".to_string()));
+        }
+
+        // Check permissions
+        if !self.can_access(&stored, auth) {
+            return Err(StorageError::AccessDenied("User not authorized".to_string()));
+        }
+
+        Ok(stored)
+    }
+}
+```
+
+**Configuration**:
+```bash
+DYN_STORAGE_PROVIDER=redis
+DYN_STORAGE_REDIS_URL=redis://localhost:6379
+DYN_STORAGE_REDIS_PASSWORD=<secure-password>
+DYN_STORAGE_REDIS_TLS=true
+DYN_STORAGE_MAX_RESPONSE_SIZE_MB=10
+DYN_STORAGE_DEFAULT_TTL_HOURS=24
+DYN_STORAGE_MAX_TTL_HOURS=168  # 7 days
+```
+
+#### Option B: PostgreSQL Storage
+
+**File**: `lib/llm/src/storage/postgres.rs`
+
+```sql
+-- Schema
+CREATE TABLE responses (
+    response_id VARCHAR(64) PRIMARY KEY,
+    tenant_id VARCHAR(64) NOT NULL,
+    user_id VARCHAR(64) NOT NULL,
+    response_data BYTEA NOT NULL,  -- Encrypted JSON
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL,
+    accessed_at BIGINT NOT NULL,
+    expires_at BIGINT,
+
+    -- Indexes for efficient queries
+    INDEX idx_tenant_user (tenant_id, user_id, created_at DESC),
+    INDEX idx_expires (expires_at) WHERE expires_at IS NOT NULL
+);
+```
+
+#### Option C: S3 + DynamoDB
+
+For very large conversations:
+- **S3**: Store response blobs
+- **DynamoDB**: Store metadata and indexes
+
+### 2.3 Encryption Provider (1 week)
+
+**File**: `lib/llm/src/storage/encryption.rs`
+
+```rust
+#[async_trait]
+pub trait EncryptionProvider: Send + Sync {
+    async fn encrypt(&self, data: &[u8], tenant_id: &str) -> Result<Vec<u8>, StorageError>;
+    async fn decrypt(&self, data: &[u8], tenant_id: &str) -> Result<Vec<u8>, StorageError>;
+}
+
+/// AES-256-GCM encryption
+pub struct Aes256GcmProvider {
+    /// Master key for encrypting tenant keys
+    master_key: Key<Aes256Gcm>,
+
+    /// Per-tenant key cache
+    tenant_keys: Arc<DashMap<String, Key<Aes256Gcm>>>,
+}
+
+/// AWS KMS-backed encryption
+pub struct AwsKmsProvider {
+    kms_client: KmsClient,
+    key_id: String,
+}
+```
+
+---
+
+## Phase 3: Response Storage Integration (3 weeks)
+
+### 3.1 Update Response Handler (1 week)
+
+**File**: `lib/llm/src/http/service/openai.rs`
+
+```rust
+async fn handler_responses(
+    State(state): State<Arc<service_v2::State>>,
+    Extension(auth): Extension<AuthContext>,  // From auth middleware
+    Json(request): Json<NvCreateResponse>,
+) -> Result<Response, ErrorResponse> {
+    // Check if previous_response_id is provided
+    if let Some(prev_id) = &request.inner.previous_response_id {
+        // Retrieve previous response from storage
+        let prev_response = state.storage()
+            .get_response(prev_id, &auth)
+            .await
+            .map_err(|e| match e {
+                StorageError::NotFound(_) => ErrorMessage::not_found(),
+                StorageError::AccessDenied(_) => ErrorMessage::forbidden("Cannot access previous response"),
+                _ => ErrorMessage::internal_server_error(&e.to_string()),
+            })?;
+
+        // Merge previous context with new input
+        let merged_input = merge_with_previous(
+            &prev_response.response,
+            &request.inner.input,
+        )?;
+
+        // Update request with merged input
+        request.inner.input = merged_input;
+    }
+
+    // Process request (existing logic)
+    let response = process_response_request(state.clone(), request).await?;
+
+    // Store response if requested
+    if request.inner.store == Some(true) {
+        let ttl = calculate_ttl(&request.inner);
+        state.storage()
+            .store_response(response.clone(), &auth, ttl)
+            .await
+            .map_err(|e| {
+                tracing::warn!("Failed to store response: {}", e);
+                // Don't fail the request if storage fails
+            });
+    }
+
+    Ok(Json(response))
+}
+
+fn merge_with_previous(
+    previous: &Response,
+    new_input: &InputParam,
+) -> Result<InputParam, ErrorResponse> {
+    // Extract all output items from previous response
+    let prev_items: Vec<InputItem> = previous.output
+        .iter()
+        .map(|item| convert_output_to_input(item))
+        .collect();
+
+    // Combine with new input
+    match new_input {
+        InputParam::Text(text) => {
+            let mut items = prev_items;
+            items.push(InputItem::EasyMessage(EasyInputMessage {
+                r#type: MessageType::Message,
+                role: Role::User,
+                content: text.clone(),
+            }));
+            Ok(InputParam::Items(items))
+        }
+        InputParam::Items(new_items) => {
+            let mut items = prev_items;
+            items.extend(new_items.clone());
+            Ok(InputParam::Items(items))
+        }
+    }
+}
+```
+
+### 3.2 Add GET /v1/responses/{id} (1 week)
+
+```rust
+async fn get_response(
+    State(state): State<Arc<service_v2::State>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(response_id): Path<String>,
+) -> Result<Json<Response>, ErrorResponse> {
+    let stored = state.storage()
+        .get_response(&response_id, &auth)
+        .await
+        .map_err(|e| match e {
+            StorageError::NotFound(_) => ErrorMessage::not_found(),
+            StorageError::AccessDenied(_) => ErrorMessage::forbidden("Access denied"),
+            _ => ErrorMessage::internal_server_error(&e.to_string()),
+        })?;
+
+    // Touch to update accessed_at
+    let _ = state.storage().touch_response(&response_id, &auth).await;
+
+    Ok(Json(stored.response))
+}
+```
+
+### 3.3 Add DELETE /v1/responses/{id} (1 week)
+
+```rust
+async fn delete_response(
+    State(state): State<Arc<service_v2::State>>,
+    Extension(auth): Extension<AuthContext>,
+    Path(response_id): Path<String>,
+) -> Result<StatusCode, ErrorResponse> {
+    state.storage()
+        .delete_response(&response_id, &auth)
+        .await
+        .map_err(|e| match e {
+            StorageError::NotFound(_) => ErrorMessage::not_found(),
+            StorageError::AccessDenied(_) => ErrorMessage::forbidden("Access denied"),
+            _ => ErrorMessage::internal_server_error(&e.to_string()),
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+```
+
+---
+
+## Phase 4: Conversation API (3 weeks)
+
+### 4.1 Conversation Storage (1 week)
+
+Similar trait to ResponseStorage:
+
+```rust
+#[async_trait]
+pub trait ConversationStorage: Send + Sync {
+    async fn create_conversation(
+        &self,
+        metadata: Option<serde_json::Value>,
+        auth: &AuthContext,
+    ) -> Result<String, StorageError>;
+
+    async fn get_conversation(
+        &self,
+        conversation_id: &str,
+        auth: &AuthContext,
+    ) -> Result<Conversation, StorageError>;
+
+    async fn add_items(
+        &self,
+        conversation_id: &str,
+        items: Vec<InputItem>,
+        auth: &AuthContext,
+    ) -> Result<(), StorageError>;
+
+    async fn list_items(
+        &self,
+        conversation_id: &str,
+        auth: &AuthContext,
+    ) -> Result<Vec<ConversationItem>, StorageError>;
+
+    async fn delete_conversation(
+        &self,
+        conversation_id: &str,
+        auth: &AuthContext,
+    ) -> Result<(), StorageError>;
+}
+```
+
+### 4.2 Conversation Endpoints (2 weeks)
+
+Implement:
+- `POST /v1/conversations` - Create conversation
+- `GET /v1/conversations/{id}` - Get conversation
+- `POST /v1/conversations/{id}/items` - Add items
+- `GET /v1/conversations/{id}/items` - List items
+- `DELETE /v1/conversations/{id}` - Delete conversation
+
+---
+
+## Phase 5: Security & Compliance (2 weeks)
+
+### 5.1 Audit Logging (1 week)
+
+**File**: `lib/llm/src/storage/audit.rs`
+
+```rust
+pub struct AuditLogger {
+    backend: Arc<dyn AuditBackend>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuditEvent {
+    pub timestamp: u64,
+    pub tenant_id: String,
+    pub user_id: String,
+    pub action: String,
+    pub resource_type: String,
+    pub resource_id: String,
+    pub success: bool,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+}
+
+#[async_trait]
+pub trait AuditBackend: Send + Sync {
+    async fn log_event(&self, event: AuditEvent) -> Result<(), AuditError>;
+}
+```
+
+### 5.2 Rate Limiting (1 week)
+
+**File**: `lib/llm/src/http/middleware/rate_limit.rs`
+
+```rust
+pub struct RateLimiter {
+    store: Arc<dyn RateLimitStore>,
+    limits: RateLimits,
+}
+
+pub struct RateLimits {
+    pub max_responses_per_hour: u32,
+    pub max_stored_responses: u32,
+    pub max_storage_bytes: u64,
+}
+
+pub async fn rate_limit_middleware(
+    State(limiter): State<Arc<RateLimiter>>,
+    Extension(auth): Extension<AuthContext>,
+    request: Request<Body>,
+    next: Next,
+) -> Result<Response, ErrorResponse> {
+    limiter.check_limit(&auth).await?;
+    Ok(next.run(request).await)
+}
+```
+
+---
+
+## Configuration Example
+
+### Development (In-Memory)
+
+```bash
+# No auth (trusted environment)
+DYN_AUTH_PROVIDER=none
+
+# In-memory storage
+DYN_STORAGE_PROVIDER=in_memory
+DYN_STORAGE_MAX_RESPONSES=1000
+DYN_STORAGE_DEFAULT_TTL_HOURS=1
+```
+
+### Production (Secure)
+
+```bash
+# API Key Auth
+DYN_AUTH_PROVIDER=api_key
+DYN_AUTH_API_KEY_STORE=redis
+DYN_AUTH_REDIS_URL=rediss://auth-redis:6379
+DYN_AUTH_REDIS_PASSWORD=<secret>
+
+# Redis Storage
+DYN_STORAGE_PROVIDER=redis
+DYN_STORAGE_REDIS_URL=rediss://storage-redis:6379
+DYN_STORAGE_REDIS_PASSWORD=<secret>
+DYN_STORAGE_REDIS_TLS=true
+DYN_STORAGE_MAX_RESPONSE_SIZE_MB=10
+DYN_STORAGE_DEFAULT_TTL_HOURS=24
+DYN_STORAGE_MAX_TTL_HOURS=168
+
+# Encryption
+DYN_STORAGE_ENCRYPTION=aes256gcm
+DYN_STORAGE_ENCRYPTION_MASTER_KEY_PATH=/secrets/master.key
+
+# Rate Limiting
+DYN_RATE_LIMIT_RESPONSES_PER_HOUR=100
+DYN_RATE_LIMIT_MAX_STORED_RESPONSES=1000
+DYN_RATE_LIMIT_MAX_STORAGE_GB=10
+
+# Audit Logging
+DYN_AUDIT_BACKEND=file
+DYN_AUDIT_LOG_PATH=/var/log/dynamo/audit.log
+```
+
+### Enterprise (Custom)
+
+```rust
+// Custom auth provider
+let auth = Arc::new(MyLdapAuthProvider::new(ldap_config));
+
+// Custom storage
+let storage = Arc::new(MyPostgresStorage::new(db_pool));
+
+// Build state with custom providers
+let state = State::builder()
+    .auth_provider(auth)
+    .response_storage(storage)
+    .build();
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- Auth provider trait implementations
+- Storage provider trait implementations
+- Permission checking logic
+- Encryption/decryption
+
+### Integration Tests
+- End-to-end flow with in-memory providers
+- Auth + storage interaction
+- Tenant isolation validation
+- TTL expiration
+
+### Security Tests
+- Cross-tenant access attempts
+- Invalid token handling
+- Storage quota enforcement
+- Rate limit enforcement
+
+### Load Tests
+- Storage performance under load
+- Redis connection pooling
+- Encryption overhead
+- Cache hit rates
+
+---
+
+## Migration Path
+
+### Phase 1: Opt-In (v0.x)
+- Stateful features disabled by default
+- Require explicit config to enable
+- Warning logs if auth is disabled
+
+### Phase 2: Opt-Out (v1.x)
+- Stateful features enabled by default
+- Require explicit flag to disable
+- Error if auth is not configured
+
+### Phase 3: Always-On (v2.x)
+- Stateful features always available
+- Auth required for all endpoints
+
+---
+
+## Rollout Checklist
+
+- [ ] Phase 1: Auth Framework (4 weeks)
+  - [ ] Auth trait + providers
+  - [ ] API key provider (default)
+  - [ ] JWT provider
+  - [ ] Auth middleware
+  - [ ] Unit tests
+  - [ ] Documentation
+
+- [ ] Phase 2: Storage Backend (4 weeks)
+  - [ ] Storage trait
+  - [ ] Redis provider (default)
+  - [ ] Postgres provider
+  - [ ] Encryption provider
+  - [ ] Unit tests
+  - [ ] Performance tests
+
+- [ ] Phase 3: Response Storage (3 weeks)
+  - [ ] Update POST /v1/responses handler
+  - [ ] Implement GET /v1/responses/{id}
+  - [ ] Implement DELETE /v1/responses/{id}
+  - [ ] Integration tests
+  - [ ] Documentation
+
+- [ ] Phase 4: Conversation API (3 weeks)
+  - [ ] Conversation storage trait
+  - [ ] Conversation endpoints
+  - [ ] Integration tests
+  - [ ] Documentation
+
+- [ ] Phase 5: Security & Compliance (2 weeks)
+  - [ ] Audit logging
+  - [ ] Rate limiting
+  - [ ] Quota management
+  - [ ] Security audit
+  - [ ] Compliance documentation
+
+- [ ] Launch
+  - [ ] Internal dogfooding
+  - [ ] Beta release
+  - [ ] GA release
+  - [ ] Monitor metrics
+
+---
+
+## Open Questions
+
+1. **Default TTL**: Should responses expire after 24h or 7d by default?
+2. **Storage Limits**: What per-user/tenant quotas are reasonable?
+3. **Conversation Scope**: Should conversations be scoped to models or global?
+4. **Sharing**: Do we need response/conversation sharing between users?
+5. **Versioning**: How to handle schema migrations for stored responses?
+6. **Backup**: Should we provide export/import for conversations?
+
+---
+
+## Success Metrics
+
+- **Adoption**: % of requests using `previous_response_id`
+- **Performance**: Latency impact of storage lookups
+- **Security**: Zero cross-tenant access violations
+- **Reliability**: Storage backend uptime > 99.9%
+- **Cost**: Storage cost per 1M responses
+
+---
+
+## References
+
+- [OpenAI Responses API Spec](https://platform.openai.com/docs/api-reference/responses)
+- [OpenResponses Compliance Tests](https://www.openresponses.org/compliance)
+- [Linear Issue DYN-2045](https://linear.app/nvidia/issue/DYN-2045)
+- [Dynamo Architecture Docs](./architecture.md)

--- a/docs/design_docs/stateful_responses_trace_replay.md
+++ b/docs/design_docs/stateful_responses_trace_replay.md
@@ -1,0 +1,221 @@
+# Trace Replay for Stateful Responses
+
+This document describes the trace replay capability for testing and debugging stateful responses without a live deployment.
+
+## Overview
+
+The trace replay system allows you to:
+
+1. **Parse** Braintrust-style JSONL trace files
+2. **Extract** conversation turns, tool calls, and LLM outputs
+3. **Replay** conversations through the storage system
+4. **Verify** session isolation and `previous_response_id` chaining
+
+This enables local development and testing of multi-turn conversations using real captured traces.
+
+## Trace Format
+
+We support Braintrust JSONL format with span hierarchy:
+
+```json
+{"id": "root-123", "span_id": "root-123", "root_span_id": "root-123", "metadata": {"session_id": "root-123"}, "span_attributes": {"name": "Session", "type": "task"}}
+{"id": "turn-1", "span_id": "turn-1", "root_span_id": "root-123", "span_parents": ["root-123"], "input": "Hello", "span_attributes": {"name": "Turn 1", "type": "task"}}
+{"id": "llm-1", "span_id": "llm-1", "root_span_id": "root-123", "span_parents": ["turn-1"], "output": {"role": "assistant", "content": "Hi!"}, "span_attributes": {"type": "llm"}}
+```
+
+### Key Fields
+
+| Field | Description |
+|-------|-------------|
+| `span_id` | Unique identifier for this span |
+| `root_span_id` | Session root (same for all spans in session) |
+| `span_parents` | Parent span IDs (forms hierarchy) |
+| `span_attributes.type` | `task` for turns, `llm` for model calls, `tool` for tool calls |
+| `metadata.session_id` | Session identifier (extracted from root span) |
+
+## API Reference
+
+### `parse_trace_file(path: &Path) -> Result<ParsedTrace, TraceParseError>`
+
+Parse a JSONL trace file from disk.
+
+```rust
+use dynamo_llm::storage::parse_trace_file;
+use std::path::Path;
+
+let trace = parse_trace_file(Path::new("my_trace.jsonl"))?;
+println!("Session: {}", trace.session_id);
+println!("Turns: {}", trace.turns.len());
+```
+
+### `parse_trace_content(content: &str) -> Result<ParsedTrace, TraceParseError>`
+
+Parse trace content from a string (useful for testing).
+
+```rust
+use dynamo_llm::storage::parse_trace_content;
+
+let trace_content = r#"{"id": "root", "span_id": "root", ...}"#;
+let trace = parse_trace_content(trace_content)?;
+```
+
+### `replay_trace(storage: &S, trace: &ParsedTrace, tenant_id: &str) -> Result<ReplayResult, StorageError>`
+
+Replay a parsed trace through the storage system.
+
+```rust
+use dynamo_llm::storage::{replay_trace, InMemoryResponseStorage};
+
+let storage = InMemoryResponseStorage::new();
+let result = replay_trace(&storage, &trace, "my_tenant").await?;
+
+println!("Replayed {} turns", result.turns_replayed);
+println!("Response IDs: {:?}", result.response_ids);
+```
+
+## Data Structures
+
+### `ParsedTrace`
+
+```rust
+pub struct ParsedTrace {
+    pub session_id: String,        // Extracted from root span metadata
+    pub root_span_id: String,      // Root span identifier
+    pub turns: Vec<ConversationTurn>,  // Extracted conversation turns
+    pub raw_spans: Vec<TraceSpan>,     // All parsed spans
+}
+```
+
+### `ConversationTurn`
+
+```rust
+pub struct ConversationTurn {
+    pub turn_id: String,           // Span ID of this turn
+    pub turn_number: usize,        // 1-indexed turn number
+    pub user_input: String,        // User's message
+    pub assistant_output: Option<String>,  // Assistant's response
+    pub tool_calls: Vec<ToolCall>, // Tool invocations in this turn
+    pub timestamp: String,         // ISO timestamp
+}
+```
+
+### `ReplayResult`
+
+```rust
+pub struct ReplayResult {
+    pub session_id: String,        // Session that was replayed
+    pub tenant_id: String,         // Tenant used for replay
+    pub turns_replayed: usize,     // Number of turns stored
+    pub response_ids: Vec<String>, // Generated response IDs
+}
+```
+
+## Usage Examples
+
+### Basic Trace Replay
+
+```rust
+use dynamo_llm::storage::{
+    parse_trace_file, replay_trace,
+    ResponseStorage, InMemoryResponseStorage
+};
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Parse the trace file
+    let trace = parse_trace_file(Path::new("traces/session.jsonl"))?;
+
+    // 2. Create storage
+    let storage = InMemoryResponseStorage::new();
+
+    // 3. Replay through storage
+    let result = replay_trace(&storage, &trace, "test_tenant").await?;
+
+    // 4. Verify the session
+    let responses = storage
+        .list_responses("test_tenant", &trace.session_id, None)
+        .await?;
+
+    for resp in responses {
+        println!("Response {}: {:?}", resp.response_id, resp.response);
+    }
+
+    Ok(())
+}
+```
+
+### Testing Session Isolation
+
+```rust
+// Replay same trace for different tenants
+let result_a = replay_trace(&storage, &trace, "tenant_A").await?;
+let result_b = replay_trace(&storage, &trace, "tenant_B").await?;
+
+// Each tenant has isolated data
+let a_responses = storage.list_responses("tenant_A", &trace.session_id, None).await?;
+let b_responses = storage.list_responses("tenant_B", &trace.session_id, None).await?;
+
+// Tenant A can't access tenant B's data
+assert!(storage.get_response("tenant_A", &trace.session_id, &result_b.response_ids[0]).await.is_err());
+```
+
+### Verifying `previous_response_id` Chaining
+
+```rust
+let result = replay_trace(&storage, &trace, "tenant").await?;
+
+// Each response after the first has previous_response_id set
+let responses = storage.list_responses("tenant", &trace.session_id, None).await?;
+
+for (i, resp) in responses.iter().enumerate().skip(1) {
+    let prev_id = resp.response["metadata"]["previous_response_id"]
+        .as_str()
+        .expect("Should have previous_response_id");
+
+    // Should point to previous response
+    assert_eq!(prev_id, responses[i - 1].response_id);
+}
+```
+
+## Integration with Tests
+
+The trace replay module is used in integration tests:
+
+```rust
+// lib/llm/tests/responses_stateful_integration_test.rs
+
+#[tokio::test]
+async fn test_trace_replay_parse_real_trace() {
+    let trace_content = r#"{"id": "4de2bcf7-...", ...}"#;
+    let parsed = parse_trace_content(trace_content).expect("Should parse");
+
+    assert_eq!(parsed.turns.len(), 1);
+    assert_eq!(parsed.turns[0].user_input, "how many lines in the README.md?");
+}
+
+#[tokio::test]
+async fn test_trace_replay_through_storage() {
+    let storage = InMemoryResponseStorage::new();
+    let trace = parse_trace_content(TRACE_CONTENT)?;
+
+    let result = replay_trace(&storage, &trace, "test").await?;
+
+    assert_eq!(result.turns_replayed, 2);
+}
+```
+
+## File Locations
+
+| File | Description |
+|------|-------------|
+| `lib/llm/src/storage/trace_replay.rs` | Core implementation |
+| `lib/llm/src/storage/mod.rs` | Module exports |
+| `lib/llm/tests/responses_stateful_integration_test.rs` | Integration tests |
+
+## Future Enhancements
+
+1. **CLI tool** - `dynamo trace replay <file.jsonl>` command
+2. **HTTP endpoint** - POST trace content for live replay
+3. **Diff comparison** - Compare replayed responses vs original trace
+4. **Streaming support** - Handle streaming response traces

--- a/docs/hidden_toctree.rst
+++ b/docs/hidden_toctree.rst
@@ -57,6 +57,14 @@
    backends/trtllm/gpt-oss.md
    backends/trtllm/prometheus.md
 
+   design_docs/distributed_runtime.md
+   design_docs/dynamo_flow.md
+   design_docs/stateful_responses_plan.md
+   design_docs/stateful_responses_custom_providers.md
+   design_docs/stateful_responses_trace_replay.md
+
+   integrations/lmcache_integration.md
+
    features/speculative_decoding/README.md
    features/speculative_decoding/speculative_decoding_vllm.md
 


### PR DESCRIPTION
## Summary

Adds design documentation covering the stateful responses feature architecture and integration patterns.

### Documents

- **`stateful_responses_plan.md`** (~1,000 lines): Architecture overview, storage design, session middleware, feature flag behavior, deployment patterns, and security considerations
- **`stateful_responses_custom_providers.md`** (~800 lines): Integration guide for custom storage providers (Redis, DynamoDB, etc.) implementing the `ResponseStorage` trait
- **`stateful_responses_trace_replay.md`** (~220 lines): Conversation trace reconstruction design for multi-turn response chains using `previous_response_id` linking

Also adds toctree entries in `docs/hidden_toctree.rst` for Sphinx discovery.

## PR Series

```
Ishan's PR (Types/Protocol) → Storage → Wiring → Tests
                             └→ [THIS PR] Docs
```

**Base branch**: `mkosec/dyn-2045-responses-api` (can merge in parallel after Ishan's PR)

## Test plan

- [ ] Sphinx docs build without warnings
- [ ] Design docs are accurate and up to date with implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)