### PR TITLE
[TEST - DO NOT MERGE] validate vllm-only changes trigger deploy tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -230,9 +230,14 @@ jobs:
 
   deploy-operator:
     runs-on: prod-default-small-v2
+    # Run when any deploy test will run: if core, any framework, or deploy files changed
     if: |
       always() &&
-      needs.changed-files.outputs.core == 'true' &&
+      (needs.changed-files.outputs.core == 'true' ||
+       needs.changed-files.outputs.vllm == 'true' ||
+       needs.changed-files.outputs.sglang == 'true' ||
+       needs.changed-files.outputs.trtllm == 'true' ||
+       needs.changed-files.outputs.deploy == 'true') &&
       (needs.operator.result == 'success' || needs.operator.result == 'skipped')
     needs: [changed-files, operator]
     outputs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -230,12 +230,24 @@ jobs:
 
   deploy-operator:
     runs-on: prod-default-small-v2
-    if: needs.changed-files.outputs.core == 'true'
+    if: |
+      needs.changed-files.outputs.core == 'true' &&
+      (needs.operator.result == 'success' || needs.operator.result == 'skipped')
     needs: [changed-files, operator]
     outputs:
       NAMESPACE: ${{ steps.deploy-operator-step.outputs.namespace }}
     steps:
     - uses: actions/checkout@v4
+    - name: Determine operator image tag
+      id: operator-tag
+      run: |
+        if [ "${{ needs.operator.result }}" == "success" ]; then
+          echo "tag=${{ needs.operator.outputs.operator_default_tag }}" >> $GITHUB_OUTPUT
+          echo "Using newly built operator image: ${{ needs.operator.outputs.operator_default_tag }}"
+        else
+          echo "tag=main-operator" >> $GITHUB_OUTPUT
+          echo "Using stable operator image: main-operator"
+        fi
     - name: Deploy Operator
       id: deploy-operator-step
       env:
@@ -292,7 +304,7 @@ jobs:
           --set dynamo-operator.namespaceRestriction.enabled=true \
           --set dynamo-operator.namespaceRestriction.allowedNamespaces[0]=${NAMESPACE} \
           --set dynamo-operator.controllerManager.manager.image.repository=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo \
-          --set dynamo-operator.controllerManager.manager.image.tag=${{ needs.operator.outputs.operator_default_tag }} \
+          --set dynamo-operator.controllerManager.manager.image.tag=${{ steps.operator-tag.outputs.tag }} \
           --set dynamo-operator.imagePullSecrets[0].name=docker-imagepullsecret
         # Wait for all deployments to be ready
         timeout 300s kubectl rollout status deployment -n $NAMESPACE --watch

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -231,6 +231,7 @@ jobs:
   deploy-operator:
     runs-on: prod-default-small-v2
     if: |
+      always() &&
       needs.changed-files.outputs.core == 'true' &&
       (needs.operator.result == 'success' || needs.operator.result == 'skipped')
     needs: [changed-files, operator]

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -145,3 +145,4 @@ class StatLoggerFactory:
     def init_publish(self):
         if self.created_logger:
             self.created_logger.init_publish()
+# Validation test: vllm-only changes should trigger deploy tests with main-operator


### PR DESCRIPTION
## Summary
- **DO NOT MERGE - Validation test only**
- Test branch to validate fix in PR #6120
- Only vllm file changed (no core/operator changes)
- Validates deploy-operator runs with main-operator when operator is skipped

## Context
This is a validation test for the fix in PR #6120 that ensures deploy tests run even when the operator job is skipped.

**Test scenario**: Only vllm files changed, no core/operator changes.

Part of investigation for OPS-3140

## Testing
- [ ] Verify `changed-files` output: vllm=true, core=false, operator=false
- [ ] Verify `operator` job is skipped
- [ ] Verify `deploy-operator` runs and logs show "Using stable operator image: main-operator"
- [ ] Verify `deploy-test-vllm` runs successfully
- [ ] Verify `deploy-test-sglang` and `deploy-test-trtllm` are skipped

## Expected CI Behavior
```
✅ changed-files: vllm=true, core=false, operator=false
⏭️ operator: skipped (no operator files changed)
✅ deploy-operator: runs (check logs for main-operator)
✅ deploy-test-vllm: runs
⏭️ deploy-test-sglang: skipped
⏭️ deploy-test-trtllm: skipped
```

## Checklist
- [x] Human has reviewed AI code
- [x] This is a test PR - will be closed after validation
- [x] Code follows project conventions

**⚠️ CLOSE THIS PR AFTER VALIDATION - DO NOT MERGE ⚠️**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment operator trigger conditions to activate when core, vllm, sglang, trtllm, or deploy components change.
  * Improved operator image tag selection logic to use newly built tags when available, with fallback to stable main-operator tag.
  * Added clarifying documentation in workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->