### PR TITLE
fix: profiler deployment timeout handling for MoE models

### DIFF
--- a/benchmarks/profiler/profile_sla.py
+++ b/benchmarks/profiler/profile_sla.py
@@ -245,8 +245,6 @@ async def run_profile(args):
             candidate_mappings = get_candidate_parallel_mappings(
                 num_gpus,
                 args.model_info,
-                EngineType.PREFILL,
-                gpu_memory_gib=getattr(args, "gpu_memory_gib", None),
             )
 
             for mapping in candidate_mappings:
@@ -369,8 +367,6 @@ async def run_profile(args):
             candidate_mappings = get_candidate_parallel_mappings(
                 num_gpus,
                 args.model_info,
-                EngineType.DECODE,
-                gpu_memory_gib=getattr(args, "gpu_memory_gib", None),
             )
 
             for mapping in candidate_mappings:

--- a/benchmarks/profiler/utils/config_modifiers/parallelization_mapping.py
+++ b/benchmarks/profiler/utils/config_modifiers/parallelization_mapping.py
@@ -23,6 +23,11 @@ formatter = logging.Formatter(
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
+# Maximum fraction of GPU VRAM that best-case per-GPU model weight may occupy
+# for DEP candidates. DEP replicates non-expert parameters (TP=1), so actual
+# memory usage is significantly higher than model_size/num_gpus.
+DEP_GPU_MEM_FRAC_MAX = 0.55
+
 
 class ParallelizationStrategy(Enum):
     """Enum for parallelization strategy types."""
@@ -168,8 +173,48 @@ def _validate_intermediate_size(
     return True
 
 
+def _check_dep_memory_feasibility(
+    model_size_mb: float,
+    num_gpus: int,
+    gpu_memory_gib: float,
+    mapping_label: str,
+) -> bool:
+    """
+    Check if a DEP candidate is likely memory-feasible.
+
+    DEP uses TP=1, so non-expert parameters (attention, embeddings, norms) are
+    fully replicated on every GPU. Only expert parameters are split by EP.
+    The minimum per-GPU model memory (assuming 100% expert params, best case)
+    is model_size/num_gpus. In practice, non-expert replication adds 30-100%+
+    on top of that. Combined with activation memory and workspace buffers,
+    DEP requires significantly more GPU memory than TEP/TP.
+
+    We skip DEP when even the best-case per-GPU model weight (model_size/N)
+    exceeds 55% of GPU VRAM, since actual usage including non-expert
+    replication and runtime overhead will be much higher.
+    """
+    model_size_gib = model_size_mb / 1024
+    best_case_per_gpu_gib = model_size_gib / num_gpus
+    threshold = gpu_memory_gib * DEP_GPU_MEM_FRAC_MAX
+
+    if best_case_per_gpu_gib > threshold:
+        logger.warning(
+            f"Skipping {mapping_label}: best-case per-GPU model weight "
+            f"({best_case_per_gpu_gib:.1f} GiB) exceeds "
+            f"{DEP_GPU_MEM_FRAC_MAX:.0%} of GPU memory "
+            f"({gpu_memory_gib:.0f} GiB). DEP replicates non-expert parameters "
+            f"(TP=1), so actual per-GPU memory will be significantly higher."
+        )
+        return False
+
+    return True
+
+
 def get_candidate_parallel_mappings(
-    num_gpus: int, model_info: ModelInfo, phase: str
+    num_gpus: int,
+    model_info: ModelInfo,
+    phase: str,
+    gpu_memory_gib: float | None = None,
 ) -> list[ParallelizationMapping]:
     """
     Return a list of candidate parallelization mappings for a given GPU count and phase,
@@ -178,6 +223,7 @@ def get_candidate_parallel_mappings(
     Verification rules:
     - TP and TEP must divide num_kv_heads (if available)
     - TEP and DEP must divide num_experts (if available)
+    - DEP must be memory-feasible (if gpu_memory_gib is provided)
     """
     is_moe = bool(model_info.is_moe)
     num_kv_heads = model_info.num_kv_heads
@@ -214,6 +260,13 @@ def get_candidate_parallel_mappings(
         # Check intermediate size and quantization block
         if not _validate_intermediate_size(m, intermediate_size, quant_block):
             continue
+
+        # Check memory feasibility for DEP candidates
+        if m.dep is not None and gpu_memory_gib is not None and model_info.model_size:
+            if not _check_dep_memory_feasibility(
+                model_info.model_size, num_gpus, gpu_memory_gib, m.label()
+            ):
+                continue
 
         verified.append(m)
 

--- a/benchmarks/profiler/utils/search_space_autogen.py
+++ b/benchmarks/profiler/utils/search_space_autogen.py
@@ -148,6 +148,7 @@ def auto_generate_search_space(args: argparse.Namespace) -> None:
             args.min_num_gpus_per_engine = min_gpu
             args.max_num_gpus_per_engine = max_gpu
             args.num_gpus_per_node = gpus_per_node  # type: ignore[assignment]
+            args.gpu_memory_gib = vram_mib / 1024
     else:
         # use default values for GPUs
         if args.min_num_gpus_per_engine == 0:

--- a/benchmarks/profiler/utils/search_space_autogen.py
+++ b/benchmarks/profiler/utils/search_space_autogen.py
@@ -148,7 +148,6 @@ def auto_generate_search_space(args: argparse.Namespace) -> None:
             args.min_num_gpus_per_engine = min_gpu
             args.max_num_gpus_per_engine = max_gpu
             args.num_gpus_per_node = gpus_per_node  # type: ignore[assignment]
-            args.gpu_memory_gib = vram_mib / 1024
     else:
         # use default values for GPUs
         if args.min_num_gpus_per_engine == 0:


### PR DESCRIPTION
## Summary
- Wrap `wait_for_deployment_ready()` in try/except TimeoutError for both prefill and decode profiling sweeps
- On timeout: log error, record via `add_profiling_error()`, clean up the timed-out deployment, and continue to the next parallelization mapping
- Previously, a single deployment timeout would crash the entire profiler job

## Test plan
- [x] Deploy profiler on Nebius H200 cluster with DeepSeek-R1 (671B MoE) via DGDR
- [x] Verify timeout handling: with `deploymentTimeout: 60`, profiler catches TimeoutError, logs `Deployment for mapping TEP=1 with 1 GPUs failed to become ready within timeout during prefill profiling, skipping`, cleans up deployment, and moves to next mapping
- [x] Verify profiler iterates through all GPU counts and mappings without crashing (tested [1, 2, 4, 8] GPUs with both TEP and DEP)
- [x] Verify `add_profiling_error()` records each timeout for downstream reporting

Fixes: DYN-2084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling during profiling: timed-out deployments are logged with phase-specific messages (prefill/decode), cleaned up, and skipped so profiling continues reliably.

* **Refactor**
  * Minor formatting and control-flow adjustments to ensure consistent cleanup and skipping behavior across profiling paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->