### PR TITLE
fix: update radix_tree_microbench after nestedmap/positionalindexer refactor

### DIFF
--- a/lib/kv-router/src/nested_map.rs
+++ b/lib/kv-router/src/nested_map.rs
@@ -376,6 +376,14 @@ impl PositionalIndexer {
         Self::remove_or_clear_worker_blocks_impl(index, worker_blocks, worker_id, true);
     }
 
+    /// Get total number of blocks across all workers.
+    pub fn current_size(&self) -> usize {
+        self.worker_blocks
+            .iter()
+            .map(|entry| entry.value().read().unwrap().len())
+            .sum()
+    }
+
     /// Remove a worker and all their blocks completely from the index.
     #[allow(dead_code)]
     fn remove_worker_blocks(&self, worker_id: WorkerId) {


### PR DESCRIPTION
#### Overview:

- as titled
- also remove some code that was refactored into test utils, might have been from bad merge?
-

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--router-event-threads` CLI flag to configure KV router event processing concurrency (default: 1). Set to 1 for single-threaded mode with TTL support; set greater than 1 for multi-threaded mode with higher throughput. Configurable via `DYN_ROUTER_EVENT_THREADS` environment variable.

* **Documentation**
  * Updated router configuration guides with threading options and behavioral differences between single and multi-threaded modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->