### PR TITLE
docs(fern): update version dropdown to match Sphinx

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -24,17 +24,25 @@ title: NVIDIA Dynamo Documentation
 products:
   - display-name: Dynamo
     slug: /
-    path: ./versions/next.yml
+    path: ./versions/latest.yml
     versions:
-      - display-name: Next
-        path: ./versions/next.yml
+      - display-name: Latest (v0.9.0)
+        path: ./versions/latest.yml
+        slug: latest
+        availability: stable
+      - display-name: dev
+        path: ./versions/dev.yml
+        slug: dev
+        availability: beta
       - display-name: v0.9.0
         path: ./versions/v0.9.0.yml
+        availability: stable
       - display-name: v0.8.1
         path: ./versions/v0.8.1.yml
+        availability: deprecated
       - display-name: v0.8.0
         path: ./versions/v0.8.0.yml
-
+        availability: deprecated
 
 # GitHub repository link in navbar
 navbar-links:

--- a/fern/versions/dev.yml
+++ b/fern/versions/dev.yml
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Navigation structure matching https://docs.nvidia.com/dynamo/dev/
-# Rebuilt to exactly replicate the rendered Sphinx sidebar
+# Navigation structure for dev (main branch) version
+# Tracks the latest development content from main
 
 navigation:
   # ==================== Getting Started ====================

--- a/fern/versions/latest.yml
+++ b/fern/versions/latest.yml
@@ -1,0 +1,334 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Navigation structure for v0.9.0 release
+# Also used as the "Latest" version (default)
+
+navigation:
+  # ==================== Getting Started ====================
+  - section: Getting Started
+    contents:
+      - page: Quickstart
+        path: ../pages-v0.9.0/getting-started/quickstart.md
+      - page: Support Matrix
+        path: ../pages-v0.9.0/reference/support-matrix.md
+      - page: Feature Matrix
+        path: ../pages-v0.9.0/reference/feature-matrix.md
+      - page: Release Artifacts
+        path: ../pages-v0.9.0/reference/release-artifacts.md
+      - page: Examples
+        path: ../pages-v0.9.0/getting-started/examples.md
+
+  # ==================== Kubernetes Deployment ====================
+  - section: Kubernetes Deployment
+    contents:
+      - section: Deployment Guide
+        path: ../pages-v0.9.0/kubernetes/README.md
+        contents:
+          - page: Detailed Installation Guide
+            path: ../pages-v0.9.0/kubernetes/installation-guide.md
+          - page: Dynamo Operator
+            path: ../pages-v0.9.0/kubernetes/dynamo-operator.md
+          - page: Service Discovery
+            path: ../pages-v0.9.0/kubernetes/service-discovery.md
+          - page: Webhooks
+            path: ../pages-v0.9.0/kubernetes/webhooks.md
+          - page: Minikube Setup
+            path: ../pages-v0.9.0/kubernetes/deployment/minikube.md
+          - page: Managing Models with DynamoModel
+            path: ../pages-v0.9.0/kubernetes/deployment/dynamomodel-guide.md
+          - page: Autoscaling
+            path: ../pages-v0.9.0/kubernetes/autoscaling.md
+      - section: Observability (K8s)
+        contents:
+          - page: Metrics
+            path: ../pages-v0.9.0/kubernetes/observability/metrics.md
+          - page: Logging
+            path: ../pages-v0.9.0/kubernetes/observability/logging.md
+          - page: Operator Metrics
+            path: ../pages-v0.9.0/kubernetes/observability/operator-metrics.md
+      - section: Multinode
+        contents:
+          - page: Multinode Deployments
+            path: ../pages-v0.9.0/kubernetes/deployment/multinode-deployment.md
+          - page: Grove
+            path: ../pages-v0.9.0/kubernetes/grove.md
+
+  # ==================== User Guides ====================
+  - section: User Guides
+    contents:
+      - page: KV Cache Aware Routing
+        path: ../pages-v0.9.0/components/router/router-guide.md
+      - page: Disaggregated Serving
+        path: ../pages-v0.9.0/features/disaggregated-serving/README.md
+      - page: KV Cache Offloading
+        path: ../pages-v0.9.0/components/kvbm/kvbm-guide.md
+      - page: Dynamo Benchmarking
+        path: ../pages-v0.9.0/benchmarks/benchmarking.md
+      - section: Multimodality Support
+        path: ../pages-v0.9.0/features/multimodal/README.md
+        contents:
+          - page: vLLM Multimodal
+            path: ../pages-v0.9.0/features/multimodal/multimodal-vllm.md
+          - page: TensorRT-LLM Multimodal
+            path: ../pages-v0.9.0/features/multimodal/multimodal-trtllm.md
+          - page: SGLang Multimodal
+            path: ../pages-v0.9.0/features/multimodal/multimodal-sglang.md
+      - page: Tool Calling
+        path: ../pages-v0.9.0/agents/tool-calling.md
+      - page: LoRA Adapters
+        path: ../pages-v0.9.0/features/lora/README.md
+      - section: Observability (Local)
+        path: ../pages-v0.9.0/observability/README.md
+        contents:
+          - page: Prometheus + Grafana Setup
+            path: ../pages-v0.9.0/observability/prometheus-grafana.md
+          - page: Metrics
+            path: ../pages-v0.9.0/observability/metrics.md
+          - page: Metrics Developer Guide
+            path: ../pages-v0.9.0/observability/metrics-developer-guide.md
+          - page: Health Checks
+            path: ../pages-v0.9.0/observability/health-checks.md
+          - page: Tracing
+            path: ../pages-v0.9.0/observability/tracing.md
+          - page: Logging
+            path: ../pages-v0.9.0/observability/logging.md
+      - section: Fault Tolerance
+        path: ../pages-v0.9.0/fault-tolerance/README.md
+        contents:
+          - page: Request Migration
+            path: ../pages-v0.9.0/fault-tolerance/request-migration.md
+          - page: Request Cancellation
+            path: ../pages-v0.9.0/fault-tolerance/request-cancellation.md
+          - page: Graceful Shutdown
+            path: ../pages-v0.9.0/fault-tolerance/graceful-shutdown.md
+          - page: Request Rejection
+            path: ../pages-v0.9.0/fault-tolerance/request-rejection.md
+          - page: Testing
+            path: ../pages-v0.9.0/fault-tolerance/testing.md
+      - page: Writing Python Workers in Dynamo
+        path: ../pages-v0.9.0/development/backend-guide.md
+
+  # ==================== Components ====================
+  - section: Components
+    contents:
+      - section: Backends
+        contents:
+          - page: vLLM
+            path: ../pages-v0.9.0/backends/vllm/README.md
+          - page: SGLang
+            path: ../pages-v0.9.0/backends/sglang/README.md
+          - page: TensorRT-LLM
+            path: ../pages-v0.9.0/backends/trtllm/README.md
+      - section: Frontend
+        path: ../pages-v0.9.0/components/frontend/README.md
+        contents:
+          - page: Frontend Guide
+            path: ../pages-v0.9.0/components/frontend/frontend-guide.md
+      - section: Router
+        path: ../pages-v0.9.0/components/router/README.md
+        contents:
+          - page: Router Guide
+            path: ../pages-v0.9.0/components/router/router-guide.md
+          - page: Router Examples
+            path: ../pages-v0.9.0/components/router/router-examples.md
+      - section: Planner
+        path: ../pages-v0.9.0/components/planner/README.md
+        contents:
+          - page: Planner Guide
+            path: ../pages-v0.9.0/components/planner/planner-guide.md
+          - page: Planner Examples
+            path: ../pages-v0.9.0/components/planner/planner-examples.md
+      - section: Profiler
+        path: ../pages-v0.9.0/components/profiler/README.md
+        contents:
+          - page: Profiler Guide
+            path: ../pages-v0.9.0/components/profiler/profiler-guide.md
+          - page: Profiler Examples
+            path: ../pages-v0.9.0/components/profiler/profiler-examples.md
+      - section: KVBM
+        path: ../pages-v0.9.0/components/kvbm/README.md
+        contents:
+          - page: KVBM Guide
+            path: ../pages-v0.9.0/components/kvbm/kvbm-guide.md
+
+  # ==================== Integrations ====================
+  - section: Integrations
+    contents:
+      - page: LMCache
+        path: ../pages-v0.9.0/integrations/lmcache-integration.md
+      - page: SGLang HiCache
+        path: ../pages-v0.9.0/integrations/sglang-hicache.md
+      - page: FlexKV
+        path: ../pages-v0.9.0/integrations/flexkv-integration.md
+      - page: KV Events for Custom Engines
+        path: ../pages-v0.9.0/integrations/kv-events-custom-engines.md
+
+  # ==================== Design Docs ====================
+  - section: Design Docs
+    contents:
+      - page: Overall Architecture
+        path: ../pages-v0.9.0/design-docs/architecture.md
+      - page: Architecture Flow
+        path: ../pages-v0.9.0/design-docs/dynamo-flow.md
+      - page: Disaggregated Serving
+        path: ../pages-v0.9.0/design-docs/disagg-serving.md
+      - page: Distributed Runtime
+        path: ../pages-v0.9.0/design-docs/distributed-runtime.md
+      - page: Request Plane
+        path: ../pages-v0.9.0/design-docs/request-plane.md
+      - page: Event Plane
+        path: ../pages-v0.9.0/design-docs/event-plane.md
+      - page: Router Design
+        path: ../pages-v0.9.0/design-docs/router-design.md
+      - page: KVBM Design
+        path: ../pages-v0.9.0/design-docs/kvbm-design.md
+      - page: Planner Design
+        path: ../pages-v0.9.0/design-docs/planner-design.md
+
+  # ==================== Hidden Pages ====================
+  # Pages accessible via direct URL but not shown in main navigation.
+  # Matches Sphinx hidden_toctree.rst -- pages linked from within content
+  # but not in the sidebar.
+  - section: Additional Resources
+    hidden: true
+    contents:
+      # -- Development --
+      - page: Runtime Guide
+        path: ../pages-v0.9.0/development/runtime-guide.md
+      - page: Jail Stream
+        path: ../pages-v0.9.0/development/jail-stream.md
+      # -- API Reference --
+      - section: NIXL Connect API
+        path: ../pages-v0.9.0/api/nixl-connect/README.md
+        contents:
+          - page: Connector
+            path: ../pages-v0.9.0/api/nixl-connect/connector.md
+          - page: Device
+            path: ../pages-v0.9.0/api/nixl-connect/device.md
+          - page: Device Kind
+            path: ../pages-v0.9.0/api/nixl-connect/device-kind.md
+          - page: Descriptor
+            path: ../pages-v0.9.0/api/nixl-connect/descriptor.md
+          - page: Read Operation
+            path: ../pages-v0.9.0/api/nixl-connect/read-operation.md
+          - page: Write Operation
+            path: ../pages-v0.9.0/api/nixl-connect/write-operation.md
+          - page: Readable Operation
+            path: ../pages-v0.9.0/api/nixl-connect/readable-operation.md
+          - page: Writable Operation
+            path: ../pages-v0.9.0/api/nixl-connect/writable-operation.md
+          - page: Operation Status
+            path: ../pages-v0.9.0/api/nixl-connect/operation-status.md
+          - page: RDMA Metadata
+            path: ../pages-v0.9.0/api/nixl-connect/rdma-metadata.md
+      # -- Kubernetes (hidden sub-pages) --
+      - page: API Reference (K8s)
+        path: ../pages-v0.9.0/kubernetes/api-reference.md
+      - page: Creating Deployments
+        path: ../pages-v0.9.0/kubernetes/deployment/create-deployment.md
+      - page: FluxCD
+        path: ../pages-v0.9.0/kubernetes/fluxcd.md
+      - page: Model Caching with Fluid
+        path: ../pages-v0.9.0/kubernetes/model-caching-with-fluid.md
+      # -- Reference --
+      - page: CLI Reference
+        path: ../pages-v0.9.0/reference/cli.md
+      - page: Glossary
+        path: ../pages-v0.9.0/reference/glossary.md
+      - page: Tuning Disaggregated Performance
+        path: ../pages-v0.9.0/performance/tuning.md
+      # -- Backend detail pages --
+      - section: vLLM Details
+        contents:
+          - page: DeepSeek-R1
+            path: ../pages-v0.9.0/backends/vllm/deepseek-r1.md
+          - page: GPT-OSS
+            path: ../pages-v0.9.0/backends/vllm/gpt-oss.md
+          - page: Multi-Node
+            path: ../pages-v0.9.0/backends/vllm/multi-node.md
+          - page: Prometheus
+            path: ../pages-v0.9.0/backends/vllm/prometheus.md
+          - page: Prompt Embeddings
+            path: ../pages-v0.9.0/backends/vllm/prompt-embeddings.md
+      - section: SGLang Details
+        contents:
+          - page: Expert Distribution (EPLB)
+            path: ../pages-v0.9.0/backends/sglang/expert-distribution-eplb.md
+          - page: GPT-OSS
+            path: ../pages-v0.9.0/backends/sglang/gpt-oss.md
+          - page: Diffusion LM
+            path: ../pages-v0.9.0/backends/sglang/diffusion-lm.md
+          - page: Profiling
+            path: ../pages-v0.9.0/backends/sglang/profiling.md
+          - page: Disaggregation
+            path: ../pages-v0.9.0/backends/sglang/sglang-disaggregation.md
+          - page: Prometheus
+            path: ../pages-v0.9.0/backends/sglang/prometheus.md
+      - section: TensorRT-LLM Details
+        contents:
+          - page: Multinode Examples
+            path: ../pages-v0.9.0/backends/trtllm/multinode/multinode-examples.md
+          - page: Llama4 + Eagle
+            path: ../pages-v0.9.0/backends/trtllm/llama4-plus-eagle.md
+          - page: KV Cache Transfer
+            path: ../pages-v0.9.0/backends/trtllm/kv-cache-transfer.md
+          - page: Gemma3 Sliding Window
+            path: ../pages-v0.9.0/backends/trtllm/gemma3-sliding-window-attention.md
+          - page: GPT-OSS
+            path: ../pages-v0.9.0/backends/trtllm/gpt-oss.md
+          - page: Prometheus
+            path: ../pages-v0.9.0/backends/trtllm/prometheus.md
+      # -- Features (hidden sub-pages) --
+      - section: Speculative Decoding
+        path: ../pages-v0.9.0/features/speculative-decoding/README.md
+        contents:
+          - page: Speculative Decoding with vLLM
+            path: ../pages-v0.9.0/features/speculative-decoding/speculative-decoding-vllm.md
+      # -- Benchmarks --
+      - page: KV Router A/B Testing
+        path: ../pages-v0.9.0/benchmarks/kv-router-ab-testing.md
+      # -- Mocker --
+      - page: Mocker
+        path: ../pages-v0.9.0/mocker/mocker.md
+      # -- Docs README --
+      - page: Building Documentation
+        path: ../pages-v0.9.0/README.md
+      # -- Templates --
+      - section: Templates
+        path: ../pages-v0.9.0/templates/README.md
+        contents:
+          - page: Backend Guide
+            path: ../pages-v0.9.0/templates/backend-guide.md
+          - page: Backend README
+            path: ../pages-v0.9.0/templates/backend-readme.md
+          - page: Component Design
+            path: ../pages-v0.9.0/templates/component-design.md
+          - page: Component Examples
+            path: ../pages-v0.9.0/templates/component-examples.md
+          - page: Component Guide
+            path: ../pages-v0.9.0/templates/component-guide.md
+          - page: Component README
+            path: ../pages-v0.9.0/templates/component-readme.md
+          - page: Feature Backend
+            path: ../pages-v0.9.0/templates/feature-backend.md
+          - page: Feature README
+            path: ../pages-v0.9.0/templates/feature-readme.md
+          - page: In-Code README
+            path: ../pages-v0.9.0/templates/incode-readme.md
+          - page: Infrastructure README
+            path: ../pages-v0.9.0/templates/infrastructure-readme.md
+          - page: Integration README
+            path: ../pages-v0.9.0/templates/integration-readme.md


### PR DESCRIPTION
## Summary

- Restructure Fern version dropdown to match Sphinx versioning scheme
- Add "Latest (v0.9.0)" as the default version with unversioned URLs
- Rename "Next" to "dev" (beta) tracking main branch content
- Add explicit "v0.9.0" version entry (stable)
- Mark v0.8.1 and v0.8.0 as deprecated
- Clean up duplicate product entries in docs.yml

## Version Dropdown (target state)

| Display Name | Version YML | Pages Dir | Availability |
|---|---|---|---|
| Latest (v0.9.0) | latest.yml | pages-v0.9.0/ | stable (default) |
| dev | dev.yml | pages/ | beta |
| v0.9.0 | v0.9.0.yml | pages-v0.9.0/ | stable |
| v0.8.1 | v0.8.1.yml | pages-v0.8.1/ | deprecated |
| v0.8.0 | v0.8.0.yml | pages-v0.8.0/ | deprecated |

## Files Changed

- `fern/docs.yml` — replaced messy products block with clean versioned dropdown
- `fern/versions/dev.yml` — renamed from next.yml, updated header
- `fern/versions/latest.yml` — copy of v0.9.0.yml navigation, updated header
- `fern/versions/next.yml` — deleted (replaced by dev.yml)

## Test Plan

- [ ] Verify Fern build succeeds with new version configuration
- [ ] Confirm version dropdown shows all 5 entries in correct order
- [ ] Verify "Latest (v0.9.0)" pages render at unversioned URLs (default)
- [ ] Verify "dev" pages render at /dev/ slug
- [ ] Confirm v0.8.1 and v0.8.0 show deprecated badge


Made with [Cursor](https://cursor.com)