### PR TITLE
fix: upgrade Pillow to 12.1.1+ 

### DIFF
--- a/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
+++ b/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
@@ -91,7 +91,8 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            image = await asyncio.to_thread(Image.open, image_data)
+            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            image = await asyncio.to_thread(Image.open, image_data, formats=["JPEG", "PNG", "WEBP"])
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/components/src/dynamo/vllm/multimodal_utils/image_loader.py
+++ b/components/src/dynamo/vllm/multimodal_utils/image_loader.py
@@ -78,7 +78,8 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            image = await asyncio.to_thread(Image.open, image_data)
+            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            image = await asyncio.to_thread(Image.open, image_data, formats=["JPEG", "PNG", "WEBP"])
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -49,6 +49,9 @@ sentencepiece==0.2.1
 # Required by kr8s
 # https://github.com/kr8s-org/kr8s/blob/750022c3ebbb7988cddb5a979aca2ee8074a1069/examples/kubectl-ng/uv.lock#L988
 sniffio==1.3.1
+# Fix GHSA-cfh3-3jmp-rvhc (CVE-2026-25990): Pillow PSD out-of-bounds write vulnerability
+# Upgrade from 11.1.0 to 12.1.1+ to fix vulnerability
+pillow>=12.1.1
 tensorboard>=2.19.0,<2.21.0
 tensorboardX==2.6.2.2
 # Transformers version constraint for container builds


### PR DESCRIPTION
## Summary
- Upgrade Pillow from 11.1.0 to 12.1.1+ 
- Fixes out-of-bounds write vulnerability when loading PSD images

## Details
Pillow 11.1.0 is vulnerable to an out-of-bounds write when loading specially crafted PSD images. The vulnerability affects Pillow >= 10.3.0, < 12.1.1 and is fixed in Pillow 12.1.1.

Pillow is pulled in as a transitive dependency via:
- `transformers` (optional extra: vision/torch-vision/all)
- `matplotlib` (runtime dependency)

By explicitly pinning `pillow>=12.1.1` in requirements.txt, we ensure all containers get the fixed version, overriding any transitive dependency constraints.

## Affected Containers
- `sglang-runtime:0.9.0-cuda13` (linux/amd64, linux/arm64)
- `vllm-runtime:0.9.0` (linux/amd64, linux/arm64)

## Impact Analysis
The vulnerable code path is reachable via user-controlled image URLs in multimodal handlers. `Image.open()` is called without the `formats` parameter, allowing PSD parsing to trigger the vulnerability before format validation.

**Note**: A separate code fix is also needed to add `formats` parameter to `Image.open()` calls in:
- `components/src/dynamo/vllm/multimodal_utils/image_loader.py:81`
- `components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py:94`

## Test Plan
- [ ] CI passes
- [ ] Container builds succeed with Pillow 12.1.1+
- [ ] Multimodal image loading still works correctly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to address a security vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->