### PR TITLE
feat(mocker): improve mocker's perf timing accuracy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,6 +2128,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-timerfd",
  "tokio-util",
  "tracing",
  "uuid",
@@ -4313,6 +4314,12 @@ checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
 dependencies = [
  "zlib-rs",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -6869,6 +6876,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -6876,7 +6896,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -7796,7 +7816,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -7903,6 +7923,15 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "timerfd"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e482e368cf7efa2c8b570f476e5b9fd9fd5e9b9219fc567832b05f13511091"
+dependencies = [
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -8068,6 +8097,19 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-timerfd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87eecdae9a9b793843b1df7a64bc136f203443c1ca9889b3c4a39590afa51094"
+dependencies = [
+ "futures-core",
+ "libc",
+ "slab",
+ "timerfd",
+ "tokio",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1760,6 +1760,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-timerfd",
  "tokio-util",
  "tracing",
  "uuid",
@@ -3741,6 +3742,12 @@ checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
 dependencies = [
  "zlib-rs",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -6158,6 +6165,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -6165,7 +6185,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -6970,7 +6990,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -7068,6 +7088,15 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "timerfd"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e482e368cf7efa2c8b570f476e5b9fd9fd5e9b9219fc567832b05f13511091"
+dependencies = [
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -7208,6 +7237,19 @@ checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-timerfd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87eecdae9a9b793843b1df7a64bc136f203443c1ca9889b3c4a39590afa51094"
+dependencies = [
+ "futures-core",
+ "libc",
+ "slab",
+ "timerfd",
  "tokio",
 ]
 

--- a/lib/mocker/Cargo.toml
+++ b/lib/mocker/Cargo.toml
@@ -34,6 +34,8 @@ uuid = { workspace = true }
 ndarray = "0.16"
 ndarray-npy = "0.9"
 ndarray-interp = "0.5"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 tokio-timerfd = "0.2"
 
 [dev-dependencies]

--- a/lib/mocker/Cargo.toml
+++ b/lib/mocker/Cargo.toml
@@ -34,6 +34,7 @@ uuid = { workspace = true }
 ndarray = "0.16"
 ndarray-npy = "0.9"
 ndarray-interp = "0.5"
+tokio-timerfd = "0.2"
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/lib/mocker/src/scheduler.rs
+++ b/lib/mocker/src/scheduler.rs
@@ -44,6 +44,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc;
 use tokio::time::Duration;
+#[cfg(target_os = "linux")]
 use tokio_timerfd::Delay;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -419,8 +420,15 @@ async fn simulate_prefill(
         let sleep_duration = Duration::from_secs_f64(total_time.as_secs_f64() / speedup_ratio);
         let deadline = start_time + sleep_duration;
 
-        if let Ok(delay) = Delay::new(deadline) {
-            let _ = delay.await;
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(delay) = Delay::new(deadline) {
+                let _ = delay.await;
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
         }
     }
 
@@ -506,8 +514,15 @@ async fn simulate_decode(
         let sleep_duration = Duration::from_secs_f64(total_time.as_secs_f64() / speedup_ratio);
         let deadline = start_time + sleep_duration;
 
-        if let Ok(delay) = Delay::new(deadline) {
-            let _ = delay.await;
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(delay) = Delay::new(deadline) {
+                let _ = delay.await;
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
         }
     }
 


### PR DESCRIPTION
#### Overview:

Improve mocker's timing accuracy by replacing `tokio::time::sleep_until` with `tokio-timerfd` for high-precision sleep operations.

#### Details:

Mocker's performance simulation was significantly slower than model predictions:
  - **Model prediction**: 4.68ms TPOT through interpolatation
  - **Actual measurement**: 7.01ms TPOT

Investigation revealed that `tokio::time::sleep_until` has inherent scheduling latency:
  - Each sleep call added 1-1.5ms of extra delay
  - The overhead accumulated in both prefill and decode phases

Replace `tokio::time::sleep_until` with `tokio-timerfd::Delay`:
  - `tokio-timerfd` uses Linux's `timerfd` system call for precise timing
  - Provides microsecond-level vs millisecond precision
 
#### Performance Impact

  Benchmark results (3 requests, 8192 input tokens, 256 output tokens each):

  | Metric | Before | After | Improvement |
  |--------|--------|-------|-------------|
  | **Avg TPOT** | 7.01ms | 4.90ms | **30%** |

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies and internal timing implementation to enhance system performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->