### PR TITLE
fix: harden KVBM integration tests with dynamic timeouts and metrics

### DIFF
--- a/tests/kvbm_integration/common.py
+++ b/tests/kvbm_integration/common.py
@@ -1314,11 +1314,11 @@ def fetch_kvbm_metrics(port: int, timeout: int = 10) -> dict:
     url = f"http://localhost:{port}/metrics"
     try:
         response = requests.get(url, timeout=timeout)
-    except requests.exceptions.ConnectionError:
+    except requests.exceptions.ConnectionError as err:
         raise RuntimeError(
             f"Metrics endpoint {url} refused connection. "
             f"Check that DYN_KVBM_METRICS_PORT={port} matches the running server."
-        )
+        ) from err
     if response.status_code != 200:
         raise RuntimeError(
             f"Metrics endpoint returned status {response.status_code}. "

--- a/tests/kvbm_integration/common.py
+++ b/tests/kvbm_integration/common.py
@@ -1311,7 +1311,14 @@ def fetch_kvbm_metrics(port: int, timeout: int = 10) -> dict:
     Raises:
         RuntimeError: If metrics endpoint is unreachable or returns error
     """
-    response = requests.get(f"http://localhost:{port}/metrics", timeout=timeout)
+    url = f"http://localhost:{port}/metrics"
+    try:
+        response = requests.get(url, timeout=timeout)
+    except requests.exceptions.ConnectionError:
+        raise RuntimeError(
+            f"Metrics endpoint {url} refused connection. "
+            f"Check that DYN_KVBM_METRICS_PORT={port} matches the running server."
+        )
     if response.status_code != 200:
         raise RuntimeError(
             f"Metrics endpoint returned status {response.status_code}. "

--- a/tests/kvbm_integration/test_chunked_prefill.py
+++ b/tests/kvbm_integration/test_chunked_prefill.py
@@ -118,7 +118,7 @@ def tester(llm_server_kvbm):  # noqa: F811
     ],
     indirect=True,
 )
-@pytest.mark.xfail(reason="Test currently failing and blocking CI")
+@pytest.mark.timeout(140)  # 4x measured (~34s), rounded up
 def test_chunked_prefill_offload(tester, llm_server_kvbm):  # noqa: F811
     """
     Validate that chunked prefill blocks are offloaded.

--- a/tests/kvbm_integration/test_consolidator_router_e2e.py
+++ b/tests/kvbm_integration/test_consolidator_router_e2e.py
@@ -508,6 +508,7 @@ class TestConsolidatorRouterE2E:
         logger.info(f"Concurrent requests: {successes}/{num_requests} succeeded")
         return successes, results
 
+    @pytest.mark.timeout(150)  # 4x measured (~37s), rounded up
     def test_basic_consolidator_flow(self, tester, llm_worker, frontend_server):
         """
         Test basic consolidator flow:
@@ -551,6 +552,7 @@ class TestConsolidatorRouterE2E:
 
         logger.info(f"Basic consolidator flow test passed ({engine.upper()})")
 
+    @pytest.mark.timeout(170)  # 4x measured (~41s), rounded up
     def test_consolidator_handles_concurrent_requests(
         self, tester, llm_worker, frontend_server
     ):
@@ -591,6 +593,7 @@ class TestConsolidatorRouterE2E:
 
         logger.info(f"Concurrent request handling test passed ({engine.upper()})")
 
+    @pytest.mark.timeout(180)  # 4x measured (~44s), rounded up
     def test_store_deduplication_across_sources(
         self, tester, llm_worker, frontend_server
     ):
@@ -686,6 +689,7 @@ class TestConsolidatorRouterE2E:
 
         logger.info(f"STORE deduplication test passed ({engine.upper()})")
 
+    @pytest.mark.timeout(340)  # 4x measured (~85s), rounded up
     @pytest.mark.parametrize("engine_type", AVAILABLE_ENGINES)
     def test_remove_deduplication_across_sources(
         self, test_directory, runtime_services, engine_type

--- a/tests/kvbm_integration/test_kvbm.py
+++ b/tests/kvbm_integration/test_kvbm.py
@@ -114,7 +114,7 @@ def tester(llm_server_kvbm):  # noqa: F811
 
 # Tests
 @pytest.mark.parametrize("llm_server_kvbm", [{"model": KVBM_TEST_MODEL}], indirect=True)
-@pytest.mark.timeout(110)  # 3x measured time (36.31s), rounded up
+@pytest.mark.timeout(170)  # 4x measured (~41s), rounded up
 def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     """
     Test offload → cache reset → onboard cycle with determinism verification.
@@ -181,7 +181,7 @@ def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     [{"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL}],
     indirect=True,
 )
-@pytest.mark.timeout(190)  # 3x measured time (63.39s), rounded up
+@pytest.mark.timeout(170)  # 4x measured (~42s), rounded up
 def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
     """
     Test GPU cache eviction mechanics.
@@ -256,7 +256,7 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
     [{"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL}],
     indirect=True,
 )
-@pytest.mark.timeout(107)  # 3x measured time (35.40s), rounded up
+@pytest.mark.timeout(160)  # 4x measured (~39s), rounded up
 def test_onboarding_determinism(tester, llm_server_kvbm):  # noqa: F811
     """
     Test onboarding determinism under eviction scenario.


### PR DESCRIPTION
#### Overview:

Fix broken KVBM integration tests after metrics_port became mandatory in fetch_kvbm_metrics. LLMServerManager was missing the metrics_port attribute, causing AttributeError in determinism tests.

#### Details:

- Fix LLMServerManager to dynamically allocate metrics_port (was hardcoded and never exposed as attribute)
- Add ConnectionError fail-fast in fetch_kvbm_metrics so bad ports fail immediately
- Add/update pytest.mark.timeout across all KVBM integration tests; determinism timeouts scale with KVBM_* env vars
- Replace xfail on test_chunked_prefill_offload with timeout (test passes now)
- Document fast local run command for determinism tests

#### Where should the reviewer start?

tests/kvbm_integration/test_determinism_agg.py

#### Related Issues:

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added timeout constraints to multiple integration tests to prevent indefinite hangs and improve test reliability.
  * Updated timeout values across test suites to better reflect expected execution times.

* **Bug Fixes**
  * Improved error handling for metrics endpoint connection failures with clearer diagnostic messages.
  * Added server startup health check to verify metrics endpoint availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->