### PR TITLE
feat: add --headless mode for multi-node TP/PP in dynamo.vllm

### DIFF
--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -266,6 +266,17 @@ class DynamoVllmArgGroup(ArgGroup):
             help="Number of GPUs used for classifier free guidance parallelism.",
         )
 
+        # Headless mode for multi-node TP/PP
+        add_negatable_bool_argument(
+            g,
+            flag_name="--headless",
+            env_var="DYN_VLLM_HEADLESS",
+            default=False,
+            help="Run in headless mode for multi-node TP/PP. "
+            "Secondary nodes run vLLM workers only, no dynamo endpoints. "
+            "See vLLM multi-node data parallel documentation for more details.",
+        )
+
         # ModelExpress P2P
         add_argument(
             g,
@@ -318,6 +329,9 @@ class DynamoVllmConfig(ConfigBase):
     ulysses_degree: int = 1
     ring_degree: int = 1
     cfg_parallel_size: int = 1
+
+    # Headless mode for multi-node TP/PP
+    headless: bool = False
 
     # ModelExpress P2P
     model_express_url: Optional[str] = None

--- a/docs/pages/backends/vllm/multi-node.md
+++ b/docs/pages/backends/vllm/multi-node.md
@@ -83,7 +83,8 @@ python -m dynamo.frontend --router-mode kv &
 python -m dynamo.vllm \
   --model meta-llama/Llama-3.3-70B-Instruct \
   --tensor-parallel-size 8 \
-  --enforce-eager
+  --enforce-eager \
+  --is-decode-worker
 ```
 
 **Node 2**: Run prefill worker
@@ -104,3 +105,5 @@ you need multiple nodes to host a **single** model instance. One node runs the f
 spawning only vLLM workers.
 
 See [`examples/backends/vllm/launch/multi_node_tp.sh`](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/launch/multi_node_tp.sh) for a ready-to-use launch script that supports both head and worker roles via `--head` / `--worker` flags. The model, TP size, and node count are configurable via `MODEL`, `TENSOR_PARALLEL_SIZE`, and `NNODES` environment variables.
+
+For details on the flags used for multi-node distributed execution (`--master-addr`, `--master-port`, `--nnodes`, `--node-rank`), see the [vLLM multiprocessing docs](https://docs.vllm.ai/en/stable/serving/parallelism_scaling/#running-vllm-with-multiprocessing).

--- a/examples/backends/vllm/launch/multi_node_tp.sh
+++ b/examples/backends/vllm/launch/multi_node_tp.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Multi-node TP deployment with dynamo.vllm
+#
+# Single script for both head and worker roles.
+#
+# Usage:
+#   Head node:
+#     bash multi_node_tp.sh --head --head-ip 10.0.0.1
+#
+#   Worker node:
+#     bash multi_node_tp.sh --worker --head-ip 10.0.0.1
+#
+# Prerequisites:
+#   - 8 GPUs per node
+#   - Head: NATS and etcd running (on this node or reachable)
+#   - Worker: torch.distributed connectivity to head node
+#   - Worker: head node must be started first
+
+set -e
+trap 'echo "Cleaning up..."; kill 0' EXIT
+
+MODEL="${MODEL:-meta-llama/Llama-3.1-8B-Instruct}"
+TP="${TENSOR_PARALLEL_SIZE:-16}"
+NNODES="${NNODES:-2}"
+ROLE=""
+HEAD_IP=""
+
+usage() {
+  echo "Usage: $0 (--head | --worker) --head-ip <IP>"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --head)   ROLE="head";   shift ;;
+    --worker) ROLE="worker"; shift ;;
+    --head-ip)
+      HEAD_IP="$2"
+      shift 2
+      ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+[[ -z "${ROLE}" ]]    && { echo "Error: specify --head or --worker"; usage; }
+[[ -z "${HEAD_IP}" ]] && { echo "Error: --head-ip is required"; usage; }
+
+if [[ "${ROLE}" == "head" ]]; then
+
+  echo "Starting Dynamo frontend..."
+  python3 -m dynamo.frontend &
+
+  echo "Starting dynamo.vllm head node (TP=${TP}, nnodes=${NNODES}, node-rank=0)..."
+  python3 -m dynamo.vllm \
+    --model "${MODEL}" \
+    --tensor-parallel-size "${TP}" \
+    --nnodes "${NNODES}" \
+    --node-rank 0 \
+    --master-addr "${HEAD_IP}" \
+    --enforce-eager &
+
+  wait
+else
+  echo "Starting dynamo.vllm headless worker (TP=${TP}, nnodes=${NNODES}, node-rank=1)..."
+  python3 -m dynamo.vllm \
+    --model "${MODEL}" \
+    --tensor-parallel-size "${TP}" \
+    --nnodes "${NNODES}" \
+    --node-rank 1 \
+    --master-addr "${HEAD_IP}" \
+    --enforce-eager \
+    --headless
+fi

--- a/tests/serve/launch/multi_node_tp_headless.sh
+++ b/tests/serve/launch/multi_node_tp_headless.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Single-machine 2-GPU test for multi-node TP with --headless flag.
+#
+# Launches frontend + head (node-rank=0, GPU 0) + headless worker (node-rank=1, GPU 1)
+# on localhost to validate the headless code path without requiring multiple machines.
+
+set -e
+trap 'echo "Cleaning up..."; kill 0' EXIT
+
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+
+echo "Starting Dynamo frontend..."
+python3 -m dynamo.frontend &
+
+echo "Starting dynamo.vllm head node (TP=2, nnodes=2, node-rank=0, GPU 0)..."
+CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
+  --model "${MODEL}" \
+  --tensor-parallel-size 2 \
+  --nnodes 2 \
+  --node-rank 0 \
+  --master-addr 127.0.0.1 \
+  --enforce-eager &
+
+echo "Starting dynamo.vllm headless worker (TP=2, nnodes=2, node-rank=1, GPU 1)..."
+CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
+  --model "${MODEL}" \
+  --tensor-parallel-size 2 \
+  --nnodes 2 \
+  --node-rank 1 \
+  --master-addr 127.0.0.1 \
+  --enforce-eager \
+  --headless &
+
+wait

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -665,6 +665,21 @@ vllm_configs = {
             completion_payload_default(),
         ],
     ),
+    "multi_node_tp_headless": VLLMConfig(
+        name="multi_node_tp_headless",
+        directory=os.path.join(WORKSPACE_DIR, "tests/serve"),
+        script_name="multi_node_tp_headless.sh",
+        marks=[
+            pytest.mark.gpu_2,
+            pytest.mark.post_merge,
+            pytest.mark.timeout(300),
+        ],
+        model="Qwen/Qwen3-0.6B",
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+        ],
+    ),
     "guided_decoding": VLLMConfig(
         name="guided_decoding",
         directory=vllm_dir,


### PR DESCRIPTION
## Summary
- Add `--headless` flag to `dynamo.vllm` enabling multi-node tensor/pipeline parallelism via vLLM's native `mp` backend
- Headless workers bypass DistributedRuntime
- Document multi-node TP/PP patterns with examples for TP=16 and TP=8+PP=2 across 2×8-GPU nodes
- Fix missing `\` line continuations in disaggregated serving examples

## Test plan
- [ ] Confirm `python3 -m dynamo.vllm --help` shows `--headless` flag
- [ ] Verify existing unit tests pass with the `parse_args()` return type change
- [ ] Verify rendered markdown reads correctly in both `docs/` and `fern/` versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added headless execution mode for distributed multi-node setups with tensor and pipeline parallelism.
  * New `--headless` CLI flag to enable headless worker execution without API server.

* **Documentation**
  * Added comprehensive multi-node execution guide with tensor/pipeline parallelism examples, covering two-node configurations and infrastructure requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->