### PR TITLE
docs: add frontmatter title to all docs pages

### DIFF
--- a/docs/pages/README.md
+++ b/docs/pages/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Building Documentation
 ---
 
 This directory contains the documentation source files for NVIDIA Dynamo.

--- a/docs/pages/agents/tool-calling.md
+++ b/docs/pages/agents/tool-calling.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Tool Calling
 subtitle: Connect Dynamo to external tools and services using function calling
 ---
 

--- a/docs/pages/api/nixl-connect/README.md
+++ b/docs/pages/api/nixl-connect/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: NIXL Connect API
 ---
 
 # Dynamo NIXL Connect

--- a/docs/pages/api/nixl-connect/connector.md
+++ b/docs/pages/api/nixl-connect/connector.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Connector
 ---
 
 # dynamo.nixl_connect.Connector

--- a/docs/pages/api/nixl-connect/descriptor.md
+++ b/docs/pages/api/nixl-connect/descriptor.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Descriptor
 ---
 
 # dynamo.nixl_connect.Descriptor

--- a/docs/pages/api/nixl-connect/device-kind.md
+++ b/docs/pages/api/nixl-connect/device-kind.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Device Kind
 ---
 
 # dynamo.nixl_connect.DeviceKind(IntEnum)

--- a/docs/pages/api/nixl-connect/device.md
+++ b/docs/pages/api/nixl-connect/device.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Device
 ---
 
 # dynamo.nixl_connect.Device

--- a/docs/pages/api/nixl-connect/operation-status.md
+++ b/docs/pages/api/nixl-connect/operation-status.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Operation Status
 ---
 
 # dynamo.nixl_connect.OperationStatus(IntEnum)

--- a/docs/pages/api/nixl-connect/rdma-metadata.md
+++ b/docs/pages/api/nixl-connect/rdma-metadata.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: RDMA Metadata
 ---
 
 # dynamo.nixl_connect.RdmaMetadata

--- a/docs/pages/api/nixl-connect/read-operation.md
+++ b/docs/pages/api/nixl-connect/read-operation.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Read Operation
 ---
 
 # dynamo.nixl_connect.ReadOperation

--- a/docs/pages/api/nixl-connect/readable-operation.md
+++ b/docs/pages/api/nixl-connect/readable-operation.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Readable Operation
 ---
 
 # dynamo.nixl_connect.ReadableOperation

--- a/docs/pages/api/nixl-connect/writable-operation.md
+++ b/docs/pages/api/nixl-connect/writable-operation.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Writable Operation
 ---
 
 # dynamo.nixl_connect.WritableOperation

--- a/docs/pages/api/nixl-connect/write-operation.md
+++ b/docs/pages/api/nixl-connect/write-operation.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Write Operation
 ---
 
 # dynamo.nixl_connect.WriteOperation

--- a/docs/pages/backends/sglang/README.md
+++ b/docs/pages/backends/sglang/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: SGLang
 ---
 
 # Running SGLang with Dynamo

--- a/docs/pages/backends/sglang/diffusion-lm.md
+++ b/docs/pages/backends/sglang/diffusion-lm.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Diffusion LM
 ---
 
 # Running Diffusion LMs with SGLang

--- a/docs/pages/backends/sglang/expert-distribution-eplb.md
+++ b/docs/pages/backends/sglang/expert-distribution-eplb.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Expert Distribution (EPLB)
 ---
 
 # Expert Parallelism Load Balancer (EPLB) in SGLang

--- a/docs/pages/backends/sglang/gpt-oss.md
+++ b/docs/pages/backends/sglang/gpt-oss.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: GPT-OSS
 ---
 
 # Running gpt-oss-120b Disaggregated with SGLang

--- a/docs/pages/backends/sglang/profiling.md
+++ b/docs/pages/backends/sglang/profiling.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Profiling
 ---
 
 # Profiling SGLang Workers in Dynamo

--- a/docs/pages/backends/sglang/prometheus.md
+++ b/docs/pages/backends/sglang/prometheus.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Prometheus
 ---
 
 # SGLang Prometheus Metrics

--- a/docs/pages/backends/sglang/sglang-disaggregation.md
+++ b/docs/pages/backends/sglang/sglang-disaggregation.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Disaggregation
 ---
 
 # SGLang Disaggregated Serving

--- a/docs/pages/backends/trtllm/README.md
+++ b/docs/pages/backends/trtllm/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: TensorRT-LLM
 ---
 
 # LLM Deployment using TensorRT-LLM

--- a/docs/pages/backends/trtllm/gemma3-sliding-window-attention.md
+++ b/docs/pages/backends/trtllm/gemma3-sliding-window-attention.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Gemma3 Sliding Window
 ---
 
 # Gemma 3 with Variable Sliding Window Attention

--- a/docs/pages/backends/trtllm/gpt-oss.md
+++ b/docs/pages/backends/trtllm/gpt-oss.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: GPT-OSS
 ---
 
 # Running gpt-oss-120b Disaggregated with TensorRT-LLM

--- a/docs/pages/backends/trtllm/kv-cache-transfer.md
+++ b/docs/pages/backends/trtllm/kv-cache-transfer.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: KV Cache Transfer
 ---
 
 # KV Cache Transfer in Disaggregated Serving

--- a/docs/pages/backends/trtllm/llama4-plus-eagle.md
+++ b/docs/pages/backends/trtllm/llama4-plus-eagle.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Llama4 + Eagle
 ---
 
 # Llama 4 Maverick Instruct with Eagle Speculative Decoding on SLURM

--- a/docs/pages/backends/trtllm/multinode/multinode-examples.md
+++ b/docs/pages/backends/trtllm/multinode/multinode-examples.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Multinode Examples
 ---
 
 # Example: Multi-node TRTLLM Workers with Dynamo on Slurm

--- a/docs/pages/backends/trtllm/prometheus.md
+++ b/docs/pages/backends/trtllm/prometheus.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Prometheus
 ---
 
 # TensorRT-LLM Prometheus Metrics

--- a/docs/pages/backends/vllm/README.md
+++ b/docs/pages/backends/vllm/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: vLLM
 ---
 
 # LLM Deployment using vLLM

--- a/docs/pages/backends/vllm/deepseek-r1.md
+++ b/docs/pages/backends/vllm/deepseek-r1.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: DeepSeek-R1
 ---
 
 # Running Deepseek R1 with Wide EP

--- a/docs/pages/backends/vllm/gpt-oss.md
+++ b/docs/pages/backends/vllm/gpt-oss.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: GPT-OSS
 ---
 
 # Running gpt-oss-120b Disaggregated with vLLM

--- a/docs/pages/backends/vllm/multi-node.md
+++ b/docs/pages/backends/vllm/multi-node.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Multi-Node
 ---
 
 # Multi-node Examples

--- a/docs/pages/backends/vllm/prometheus.md
+++ b/docs/pages/backends/vllm/prometheus.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Prometheus
 ---
 
 # vLLM Prometheus Metrics

--- a/docs/pages/backends/vllm/prompt-embeddings.md
+++ b/docs/pages/backends/vllm/prompt-embeddings.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Prompt Embeddings
 ---
 
 # Prompt Embeddings

--- a/docs/pages/backends/vllm/vllm-omni.md
+++ b/docs/pages/backends/vllm/vllm-omni.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: vLLM-Omni
 ---
 
 # [Experimental] Running Omni Models with vLLM

--- a/docs/pages/benchmarks/benchmarking.md
+++ b/docs/pages/benchmarks/benchmarking.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Dynamo Benchmarking
 subtitle: Benchmark and compare performance across Dynamo deployment configurations
 ---
 

--- a/docs/pages/benchmarks/kv-router-ab-testing.md
+++ b/docs/pages/benchmarks/kv-router-ab-testing.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: KV Router A/B Testing
 ---
 
 This guide walks you through setting up and running A/B benchmarks to compare Dynamo's KV Smart Router against standard round-robin routing on a Kubernetes cluster.

--- a/docs/pages/components/frontend/README.md
+++ b/docs/pages/components/frontend/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Frontend
 ---
 
 # Frontend

--- a/docs/pages/components/frontend/frontend-guide.md
+++ b/docs/pages/components/frontend/frontend-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Frontend Guide
 ---
 
 # Frontend Guide

--- a/docs/pages/components/kvbm/README.md
+++ b/docs/pages/components/kvbm/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: KVBM
 ---
 
 # KV Block Manager (KVBM)

--- a/docs/pages/components/kvbm/kvbm-guide.md
+++ b/docs/pages/components/kvbm/kvbm-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: KVBM Guide
 subtitle: Enable KV offloading using KV Block Manager (KVBM) for Dynamo deployments
 ---
 

--- a/docs/pages/components/planner/README.md
+++ b/docs/pages/components/planner/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Planner
 ---
 
 # Planner

--- a/docs/pages/components/planner/planner-examples.md
+++ b/docs/pages/components/planner/planner-examples.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Planner Examples
 ---
 
 # Planner Examples

--- a/docs/pages/components/planner/planner-guide.md
+++ b/docs/pages/components/planner/planner-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Planner Guide
 ---
 
 # Planner Guide

--- a/docs/pages/components/profiler/README.md
+++ b/docs/pages/components/profiler/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Profiler
 ---
 
 # Profiler

--- a/docs/pages/components/profiler/profiler-examples.md
+++ b/docs/pages/components/profiler/profiler-examples.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Profiler Examples
 ---
 
 # Profiler Examples

--- a/docs/pages/components/profiler/profiler-guide.md
+++ b/docs/pages/components/profiler/profiler-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Profiler Guide
 ---
 
 # Profiler Guide

--- a/docs/pages/components/router/README.md
+++ b/docs/pages/components/router/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Router
 ---
 
 # Router

--- a/docs/pages/components/router/router-examples.md
+++ b/docs/pages/components/router/router-examples.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Router Examples
 ---
 
 # Router Examples

--- a/docs/pages/components/router/router-guide.md
+++ b/docs/pages/components/router/router-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Router Guide
 subtitle: Enable KV-aware routing using Router for Dynamo deployments
 ---
 

--- a/docs/pages/design-docs/architecture.md
+++ b/docs/pages/design-docs/architecture.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Overall Architecture
 ---
 
 # High Level Architecture

--- a/docs/pages/design-docs/disagg-serving.md
+++ b/docs/pages/design-docs/disagg-serving.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Disaggregated Serving
 ---
 
 # Dynamo Disaggregation: Separating Prefill and Decode for Enhanced Performance

--- a/docs/pages/design-docs/discovery-plane.md
+++ b/docs/pages/design-docs/discovery-plane.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Discovery Plane
 ---
 
 # Discovery Plane

--- a/docs/pages/design-docs/distributed-runtime.md
+++ b/docs/pages/design-docs/distributed-runtime.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Distributed Runtime
 ---
 
 # Dynamo Distributed Runtime

--- a/docs/pages/design-docs/dynamo-flow.md
+++ b/docs/pages/design-docs/dynamo-flow.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Architecture Flow
 ---
 
 # Dynamo Architecture Flow

--- a/docs/pages/design-docs/event-plane.md
+++ b/docs/pages/design-docs/event-plane.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Event Plane
 ---
 
 # Dynamo Event Plane

--- a/docs/pages/design-docs/kvbm-design.md
+++ b/docs/pages/design-docs/kvbm-design.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: KVBM Design
 ---
 
 # KVBM Design

--- a/docs/pages/design-docs/planner-design.md
+++ b/docs/pages/design-docs/planner-design.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Planner Design
 ---
 
 # Planner Design

--- a/docs/pages/design-docs/request-plane.md
+++ b/docs/pages/design-docs/request-plane.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Request Plane
 ---
 
 # Dynamo Request Planes User Guide

--- a/docs/pages/design-docs/router-design.md
+++ b/docs/pages/design-docs/router-design.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Router Design
 ---
 
 # Router Design

--- a/docs/pages/development/backend-guide.md
+++ b/docs/pages/development/backend-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Writing Python Workers in Dynamo
 subtitle: Create custom Python workers and engines for Dynamo
 ---
 

--- a/docs/pages/development/jail-stream.md
+++ b/docs/pages/development/jail-stream.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Jail Stream
 ---
 
 # JailedStream Implementation

--- a/docs/pages/development/runtime-guide.md
+++ b/docs/pages/development/runtime-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Runtime Guide
 ---
 
 # Dynamo Runtime

--- a/docs/pages/fault-tolerance/README.md
+++ b/docs/pages/fault-tolerance/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Fault Tolerance
 subtitle: Handle failures gracefully with request migration, cancellation, and graceful shutdown
 ---
 

--- a/docs/pages/fault-tolerance/graceful-shutdown.md
+++ b/docs/pages/fault-tolerance/graceful-shutdown.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Graceful Shutdown
 ---
 
 # Graceful Shutdown

--- a/docs/pages/fault-tolerance/request-cancellation.md
+++ b/docs/pages/fault-tolerance/request-cancellation.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Request Cancellation
 ---
 
 This document describes how Dynamo implements request cancellation to cancel in-flight requests between Dynamo workers. Request cancellation allows in-flight requests to terminate early, saving computational resources that would otherwise be spent on responses that are no longer needed.

--- a/docs/pages/fault-tolerance/request-migration.md
+++ b/docs/pages/fault-tolerance/request-migration.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Request Migration
 ---
 
 This document describes how Dynamo implements request migration to handle worker failures gracefully during LLM text generation. Request migration allows in-progress requests to continue on different workers when the original worker becomes unavailable, providing fault tolerance and improved user experience.

--- a/docs/pages/fault-tolerance/request-rejection.md
+++ b/docs/pages/fault-tolerance/request-rejection.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Request Rejection
 ---
 
 # Request Rejection (Load Shedding)

--- a/docs/pages/fault-tolerance/testing.md
+++ b/docs/pages/fault-tolerance/testing.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Testing
 ---
 
 # Fault Tolerance Testing

--- a/docs/pages/features/disaggregated-serving/README.md
+++ b/docs/pages/features/disaggregated-serving/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Disaggregated Serving
 subtitle: Find optimal prefill/decode configuration for disaggregated serving deployments
 ---
 

--- a/docs/pages/features/lora/README.md
+++ b/docs/pages/features/lora/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: LoRA Adapters
 subtitle: Serve fine-tuned LoRA adapters with dynamic loading and routing in Dynamo
 ---
 

--- a/docs/pages/features/multimodal/README.md
+++ b/docs/pages/features/multimodal/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Multimodality Support
 subtitle: Deploy multimodal models with image, video, and audio support in Dynamo
 ---
 

--- a/docs/pages/features/multimodal/multimodal-sglang.md
+++ b/docs/pages/features/multimodal/multimodal-sglang.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: SGLang Multimodal
 ---
 
 # SGLang Multimodal

--- a/docs/pages/features/multimodal/multimodal-trtllm.md
+++ b/docs/pages/features/multimodal/multimodal-trtllm.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: TensorRT-LLM Multimodal
 ---
 
 # TensorRT-LLM Multimodal

--- a/docs/pages/features/multimodal/multimodal-vllm.md
+++ b/docs/pages/features/multimodal/multimodal-vllm.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: vLLM Multimodal
 ---
 
 # vLLM Multimodal

--- a/docs/pages/features/speculative-decoding/README.md
+++ b/docs/pages/features/speculative-decoding/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Speculative Decoding
 ---
 
 # Speculative Decoding

--- a/docs/pages/features/speculative-decoding/speculative-decoding-vllm.md
+++ b/docs/pages/features/speculative-decoding/speculative-decoding-vllm.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Speculative Decoding with vLLM
 ---
 
 # Speculative Decoding with vLLM

--- a/docs/pages/getting-started/examples.md
+++ b/docs/pages/getting-started/examples.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Examples
 ---
 
 The examples below assume you build the latest image yourself from source. If using a prebuilt image, follow the examples from the corresponding branch.

--- a/docs/pages/getting-started/quickstart.md
+++ b/docs/pages/getting-started/quickstart.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Quickstart
 ---
 
 This guide covers running Dynamo **using the CLI on your local machine or VM**.

--- a/docs/pages/integrations/flexkv-integration.md
+++ b/docs/pages/integrations/flexkv-integration.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: FlexKV
 ---
 
 # FlexKV Integration in Dynamo

--- a/docs/pages/integrations/kv-events-custom-engines.md
+++ b/docs/pages/integrations/kv-events-custom-engines.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: KV Events for Custom Engines
 ---
 
 # KV Event Publishing for Custom Engines

--- a/docs/pages/integrations/lmcache-integration.md
+++ b/docs/pages/integrations/lmcache-integration.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: LMCache
 ---
 
 # LMCache Integration in Dynamo

--- a/docs/pages/integrations/sglang-hicache.md
+++ b/docs/pages/integrations/sglang-hicache.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: SGLang HiCache
 ---
 
 # Enable SGLang Hierarchical Cache (HiCache)

--- a/docs/pages/kubernetes/README.md
+++ b/docs/pages/kubernetes/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Deployment Guide
 ---
 
 # Deploying Dynamo on Kubernetes

--- a/docs/pages/kubernetes/api-reference.md
+++ b/docs/pages/kubernetes/api-reference.md
@@ -1,7 +1,6 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: API Reference (K8s)
 ---
 
 > **⚠️ Important**: This documentation is automatically generated from source code.

--- a/docs/pages/kubernetes/api-reference.md
+++ b/docs/pages/kubernetes/api-reference.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: API Reference (K8s)
 ---
 
 > **⚠️ Important**: This documentation is automatically generated from source code.

--- a/docs/pages/kubernetes/autoscaling.md
+++ b/docs/pages/kubernetes/autoscaling.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Autoscaling
 ---
 
 This guide explains how to configure autoscaling for DynamoGraphDeployment (DGD) services using the `sglang-agg` example from `examples/backends/sglang/deploy/agg.yaml`.

--- a/docs/pages/kubernetes/chrek/README.md
+++ b/docs/pages/kubernetes/chrek/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Checkpointing
 ---
 
 > ⚠️ **Experimental Feature**: ChReK is currently in **beta/preview**. It requires privileged mode for restore operations, which may not be suitable for all production environments. See [Limitations](#limitations) for details.

--- a/docs/pages/kubernetes/chrek/dynamo.md
+++ b/docs/pages/kubernetes/chrek/dynamo.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Integration with Dynamo
 ---
 
 # Checkpoint/Restore for Fast Pod Startup

--- a/docs/pages/kubernetes/chrek/standalone.md
+++ b/docs/pages/kubernetes/chrek/standalone.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Standalone Usage
 ---
 
 > ⚠️ **Experimental Feature**: ChReK is currently in **beta/preview**. It requires privileged mode for restore operations, which may not be suitable for all production environments. Review the [security implications](#security-considerations) before deploying.

--- a/docs/pages/kubernetes/deployment/create-deployment.md
+++ b/docs/pages/kubernetes/deployment/create-deployment.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Creating Deployments
 ---
 
 The scripts in the `examples/<backend>/launch` folder like [agg.sh](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/vllm/launch/agg.sh) demonstrate how you can serve your models locally.

--- a/docs/pages/kubernetes/deployment/dynamomodel-guide.md
+++ b/docs/pages/kubernetes/deployment/dynamomodel-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Managing Models with DynamoModel
 ---
 
 ## Overview

--- a/docs/pages/kubernetes/deployment/minikube.md
+++ b/docs/pages/kubernetes/deployment/minikube.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Minikube Setup
 ---
 
 # Minikube Setup Guide

--- a/docs/pages/kubernetes/deployment/multinode-deployment.md
+++ b/docs/pages/kubernetes/deployment/multinode-deployment.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Multinode Deployments
 ---
 
 This guide explains how to deploy Dynamo workloads across multiple nodes. Multinode deployments enable you to scale compute-intensive LLM workloads across multiple physical machines, maximizing GPU utilization and supporting larger models.

--- a/docs/pages/kubernetes/dynamo-operator.md
+++ b/docs/pages/kubernetes/dynamo-operator.md
@@ -1,7 +1,6 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: Dynamo Operator
 ---
 
 ## Overview

--- a/docs/pages/kubernetes/dynamo-operator.md
+++ b/docs/pages/kubernetes/dynamo-operator.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Dynamo Operator
 ---
 
 ## Overview

--- a/docs/pages/kubernetes/fluxcd.md
+++ b/docs/pages/kubernetes/fluxcd.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: FluxCD
 ---
 
 This section describes how to use FluxCD for GitOps-based deployment of Dynamo inference graphs. GitOps enables you to manage your Dynamo deployments declaratively using Git as the source of truth. We'll use the [aggregated vLLM example](../backends/vllm/README.md) to demonstrate the workflow.

--- a/docs/pages/kubernetes/grove.md
+++ b/docs/pages/kubernetes/grove.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Grove
 ---
 
 Grove is a Kubernetes API specifically designed to address the orchestration challenges of modern AI workloads, particularly disaggregated inference systems. Grove provides seamless integration with NVIDIA Dynamo for comprehensive AI infrastructure management.

--- a/docs/pages/kubernetes/installation-guide.md
+++ b/docs/pages/kubernetes/installation-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Detailed Installation Guide
 ---
 
 # Installation Guide for Dynamo Kubernetes Platform

--- a/docs/pages/kubernetes/model-caching-with-fluid.md
+++ b/docs/pages/kubernetes/model-caching-with-fluid.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Model Caching with Fluid
 ---
 
 Fluid is an open-source, cloud-native data orchestration and acceleration platform for Kubernetes. It virtualizes and accelerates data access from various sources (object storage, distributed file systems, cloud storage), making it ideal for AI, machine learning, and big data workloads.

--- a/docs/pages/kubernetes/observability/logging.md
+++ b/docs/pages/kubernetes/observability/logging.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Logging
 ---
 
 This guide demonstrates how to set up logging for Dynamo in Kubernetes using Grafana Loki and Alloy. This setup provides a simple reference logging setup that can be followed in Kubernetes clusters including Minikube and MicroK8s.

--- a/docs/pages/kubernetes/observability/metrics.md
+++ b/docs/pages/kubernetes/observability/metrics.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Metrics
 ---
 
 ## Overview

--- a/docs/pages/kubernetes/observability/operator-metrics.md
+++ b/docs/pages/kubernetes/observability/operator-metrics.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Operator Metrics
 ---
 
 ## Overview

--- a/docs/pages/kubernetes/service-discovery.md
+++ b/docs/pages/kubernetes/service-discovery.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Service Discovery
 ---
 
 # Service Discovery

--- a/docs/pages/kubernetes/webhooks.md
+++ b/docs/pages/kubernetes/webhooks.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Webhooks
 ---
 
 This document describes the webhook functionality in the Dynamo Operator, including validation webhooks, certificate management, and troubleshooting.

--- a/docs/pages/mocker/mocker.md
+++ b/docs/pages/mocker/mocker.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Mocker
 ---
 
 # Mocker: LLM Engine Simulation in Rust

--- a/docs/pages/observability/README.md
+++ b/docs/pages/observability/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Observability (Local)
 subtitle: Monitor Dynamo deployments with metrics, logging, and tracing
 ---
 

--- a/docs/pages/observability/health-checks.md
+++ b/docs/pages/observability/health-checks.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Health Checks
 ---
 
 # Dynamo Health Checks

--- a/docs/pages/observability/logging.md
+++ b/docs/pages/observability/logging.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Logging
 ---
 
 # Dynamo Logging

--- a/docs/pages/observability/metrics-developer-guide.md
+++ b/docs/pages/observability/metrics-developer-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Metrics Developer Guide
 ---
 
 # Metrics Developer Guide

--- a/docs/pages/observability/metrics.md
+++ b/docs/pages/observability/metrics.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Metrics
 ---
 
 # Dynamo Metrics

--- a/docs/pages/observability/prometheus-grafana.md
+++ b/docs/pages/observability/prometheus-grafana.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Prometheus + Grafana Setup
 ---
 
 # Metrics Visualization with Prometheus and Grafana

--- a/docs/pages/observability/tracing.md
+++ b/docs/pages/observability/tracing.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Tracing
 ---
 
 # Distributed Tracing with Tempo

--- a/docs/pages/performance/tuning.md
+++ b/docs/pages/performance/tuning.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Tuning Disaggregated Performance
 ---
 
 # Disaggregation and Performance Tuning

--- a/docs/pages/reference/feature-matrix.md
+++ b/docs/pages/reference/feature-matrix.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Feature Matrix
 ---
 
 # Dynamo Feature Compatibility Matrices

--- a/docs/pages/reference/glossary.md
+++ b/docs/pages/reference/glossary.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Glossary
 ---
 
 ## B

--- a/docs/pages/reference/release-artifacts.md
+++ b/docs/pages/reference/release-artifacts.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Release Artifacts
 ---
 
 # Dynamo Release Artifacts

--- a/docs/pages/reference/support-matrix.md
+++ b/docs/pages/reference/support-matrix.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Support Matrix
 ---
 
 # Dynamo Support Matrix

--- a/docs/pages/templates/README.md
+++ b/docs/pages/templates/README.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Templates
 ---
 
 Templates for creating consistent Dynamo documentation.

--- a/docs/pages/templates/backend-guide.md
+++ b/docs/pages/templates/backend-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Backend Guide
 ---
 
 Advanced deployment and configuration for the `<Backend>` backend.

--- a/docs/pages/templates/backend-readme.md
+++ b/docs/pages/templates/backend-readme.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Backend README
 ---
 
 {/* 2-3 sentence overview of this backend integration */}

--- a/docs/pages/templates/component-design.md
+++ b/docs/pages/templates/component-design.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Component Design
 ---
 
 Architecture and design decisions for the `<Component>`.

--- a/docs/pages/templates/component-examples.md
+++ b/docs/pages/templates/component-examples.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Component Examples
 ---
 
 Usage examples for the `<Component>`.

--- a/docs/pages/templates/component-guide.md
+++ b/docs/pages/templates/component-guide.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Component Guide
 ---
 
 This guide covers deployment, configuration, and integration for the `<Component>`.

--- a/docs/pages/templates/component-readme.md
+++ b/docs/pages/templates/component-readme.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Component README
 ---
 
 {/* 2-3 sentence overview of what this component does and its role in Dynamo */}

--- a/docs/pages/templates/feature-backend.md
+++ b/docs/pages/templates/feature-backend.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Feature Backend
 ---
 
 Using `<Feature>` with the `<Backend>` backend.

--- a/docs/pages/templates/feature-readme.md
+++ b/docs/pages/templates/feature-readme.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Feature README
 ---
 
 {/* 2-3 sentence overview of this cross-cutting feature */}

--- a/docs/pages/templates/incode-readme.md
+++ b/docs/pages/templates/incode-readme.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: In-Code README
 ---
 
 {/* One-sentence description */}

--- a/docs/pages/templates/infrastructure-readme.md
+++ b/docs/pages/templates/infrastructure-readme.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Infrastructure README
 ---
 
 {/* 2-3 sentence overview of this infrastructure topic. */}

--- a/docs/pages/templates/integration-readme.md
+++ b/docs/pages/templates/integration-readme.md
@@ -1,6 +1,7 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Integration README
 ---
 
 {/* 2-3 sentence overview of this external integration */}


### PR DESCRIPTION
## Summary

- Adds `title:` field to YAML frontmatter of all 128 markdown files in `docs/pages/`
- Titles sourced from the `page:` or `section:` values in `docs/versions/next.yml`, ensuring browser tab titles and SEO metadata match the navigation structure
- Ensures SPDX license headers in frontmatter render correctly by providing an explicit YAML key alongside the comment-only headers

### Before
```yaml
---
# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
# SPDX-License-Identifier: Apache-2.0
---
```

### After
```yaml
---
# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
# SPDX-License-Identifier: Apache-2.0
title: Quickstart
---
```

## Details

- For pages appearing twice in nav (e.g., Router Guide cross-referenced as "KV Cache Aware Routing"), the canonical title from the Components section is used
- For section index pages (README.md files with `section:` in nav), the section name is used as the title
- Existing frontmatter fields (e.g., `subtitle:`) are preserved
- No content changes -- only frontmatter insertion

## Test plan

- [ ] Verify Fern docs build succeeds (`fern generate --docs`)
- [ ] Spot-check a few pages to confirm `title:` renders correctly in browser tabs
- [ ] Confirm existing `subtitle:` fields still render (e.g., Router Guide, Disaggregated Serving)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added title metadata to documentation pages across multiple sections including getting started guides, API references, backend documentation, feature guides, component documentation, and deployment guides. These metadata enhancements improve documentation organization and searchability without altering page content or system functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->