### PR TITLE
feat: Add SGLang /engine weight update endpoints

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -255,9 +255,11 @@ class BaseWorkerHandler(BaseGenerativeHandler):
         from sglang.srt.managers.io_struct import UpdateWeightFromDiskReqInput
 
         req = UpdateWeightFromDiskReqInput(**body)
-        success, message, num_paused_requests = (
-            await self.engine.tokenizer_manager.update_weights_from_disk(req, None)
-        )
+        (
+            success,
+            message,
+            num_paused_requests,
+        ) = await self.engine.tokenizer_manager.update_weights_from_disk(req, None)
         return {
             "success": success,
             "message": message,
@@ -269,9 +271,10 @@ class BaseWorkerHandler(BaseGenerativeHandler):
         from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
 
         req = UpdateWeightsFromTensorReqInput(**body)
-        success, message = await self.engine.tokenizer_manager.update_weights_from_tensor(
-            req, None
-        )
+        (
+            success,
+            message,
+        ) = await self.engine.tokenizer_manager.update_weights_from_tensor(req, None)
         return {"success": success, "message": message}
 
     async def update_weights_from_distributed(self, body: dict) -> dict:
@@ -279,8 +282,11 @@ class BaseWorkerHandler(BaseGenerativeHandler):
         from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
 
         req = UpdateWeightsFromDistributedReqInput(**body)
-        success, message = (
-            await self.engine.tokenizer_manager.update_weights_from_distributed(req, None)
+        (
+            success,
+            message,
+        ) = await self.engine.tokenizer_manager.update_weights_from_distributed(
+            req, None
         )
         return {"success": success, "message": message}
 

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -250,6 +250,67 @@ class BaseWorkerHandler(BaseGenerativeHandler):
         await self.engine.tokenizer_manager.stop_profile()
         return {"status": "ok", "message": "Profiling stopped"}
 
+    async def update_weights_from_disk(self, body: dict) -> dict:
+        """Update model weights from disk without restarting the server."""
+        from sglang.srt.managers.io_struct import UpdateWeightFromDiskReqInput
+
+        req = UpdateWeightFromDiskReqInput(**body)
+        success, message, num_paused_requests = (
+            await self.engine.tokenizer_manager.update_weights_from_disk(req, None)
+        )
+        return {
+            "success": success,
+            "message": message,
+            "num_paused_requests": num_paused_requests,
+        }
+
+    async def update_weights_from_tensor(self, body: dict) -> dict:
+        """Update model weights from tensors without restarting the server."""
+        from sglang.srt.managers.io_struct import UpdateWeightsFromTensorReqInput
+
+        req = UpdateWeightsFromTensorReqInput(**body)
+        success, message = await self.engine.tokenizer_manager.update_weights_from_tensor(
+            req, None
+        )
+        return {"success": success, "message": message}
+
+    async def update_weights_from_distributed(self, body: dict) -> dict:
+        """Update model weights using distributed online synchronization."""
+        from sglang.srt.managers.io_struct import UpdateWeightsFromDistributedReqInput
+
+        req = UpdateWeightsFromDistributedReqInput(**body)
+        success, message = (
+            await self.engine.tokenizer_manager.update_weights_from_distributed(req, None)
+        )
+        return {"success": success, "message": message}
+
+    async def update_weights_from_ipc(self, body: dict) -> dict:
+        """Update model weights from IPC for checkpoint-engine integration."""
+        from sglang.srt.managers.io_struct import UpdateWeightsFromIPCReqInput
+
+        req = UpdateWeightsFromIPCReqInput(**body)
+        success, message = await self.engine.tokenizer_manager.update_weights_from_ipc(
+            req, None
+        )
+        if success and not self.engine.tokenizer_manager.initial_weights_loaded:
+            self.engine.tokenizer_manager.initial_weights_loaded = True
+        return {"success": success, "message": message}
+
+    async def update_weight_version(self, body: dict) -> dict:
+        """Update the active weight version without changing model weights."""
+        from sglang.srt.managers.io_struct import UpdateWeightVersionReqInput
+
+        req = UpdateWeightVersionReqInput(**body)
+        if req.abort_all_requests:
+            self.engine.tokenizer_manager.abort_request(abort_all=True)
+
+        self.engine.tokenizer_manager.server_args.weight_version = req.new_version
+        return {
+            "success": True,
+            "message": f"Weight version updated to {req.new_version}",
+            "new_version": req.new_version,
+        }
+
     def register_engine_routes(self, runtime) -> None:
         """Register all engine routes for this handler.
 
@@ -263,6 +324,21 @@ class BaseWorkerHandler(BaseGenerativeHandler):
         )
         runtime.register_engine_route(
             "resume_memory_occupation", self.resume_memory_occupation
+        )
+        runtime.register_engine_route(
+            "update_weights_from_disk", self.update_weights_from_disk
+        )
+        runtime.register_engine_route(
+            "update_weights_from_tensor", self.update_weights_from_tensor
+        )
+        runtime.register_engine_route(
+            "update_weights_from_distributed", self.update_weights_from_distributed
+        )
+        runtime.register_engine_route(
+            "update_weights_from_ipc", self.update_weights_from_ipc
+        )
+        runtime.register_engine_route(
+            "update_weight_version", self.update_weight_version
         )
 
     @abstractmethod


### PR DESCRIPTION
#### Overview:

Wire update_weights and update_weight_version routes to tokenizer manager

#### Details:

Adds the basic /engine/ routes needed for sglang weight update support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dynamic model weight update functionality enabling seamless on-the-fly model updates from multiple sources—disk, tensor, distributed systems, and inter-process communication—without requiring server restarts, improving operational flexibility and reducing downtime during model changes.
  * Added comprehensive weight versioning management system with configurable request handling for managed version transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->