### PR TITLE
fix: fix trtllm build scripts for two trtllm wheel build errors

### DIFF
--- a/container/build_trtllm_wheel.sh
+++ b/container/build_trtllm_wheel.sh
@@ -97,7 +97,7 @@ if [ "$ARCH" = "amd64" ]; then
 else
     # NIXL backend is not supported on arm64 for TensorRT-LLM.
     # See here: https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/common/install_nixl.sh
-    make -C docker wheel_build
+    make -C docker wheel_build SHELL=/bin/bash
 fi
 
 # Copy the wheel to the host

--- a/container/build_trtllm_wheel.sh
+++ b/container/build_trtllm_wheel.sh
@@ -92,8 +92,8 @@ grep "__version__" "$VERSION_FILE"
 
 if [ "$ARCH" = "amd64" ]; then
     # Need to build in the Triton Devel Image for NIXL support.
-    make -C docker tritondevel_build
-    make -C docker wheel_build DEVEL_IMAGE=tritondevel BUILD_WHEEL_OPTS='--extra-cmake-vars NIXL_ROOT=/opt/nvidia/nvda_nixl'
+    make -C docker tritondevel_build SHELL=/bin/bash
+    make -C docker wheel_build DEVEL_IMAGE=tritondevel BUILD_WHEEL_OPTS='--extra-cmake-vars NIXL_ROOT=/opt/nvidia/nvda_nixl' SHELL=/bin/bash
 else
     # NIXL backend is not supported on arm64 for TensorRT-LLM.
     # See here: https://github.com/NVIDIA/TensorRT-LLM/blob/main/docker/common/install_nixl.sh

--- a/docs/components/kvbm/kvbm_guide.md
+++ b/docs/components/kvbm/kvbm_guide.md
@@ -218,6 +218,7 @@ cd $DYNAMO_HOME/examples/backends/vllm
 
 ```bash
 # Build the Dynamo TensorRT-LLM container using commit ID 18e611da773026a55d187870ebcfa95ff00c8482. Note: This build can take a long time.
+rm -rf /tmp/TensorRT-LLM && \ 
 ./container/build.sh --framework trtllm --tensorrtllm-commit 18e611da773026a55d187870ebcfa95ff00c8482 --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git
 
 # Launch the container

--- a/docs/components/kvbm/kvbm_guide.md
+++ b/docs/components/kvbm/kvbm_guide.md
@@ -218,7 +218,7 @@ cd $DYNAMO_HOME/examples/backends/vllm
 
 ```bash
 # Build the Dynamo TensorRT-LLM container using commit ID 18e611da773026a55d187870ebcfa95ff00c8482. Note: This build can take a long time.
-rm -rf /tmp/TensorRT-LLM && \ 
+rm -rf /tmp/TensorRT-LLM && \
 ./container/build.sh --framework trtllm --tensorrtllm-commit 18e611da773026a55d187870ebcfa95ff00c8482 --tensorrtllm-git-url https://github.com/NVIDIA/TensorRT-LLM.git
 
 # Launch the container


### PR DESCRIPTION
#### Overview:
1. Add SHELL=/bin/bash to the make command to make sure the PATH is attached to the cmake
2. Add rm -rf /tmp/TensorRT-LLM to clean up the build environment for retry


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build process to explicitly use Bash shell for amd64 and arm64 architectures, ensuring consistent shell behavior during builds across all platforms.

* **Documentation**
  * Updated build instructions to include cleanup of temporary directories before building, ensuring clean builds and preventing potential conflicts from previous build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->