### PR TITLE
fix: sanitize docker tags on main to arm64/amd64 removing 'linux/...'

### DIFF
--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -125,7 +125,7 @@ jobs:
             RESULT=""
             while IFS= read -r tag; do
               if [ -n "$tag" ]; then
-                RESULT+="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${tag}-${PLATFORM}"$'\n'
+                RESULT+="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${tag}-${{ inputs.platform }}"$'\n'
               fi
             done <<< "$EXTRA_TAGS"
             echo "tags<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
#### Overview:

When the template PR merged to `main` that was the first time that the `extra_tags` input ato the composite action docker-remote-build were populated with references to the main branch, e.g. [***.dkr.ecr.***.amazonaws.com/ai-dynamo/dynamo:main-sglang-ac0206293ca3f9c879587cc2e22acfe69f3d9cca-linux/amd64](https://github.com/ai-dynamo/dynamo/actions/runs/21867757522/job/63113628059#step:10:19).

By sanitizing the extra tags using the input platform directly of `amd64` or `arm64` we are should have a valid tag.


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes OPS-2731


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build workflow to improve image tag generation consistency. The platform suffix used in generated tags is now resolved directly from workflow action inputs rather than through intermediate shell variables, providing a more direct and predictable approach to container image tag construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->