### PR TITLE
docs: Change `FRAMEWORK` variable to lowercase

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -142,7 +142,7 @@ Build the appropriate framework image (e.g., `dynamo:latest-vllm-local-dev`) fro
 
 ```bash
 # Single command approach (recommended)
-export FRAMEWORK=VLLM         # Note: any of VLLM, SGLANG, TRTLLM can be used
+export FRAMEWORK=vllm         # Note: any of vllm, sglang, trtllm can be used
 python container/render.py --framework=${FRAMEWORK} --target=local-dev --output-short-filename
 docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f container/rendered.Dockerfile .
 


### PR DESCRIPTION
Updated framework variable to use lowercase values to match what `render.py` expects.

Previous error:
```
Traceback (most recent call last):
  File "/home/kprashanth/code/dynamo-custom-preprocess-bench/container/render.py", line 132, in <module>
    main()
  File "/home/kprashanth/code/dynamo-custom-preprocess-bench/container/render.py", line 115, in main
    validate_args(args)
  File "/home/kprashanth/code/dynamo-custom-preprocess-bench/container/render.py", line 71, in validate_args
    raise ValueError(
ValueError: Invalid input combination: [framework=VLLM,target=local-dev]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated framework configuration examples to use lowercase values (vllm, sglang, trtllm) instead of uppercase, aligning with the expected input format for build and rendering processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->