### PR TITLE
fix: TRTLLM runtime tag to be 25.12-cuda13.1-runtime-ubuntu24.04

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -63,7 +63,7 @@ trtllm:
   base_image: nvcr.io/nvidia/pytorch
   base_image_tag: 25.12-py3
   runtime_image: nvcr.io/nvidia/cuda-dl-base
-  runtime_image_tag: 25.10-cuda13.0-runtime-ubuntu24.04
+  runtime_image_tag: 25.12-cuda13.1-runtime-ubuntu24.04
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "false"
   enable_kvbm: "true"


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container runtime to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->