### PR TITLE
chore: Merge bindings client and client2 functions

### DIFF
--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -448,7 +448,9 @@ class EngineFactory:
                 kv_router_config=self.router_config.kv_router_config,
             )
         else:
-            router = await generate_endpoint.client2(self.router_config.router_mode)
+            router = await generate_endpoint.client(
+                router_mode=self.router_config.router_mode
+            )
 
         gen = VllmProcessor(
             tokenizer,

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -835,11 +835,13 @@ impl Endpoint {
         })
     }
 
-    fn client<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
-        self.client2(py, RouterMode::RoundRobin)
-    }
-
-    fn client2<'p>(&self, py: Python<'p>, router_mode: RouterMode) -> PyResult<Bound<'p, PyAny>> {
+    #[pyo3(signature = (router_mode = None))]
+    fn client<'p>(
+        &self,
+        py: Python<'p>,
+        router_mode: Option<RouterMode>,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let router_mode = router_mode.unwrap_or(RouterMode::RoundRobin);
         let inner = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let client = inner.client().await.map_err(to_pyerr)?;

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -164,16 +164,11 @@ class Endpoint:
         """
         ...
 
-    async def client(self) -> Client:
+    async def client(self, router_mode: Optional[RouterMode] = None) -> Client:
         """
-        Create a `Client` capable of calling served instances of this endpoint using round-robin routing.
-        """
-        ...
+        Create a `Client` capable of calling served instances of this endpoint.
 
-    async def client2(self, router_mode: RouterMode) -> Client:
-        """
-        Create a `Client` capable of calling served instances of this endpoint, using a specific
-        router mode (random, round-robin, kv).
+        By default this uses round-robin routing when `router_mode` is not provided.
         """
         ...
 


### PR DESCRIPTION
Follow-up to #5544

In the above PR I temporarily added a `client2` function to the `Endpoint` bindings to pass `RouterMode`. Merge with `client` now.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Python SDK: You can now choose the router mode explicitly when creating a client; it defaults to round-robin if unspecified.
- Refactor
  - Consolidated duplicate client-creation APIs into a single entry point; the alternate method has been removed.
- Documentation
  - Updated type hints and descriptions to reflect the unified API and its default routing behavior.
- Chores
  - Internal call sites updated to use the unified client-creation API for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->