### PR TITLE
fix: test_router_decisions async fix race condition

### DIFF
--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -361,6 +361,12 @@ pub mod build {
 pub mod mocker {
     /// Enable structured KV cache allocation/eviction trace logs (set to "1" or "true" to enable)
     pub const DYN_MOCKER_KV_CACHE_TRACE: &str = "DYN_MOCKER_KV_CACHE_TRACE";
+
+    /// Use the original direct() code path in the mocker request dispatch.
+    ///
+    /// This path is race-prone during startup; prefer leaving it unset unless you are
+    /// explicitly trying to reproduce the original behavior.
+    pub const DYN_MOCKER_SYNC_DIRECT: &str = "DYN_MOCKER_SYNC_DIRECT";
 }
 
 /// Testing environment variables
@@ -463,6 +469,7 @@ mod tests {
             build::OUT_DIR,
             // Mocker
             mocker::DYN_MOCKER_KV_CACHE_TRACE,
+            mocker::DYN_MOCKER_SYNC_DIRECT,
             // Testing
             testing::DYN_QUEUED_UP_PROCESSING,
             testing::DYN_SOAK_RUN_DURATION,


### PR DESCRIPTION
#### Overview:

Fix a startup race condition in the mocker's `direct()` method that caused ~8% test flakiness in `test_router_decisions` E2E tests under heavy CPU load.

#### Details:

- The mocker's `direct()` used `.expect("Not initialized")` on the `request_senders` OnceCell, which panics if a request arrives before `start_schedulers()` finishes populating it.
- Under heavy load (10 parallel test containers), this caused ~8% ERR_MOCKER_PANIC failures (922/1000 pass rate).
- Replace the synchronous `.expect()` with an async polling loop that waits up to 10s (50ms intervals) for `request_senders` to be initialized, giving `start_schedulers()` time to finish.
- Tested at 1000/1000 pass rate on `test_router_decisions[jetstream-tcp]` with 10 parallel containers.
- The original synchronous behavior is preserved behind `MOCKER_DIRECT_SYNC=1` env var for debugging/comparison.

#### Where should the reviewer start?

`lib/llm/src/mocker.rs` — the `direct()` method (line ~134) and its call site in the `AsyncEngine` impl (line ~391).

#### Related Issues:

Relates to DIS-1406

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request handling reliability with automatic retry logic for unavailable request handlers, improving robustness in mock engine operations.
  * Added backward compatibility option via environment variable for legacy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->