### PR TITLE
feat(profiler): TRT-LLM DEP/TEP profiling with WIDEEP support

### DIFF
--- a/components/src/dynamo/planner/defaults.py
+++ b/components/src/dynamo/planner/defaults.py
@@ -114,10 +114,12 @@ class TrtllmComponentName:
     # Unified frontend architecture (consistent with vLLM/SGLang):
     # - Prefill workers use "prefill" component
     # - Decode workers use "tensorrt_llm" component
-    prefill_worker_k8s_name = "TRTLLMPrefillWorker"
+    # Note: profiler output uses "PrefillWorker"/"DecodeWorker" (shortened from the legacy
+    # "TRTLLMPrefillWorker"/"TRTLLMDecodeWorker") to satisfy Grove's 45-char naming limit.
+    prefill_worker_k8s_name = "PrefillWorker"
     prefill_worker_component_name = "prefill"
     prefill_worker_endpoint = "generate"
-    decode_worker_k8s_name = "TRTLLMDecodeWorker"
+    decode_worker_k8s_name = "DecodeWorker"
     decode_worker_component_name = "tensorrt_llm"
     decode_worker_endpoint = "generate"
 

--- a/components/src/dynamo/profiler/utils/config.py
+++ b/components/src/dynamo/profiler/utils/config.py
@@ -100,7 +100,7 @@ class DgdPlannerServiceConfig(BaseModel):
         mainContainer=Container(
             image="my-registry/dynamo-runtime:my-tag",  # placeholder
             workingDir=f"{get_workspace_dir()}/components/src/dynamo/planner",
-            command=["python3", "-m", "dynamo.planner.planner_sla"],
+            command=["python3", "-m", "dynamo.planner"],
             args=[],
         )
     )

--- a/components/src/dynamo/profiler/utils/config_modifiers/parallelization_mapping.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/parallelization_mapping.py
@@ -261,4 +261,9 @@ def apply_parallel_mapping_to_config(
             max_num_tokens=PREFILL_MAX_NUM_TOKENS * mapping.get_attn_dp_size(),
             component_type=prefill_component_type,
         )
+    elif phase == SubComponentType.DECODE:
+        cfg = config_modifier.set_decode_config(
+            cfg,
+            component_type=SubComponentType.DECODE,
+        )
     return cfg

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -49,7 +49,8 @@ class ConfigModifierProtocol(Protocol):
         config: dict,
         target: EngineType,
         is_moe_model: bool = False,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
     def set_config_tp_size(
@@ -57,7 +58,8 @@ class ConfigModifierProtocol(Protocol):
         config: dict,
         tp_size: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
     def set_config_tep_size(
@@ -66,7 +68,8 @@ class ConfigModifierProtocol(Protocol):
         tep_size: int,
         num_gpus_per_node: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
     def set_config_dep_size(
@@ -75,10 +78,12 @@ class ConfigModifierProtocol(Protocol):
         dep_size: int,
         num_gpus_per_node: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
-    def get_model_name(cls, config: dict) -> Tuple[str, str]: ...
+    def get_model_name(cls, config: dict) -> Tuple[str, str]:
+        ...
 
     @classmethod
     def set_prefill_config(
@@ -87,33 +92,40 @@ class ConfigModifierProtocol(Protocol):
         max_batch_size: int,
         max_num_tokens: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
     def set_decode_config(
         cls,
         config: dict,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
-    def get_port(cls, config: dict) -> int: ...
+    def get_port(cls, config: dict) -> int:
+        ...
 
     @classmethod
     def get_kv_cache_size_from_dynamo_log(
         cls, dynamo_log_fn: str, attention_dp_size: int = 1
-    ) -> int: ...
+    ) -> int:
+        ...
 
     @classmethod
-    def load_default_config(cls, mode: str = "disagg") -> dict: ...
+    def load_default_config(cls, mode: str = "disagg") -> dict:
+        ...
 
     @classmethod
     def update_model(
         cls, config: dict, model_name: str, model_path: str | None = None
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
     @classmethod
-    def update_image(cls, config: dict, image: str) -> dict: ...
+    def update_image(cls, config: dict, image: str) -> dict:
+        ...
 
     @classmethod
     def update_model_from_pvc(
@@ -123,7 +135,8 @@ class ConfigModifierProtocol(Protocol):
         pvc_name: str,
         pvc_mount_path: str,
         pvc_path: str,
-    ) -> dict: ...
+    ) -> dict:
+        ...
 
 
 class BaseConfigModifier:

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -159,6 +159,11 @@ class BaseConfigModifier:
         """Configure decode engine limits. No-op by default; override in backends that need it."""
         return config
 
+    @classmethod
+    def normalize_output_service_names(cls, config_dict: dict) -> None:
+        """Rename service names in an output DGD config dict (in-place). No-op by default."""
+        pass
+
     # Worker CLI arg name for model path / name. vLLM uses "--model"; others use "--model-path".
     WORKER_MODEL_PATH_ARG: str = "--model-path"
     WORKER_SERVED_MODEL_NAME_ARG: str = "--served-model-name"

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -49,8 +49,7 @@ class ConfigModifierProtocol(Protocol):
         config: dict,
         target: EngineType,
         is_moe_model: bool = False,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
     def set_config_tp_size(
@@ -58,8 +57,7 @@ class ConfigModifierProtocol(Protocol):
         config: dict,
         tp_size: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
     def set_config_tep_size(
@@ -68,8 +66,7 @@ class ConfigModifierProtocol(Protocol):
         tep_size: int,
         num_gpus_per_node: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
     def set_config_dep_size(
@@ -78,12 +75,10 @@ class ConfigModifierProtocol(Protocol):
         dep_size: int,
         num_gpus_per_node: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
-    def get_model_name(cls, config: dict) -> Tuple[str, str]:
-        ...
+    def get_model_name(cls, config: dict) -> Tuple[str, str]: ...
 
     @classmethod
     def set_prefill_config(
@@ -92,40 +87,33 @@ class ConfigModifierProtocol(Protocol):
         max_batch_size: int,
         max_num_tokens: int,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
     def set_decode_config(
         cls,
         config: dict,
         component_type: SubComponentType = SubComponentType.DECODE,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
-    def get_port(cls, config: dict) -> int:
-        ...
+    def get_port(cls, config: dict) -> int: ...
 
     @classmethod
     def get_kv_cache_size_from_dynamo_log(
         cls, dynamo_log_fn: str, attention_dp_size: int = 1
-    ) -> int:
-        ...
+    ) -> int: ...
 
     @classmethod
-    def load_default_config(cls, mode: str = "disagg") -> dict:
-        ...
+    def load_default_config(cls, mode: str = "disagg") -> dict: ...
 
     @classmethod
     def update_model(
         cls, config: dict, model_name: str, model_path: str | None = None
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
     @classmethod
-    def update_image(cls, config: dict, image: str) -> dict:
-        ...
+    def update_image(cls, config: dict, image: str) -> dict: ...
 
     @classmethod
     def update_model_from_pvc(
@@ -135,8 +123,7 @@ class ConfigModifierProtocol(Protocol):
         pvc_name: str,
         pvc_mount_path: str,
         pvc_path: str,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
 
 class BaseConfigModifier:

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -139,12 +139,12 @@ class TrtllmConfigModifier(BaseConfigModifier):
             ):
                 override_dict["kv_cache_config"] = {}
             override_dict["kv_cache_config"]["enable_block_reuse"] = False
-            override_dict["disable_overlap_scheduler"] = (
-                False  # Enable overlap scheduler for agg
-            )
-            override_dict["cache_transceiver_config"] = (
-                None  # Remove cache transceiver for agg
-            )
+            override_dict[
+                "disable_overlap_scheduler"
+            ] = False  # Enable overlap scheduler for agg
+            override_dict[
+                "cache_transceiver_config"
+            ] = None  # Remove cache transceiver for agg
 
             override_str = json.dumps(override_dict)
             args = append_argument(args, ["--override-engine-args", override_str])
@@ -192,9 +192,9 @@ class TrtllmConfigModifier(BaseConfigModifier):
             ):
                 override_dict["kv_cache_config"] = {}
             override_dict["kv_cache_config"]["enable_block_reuse"] = True
-            override_dict["cache_transceiver_config"] = (
-                None  # Remove cache transceiver for agg
-            )
+            override_dict[
+                "cache_transceiver_config"
+            ] = None  # Remove cache transceiver for agg
 
             override_str = json.dumps(override_dict)
             args = append_argument(args, ["--override-engine-args", override_str])

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -139,12 +139,12 @@ class TrtllmConfigModifier(BaseConfigModifier):
             ):
                 override_dict["kv_cache_config"] = {}
             override_dict["kv_cache_config"]["enable_block_reuse"] = False
-            override_dict[
-                "disable_overlap_scheduler"
-            ] = False  # Enable overlap scheduler for agg
-            override_dict[
-                "cache_transceiver_config"
-            ] = None  # Remove cache transceiver for agg
+            override_dict["disable_overlap_scheduler"] = (
+                False  # Enable overlap scheduler for agg
+            )
+            override_dict["cache_transceiver_config"] = (
+                None  # Remove cache transceiver for agg
+            )
 
             override_str = json.dumps(override_dict)
             args = append_argument(args, ["--override-engine-args", override_str])
@@ -192,9 +192,9 @@ class TrtllmConfigModifier(BaseConfigModifier):
             ):
                 override_dict["kv_cache_config"] = {}
             override_dict["kv_cache_config"]["enable_block_reuse"] = True
-            override_dict[
-                "cache_transceiver_config"
-            ] = None  # Remove cache transceiver for agg
+            override_dict["cache_transceiver_config"] = (
+                None  # Remove cache transceiver for agg
+            )
 
             override_str = json.dumps(override_dict)
             args = append_argument(args, ["--override-engine-args", override_str])

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -71,19 +71,29 @@ class TrtllmConfigModifier(BaseConfigModifier):
         target: EngineType,
         is_moe_model: bool = False,
     ) -> dict:
-        if is_moe_model:
-            raise NotImplementedError(
-                "MoE model support is not implemented for TrtLLM backend"
-            )
-
         cfg = Config.model_validate(config)
 
-        # set metadata name
-        cfg.metadata.name = "trtllm-agg"
+        # set metadata name (short to avoid Grove 45-char limit for multinode)
+        cfg.metadata.name = "agg"
 
         # disable planner
         if "Planner" in cfg.spec.services:
             del cfg.spec.services["Planner"]
+
+        # Rename services to shorter names to avoid Grove 45-char naming limit for multinode
+        # TRTLLMDecodeWorker (18 chars) -> dec (3 chars)
+        # TRTLLMPrefillWorker (18 chars) -> pre (3 chars)
+        old_decode_name = "TRTLLMDecodeWorker"
+        old_prefill_name = "TRTLLMPrefillWorker"
+        new_decode_name = "dec"
+        new_prefill_name = "pre"
+
+        if old_decode_name in cfg.spec.services:
+            cfg.spec.services[new_decode_name] = cfg.spec.services.pop(old_decode_name)
+        if old_prefill_name in cfg.spec.services:
+            cfg.spec.services[new_prefill_name] = cfg.spec.services.pop(
+                old_prefill_name
+            )
 
         if target == EngineType.PREFILL:
             # Get service names by inferring from subComponentType first
@@ -246,9 +256,53 @@ class TrtllmConfigModifier(BaseConfigModifier):
         num_gpus_per_node: int,
         component_type: SubComponentType = SubComponentType.DECODE,
     ):
-        raise NotImplementedError(
-            "TEP (Tensor Expert Parallelism) is not implemented for TrtLLM backend"
+        """
+        Set Tensor Expert Parallelism (TEP) for TensorRT-LLM MoE models.
+
+        TRTLLM uses JSON fields in --override-engine-args.
+        All MoE configuration is done via JSON, not command-line args.
+        """
+        cfg = Config.model_validate(config)
+        worker_service = get_worker_service_from_config(
+            cfg, backend="trtllm", sub_component_type=component_type
         )
+
+        # Set up resources with multinode configuration
+        setup_worker_service_resources(worker_service, tep_size, num_gpus_per_node)
+
+        # Get and validate args
+        args = validate_and_get_worker_args(worker_service, backend="trtllm")
+        args = break_arguments(args)
+
+        # Parse existing override-engine-args (if any) and update
+        override_dict, args = parse_override_engine_args(args)
+
+        # 1. Set tensor_parallel_size=tep_size (splits KV heads)
+        override_dict["tensor_parallel_size"] = tep_size
+
+        # 2. Set moe_expert_parallel_size=tep_size (distributes experts across GPUs)
+        override_dict["moe_expert_parallel_size"] = tep_size
+
+        # 3. Set moe_tensor_parallel_size=1 (each expert's weights fully on one GPU)
+        override_dict["moe_tensor_parallel_size"] = 1
+
+        # 4. Disable attention DP (TEP uses TP for attention)
+        override_dict["enable_attention_dp"] = False
+
+        # 5. Remove WIDEEP backend if present -- WIDEEP requires attention DP
+        #    which is incompatible with TEP. Let TRT-LLM use its default backend.
+        moe_config = override_dict.get("moe_config")
+        if isinstance(moe_config, dict) and moe_config.get("backend") == "WIDEEP":
+            del moe_config["backend"]
+            if not moe_config:
+                del override_dict["moe_config"]
+
+        # Serialize JSON and append to args
+        override_str = json.dumps(override_dict)
+        args = append_argument(args, ["--override-engine-args", override_str])
+
+        worker_service.extraPodSpec.mainContainer.args = args
+        return cfg.model_dump()
 
     @classmethod
     def set_config_dep_size(
@@ -258,9 +312,76 @@ class TrtllmConfigModifier(BaseConfigModifier):
         num_gpus_per_node: int,
         component_type: SubComponentType = SubComponentType.DECODE,
     ):
-        raise NotImplementedError(
-            "DEP (Data Expert Parallelism) is not implemented for TrtLLM backend"
+        """
+        Set Data Expert Parallelism (DEP) for TensorRT-LLM MoE models.
+
+        TRTLLM uses JSON fields in --override-engine-args.
+        All MoE configuration is done via JSON, not command-line args.
+        """
+        cfg = Config.model_validate(config)
+        worker_service = get_worker_service_from_config(
+            cfg, backend="trtllm", sub_component_type=component_type
         )
+
+        # Set up resources with multinode configuration
+        setup_worker_service_resources(worker_service, dep_size, num_gpus_per_node)
+
+        # Get and validate args
+        args = validate_and_get_worker_args(worker_service, backend="trtllm")
+        args = break_arguments(args)
+
+        # Parse existing override-engine-args (if any) and update
+        override_dict, args = parse_override_engine_args(args)
+
+        # 1. Set tensor_parallel_size=dep_size (use all GPUs)
+        #    Attention DP below ensures KV heads aren't split
+        override_dict["tensor_parallel_size"] = dep_size
+
+        # 2. Set moe_expert_parallel_size=dep_size (distributes experts across GPUs)
+        override_dict["moe_expert_parallel_size"] = dep_size
+
+        # 3. Set moe_tensor_parallel_size=1 (each expert's weights fully on one GPU)
+        override_dict["moe_tensor_parallel_size"] = 1
+
+        # 4. Enable attention DP (replicates KV heads, partitions requests)
+        override_dict["enable_attention_dp"] = True
+
+        # 5. Set WIDEEP MoE backend for DEP on Blackwell (SM100).
+        #    Also set moe_config.max_num_tokens to bound the MoE workspace
+        #    independently of the top-level max_num_tokens. Without this, the
+        #    DeepGemmMoEOp workspace defaults to the top-level max_num_tokens
+        #    and can OOM when it is set high for prefill.
+        #    Note: The pydantic field is MoeConfig.max_num_tokens (not
+        #    moe_max_num_tokens). The top-level max_num_tokens controls sequence
+        #    chunking; moe_config.max_num_tokens controls MoE workspace size.
+        #    Reference: deepseek-r1/agg/wide_ep/wide_ep_agg.yaml uses
+        #    max_num_tokens = max_batch_size * ep_size = 256 * 16 = 4096.
+        if dep_size > 1:
+            if "moe_config" not in override_dict:
+                override_dict["moe_config"] = {}
+            override_dict["moe_config"]["backend"] = "WIDEEP"
+            override_dict["moe_config"]["max_num_tokens"] = dep_size * 256
+
+            # Add required environment variables for WIDEEP
+            container = worker_service.extraPodSpec.mainContainer
+            if container.env is None:
+                container.env = []
+            existing_env_names = {
+                e["name"] if isinstance(e, dict) else e.name for e in container.env
+            }
+            for name, value in [
+                ("TRTLLM_MOE_ENABLE_ALLTOALL_WITHOUT_ALLGATHER", "1"),
+                ("TRTLLM_ENABLE_PDL", "1"),
+            ]:
+                if name not in existing_env_names:
+                    container.env.append({"name": name, "value": value})
+
+        # Serialize JSON and append to args
+        override_str = json.dumps(override_dict)
+        args = append_argument(args, ["--override-engine-args", override_str])
+
+        worker_service.extraPodSpec.mainContainer.args = args
+        return cfg.model_dump()
 
     @classmethod
     def get_model_name(cls, config: dict) -> Tuple[str, str]:
@@ -304,11 +425,14 @@ class TrtllmConfigModifier(BaseConfigModifier):
                         # Extract the number in parentheses at the end
                         match = re.search(r"paged KV cache \((\d+)\)", line)
                         if match:
-                            max_tokens = int(match.group(1))
-                            logger.info(
-                                f"Found TRT-LLM KV cache max tokens: {max_tokens}"
+                            kv_tokens_per_rank = int(match.group(1))
+                            total_kv_tokens = kv_tokens_per_rank * max(
+                                1, int(attention_dp_size)
                             )
-                            return max_tokens
+                            logger.info(
+                                f"Found TRT-LLM KV cache: {kv_tokens_per_rank} per rank x {attention_dp_size} = {total_kv_tokens} total"
+                            )
+                            return total_kv_tokens
         except Exception as e:
             logger.warning(f"Failed to parse KV cache size from log file. Error: {e}")
 
@@ -341,8 +465,56 @@ class TrtllmConfigModifier(BaseConfigModifier):
 
         # Parse existing override-engine-args (if any) and update
         override_dict, args = parse_override_engine_args(args)
-        override_dict["max_batch_size"] = int(max_batch_size)
-        override_dict["max_num_tokens"] = int(max_num_tokens)
+
+        # Note: max_batch_size here is the attention DP size (== DEP size for
+        # MoE), not a literal batch size.  The caller in
+        # parallelization_mapping passes mapping.get_attn_dp_size().
+        attn_dp_size = max(1, int(max_batch_size))
+        max_num_tokens_int = max(1, int(max_num_tokens))
+
+        # TRT-LLM build config is per-rank, so divide the total token cap by
+        # the number of attention DP ranks.
+        per_rank_max_num_tokens = (
+            max(1, max_num_tokens_int // attn_dp_size)
+            if attn_dp_size > 1
+            else max_num_tokens_int
+        )
+
+        override_dict["max_batch_size"] = attn_dp_size
+        override_dict["max_num_tokens"] = per_rank_max_num_tokens
+        override_str = json.dumps(override_dict)
+        args = append_argument(args, ["--override-engine-args", override_str])
+
+        worker_service.extraPodSpec.mainContainer.args = args
+        return cfg.model_dump()
+
+    @classmethod
+    def set_decode_config(
+        cls,
+        config: dict,
+        component_type: SubComponentType = SubComponentType.DECODE,
+    ) -> dict:
+        """
+        Configure decode engine limits for decode profiling runs.
+
+        Removes max_batch_size so TRT-LLM auto-tunes for decode concurrency
+        sweeps (default 2048). Does not override max_num_tokens -- the base
+        config value (e.g. 8192 from qwen3) is sufficient for decode, and
+        moe_config.max_num_tokens (set by set_config_dep_size) independently
+        bounds the WIDEEP MoE workspace.
+        """
+        cfg = Config.model_validate(config)
+        worker_service = get_worker_service_from_config(
+            cfg, backend="trtllm", sub_component_type=component_type
+        )
+        args = validate_and_get_worker_args(worker_service, backend="trtllm")
+        args = break_arguments(args)
+
+        override_dict, args = parse_override_engine_args(args)
+
+        # Remove max_batch_size to let TRT-LLM auto-tune (default 2048).
+        override_dict.pop("max_batch_size", None)
+
         override_str = json.dumps(override_dict)
         args = append_argument(args, ["--override-engine-args", override_str])
 

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -360,7 +360,14 @@ class TrtllmConfigModifier(BaseConfigModifier):
             if "moe_config" not in override_dict:
                 override_dict["moe_config"] = {}
             override_dict["moe_config"]["backend"] = "WIDEEP"
-            override_dict["moe_config"]["max_num_tokens"] = dep_size * 256
+            # moe_config.max_num_tokens bounds the DeepGemmMoEOp workspace per
+            # EP rank. Derive it from the base config's max_num_tokens (e.g.
+            # decode.yaml sets max_num_tokens=256 for disagg decode) so this
+            # works for any model rather than hardcoding 256.
+            base_max_num_tokens = override_dict.get("max_num_tokens", 256)
+            override_dict["moe_config"]["max_num_tokens"] = (
+                dep_size * base_max_num_tokens
+            )
 
             # Add required environment variables for WIDEEP
             container = worker_service.extraPodSpec.mainContainer

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -211,11 +211,11 @@ def generate_prefill_decode_services_config_preview(
     config_modifier.normalize_output_service_names(config_dict)
     # Service names may have been renamed; select workers by subComponentType.
     services = config_dict["spec"]["services"]
+    worker_sub_types = (SubComponentType.PREFILL, SubComponentType.DECODE)
     return {
         svc_name: svc_val
         for svc_name, svc_val in services.items()
-        if svc_val.get("subComponentType")
-        in (SubComponentType.PREFILL, SubComponentType.DECODE)
+        if svc_val.get("subComponentType") in worker_sub_types
     }
 
 

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -277,13 +277,13 @@ def generate_dgd_config_with_planner(
     planner_config_dict = json.loads(planner_args[config_idx + 1])
 
     if best_prefill_mapping is not None:
-        planner_config_dict["prefill_engine_num_gpu"] = (
-            best_prefill_mapping.get_num_gpus()
-        )
+        planner_config_dict[
+            "prefill_engine_num_gpu"
+        ] = best_prefill_mapping.get_num_gpus()
     if best_decode_mapping is not None:
-        planner_config_dict["decode_engine_num_gpu"] = (
-            best_decode_mapping.get_num_gpus()
-        )
+        planner_config_dict[
+            "decode_engine_num_gpu"
+        ] = best_decode_mapping.get_num_gpus()
 
     planner_args[config_idx + 1] = json.dumps(planner_config_dict)
 

--- a/components/src/dynamo/profiler/utils/planner_utils.py
+++ b/components/src/dynamo/profiler/utils/planner_utils.py
@@ -14,247 +14,114 @@
 # limitations under the License.
 
 import argparse
-from typing import Any
+import json
+from typing import Any, get_args, get_origin
 
-from dynamo.planner.utils.planner_argparse import create_sla_planner_parser
+import typing
 
-
-def _get_action_type(action: argparse.Action) -> str | None:
-    """
-    Extract action type string from an argparse Action object.
-
-    Args:
-        action: The argparse Action object
-
-    Returns:
-        Action type string ('store_true', 'store_false', 'store_const') or None
-    """
-    action_class_name = type(action).__name__
-    if action_class_name == "_StoreTrueAction":
-        return "store_true"
-    elif action_class_name == "_StoreFalseAction":
-        return "store_false"
-    elif action_class_name == "_StoreConstAction":
-        return "store_const"
-    return None
+from dynamo.planner.utils.planner_config import PlannerConfig
 
 
-def _build_action_kwargs(
-    action: argparse.Action, action_type: str | None, prefix: str
-) -> dict:
-    """
-    Build kwargs dictionary for add_argument based on action type.
+def _pydantic_default(field_name: str) -> Any:
+    """Return the static default for a PlannerConfig field, or None for factory defaults."""
+    field_info = PlannerConfig.model_fields[field_name]
+    default = field_info.default
+    try:
+        from pydantic_core import PydanticUndefinedType
 
-    Args:
-        action: The argparse Action object
-        action_type: The action type string ('store_true', 'store_false', etc.)
-        prefix: Prefix for the destination name
-
-    Returns:
-        Dictionary of kwargs for add_argument
-    """
-    kwargs = {
-        "dest": f"{prefix.replace('-', '_')}{action.dest}",
-        "default": action.default,
-        "help": action.help,
-    }
-
-    # Add action type if specified
-    if action_type is not None:
-        kwargs["action"] = action_type
-
-    # For store_true/store_false, don't add type, nargs, metavar, const
-    # For other actions, add them if they're set
-    if action_type not in ["store_true", "store_false"]:
-        if action.type is not None:
-            kwargs["type"] = action.type
-        if action.nargs is not None:
-            kwargs["nargs"] = action.nargs
-        if action.metavar is not None:
-            kwargs["metavar"] = action.metavar
-        if action.choices is not None:
-            kwargs["choices"] = action.choices
-        if action_type == "store_const" and action.const is not None:
-            kwargs["const"] = action.const
-
-    return kwargs
+        if isinstance(default, PydanticUndefinedType):
+            return None
+    except ImportError:
+        pass
+    return default
 
 
-def _get_planner_defaults() -> dict[str, Any]:
-    """
-    Get default values for all planner arguments from the planner parser.
-
-    Returns:
-        Dictionary mapping argument names (with dashes) to their default values
-    """
-    planner_parser = create_sla_planner_parser()
-    defaults = {}
-    for action in planner_parser._actions:
-        if action.dest == "help" or not action.option_strings:
-            continue
-        # Convert dest (underscores) to arg name (dashes)
-        arg_name = action.dest.replace("_", "-")
-        defaults[arg_name] = action.default
-    return defaults
-
-
-def _format_arg_for_command_line(
-    arg_name: str, value, defaults: dict[str, Any] | None = None
-) -> list[str]:
-    """
-    Format an argument name and value for command line usage.
-
-    Args:
-        arg_name: The argument name (without dashes)
-        value: The argument value
-        defaults: Optional dict of default values. If provided and value matches
-                  the default, the arg is skipped (allows operator env vars to take effect)
-
-    Returns:
-        List of command-line argument strings (empty list if value is None or False bool)
-    """
-    if value is None:
-        return []
-
-    # Skip args that match their default values
-    # This allows the operator's injected env vars to take effect
-    # (e.g., PLANNER_PROMETHEUS_PORT=9085 won't be overridden by --prometheus-port=0)
-    if defaults is not None and arg_name in defaults:
-        if value == defaults[arg_name]:
-            return []
-
-    if isinstance(value, bool):
-        # For boolean flags, only add if True
-        if value:
-            return [f"--{arg_name}"]
-        return []
-    else:
-        # For valued arguments
-        return [f"--{arg_name}={value}"]
-
-
-def _collect_args_from_namespace(
-    args: argparse.Namespace,
-    arg_names: list[str],
-    prefix_to_strip: str = "",
-    defaults: dict[str, Any] | None = None,
-) -> list[str]:
-    """
-    Collect and format command-line arguments from a namespace for given attribute names.
-
-    Args:
-        args: The argparse Namespace containing parsed arguments
-        arg_names: List of attribute names to collect from the namespace
-        prefix_to_strip: Optional prefix to remove from attribute names before formatting
-        defaults: Optional dict of default values. Args matching defaults are skipped.
-
-    Returns:
-        List of formatted command-line argument strings
-    """
-    result = []
-    for attr_name in sorted(arg_names):  # sorted for consistent ordering
-        value = getattr(args, attr_name)
-        # Strip prefix and convert to command-line argument name
-        if prefix_to_strip and attr_name.startswith(prefix_to_strip):
-            arg_name = attr_name[len(prefix_to_strip) :].replace("_", "-")
-        else:
-            arg_name = attr_name.replace("_", "-")
-        result.extend(_format_arg_for_command_line(arg_name, value, defaults))
-    return result
+def _unwrap_optional(annotation: Any) -> Any:
+    """Unwrap Optional[X] / Union[X, None] to X; return annotation unchanged otherwise."""
+    if get_origin(annotation) is typing.Union:
+        non_none = [a for a in get_args(annotation) if a is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+    return annotation
 
 
 def add_planner_arguments_to_parser(
     parser: argparse.ArgumentParser, prefix: str = "planner-"
 ):
-    """
-    Dynamically add planner arguments from create_sla_planner_parser() to the given parser.
-    Only adds arguments that don't already exist in the parser (without prefix).
+    """Add PlannerConfig fields as prefixed CLI args to *parser*.
 
-    Args:
-        parser: The ArgumentParser to add arguments to
-        prefix: Prefix to add to planner argument names to avoid conflicts
+    Skips any field already present in the parser (shared args such as
+    ``backend``, ``itl``, ``ttft``, ``namespace``).  The resulting namespace
+    attributes are read back by :func:`build_planner_args_from_namespace` and
+    forwarded to the planner as ``--config '<json>'``.
     """
-    # Create a temporary planner parser to extract its arguments
-    planner_parser = create_sla_planner_parser()
-
-    # Get existing argument names in the parser (without dashes)
     existing_dests = {action.dest for action in parser._actions}
+    dest_prefix = prefix.replace("-", "_")
 
-    # Add a group for planner arguments
     planner_group = parser.add_argument_group(
         "planner arguments",
-        "Arguments that will be passed to the planner service (only showing args not already in profile_sla)",
+        "Arguments forwarded to the planner service "
+        "(only showing args not already in profile_sla)",
     )
 
-    # Iterate through planner parser actions and add them with prefix
-    for action in planner_parser._actions:
-        # Skip help and positional arguments
-        if action.dest in ["help"] or not action.option_strings:
+    for field_name, field_info in PlannerConfig.model_fields.items():
+        if field_name in existing_dests:
             continue
 
-        # Skip if this argument already exists in the main parser (without prefix)
-        if action.dest in existing_dests:
-            continue
+        dest = f"{dest_prefix}{field_name}"
+        opt = f"--{prefix}{field_name.replace('_', '-')}"
+        default = _pydantic_default(field_name)
+        inner = _unwrap_optional(field_info.annotation)
 
-        # Create new option strings with prefix
-        new_option_strings = [
-            f"--{prefix}{opt.lstrip('-')}" for opt in action.option_strings
-        ]
-
-        # Determine the action type and build kwargs
-        action_type = _get_action_type(action)
-        kwargs = _build_action_kwargs(action, action_type, prefix)
-
-        planner_group.add_argument(*new_option_strings, **kwargs)
+        if inner is bool:
+            # Boolean flags: store_true / store_false based on default
+            if not default:
+                planner_group.add_argument(
+                    opt, dest=dest, action="store_true", default=False
+                )
+            else:
+                planner_group.add_argument(
+                    opt, dest=dest, action="store_false", default=True
+                )
+        else:
+            # All other types: accept as string; PlannerConfig coerces on
+            # model_validate so we don't need strict type parsing here.
+            planner_group.add_argument(opt, dest=dest, type=str, default=None)
 
 
 def build_planner_args_from_namespace(
     args: argparse.Namespace, prefix: str = "planner_"
 ) -> list[str]:
+    """Build a ``--config '<json>'`` argument list for the planner process.
+
+    For each PlannerConfig field the function checks:
+    1. A prefixed namespace attribute (``planner_<field>``), for planner-specific
+       overrides added by :func:`add_planner_arguments_to_parser`.
+    2. A shared namespace attribute (``<field>`` without prefix), for args that
+       profile_sla and the planner share (``backend``, ``itl``, ``ttft``, …).
+
+    Only non-``None`` values are included in the config dict, so PlannerConfig
+    defaults apply for everything not explicitly set.
     """
-    Build planner command-line arguments from parsed args namespace.
-    Automatically detects shared arguments between profile_sla and planner,
-    and uses profile_sla values for those.
+    config_dict: dict[str, Any] = {}
 
-    Args that match their default values are skipped, allowing the operator's
-    injected environment variables to take effect (e.g., PLANNER_PROMETHEUS_PORT).
+    for field_name in PlannerConfig.model_fields:
+        value = None
 
-    Args:
-        args: Parsed arguments namespace
-        prefix: Prefix used for planner arguments
+        # Prefixed attr takes priority (planner-specific override)
+        prefixed = f"{prefix}{field_name}"
+        if hasattr(args, prefixed):
+            candidate = getattr(args, prefixed)
+            if candidate is not None:
+                value = candidate
 
-    Returns:
-        List of planner command-line arguments
-    """
-    planner_args = []
+        # Fall back to shared attr (e.g. backend, ttft, itl, namespace)
+        if value is None and hasattr(args, field_name):
+            candidate = getattr(args, field_name)
+            if candidate is not None:
+                value = candidate
 
-    # Get default values to skip args that match defaults
-    # This allows operator-injected env vars to take effect
-    defaults = _get_planner_defaults()
+        if value is not None:
+            config_dict[field_name] = value
 
-    # Auto-detect shared arguments by comparing planner parser with args namespace
-    planner_parser = create_sla_planner_parser()
-    planner_arg_dests = {
-        action.dest
-        for action in planner_parser._actions
-        if action.dest != "help" and action.option_strings
-    }
-
-    # Find arguments in args namespace that match planner arguments (not prefixed)
-    # These are shared arguments that should come from profile_sla
-    shared_arg_dests = {dest for dest in planner_arg_dests if hasattr(args, dest)}
-
-    # Add shared arguments from profile_sla (without prefix)
-    planner_args.extend(
-        _collect_args_from_namespace(args, list(shared_arg_dests), defaults=defaults)
-    )
-
-    # Get all planner-prefixed attributes from args (planner-specific only)
-    prefixed_attrs = [attr for attr in dir(args) if attr.startswith(prefix)]
-    planner_args.extend(
-        _collect_args_from_namespace(
-            args, prefixed_attrs, prefix_to_strip=prefix, defaults=defaults
-        )
-    )
-
-    return planner_args
+    return ["--config", json.dumps(config_dict)]

--- a/components/src/dynamo/profiler/utils/planner_utils.py
+++ b/components/src/dynamo/profiler/utils/planner_utils.py
@@ -15,9 +15,8 @@
 
 import argparse
 import json
-from typing import Any, get_args, get_origin
-
 import typing
+from typing import Any, get_args, get_origin
 
 from dynamo.planner.utils.planner_config import PlannerConfig
 

--- a/docs/pages/components/profiler/profiler-guide.md
+++ b/docs/pages/components/profiler/profiler-guide.md
@@ -34,7 +34,7 @@ The Dynamo Operator watches for DGDRs and automatically:
 |---------|-------------|------------|
 | vLLM | ✅ | 🚧 |
 | SGLang | ✅ | ✅ |
-| TensorRT-LLM | ✅ | 🚧 |
+| TensorRT-LLM | ✅ | ✅ |
 
 The profiler sweeps over the following parallelization mappings for prefill and decode:
 


### PR DESCRIPTION
## Summary
- Implement TEP (Tensor Expert Parallel) and DEP (Data Expert Parallel) config methods for TRT-LLM backend in the SLA Planner profiler — previously `NotImplementedError` stubs
- Add WIDEEP MoE backend support for DEP configs on Blackwell (SM100), with allgather correction for `max_num_tokens` to prevent DeepGemmMoEOp workspace OOM
- Add `set_decode_config()` to explicitly set `max_num_tokens` for decode profiling — TRT-LLM auto-tune was too small (e.g. 256), rejecting prompts at configured ISL (default 3000)
- Shorten TRT-LLM service names to fit Grove 45-char multinode naming limit
- Add `nodeSelector` support to `profilingConfig` in the operator CRD
- Support `deployment_ready_timeout_s` DGDR CRD field name in profiler argparse

## Test plan
- [ ] SLA profiler run with MoE model (e.g. DeepSeek-R1) using TRT-LLM backend with DEP config
- [ ] SLA profiler run with MoE model using TRT-LLM backend with TEP config
- [ ] Verify decode profiling accepts prompts at ISL 3000 (no rejection from small max_num_tokens)
- [ ] Verify WIDEEP allgather correction prevents OOM on multi-GPU DEP

Relates to: DYN-1236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in visualization plotting for decode operations with fallback mechanisms.

* **Chores**
  * Shortened internal service naming conventions for multinode deployment compatibility.
  * Refactored configuration management to use JSON-based approach for improved clarity.
  * Enhanced decode phase configuration support in system architecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->