### PR TITLE
feat: fine grained error in prometheus metrics

### DIFF
--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1635,6 +1635,7 @@ dependencies = [
  "ahash",
  "aho-corasick",
  "akin",
+ "aligned-vec",
  "anyhow",
  "async-nats",
  "async-stream",
@@ -1651,6 +1652,7 @@ dependencies = [
  "bytes",
  "candle-core",
  "chrono",
+ "cudarc",
  "dashmap 5.5.3",
  "derive-getters",
  "derive_builder",
@@ -1685,6 +1687,8 @@ dependencies = [
  "ndarray",
  "ndarray-interp",
  "ndarray-npy",
+ "nix 0.26.4",
+ "nixl-sys",
  "object_store",
  "offset-allocator",
  "oneshot",
@@ -3957,6 +3961,15 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -4246,6 +4259,19 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.4",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
@@ -5494,7 +5520,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "indoc",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -171,6 +171,12 @@ pub fn monitor_for_disconnects(
     mut stream_handle: ConnectionHandle,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     stream_handle.arm();
+
+    // Default to Cancelled: if the stream is dropped unexpectedly (e.g. client
+    // disconnect causing a broken-pipe on the SSE write), the guard will report
+    // "cancelled" instead of "internal". The happy path overrides this via mark_ok().
+    inflight_guard.mark_error(ErrorType::Cancelled);
+
     async_stream::try_stream! {
         tokio::pin!(stream);
         loop {

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -184,6 +184,8 @@ pub fn monitor_for_disconnects(
                             // Mark error as internal since it's a streaming error
                             inflight_guard.mark_error(ErrorType::Internal);
                             yield Event::default().event("error").comment(err.to_string());
+                            // Break to prevent any subsequent mark_ok() from overwriting the error
+                            break;
                         }
                         None => {
                             // Stream ended normally

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -672,6 +672,7 @@ impl Metrics {
         endpoint: &Endpoint,
         request_type: &RequestType,
         status: &Status,
+        error_type: &ErrorType,
     ) -> u64 {
         self.request_counter
             .with_label_values(&[
@@ -679,6 +680,7 @@ impl Metrics {
                 endpoint.as_str(),
                 request_type.as_str(),
                 status.as_str(),
+                error_type.as_str(),
             ])
             .get()
     }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -279,6 +279,7 @@ pub struct InflightGuard {
 
 /// Requests will be logged by the type of endpoint hit
 /// This will include llamastack in the future
+#[derive(Clone, Copy)]
 pub enum Endpoint {
     /// OAI Completions
     Completions,
@@ -316,7 +317,7 @@ pub enum Status {
 }
 
 /// Error type classification for fine-grained observability
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum ErrorType {
     /// No error (for successful requests)
     None,
@@ -1993,35 +1994,26 @@ mod tests {
         let model = "test-model";
 
         {
-            let mut guard =
-                metrics
-                    .clone()
-                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
+            let mut guard = metrics.clone().create_inflight_guard(
+                model,
+                Endpoint::ChatCompletions,
+                false,
+            );
             guard.mark_ok();
         } // guard drops here
 
         // Verify counter incremented with status=success, error_type=""
-        let metric_families = registry.gather();
-        let counter_family = metric_families
-            .iter()
-            .find(|mf| mf.get_name().ends_with("requests_total"))
-            .expect("requests_total metric should exist");
-
-        let metrics_vec = counter_family.get_metric();
-        let success_metric = metrics_vec
-            .iter()
-            .find(|m| {
-                let labels = m.get_label();
-                labels
-                    .iter()
-                    .any(|l| l.get_name() == "status" && l.get_value() == "success")
-                    && labels
-                        .iter()
-                        .any(|l| l.get_name() == "error_type" && l.get_value() == "")
-            })
-            .expect("Should find success metric with empty error_type");
-
-        assert_eq!(success_metric.get_counter().get_value(), 1.0);
+        let counter_value = metrics
+            .request_counter
+            .with_label_values(&[
+                model,
+                Endpoint::ChatCompletions.as_str(),
+                RequestType::Unary.as_str(),
+                Status::Success.as_str(),
+                ErrorType::None.as_str(),
+            ])
+            .get();
+        assert_eq!(counter_value, 1);
     }
 
     #[test]
@@ -2033,35 +2025,26 @@ mod tests {
         let model = "test-model";
 
         {
-            let mut guard =
-                metrics
-                    .clone()
-                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
+            let mut guard = metrics.clone().create_inflight_guard(
+                model,
+                Endpoint::ChatCompletions,
+                false,
+            );
             guard.mark_error(ErrorType::Validation);
         } // guard drops here
 
         // Verify counter incremented with status=error, error_type=validation
-        let metric_families = registry.gather();
-        let counter_family = metric_families
-            .iter()
-            .find(|mf| mf.get_name().ends_with("requests_total"))
-            .expect("requests_total metric should exist");
-
-        let metrics_vec = counter_family.get_metric();
-        let error_metric = metrics_vec
-            .iter()
-            .find(|m| {
-                let labels = m.get_label();
-                labels
-                    .iter()
-                    .any(|l| l.get_name() == "status" && l.get_value() == "error")
-                    && labels
-                        .iter()
-                        .any(|l| l.get_name() == "error_type" && l.get_value() == "validation")
-            })
-            .expect("Should find error metric with validation error_type");
-
-        assert_eq!(error_metric.get_counter().get_value(), 1.0);
+        let counter_value = metrics
+            .request_counter
+            .with_label_values(&[
+                model,
+                Endpoint::ChatCompletions.as_str(),
+                RequestType::Unary.as_str(),
+                Status::Error.as_str(),
+                ErrorType::Validation.as_str(),
+            ])
+            .get();
+        assert_eq!(counter_value, 1);
     }
 
     #[test]
@@ -2073,35 +2056,26 @@ mod tests {
         let model = "test-model";
 
         {
-            let _guard =
-                metrics
-                    .clone()
-                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
+            let _guard = metrics.clone().create_inflight_guard(
+                model,
+                Endpoint::ChatCompletions,
+                false,
+            );
             // Don't call mark_ok() or mark_error() - simulate panic/unhandled error
         } // guard drops with default error_type=Internal
 
         // Verify counter incremented with status=error, error_type=internal
-        let metric_families = registry.gather();
-        let counter_family = metric_families
-            .iter()
-            .find(|mf| mf.get_name().ends_with("requests_total"))
-            .expect("requests_total metric should exist");
-
-        let metrics_vec = counter_family.get_metric();
-        let error_metric = metrics_vec
-            .iter()
-            .find(|m| {
-                let labels = m.get_label();
-                labels
-                    .iter()
-                    .any(|l| l.get_name() == "status" && l.get_value() == "error")
-                    && labels
-                        .iter()
-                        .any(|l| l.get_name() == "error_type" && l.get_value() == "internal")
-            })
-            .expect("Should find error metric with internal error_type by default");
-
-        assert_eq!(error_metric.get_counter().get_value(), 1.0);
+        let counter_value = metrics
+            .request_counter
+            .with_label_values(&[
+                model,
+                Endpoint::ChatCompletions.as_str(),
+                RequestType::Unary.as_str(),
+                Status::Error.as_str(),
+                ErrorType::Internal.as_str(),
+            ])
+            .get();
+        assert_eq!(counter_value, 1);
     }
 
     #[test]
@@ -2123,55 +2097,28 @@ mod tests {
             ErrorType::NotImplemented,
         ];
 
-        for error_type in error_types {
+        for error_type in &error_types {
             let mut guard = metrics.clone().create_inflight_guard(model, endpoint, false);
             guard.mark_error(error_type.clone());
             drop(guard);
         }
 
-        // Verify all 6 error types recorded
-        let metric_families = registry.gather();
-        let counter_family = metric_families
-            .iter()
-            .find(|mf| mf.get_name().ends_with("requests_total"))
-            .unwrap();
-
-        let error_metrics: Vec<_> = counter_family
-            .get_metric()
-            .iter()
-            .filter(|m| {
-                m.get_label()
-                    .iter()
-                    .any(|l| l.get_name() == "status" && l.get_value() == "error")
-            })
-            .collect();
-
-        assert_eq!(
-            error_metrics.len(),
-            6,
-            "Should have 6 different error types"
-        );
-
-        // Verify each error type is present
-        let expected_types = vec![
-            "validation",
-            "not_found",
-            "overload",
-            "cancelled",
-            "internal",
-            "not_implemented",
-        ];
-
-        for expected_type in expected_types {
-            let found = error_metrics.iter().any(|m| {
-                m.get_label()
-                    .iter()
-                    .any(|l| l.get_name() == "error_type" && l.get_value() == expected_type)
-            });
-            assert!(
-                found,
-                "Should find error metric with error_type={}",
-                expected_type
+        // Verify each error type recorded correctly
+        for error_type in &error_types {
+            let counter_value = metrics
+                .request_counter
+                .with_label_values(&[
+                    model,
+                    endpoint.as_str(),
+                    RequestType::Unary.as_str(),
+                    Status::Error.as_str(),
+                    error_type.as_str(),
+                ])
+                .get();
+            assert_eq!(
+                counter_value, 1,
+                "Should have 1 request for error_type={}",
+                error_type.as_str()
             );
         }
     }
@@ -2186,70 +2133,72 @@ mod tests {
 
         // Record 2 validation errors, 3 internal errors, 1 success
         for _ in 0..2 {
-            let mut guard =
-                metrics
-                    .clone()
-                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
+            let mut guard = metrics.clone().create_inflight_guard(
+                model,
+                Endpoint::ChatCompletions,
+                false,
+            );
             guard.mark_error(ErrorType::Validation);
             drop(guard);
         }
 
         for _ in 0..3 {
-            let mut guard = metrics.clone().create_inflight_guard(model, Endpoint::Completions, false);
+            let mut guard = metrics.clone().create_inflight_guard(
+                model,
+                Endpoint::Completions,
+                false,
+            );
             guard.mark_error(ErrorType::Internal);
             drop(guard);
         }
 
         {
-            let mut guard = metrics.clone().create_inflight_guard(model, Endpoint::Embeddings, false);
+            let mut guard = metrics.clone().create_inflight_guard(
+                model,
+                Endpoint::Embeddings,
+                false,
+            );
             guard.mark_ok();
             drop(guard);
         }
 
-        // Verify counts
-        let metric_families = registry.gather();
-        let counter_family = metric_families
-            .iter()
-            .find(|mf| mf.get_name().ends_with("requests_total"))
-            .unwrap();
+        // Check validation errors (2 from ChatCompletions)
+        let validation_count = metrics
+            .request_counter
+            .with_label_values(&[
+                model,
+                Endpoint::ChatCompletions.as_str(),
+                RequestType::Unary.as_str(),
+                Status::Error.as_str(),
+                ErrorType::Validation.as_str(),
+            ])
+            .get();
+        assert_eq!(validation_count, 2);
 
-        // Check validation errors
-        let validation_metric = counter_family
-            .get_metric()
-            .iter()
-            .find(|m| {
-                let labels = m.get_label();
-                labels
-                    .iter()
-                    .any(|l| l.get_name() == "error_type" && l.get_value() == "validation")
-            })
-            .expect("Should find validation error metric");
-        assert_eq!(validation_metric.get_counter().get_value(), 2.0);
+        // Check internal errors (3 from Completions)
+        let internal_count = metrics
+            .request_counter
+            .with_label_values(&[
+                model,
+                Endpoint::Completions.as_str(),
+                RequestType::Unary.as_str(),
+                Status::Error.as_str(),
+                ErrorType::Internal.as_str(),
+            ])
+            .get();
+        assert_eq!(internal_count, 3);
 
-        // Check internal errors
-        let internal_metric = counter_family
-            .get_metric()
-            .iter()
-            .find(|m| {
-                let labels = m.get_label();
-                labels
-                    .iter()
-                    .any(|l| l.get_name() == "error_type" && l.get_value() == "internal")
-            })
-            .expect("Should find internal error metric");
-        assert_eq!(internal_metric.get_counter().get_value(), 3.0);
-
-        // Check success
-        let success_metric = counter_family
-            .get_metric()
-            .iter()
-            .find(|m| {
-                let labels = m.get_label();
-                labels
-                    .iter()
-                    .any(|l| l.get_name() == "status" && l.get_value() == "success")
-            })
-            .expect("Should find success metric");
-        assert_eq!(success_metric.get_counter().get_value(), 1.0);
+        // Check success (1 from Embeddings)
+        let success_count = metrics
+            .request_counter
+            .with_label_values(&[
+                model,
+                Endpoint::Embeddings.as_str(),
+                RequestType::Unary.as_str(),
+                Status::Success.as_str(),
+                ErrorType::None.as_str(),
+            ])
+            .get();
+        assert_eq!(success_count, 1);
     }
 }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -1994,11 +1994,10 @@ mod tests {
         let model = "test-model";
 
         {
-            let mut guard = metrics.clone().create_inflight_guard(
-                model,
-                Endpoint::ChatCompletions,
-                false,
-            );
+            let mut guard =
+                metrics
+                    .clone()
+                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
             guard.mark_ok();
         } // guard drops here
 
@@ -2025,11 +2024,10 @@ mod tests {
         let model = "test-model";
 
         {
-            let mut guard = metrics.clone().create_inflight_guard(
-                model,
-                Endpoint::ChatCompletions,
-                false,
-            );
+            let mut guard =
+                metrics
+                    .clone()
+                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
             guard.mark_error(ErrorType::Validation);
         } // guard drops here
 
@@ -2056,11 +2054,10 @@ mod tests {
         let model = "test-model";
 
         {
-            let _guard = metrics.clone().create_inflight_guard(
-                model,
-                Endpoint::ChatCompletions,
-                false,
-            );
+            let _guard =
+                metrics
+                    .clone()
+                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
             // Don't call mark_ok() or mark_error() - simulate panic/unhandled error
         } // guard drops with default error_type=Internal
 
@@ -2098,7 +2095,9 @@ mod tests {
         ];
 
         for error_type in &error_types {
-            let mut guard = metrics.clone().create_inflight_guard(model, endpoint, false);
+            let mut guard = metrics
+                .clone()
+                .create_inflight_guard(model, endpoint, false);
             guard.mark_error(error_type.clone());
             drop(guard);
         }
@@ -2116,7 +2115,8 @@ mod tests {
                 ])
                 .get();
             assert_eq!(
-                counter_value, 1,
+                counter_value,
+                1,
                 "Should have 1 request for error_type={}",
                 error_type.as_str()
             );
@@ -2133,31 +2133,28 @@ mod tests {
 
         // Record 2 validation errors, 3 internal errors, 1 success
         for _ in 0..2 {
-            let mut guard = metrics.clone().create_inflight_guard(
-                model,
-                Endpoint::ChatCompletions,
-                false,
-            );
+            let mut guard =
+                metrics
+                    .clone()
+                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
             guard.mark_error(ErrorType::Validation);
             drop(guard);
         }
 
         for _ in 0..3 {
-            let mut guard = metrics.clone().create_inflight_guard(
-                model,
-                Endpoint::Completions,
-                false,
-            );
+            let mut guard =
+                metrics
+                    .clone()
+                    .create_inflight_guard(model, Endpoint::Completions, false);
             guard.mark_error(ErrorType::Internal);
             drop(guard);
         }
 
         {
-            let mut guard = metrics.clone().create_inflight_guard(
-                model,
-                Endpoint::Embeddings,
-                false,
-            );
+            let mut guard =
+                metrics
+                    .clone()
+                    .create_inflight_guard(model, Endpoint::Embeddings, false);
             guard.mark_ok();
             drop(guard);
         }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -273,6 +273,7 @@ pub struct InflightGuard {
     endpoint: Endpoint,
     request_type: RequestType,
     status: Status,
+    error_type: ErrorType,
     timer: Instant,
 }
 
@@ -312,6 +313,25 @@ pub enum RequestType {
 pub enum Status {
     Success,
     Error,
+}
+
+/// Error type classification for fine-grained observability
+#[derive(PartialEq, Clone)]
+pub enum ErrorType {
+    /// No error (for successful requests)
+    None,
+    /// Client validation error (4xx with "Validation:" prefix)
+    Validation,
+    /// Model or resource not found (404)
+    NotFound,
+    /// Service overloaded, too many requests (503)
+    Overload,
+    /// Request cancelled by client or timeout
+    Cancelled,
+    /// Internal server error (500 and other unexpected errors)
+    Internal,
+    /// Feature not implemented (501)
+    NotImplemented,
 }
 
 /// Track response-specific metrics
@@ -416,7 +436,7 @@ impl Metrics {
                 frontend_metric_name(frontend_service::REQUESTS_TOTAL),
                 "Total number of LLM requests processed",
             ),
-            &["model", "endpoint", "request_type", "status"],
+            &["model", "endpoint", "request_type", "status", "error_type"],
         )
         .unwrap();
 
@@ -673,6 +693,7 @@ impl Metrics {
         endpoint: &Endpoint,
         request_type: &RequestType,
         status: &Status,
+        error_type: &ErrorType,
     ) {
         self.request_counter
             .with_label_values(&[
@@ -680,6 +701,7 @@ impl Metrics {
                 endpoint.as_str(),
                 request_type.as_str(),
                 status.as_str(),
+                error_type.as_str(),
             ])
             .inc()
     }
@@ -902,12 +924,19 @@ impl InflightGuard {
             endpoint,
             request_type,
             status: Status::Error,
+            error_type: ErrorType::Internal,
             timer,
         }
     }
 
     pub(crate) fn mark_ok(&mut self) {
         self.status = Status::Success;
+        self.error_type = ErrorType::None;
+    }
+
+    pub(crate) fn mark_error(&mut self, error_type: ErrorType) {
+        self.status = Status::Error;
+        self.error_type = error_type;
     }
 }
 
@@ -926,6 +955,7 @@ impl Drop for InflightGuard {
             &self.endpoint,
             &self.request_type,
             &self.status,
+            &self.error_type,
         );
 
         // Record the duration of the request
@@ -976,6 +1006,20 @@ impl Status {
         match self {
             Status::Success => frontend_service::status::SUCCESS,
             Status::Error => frontend_service::status::ERROR,
+        }
+    }
+}
+
+impl ErrorType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ErrorType::None => frontend_service::error_type::NONE,
+            ErrorType::Validation => frontend_service::error_type::VALIDATION,
+            ErrorType::NotFound => frontend_service::error_type::NOT_FOUND,
+            ErrorType::Overload => frontend_service::error_type::OVERLOAD,
+            ErrorType::Cancelled => frontend_service::error_type::CANCELLED,
+            ErrorType::Internal => frontend_service::error_type::INTERNAL,
+            ErrorType::NotImplemented => frontend_service::error_type::NOT_IMPLEMENTED,
         }
     }
 }
@@ -1927,5 +1971,285 @@ mod tests {
             "detokenize average latency should be 0.05ms, got {}",
             detokenize_metric.get_histogram().get_sample_sum()
         );
+    }
+
+    #[test]
+    fn test_error_type_as_str() {
+        assert_eq!(ErrorType::None.as_str(), "");
+        assert_eq!(ErrorType::Validation.as_str(), "validation");
+        assert_eq!(ErrorType::NotFound.as_str(), "not_found");
+        assert_eq!(ErrorType::Overload.as_str(), "overload");
+        assert_eq!(ErrorType::Cancelled.as_str(), "cancelled");
+        assert_eq!(ErrorType::Internal.as_str(), "internal");
+        assert_eq!(ErrorType::NotImplemented.as_str(), "not_implemented");
+    }
+
+    #[test]
+    fn test_inflight_guard_marks_success_with_correct_error_type() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        let model = "test-model";
+
+        {
+            let mut guard =
+                metrics
+                    .clone()
+                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
+            guard.mark_ok();
+        } // guard drops here
+
+        // Verify counter incremented with status=success, error_type=""
+        let metric_families = registry.gather();
+        let counter_family = metric_families
+            .iter()
+            .find(|mf| mf.get_name().ends_with("requests_total"))
+            .expect("requests_total metric should exist");
+
+        let metrics_vec = counter_family.get_metric();
+        let success_metric = metrics_vec
+            .iter()
+            .find(|m| {
+                let labels = m.get_label();
+                labels
+                    .iter()
+                    .any(|l| l.get_name() == "status" && l.get_value() == "success")
+                    && labels
+                        .iter()
+                        .any(|l| l.get_name() == "error_type" && l.get_value() == "")
+            })
+            .expect("Should find success metric with empty error_type");
+
+        assert_eq!(success_metric.get_counter().get_value(), 1.0);
+    }
+
+    #[test]
+    fn test_inflight_guard_marks_validation_error() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        let model = "test-model";
+
+        {
+            let mut guard =
+                metrics
+                    .clone()
+                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
+            guard.mark_error(ErrorType::Validation);
+        } // guard drops here
+
+        // Verify counter incremented with status=error, error_type=validation
+        let metric_families = registry.gather();
+        let counter_family = metric_families
+            .iter()
+            .find(|mf| mf.get_name().ends_with("requests_total"))
+            .expect("requests_total metric should exist");
+
+        let metrics_vec = counter_family.get_metric();
+        let error_metric = metrics_vec
+            .iter()
+            .find(|m| {
+                let labels = m.get_label();
+                labels
+                    .iter()
+                    .any(|l| l.get_name() == "status" && l.get_value() == "error")
+                    && labels
+                        .iter()
+                        .any(|l| l.get_name() == "error_type" && l.get_value() == "validation")
+            })
+            .expect("Should find error metric with validation error_type");
+
+        assert_eq!(error_metric.get_counter().get_value(), 1.0);
+    }
+
+    #[test]
+    fn test_inflight_guard_defaults_to_internal_error_on_drop() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        let model = "test-model";
+
+        {
+            let _guard =
+                metrics
+                    .clone()
+                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
+            // Don't call mark_ok() or mark_error() - simulate panic/unhandled error
+        } // guard drops with default error_type=Internal
+
+        // Verify counter incremented with status=error, error_type=internal
+        let metric_families = registry.gather();
+        let counter_family = metric_families
+            .iter()
+            .find(|mf| mf.get_name().ends_with("requests_total"))
+            .expect("requests_total metric should exist");
+
+        let metrics_vec = counter_family.get_metric();
+        let error_metric = metrics_vec
+            .iter()
+            .find(|m| {
+                let labels = m.get_label();
+                labels
+                    .iter()
+                    .any(|l| l.get_name() == "status" && l.get_value() == "error")
+                    && labels
+                        .iter()
+                        .any(|l| l.get_name() == "error_type" && l.get_value() == "internal")
+            })
+            .expect("Should find error metric with internal error_type by default");
+
+        assert_eq!(error_metric.get_counter().get_value(), 1.0);
+    }
+
+    #[test]
+    fn test_all_error_types_recorded_correctly() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        let model = "test-model";
+        let endpoint = Endpoint::ChatCompletions;
+
+        // Test each error type
+        let error_types = vec![
+            ErrorType::Validation,
+            ErrorType::NotFound,
+            ErrorType::Overload,
+            ErrorType::Cancelled,
+            ErrorType::Internal,
+            ErrorType::NotImplemented,
+        ];
+
+        for error_type in error_types {
+            let mut guard = metrics.clone().create_inflight_guard(model, endpoint, false);
+            guard.mark_error(error_type.clone());
+            drop(guard);
+        }
+
+        // Verify all 6 error types recorded
+        let metric_families = registry.gather();
+        let counter_family = metric_families
+            .iter()
+            .find(|mf| mf.get_name().ends_with("requests_total"))
+            .unwrap();
+
+        let error_metrics: Vec<_> = counter_family
+            .get_metric()
+            .iter()
+            .filter(|m| {
+                m.get_label()
+                    .iter()
+                    .any(|l| l.get_name() == "status" && l.get_value() == "error")
+            })
+            .collect();
+
+        assert_eq!(
+            error_metrics.len(),
+            6,
+            "Should have 6 different error types"
+        );
+
+        // Verify each error type is present
+        let expected_types = vec![
+            "validation",
+            "not_found",
+            "overload",
+            "cancelled",
+            "internal",
+            "not_implemented",
+        ];
+
+        for expected_type in expected_types {
+            let found = error_metrics.iter().any(|m| {
+                m.get_label()
+                    .iter()
+                    .any(|l| l.get_name() == "error_type" && l.get_value() == expected_type)
+            });
+            assert!(
+                found,
+                "Should find error metric with error_type={}",
+                expected_type
+            );
+        }
+    }
+
+    #[test]
+    fn test_multiple_requests_different_error_types() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        let model = "test-model";
+
+        // Record 2 validation errors, 3 internal errors, 1 success
+        for _ in 0..2 {
+            let mut guard =
+                metrics
+                    .clone()
+                    .create_inflight_guard(model, Endpoint::ChatCompletions, false);
+            guard.mark_error(ErrorType::Validation);
+            drop(guard);
+        }
+
+        for _ in 0..3 {
+            let mut guard = metrics.clone().create_inflight_guard(model, Endpoint::Completions, false);
+            guard.mark_error(ErrorType::Internal);
+            drop(guard);
+        }
+
+        {
+            let mut guard = metrics.clone().create_inflight_guard(model, Endpoint::Embeddings, false);
+            guard.mark_ok();
+            drop(guard);
+        }
+
+        // Verify counts
+        let metric_families = registry.gather();
+        let counter_family = metric_families
+            .iter()
+            .find(|mf| mf.get_name().ends_with("requests_total"))
+            .unwrap();
+
+        // Check validation errors
+        let validation_metric = counter_family
+            .get_metric()
+            .iter()
+            .find(|m| {
+                let labels = m.get_label();
+                labels
+                    .iter()
+                    .any(|l| l.get_name() == "error_type" && l.get_value() == "validation")
+            })
+            .expect("Should find validation error metric");
+        assert_eq!(validation_metric.get_counter().get_value(), 2.0);
+
+        // Check internal errors
+        let internal_metric = counter_family
+            .get_metric()
+            .iter()
+            .find(|m| {
+                let labels = m.get_label();
+                labels
+                    .iter()
+                    .any(|l| l.get_name() == "error_type" && l.get_value() == "internal")
+            })
+            .expect("Should find internal error metric");
+        assert_eq!(internal_metric.get_counter().get_value(), 3.0);
+
+        // Check success
+        let success_metric = counter_family
+            .get_metric()
+            .iter()
+            .find(|m| {
+                let labels = m.get_label();
+                labels
+                    .iter()
+                    .any(|l| l.get_name() == "status" && l.get_value() == "success")
+            })
+            .expect("Should find success metric");
+        assert_eq!(success_metric.get_counter().get_value(), 1.0);
     }
 }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -104,6 +104,7 @@ fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
         }
         StatusCode::NOT_FOUND => ErrorType::NotFound,
         StatusCode::NOT_IMPLEMENTED => ErrorType::NotImplemented,
+        StatusCode::TOO_MANY_REQUESTS => ErrorType::Overload,
         StatusCode::SERVICE_UNAVAILABLE => ErrorType::Overload,
         StatusCode::INTERNAL_SERVER_ERROR => ErrorType::Internal,
         _ if code.is_client_error() => ErrorType::Validation,
@@ -917,13 +918,30 @@ async fn chat_completions(
 
     let request_id = request.id().to_string();
 
-    // Determine streaming mode and model early for guard creation
+    // Determine streaming mode early
     // todo - decide on default
     let streaming = request.inner.stream.unwrap_or(false);
+
+    // Apply template values first to resolve the model before creating metrics guards
+    if let Some(template) = template {
+        if request.inner.model.is_empty() {
+            request.inner.model = template.model.clone();
+        }
+        if request.inner.temperature.unwrap_or(0.0) == 0.0 {
+            request.inner.temperature = Some(template.temperature);
+        }
+        if request.inner.max_completion_tokens.unwrap_or(0) == 0 {
+            request.inner.max_completion_tokens = Some(template.max_completion_tokens);
+        }
+    }
+
+    // Capture the resolved model after template application for metrics and engine lookup
     // todo - make the protocols be optional for model name
     // todo - when optional, if none, apply a default
     // todo - determine the proper error code for when a request model is not present
     let model = request.inner.model.clone();
+
+    tracing::trace!("Received chat completions request: {:?}", request.content());
 
     // Create inflight_guard early to ensure all errors (including validation) are counted
     let mut inflight_guard =
@@ -957,20 +975,6 @@ async fn chat_completions(
         inflight_guard.mark_error(extract_error_type_from_response(&err_response));
         return Err(err_response);
     }
-
-    // Apply template values if present
-    if let Some(template) = template {
-        if request.inner.model.is_empty() {
-            request.inner.model = template.model.clone();
-        }
-        if request.inner.temperature.unwrap_or(0.0) == 0.0 {
-            request.inner.temperature = Some(template.temperature);
-        }
-        if request.inner.max_completion_tokens.unwrap_or(0) == 0 {
-            request.inner.max_completion_tokens = Some(template.max_completion_tokens);
-        }
-    }
-    tracing::trace!("Received chat completions request: {:?}", request.content());
 
     // Create HTTP queue guard after template resolution so labels are correct
     let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
@@ -1250,8 +1254,32 @@ async fn responses(
     // return a 503 if the service is not ready
     check_ready(&state)?;
 
-    // Determine streaming mode and model early for guard creation
+    // Determine streaming mode early for guard creation
     let streaming = request.inner.stream.unwrap_or(false);
+
+    // Apply template values first to resolve the model before creating metrics guards.
+    // Unlike chat completions where backends may have their own defaults, the Responses API
+    // should provide a generous default to avoid truncated responses (especially with
+    // reasoning models that emit <think> tokens).
+    const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 4096;
+
+    if let Some(template) = template {
+        if request.inner.model.as_deref().unwrap_or("").is_empty() {
+            request.inner.model = Some(template.model.clone());
+        }
+        if request.inner.temperature.is_none() {
+            request.inner.temperature = Some(template.temperature);
+        }
+        if request.inner.max_output_tokens.is_none() {
+            request.inner.max_output_tokens = Some(template.max_completion_tokens);
+        }
+    } else if request.inner.max_output_tokens.is_none() {
+        request.inner.max_output_tokens = Some(DEFAULT_MAX_OUTPUT_TOKENS);
+    }
+
+    tracing::trace!("Received responses request: {:?}", request.inner);
+
+    // Capture the resolved model after template application for metrics
     // model is Option<String> in upstream; extract to String, defaulting to empty
     let model = request.inner.model.clone().unwrap_or_default();
 
@@ -1272,27 +1300,6 @@ async fn responses(
         // So we don't mark_error here - they're successful HTTP responses with 501 status
         return Ok(resp.into_response());
     }
-
-    // Apply template values if present, with sensible defaults for the Responses API.
-    // Unlike chat completions where backends may have their own defaults, the Responses API
-    // should provide a generous default to avoid truncated responses (especially with
-    // reasoning models that emit <think> tokens).
-    const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 4096;
-
-    if let Some(template) = template {
-        if request.inner.model.as_deref().unwrap_or("").is_empty() {
-            request.inner.model = Some(template.model.clone());
-        }
-        if request.inner.temperature.is_none() {
-            request.inner.temperature = Some(template.temperature);
-        }
-        if request.inner.max_output_tokens.is_none() {
-            request.inner.max_output_tokens = Some(template.max_completion_tokens);
-        }
-    } else if request.inner.max_output_tokens.is_none() {
-        request.inner.max_output_tokens = Some(DEFAULT_MAX_OUTPUT_TOKENS);
-    }
-    tracing::trace!("Received responses request: {:?}", request.inner);
 
     // Extract request parameters before into_parts() consumes the request.
     // These are echoed back in the Response object per the OpenAI spec.
@@ -2603,6 +2610,10 @@ mod tests {
         assert_eq!(
             classify_error_for_metrics(StatusCode::NOT_IMPLEMENTED, "Feature not supported"),
             ErrorType::NotImplemented
+        );
+        assert_eq!(
+            classify_error_for_metrics(StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded"),
+            ErrorType::Overload
         );
         assert_eq!(
             classify_error_for_metrics(StatusCode::SERVICE_UNAVAILABLE, "Overloaded"),

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -22,7 +22,7 @@ use dynamo_llm::{
         service::{
             Metrics,
             error::HttpError,
-            metrics::{Endpoint, RequestType, Status},
+            metrics::{Endpoint, ErrorType, RequestType, Status},
             service_v2::HttpService,
         },
     },
@@ -197,16 +197,18 @@ fn compare_counter(
     endpoint: &Endpoint,
     request_type: &RequestType,
     status: &Status,
+    error_type: &ErrorType,
     expected: u64,
 ) {
     assert_eq!(
-        metrics.get_request_counter(model, endpoint, request_type, status),
+        metrics.get_request_counter(model, endpoint, request_type, status, error_type),
         expected,
-        "model: {}, endpoint: {:?}, request_type: {:?}, status: {:?}",
+        "model: {}, endpoint: {:?}, request_type: {:?}, status: {:?}, error_type: {:?}",
         model,
         endpoint.as_str(),
         request_type.as_str(),
-        status.as_str()
+        status.as_str(),
+        error_type.as_str()
     );
 }
 
@@ -238,12 +240,17 @@ fn compare_counters(metrics: &Metrics, model: &str, expected: &[u64; 8]) {
         for request_type in &[RequestType::Unary, RequestType::Stream] {
             for status in &[Status::Success, Status::Error] {
                 let index = compute_index(endpoint, request_type, status);
+                let error_type = match status {
+                    Status::Success => &ErrorType::None,
+                    Status::Error => &ErrorType::Validation, // Test engines return 4xx errors
+                };
                 compare_counter(
                     metrics,
                     model,
                     endpoint,
                     request_type,
                     status,
+                    error_type,
                     expected[index],
                 );
             }

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -249,6 +249,30 @@ pub mod frontend_service {
         /// Value for unary requests
         pub const UNARY: &str = "unary";
     }
+
+    /// Error type label values for fine-grained error classification
+    pub mod error_type {
+        /// No error (used for successful requests)
+        pub const NONE: &str = "";
+
+        /// Client validation error (4xx with "Validation:" prefix)
+        pub const VALIDATION: &str = "validation";
+
+        /// Model or resource not found (404)
+        pub const NOT_FOUND: &str = "not_found";
+
+        /// Service overloaded, too many requests (503)
+        pub const OVERLOAD: &str = "overload";
+
+        /// Request cancelled by client or timeout
+        pub const CANCELLED: &str = "cancelled";
+
+        /// Internal server error (500 and other unexpected errors)
+        pub const INTERNAL: &str = "internal";
+
+        /// Feature not implemented (501)
+        pub const NOT_IMPLEMENTED: &str = "not_implemented";
+    }
 }
 
 /// Work handler Prometheus metric names


### PR DESCRIPTION
#### Overview:

Adds a new `error_type` label to the `dynamo_frontend_requests_total` Prometheus metric to enable fine-grained classification of errors (validation, not_found, overload, cancelled, internal, not_implemented). This allows distinguishing client validation errors (4xx) from internal server errors (5xx) for better observability and SLI/SLO tracking.

<img width="502" height="256" alt="Снимок экрана 2026-01-30 в 17 06 40" src="https://github.com/user-attachments/assets/95c78ade-96e0-4ca0-81c5-c76888cc1c0a" />

#### Details:

- Added `ErrorType` enum with 7 variants and `error_type` label to `requests_total` metric
- Implemented error classification logic based on HTTP status codes and message prefixes
- Updated `InflightGuard` to track and report `error_type` on drop
- Modified all HTTP handlers (chat completions, completions, embeddings, responses) to classify errors before returning
- Added streaming error classification in `monitor_for_disconnects` (cancelled on disconnect, internal on stream errors)
- Added 15 unit and integration tests covering error classification and metrics recording

#### Where should the reviewer start?

1. `lib/runtime/src/metrics/prometheus_names.rs` - new `error_type` constants
2. `lib/llm/src/http/service/metrics.rs` - `ErrorType` enum and `InflightGuard` changes
3. `lib/llm/src/http/service/openai.rs` - classification logic and handler updates

#### Issues

Linear DIS-1430
https://github.com/ai-dynamo/dynamo/issues/5782
https://github.com/ai-dynamo/dynamo/pull/5568
Resolves https://github.com/ai-dynamo/dynamo/issues/5782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented error classification system to categorize and track different error types (validation, not found, overload, cancelled, internal, not implemented) in request metrics.

* **Tests**
  * Added comprehensive tests for error classification and end-to-end metrics recording across success and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

