### PR TITLE
fix: omit nil/empty containers from ExtraPodSpec JSON to prevent CRD validation failure

### DIFF
--- a/deploy/operator/api/v1alpha1/common_test.go
+++ b/deploy/operator/api/v1alpha1/common_test.go
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestExtraPodSpec_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     ExtraPodSpec
+		wantJSON string
+	}{
+		{
+			name: "nil PodSpec with mainContainer",
+			spec: ExtraPodSpec{
+				PodSpec:       nil,
+				MainContainer: &corev1.Container{Name: "main"},
+			},
+			wantJSON: `{"mainContainer":{"name":"main","resources":{}}}`,
+		},
+		{
+			name: "nil Containers omits containers key entirely",
+			spec: ExtraPodSpec{
+				PodSpec: &corev1.PodSpec{
+					NodeSelector: map[string]string{"gpu": "true"},
+				},
+			},
+			wantJSON: `{"nodeSelector":{"gpu":"true"}}`,
+		},
+		{
+			name: "empty Containers omits containers key",
+			spec: ExtraPodSpec{
+				PodSpec: &corev1.PodSpec{
+					Containers: []corev1.Container{},
+				},
+			},
+			wantJSON: `{}`,
+		},
+		{
+			name: "populated Containers are serialized",
+			spec: ExtraPodSpec{
+				PodSpec: &corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "sidecar"}},
+				},
+			},
+			wantJSON: `{"containers":[{"name":"sidecar","resources":{}}]}`,
+		},
+		{
+			name: "tolerations preserved without containers",
+			spec: ExtraPodSpec{
+				PodSpec: &corev1.PodSpec{
+					Tolerations: []corev1.Toleration{{Key: "nvidia.com/gpu"}},
+				},
+			},
+			wantJSON: `{"tolerations":[{"key":"nvidia.com/gpu"}]}`,
+		},
+		{
+			name: "mainContainer alongside PodSpec fields",
+			spec: ExtraPodSpec{
+				PodSpec: &corev1.PodSpec{
+					NodeSelector: map[string]string{"zone": "us-east"},
+				},
+				MainContainer: &corev1.Container{Name: "main"},
+			},
+			wantJSON: `{"nodeSelector":{"zone":"us-east"},"mainContainer":{"name":"main","resources":{}}}`,
+		},
+		{
+			name:     "nil PodSpec and nil mainContainer",
+			spec:     ExtraPodSpec{},
+			wantJSON: `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.spec)
+			if err != nil {
+				t.Fatalf("MarshalJSON() error = %v", err)
+			}
+
+			if string(got) != tt.wantJSON {
+				t.Errorf("MarshalJSON() mismatch\n got: %s\nwant: %s", string(got), tt.wantJSON)
+			}
+		})
+	}
+}
+
+func TestExtraPodSpec_MarshalJSON_RoundTrip(t *testing.T) {
+	original := ExtraPodSpec{
+		PodSpec: &corev1.PodSpec{
+			Containers:   []corev1.Container{{Name: "main", Image: "nginx"}},
+			NodeSelector: map[string]string{"gpu": "true"},
+			Tolerations:  []corev1.Toleration{{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists}},
+		},
+		MainContainer: &corev1.Container{Name: "override", Image: "custom"},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("MarshalJSON() error = %v", err)
+	}
+
+	var restored ExtraPodSpec
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("UnmarshalJSON() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(original.PodSpec, restored.PodSpec) {
+		t.Errorf("round-trip: PodSpec mismatch\n got: %+v\nwant: %+v", restored.PodSpec, original.PodSpec)
+	}
+
+	if !reflect.DeepEqual(original.MainContainer, restored.MainContainer) {
+		t.Errorf("round-trip: MainContainer mismatch\n got: %+v\nwant: %+v", restored.MainContainer, original.MainContainer)
+	}
+}


### PR DESCRIPTION
## Problem

Creating a `DynamoGraphDeployment` with an `extraPodSpec` that does not set `containers` fails CRD validation after the mutating webhook runs:

```
spec.services.Frontend.extraPodSpec.containers: Invalid value: "null":
  spec.services.Frontend.extraPodSpec.containers in body must be of type array: "null"
```

## Root Cause

`ExtraPodSpec` embeds `*corev1.PodSpec` inline. The upstream `Containers` field is declared without `omitempty`:

```go
Containers []Container `json:"containers" ...`
```

When the `CustomDefaulter` webhook round-trips the object through Go's JSON serialization, a nil `Containers` slice serializes as `"containers": null`. The CRD structural schema defines `containers` as `type: array` and rejects `null`.

## Fix

Add a custom `MarshalJSON` method to `ExtraPodSpec` that shadows the `Containers` field with an `omitempty`-tagged copy during marshalling. This uses a type alias of `corev1.PodSpec` to prevent infinite recursion, and an anonymous struct with an explicit `Containers` field to override the promoted one.

| `Containers` value | Before | After |
|---|---|---|
| `nil` | `"containers": null` | key omitted |
| `[]` (empty) | `"containers": []` | key omitted |
| `[{...}]` (populated) | `"containers": [...]` | `"containers": [...]` (unchanged) |

## Changes

| File | Change |
|---|---|
| `api/v1alpha1/common.go` | Added `MarshalJSON` to `ExtraPodSpec` (+30 lines) |
| `api/v1alpha1/common_test.go` | New file: 7 marshal tests (exact JSON string comparison) + 1 round-trip test (`reflect.DeepEqual`) |

## Alternatives Considered

### 1. Initialize nil Containers to `[]` in the defaulter

Produce `"containers": []` instead of `null`, which passes validation.

**Rejected:** Pollutes stored objects with a field the user never set. Couples the fix to the webhook rather than the type -- any other code path that marshals `ExtraPodSpec` would need the same workaround.

### 2. Patch CRD to add `nullable: true`

Post-process the generated CRD YAML to mark `containers` as nullable.

**Rejected:** Diverges from upstream Kubernetes conventions and masks the serialization issue.

### 3. Redesign `ExtraPodSpec` with explicit fields

Replace the embedded `*corev1.PodSpec` with individual fields (e.g., `Tolerations`, `NodeSelector`).

**Rejected:** Significant API change, loses pass-through PodSpec flexibility. Shadowing only `containers` while keeping the embedded PodSpec causes `controller-gen` to duplicate the entire PodSpec schema under the shadowed field, bloating the CRD.

### 4. Fork `corev1.PodSpec` locally

Copy the entire `corev1.PodSpec` struct, add `omitempty` and `+optional` to `Containers`, and embed the forked type.

**Rejected:** Creates a ~350-line struct that must be kept in sync with upstream Kubernetes on every dependency bump.

### 5. Switch to raw `admission.Handler` with JSON Patch

Replace `CustomDefaulter` with a low-level handler that builds targeted JSON patches, avoiding full object round-tripping.

**Rejected:** Increases webhook complexity, loses the type-safe defaulting interface, and doesn't fix other code paths that marshal `ExtraPodSpec`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON serialization behavior for pod specifications to properly omit empty container arrays and ensure correct output shape according to CRD schema requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->