### PR TITLE
feat: use RNG when dp routing targets are tied; override no-assume-kv-reuse for decode requests

### DIFF
--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -921,6 +921,7 @@ pub unsafe extern "C" fn dynamo_router_add_request(
                 None,
                 worker,
                 None, // lora_name not exposed in C API yet
+                None, // router_config_override not exposed in C API yet
             )
             .await;
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1051,7 +1051,7 @@ impl KvPushRouter {
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let loads = chooser
-                .get_potential_loads(&token_ids)
+                .get_potential_loads(&token_ids, None)
                 .await
                 .map_err(to_pyerr)?;
 

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -387,9 +387,11 @@ impl KvRouter {
         let find_matches_elapsed = start.elapsed();
 
         // Compute seq_hashes only if scheduler needs it for active blocks tracking
-        let maybe_seq_hashes = self
-            .kv_router_config
-            .compute_seq_hashes_for_tracking(tokens, self.block_size, router_config_override);
+        let maybe_seq_hashes = self.kv_router_config.compute_seq_hashes_for_tracking(
+            tokens,
+            self.block_size,
+            router_config_override,
+        );
         let seq_hash_elapsed = start.elapsed();
 
         let best_worker = self
@@ -444,12 +446,15 @@ impl KvRouter {
         expected_output_tokens: Option<u32>,
         worker: WorkerWithDpRank,
         lora_name: Option<String>,
+        router_config_override: Option<&RouterConfigOverride>,
     ) {
         let isl_tokens = tokens.len();
 
-        let maybe_seq_hashes = self
-            .kv_router_config
-            .compute_seq_hashes_for_tracking(tokens, self.block_size, None);
+        let maybe_seq_hashes = self.kv_router_config.compute_seq_hashes_for_tracking(
+            tokens,
+            self.block_size,
+            router_config_override,
+        );
 
         if let Err(e) = self
             .scheduler
@@ -509,14 +514,20 @@ impl KvRouter {
     }
 
     /// Get potential prefill and decode loads for all workers
-    pub async fn get_potential_loads(&self, tokens: &[u32]) -> Result<Vec<PotentialLoad>> {
+    pub async fn get_potential_loads(
+        &self,
+        tokens: &[u32],
+        router_config_override: Option<&RouterConfigOverride>,
+    ) -> Result<Vec<PotentialLoad>> {
         let isl_tokens = tokens.len();
         let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, None);
         let overlap_scores = self.indexer.find_matches(block_hashes.clone()).await?;
 
-        let maybe_seq_hashes = self
-            .kv_router_config
-            .compute_seq_hashes_for_tracking(tokens, self.block_size, None);
+        let maybe_seq_hashes = self.kv_router_config.compute_seq_hashes_for_tracking(
+            tokens,
+            self.block_size,
+            router_config_override,
+        );
 
         Ok(self
             .scheduler

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -389,7 +389,7 @@ impl KvRouter {
         // Compute seq_hashes only if scheduler needs it for active blocks tracking
         let maybe_seq_hashes = self
             .kv_router_config
-            .compute_seq_hashes_for_tracking(tokens, self.block_size);
+            .compute_seq_hashes_for_tracking(tokens, self.block_size, router_config_override);
         let seq_hash_elapsed = start.elapsed();
 
         let best_worker = self
@@ -449,7 +449,7 @@ impl KvRouter {
 
         let maybe_seq_hashes = self
             .kv_router_config
-            .compute_seq_hashes_for_tracking(tokens, self.block_size);
+            .compute_seq_hashes_for_tracking(tokens, self.block_size, None);
 
         if let Err(e) = self
             .scheduler
@@ -516,7 +516,7 @@ impl KvRouter {
 
         let maybe_seq_hashes = self
             .kv_router_config
-            .compute_seq_hashes_for_tracking(tokens, self.block_size);
+            .compute_seq_hashes_for_tracking(tokens, self.block_size, None);
 
         Ok(self
             .scheduler

--- a/lib/llm/src/kv_router/config.rs
+++ b/lib/llm/src/kv_router/config.rs
@@ -17,6 +17,9 @@ pub struct RouterConfigOverride {
     #[builder(default)]
     #[validate(range(min = 0.0))]
     pub router_temperature: Option<f64>,
+
+    #[builder(default)]
+    pub assume_kv_reuse: Option<bool>,
 }
 
 /// KV Router configuration parameters
@@ -129,6 +132,7 @@ impl KvRouterConfig {
         &self,
         tokens: &[u32],
         block_size: u32,
+        config_override: Option<&RouterConfigOverride>,
     ) -> Option<Vec<u64>> {
         if !self.router_track_active_blocks {
             return None;
@@ -139,7 +143,12 @@ impl KvRouterConfig {
             return Some(Vec::new());
         }
 
-        if self.router_assume_kv_reuse {
+        // Use override if provided, otherwise use default config
+        let assume_kv_reuse = config_override
+            .and_then(|cfg| cfg.assume_kv_reuse)
+            .unwrap_or(self.router_assume_kv_reuse);
+
+        if assume_kv_reuse {
             // Compute actual block hashes and sequence hashes
             let block_hashes = compute_block_hash_for_seq(tokens, block_size, None);
             Some(compute_seq_hash_for_block(&block_hashes))

--- a/lib/llm/src/kv_router/prefill_router.rs
+++ b/lib/llm/src/kv_router/prefill_router.rs
@@ -627,10 +627,14 @@ impl
                     decode_req.bootstrap_info = Some(info);
                 }
 
-                // Set router_config_override for decode: overlap_score_weight = 0
+                // Set router_config_override for decode:
+                // - overlap_score_weight = 0 (no KV cache overlap scoring for decode)
+                // - assume_kv_reuse = false (generate random hashes since decode workers
+                //   may already have blocks cached from prefill transfer)
                 let existing_override = decode_req.router_config_override.take();
                 decode_req.router_config_override = Some(RouterConfigOverride {
                     overlap_score_weight: Some(0.0),
+                    assume_kv_reuse: Some(false),
                     ..existing_override.unwrap_or_default()
                 });
 

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -113,6 +113,7 @@ impl KvPushRouter {
                     expected_output_tokens,
                     worker,
                     lora_name,
+                    request.router_config_override.as_ref(),
                 )
                 .await;
         } else {

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -540,20 +540,31 @@ impl WorkerSelector for DefaultWorkerSelector {
         let candidates = softmax_sample(&worker_logits, temperature);
 
         // If multiple candidates (tied), use tree size as tie-breaker
-        // If tree sizes are also equal, min_by_key uses HashMap iteration order (pseudo-random)
+        // If tree sizes are also equal, use random selection to avoid bias
         let best_worker = if candidates.len() > 1 {
             tracing::info!("Multiple workers tied with same logit, using tree size as tie-breaker");
-            *candidates
+            let tree_sizes: Vec<_> = candidates
                 .iter()
-                .min_by_key(|worker| {
-                    request
-                        .overlaps
-                        .tree_sizes
-                        .get(worker)
-                        .copied()
-                        .unwrap_or(0)
-                })
-                .expect("candidates should not be empty")
+                .map(|w| request.overlaps.tree_sizes.get(w).copied().unwrap_or(0))
+                .collect();
+
+            // If all tree_sizes are equal, use random selection to avoid bias
+            if tree_sizes.iter().all(|&s| s == tree_sizes[0]) {
+                let idx = rand::rng().random_range(0..candidates.len());
+                candidates[idx]
+            } else {
+                *candidates
+                    .iter()
+                    .min_by_key(|worker| {
+                        request
+                            .overlaps
+                            .tree_sizes
+                            .get(worker)
+                            .copied()
+                            .unwrap_or(0)
+                    })
+                    .expect("candidates should not be empty")
+            }
         } else {
             candidates[0]
         };


### PR DESCRIPTION
#### Overview:

Two features:
(1) When routing targets are tied in tree_size, it makes a selection based on a hashmap id. The existing comment suggests this is pseudorandom, but empirically it seems that these hashmap id rankings are actually quite deterministic -- there is load imbalance among `(worker_id, dp_rank)`s in dp rank routing scenarios.
(2) Add an override for decode requests such that we always do `no-assume-kv-reuse` for more accurate load balancing

#### Details:

Modifies tiebreaking logic in router scheduler ; adds a assume-kv-reuse field to override config

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-request routing configuration overrides to enable fine-grained control over caching behavior and routing decisions for individual requests.

* **Improvements**
  * Enhanced worker selection algorithm with improved tie-breaking logic to provide better load distribution and fairness when multiple workers have equivalent performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->