### PR TITLE
fix: restrict Image.open() formats to prevent PSD parsing (workaround)

### DIFF
--- a/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
+++ b/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
@@ -91,7 +91,7 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            # Restrict to supported formats to prevent PSD parsing
             image = await asyncio.to_thread(
                 Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
             )

--- a/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
+++ b/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
@@ -91,7 +91,8 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            image = await asyncio.to_thread(Image.open, image_data)
+            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            image = await asyncio.to_thread(Image.open, image_data, formats=["JPEG", "PNG", "WEBP"])
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
+++ b/components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py
@@ -92,7 +92,9 @@ class ImageLoader:
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
             # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
-            image = await asyncio.to_thread(Image.open, image_data, formats=["JPEG", "PNG", "WEBP"])
+            image = await asyncio.to_thread(
+                Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
+            )
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/components/src/dynamo/vllm/multimodal_utils/image_loader.py
+++ b/components/src/dynamo/vllm/multimodal_utils/image_loader.py
@@ -79,7 +79,9 @@ class ImageLoader:
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
             # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
-            image = await asyncio.to_thread(Image.open, image_data, formats=["JPEG", "PNG", "WEBP"])
+            image = await asyncio.to_thread(
+                Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
+            )
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/components/src/dynamo/vllm/multimodal_utils/image_loader.py
+++ b/components/src/dynamo/vllm/multimodal_utils/image_loader.py
@@ -78,7 +78,8 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            image = await asyncio.to_thread(Image.open, image_data)
+            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            image = await asyncio.to_thread(Image.open, image_data, formats=["JPEG", "PNG", "WEBP"])
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/components/src/dynamo/vllm/multimodal_utils/image_loader.py
+++ b/components/src/dynamo/vllm/multimodal_utils/image_loader.py
@@ -78,7 +78,7 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            # Restrict to supported formats to prevent PSD parsing
             image = await asyncio.to_thread(
                 Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
             )

--- a/examples/multimodal/utils/image_loader.py
+++ b/examples/multimodal/utils/image_loader.py
@@ -78,7 +78,10 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            image = await asyncio.to_thread(Image.open, image_data)
+            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            image = await asyncio.to_thread(
+                Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
+            )
 
             # Validate image format and convert to RGB
             if image.format not in ("JPEG", "PNG", "WEBP"):

--- a/examples/multimodal/utils/image_loader.py
+++ b/examples/multimodal/utils/image_loader.py
@@ -78,7 +78,7 @@ class ImageLoader:
                 raise ValueError(f"Invalid image source scheme: {parsed_url.scheme}")
 
             # PIL is sync, so offload to a thread to avoid blocking the event loop
-            # Restrict to supported formats to prevent PSD parsing (GHSA-cfh3-3jmp-rvhc)
+            # Restrict to supported formats to prevent PSD parsing
             image = await asyncio.to_thread(
                 Image.open, image_data, formats=["JPEG", "PNG", "WEBP"]
             )


### PR DESCRIPTION
## Summary
- Cherry-pick of #6212 to release/0.9.0
- Adds `formats` parameter to `Image.open()` calls to restrict parsing to supported image formats (JPEG, PNG, WEBP), preventing unexpected format handling

## Changes
- `components/src/dynamo/vllm/multimodal_utils/image_loader.py`
- `components/src/dynamo/sglang/multimodal_utils/multimodal_image_loader.py`
- `examples/multimodal/utils/image_loader.py`

## Original PR
- Main PR: #6212
- Commits: 0e19bc6ef, 59cb2ad52, 7d89b0706

Made with [Cursor](https://cursor.com)