### PR TITLE
fix: skip double-add of device blocks in KVBM connector

### DIFF
--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
@@ -542,6 +542,20 @@ impl Slot for VllmConnectorSlot {
         num_scheduled_tokens: usize,
         priorities: Option<&[u32]>,
     ) -> Result<(), SlotError> {
+        // Debug logging for chunked prefill analysis
+        tracing::info!(
+            request_id = %self.request_id,
+            "apply_scheduler_output: computed={}, scheduled={}, new_blocks={}, priorities={:?}, \
+             current_pos={}, evaluated_blocks={}, offload_terminated={:?}",
+            num_computed_tokens,
+            num_scheduled_tokens,
+            block_ids.len(),
+            priorities.map(|p| p.len()),
+            self.current_position,
+            self.evaluated_blocks,
+            self.offload_terminated_at_block
+        );
+
         // Validate contract: priorities must match block_ids length when provided
         if let Some(prios) = priorities {
             assert_eq!(


### PR DESCRIPTION
## Summary
- Fix priority-based KV cache offload filtering being broken due to device blocks being added twice in `apply_scheduler_output`
- `update_state_after_alloc` already appends blocks before `apply_scheduler_output` is called. The redundant `extend()` shifts priority array indexing, zeroing all priorities and causing the offload filter to skip all blocks
- Add a tail-match check to skip the extend when blocks are already present

## Context
- Companion to TensorRT-LLM PR: https://github.com/NVIDIA/TensorRT-LLM/pull/10751
- Affects both regular and chunked prefill modes

## Test plan
- [x] Standalone reproducer (`test_connector_double_add.py`) — 7 test cases covering regular, chunked, and decode paths
- [x] E2E verification in regular mode — all 5 scenarios pass (mixed priorities, all-high, all-low, contiguity break, boundary)
- [x] E2E verification in chunked prefill mode — all scenarios pass