### PR TITLE
fix: fix cross selection issue amongst services in DGD

### DIFF
--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -1352,8 +1352,11 @@ func (r *DynamoComponentDeploymentReconciler) generateService(opt generateResour
 	}
 
 	selector := map[string]string{
-		commonconsts.KubeLabelDynamoComponentType: opt.dynamoComponentDeployment.Spec.ComponentType,
-		commonconsts.KubeLabelDynamoNamespace:     *opt.dynamoComponentDeployment.Spec.DynamoNamespace,
+		commonconsts.KubeLabelDynamoComponentType: opt.dynamoComponentDeployment.Spec.ComponentType,    // e.g. "worker"
+		commonconsts.KubeLabelDynamoNamespace:     *opt.dynamoComponentDeployment.Spec.DynamoNamespace, // result of ComputeDynamoNamespace(k8sNamespace, dgdName)
+		// The original user provided component name (the service map key, e.g. "VllmDecodeWorker" in the DGD).
+		// Needed to disambiguate amongst distinct components with the same component type within a DGD (e.g prefill/decode workers).
+		commonconsts.KubeLabelDynamoComponent: opt.dynamoComponentDeployment.Spec.ServiceName,
 	}
 	// // If using LeaderWorkerSet, modify selector to only target leaders
 	if opt.dynamoComponentDeployment.IsMultinode() {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -1367,9 +1367,6 @@ func (r *DynamoComponentDeploymentReconciler) generateService(opt generateResour
 	}
 	if isK8sDiscovery {
 		labels[commonconsts.KubeLabelDynamoDiscoveryBackend] = "kubernetes"
-	}
-	// Discovery is enabled for non frontend components
-	if isK8sDiscovery && !opt.dynamoComponentDeployment.IsFrontendComponent() {
 		labels[commonconsts.KubeLabelDynamoDiscoveryEnabled] = commonconsts.KubeLabelValueTrue
 	}
 


### PR DESCRIPTION
#### Overview:

- Service selector cross-selection -- Services for different components sharing the same componentType (e.g., prefill and decode workers both typed "worker") had identical selectors, so each service selected all workers instead of just its own. Fixed by adding nvidia.com/dynamo-component (the unique service map key) to the selector in both the Grove and DCD paths.
- Discovery label inconsistency -- The DCD path excluded frontend services from discovery-enabled=true, while the Grove path included them. Frontends need to be discoverable, so aligned the DCD path to match Grove: both labels are now set on all components when k8s discovery is enabled.

closes https://linear.app/nvidia/issue/DYN-2042


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced service selector labeling to properly distinguish between different component types (such as prefill and decode workers) within the same deployment configuration.

* **Chores**
  * Updated internal service generation with improved DNS-safe naming conventions for better component identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->