### PR TITLE
fix: restrict Image.open() formats to prevent PSD parsing (workaround)

### DIFF
--- a/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
+++ b/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
@@ -91,7 +91,8 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            image = await asyncio.to_thread(Image.open, image_data)
+            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            image = await asyncio.to_thread(Image.open, image_data, formats=["JPEG", "PNG", "WEBP"])
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
+++ b/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
@@ -92,7 +92,9 @@ class ImageLoader:
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
             # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
-            image = await asyncio.to_thread(Image.open, image_data, formats=["JPEG", "PNG", "WEBP"])
+            image = await asyncio.to_thread(
+                Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
+            )
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/components/src/dynamo/vllm/multimodal_utils/image_loader.py
+++ b/components/src/dynamo/vllm/multimodal_utils/image_loader.py
@@ -79,7 +79,9 @@ class ImageLoader:
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
             # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
-            image = await asyncio.to_thread(Image.open, image_data, formats=["JPEG", "PNG", "WEBP"])
+            image = await asyncio.to_thread(
+                Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
+            )
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/components/src/dynamo/vllm/multimodal_utils/image_loader.py
+++ b/components/src/dynamo/vllm/multimodal_utils/image_loader.py
@@ -78,7 +78,8 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            image = await asyncio.to_thread(Image.open, image_data)
+            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            image = await asyncio.to_thread(Image.open, image_data, formats=["JPEG", "PNG", "WEBP"])
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/examples/multimodal/utils/image_loader.py
+++ b/examples/multimodal/utils/image_loader.py
@@ -78,7 +78,10 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            image = await asyncio.to_thread(Image.open, image_data)
+            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            image = await asyncio.to_thread(
+                Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
+            )
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):


### PR DESCRIPTION
## Summary

Adds `formats` parameter to `Image.open()` calls as a workaround to prevent PSD image parsing

## Changes

- `components/src/dynamo/vllm/multimodal_utils/image_loader.py:81`
- `components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py:94`

## Rationale

This provides defense-in-depth by rejecting PSD files immediately without parsing, even if Pillow's format detection fails or is bypassed. This workaround can be merged independently of the Pillow upgrade PR.

## Related


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted image loading to JPEG, PNG, and WEBP formats for improved system reliability and consistency across multimodal image processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->