### PR TITLE
ci: verified external collaborator workflow

### DIFF
--- a/.github/workflows/approved-external-contributor.yml
+++ b/.github/workflows/approved-external-contributor.yml
@@ -28,13 +28,13 @@ jobs:
           else
             echo "is_fork=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Comment /ok to test for approved contributor
+      - name: Validate approved contributor
+        id: author_check
         if: steps.fork_check.outputs.is_fork == 'true'
         uses: actions/github-script@v7
         env:
           APPROVED_EXTERNAL_CONTRIBUTORS: ${{ secrets.APPROVED_EXTERNAL_CONTRIBUTORS }}
         with:
-          github-token: ${{ secrets.AUTO_VERIFIER_CI_TOKEN }}
           script: |
             const approvedRaw = process.env.APPROVED_EXTERNAL_CONTRIBUTORS || "[]";
             let approved = [];
@@ -58,20 +58,22 @@ jobs:
 
             if (!approved.includes(author)) {
               core.info(`Author ${author} is not in APPROVED_EXTERNAL_CONTRIBUTORS.`);
+              core.setOutput("is_approved", "false");
               return;
             }
 
+            core.setOutput("is_approved", "true");
+      - name: Comment /ok to test
+        if: steps.fork_check.outputs.is_fork == 'true' && steps.author_check.outputs.is_approved == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.AUTO_VERIFIER_CI_TOKEN }}
+          script: |
             const sha = context.payload.pull_request?.head?.sha || context.sha;
             const body = `/ok to test ${sha}`;
 
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
 
             await github.rest.issues.createComment({
               owner,

--- a/.github/workflows/approved-external-contributor.yml
+++ b/.github/workflows/approved-external-contributor.yml
@@ -17,11 +17,19 @@ permissions:
 
 jobs:
   ok-to-test:
-    if: github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
     environment: external_collaborator
     steps:
+      - name: Check if PR is from a fork
+        id: fork_check
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Comment /ok to test for approved contributor
+        if: steps.fork_check.outputs.is_fork == 'true'
         uses: actions/github-script@v7
         env:
           APPROVED_EXTERNAL_CONTRIBUTORS: ${{ secrets.APPROVED_EXTERNAL_CONTRIBUTORS }}

--- a/.github/workflows/approved-external-contributor.yml
+++ b/.github/workflows/approved-external-contributor.yml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Approved External Contributor
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  ok-to-test:
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    environment: external_collaborator
+    steps:
+      - name: Comment /ok to test for approved contributor
+        uses: actions/github-script@v7
+        env:
+          APPROVED_EXTERNAL_CONTRIBUTORS: ${{ secrets.APPROVED_EXTERNAL_CONTRIBUTORS }}
+        with:
+          github-token: ${{ secrets.AUTO_VERIFIER_CI_TOKEN }}
+          script: |
+            const approvedRaw = process.env.APPROVED_EXTERNAL_CONTRIBUTORS || "[]";
+            let approved = [];
+            try {
+              approved = JSON.parse(approvedRaw);
+            } catch (error) {
+              core.warning(`Invalid APPROVED_EXTERNAL_CONTRIBUTORS JSON: ${error.message}`);
+              return;
+            }
+
+            if (!Array.isArray(approved)) {
+              core.warning("APPROVED_EXTERNAL_CONTRIBUTORS is not a JSON array.");
+              return;
+            }
+
+            const author = context.payload.pull_request?.user?.login;
+            if (!author) {
+              core.warning("No PR author found.");
+              return;
+            }
+
+            if (!approved.includes(author)) {
+              core.info(`Author ${author} is not in APPROVED_EXTERNAL_CONTRIBUTORS.`);
+              return;
+            }
+
+            const sha = context.payload.pull_request?.head?.sha || context.sha;
+            const body = `/ok to test ${sha}`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });


### PR DESCRIPTION
#### Overview:

This creates a new workflow which will follow the `/ok to test <git hash>` pattern of execution for a list of verified external collaborators without the need for an NVIDIAN to first review. This in turn will trigger the CI workflows which run on our cloud instance runners and report the status back to the PR.

#### Details:

This adds several things to the repo:
* The `external_collaborator` environment in which the workflow runs there are two secrets in this environment:
  * `APPROVED_EXTERNAL_CONTRIBUTORS` which is a JSON list of strings of the form `["github_username_1", "github_username_2"]`
  * `AUTO_VERIFIER_CI_TOKEN` is a PAT of the Ops Bot that allows for comments on PRs. Since this is an NVIDIAN account it is able to trigger `copy-pr-bot`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- relates to OPS-3194