### PR TITLE
DUPLICATE of PR #5782 / feat: add fine-grained error classification to frontend request metrics

### DIFF
--- a/lib/bindings/python/codegen/src/prometheus_parser.rs
+++ b/lib/bindings/python/codegen/src/prometheus_parser.rs
@@ -21,6 +21,8 @@ pub struct ModuleDef {
     pub doc_comment: String,
     pub is_macro_generated: bool,
     pub macro_prefix: Option<String>,
+    /// Nested sub-modules (e.g. `frontend_service::labels`)
+    pub submodules: Vec<ModuleDef>,
 }
 
 pub struct PrometheusParser {
@@ -61,6 +63,7 @@ impl PrometheusParser {
         let mut constants = Vec::new();
         let mut is_macro_generated = false;
         let mut macro_prefix = None;
+        let mut submodules = Vec::new();
 
         for item in items {
             match item {
@@ -74,6 +77,11 @@ impl PrometheusParser {
                     if let Some(prefix) = Self::extract_macro_prefix(macro_item) {
                         is_macro_generated = true;
                         macro_prefix = Some(prefix);
+                    }
+                }
+                Item::Mod(sub_module) => {
+                    if let Some(parsed_sub) = Self::parse_module(sub_module)? {
+                        submodules.push(parsed_sub);
                     }
                 }
                 _ => {}
@@ -103,6 +111,7 @@ impl PrometheusParser {
             doc_comment,
             is_macro_generated,
             macro_prefix,
+            submodules,
         }))
     }
 

--- a/lib/llm/src/grpc/service/openai.rs
+++ b/lib/llm/src/grpc/service/openai.rs
@@ -20,7 +20,7 @@ use super::kserve::inference;
 // [gluo NOTE] These are common utilities that should be shared between frontends
 use crate::http::service::{
     disconnect::{ConnectionHandle, create_connection_monitor},
-    metrics::{Endpoint, InflightGuard, process_response_and_observe_metrics},
+    metrics::{Endpoint, InflightGuard, ResultType, process_response_and_observe_metrics},
 };
 use dynamo_async_openai::types::{CompletionFinishReason, CreateCompletionRequest, Prompt};
 
@@ -165,6 +165,8 @@ pub fn grpc_monitor_for_disconnects<T>(
                     }
                 }
                 _ = context.stopped() => {
+                    // Client disconnected or context cancelled
+                    inflight_guard.set_result_type(ResultType::Cancelled);
                     tracing::trace!("Context stopped; breaking stream");
                     break;
                 }

--- a/lib/llm/src/grpc/service/tensor.rs
+++ b/lib/llm/src/grpc/service/tensor.rs
@@ -17,7 +17,7 @@ use super::kserve;
 use validator::Validate;
 
 // [gluo NOTE] These are common utilities that should be shared between frontends
-use crate::http::service::metrics::InflightGuard;
+use crate::http::service::metrics::{InflightGuard, ResultType};
 use crate::http::service::{
     disconnect::{ConnectionHandle, create_connection_monitor},
     metrics::{Endpoint, process_response_and_observe_metrics},
@@ -172,6 +172,8 @@ pub fn grpc_monitor_for_disconnects<T>(
                 }
                 // todo - test request cancellation with kserve frontend and tensor-based models
                 _ = context.stopped() => {
+                    // Client disconnected or context cancelled
+                    inflight_guard.set_result_type(ResultType::Cancelled);
                     tracing::trace!("Context stopped; breaking stream");
                     break;
                 }

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -112,6 +112,36 @@ pub mod labels {
 
     /// Label for worker type (e.g., "aggregated", "prefill", "decode", "encoder", etc.)
     pub const WORKER_TYPE: &str = "worker_type";
+
+    /// Label name for the endpoint on frontend request metrics
+    /// (e.g. "chat_completions", "completions", "embeddings").
+    ///
+    /// Note: distinct from [`ENDPOINT`] (`"dynamo_endpoint"`) which is the
+    /// auto-injected system-level endpoint label.
+    pub const REQUEST_ENDPOINT: &str = "endpoint";
+
+    /// Label name for the request type on frontend request metrics
+    /// (e.g. "stream", "unary").
+    pub const REQUEST_TYPE: &str = "request_type";
+
+    /// Label name for result type classification on frontend request metrics.
+    ///
+    /// Categorises each completed request into a high-level bucket so that
+    /// operators can distinguish client-side errors from server-side failures
+    /// and define SLIs/SLOs that exclude expected 4xx behaviour.
+    pub const RESULT_TYPE: &str = "result_type";
+
+    /// Label name for the HTTP status code on frontend request metrics.
+    ///
+    /// Carries the numeric status code as a string (e.g. "200", "404", "500")
+    /// for fine-grained drill-down alongside the coarser [`RESULT_TYPE`].
+    pub const HTTP_STATUS_CODE: &str = "http_status_code";
+
+    /// Label name for the type of migration.
+    pub const MIGRATION_TYPE: &str = "migration_type";
+
+    /// Label name for tokenizer operation.
+    pub const OPERATION: &str = "operation";
 }
 
 /// Frontend service metrics (LLM HTTP service)
@@ -208,12 +238,6 @@ pub mod frontend_service {
     pub const WORKER_LAST_INTER_TOKEN_LATENCY_SECONDS: &str =
         "worker_last_inter_token_latency_seconds";
 
-    /// Label name for the type of migration
-    pub const MIGRATION_TYPE_LABEL: &str = "migration_type";
-
-    /// Label name for tokenizer operation
-    pub const OPERATION_LABEL: &str = "operation";
-
     /// Operation label values for tokenizer latency metric
     pub mod operation {
         /// Tokenization operation
@@ -233,13 +257,28 @@ pub mod frontend_service {
         pub const ONGOING_REQUEST: &str = "ongoing_request";
     }
 
-    /// Status label values
-    pub mod status {
-        /// Value for successful requests
+    /// Result type label values for frontend request metrics.
+    pub mod result_type {
+        /// Request completed successfully (2xx)
         pub const SUCCESS: &str = "success";
 
-        /// Value for failed requests
-        pub const ERROR: &str = "error";
+        /// Client sent an invalid request (400 Bad Request, 422 Unprocessable Entity)
+        pub const VALIDATION: &str = "validation";
+
+        /// Requested resource was not found (404 Not Found)
+        pub const NOT_FOUND: &str = "not_found";
+
+        /// Service is overloaded or temporarily unavailable (503, 429)
+        pub const OVERLOAD: &str = "overload";
+
+        /// Request was cancelled by the client (stream disconnect)
+        pub const CANCELLED: &str = "cancelled";
+
+        /// Unexpected server-side failure (500 Internal Server Error)
+        pub const INTERNAL: &str = "internal";
+
+        /// Requested feature is not implemented (501 Not Implemented)
+        pub const NOT_IMPLEMENTED: &str = "not_implemented";
     }
 
     /// Request type label values


### PR DESCRIPTION
#### Overview:

Adds fine-grained error classification to `dynamo_frontend_requests_total` by introducing `result_type` and `http_status_code` labels, replacing the coarse binary success/error classification.

#### Examples:

Before, course grained success/error:
```
# HELP dynamo_frontend_requests_total Total number of LLM requests processed
# TYPE dynamo_frontend_requests_total counter
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="stream",status="success"} 1523
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="stream",status="error"} 47
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="unary",status="success"} 892
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="unary",status="error"} 31
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="completions",request_type="unary",status="success"} 210
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="completions",request_type="unary",status="error"} 5
```

After (note the new `http_status_code` and `result_type` finer grained data, per our clients' request):
```
# HELP dynamo_frontend_requests_total Total number of LLM requests processed
# TYPE dynamo_frontend_requests_total counter
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="stream",result_type="success",http_status_code="200"} 1502
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="stream",result_type="cancelled",http_status_code="499"} 18
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="stream",result_type="internal",http_status_code="500"} 3
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="unary",result_type="success",http_status_code="200"} 880
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="unary",result_type="validation",http_status_code="400"} 8
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="unary",result_type="not_found",http_status_code="404"} 12
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="unary",result_type="overload",http_status_code="429"} 6
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="unary",result_type="cancelled",http_status_code="499"} 3
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="chat_completions",request_type="unary",result_type="internal",http_status_code="500"} 2
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="completions",request_type="unary",result_type="success",http_status_code="200"} 208
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="completions",request_type="unary",result_type="not_implemented",http_status_code="501"} 2
dynamo_frontend_requests_total{model="Qwen/Qwen3-0.6B",endpoint="completions",request_type="unary",result_type="overload",http_status_code="503"} 3
```

#### Details:

- Add `ResultType` enum with variants: `success`, `validation`, `not_found`, `overload`, `cancelled`, `internal`, `not_implemented`; these specific names are requested by our client in the Linear ticket
- Extend `InflightGuard` to carry both `result_type` and `http_status_code` through the request lifecycle
- Fix streaming cancellation race: pre-set guard to `cancelled/499` before the SSE loop so broken-pipe drops are classified correctly instead of as `internal/500`
- Fix unary cancellation: check `ctx.is_killed()` after `mark_ok()` to override to `cancelled/499` when the client disconnects mid-request
- Promote all metric label name strings to constants in `prometheus_names.rs` (`labels` module) and update all call sites for consistency
- Update Python codegen to support nested Rust sub-modules as nested Python classes in `prometheus_names.py`
- Add comprehensive unit tests for `ResultType` classification, display, and default status codes
- Update integration tests (`http-service`, `http_metrics`) to validate new labels and cancellation metrics

#### Where should the reviewer start?

- `lib/runtime/src/metrics/prometheus_names.rs` for the new label constants and `result_type` values
- `lib/llm/src/http/service/metrics.rs` for the `ResultType` enum, classification logic, and `InflightGuard` changes
- `lib/llm/src/http/service/openai.rs` for error classification in HTTP handlers and the unary cancellation fix
- `lib/llm/src/http/service/disconnect.rs` for the streaming cancellation fix

#### Related Issues:

Closes DIS-1430

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced result type classification for request metrics: Success, Validation, NotFound, Overload, Cancelled, Internal, NotImplemented.
  * Added HTTP status code tracking for improved request telemetry.
  * Added routing overhead metrics namespace for latency monitoring.
  * Enhanced client disconnect handling with explicit Cancelled result type labeling.

* **Bug Fixes**
  * Improved error classification and metric labeling accuracy for backend and network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->