### PR TITLE
feat: support `reasoning_content` context management (DeepSeek v3.2 & GLM-4.7 & Kimi-2.5)

### DIFF
--- a/lib/llm/src/entrypoint/input/text.rs
+++ b/lib/llm/src/entrypoint/input/text.rs
@@ -130,6 +130,7 @@ async fn main_loop(
         // Stream the output to stdout
         let mut stdout = std::io::stdout();
         let mut assistant_message = String::new();
+        let mut assistant_reasoning = String::new();
         while let Some(item) = stream.next().await {
             if cancel_token.is_cancelled() {
                 break;
@@ -153,6 +154,9 @@ async fn main_loop(
                                 let _ = stdout.flush();
                             }
                         }
+                    }
+                    if let Some(reasoning) = &chat_comp.delta.reasoning_content {
+                        assistant_reasoning += reasoning;
                     }
                     if let Some(reason) = chat_comp.finish_reason {
                         tracing::trace!("finish reason: {reason:?}");
@@ -183,6 +187,7 @@ async fn main_loop(
         let assistant_message = dynamo_async_openai::types::ChatCompletionRequestMessage::Assistant(
             dynamo_async_openai::types::ChatCompletionRequestAssistantMessage {
                 content: Some(assistant_content),
+                reasoning_content: (!assistant_reasoning.is_empty()).then_some(assistant_reasoning),
                 ..Default::default()
             },
         );


### PR DESCRIPTION
#### Overview:

Adds support for carrying assistant `reasoning_content` across turns for reasoning-capable chat flows, with native prompt rendering support for DeepSeek v3.2 and compatibility with GLM-4.7 templates that consume `reasoning_content` in jinja template. 

Modern SOTA OSS LLMs add `reasoning_content` support in their API and chat templates:
* GLM-4.7: [API](https://docs.z.ai/guides/capabilities/thinking-mode) & [Chat template](https://huggingface.co/zai-org/GLM-4.7/blob/main/chat_template.jinja#L44)
* DeepSeek V3.2: [API](https://api-docs.deepseek.com/guides/thinking_mode#api-example) & [Chat template](https://huggingface.co/deepseek-ai/DeepSeek-V3.2/blob/main/encoding/encoding_dsv32.py#L153)
* Kimi-2.5: [API](https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model#usage-notes) & [Chat template](https://huggingface.co/moonshotai/Kimi-K2.5/blob/main/chat_template.jinja#L84)

#### Details:

* Extended OpenAI-compatible assistant request message schema with optional `reasoning_content`
* Added serde tests for `reasoning_content` in chat request types
* Updated DeepSeek v3.2 native encoding

#### Where should the reviewer start?

- lib/async-openai/src/types/chat.rs
- lib/llm/src/preprocessor/prompt/deepseek_v32.rs
- lib/llm/tests/deepseek_v32_encoding.rs
- lib/llm/src/preprocessor/prompt/template.rs (model-specific formatter selection)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to https://github.com/ai-dynamo/dynamo/issues/4796
- Relates to https://github.com/ai-dynamo/dynamo/issues/6070
- Relates to https://github.com/ai-dynamo/dynamo/issues/5512