### PR TITLE
feat: use dynamic port allocation for DYN_SYSTEM_PORT in e2e router t…

### DIFF
--- a/tests/basic/test_autodeploy_backend.py
+++ b/tests/basic/test_autodeploy_backend.py
@@ -47,6 +47,7 @@ class DynamoWorkerProcess(ManagedProcess):
         env = os.environ.copy()
         env["DYN_LOG"] = "debug"
         env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
+        # TODO: Replace hardcoded port with allocate_ports() for xdist-safe parallel execution
         env["DYN_SYSTEM_PORT"] = "9345"
         env["DYN_KVBM_CPU_CACHE_GB"] = "20"
         env["DYN_KVBM_DISK_CACHE_GB"] = "60"

--- a/tests/fault_tolerance/test_vllm_health_check.py
+++ b/tests/fault_tolerance/test_vllm_health_check.py
@@ -43,6 +43,7 @@ class DynamoWorkerProcess(ManagedProcess):
         env = os.environ.copy()
         env["DYN_LOG"] = "debug"
         env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
+        # TODO: Replace hardcoded port with allocate_ports() for xdist-safe parallel execution
         env["DYN_SYSTEM_PORT"] = "9345"
 
         # TODO: Have the managed process take a command name explicitly to distinguish

--- a/tests/kvbm_integration/test_cuda_graph.py
+++ b/tests/kvbm_integration/test_cuda_graph.py
@@ -62,6 +62,7 @@ class DynamoWorkerProcess(ManagedProcess):
         env = os.environ.copy()
         env["DYN_LOG"] = "debug"
         env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
+        # TODO: Replace hardcoded port with allocate_ports() for xdist-safe parallel execution
         env["DYN_SYSTEM_PORT"] = "9345"
         env["DYN_KVBM_CPU_CACHE_GB"] = "20"
         env["DYN_KVBM_DISK_CACHE_GB"] = "60"

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -118,6 +118,17 @@ class VLLMProcess:
         self.worker_processes = []
         self.store_backend = store_backend
 
+        # Dynamically allocate unique system, KV event, and NIXL side-channel
+        # ports (one of each per worker) to avoid conflicts in parallel test runs.
+        self._system_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
+        self._kv_event_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
+        self._nixl_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
+        request.addfinalizer(
+            lambda: deallocate_ports(
+                self._system_ports + self._kv_event_ports + self._nixl_ports
+            )
+        )
+
         if vllm_args is None:
             vllm_args = {}
 
@@ -202,13 +213,19 @@ class VLLMProcess:
             if durable_kv_events:
                 command.append("--durable-kv-events")
 
+            # Ports are dynamically allocated for xdist-safe parallel execution.
+            system_port = self._system_ports[worker_idx]
+            kv_event_port = self._kv_event_ports[worker_idx]
+            nixl_port = self._nixl_ports[worker_idx]
+
             env = os.environ.copy()  # Copy parent environment
             env_vars = {
                 "CUDA_VISIBLE_DEVICES": gpu_device,
                 "DYN_NAMESPACE": self.namespace,
                 "DYN_REQUEST_PLANE": request_plane,
-                "DYN_VLLM_KV_EVENT_PORT": str(20080 + worker_idx),
-                "VLLM_NIXL_SIDE_CHANNEL_PORT": str(20090 + worker_idx),
+                "DYN_SYSTEM_PORT": str(system_port),
+                "DYN_VLLM_KV_EVENT_PORT": str(kv_event_port),
+                "VLLM_NIXL_SIDE_CHANNEL_PORT": str(nixl_port),
                 "PYTHONHASHSEED": "0",  # for deterministic event id's
             }
 
@@ -233,13 +250,13 @@ class VLLMProcess:
             if data_parallel_size is not None:
                 logger.info(
                     f"Created {data_parallel_size} DP ranks per worker on GPU(s) {gpu_device} "
-                    f"(gpu_mem={gpu_memory_utilization}) "
+                    f"(gpu_mem={gpu_memory_utilization}, system_port={system_port}) "
                     f"with endpoint: {self.endpoint}"
                 )
             else:
                 logger.info(
                     f"Created vLLM worker {worker_idx} on GPU {gpu_device} "
-                    f"(gpu_mem={gpu_memory_utilization}) "
+                    f"(gpu_mem={gpu_memory_utilization}, system_port={system_port}) "
                     f"with endpoint: {self.endpoint}"
                 )
 


### PR DESCRIPTION
#### Overview:

Replace hardcoded port assignments (DYN_SYSTEM_PORT, DYN_VLLM_KV_EVENT_PORT, VLLM_NIXL_SIDE_CHANNEL_PORT, KV events ZMQ ports) with dynamically allocated ports via allocate_ports() in tests.

#### Details:

- VLLMProcess: add dynamic allocation for DYN_SYSTEM_PORT, DYN_VLLM_KV_EVENT_PORT, and VLLM_NIXL_SIDE_CHANNEL_PORT (previously hardcoded as 20080+idx and 20090+idx, and DYN_SYSTEM_PORT was missing entirely)
- SGLangProcess: add dynamic allocation for DYN_SYSTEM_PORT (was missing) and KV events ZMQ port (was hardcoded as 20080+idx)
- TRTLLMProcess: switch DYN_SYSTEM_PORT from hardcoded 8081+idx to dynamically allocated ports with proper deallocation via finalizer
- Add TODO comments in test_autodeploy_backend.py, test_vllm_health_check.py, and test_cuda_graph.py for remaining hardcoded DYN_SYSTEM_PORT=9345
- All dynamically allocated ports are properly deallocated via request.addfinalizer()
- Log messages updated to include system_port for debugging visibility

#### Where should the reviewer start?

tests/router/test_router_e2e_with_vllm.py (VLLMProcess.__init__ and env_vars setup) — most comprehensive change with three port types dynamically allocated

#### Related Issues:

Closes DIS-1449

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for parallel execution support by implementing dynamic port allocation across multiple test suites, replacing fixed port assumptions.
  * Added documentation notes for planned test configuration improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->