### PR TITLE
fix: add trtllm build dependency for fault tolerance tests

### DIFF
--- a/.github/workflows/ci-test-suite.yml
+++ b/.github/workflows/ci-test-suite.yml
@@ -822,7 +822,7 @@ jobs:
     needs: [build-amd64, build-cuda13-amd64]
     if: always()
     runs-on: prod-builder-amd-v1
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-test-suite.yml
+++ b/.github/workflows/ci-test-suite.yml
@@ -881,8 +881,8 @@ jobs:
         id: operator-tag
         run: |
           # Try to use nightly-operator-amd64 if it exists, otherwise fall back to main-operator
-          export ECR_HOSTNAME=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-          if docker pull ${ECR_HOSTNAME}/${{ env.REGISTRY_IMAGE }}:${{ env.NIGHTLY_IMAGE_PREFIX }}-operator-amd64 2>/dev/null; then
+          # Check Azure ACR since that's where helm will pull from
+          if docker pull ${{ secrets.AZURE_ACR_HOSTNAME }}/${{ env.REGISTRY_IMAGE }}:${{ env.NIGHTLY_IMAGE_PREFIX }}-operator-amd64 2>/dev/null; then
             echo "tag=${{ env.NIGHTLY_IMAGE_PREFIX }}-operator-amd64" >> $GITHUB_OUTPUT
             echo "Using nightly operator image: ${{ env.NIGHTLY_IMAGE_PREFIX }}-operator-amd64"
           else

--- a/.github/workflows/ci-test-suite.yml
+++ b/.github/workflows/ci-test-suite.yml
@@ -877,6 +877,18 @@ jobs:
           chmod 600 .kubeconfig
           export KUBECONFIG=$(pwd)/.kubeconfig
           kubectl cluster-info
+      - name: Determine operator image tag
+        id: operator-tag
+        run: |
+          # Try to use nightly-operator-amd64 if it exists, otherwise fall back to main-operator
+          export ECR_HOSTNAME=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+          if docker pull ${ECR_HOSTNAME}/${{ env.REGISTRY_IMAGE }}:${{ env.NIGHTLY_IMAGE_PREFIX }}-operator-amd64 2>/dev/null; then
+            echo "tag=${{ env.NIGHTLY_IMAGE_PREFIX }}-operator-amd64" >> $GITHUB_OUTPUT
+            echo "Using nightly operator image: ${{ env.NIGHTLY_IMAGE_PREFIX }}-operator-amd64"
+          else
+            echo "tag=main-operator" >> $GITHUB_OUTPUT
+            echo "Nightly operator image not found, using stable operator image: main-operator"
+          fi
       - name: Deploy Operator
         run: |
           set -x
@@ -903,9 +915,6 @@ jobs:
           kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=${{ secrets.HF_TOKEN }} -n $KUBE_NS || true
           # Create docker pull secret for operator image
           kubectl create secret docker-registry docker-imagepullsecret --docker-server=${{ secrets.AZURE_ACR_HOSTNAME }} --docker-username=${{ secrets.AZURE_ACR_USER }} --docker-password=${{ secrets.AZURE_ACR_PASSWORD }} --namespace=${NAMESPACE}
-          # Pull operator image (using nightly tag for operator too)
-          export ECR_HOSTNAME=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
-          docker pull ${ECR_HOSTNAME}/${{ env.REGISTRY_IMAGE }}:${{ env.NIGHTLY_IMAGE_PREFIX }}-operator-amd64 || echo "Operator image not found, will use SHA-based tag"
           # Install helm dependencies
           helm repo add bitnami https://charts.bitnami.com/bitnami
           cd deploy/helm/charts/platform/
@@ -915,7 +924,7 @@ jobs:
             --set dynamo-operator.namespaceRestriction.enabled=true \
             --set dynamo-operator.namespaceRestriction.allowedNamespaces[0]=${NAMESPACE} \
             --set dynamo-operator.controllerManager.manager.image.repository=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo \
-            --set dynamo-operator.controllerManager.manager.image.tag=${{ github.sha }}-operator-amd64 \
+            --set dynamo-operator.controllerManager.manager.image.tag=${{ steps.operator-tag.outputs.tag }} \
             --set dynamo-operator.imagePullSecrets[0].name=docker-imagepullsecret \
             --timeout 10m --wait
           # Wait for all deployments to be ready

--- a/.github/workflows/ci-test-suite.yml
+++ b/.github/workflows/ci-test-suite.yml
@@ -819,7 +819,7 @@ jobs:
   ############################## FAULT TOLERANCE TESTS ##############################
   fault-tolerance-tests:
     name: ${{ matrix.framework.name }}-ft-k8s
-    needs: [build-amd64]
+    needs: [build-amd64, build-cuda13-amd64]
     if: always()
     runs-on: prod-builder-amd-v1
     timeout-minutes: 60
@@ -846,7 +846,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set +x
-          BUILD_JOB_PATTERN="Build ${{ matrix.framework.name }} (amd64)"
+          BUILD_JOB_PATTERN="Build ${{ matrix.framework.name }} ${{ matrix.framework.name == 'trtllm' && 'CUDA13 ' || '' }}(amd64)"
           JOBS_RESPONSE=$(curl -s -S -L -w "\n%{http_code}" \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
## Summary
This PR fixes the fault tolerance tests in the nightly CI pipeline by adding the missing build dependency for TRT-LLM.

## Changes
- Added `build-cuda13-amd64` to `fault-tolerance-tests` needs array
- Updated `BUILD_JOB_PATTERN` to include CUDA13 conditional for trtllm
- Aligns with the pattern used by other test jobs (unit-tests, integration-tests, etc.)

## Problem
The fault-tolerance tests were failing because:
1. TRT-LLM is only built in `build-cuda13-amd64`, not `build-amd64`
2. The build check pattern didn't account for the "CUDA13" suffix in TRT-LLM build job names

## Testing
This can be tested by triggering the nightly CI workflow on this branch:
```bash
gh workflow run nightly-ci.yml --ref tusharma/fix-nightly-ci-fault-tolerance-tests
```

Closes OPS-3217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded continuous integration pipeline to support CUDA 13 testing, enabling validation across additional GPU configurations for enhanced platform compatibility.
  * Improved test workflow dependencies and execution sequencing to ensure test suites run with correct build artifacts in proper order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->