### PR TITLE
ci: allow deploy tests to run even when operator is skipped

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -230,9 +230,14 @@ jobs:
 
   deploy-operator:
     runs-on: prod-default-small-v2
+    # Run when any deploy test will run: if core, any framework, or deploy files changed
     if: |
       always() &&
-      needs.changed-files.outputs.core == 'true' &&
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.vllm == 'true' ||
+       needs.changed-files.outputs.sglang == 'true' ||
+       needs.changed-files.outputs.trtllm == 'true' ||
+       needs.changed-files.outputs.deploy == 'true') &&
       (needs.operator.result == 'success' || needs.operator.result == 'skipped')
     needs: [changed-files, operator]
     outputs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -230,12 +230,24 @@ jobs:
 
   deploy-operator:
     runs-on: prod-default-small-v2
-    if: needs.changed-files.outputs.core == 'true'
+    if: |
+      needs.changed-files.outputs.core == 'true' &&
+      (needs.operator.result == 'success' || needs.operator.result == 'skipped')
     needs: [changed-files, operator]
     outputs:
       NAMESPACE: ${{ steps.deploy-operator-step.outputs.namespace }}
     steps:
     - uses: actions/checkout@v4
+    - name: Determine operator image tag
+      id: operator-tag
+      run: |
+        if [ "${{ needs.operator.result }}" == "success" ]; then
+          echo "tag=${{ needs.operator.outputs.operator_default_tag }}" >> $GITHUB_OUTPUT
+          echo "Using newly built operator image: ${{ needs.operator.outputs.operator_default_tag }}"
+        else
+          echo "tag=main-operator" >> $GITHUB_OUTPUT
+          echo "Using stable operator image: main-operator"
+        fi
     - name: Deploy Operator
       id: deploy-operator-step
       env:
@@ -292,7 +304,7 @@ jobs:
           --set dynamo-operator.namespaceRestriction.enabled=true \
           --set dynamo-operator.namespaceRestriction.allowedNamespaces[0]=${NAMESPACE} \
           --set dynamo-operator.controllerManager.manager.image.repository=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo \
-          --set dynamo-operator.controllerManager.manager.image.tag=${{ needs.operator.outputs.operator_default_tag }} \
+          --set dynamo-operator.controllerManager.manager.image.tag=${{ steps.operator-tag.outputs.tag }} \
           --set dynamo-operator.imagePullSecrets[0].name=docker-imagepullsecret
         # Wait for all deployments to be ready
         timeout 300s kubectl rollout status deployment -n $NAMESPACE --watch

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -231,6 +231,7 @@ jobs:
   deploy-operator:
     runs-on: prod-default-small-v2
     if: |
+      always() &&
       needs.changed-files.outputs.core == 'true' &&
       (needs.operator.result == 'success' || needs.operator.result == 'skipped')
     needs: [changed-files, operator]


### PR DESCRIPTION
## Summary
- Fixed deploy tests not triggering when operator files unchanged but core/framework files changed
- Added fallback logic to use stable `main-operator` image when operator job is skipped
- Updated job condition to handle skipped operator dependency

Validated that main operator gets picked up when *ci or *core files aren't changed: https://github.com/ai-dynamo/dynamo/pull/6144

## Context
Deploy tests were being skipped even when `core`, `vllm`, `sglang`, or `deploy` filters matched. This was due to GitHub Actions skipping dependent jobs when a required job is skipped, even if the dependent job's own `if` condition is true.

**Root cause**: The `deploy-operator` job depended on the `operator` job, which only runs when operator files change. When operator was skipped, deploy-operator was also skipped despite `core == true`.

**Example commit**: [027d265](https://github.com/ai-dynamo/dynamo/commit/027d2653a5bbcc24be9cb668e45baa5379eec632) changed lib/, tests/, and framework files but no deploy tests ran.

Part of investigation for OPS-3140 (Make Deploy Tests gating)

## Testing
- [x] YAML syntax validated
- [ ] Observe CI run on this PR - operator should be skipped, deploy tests should run with main-operator image
- [ ] Verify deploy-operator step logs show "Using stable operator image: main-operator"

## Checklist
- [x] Human has reviewed AI code
- [x] Relevant context for this fix has been tracked in this issue and/or in associated linear ticket for future debugging
- [x] Code follows project conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow to conditionally deploy the operator based on build status and dynamically select appropriate image tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->