### PR TITLE
fix: bumping up versions to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,7 +2226,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -2265,14 +2265,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-engine-mistralrs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-llm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-run"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokens"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -4705,7 +4705,7 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libdynamo_llm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "Dynamo Inference Framework"
 authors = ["NVIDIA Inc. <sw-dl-dynamo@nvidia.com>"]
@@ -43,15 +43,15 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 
 [workspace.dependencies]
 # Local crates
-dynamo-runtime = { path = "lib/runtime", version = "0.9.0" }
-dynamo-llm = { path = "lib/llm", version = "0.9.0" }
-dynamo-config = { path = "lib/config", version = "0.9.0" }
-dynamo-tokens = { path = "lib/tokens", version = "0.9.0" }
-dynamo-async-openai = { path = "lib/async-openai", version = "0.9.0", features = [
+dynamo-runtime = { path = "lib/runtime", version = "0.9.1" }
+dynamo-llm = { path = "lib/llm", version = "0.9.1" }
+dynamo-config = { path = "lib/config", version = "0.9.1" }
+dynamo-tokens = { path = "lib/tokens", version = "0.9.1" }
+dynamo-async-openai = { path = "lib/async-openai", version = "0.9.1", features = [
     "byot",
     "rustls",
 ] }
-dynamo-parsers = { path = "lib/parsers", version = "0.9.0" }
+dynamo-parsers = { path = "lib/parsers", version = "0.9.1" }
 
 # External dependencies
 anyhow = { version = "1" }

--- a/deploy/helm/charts/crds/Chart.yaml
+++ b/deploy/helm/charts/crds/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v2
 name: dynamo-crds
 description: A Helm chart for dynamo CRDs
 type: application
-version: 0.9.0
+version: 0.9.1
 dependencies: []

--- a/deploy/helm/charts/platform/Chart.yaml
+++ b/deploy/helm/charts/platform/Chart.yaml
@@ -19,11 +19,11 @@ maintainers:
     url: https://www.nvidia.com
 description: A Helm chart for NVIDIA Dynamo Platform.
 type: application
-version: 0.9.0
+version: 0.9.1
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator
-    version: 0.7.1
+    version: 0.9.1
     repository: file://components/operator
     condition: dynamo-operator.enabled
   - name: nats

--- a/deploy/helm/charts/platform/components/operator/Chart.yaml
+++ b/deploy/helm/charts/platform/components/operator/Chart.yaml
@@ -27,9 +27,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.9.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.1"
+appVersion: "0.9.1"

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -683,15 +683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "bs62"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,7 +1557,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1593,32 +1584,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
-]
-
-[[package]]
-name = "dynamo-kv-router"
-version = "0.9.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "dynamo-runtime",
- "dynamo-tokens",
- "prometheus",
- "rand 0.9.2",
- "serde",
- "thiserror 2.0.17",
- "tokio",
- "tokio-util",
- "tracing",
- "xxhash-rust",
 ]
 
 [[package]]
 name = "dynamo-llm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1646,16 +1619,12 @@ dependencies = [
  "derive_builder",
  "dialoguer",
  "dynamo-async-openai",
- "dynamo-kv-router",
  "dynamo-memory",
- "dynamo-mocker",
  "dynamo-parsers",
  "dynamo-runtime",
- "dynamo-tokens",
  "either",
  "erased-serde",
  "etcd-client",
- "flate2",
  "futures",
  "futures-util",
  "galil-seiferas",
@@ -1717,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "cudarc 0.17.8",
@@ -1732,30 +1701,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "dynamo-mocker"
-version = "0.9.0"
-dependencies = [
- "anyhow",
- "dashmap 6.1.0",
- "derive-getters",
- "derive_builder",
- "dynamo-kv-router",
- "dynamo-tokens",
- "ndarray",
- "ndarray-interp",
- "ndarray-npy",
- "rand 0.9.2",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "dynamo-parsers"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -1773,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1841,20 +1788,6 @@ dependencies = [
  "validator",
  "xxhash-rust",
  "zmq",
-]
-
-[[package]]
-name = "dynamo-tokens"
-version = "0.9.0"
-dependencies = [
- "bs58",
- "bytemuck",
- "dashmap 6.1.0",
- "derive-getters",
- "serde",
- "thiserror 2.0.17",
- "uuid",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -3587,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kvbm-py3"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/lib/bindings/kvbm/Cargo.toml
+++ b/lib/bindings/kvbm/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "kvbm-py3"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/kvbm/pyproject.toml
+++ b/lib/bindings/kvbm/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "kvbm"
-version = "0.9.0"
+version = "0.9.1"
 description = "Dynamo KVBM"
 readme = "README.md"
 authors = [

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1566,7 +1566,7 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "dynamo-async-openai"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -1593,14 +1593,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-llm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-memory"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "cudarc",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "dynamo-async-openai",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-py3"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "dynamo-py3"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/lib/bindings/python/pyproject.toml
+++ b/lib/bindings/python/pyproject.toml
@@ -16,7 +16,7 @@
 
 [project]
 name = "ai-dynamo-runtime"
-version = "0.9.0"
+version = "0.9.1"
 description = "Dynamo Inference Framework Runtime"
 readme = "README.md"
 authors = [

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -873,14 +873,14 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamo-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "dynamo-runtime"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -912,6 +912,7 @@ dependencies = [
  "libc",
  "local-ip-address",
  "log",
+ "lru",
  "nid",
  "nix",
  "notify",
@@ -932,6 +933,7 @@ dependencies = [
  "serde_json",
  "socket2 0.5.9",
  "thiserror 2.0.17",
+ "tmq",
  "tokio",
  "tokio-rayon",
  "tokio-stream",
@@ -945,6 +947,7 @@ dependencies = [
  "uuid",
  "validator",
  "xxhash-rust",
+ "zmq",
 ]
 
 [[package]]
@@ -1364,7 +1367,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello_world"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -2073,6 +2076,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.2",
+]
 
 [[package]]
 name = "lru-slab"
@@ -3463,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "service_metrics"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -3650,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "system_metrics"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "dynamo-runtime",
@@ -3790,6 +3802,19 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tmq"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f41ac3a42f65436eed7e1afe80dbe8a982dcac2ea4581bf61bc2d3dcfb19a1"
+dependencies = [
+ "futures",
+ "log",
+ "thiserror 1.0.69",
+ "tokio",
+ "zmq",
+]
 
 [[package]]
 name = "tokio"

--- a/lib/runtime/examples/Cargo.toml
+++ b/lib/runtime/examples/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 authors = ["NVIDIA"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "ai-dynamo"
-version = "0.9.0"
+version = "0.9.1"
 description = "Distributed Inference Framework"
 readme = "README.md"
 authors = [
@@ -13,7 +13,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "ai-dynamo-runtime==0.9.0",
+    "ai-dynamo-runtime==0.9.1",
     "transformers>=4.56.0",
     "pytest>=8.3.4",
     "types-psutil>=7.0.0.20250218",


### PR DESCRIPTION
#### Overview:

bumping up versions to 0.9.1

script https://gitlab-master.nvidia.com/dl/ai-dynamo/runbooks/-/blob/main/codefreeze/dynamo/update_version.sh?ref_type=heads wasn't updating the helm chart properly
