### PR TITLE
docs: update docs URLs from Sphinx index.html to Fern paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,6 +286,6 @@ By contributing, you agree that your contributions will be licensed under the [A
 
 - **Discord**: [Join our community](https://discord.gg/nvidia-dynamo)
 - **Discussions**: [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
-- **Documentation**: [docs.nvidia.com/dynamo](https://docs.nvidia.com/dynamo/latest/index.html)
+- **Documentation**: [docs.nvidia.com/dynamo](https://docs.nvidia.com/dynamo/)
 
 Thank you for contributing to Dynamo!

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ limitations under the License.
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ai-dynamo/dynamo)
 [![Discord](https://dcbadge.limes.pink/api/server/D92uqZRjCZ?style=flat)](https://discord.gg/D92uqZRjCZ) ![Community Contributors](https://img.shields.io/badge/community_contributors-70%2B-brightgreen)
 
-| **[Roadmap](https://github.com/ai-dynamo/dynamo/issues/5506)** | **[Support Matrix](https://github.com/ai-dynamo/dynamo/blob/main/docs/reference/support-matrix.md)** | **[Docs](https://docs.nvidia.com/dynamo/latest/index.html)** | **[Recipes](https://github.com/ai-dynamo/dynamo/tree/main/recipes)** | **[Examples](https://github.com/ai-dynamo/dynamo/tree/main/examples)** | **[Prebuilt Containers](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)** | **[Design Proposals](https://github.com/ai-dynamo/enhancements)** | **[Blogs](https://developer.nvidia.com/blog/tag/nvidia-dynamo)**
+| **[Roadmap](https://github.com/ai-dynamo/dynamo/issues/5506)** | **[Support Matrix](https://github.com/ai-dynamo/dynamo/blob/main/docs/reference/support-matrix.md)** | **[Docs](https://docs.nvidia.com/dynamo/)** | **[Recipes](https://github.com/ai-dynamo/dynamo/tree/main/recipes)** | **[Examples](https://github.com/ai-dynamo/dynamo/tree/main/examples)** | **[Prebuilt Containers](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)** | **[Design Proposals](https://github.com/ai-dynamo/enhancements)** | **[Blogs](https://developer.nvidia.com/blog/tag/nvidia-dynamo)**
 
 # NVIDIA Dynamo
 

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -2,7 +2,7 @@
     {
         "name": "0.1.0 (current release)",
         "version": "0.1.0",
-        "url": "https://docs.nvidia.com/dynamo/latest/index.html"
+        "url": "https://docs.nvidia.com/dynamo/"
     },
     {
         "name": "older releases",

--- a/docs/kubernetes/model_caching_with_fluid.md
+++ b/docs/kubernetes/model_caching_with_fluid.md
@@ -325,4 +325,4 @@ spec:
 - [MinIO Documentation](https://docs.min.io/)
 - [Hugging Face Hub](https://huggingface.co/docs/hub/index)
 - [Dynamo README](https://github.com/ai-dynamo/dynamo/blob/main/.devcontainer/README.md)
-- [Dynamo Documentation](https://docs.nvidia.com/dynamo/latest/index.html)
+- [Dynamo Documentation](https://docs.nvidia.com/dynamo/)

--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -15,7 +15,7 @@ Release history in this document begins at v0.6.0.
 ## Current Release: Dynamo v0.8.1
 
 - **GitHub Release:** [v0.8.1](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1)
-- **Docs:** [v0.8.1](https://docs.nvidia.com/dynamo/archive/0.8.1/index.html)
+- **Docs:** [v0.8.1](https://docs.nvidia.com/dynamo/v-0-8-1/)
 - **NGC Collection:** [ai-dynamo](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)
 
 ### Patch Release: v0.8.1.post1 (Jan 23, 2026)
@@ -165,12 +165,12 @@ For a complete list of known issues, refer to the release notes for each patch:
 
 | Version | Release Date | GitHub | Docs |
 |---------|--------------|--------|------|
-| `v0.8.1` | Jan 23, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1) | [Docs](https://docs.nvidia.com/dynamo/archive/0.8.1/index.html) |
-| `v0.8.0` | Jan 15, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.0) | [Docs](https://docs.nvidia.com/dynamo/archive/0.8.0/index.html) |
-| `v0.7.1` | Dec 15, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.1) | [Docs](https://docs.nvidia.com/dynamo/archive/0.7.1/index.html) |
-| `v0.7.0` | Nov 26, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.0) | [Docs](https://docs.nvidia.com/dynamo/archive/0.7.0/index.html) |
-| `v0.6.1` | Nov 6, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.1) | [Docs](https://docs.nvidia.com/dynamo/archive/0.6.1/index.html) |
-| `v0.6.0` | Oct 28, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.0) | [Docs](https://docs.nvidia.com/dynamo/archive/0.6.0/index.html) |
+| `v0.8.1` | Jan 23, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1) | [Docs](https://docs.nvidia.com/dynamo/v-0-8-1/) |
+| `v0.8.0` | Jan 15, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.0) | [Docs](https://docs.nvidia.com/dynamo/v-0-8-0/) |
+| `v0.7.1` | Dec 15, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.1) | [GitHub](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.1) |
+| `v0.7.0` | Nov 26, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.0) | [GitHub](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.0) |
+| `v0.6.1` | Nov 6, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.1) | [GitHub](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.1) |
+| `v0.6.0` | Oct 28, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.0) | [GitHub](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.0) |
 
 ### Container Images
 

--- a/fern/pages/README.md
+++ b/fern/pages/README.md
@@ -106,10 +106,11 @@ uv pip install --python .venv-docs --group docs
 
 ## Viewing the Documentation
 
-After building, open `docs/build/html/index.html` in your, or use Python's built-in HTTP server:
+After building, use Fern's local preview server:
 
 ```bash
-cd docs/build/html
-python -m http.server 8000
-# Then visit http://localhost:8000 in your browser
+fern docs dev
+# Then visit the local URL shown in your browser
 ```
+
+Or view the published docs at [docs.nvidia.com/dynamo](https://docs.nvidia.com/dynamo/).

--- a/fern/pages/kubernetes/model-caching-with-fluid.md
+++ b/fern/pages/kubernetes/model-caching-with-fluid.md
@@ -328,4 +328,4 @@ spec:
 - [MinIO Documentation](https://docs.min.io/)
 - [Hugging Face Hub](https://huggingface.co/docs/hub/index)
 - [Dynamo README](https://github.com/ai-dynamo/dynamo/blob/main/.devcontainer/README.md)
-- [Dynamo Documentation](https://docs.nvidia.com/dynamo/latest/index.html)
+- [Dynamo Documentation](https://docs.nvidia.com/dynamo/)

--- a/fern/pages/reference/release-artifacts.md
+++ b/fern/pages/reference/release-artifacts.md
@@ -14,7 +14,7 @@ Release history in this document begins at v0.6.0.
 ## Current Release: Dynamo v0.8.1
 
 - **GitHub Release:** [v0.8.1](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1)
-- **Docs:** [v0.8.1](https://docs.nvidia.com/dynamo/archive/0.8.1/index.html)
+- **Docs:** [v0.8.1](https://docs.nvidia.com/dynamo/v-0-8-1/)
 - **NGC Collection:** [ai-dynamo](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)
 
 ### Patch Release: v0.8.1.post1 (Jan 23, 2026)
@@ -164,12 +164,12 @@ For a complete list of known issues, refer to the release notes for each patch:
 
 | Version | Release Date | GitHub | Docs |
 |---------|--------------|--------|------|
-| `v0.8.1` | Jan 23, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1) | [Docs](https://docs.nvidia.com/dynamo/archive/0.8.1/index.html) |
-| `v0.8.0` | Jan 15, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.0) | [Docs](https://docs.nvidia.com/dynamo/archive/0.8.0/index.html) |
-| `v0.7.1` | Dec 15, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.1) | [Docs](https://docs.nvidia.com/dynamo/archive/0.7.1/index.html) |
-| `v0.7.0` | Nov 26, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.0) | [Docs](https://docs.nvidia.com/dynamo/archive/0.7.0/index.html) |
-| `v0.6.1` | Nov 6, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.1) | [Docs](https://docs.nvidia.com/dynamo/archive/0.6.1/index.html) |
-| `v0.6.0` | Oct 28, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.0) | [Docs](https://docs.nvidia.com/dynamo/archive/0.6.0/index.html) |
+| `v0.8.1` | Jan 23, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.1) | [Docs](https://docs.nvidia.com/dynamo/v-0-8-1/) |
+| `v0.8.0` | Jan 15, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.8.0) | [Docs](https://docs.nvidia.com/dynamo/v-0-8-0/) |
+| `v0.7.1` | Dec 15, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.1) | [GitHub](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.1) |
+| `v0.7.0` | Nov 26, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.0) | [GitHub](https://github.com/ai-dynamo/dynamo/releases/tag/v0.7.0) |
+| `v0.6.1` | Nov 6, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.1) | [GitHub](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.1) |
+| `v0.6.0` | Oct 28, 2025 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.0) | [GitHub](https://github.com/ai-dynamo/dynamo/releases/tag/v0.6.0) |
 
 ### Container Images
 


### PR DESCRIPTION
## Summary
- Update all `docs.nvidia.com/dynamo` references from old Sphinx archive URLs (`archive/X.Y.Z/index.html`) to new Fern versioned paths (`v-X-Y-Z/`)
- Update latest docs links from `docs.nvidia.com/dynamo/latest/index.html` to `docs.nvidia.com/dynamo/`
- Pre-0.8.0 versions (v0.7.1, v0.7.0, v0.6.1, v0.6.0) without Fern archives now point to GitHub releases
- Replace stale Sphinx build instructions in `fern/pages/README.md` with Fern preview

## Test plan
- [x] Verified all new URLs resolve correctly:
  - https://docs.nvidia.com/dynamo/
  - https://docs.nvidia.com/dynamo/v-0-8-1/
  - https://docs.nvidia.com/dynamo/v-0-8-0/
  - GitHub release links for pre-0.8.0
- [x] Confirmed no remaining `index.html` references to Dynamo docs
- [x] External links (lmcache, CUDA, fsspec, ATTRIBUTIONS) left unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated documentation links across guides and reference materials to point to current documentation structure.
* Updated release artifacts documentation with versioned paths for historical releases.
* Improved local documentation viewing instructions to use updated preview workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->