### PR TITLE
feat: reasoning effort parsing for the DeepSeek V3.2 model

### DIFF
--- a/lib/async-openai/src/types/chat.rs
+++ b/lib/async-openai/src/types/chat.rs
@@ -704,6 +704,7 @@ pub enum ServiceTierResponse {
 #[derive(ToSchema, Clone, Serialize, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffort {
+    None,
     Minimal,
     Low,
     Medium,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1059,7 +1059,7 @@ impl
         let reasoning_disabled = match request.extract_reasoning_effort() {
             Some(dynamo_async_openai::types::ReasoningEffort::None) => true,
             Some(_) => false,
-            None => false
+            None => false,
         };
         let should_parse_reasoning =
             self.runtime_config.reasoning_parser.is_some() && !reasoning_disabled;

--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -19,6 +19,7 @@
 //      partial assistant responses without add_generation_prompt
 
 use anyhow::Result;
+use dynamo_async_openai::types::ReasoningEffort;
 use minijinja::value::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -82,6 +83,10 @@ pub trait OAIChatLikeRequest {
     }
 
     fn extract_text(&self) -> Option<TextInput> {
+        None
+    }
+
+    fn extract_reasoning_effort(&self) -> Option<ReasoningEffort> {
         None
     }
 

--- a/lib/llm/src/preprocessor/prompt/deepseek_v32.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_v32.rs
@@ -451,13 +451,10 @@ impl super::OAIPromptFormatter for DeepSeekV32Formatter {
             .context("Messages is not an array")?;
 
         // Parse thinking mode from the request
-        let thinking_mode = {
-            let reasoning_effort = req.extract_reasoning_effort();
-            match reasoning_effort {
-                Some(ReasoningEffort::None) => ThinkingMode::Chat,
-                Some(_) => ThinkingMode::Thinking,
-                None => self.thinking_mode,
-            }
+        let thinking_mode = match req.extract_reasoning_effort() {
+            Some(ReasoningEffort::None) => ThinkingMode::Chat,
+            Some(_) => ThinkingMode::Thinking,
+            None => self.thinking_mode,
         };
 
         // Encode with native implementation
@@ -526,7 +523,9 @@ mod tests {
     #[test]
     fn test_reasoning_effort_disabling() {
         use super::super::OAIPromptFormatter;
-        use crate::{types::openai::{chat_completions::NvCreateChatCompletionRequest, completions::NvCreateCompletionRequest}};
+        use crate::types::openai::{
+            chat_completions::NvCreateChatCompletionRequest, completions::NvCreateCompletionRequest,
+        };
 
         let json_str = r#"{
             "model": "deepseek-v3.2",
@@ -558,8 +557,10 @@ mod tests {
     #[test]
     fn test_reasoning_effort_enabling() {
         use super::super::OAIPromptFormatter;
-        use crate::{types::openai::{chat_completions::NvCreateChatCompletionRequest, completions::NvCreateCompletionRequest}};
-        
+        use crate::types::openai::{
+            chat_completions::NvCreateChatCompletionRequest, completions::NvCreateCompletionRequest,
+        };
+
         let json_str = r#"{
             "model": "deepseek-v3.2",
             "messages": [
@@ -572,7 +573,7 @@ mod tests {
             "reasoning_effort": "high"
         }"#;
 
-        let formatter = DeepSeekV32Formatter::new_thinking();
+        let formatter = DeepSeekV32Formatter::new_chat();
 
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
         let result = formatter.render(&request).unwrap();

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -267,13 +267,14 @@ impl OAIChatLikeRequest for NvCreateChatCompletionRequest {
         if let Some(reasoning_effort) = self.inner.reasoning_effort.clone() {
             return Some(reasoning_effort);
         }
-        
-        if let Some(enable_thinking) = self.chat_template_args()
+
+        if let Some(enable_thinking) = self
+            .chat_template_args()
             .and_then(|obj| obj.get("enable_thinking"))
             .and_then(|value| value.as_bool())
         {
             return Some(if enable_thinking {
-                ReasoningEffort::Low
+                ReasoningEffort::Medium
             } else {
                 ReasoningEffort::None
             });
@@ -350,21 +351,23 @@ impl OAIChatLikeRequest for NvCreateCompletionRequest {
     }
 
     fn extract_reasoning_effort(&self) -> Option<ReasoningEffort> {
-        if let Some(reasoning_effort) = self.unsupported_fields
+        if let Some(reasoning_effort) = self
+            .unsupported_fields
             .get("reasoning_effort")
             .and_then(|value| serde_json::from_value(value.clone()).ok())
         {
             return Some(reasoning_effort);
         }
 
-        if let Some(enable_thinking) = self.unsupported_fields
+        if let Some(enable_thinking) = self
+            .unsupported_fields
             .get("chat_template_kwargs")
             .and_then(|kwargs| kwargs.as_object())
             .and_then(|obj| obj.get("enable_thinking"))
             .and_then(|value| value.as_bool())
         {
             return Some(if enable_thinking {
-                ReasoningEffort::Low
+                ReasoningEffort::Medium
             } else {
                 ReasoningEffort::None
             });
@@ -598,22 +601,12 @@ mod tests {
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
         let reasoning_effort = request.extract_reasoning_effort();
 
-        assert!(
-            match reasoning_effort {
-                Some(ReasoningEffort::High) => true,
-                _ => false,
-            }
-        );
+        assert!(matches!(reasoning_effort, Some(ReasoningEffort::High)));
 
         let request: NvCreateCompletionRequest = serde_json::from_str(json_str).unwrap();
         let reasoning_effort = request.extract_reasoning_effort();
-    
-        assert!(
-            match reasoning_effort {
-                Some(ReasoningEffort::High) => true,
-                _ => false,
-            }
-        );
+
+        assert!(matches!(reasoning_effort, Some(ReasoningEffort::High)));
     }
 
     #[test]
@@ -630,22 +623,12 @@ mod tests {
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
         let reasoning_effort = request.extract_reasoning_effort();
 
-        assert!(
-            match reasoning_effort {
-                Some(ReasoningEffort::Low) => true,
-                _ => false,
-            }
-        );
+        assert!(matches!(reasoning_effort, Some(ReasoningEffort::Medium)));
 
         let request: NvCreateCompletionRequest = serde_json::from_str(json_str).unwrap();
         let reasoning_effort = request.extract_reasoning_effort();
-    
-        assert!(
-            match reasoning_effort {
-                Some(ReasoningEffort::Low) => true,
-                _ => false,
-            }
-        );
+
+        assert!(matches!(reasoning_effort, Some(ReasoningEffort::Medium)));
     }
 
     #[test]
@@ -662,23 +645,13 @@ mod tests {
 
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
         let reasoning_effort = request.extract_reasoning_effort();
-        
-        assert!(
-            match reasoning_effort {
-                Some(ReasoningEffort::High) => true,
-                _ => false,
-            }
-        );
+
+        assert!(matches!(reasoning_effort, Some(ReasoningEffort::High)));
 
         let request: NvCreateCompletionRequest = serde_json::from_str(json_str).unwrap();
         let reasoning_effort = request.extract_reasoning_effort();
-    
-        assert!(
-            match reasoning_effort {
-                Some(ReasoningEffort::High) => true,
-                _ => false,
-            }
-        );
+
+        assert!(matches!(reasoning_effort, Some(ReasoningEffort::High)));
     }
 
     #[test]


### PR DESCRIPTION
#### Overview:

This PR adds support for parsing and handling the `reasoning_effort` parameter for the DeepSeek V3.2 model, enabling dynamic control over the model's thinking mode based on OpenAI-compatible API requests.

#### Details:

1. **Enhanced ReasoningEffort enum** ([`lib/async-openai/src/types/chat.rs`](lib/async-openai/src/types/chat.rs:707))
   - Added `None` variant to the `ReasoningEffort` enum to explicitly disable reasoning/thinking mode

2. **New OAIChatLikeRequest trait method** ([`lib/llm/src/preprocessor/prompt.rs`](lib/llm/src/preprocessor/prompt.rs:89))
   - Added `extract_reasoning_effort()` method to the trait for extracting reasoning effort from requests

3. **DeepSeek V3.2 formatter improvements** ([`lib/llm/src/preprocessor/prompt/deepseek_v32.rs`](lib/llm/src/preprocessor/prompt/deepseek_v32.rs:453))
   - Modified the formatter to dynamically determine thinking mode based on the `reasoning_effort` parameter
   - `ReasoningEffort::None` → `ThinkingMode::Chat` (disables thinking tokens)
   - Any other `ReasoningEffort` value → `ThinkingMode::Thinking` (enables thinking tokens)
   - Falls back to the formatter's default thinking mode if no reasoning effort is specified

4. **Request parsing implementation** ([`lib/llm/src/preprocessor/prompt/template/oai.rs`](lib/llm/src/preprocessor/prompt/template/oai.rs:266))
   - Implemented `extract_reasoning_effort()` for both `NvCreateChatCompletionRequest` and `NvCreateCompletionRequest`
   - Supports direct `reasoning_effort` field parsing
   - Supports legacy `chat_template_kwargs.enable_thinking` boolean parameter
   - Prioritizes direct `reasoning_effort` field over legacy parameters

5. **Testing**
   - Added comprehensive unit tests covering both direct reasoning effort extraction and legacy parameter handling
   - Tests verify proper thinking mode switching based on reasoning effort values
   - Tests ensure both chat completion and completion request types work correctly

#### Where should the reviewer start?
1. **Core logic**: [`lib/llm/src/preprocessor/prompt/deepseek_v32.rs:453-463`](lib/llm/src/preprocessor/prompt/deepseek_v32.rs:453)
2. **Request parsing**: [`lib/llm/src/preprocessor/prompt/template/oai.rs:266-290`](lib/llm/src/preprocessor/prompt/template/oai.rs:266)
3. **Test coverage**: [`lib/llm/src/preprocessor/prompt/deepseek_v32.rs:525-577`](lib/llm/src/preprocessor/prompt/deepseek_v32.rs:525) and [`lib/llm/src/preprocessor/prompt/template/oai.rs:589-682`](lib/llm/src/preprocessor/prompt/template/oai.rs:589)
4. **API compatibility**: [`lib/async-openai/src/types/chat.rs:707`](lib/async-openai/src/types/chat.rs:707)

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: #4796


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reasoning effort controls in LLM requests, including a new "None" level option alongside existing levels.
  * Improved dynamic reasoning mode configuration to adapt based on individual request settings rather than fixed defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->