### PR TITLE
docs(fern): change v0.8.1 and v0.8.0 availability to stable

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -39,10 +39,10 @@ products:
         availability: stable
       - display-name: v0.8.1
         path: ./versions/v0.8.1.yml
-        availability: deprecated
+        availability: stable
       - display-name: v0.8.0
         path: ./versions/v0.8.0.yml
-        availability: deprecated
+        availability: stable
 
 # GitHub repository link in navbar
 navbar-links:


### PR DESCRIPTION
## Summary

- Change v0.8.1 and v0.8.0 version badges from `deprecated` to `stable` in the Fern version dropdown

One-line fix in `fern/docs.yml`.

## Test Plan

- [ ] Verify v0.8.1 and v0.8.0 show "Stable" badge instead of "Deprecated"

Made with [Cursor](https://cursor.com)