### PR TITLE
test: change KVBM vLLM interface tests to gpu_0 marker

### DIFF
--- a/tests/kvbm_integration/test_kvbm_vllm_integration.py
+++ b/tests/kvbm_integration/test_kvbm_vllm_integration.py
@@ -43,7 +43,7 @@ if HAS_VLLM:
 pytestmark = [
     pytest.mark.kvbm,
     pytest.mark.integration,
-    pytest.mark.gpu_1,
+    pytest.mark.gpu_0,
     pytest.mark.vllm,
     pytest.mark.nightly,
     pytest.mark.pre_merge,


### PR DESCRIPTION
## Summary
- Changed `pytest.mark.gpu_1` to `pytest.mark.gpu_0` for KVBM vLLM interface tests

## Rationale
The KVBM vLLM integration tests in `test_kvbm_vllm_integration.py` validate interface contracts (dataclass fields, method signatures, type annotations) without executing GPU operations. These tests:

- Check Python interface assumptions only
- Don't require GPU hardware
- Can run in CPU-only environments

By changing to `gpu_0` marker, these tests can run in faster CPU-based CI pipelines.

## Test Verification
Verified with:
```bash
pytest tests/kvbm_integration/test_kvbm_vllm_integration.py -v -m "gpu_0 and vllm" --collect-only
```

Result: 5/7 tests collected (2 mypy tests excluded by `--ignore-glob=*vllm_integration*` config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GPU resource allocation configuration for test execution.

---

**Note:** This release contains no user-facing changes. It includes internal testing infrastructure updates only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->