### PR TITLE
feat: external restore via nsenter for ChReK

### DIFF
--- a/deploy/chrek/Dockerfile
+++ b/deploy/chrek/Dockerfile
@@ -68,6 +68,7 @@ ARG TARGETARCH=amd64
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -o /chrek-agent ./cmd/agent
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -o /restore-entrypoint ./cmd/restore-entrypoint
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -o /criu-helper ./cmd/criu-helper
 
 # =============================================================================
 # Stage: CRIU Builder - Build CRIU with CUDA plugin
@@ -138,6 +139,7 @@ RUN chmod +x /usr/local/sbin/cuda-checkpoint
 # Copy the built binaries
 COPY --from=builder /chrek-agent /usr/local/bin/chrek-agent
 COPY --from=builder /restore-entrypoint /restore-entrypoint
+COPY --from=builder /criu-helper /usr/local/bin/criu-helper
 
 # Create checkpoint directory
 RUN mkdir -p /checkpoints
@@ -196,6 +198,9 @@ RUN mkdir -p /checkpoints /var/run/criu /tmp /var/criu-work
 # Copy restore binaries
 COPY --from=builder /restore-entrypoint /restore-entrypoint
 RUN chmod +x /restore-entrypoint
+
+COPY --from=builder /criu-helper /usr/local/bin/criu-helper
+RUN chmod +x /usr/local/bin/criu-helper
 
 COPY scripts/smart-entrypoint.sh /smart-entrypoint.sh
 RUN chmod +x /smart-entrypoint.sh

--- a/deploy/chrek/Makefile
+++ b/deploy/chrek/Makefile
@@ -54,9 +54,10 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
 ##@ Build
 
 .PHONY: build
-build: fmt vet ## Build chrek-agent and restore-entrypoint binaries.
+build: fmt vet ## Build chrek-agent, restore-entrypoint, and criu-helper binaries.
 	CGO_ENABLED=0 go build -ldflags="-w -s" -o bin/chrek-agent ./cmd/agent
 	CGO_ENABLED=0 go build -ldflags="-w -s" -o bin/restore-entrypoint ./cmd/restore-entrypoint
+	CGO_ENABLED=0 go build -ldflags="-w -s" -o bin/criu-helper ./cmd/criu-helper
 
 .PHONY: build-agent
 build-agent: fmt vet ## Build chrek-agent binary only.
@@ -65,6 +66,10 @@ build-agent: fmt vet ## Build chrek-agent binary only.
 .PHONY: build-restore
 build-restore: fmt vet ## Build restore-entrypoint binary only.
 	CGO_ENABLED=0 go build -ldflags="-w -s" -o bin/restore-entrypoint ./cmd/restore-entrypoint
+
+.PHONY: build-criu-helper
+build-criu-helper: fmt vet ## Build criu-helper binary only.
+	CGO_ENABLED=0 go build -ldflags="-w -s" -o bin/criu-helper ./cmd/criu-helper
 
 .PHONY: run
 run: build ## Run chrek-agent from your host.

--- a/deploy/chrek/cmd/agent/main.go
+++ b/deploy/chrek/cmd/agent/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -20,7 +21,20 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/chrek/pkg/checkpoint"
 	checkpointk8s "github.com/ai-dynamo/dynamo/deploy/chrek/pkg/checkpoint/k8s"
 	"github.com/ai-dynamo/dynamo/deploy/chrek/pkg/common"
+	"github.com/ai-dynamo/dynamo/deploy/chrek/pkg/restore"
 	"github.com/ai-dynamo/dynamo/deploy/chrek/pkg/watcher"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	maxPID                   = 4194304
+	maxCheckpointIDLength    = 255
+	defaultReadTimeout       = 30 * time.Second
+	defaultWriteTimeout      = 300 * time.Second
+	defaultIdleTimeout       = 120 * time.Second
+	defaultShutdownTimeout   = 30 * time.Second
+	defaultTriggerFilePerm   = 0644
+	defaultCheckpointDirPerm = 0700
 )
 
 // CheckpointSignalSource determines how checkpoint operations are triggered
@@ -71,7 +85,7 @@ type CheckpointRequest struct {
 	DisableCUDA  bool   `json:"disable_cuda,omitempty"` // Disable CUDA plugin for non-GPU workloads
 }
 
-// TriggerRestoreRequest is the request body for Option A self-restoring trigger
+// TriggerRestoreRequest is the request body for self-restoring trigger
 type TriggerRestoreRequest struct {
 	CheckpointID           string `json:"checkpoint_id"`
 	PlaceholderContainerID string `json:"placeholder_container_id"`
@@ -84,6 +98,23 @@ type TriggerRestoreResponse struct {
 	Message          string `json:"message,omitempty"`
 	Error            string `json:"error,omitempty"`
 	TriggerPath      string `json:"trigger_path,omitempty"`
+	CheckpointImage  string `json:"checkpoint_image,omitempty"`
+	PlaceholderImage string `json:"placeholder_image,omitempty"`
+}
+
+// ExternalRestoreRequest is the request body for external restore operations
+type ExternalRestoreRequest struct {
+	CheckpointID           string `json:"checkpoint_id"`
+	PlaceholderContainerID string `json:"placeholder_container_id"`
+	SkipImageValidation    bool   `json:"skip_image_validation,omitempty"` // Skip image matching check
+}
+
+// ExternalRestoreResponse is the response for external restore operations
+type ExternalRestoreResponse struct {
+	Success          bool   `json:"success"`
+	Message          string `json:"message,omitempty"`
+	Error            string `json:"error,omitempty"`
+	RestoredPID      int    `json:"restored_pid,omitempty"`
 	CheckpointImage  string `json:"checkpoint_image,omitempty"`
 	PlaceholderImage string `json:"placeholder_image,omitempty"`
 }
@@ -116,6 +147,67 @@ type ListCheckpointsResponse struct {
 type HealthResponse struct {
 	Status   string `json:"status"`
 	NodeName string `json:"node_name"`
+}
+
+// Common HTTP handler helpers
+
+type errorResponse interface {
+	setError(msg string)
+}
+
+// Implementations for error response interface
+func (r *TriggerRestoreResponse) setError(msg string)  { r.Success = false; r.Error = msg }
+func (r *ExternalRestoreResponse) setError(msg string) { r.Success = false; r.Error = msg }
+func (r *CheckpointResponse) setError(msg string)      { r.Success = false; r.Error = msg }
+
+// validateRestoreRequest validates common restore request fields and loads checkpoint metadata.
+// Returns checkpoint path, metadata, and container info, or writes error response and returns empty string.
+func (s *Server) validateRestoreRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	checkpointID, placeholderContainerID string,
+	respTemplate errorResponse,
+) (string, *common.CheckpointMetadata, *checkpointk8s.ContainerInfo, bool) {
+
+	// Validate checkpoint ID
+	if checkpointID == "" {
+		respTemplate.setError("checkpoint_id is required")
+		writeJSON(w, http.StatusBadRequest, respTemplate)
+		return "", nil, nil, false
+	}
+
+	if err := validateCheckpointID(checkpointID); err != nil {
+		respTemplate.setError(fmt.Sprintf("Invalid checkpoint_id: %v", err))
+		writeJSON(w, http.StatusBadRequest, respTemplate)
+		return "", nil, nil, false
+	}
+
+	// Validate placeholder container ID
+	if placeholderContainerID == "" {
+		respTemplate.setError("placeholder_container_id is required")
+		writeJSON(w, http.StatusBadRequest, respTemplate)
+		return "", nil, nil, false
+	}
+
+	// Load checkpoint metadata
+	checkpointPath := common.GetCheckpointDir(s.config.CheckpointDir, checkpointID)
+	checkpointMeta, err := common.LoadMetadata(checkpointPath)
+	if err != nil {
+		respTemplate.setError(fmt.Sprintf("Checkpoint not found: %v", err))
+		writeJSON(w, http.StatusNotFound, respTemplate)
+		return "", nil, nil, false
+	}
+
+	// Resolve placeholder container
+	ctx := r.Context()
+	containerInfo, err := s.discoveryClient.ResolveContainer(ctx, placeholderContainerID)
+	if err != nil {
+		respTemplate.setError(fmt.Sprintf("Failed to resolve placeholder container: %v", err))
+		writeJSON(w, http.StatusInternalServerError, respTemplate)
+		return "", nil, nil, false
+	}
+
+	return checkpointPath, checkpointMeta, containerInfo, true
 }
 
 func main() {
@@ -200,21 +292,22 @@ func main() {
 		mux.HandleFunc("/health", server.handleHealth)
 		mux.HandleFunc("/checkpoint", server.handleCheckpoint)
 		mux.HandleFunc("/restore/trigger", server.handleTriggerRestore)
+		mux.HandleFunc("/restore/external", server.handleExternalRestore)
 		mux.HandleFunc("/checkpoints", server.handleListCheckpoints)
 
 		httpServer := &http.Server{
 			Addr:         config.ListenAddr,
 			Handler:      loggingMiddleware(mux),
-			ReadTimeout:  30 * time.Second,
-			WriteTimeout: 300 * time.Second,
-			IdleTimeout:  120 * time.Second,
+			ReadTimeout:  defaultReadTimeout,
+			WriteTimeout: defaultWriteTimeout,
+			IdleTimeout:  defaultIdleTimeout,
 		}
 
 		// Handle graceful shutdown
 		go func() {
 			<-sigChan
 			log.Println("Shutting down HTTP server...")
-			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
 			defer shutdownCancel()
 			if err := httpServer.Shutdown(shutdownCtx); err != nil {
 				log.Printf("HTTP server shutdown error: %v", err)
@@ -275,6 +368,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// handleCheckpoint creates a CRIU checkpoint of a running container.
+// It validates the request, resolves the container, and performs the checkpoint operation
+// using the configured checkpointer.
+//
+// Request body: CheckpointRequest with container_id and optional checkpoint_id
+// Response: CheckpointResponse with success status and checkpoint_id
 func (s *Server) handleCheckpoint(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -300,6 +399,14 @@ func (s *Server) handleCheckpoint(w http.ResponseWriter, r *http.Request) {
 
 	if req.CheckpointID == "" {
 		req.CheckpointID = fmt.Sprintf("ckpt-%d", time.Now().UnixNano())
+	}
+
+	if err := validateCheckpointID(req.CheckpointID); err != nil {
+		writeJSON(w, http.StatusBadRequest, CheckpointResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Invalid checkpoint_id: %v", err),
+		})
+		return
 	}
 
 	// Determine CUDA plugin directory - only use if not explicitly disabled
@@ -352,10 +459,13 @@ func (s *Server) handleCheckpoint(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleTriggerRestore implements Option A from RESTORE_ANALYSIS.md
-// It triggers a self-restoring placeholder container to start CRIU restore.
-// The agent writes a trigger file to the placeholder's filesystem, which
-// the placeholder's entrypoint script detects and uses to start restoration.
+// handleTriggerRestore implements Option A self-restore mechanism.
+// It triggers a self-restoring placeholder container to start CRIU restore by writing
+// a trigger file to the placeholder's filesystem.
+// The placeholder's entrypoint script detects this file and starts restoration.
+//
+// Request body: TriggerRestoreRequest with checkpoint_id and placeholder_container_id
+// Response: TriggerRestoreResponse with success status and trigger file path
 func (s *Server) handleTriggerRestore(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -371,41 +481,11 @@ func (s *Server) handleTriggerRestore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.CheckpointID == "" {
-		writeJSON(w, http.StatusBadRequest, TriggerRestoreResponse{
-			Success: false,
-			Error:   "checkpoint_id is required",
-		})
-		return
-	}
-
-	if req.PlaceholderContainerID == "" {
-		writeJSON(w, http.StatusBadRequest, TriggerRestoreResponse{
-			Success: false,
-			Error:   "placeholder_container_id is required",
-		})
-		return
-	}
-
-	// Verify checkpoint exists and load metadata
-	checkpointPath := common.GetCheckpointDir(s.config.CheckpointDir, req.CheckpointID)
-	checkpointMeta, err := common.LoadMetadata(checkpointPath)
-	if err != nil {
-		writeJSON(w, http.StatusNotFound, TriggerRestoreResponse{
-			Success: false,
-			Error:   fmt.Sprintf("Checkpoint not found: %v", err),
-		})
-		return
-	}
-
-	// Resolve placeholder container to get PID and image
-	ctx := r.Context()
-	containerInfo, err := s.discoveryClient.ResolveContainer(ctx, req.PlaceholderContainerID)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, TriggerRestoreResponse{
-			Success: false,
-			Error:   fmt.Sprintf("Failed to resolve placeholder container: %v", err),
-		})
+	// Validate request and load checkpoint/container info
+	checkpointPath, checkpointMeta, containerInfo, ok := s.validateRestoreRequest(
+		w, r, req.CheckpointID, req.PlaceholderContainerID, &TriggerRestoreResponse{},
+	)
+	if !ok {
 		return
 	}
 
@@ -425,12 +505,18 @@ func (s *Server) handleTriggerRestore(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Image validation passed: checkpoint=%s, placeholder=%s", checkpointMeta.Image, containerInfo.Image)
 	}
 
+	if containerInfo.PID <= 0 || containerInfo.PID > maxPID {
+		writeJSON(w, http.StatusBadRequest, TriggerRestoreResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Invalid container PID: %d", containerInfo.PID),
+		})
+		return
+	}
+
 	// Write trigger file to placeholder's filesystem via /proc/<pid>/root
-	// The trigger file contains the checkpoint path
 	triggerPath := fmt.Sprintf("%s/%d/root/tmp/restore-trigger", s.config.HostProc, containerInfo.PID)
 
-	// Write the checkpoint path to the trigger file
-	if err := os.WriteFile(triggerPath, []byte(checkpointPath), 0644); err != nil {
+	if err := os.WriteFile(triggerPath, []byte(checkpointPath), defaultTriggerFilePerm); err != nil {
 		writeJSON(w, http.StatusInternalServerError, TriggerRestoreResponse{
 			Success: false,
 			Error:   fmt.Sprintf("Failed to write trigger file: %v", err),
@@ -448,6 +534,130 @@ func (s *Server) handleTriggerRestore(w http.ResponseWriter, r *http.Request) {
 		CheckpointImage:  checkpointMeta.Image,
 		PlaceholderImage: containerInfo.Image,
 	})
+}
+
+// handleExternalRestore restores a checkpoint into a placeholder pod via nsenter.
+// POST /restore/external with checkpoint_id and placeholder_container_id.
+func (s *Server) handleExternalRestore(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ExternalRestoreRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, ExternalRestoreResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Invalid request body: %v", err),
+		})
+		return
+	}
+
+	checkpointPath, checkpointMeta, containerInfo, ok := s.validateRestoreRequest(
+		w, r, req.CheckpointID, req.PlaceholderContainerID, &ExternalRestoreResponse{},
+	)
+	if !ok {
+		return
+	}
+
+	if !s.validateImages(w, req.SkipImageValidation, checkpointMeta, containerInfo) {
+		return
+	}
+
+	if !s.validatePID(w, containerInfo.PID) {
+		return
+	}
+
+	log.Printf("Starting external restore for placeholder %s (PID %d) from checkpoint %s",
+		req.PlaceholderContainerID, containerInfo.PID, req.CheckpointID)
+
+	rootfsPath := fmt.Sprintf("%s/%d/root", s.config.HostProc, containerInfo.PID)
+	s.prepareFilesystem(checkpointPath, rootfsPath)
+
+	opts := s.buildExternalRestoreOpts(checkpointPath, containerInfo.PID)
+
+	restoredPID, err := restore.Restore(r.Context(), opts, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, ExternalRestoreResponse{
+			Success:          false,
+			Error:            fmt.Sprintf("External restore failed: %v", err),
+			CheckpointImage:  checkpointMeta.Image,
+			PlaceholderImage: containerInfo.Image,
+		})
+		return
+	}
+
+	log.Printf("External restore completed successfully: placeholder=%s, restored_pid=%d",
+		req.PlaceholderContainerID, restoredPID)
+
+	writeJSON(w, http.StatusOK, ExternalRestoreResponse{
+		Success:          true,
+		Message:          fmt.Sprintf("External restore completed for checkpoint %s", req.CheckpointID),
+		RestoredPID:      restoredPID,
+		CheckpointImage:  checkpointMeta.Image,
+		PlaceholderImage: containerInfo.Image,
+	})
+}
+
+func (s *Server) validateImages(w http.ResponseWriter, skipValidation bool, checkpointMeta *common.CheckpointMetadata, containerInfo *checkpointk8s.ContainerInfo) bool {
+	if skipValidation || checkpointMeta.Image == "" {
+		return true
+	}
+
+	if !imagesCompatible(checkpointMeta.Image, containerInfo.Image) {
+		writeJSON(w, http.StatusBadRequest, ExternalRestoreResponse{
+			Success:          false,
+			Error:            fmt.Sprintf("Image mismatch: checkpoint was from '%s' but placeholder uses '%s'. The placeholder must use the same base image. Use skip_image_validation=true to override.", checkpointMeta.Image, containerInfo.Image),
+			CheckpointImage:  checkpointMeta.Image,
+			PlaceholderImage: containerInfo.Image,
+		})
+		return false
+	}
+
+	log.Printf("Image validation passed: checkpoint=%s, placeholder=%s", checkpointMeta.Image, containerInfo.Image)
+	return true
+}
+
+func (s *Server) validatePID(w http.ResponseWriter, pid uint32) bool {
+	if pid <= 0 || pid > maxPID {
+		writeJSON(w, http.StatusBadRequest, ExternalRestoreResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Invalid container PID: %d", pid),
+		})
+		return false
+	}
+	return true
+}
+
+func (s *Server) prepareFilesystem(checkpointPath, rootfsPath string) {
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	if err := restore.ApplyRootfsDiff(checkpointPath, rootfsPath, logger); err != nil {
+		log.Printf("Warning: Failed to apply rootfs diff: %v", err)
+	}
+
+	if err := restore.ApplyDeletedFiles(checkpointPath, rootfsPath, logger); err != nil {
+		log.Printf("Warning: Failed to apply deleted files: %v", err)
+	}
+}
+
+func (s *Server) buildExternalRestoreOpts(checkpointPath string, containerPID uint32) *restore.RestoreOptions {
+	opts, err := restore.LoadRestoreOptions(checkpointPath, 4)
+	if err != nil {
+		log.Printf("Warning: Could not load restore options from metadata, using defaults: %v", err)
+		opts = restore.DefaultRestoreOptions(checkpointPath)
+		opts.LogLevel = 4
+	}
+
+	opts.ExternalRestore = true
+	opts.TargetPID = int(containerPID)
+
+	if s.config.CUDAPluginDir != "" {
+		opts.LibDir = s.config.CUDAPluginDir
+		opts.Timeout = s.config.Timeout
+	}
+
+	return opts
 }
 
 func (s *Server) handleListCheckpoints(w http.ResponseWriter, r *http.Request) {
@@ -489,7 +699,7 @@ func (s *Server) handleListCheckpoints(w http.ResponseWriter, r *http.Request) {
 func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(data)
+	_ = json.NewEncoder(w).Encode(data)
 }
 
 func loggingMiddleware(next http.Handler) http.Handler {
@@ -506,6 +716,23 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// validateCheckpointID validates that a checkpoint ID is safe for filesystem operations.
+// It prevents path traversal by ensuring the ID is a simple filename without path separators.
+func validateCheckpointID(id string) error {
+	if id == "" {
+		return fmt.Errorf("checkpoint ID cannot be empty")
+	}
+	if len(id) > maxCheckpointIDLength {
+		return fmt.Errorf("checkpoint ID too long (max %d characters)", maxCheckpointIDLength)
+	}
+	// filepath.Base returns the last element of the path.
+	// If id contains path separators or traversal (..), Base(id) != id
+	if filepath.Base(id) != id {
+		return fmt.Errorf("checkpoint ID must be a simple filename without path separators")
+	}
+	return nil
 }
 
 // imagesCompatible checks if two container images are compatible for CRIU restore.

--- a/deploy/chrek/cmd/agent/main_test.go
+++ b/deploy/chrek/cmd/agent/main_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestGetEnv tests environment variable retrieval with defaults
+func TestGetEnv(t *testing.T) {
+	tests := []struct {
+		name         string
+		key          string
+		envValue     string
+		setEnv       bool
+		defaultValue string
+		want         string
+	}{
+		{
+			name:         "env var set",
+			key:          "TEST_VAR_SET",
+			envValue:     "custom_value",
+			setEnv:       true,
+			defaultValue: "default",
+			want:         "custom_value",
+		},
+		{
+			name:         "env var not set - use default",
+			key:          "TEST_VAR_UNSET",
+			setEnv:       false,
+			defaultValue: "default_value",
+			want:         "default_value",
+		},
+		{
+			name:         "env var empty string - use default",
+			key:          "TEST_VAR_EMPTY",
+			envValue:     "",
+			setEnv:       true,
+			defaultValue: "default",
+			want:         "default",
+		},
+		{
+			name:         "empty default value",
+			key:          "TEST_VAR_UNSET2",
+			setEnv:       false,
+			defaultValue: "",
+			want:         "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean up before test
+			os.Unsetenv(tt.key)
+
+			if tt.setEnv {
+				os.Setenv(tt.key, tt.envValue)
+				defer os.Unsetenv(tt.key)
+			}
+
+			got := getEnv(tt.key, tt.defaultValue)
+			if got != tt.want {
+				t.Errorf("getEnv(%q, %q) = %q, want %q", tt.key, tt.defaultValue, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestImagesCompatible tests image name compatibility checking
+func TestImagesCompatible(t *testing.T) {
+	tests := []struct {
+		name             string
+		checkpointImage  string
+		placeholderImage string
+		want             bool
+	}{
+		// Exact matches
+		{
+			name:             "exact match - simple",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "nginx:alpine",
+			want:             true,
+		},
+		{
+			name:             "exact match - with registry",
+			checkpointImage:  "docker.io/library/nginx:alpine",
+			placeholderImage: "docker.io/library/nginx:alpine",
+			want:             true,
+		},
+
+		// Registry normalization - docker.io/library/
+		{
+			name:             "checkpoint has docker.io/library prefix",
+			checkpointImage:  "docker.io/library/nginx:alpine",
+			placeholderImage: "nginx:alpine",
+			want:             true,
+		},
+		{
+			name:             "placeholder has docker.io/library prefix",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "docker.io/library/nginx:alpine",
+			want:             true,
+		},
+		{
+			name:             "both have docker.io/library prefix - same image",
+			checkpointImage:  "docker.io/library/ubuntu:22.04",
+			placeholderImage: "docker.io/library/ubuntu:22.04",
+			want:             true,
+		},
+
+		// Registry normalization - docker.io/
+		{
+			name:             "checkpoint has docker.io prefix",
+			checkpointImage:  "docker.io/nginx:alpine",
+			placeholderImage: "nginx:alpine",
+			want:             true,
+		},
+		{
+			name:             "placeholder has docker.io prefix",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "docker.io/nginx:alpine",
+			want:             true,
+		},
+
+		// Placeholder naming convention
+		{
+			name:             "placeholder convention - simple",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "criu-placeholder-nginx-alpine",
+			want:             true,
+		},
+		{
+			name:             "placeholder convention - with tag",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "criu-placeholder-nginx-alpine:v1",
+			want:             true,
+		},
+		{
+			name:             "placeholder convention - ubuntu",
+			checkpointImage:  "ubuntu:22.04",
+			placeholderImage: "criu-placeholder-ubuntu-22.04",
+			want:             true,
+		},
+		{
+			name:             "placeholder convention - with registry normalization",
+			checkpointImage:  "docker.io/library/nginx:alpine",
+			placeholderImage: "criu-placeholder-nginx-alpine",
+			want:             true,
+		},
+		{
+			name:             "placeholder convention - multi-part image",
+			checkpointImage:  "myregistry.io/myorg/app:v1.0",
+			placeholderImage: "criu-placeholder-myregistry.io-myorg-app-v1.0",
+			want:             true,
+		},
+
+		// Mismatches
+		{
+			name:             "different images",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "ubuntu:22.04",
+			want:             false,
+		},
+		{
+			name:             "different tags",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "nginx:latest",
+			want:             false,
+		},
+		{
+			name:             "wrong placeholder convention",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "criu-placeholder-ubuntu-22.04",
+			want:             false,
+		},
+		{
+			name:             "placeholder without prefix",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "nginx-alpine",
+			want:             false,
+		},
+		{
+			name:             "empty checkpoint image",
+			checkpointImage:  "",
+			placeholderImage: "nginx:alpine",
+			want:             false,
+		},
+		{
+			name:             "empty placeholder image",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "",
+			want:             false,
+		},
+		{
+			name:             "both empty",
+			checkpointImage:  "",
+			placeholderImage: "",
+			want:             true,
+		},
+
+		// Edge cases
+		{
+			name:             "registry with different paths",
+			checkpointImage:  "docker.io/library/nginx:alpine",
+			placeholderImage: "docker.io/myuser/nginx:alpine",
+			want:             false,
+		},
+		{
+			name:             "image with slashes in org",
+			checkpointImage:  "myregistry.io/org/team/app:v1",
+			placeholderImage: "criu-placeholder-myregistry.io-org-team-app-v1",
+			want:             true,
+		},
+		{
+			name:             "placeholder with extra suffix",
+			checkpointImage:  "nginx:alpine",
+			placeholderImage: "criu-placeholder-nginx-alpine-extra",
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := imagesCompatible(tt.checkpointImage, tt.placeholderImage)
+			if got != tt.want {
+				t.Errorf("imagesCompatible(%q, %q) = %v, want %v",
+					tt.checkpointImage, tt.placeholderImage, got, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/chrek/cmd/criu-helper/main.go
+++ b/deploy/chrek/cmd/criu-helper/main.go
@@ -1,0 +1,421 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ai-dynamo/dynamo/deploy/chrek/pkg/criulog"
+	criu "github.com/checkpoint-restore/go-criu/v7"
+	criurpc "github.com/checkpoint-restore/go-criu/v7/rpc"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	defaultCRIULogLevel   = 5
+	defaultWorkDirPerm    = 0755
+	mountinfoBatchSize    = 100
+	mountinfoMinFields    = 5
+	mountinfoMountPtIndex = 4
+)
+
+// criu-helper is executed via nsenter inside the target container's namespaces.
+// It performs remount and CRIU restore using go-criu library.
+
+func main() {
+	checkpointPath := flag.String("checkpoint", "", "Path to checkpoint directory (required)")
+	logLevel := flag.Int("log-level", defaultCRIULogLevel, "CRIU log level (default: 5 for debug)")
+	logFile := flag.String("log-file", "restore.log", "CRIU log filename")
+	workDir := flag.String("work-dir", "", "CRIU work directory")
+	libDir := flag.String("lib-dir", "", "CRIU plugin library directory")
+	cgroupRoot := flag.String("cgroup-root", "", "Cgroup path to restore into (absolute path from host)")
+	tcpEstablished := flag.Bool("tcp-established", false, "Restore TCP established connections")
+	tcpClose := flag.Bool("tcp-close", false, "Close TCP connections instead of restoring")
+	remount := flag.Bool("remount", true, "Remount /proc/sys as rw/ro around restore")
+	verbose := flag.Bool("verbose", false, "Verbose logging")
+	inheritFd := flag.Bool("inherit-fd", true, "Redirect stdout/stderr to container logging (default: true)")
+
+	flag.Parse()
+
+	// Setup logging - quiet by default to not clutter agent logs
+	log := logrus.New()
+	log.SetOutput(os.Stderr)
+	log.SetFormatter(&logrus.TextFormatter{
+		DisableTimestamp: false,
+		DisableColors:    true,
+	})
+	if *verbose {
+		log.SetLevel(logrus.DebugLevel)
+	} else {
+		// Default: only warnings and errors (agent already logs the important stuff)
+		log.SetLevel(logrus.WarnLevel)
+	}
+
+	// Validate required flags
+	if *checkpointPath == "" {
+		log.Fatal("--checkpoint is required")
+	}
+
+	log.WithFields(logrus.Fields{
+		"checkpoint":  *checkpointPath,
+		"log_level":   *logLevel,
+		"work_dir":    *workDir,
+		"lib_dir":     *libDir,
+		"cgroup_root": *cgroupRoot,
+		"remount":     *remount,
+	}).Info("CRIU helper starting")
+
+	// Remount /proc/sys as read-write if requested
+	if *remount {
+		log.Info("Remounting /proc/sys as read-write")
+		if err := unix.Mount("proc", "/proc/sys", "", unix.MS_REMOUNT, ""); err != nil {
+			log.WithError(err).Warn("Failed to remount /proc/sys as rw (continuing anyway)")
+		} else {
+			log.Debug("Successfully remounted /proc/sys as rw")
+			// Ensure we restore it to read-only on exit
+			defer func() {
+				log.Info("Remounting /proc/sys as read-only")
+				if err := unix.Mount("proc", "/proc/sys", "", unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {
+					log.WithError(err).Warn("Failed to remount /proc/sys as ro")
+				}
+			}()
+		}
+	}
+
+	// Perform CRIU restore using go-criu library
+	// With SOFT mode, CRIU automatically moves the restored process into the target cgroup
+	pid, err := performRestore(*checkpointPath, *logLevel, *logFile, *workDir, *libDir, *cgroupRoot, *tcpEstablished, *tcpClose, *inheritFd, log)
+	if err != nil {
+		log.WithError(err).Fatal("CRIU restore failed")
+	}
+
+	// Output PID to stdout for parent process to capture
+	fmt.Fprintf(os.Stdout, "RESTORED_PID=%d\n", pid)
+	log.WithField("pid", pid).Info("CRIU restore completed successfully")
+}
+
+// performRestore executes CRIU restore using the go-criu library.
+func performRestore(checkpointPath string, logLevel int, logFile string, workDir string, libDir string, cgroupRoot string, tcpEstablished bool, tcpClose bool, inheritFd bool, log *logrus.Logger) (int, error) {
+	startTime := time.Now()
+
+	imageDir, netNsFile, workDirFile, err := openRestoreFDs(checkpointPath, workDir, log)
+	if err != nil {
+		return 0, err
+	}
+	defer imageDir.Close()
+	defer netNsFile.Close()
+	if workDirFile != nil {
+		defer workDirFile.Close()
+	}
+
+	inheritFds := buildInheritFds(netNsFile, log)
+	workDirFd := getWorkDirFd(workDirFile)
+	extMounts := generateExtMounts(log)
+	// cgroupRoot is now passed from the agent (read from host before nsenter)
+	// No longer extracting it inside criu-helper which runs after nsenter
+
+	criuOpts := buildCRIUOpts(checkpointPath, imageDir, netNsFile, workDirFd, logLevel, logFile, tcpEstablished, tcpClose, cgroupRoot, inheritFds, extMounts)
+	criuOpts.InheritFd = inheritFds
+
+	return executeCRIURestore(criuOpts, checkpointPath, workDir, logFile, startTime, log)
+}
+
+// openRestoreFDs opens all required file descriptors for restore.
+func openRestoreFDs(checkpointPath, workDir string, log *logrus.Logger) (*os.File, *os.File, *os.File, error) {
+	imageDir, err := os.Open(checkpointPath)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to open checkpoint directory: %w", err)
+	}
+
+	if _, err := unix.FcntlInt(imageDir.Fd(), unix.F_SETFD, 0); err != nil {
+		imageDir.Close()
+		return nil, nil, nil, fmt.Errorf("failed to clear CLOEXEC on images dir: %w", err)
+	}
+	log.WithField("fd", imageDir.Fd()).Debug("Opened checkpoint directory")
+
+	netNsFile, err := os.Open("/proc/1/ns/net")
+	if err != nil {
+		imageDir.Close()
+		return nil, nil, nil, fmt.Errorf("failed to open /proc/1/ns/net: %w", err)
+	}
+
+	if _, err := unix.FcntlInt(netNsFile.Fd(), unix.F_SETFD, 0); err != nil {
+		imageDir.Close()
+		netNsFile.Close()
+		return nil, nil, nil, fmt.Errorf("failed to clear CLOEXEC on netns fd: %w", err)
+	}
+
+	var workDirFile *os.File
+	if workDir != "" {
+		if err := os.MkdirAll(workDir, defaultWorkDirPerm); err == nil {
+			workDirFile, err = os.Open(workDir)
+			if err == nil {
+				if _, err := unix.FcntlInt(workDirFile.Fd(), unix.F_SETFD, 0); err != nil {
+					log.WithError(err).Warn("Failed to clear CLOEXEC on work dir")
+					workDirFile.Close()
+					workDirFile = nil
+				} else {
+					log.WithField("fd", workDirFile.Fd()).Debug("Opened work directory")
+				}
+			}
+		}
+	}
+
+	return imageDir, netNsFile, workDirFile, nil
+}
+
+// buildInheritFds creates the InheritFd list for external network namespace.
+func buildInheritFds(netNsFile *os.File, log *logrus.Logger) []*criurpc.InheritFd {
+	inheritFds := []*criurpc.InheritFd{
+		{
+			Key: proto.String("extNetNs"),
+			Fd:  proto.Int32(int32(netNsFile.Fd())),
+		},
+	}
+	log.WithField("netns_fd", netNsFile.Fd()).Info("Network namespace fd prepared")
+	return inheritFds
+}
+
+// getWorkDirFd returns the work directory FD or -1 if not set.
+func getWorkDirFd(workDirFile *os.File) int32 {
+	if workDirFile != nil {
+		return int32(workDirFile.Fd())
+	}
+	return -1
+}
+
+// generateExtMounts generates external mount mappings with error handling.
+func generateExtMounts(log *logrus.Logger) []*criurpc.ExtMountMap {
+	extMounts, err := generateExtMountMaps()
+	if err != nil {
+		log.WithError(err).Warn("Failed to generate ExtMnt")
+		return nil
+	}
+	log.WithField("count", len(extMounts)).Info("Generated ExtMnt mappings")
+	return extMounts
+}
+
+// buildCRIUOpts constructs the CRIU options structure.
+func buildCRIUOpts(checkpointPath string, imageDir, netNsFile *os.File, workDirFd int32, logLevel int, logFile string, tcpEstablished, tcpClose bool, cgroupRoot string, inheritFds []*criurpc.InheritFd, extMounts []*criurpc.ExtMountMap) *criurpc.CriuOpts {
+	// Use SOFT mode to enable cgroup management with --cgroup-root
+	// SOFT mode allows CRIU to call cgroup_move_into() during restore
+	// This moves the restored process into the target cgroup BEFORE memory allocation
+	cgMode := criurpc.CriuCgMode_SOFT
+	criuOpts := &criurpc.CriuOpts{
+		ImagesDirFd: proto.Int32(int32(imageDir.Fd())),
+		LogLevel:    proto.Int32(int32(logLevel)),
+		LogFile:     proto.String(logFile),
+
+		// Root filesystem - use current container's root
+		Root: proto.String("/"),
+
+		// Restore in detached mode
+		RstSibling: proto.Bool(true),
+
+		// Mount namespace compatibility mode
+		MntnsCompatMode: proto.Bool(true),
+
+		// Network namespace is provided via InheritFd (not JoinNs) because it was
+		// marked as external during checkpoint. CRIU expects to receive external
+		// namespaces via InheritFd with the matching key ("extNetNs").
+
+		// TCP options
+		ShellJob:       proto.Bool(true),
+		TcpEstablished: proto.Bool(tcpEstablished),
+		TcpClose:       proto.Bool(tcpClose),
+
+		// External Unix socket handling
+		ExtUnixSk: proto.Bool(true),
+
+		// Cgroup management - FULL mode with cgroup root redirection
+		ManageCgroups:     proto.Bool(true),
+		ManageCgroupsMode: &cgMode,
+
+		// Device and inode handling
+		EvasiveDevices: proto.Bool(true),
+		ForceIrmap:     proto.Bool(true),
+
+		// External mount mappings
+		ExtMnt: extMounts,
+	}
+
+	// Set --cgroup-root to redirect restored process to placeholder's cgroup
+	// This tells CRIU to restore under this path instead of the original checkpoint's path
+	if cgroupRoot != "" {
+		criuOpts.CgRoot = []*criurpc.CgroupRoot{
+			{
+				// No controller specified = applies to unified cgroup (cgroup v2)
+				Path: proto.String(cgroupRoot),
+			},
+		}
+	}
+
+	// Add work directory if specified
+	if workDirFd >= 0 {
+		criuOpts.WorkDirFd = proto.Int32(workDirFd)
+	}
+
+	criuConfigPath := filepath.Join(checkpointPath, "criu.conf")
+	criuOpts.ConfigFile = proto.String(criuConfigPath)
+
+	return criuOpts
+}
+
+// executeCRIURestore runs the CRIU restore operation and returns the restored PID.
+func executeCRIURestore(criuOpts *criurpc.CriuOpts, checkpointPath, workDir, logFile string, startTime time.Time, log *logrus.Logger) (int, error) {
+	c := criu.MakeCriu()
+	notify := &notifyHandler{log: log}
+
+	logFields := logrus.Fields{
+		"images_dir_fd":    criuOpts.GetImagesDirFd(),
+		"root":             criuOpts.GetRoot(),
+		"tcp_established":  criuOpts.GetTcpEstablished(),
+		"tcp_close":        criuOpts.GetTcpClose(),
+		"shell_job":        criuOpts.GetShellJob(),
+		"rst_sibling":      criuOpts.GetRstSibling(),
+		"mntns_compat":     criuOpts.GetMntnsCompatMode(),
+		"work_dir_fd":      criuOpts.GetWorkDirFd(),
+		"config_file":      criuOpts.GetConfigFile(),
+		"cgroup_mode":      criuOpts.GetManageCgroupsMode(),
+		"inherit_fd_count": len(criuOpts.GetInheritFd()),
+	}
+	if len(criuOpts.GetCgRoot()) > 0 {
+		logFields["cgroup_root"] = criuOpts.GetCgRoot()[0].GetPath()
+	}
+	log.WithFields(logFields).Info("Executing CRIU restore")
+
+	// Log InheritFd details if present
+	if len(criuOpts.GetInheritFd()) > 0 {
+		for i, ifd := range criuOpts.GetInheritFd() {
+			log.WithFields(logrus.Fields{
+				"index": i,
+				"key":   ifd.GetKey(),
+				"fd":    ifd.GetFd(),
+			}).Info("InheritFd entry")
+		}
+	}
+
+	if err := c.Restore(criuOpts, notify); err != nil {
+		log.WithError(err).Error("CRIU restore failed")
+		criulog.LogErrorsWithWorkDir(checkpointPath, workDir, logFile, log)
+		return 0, fmt.Errorf("CRIU restore failed: %w", err)
+	}
+
+	duration := time.Since(startTime)
+	log.WithFields(logrus.Fields{
+		"restored_pid": notify.restoredPID,
+		"duration":     duration,
+	}).Info("CRIU restore completed")
+
+	if notify.restoredPID > 0 {
+		return int(notify.restoredPID), nil
+	}
+
+	return 0, fmt.Errorf("could not determine restored process PID")
+}
+
+// notifyHandler implements criu.Notify interface
+type notifyHandler struct {
+	log         *logrus.Logger
+	restoredPID int32
+}
+
+func (n *notifyHandler) PreDump() error {
+	n.log.Debug("CRIU notification: PreDump")
+	return nil
+}
+
+func (n *notifyHandler) PostDump() error {
+	n.log.Debug("CRIU notification: PostDump")
+	return nil
+}
+
+func (n *notifyHandler) PreRestore() error {
+	n.log.Debug("CRIU notification: PreRestore")
+	return nil
+}
+
+func (n *notifyHandler) PostRestore(pid int32) error {
+	n.log.WithField("pid", pid).Info("CRIU notification: PostRestore")
+	n.restoredPID = pid
+	return nil
+}
+
+func (n *notifyHandler) NetworkLock() error {
+	n.log.Debug("CRIU notification: NetworkLock")
+	return nil
+}
+
+func (n *notifyHandler) NetworkUnlock() error {
+	n.log.Debug("CRIU notification: NetworkUnlock")
+	return nil
+}
+
+func (n *notifyHandler) SetupNamespaces(pid int32) error {
+	n.log.WithField("pid", pid).Debug("CRIU notification: SetupNamespaces")
+	return nil
+}
+
+func (n *notifyHandler) PostSetupNamespaces() error {
+	n.log.Debug("CRIU notification: PostSetupNamespaces")
+	return nil
+}
+
+func (n *notifyHandler) PostResume() error {
+	n.log.Debug("CRIU notification: PostResume")
+	return nil
+}
+
+// generateExtMountMaps generates external mount mappings for CRIU restore.
+// It parses /proc/1/mountinfo (the restore container's mounts) and creates
+// ExtMountMap entries for each mount point.
+func generateExtMountMaps() ([]*criurpc.ExtMountMap, error) {
+	var maps []*criurpc.ExtMountMap
+	addedMounts := make(map[string]bool)
+
+	// Add root filesystem mapping first
+	maps = append(maps, &criurpc.ExtMountMap{
+		Key: proto.String("/"),
+		Val: proto.String("."),
+	})
+	addedMounts["/"] = true
+
+	// Parse /proc/1/mountinfo for all current mount points
+	file, err := os.Open("/proc/1/mountinfo")
+	if err != nil {
+		return nil, fmt.Errorf("failed to open mountinfo: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) < mountinfoMinFields {
+			continue
+		}
+		mountPoint := fields[mountinfoMountPtIndex]
+
+		if mountPoint == "/" || addedMounts[mountPoint] {
+			continue
+		}
+
+		maps = append(maps, &criurpc.ExtMountMap{
+			Key: proto.String(mountPoint),
+			Val: proto.String(mountPoint),
+		})
+		addedMounts[mountPoint] = true
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading mountinfo: %w", err)
+	}
+
+	return maps, nil
+}

--- a/deploy/chrek/pkg/checkpoint/criu_test.go
+++ b/deploy/chrek/pkg/checkpoint/criu_test.go
@@ -1,0 +1,340 @@
+package checkpoint
+
+import (
+	"testing"
+
+	criurpc "github.com/checkpoint-restore/go-criu/v7/rpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/ai-dynamo/dynamo/deploy/chrek/pkg/common"
+)
+
+func TestBuildCRIUOpts(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  CRIUConfig
+	}{
+		{
+			name: "basic config",
+			cfg: CRIUConfig{
+				PID:        12345,
+				ImageDirFD: 5,
+				RootFS:     "/",
+				GhostLimit: 0,
+				Timeout:    0,
+			},
+		},
+		{
+			name: "config with ghost limit",
+			cfg: CRIUConfig{
+				PID:        99999,
+				ImageDirFD: 10,
+				RootFS:     "/container/root",
+				GhostLimit: 1048576,
+				Timeout:    0,
+			},
+		},
+		{
+			name: "config with timeout",
+			cfg: CRIUConfig{
+				PID:        54321,
+				ImageDirFD: 3,
+				RootFS:     "/",
+				GhostLimit: 0,
+				Timeout:    120,
+			},
+		},
+		{
+			name: "config with both ghost limit and timeout",
+			cfg: CRIUConfig{
+				PID:        11111,
+				ImageDirFD: 7,
+				RootFS:     "/rootfs",
+				GhostLimit: 2097152,
+				Timeout:    300,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := BuildCRIUOpts(tt.cfg)
+
+			// Check required fields
+			if opts.GetPid() != int32(tt.cfg.PID) {
+				t.Errorf("Pid = %v, want %v", opts.GetPid(), tt.cfg.PID)
+			}
+			if opts.GetImagesDirFd() != tt.cfg.ImageDirFD {
+				t.Errorf("ImagesDirFd = %v, want %v", opts.GetImagesDirFd(), tt.cfg.ImageDirFD)
+			}
+			if opts.GetRoot() != tt.cfg.RootFS {
+				t.Errorf("Root = %v, want %v", opts.GetRoot(), tt.cfg.RootFS)
+			}
+
+			// Check common K8s flags
+			common.AssertCommonK8sFlags(t, opts)
+
+			// Check checkpoint-specific flags
+			if !opts.GetLeaveRunning() {
+				t.Error("LeaveRunning should be true")
+			}
+			if !opts.GetOrphanPtsMaster() {
+				t.Error("OrphanPtsMaster should be true")
+			}
+			if !opts.GetLinkRemap() {
+				t.Error("LinkRemap should be true")
+			}
+			if !opts.GetExtMasters() {
+				t.Error("ExtMasters should be true")
+			}
+
+			// Check optional fields
+			if tt.cfg.GhostLimit > 0 {
+				if opts.GetGhostLimit() != tt.cfg.GhostLimit {
+					t.Errorf("GhostLimit = %v, want %v", opts.GetGhostLimit(), tt.cfg.GhostLimit)
+				}
+			}
+			if tt.cfg.Timeout > 0 {
+				if opts.GetTimeout() != tt.cfg.Timeout {
+					t.Errorf("Timeout = %v, want %v", opts.GetTimeout(), tt.cfg.Timeout)
+				}
+			}
+
+			// Check log settings
+			if opts.GetLogLevel() != 4 {
+				t.Errorf("LogLevel = %v, want 4", opts.GetLogLevel())
+			}
+			if opts.GetLogFile() != "dump.log" {
+				t.Errorf("LogFile = %v, want dump.log", opts.GetLogFile())
+			}
+
+			// Check cgroup mode is SOFT (for external restore)
+			if opts.GetManageCgroupsMode() != criurpc.CriuCgMode_SOFT {
+				t.Errorf("ManageCgroupsMode = %v, want SOFT", opts.GetManageCgroupsMode())
+			}
+		})
+	}
+}
+
+func TestAddExternalMounts(t *testing.T) {
+	tests := []struct {
+		name   string
+		mounts []AllMountInfo
+		want   int // number of external mounts
+	}{
+		{
+			name:   "empty mounts",
+			mounts: []AllMountInfo{},
+			want:   0,
+		},
+		{
+			name: "single mount",
+			mounts: []AllMountInfo{
+				{MountPoint: "/data", FSType: "ext4"},
+			},
+			want: 1,
+		},
+		{
+			name: "multiple mounts",
+			mounts: []AllMountInfo{
+				{MountPoint: "/data", FSType: "ext4"},
+				{MountPoint: "/var/cache", FSType: "tmpfs"},
+				{MountPoint: "/mnt/nfs", FSType: "nfs4"},
+			},
+			want: 3,
+		},
+		{
+			name: "duplicate mount points",
+			mounts: []AllMountInfo{
+				{MountPoint: "/data", FSType: "ext4"},
+				{MountPoint: "/data", FSType: "ext4"},
+				{MountPoint: "/cache", FSType: "tmpfs"},
+			},
+			want: 2, // duplicates should be deduplicated
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			criuOpts := &criurpc.CriuOpts{}
+			AddExternalMounts(criuOpts, tt.mounts)
+
+			if len(criuOpts.ExtMnt) != tt.want {
+				t.Errorf("len(ExtMnt) = %v, want %v", len(criuOpts.ExtMnt), tt.want)
+			}
+
+			// Verify mount points are correctly added (Key == Val == MountPoint)
+			for i, extMnt := range criuOpts.ExtMnt {
+				if extMnt.GetKey() != extMnt.GetVal() {
+					t.Errorf("ExtMnt[%d].Key = %v, want %v", i, extMnt.GetKey(), extMnt.GetVal())
+				}
+			}
+		})
+	}
+}
+
+func TestAddExternalPaths(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingMnts []string
+		newPaths     []string
+		wantTotal    int
+	}{
+		{
+			name:         "add to empty",
+			existingMnts: []string{},
+			newPaths:     []string{"/proc/sys", "/sys/firmware"},
+			wantTotal:    2,
+		},
+		{
+			name:         "add without duplicates",
+			existingMnts: []string{"/data"},
+			newPaths:     []string{"/proc/sys", "/sys/firmware"},
+			wantTotal:    3,
+		},
+		{
+			name:         "skip duplicates",
+			existingMnts: []string{"/proc/sys", "/data"},
+			newPaths:     []string{"/proc/sys", "/sys/firmware"},
+			wantTotal:    3, // /proc/sys already exists, only /sys/firmware added
+		},
+		{
+			name:         "all duplicates",
+			existingMnts: []string{"/proc/sys", "/sys/firmware"},
+			newPaths:     []string{"/proc/sys", "/sys/firmware"},
+			wantTotal:    2, // nothing added
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			criuOpts := &criurpc.CriuOpts{}
+
+			// Add existing mounts
+			for _, path := range tt.existingMnts {
+				criuOpts.ExtMnt = append(criuOpts.ExtMnt, &criurpc.ExtMountMap{
+					Key: proto.String(path),
+					Val: proto.String(path),
+				})
+			}
+
+			// Add new paths
+			AddExternalPaths(criuOpts, tt.newPaths)
+
+			if len(criuOpts.ExtMnt) != tt.wantTotal {
+				t.Errorf("len(ExtMnt) = %v, want %v", len(criuOpts.ExtMnt), tt.wantTotal)
+			}
+		})
+	}
+}
+
+func TestAddExternalNamespace(t *testing.T) {
+	tests := []struct {
+		name   string
+		nsType NamespaceType
+		inode  uint64
+		key    string
+		want   string
+	}{
+		{
+			name:   "network namespace",
+			nsType: NamespaceNet,
+			inode:  4026531956,
+			key:    "extRootNetNS",
+			want:   "net[4026531956]:extRootNetNS",
+		},
+		{
+			name:   "pid namespace",
+			nsType: NamespacePID,
+			inode:  4026531957,
+			key:    "extRootPidNS",
+			want:   "pid[4026531957]:extRootPidNS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			criuOpts := &criurpc.CriuOpts{}
+			AddExternalNamespace(criuOpts, tt.nsType, tt.inode, tt.key)
+
+			if len(criuOpts.External) != 1 {
+				t.Fatalf("len(External) = %v, want 1", len(criuOpts.External))
+			}
+
+			if criuOpts.External[0] != tt.want {
+				t.Errorf("External[0] = %v, want %v", criuOpts.External[0], tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigureExternalNamespaces(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespaces     map[NamespaceType]*NamespaceInfo
+		externalMounts []string
+		wantExtCount   int
+		wantNetNsInode uint64
+	}{
+		{
+			name: "network namespace with external mounts",
+			namespaces: map[NamespaceType]*NamespaceInfo{
+				NamespaceNet: {
+					Type:  NamespaceNet,
+					Inode: 4026531956,
+				},
+			},
+			externalMounts: []string{"extfile:/dev/nvidia0", "extfile:/dev/nvidiactl"},
+			wantExtCount:   3, // 1 net NS + 2 external mounts
+			wantNetNsInode: 4026531956,
+		},
+		{
+			name: "network namespace without external mounts",
+			namespaces: map[NamespaceType]*NamespaceInfo{
+				NamespaceNet: {
+					Type:  NamespaceNet,
+					Inode: 4026531957,
+				},
+			},
+			externalMounts: []string{},
+			wantExtCount:   1, // only net NS
+			wantNetNsInode: 4026531957,
+		},
+		{
+			name:           "no network namespace",
+			namespaces:     map[NamespaceType]*NamespaceInfo{},
+			externalMounts: []string{"extfile:/dev/nvidia0"},
+			wantExtCount:   1, // only external mounts
+			wantNetNsInode: 0,
+		},
+		{
+			name:           "empty everything",
+			namespaces:     map[NamespaceType]*NamespaceInfo{},
+			externalMounts: []string{},
+			wantExtCount:   0,
+			wantNetNsInode: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			criuOpts := &criurpc.CriuOpts{}
+			netNsInode := ConfigureExternalNamespaces(criuOpts, tt.namespaces, tt.externalMounts)
+
+			if len(criuOpts.External) != tt.wantExtCount {
+				t.Errorf("len(External) = %v, want %v", len(criuOpts.External), tt.wantExtCount)
+			}
+
+			if netNsInode != tt.wantNetNsInode {
+				t.Errorf("netNsInode = %v, want %v", netNsInode, tt.wantNetNsInode)
+			}
+
+			// Verify format of external strings
+			for _, ext := range criuOpts.External {
+				if ext == "" {
+					t.Error("External string should not be empty")
+				}
+			}
+		})
+	}
+}

--- a/deploy/chrek/pkg/checkpoint/k8s/volumes_test.go
+++ b/deploy/chrek/pkg/checkpoint/k8s/volumes_test.go
@@ -1,0 +1,237 @@
+package k8s
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestGetVolumeDetails tests the getVolumeDetails function with common volume types
+func TestGetVolumeDetails(t *testing.T) {
+	tests := []struct {
+		name            string
+		volume          *corev1.Volume
+		expectedType    string
+		expectedCMName  string
+		expectedSecret  string
+		expectedPVCName string
+	}{
+		{
+			name:         "emptyDir",
+			volume:       &corev1.Volume{VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			expectedType: "emptyDir",
+		},
+		{
+			name:           "configMap",
+			volume:         &corev1.Volume{VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"}}}},
+			expectedType:   "configMap",
+			expectedCMName: "my-config",
+		},
+		{
+			name:           "secret",
+			volume:         &corev1.Volume{VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "my-secret"}}},
+			expectedType:   "secret",
+			expectedSecret: "my-secret",
+		},
+		{
+			name:            "persistentVolumeClaim",
+			volume:          &corev1.Volume{VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}}},
+			expectedType:    "persistentVolumeClaim",
+			expectedPVCName: "my-pvc",
+		},
+		{
+			name:         "hostPath",
+			volume:       &corev1.Volume{VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib"}}},
+			expectedType: "hostPath",
+		},
+		{
+			name:         "projected",
+			volume:       &corev1.Volume{VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{}}},
+			expectedType: "projected",
+		},
+		{
+			name:         "downwardAPI",
+			volume:       &corev1.Volume{VolumeSource: corev1.VolumeSource{DownwardAPI: &corev1.DownwardAPIVolumeSource{}}},
+			expectedType: "downwardAPI",
+		},
+		{
+			name:         "csi",
+			volume:       &corev1.Volume{VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{Driver: "csi.example.com"}}},
+			expectedType: "csi",
+		},
+		{
+			name:         "unknown - no volume source",
+			volume:       &corev1.Volume{},
+			expectedType: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getVolumeDetails(tt.volume)
+
+			if result.volumeType != tt.expectedType {
+				t.Errorf("volumeType = %q, want %q", result.volumeType, tt.expectedType)
+			}
+			if tt.expectedCMName != "" && result.configMapName != tt.expectedCMName {
+				t.Errorf("configMapName = %q, want %q", result.configMapName, tt.expectedCMName)
+			}
+			if tt.expectedSecret != "" && result.secretName != tt.expectedSecret {
+				t.Errorf("secretName = %q, want %q", result.secretName, tt.expectedSecret)
+			}
+			if tt.expectedPVCName != "" && result.pvcName != tt.expectedPVCName {
+				t.Errorf("pvcName = %q, want %q", result.pvcName, tt.expectedPVCName)
+			}
+		})
+	}
+}
+
+// TestDetectVolumeTypeFromPath tests path pattern matching for K8s volume types
+func TestDetectVolumeTypeFromPath(t *testing.T) {
+	tests := []struct {
+		name           string
+		hostPath       string
+		expectedType   string
+		expectedVolume string
+	}{
+		{
+			name:           "emptyDir volume",
+			hostPath:       "/var/lib/kubelet/pods/abc123/volumes/kubernetes.io~empty-dir/cache-volume",
+			expectedType:   "emptyDir",
+			expectedVolume: "cache-volume",
+		},
+		{
+			name:           "configMap volume",
+			hostPath:       "/var/lib/kubelet/pods/abc123/volumes/kubernetes.io~configmap/config-vol",
+			expectedType:   "configMap",
+			expectedVolume: "config-vol",
+		},
+		{
+			name:           "secret volume",
+			hostPath:       "/var/lib/kubelet/pods/abc123/volumes/kubernetes.io~secret/secret-vol",
+			expectedType:   "secret",
+			expectedVolume: "secret-vol",
+		},
+		{
+			name:           "projected volume",
+			hostPath:       "/var/lib/kubelet/pods/abc123/volumes/kubernetes.io~projected/kube-api-access",
+			expectedType:   "projected",
+			expectedVolume: "kube-api-access",
+		},
+		{
+			name:           "persistentVolumeClaim volume",
+			hostPath:       "/var/lib/kubelet/pods/abc123/volumes/kubernetes.io~persistentvolumeclaim/data-pvc",
+			expectedType:   "persistentVolumeClaim",
+			expectedVolume: "data-pvc",
+		},
+		{
+			name:           "unknown volume type",
+			hostPath:       "/some/other/path/without/kubernetes/pattern",
+			expectedType:   "unknown",
+			expectedVolume: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			volType, volName := DetectVolumeTypeFromPath(tt.hostPath)
+
+			if volType != tt.expectedType {
+				t.Errorf("volumeType = %q, want %q", volType, tt.expectedType)
+			}
+			if volName != tt.expectedVolume {
+				t.Errorf("volumeName = %q, want %q", volName, tt.expectedVolume)
+			}
+		})
+	}
+}
+
+// TestExtractVolumeInfo tests the ExtractVolumeInfo function with various pod configurations
+func TestExtractVolumeInfo(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		containerName string
+		wantErr       bool
+		wantCount     int
+	}{
+		{
+			name: "single emptyDir mount",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes:    []corev1.Volume{{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+					Containers: []corev1.Container{{Name: "app", VolumeMounts: []corev1.VolumeMount{{Name: "cache", MountPath: "/cache"}}}},
+				},
+			},
+			containerName: "app",
+			wantCount:     1,
+		},
+		{
+			name: "multiple volume types",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{Name: "cache", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+						{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "app-config"}}}},
+						{Name: "data", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "data-pvc"}}},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "app",
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "cache", MountPath: "/cache"},
+								{Name: "config", MountPath: "/etc/config", ReadOnly: true},
+								{Name: "data", MountPath: "/data"},
+							},
+						},
+					},
+				},
+			},
+			containerName: "app",
+			wantCount:     3,
+		},
+		{
+			name: "container not found",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app"}},
+				},
+			},
+			containerName: "nonexistent",
+			wantErr:       true,
+		},
+		{
+			name: "no volume mounts",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes:    []corev1.Volume{{Name: "unused", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+					Containers: []corev1.Container{{Name: "app"}},
+				},
+			},
+			containerName: "app",
+			wantCount:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractVolumeInfo(tt.pod, tt.containerName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(got) != tt.wantCount {
+				t.Errorf("got %d volumes, want %d", len(got), tt.wantCount)
+			}
+		})
+	}
+}

--- a/deploy/chrek/pkg/checkpoint/metadata_builder.go
+++ b/deploy/chrek/pkg/checkpoint/metadata_builder.go
@@ -143,4 +143,3 @@ func buildMountMetadata(mount MountMapping, k8sVolumes map[string]*checkpointk8s
 
 	return mountMeta
 }
-

--- a/deploy/chrek/pkg/checkpoint/mounts.go
+++ b/deploy/chrek/pkg/checkpoint/mounts.go
@@ -20,22 +20,22 @@ type MountMapping struct {
 
 // System mount types that should be filtered out
 var systemMountTypes = map[string]bool{
-	"proc":        true,
-	"sysfs":       true,
-	"devpts":      true,
-	"mqueue":      true,
-	"tmpfs":       true, // Note: some tmpfs mounts may need special handling
-	"cgroup":      true,
-	"cgroup2":     true,
-	"securityfs":  true,
-	"debugfs":     true,
-	"tracefs":     true,
-	"fusectl":     true,
-	"configfs":    true,
-	"devtmpfs":    true,
-	"hugetlbfs":   true,
-	"pstore":      true,
-	"bpf":         true,
+	"proc":       true,
+	"sysfs":      true,
+	"devpts":     true,
+	"mqueue":     true,
+	"tmpfs":      true, // Note: some tmpfs mounts may need special handling
+	"cgroup":     true,
+	"cgroup2":    true,
+	"securityfs": true,
+	"debugfs":    true,
+	"tracefs":    true,
+	"fusectl":    true,
+	"configfs":   true,
+	"devtmpfs":   true,
+	"hugetlbfs":  true,
+	"pstore":     true,
+	"bpf":        true,
 }
 
 // System mount paths that should always be filtered

--- a/deploy/chrek/pkg/checkpoint/mounts_test.go
+++ b/deploy/chrek/pkg/checkpoint/mounts_test.go
@@ -1,0 +1,253 @@
+package checkpoint
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseMountInfoLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		want     MountMapping
+		wantSkip bool
+	}{
+		{
+			name: "kubernetes pvc bind mount",
+			line: "200 199 8:1 /volumes/pvc-123/data /data rw,relatime shared:1 - ext4 /dev/sda1 rw,data=ordered",
+			want: MountMapping{
+				InsidePath:  "/data",
+				OutsidePath: "/volumes/pvc-123/data",
+				FSType:      "ext4",
+				Source:      "/dev/sda1",
+				Options:     "rw,relatime,rw,data=ordered",
+			},
+			wantSkip: false,
+		},
+		{
+			name:     "kubernetes emptyDir tmpfs",
+			line:     "300 299 0:50 / /var/lib/kubelet/pods/abc/volumes/kubernetes.io~empty-dir/cache rw,relatime shared:2 - tmpfs tmpfs rw,size=1024k",
+			want:     MountMapping{},
+			wantSkip: true, // tmpfs is filtered out
+		},
+		{
+			name: "bind mount with root as /",
+			line: "400 399 8:1 / /mnt/host rw,relatime shared:3 - ext4 /dev/sda1 rw",
+			want: MountMapping{
+				InsidePath:  "/mnt/host",
+				OutsidePath: "/dev/sda1",
+				FSType:      "ext4",
+				Source:      "/dev/sda1",
+				Options:     "rw,relatime,rw",
+			},
+			wantSkip: false,
+		},
+		{
+			name:     "proc mount (should skip)",
+			line:     "100 99 0:5 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw",
+			want:     MountMapping{},
+			wantSkip: true,
+		},
+		{
+			name:     "sys mount (should skip)",
+			line:     "101 99 0:6 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro",
+			want:     MountMapping{},
+			wantSkip: true,
+		},
+		{
+			name:     "dev mount (should skip)",
+			line:     "102 99 0:7 / /dev rw,nosuid - devtmpfs devtmpfs rw,size=1024k",
+			want:     MountMapping{},
+			wantSkip: true,
+		},
+		{
+			name:     "cgroup mount (should skip)",
+			line:     "103 99 0:25 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:10 - cgroup cgroup rw,memory",
+			want:     MountMapping{},
+			wantSkip: true,
+		},
+		{
+			name:     "overlay root mount (should skip)",
+			line:     "500 499 0:100 / / rw,relatime - overlay overlay rw,lowerdir=/lower,upperdir=/upper,workdir=/work",
+			want:     MountMapping{},
+			wantSkip: true,
+		},
+		{
+			name:     "sys subdirectory (should skip)",
+			line:     "600 599 0:30 / /sys/kernel/debug rw,relatime - debugfs debugfs rw",
+			want:     MountMapping{},
+			wantSkip: true,
+		},
+		{
+			name:     "proc subdirectory (should skip)",
+			line:     "601 599 0:31 / /proc/sys/fs/binfmt_misc rw,relatime - binfmt_misc binfmt_misc rw",
+			want:     MountMapping{},
+			wantSkip: true,
+		},
+		{
+			name: "nfs mount",
+			line: "700 699 0:40 / /mnt/nfs rw,relatime shared:5 - nfs4 server.example.com:/export rw,vers=4.1",
+			want: MountMapping{
+				InsidePath:  "/mnt/nfs",
+				OutsidePath: "server.example.com:/export", // When root is "/", use source
+				FSType:      "nfs4",
+				Source:      "server.example.com:/export",
+				Options:     "rw,relatime,rw,vers=4.1",
+			},
+			wantSkip: false,
+		},
+		{
+			name:     "malformed line - too few fields",
+			line:     "36 35 98:0",
+			want:     MountMapping{},
+			wantSkip: true,
+		},
+		{
+			name:     "malformed line - no separator",
+			line:     "36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 ext3 /dev/root",
+			want:     MountMapping{},
+			wantSkip: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, skip := parseMountInfoLine(tt.line)
+			if skip != tt.wantSkip {
+				t.Errorf("parseMountInfoLine() skip = %v, want %v", skip, tt.wantSkip)
+				return
+			}
+			if !tt.wantSkip && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseMountInfoLine() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAllMountInfoLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		want    AllMountInfo
+		wantErr bool
+	}{
+		{
+			name: "valid mount with all fields",
+			line: "36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue",
+			want: AllMountInfo{
+				MountID:      "36",
+				ParentID:     "35",
+				Root:         "/mnt1",
+				MountPoint:   "/mnt2",
+				Options:      "rw,noatime",
+				FSType:       "ext3",
+				Source:       "/dev/root",
+				SuperOptions: "rw,errors=continue",
+			},
+			wantErr: false,
+		},
+		{
+			name: "proc mount",
+			line: "100 99 0:5 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw",
+			want: AllMountInfo{
+				MountID:      "100",
+				ParentID:     "99",
+				Root:         "/",
+				MountPoint:   "/proc",
+				Options:      "rw,nosuid,nodev,noexec,relatime",
+				FSType:       "proc",
+				Source:       "proc",
+				SuperOptions: "rw",
+			},
+			wantErr: false,
+		},
+		{
+			name: "overlay root mount",
+			line: "500 499 0:100 / / rw,relatime - overlay overlay rw,lowerdir=/lower,upperdir=/upper,workdir=/work",
+			want: AllMountInfo{
+				MountID:      "500",
+				ParentID:     "499",
+				Root:         "/",
+				MountPoint:   "/",
+				Options:      "rw,relatime",
+				FSType:       "overlay",
+				Source:       "overlay",
+				SuperOptions: "rw,lowerdir=/lower,upperdir=/upper,workdir=/work",
+			},
+			wantErr: false,
+		},
+		{
+			name: "tmpfs mount",
+			line: "200 199 0:50 / /tmp rw,nosuid,nodev shared:1 - tmpfs tmpfs rw,size=65536k",
+			want: AllMountInfo{
+				MountID:      "200",
+				ParentID:     "199",
+				Root:         "/",
+				MountPoint:   "/tmp",
+				Options:      "rw,nosuid,nodev",
+				FSType:       "tmpfs",
+				Source:       "tmpfs",
+				SuperOptions: "rw,size=65536k",
+			},
+			wantErr: false,
+		},
+		{
+			name: "mount without super options",
+			line: "300 299 0:60 / /dev/shm rw,nosuid,nodev shared:2 - tmpfs tmpfs",
+			want: AllMountInfo{
+				MountID:      "300",
+				ParentID:     "299",
+				Root:         "/",
+				MountPoint:   "/dev/shm",
+				Options:      "rw,nosuid,nodev",
+				FSType:       "tmpfs",
+				Source:       "tmpfs",
+				SuperOptions: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "cgroup mount",
+			line: "400 399 0:25 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:10 - cgroup cgroup rw,memory",
+			want: AllMountInfo{
+				MountID:      "400",
+				ParentID:     "399",
+				Root:         "/",
+				MountPoint:   "/sys/fs/cgroup/memory",
+				Options:      "rw,nosuid,nodev,noexec,relatime",
+				FSType:       "cgroup",
+				Source:       "cgroup",
+				SuperOptions: "rw,memory",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "malformed line - too few fields",
+			line:    "36 35 98:0",
+			wantErr: true,
+		},
+		{
+			name:    "malformed line - no separator",
+			line:    "36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 ext3 /dev/root rw",
+			wantErr: true,
+		},
+		{
+			name:    "malformed line - separator at end",
+			line:    "36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAllMountInfoLine(tt.line)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseAllMountInfoLine() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseAllMountInfoLine() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/chrek/pkg/common/criu_flags.go
+++ b/deploy/chrek/pkg/common/criu_flags.go
@@ -1,0 +1,17 @@
+// Package common provides shared utilities for CRIU operations.
+package common
+
+import (
+	criurpc "github.com/checkpoint-restore/go-criu/v7/rpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// SetCommonK8sFlags sets CRIU flags that are always-on for K8s environments.
+// These flags are shared between checkpoint and restore operations.
+func SetCommonK8sFlags(opts *criurpc.CriuOpts) {
+	opts.ShellJob = proto.Bool(true)   // Containers are often session leaders
+	opts.TcpClose = proto.Bool(true)   // Pod IPs change on restore/migration
+	opts.FileLocks = proto.Bool(true)  // Applications use file locks
+	opts.ExtUnixSk = proto.Bool(true)  // Containers have external Unix sockets
+	opts.ManageCgroups = proto.Bool(true)
+}

--- a/deploy/chrek/pkg/common/criu_test.go
+++ b/deploy/chrek/pkg/common/criu_test.go
@@ -1,0 +1,89 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCRIUMountInfoLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		want    CRIUMountPoint
+		wantErr bool
+	}{
+		{
+			name: "valid mount with all fields",
+			line: "36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue",
+			want: CRIUMountPoint{
+				MountID:   "36",
+				ParentID:  "35",
+				Root:      "/mnt1",
+				Path:      "/mnt2",
+				Options:   "rw,noatime",
+				FSType:    "ext3",
+				Source:    "/dev/root",
+				SuperOpts: "rw,errors=continue",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid mount without super options",
+			line: "100 99 0:22 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:10 - cgroup cgroup",
+			want: CRIUMountPoint{
+				MountID:   "100",
+				ParentID:  "99",
+				Root:      "/",
+				Path:      "/sys/fs/cgroup/memory",
+				Options:   "rw,nosuid,nodev,noexec,relatime",
+				FSType:    "cgroup",
+				Source:    "cgroup",
+				SuperOpts: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "kubernetes volume mount",
+			line: "200 199 0:50 / /var/lib/kubelet/pods/abc-123/volumes/kubernetes.io~empty-dir/cache rw,relatime shared:1 - tmpfs tmpfs rw,size=1024k",
+			want: CRIUMountPoint{
+				MountID:   "200",
+				ParentID:  "199",
+				Root:      "/",
+				Path:      "/var/lib/kubelet/pods/abc-123/volumes/kubernetes.io~empty-dir/cache",
+				Options:   "rw,relatime",
+				FSType:    "tmpfs",
+				Source:    "tmpfs",
+				SuperOpts: "rw,size=1024k",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "malformed line - too few fields",
+			line:    "36 35 98:0",
+			wantErr: true,
+		},
+		{
+			name:    "malformed line - no separator",
+			line:    "36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 ext3 /dev/root rw,errors=continue",
+			wantErr: true,
+		},
+		{
+			name:    "malformed line - separator at end",
+			line:    "36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 -",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCRIUMountInfoLine(tt.line)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseCRIUMountInfoLine() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseCRIUMountInfoLine() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/chrek/pkg/common/criu_test_helpers.go
+++ b/deploy/chrek/pkg/common/criu_test_helpers.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"testing"
+
+	criurpc "github.com/checkpoint-restore/go-criu/v7/rpc"
+)
+
+// AssertCommonK8sFlags verifies that common K8s CRIU flags are set correctly.
+// These flags are shared between checkpoint and restore operations.
+func AssertCommonK8sFlags(t *testing.T, opts *criurpc.CriuOpts) {
+	t.Helper()
+
+	if !opts.GetShellJob() {
+		t.Error("ShellJob should be true")
+	}
+	if !opts.GetTcpClose() {
+		t.Error("TcpClose should be true")
+	}
+	if !opts.GetFileLocks() {
+		t.Error("FileLocks should be true")
+	}
+	if !opts.GetExtUnixSk() {
+		t.Error("ExtUnixSk should be true")
+	}
+	if !opts.GetManageCgroups() {
+		t.Error("ManageCgroups should be true")
+	}
+}

--- a/deploy/chrek/pkg/common/metadata.go
+++ b/deploy/chrek/pkg/common/metadata.go
@@ -34,10 +34,10 @@ type CheckpointMetadata struct {
 	PID int `json:"pid"`
 
 	// Filesystem information
-	RootfsDiffPath  string `json:"rootfs_diff_path,omitempty"`   // Path to rootfs-diff.tar
-	UpperDir        string `json:"upper_dir,omitempty"`          // Original overlay upperdir
-	HasRootfsDiff   bool   `json:"has_rootfs_diff"`              // Whether rootfs diff was captured
-	HasDeletedFiles bool   `json:"has_deleted_files"`            // Whether deleted files were tracked
+	RootfsDiffPath  string `json:"rootfs_diff_path,omitempty"` // Path to rootfs-diff.tar
+	UpperDir        string `json:"upper_dir,omitempty"`        // Original overlay upperdir
+	HasRootfsDiff   bool   `json:"has_rootfs_diff"`            // Whether rootfs diff was captured
+	HasDeletedFiles bool   `json:"has_deleted_files"`          // Whether deleted files were tracked
 
 	// Mount mappings from original container
 	Mounts []MountMetadata `json:"mounts"`
@@ -71,15 +71,15 @@ type CRIUOptionsMetadata struct {
 
 // MountMetadata stores information about a mount for remapping during restore
 type MountMetadata struct {
-	ContainerPath string   `json:"container_path"`           // Path inside container (e.g., /usr/share/nginx/html)
-	HostPath      string   `json:"host_path"`                // Original host path from mountinfo
-	OCISource     string   `json:"oci_source,omitempty"`     // Source path from OCI spec (may differ from HostPath)
-	OCIType       string   `json:"oci_type,omitempty"`       // Mount type from OCI spec (bind, tmpfs, etc.)
-	OCIOptions    []string `json:"oci_options,omitempty"`    // Mount options from OCI spec
-	VolumeType    string   `json:"volume_type"`              // emptyDir, pvc, configMap, secret, hostPath (best-effort)
-	VolumeName    string   `json:"volume_name"`              // Kubernetes volume name (best-effort from path parsing)
-	FSType        string   `json:"fs_type"`                  // Filesystem type from mountinfo
-	ReadOnly      bool     `json:"read_only"`                // Whether mount is read-only
+	ContainerPath string   `json:"container_path"`        // Path inside container (e.g., /usr/share/nginx/html)
+	HostPath      string   `json:"host_path"`             // Original host path from mountinfo
+	OCISource     string   `json:"oci_source,omitempty"`  // Source path from OCI spec (may differ from HostPath)
+	OCIType       string   `json:"oci_type,omitempty"`    // Mount type from OCI spec (bind, tmpfs, etc.)
+	OCIOptions    []string `json:"oci_options,omitempty"` // Mount options from OCI spec
+	VolumeType    string   `json:"volume_type"`           // emptyDir, pvc, configMap, secret, hostPath (best-effort)
+	VolumeName    string   `json:"volume_name"`           // Kubernetes volume name (best-effort from path parsing)
+	FSType        string   `json:"fs_type"`               // Filesystem type from mountinfo
+	ReadOnly      bool     `json:"read_only"`             // Whether mount is read-only
 }
 
 // NamespaceMetadata stores namespace information

--- a/deploy/chrek/pkg/common/metadata_test.go
+++ b/deploy/chrek/pkg/common/metadata_test.go
@@ -1,0 +1,182 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveAndLoadMetadata(t *testing.T) {
+	// Create temp directory
+	tempDir := t.TempDir()
+
+	// Create metadata
+	meta := NewCheckpointMetadata("test-checkpoint")
+	meta.SourceNode = "node-1"
+	meta.ContainerID = "container-abc123"
+	meta.PodName = "test-pod"
+	meta.PodNamespace = "default"
+	meta.Image = "nginx:latest"
+	meta.PID = 12345
+	meta.HasRootfsDiff = true
+	meta.Mounts = []MountMetadata{
+		{
+			ContainerPath: "/data",
+			HostPath:      "/var/lib/kubelet/pods/abc/volumes/pvc-123/data",
+			VolumeType:    "pvc",
+			FSType:        "ext4",
+			ReadOnly:      false,
+		},
+	}
+	meta.Namespaces = []NamespaceMetadata{
+		{
+			Type:       "net",
+			Inode:      4026531956,
+			IsExternal: true,
+		},
+	}
+
+	// Save metadata
+	err := SaveMetadata(tempDir, meta)
+	if err != nil {
+		t.Fatalf("SaveMetadata() error = %v", err)
+	}
+
+	// Check that file was created
+	metadataPath := filepath.Join(tempDir, MetadataFilename)
+	if _, err := os.Stat(metadataPath); os.IsNotExist(err) {
+		t.Fatalf("Metadata file was not created at %s", metadataPath)
+	}
+
+	// Load metadata
+	loaded, err := LoadMetadata(tempDir)
+	if err != nil {
+		t.Fatalf("LoadMetadata() error = %v", err)
+	}
+
+	// Compare fields
+	if loaded.CheckpointID != meta.CheckpointID {
+		t.Errorf("CheckpointID = %v, want %v", loaded.CheckpointID, meta.CheckpointID)
+	}
+	if loaded.SourceNode != meta.SourceNode {
+		t.Errorf("SourceNode = %v, want %v", loaded.SourceNode, meta.SourceNode)
+	}
+	if loaded.ContainerID != meta.ContainerID {
+		t.Errorf("ContainerID = %v, want %v", loaded.ContainerID, meta.ContainerID)
+	}
+	if loaded.PodName != meta.PodName {
+		t.Errorf("PodName = %v, want %v", loaded.PodName, meta.PodName)
+	}
+	if loaded.PodNamespace != meta.PodNamespace {
+		t.Errorf("PodNamespace = %v, want %v", loaded.PodNamespace, meta.PodNamespace)
+	}
+	if loaded.Image != meta.Image {
+		t.Errorf("Image = %v, want %v", loaded.Image, meta.Image)
+	}
+	if loaded.PID != meta.PID {
+		t.Errorf("PID = %v, want %v", loaded.PID, meta.PID)
+	}
+	if loaded.HasRootfsDiff != meta.HasRootfsDiff {
+		t.Errorf("HasRootfsDiff = %v, want %v", loaded.HasRootfsDiff, meta.HasRootfsDiff)
+	}
+	if len(loaded.Mounts) != len(meta.Mounts) {
+		t.Errorf("len(Mounts) = %v, want %v", len(loaded.Mounts), len(meta.Mounts))
+	}
+	if len(loaded.Namespaces) != len(meta.Namespaces) {
+		t.Errorf("len(Namespaces) = %v, want %v", len(loaded.Namespaces), len(meta.Namespaces))
+	}
+}
+
+func TestSaveAndLoadDescriptors(t *testing.T) {
+	// Create temp directory
+	tempDir := t.TempDir()
+
+	// Create descriptors
+	descriptors := []string{"/dev/null", "/dev/zero", "/dev/random"}
+
+	// Save descriptors
+	err := SaveDescriptors(tempDir, descriptors)
+	if err != nil {
+		t.Fatalf("SaveDescriptors() error = %v", err)
+	}
+
+	// Check that file was created
+	descriptorsPath := filepath.Join(tempDir, DescriptorsFilename)
+	if _, err := os.Stat(descriptorsPath); os.IsNotExist(err) {
+		t.Fatalf("Descriptors file was not created at %s", descriptorsPath)
+	}
+
+	// Load descriptors
+	loaded, err := LoadDescriptors(tempDir)
+	if err != nil {
+		t.Fatalf("LoadDescriptors() error = %v", err)
+	}
+
+	// Compare
+	if len(loaded) != len(descriptors) {
+		t.Errorf("len(descriptors) = %v, want %v", len(loaded), len(descriptors))
+	}
+
+	for i, desc := range descriptors {
+		if i >= len(loaded) {
+			break
+		}
+		if loaded[i] != desc {
+			t.Errorf("descriptor[%d] = %v, want %v", i, loaded[i], desc)
+		}
+	}
+}
+
+func TestListCheckpoints(t *testing.T) {
+	// Create temp directory
+	tempDir := t.TempDir()
+
+	// Create some checkpoint directories with metadata
+	checkpoints := []string{"ckpt-1", "ckpt-2", "ckpt-3"}
+	for _, ckptID := range checkpoints {
+		ckptDir := filepath.Join(tempDir, ckptID)
+		if err := os.Mkdir(ckptDir, 0755); err != nil {
+			t.Fatalf("Failed to create checkpoint dir: %v", err)
+		}
+
+		meta := NewCheckpointMetadata(ckptID)
+		if err := SaveMetadata(ckptDir, meta); err != nil {
+			t.Fatalf("Failed to save metadata: %v", err)
+		}
+	}
+
+	// Create a directory without metadata (should be ignored)
+	invalidDir := filepath.Join(tempDir, "invalid")
+	if err := os.Mkdir(invalidDir, 0755); err != nil {
+		t.Fatalf("Failed to create invalid dir: %v", err)
+	}
+
+	// Create a file (should be ignored)
+	invalidFile := filepath.Join(tempDir, "file.txt")
+	if err := os.WriteFile(invalidFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create file: %v", err)
+	}
+
+	// List checkpoints
+	found, err := ListCheckpoints(tempDir)
+	if err != nil {
+		t.Fatalf("ListCheckpoints() error = %v", err)
+	}
+
+	// Should find exactly the 3 valid checkpoints
+	if len(found) != len(checkpoints) {
+		t.Errorf("ListCheckpoints() found %d checkpoints, want %d", len(found), len(checkpoints))
+	}
+
+	// Check that all expected checkpoints are present
+	foundMap := make(map[string]bool)
+	for _, ckptID := range found {
+		foundMap[ckptID] = true
+	}
+
+	for _, expected := range checkpoints {
+		if !foundMap[expected] {
+			t.Errorf("Expected checkpoint %s not found in results", expected)
+		}
+	}
+}

--- a/deploy/chrek/pkg/criulog/criulog.go
+++ b/deploy/chrek/pkg/criulog/criulog.go
@@ -1,0 +1,93 @@
+// Package criulog provides shared CRIU log reading and error reporting utilities.
+package criulog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultLogCopyPerm = 0644
+	defaultLogDirPerm  = 0755
+)
+
+// LogErrors reads a CRIU log file and logs all lines as errors.
+// If CRIU_LOG_DIR environment variable is set, copies the log there.
+func LogErrors(logPath string, logger interface{}) {
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		logWarning(logger, err, logPath)
+		return
+	}
+
+	logError(logger, "=== CRIU RESTORE LOG START ===")
+	for _, line := range strings.Split(string(data), "\n") {
+		if line != "" {
+			logError(logger, line)
+		}
+	}
+	logError(logger, "=== CRIU RESTORE LOG END ===")
+
+	copyLogToSharedDir(data, logger)
+}
+
+// LogErrorsWithWorkDir reads CRIU log from workDir if set, otherwise from checkpointPath.
+func LogErrorsWithWorkDir(checkpointPath, workDir, logFile string, logger interface{}) {
+	logBase := checkpointPath
+	if workDir != "" {
+		logBase = workDir
+	}
+	LogErrors(filepath.Join(logBase, logFile), logger)
+}
+
+// copyLogToSharedDir copies log data to CRIU_LOG_DIR if configured.
+func copyLogToSharedDir(data []byte, logger interface{}) {
+	logDir := os.Getenv("CRIU_LOG_DIR")
+	if logDir == "" {
+		return
+	}
+
+	if err := os.MkdirAll(logDir, defaultLogDirPerm); err != nil {
+		return
+	}
+
+	destPath := filepath.Join(logDir, fmt.Sprintf("restore-%d.log", time.Now().Unix()))
+	if err := os.WriteFile(destPath, data, defaultLogCopyPerm); err == nil {
+		logInfo(logger, "CRIU log copied to shared directory", destPath)
+	}
+}
+
+// logError logs an error message, adapting to either logrus.Entry or logrus.Logger.
+func logError(logger interface{}, msg string) {
+	switch l := logger.(type) {
+	case *logrus.Entry:
+		l.Error(msg)
+	case *logrus.Logger:
+		l.Error(msg)
+	}
+}
+
+// logWarning logs a warning with error and path field.
+func logWarning(logger interface{}, err error, path string) {
+	switch l := logger.(type) {
+	case *logrus.Entry:
+		l.WithError(err).WithField("path", path).Warn("Could not read CRIU log file")
+	case *logrus.Logger:
+		l.WithError(err).WithField("path", path).Warn("Could not read CRIU log file")
+	}
+}
+
+// logInfo logs an info message with path field.
+func logInfo(logger interface{}, msg, path string) {
+	switch l := logger.(type) {
+	case *logrus.Entry:
+		l.WithField("path", path).Info(msg)
+	case *logrus.Logger:
+		l.WithField("path", path).Info(msg)
+	}
+}

--- a/deploy/chrek/pkg/restore/criu_test.go
+++ b/deploy/chrek/pkg/restore/criu_test.go
@@ -1,0 +1,130 @@
+package restore
+
+import (
+	"testing"
+
+	criurpc "github.com/checkpoint-restore/go-criu/v7/rpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/ai-dynamo/dynamo/deploy/chrek/pkg/common"
+)
+
+func TestBuildRestoreCRIUOpts(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  CRIURestoreConfig
+	}{
+		{
+			name: "basic restore config",
+			cfg: CRIURestoreConfig{
+				ImageDirFD: 5,
+				RootPath:   "/",
+				LogLevel:   4,
+				LogFile:    "restore.log",
+				WorkDirFD:  -1,
+				NetNsFD:    -1,
+			},
+		},
+		{
+			name: "restore with work dir",
+			cfg: CRIURestoreConfig{
+				ImageDirFD: 10,
+				RootPath:   "/container/root",
+				LogLevel:   2,
+				LogFile:    "criu-restore.log",
+				WorkDirFD:  8,
+				NetNsFD:    -1,
+			},
+		},
+		{
+			name: "restore with network namespace",
+			cfg: CRIURestoreConfig{
+				ImageDirFD: 7,
+				RootPath:   "/",
+				LogLevel:   4,
+				LogFile:    "restore.log",
+				WorkDirFD:  -1,
+				NetNsFD:    12,
+			},
+		},
+		{
+			name: "restore with external mounts",
+			cfg: CRIURestoreConfig{
+				ImageDirFD: 5,
+				RootPath:   "/",
+				LogLevel:   4,
+				LogFile:    "restore.log",
+				WorkDirFD:  -1,
+				NetNsFD:    -1,
+				ExtMountMaps: []*criurpc.ExtMountMap{
+					{Key: proto.String("/proc/sys"), Val: proto.String("/proc/sys")},
+					{Key: proto.String("/data"), Val: proto.String("/var/lib/data")},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := BuildRestoreCRIUOpts(tt.cfg)
+
+			// Check required fields
+			if opts.GetImagesDirFd() != tt.cfg.ImageDirFD {
+				t.Errorf("ImagesDirFd = %v, want %v", opts.GetImagesDirFd(), tt.cfg.ImageDirFD)
+			}
+			if opts.GetRoot() != tt.cfg.RootPath {
+				t.Errorf("Root = %v, want %v", opts.GetRoot(), tt.cfg.RootPath)
+			}
+			if opts.GetLogLevel() != tt.cfg.LogLevel {
+				t.Errorf("LogLevel = %v, want %v", opts.GetLogLevel(), tt.cfg.LogLevel)
+			}
+			if opts.GetLogFile() != tt.cfg.LogFile {
+				t.Errorf("LogFile = %v, want %v", opts.GetLogFile(), tt.cfg.LogFile)
+			}
+
+			// Check common K8s flags
+			common.AssertCommonK8sFlags(t, opts)
+
+			// Check restore-specific flags
+			if !opts.GetRstSibling() {
+				t.Error("RstSibling should be true (detached restore)")
+			}
+			if !opts.GetMntnsCompatMode() {
+				t.Error("MntnsCompatMode should be true (cross-container restore)")
+			}
+
+			// Check cgroup mode is SOFT (for external restore)
+			if opts.GetManageCgroupsMode() != criurpc.CriuCgMode_SOFT {
+				t.Errorf("ManageCgroupsMode = %v, want SOFT", opts.GetManageCgroupsMode())
+			}
+
+			// Check optional work dir FD
+			if tt.cfg.WorkDirFD > 0 {
+				if opts.GetWorkDirFd() != tt.cfg.WorkDirFD {
+					t.Errorf("WorkDirFd = %v, want %v", opts.GetWorkDirFd(), tt.cfg.WorkDirFD)
+				}
+			}
+
+			// Check optional network namespace FD
+			if tt.cfg.NetNsFD >= 0 {
+				if len(opts.InheritFd) != 1 {
+					t.Errorf("len(InheritFd) = %v, want 1 when NetNsFD is provided", len(opts.InheritFd))
+				} else {
+					if opts.InheritFd[0].GetKey() != "extNetNs" {
+						t.Errorf("InheritFd[0].Key = %v, want extNetNs", opts.InheritFd[0].GetKey())
+					}
+					if opts.InheritFd[0].GetFd() != tt.cfg.NetNsFD {
+						t.Errorf("InheritFd[0].Fd = %v, want %v", opts.InheritFd[0].GetFd(), tt.cfg.NetNsFD)
+					}
+				}
+			}
+
+			// Check external mount maps
+			if len(tt.cfg.ExtMountMaps) > 0 {
+				if len(opts.ExtMnt) != len(tt.cfg.ExtMountMaps) {
+					t.Errorf("len(ExtMnt) = %v, want %v", len(opts.ExtMnt), len(tt.cfg.ExtMountMaps))
+				}
+			}
+		})
+	}
+}

--- a/deploy/chrek/pkg/restore/exec.go
+++ b/deploy/chrek/pkg/restore/exec.go
@@ -1,0 +1,133 @@
+package restore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/ai-dynamo/dynamo/deploy/chrek/pkg/criulog"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultRestoreTimeout = 5 * time.Minute
+)
+
+// restoreViaExec performs external restore by executing criu-helper via nsenter.
+func restoreViaExec(ctx context.Context, opts *RestoreOptions, log *logrus.Entry) (int, error) {
+	log.WithFields(logrus.Fields{
+		"target_pid": opts.TargetPID,
+		"checkpoint": opts.CheckpointPath,
+	}).Info("Starting external restore via nsenter + criu-helper")
+
+	helperArgs := buildHelperArgs(opts, log)
+	nsenterArgs := buildNsenterArgs(opts.TargetPID, helperArgs)
+
+	stdout, err := executeNsenter(ctx, nsenterArgs, opts, log)
+	if err != nil {
+		return 0, err
+	}
+
+	pid, err := parseRestoredPID(stdout)
+	if err != nil {
+		return 0, err
+	}
+
+	log.WithField("pid", pid).Info("Restored PID from criu-helper")
+	return pid, nil
+}
+
+func buildHelperArgs(opts *RestoreOptions, log *logrus.Entry) []string {
+	args := []string{
+		"--checkpoint", opts.CheckpointPath,
+		fmt.Sprintf("--log-level=%d", opts.LogLevel),
+		"--log-file", opts.LogFile,
+		"--cgroup-root", "/",
+	}
+
+	if opts.WorkDir != "" {
+		args = append(args, "--work-dir", opts.WorkDir)
+		log.WithField("work_dir", opts.WorkDir).Info("Using custom work directory")
+	}
+
+	if opts.LibDir != "" {
+		args = append(args, "--lib-dir", opts.LibDir)
+		log.WithField("lib_dir", opts.LibDir).Info("Using custom plugin library directory")
+	}
+
+	if opts.TcpEstablished {
+		args = append(args, "--tcp-established")
+	}
+	if opts.TcpClose {
+		args = append(args, "--tcp-close")
+	}
+
+	args = append(args, "--verbose")
+	return args
+}
+
+func buildNsenterArgs(targetPID int, helperArgs []string) []string {
+	nsenterArgs := []string{
+		"-t", fmt.Sprintf("%d", targetPID),
+		"-a", // all namespaces
+		"--",
+		"/usr/local/bin/criu-helper",
+	}
+	return append(nsenterArgs, helperArgs...)
+}
+
+func executeNsenter(ctx context.Context, nsenterArgs []string, opts *RestoreOptions, log *logrus.Entry) (string, error) {
+	restoreCtx, cancel := context.WithTimeout(ctx, defaultRestoreTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(restoreCtx, "nsenter", nsenterArgs...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = log.Logger.Out
+
+	log.Info("Executing criu-helper via nsenter")
+	execStart := time.Now()
+	err := cmd.Run()
+	duration := time.Since(execStart)
+
+	if errors.Is(restoreCtx.Err(), context.DeadlineExceeded) {
+		return "", fmt.Errorf("restore timed out after %v", defaultRestoreTimeout)
+	}
+
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"error":    err,
+			"duration": duration,
+		}).Error("criu-helper via nsenter failed")
+
+		if stdout.Len() > 0 {
+			log.WithField("stdout", stdout.String()).Error("Helper stdout:")
+		}
+
+		criulog.LogErrorsWithWorkDir(opts.CheckpointPath, opts.WorkDir, opts.LogFile, log)
+		return "", fmt.Errorf("criu-helper via nsenter failed: %w", err)
+	}
+
+	log.WithField("duration", duration).Info("criu-helper via nsenter completed successfully")
+	return stdout.String(), nil
+}
+
+func parseRestoredPID(stdout string) (int, error) {
+	pidRegex := regexp.MustCompile(`RESTORED_PID=(\d+)`)
+	matches := pidRegex.FindStringSubmatch(stdout)
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("criu-helper did not output RESTORED_PID")
+	}
+
+	pid, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid PID from criu-helper: %w", err)
+	}
+
+	return pid, nil
+}

--- a/deploy/chrek/pkg/restore/process.go
+++ b/deploy/chrek/pkg/restore/process.go
@@ -108,11 +108,11 @@ func forwardFD(fdPath string, dst io.Writer, name string, log *logrus.Entry, don
 			return
 		default:
 			// Set a read deadline to allow checking done channel periodically
-			src.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			_ = src.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
 
 			n, err := src.Read(buf)
 			if n > 0 {
-				dst.Write(buf[:n])
+				_, _ = dst.Write(buf[:n])
 			}
 			if err != nil {
 				if os.IsTimeout(err) {
@@ -200,7 +200,7 @@ func SetupSignalForwarding(pid int, log *logrus.Entry) func() {
 
 			proc, err := os.FindProcess(pid)
 			if err == nil {
-				proc.Signal(sig)
+				_ = proc.Signal(sig)
 			}
 		case <-done:
 			return

--- a/deploy/chrek/pkg/watcher/watcher.go
+++ b/deploy/chrek/pkg/watcher/watcher.go
@@ -112,7 +112,7 @@ func (w *Watcher) Start(ctx context.Context) error {
 		defer func() {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			httpServer.Shutdown(shutdownCtx)
+			_ = httpServer.Shutdown(shutdownCtx)
 		}()
 	}
 
@@ -144,7 +144,7 @@ func (w *Watcher) Start(ctx context.Context) error {
 	podInformer := factory.Core().V1().Pods().Informer()
 
 	// Add event handlers
-	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*corev1.Pod)
 			w.handlePodEvent(ctx, pod)
@@ -187,7 +187,7 @@ func (w *Watcher) startHealthServer(ctx context.Context) *http.Server {
 			return
 		}
 		rw.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(rw).Encode(HealthResponse{
+		_ = json.NewEncoder(rw).Encode(HealthResponse{
 			Status:   "healthy",
 			NodeName: w.config.NodeName,
 		})


### PR DESCRIPTION
Agent performs CRIU restore from outside placeholder using nsenter + criu-helper.

## Core Changes
- **criu-helper binary**: Executes restore via nsenter in target namespaces
- **restoreViaExec()**: Orchestrates external restore
- **SOFT cgroup mode**: Fixes memory accounting for both checkpoint and restore
- **Path Traversal Protection**: added validateCheckpointID. Previously there was path traversal in GetCheckpointDir

## Benefits
- Enables checkpointing unprivileged workload pods
- Simpler placeholder pods (just need basic sleep)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added external restore capability via HTTP endpoint for triggering restores from external sources.
  * Introduced image compatibility validation during restore operations.
  * New helper binary for restore operations within container namespaces.

* **Tests**
  * Comprehensive test coverage for CRIU options, mount parsing, image compatibility, and restore workflows.

* **Chores**
  * Enhanced error handling and logging throughout restore pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->