### PR TITLE
fix: Rename fetch_llm/register_llm to fetch_model/register_model

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -5,7 +5,7 @@
 #
 # Start a frontend node. This runs:
 # - OpenAI HTTP server.
-# - Auto-discovery: Watches etcd for engine/worker registration (via `register_llm`).
+# - Auto-discovery: Watches etcd for engine/worker registration (via `register_model`).
 # - Pre-processor: Prompt templating and tokenization.
 # - Router, defaulting to round-robin. Use --router-mode to switch (round-robin, random, kv, direct).
 #

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -32,7 +32,7 @@ from dynamo.llm import (
     PythonAsyncEngine,
     RouterConfig,
     RouterMode,
-    fetch_llm,
+    fetch_model,
 )
 from dynamo.runtime import DistributedRuntime
 
@@ -393,7 +393,7 @@ class EngineFactory:
 
         source_path = mdc.source_path()
         if not os.path.exists(source_path):
-            await fetch_llm(source_path, ignore_weights=True)
+            await fetch_model(source_path, ignore_weights=True)
 
         tokenizer_mode = getattr(self.flags, "tokenizer_mode", None) or "auto"
         config_format = getattr(self.flags, "config_format", None) or "auto"

--- a/components/src/dynamo/global_router/__main__.py
+++ b/components/src/dynamo/global_router/__main__.py
@@ -11,7 +11,7 @@ but internally routes requests to local routers in different namespaces based on
 a grid-based pool selection strategy.
 
 Key features:
-- Registers as BOTH prefill AND decode worker via register_llm()
+- Registers as BOTH prefill AND decode worker via register_model()
 - Routes prefill requests based on (ISL, TTFT) to prefill pools
 - Routes decode requests based on (context_length, ITL) to decode pools
 - Connects to local routers in each pool's namespace
@@ -24,7 +24,7 @@ import os
 
 import uvloop
 
-from dynamo.llm import ModelInput, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -122,7 +122,7 @@ async def worker(runtime: DistributedRuntime):
     logger.info("Registering as prefill worker...")
     # Register as prefill worker - frontend will send prefill requests here
     # Use model_name as model_path since we don't need tokenizer/model files
-    await register_llm(
+    await register_model(
         model_input=ModelInput.Tokens,
         model_type=ModelType.Prefill,
         endpoint=prefill_endpoint,
@@ -135,7 +135,7 @@ async def worker(runtime: DistributedRuntime):
 
     logger.info("Registering as decode worker...")
     # Register as decode worker - frontend will send decode requests here
-    await register_llm(
+    await register_model(
         model_input=ModelInput.Tokens,
         model_type=ModelType.Chat | ModelType.Completions,
         endpoint=decode_endpoint,

--- a/components/src/dynamo/mocker/main.py
+++ b/components/src/dynamo/mocker/main.py
@@ -16,7 +16,7 @@ import uvloop
 
 os.environ.setdefault("DYN_COMPUTE_THREADS", "0")
 
-from dynamo.llm import EngineType, EntrypointArgs, fetch_llm, make_engine, run_input
+from dynamo.llm import EngineType, EntrypointArgs, fetch_model, make_engine, run_input
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -46,7 +46,7 @@ async def prefetch_model(model_path: str) -> None:
 
     logger.info(f"Pre-fetching model from HuggingFace: {model_path}")
     try:
-        local_path = await fetch_llm(model_path, ignore_weights=True)
+        local_path = await fetch_model(model_path, ignore_weights=True)
         logger.info(f"Model cached at: {local_path}")
     except Exception as e:
         logger.warning(

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -21,7 +21,7 @@ from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 from dynamo._core import get_reasoning_parser_names, get_tool_parser_names
 from dynamo.common.config_dump import register_encoder
 from dynamo.common.utils.runtime import parse_endpoint
-from dynamo.llm import fetch_llm
+from dynamo.llm import fetch_model
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sglang import __version__
 
@@ -507,17 +507,17 @@ async def parse_args(args: list[str]) -> Config:
     if not parsed_args.served_model_name:
         parsed_args.served_model_name = model_path
     # Download the model if necessary using modelexpress.
-    # We don't set `parsed_args.model_path` to the local path fetch_llm returns
+    # We don't set `parsed_args.model_path` to the local path fetch_model returns
     # because sglang will send this to its pipeline-parallel workers, which may
     # not have the local path.
     # sglang will attempt to download the model again, but find it in the HF cache.
     # For non-HF models use a path instead of an HF name, and ensure all workers have
     # that path (ideally via a shared folder).
     if not os.path.exists(model_path):
-        await fetch_llm(model_path)
+        await fetch_model(model_path)
 
     # TODO: sglang downloads the model in `from_cli_args`, which means we had to
-    # fetch_llm (download the model) here, in `parse_args`. `parse_args` should not
+    # fetch_model (download the model) here, in `parse_args`. `parse_args` should not
     # contain code to download a model, it should only parse the args.
 
     # For diffusion/video workers, create a minimal dummy ServerArgs since diffusion

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -32,7 +32,7 @@ from dynamo.sglang.health_check import (
 from dynamo.sglang.publisher import DynamoSglangPublisher, setup_sgl_metrics
 from dynamo.sglang.register import (
     register_image_diffusion_model,
-    register_llm_with_readiness_gate,
+    register_model_with_readiness_gate,
     register_video_generation_model,
 )
 from dynamo.sglang.request_handlers import (
@@ -307,7 +307,7 @@ async def init(
                 metrics_labels=metrics_labels,
                 health_check_payload=health_check_payload,
             ),
-            register_llm_with_readiness_gate(
+            register_model_with_readiness_gate(
                 engine,
                 generate_endpoint,
                 server_args,
@@ -385,7 +385,7 @@ async def init_prefill(
                 metrics_labels=metrics_labels,
                 health_check_payload=health_check_payload,
             ),
-            register_llm_with_readiness_gate(
+            register_model_with_readiness_gate(
                 engine,
                 generate_endpoint,
                 server_args,
@@ -474,7 +474,7 @@ async def init_diffusion(
                 metrics_labels=metrics_labels,
                 health_check_payload=health_check_payload,
             ),
-            register_llm_with_readiness_gate(
+            register_model_with_readiness_gate(
                 engine,
                 generate_endpoint,
                 server_args,
@@ -538,7 +538,7 @@ async def init_embedding(
                 metrics_labels=metrics_labels,
                 health_check_payload=health_check_payload,
             ),
-            register_llm_with_readiness_gate(
+            register_model_with_readiness_gate(
                 engine,
                 generate_endpoint,
                 server_args,
@@ -766,7 +766,7 @@ async def init_multimodal_processor(
                     (prometheus_names.labels.MODEL_NAME, server_args.served_model_name),
                 ],
             ),
-            register_llm_with_readiness_gate(
+            register_model_with_readiness_gate(
                 None,  # engine
                 generate_endpoint,
                 server_args,

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -11,11 +11,11 @@ from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_local_ip_auto
 
 from dynamo._core import Endpoint
-from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_model
 from dynamo.sglang.args import DynamoArgs
 
 
-async def _register_llm_with_runtime_config(
+async def _register_model_with_runtime_config(
     engine: sgl.Engine,
     endpoint: Endpoint,
     server_args: ServerArgs,
@@ -49,7 +49,7 @@ async def _register_llm_with_runtime_config(
             output_type = ModelType.Chat
 
     try:
-        await register_llm(
+        await register_model(
             input_type,
             output_type,
             endpoint,
@@ -231,7 +231,7 @@ async def _get_runtime_config(
         return runtime_config
 
 
-async def register_llm_with_readiness_gate(
+async def register_model_with_readiness_gate(
     engine: sgl.Engine,
     generate_endpoint: Endpoint,
     server_args: ServerArgs,
@@ -254,7 +254,7 @@ async def register_llm_with_readiness_gate(
     Raises:
         RuntimeError: If model registration fails.
     """
-    registration_success = await _register_llm_with_runtime_config(
+    registration_success = await _register_model_with_runtime_config(
         engine,
         generate_endpoint,
         server_args,
@@ -295,7 +295,7 @@ async def register_image_diffusion_model(
     model_name = server_args.model_path
 
     try:
-        await register_llm(
+        await register_model(
             ModelInput.Text,
             ModelType.Images,
             endpoint,
@@ -335,7 +335,7 @@ async def register_video_generation_model(
     model_name = server_args.model_path
 
     try:
-        await register_llm(
+        await register_model(
             ModelInput.Text,
             ModelType.Videos,
             endpoint,

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -42,7 +42,7 @@ from dynamo.llm import (
     ModelInput,
     ModelRuntimeConfig,
     ModelType,
-    register_llm,
+    register_model,
 )
 from dynamo.runtime import DistributedRuntime
 from dynamo.trtllm.constants import DisaggregationMode
@@ -437,7 +437,7 @@ async def init_llm_worker(
         # Encode workers do NOT register - they're internal workers only
         # Prefill and decode workers register - frontend detects their role via ModelType
         if config.disaggregation_mode != DisaggregationMode.ENCODE:
-            await register_llm(
+            await register_model(
                 model_input,
                 model_type,
                 endpoint,

--- a/components/src/dynamo/trtllm/workers/video_diffusion_worker.py
+++ b/components/src/dynamo/trtllm/workers/video_diffusion_worker.py
@@ -10,7 +10,7 @@ workers using diffusion models (Wan, Flux, Cosmos, etc.).
 import asyncio
 import logging
 
-from dynamo.llm import ModelInput, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelType, register_model
 from dynamo.runtime import DistributedRuntime
 from dynamo.trtllm.utils.trtllm_utils import Config
 
@@ -91,9 +91,8 @@ async def init_video_diffusion_worker(
 
     logging.info(f"Registering model '{model_name}' with ModelType={model_type}")
 
-    # register_llm is a misnomer — it's actually Dynamo's generic model
-    # registration function and the video diffisuion model is not an llm
-    await register_llm(
+    # register_model is Dynamo's generic model registration function
+    await register_model(
         ModelInput.Text,
         model_type,
         endpoint,

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -31,8 +31,8 @@ from dynamo.llm import (
     ModelInput,
     ModelType,
     lora_name_to_id,
-    register_llm,
-    unregister_llm,
+    register_model,
+    unregister_model,
 )
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -571,7 +571,7 @@ class BaseWorkerHandler(ABC):
                             }
 
                             # Publish with format: v1/mdc/dynamo/backend/generate/{instance_id}/{lora_slug}
-                            await register_llm(
+                            await register_model(
                                 model_input=ModelInput.Tokens,
                                 model_type=ModelType.Chat | ModelType.Completions,
                                 endpoint=self.generate_endpoint,
@@ -691,7 +691,7 @@ class BaseWorkerHandler(ABC):
                             f"Unregistering LoRA '{lora_name}' ModelDeploymentCard"
                         )
                         try:
-                            await unregister_llm(
+                            await unregister_model(
                                 endpoint=self.generate_endpoint,
                                 lora_name=lora_name,
                             )

--- a/docs/pages/components/frontend/README.md
+++ b/docs/pages/components/frontend/README.md
@@ -34,7 +34,7 @@ The Dynamo Frontend is the API gateway for serving LLM inference requests. It pr
 python -m dynamo.frontend --http-port 8000
 ```
 
-This starts an OpenAI-compatible HTTP server with integrated preprocessing and routing. Backends are auto-discovered when they call `register_llm`.
+This starts an OpenAI-compatible HTTP server with integrated preprocessing and routing. Backends are auto-discovered when they call `register_model`.
 
 ### KServe gRPC Frontend
 

--- a/docs/pages/components/frontend/frontend-guide.md
+++ b/docs/pages/components/frontend/frontend-guide.md
@@ -57,7 +57,7 @@ Tune these values based on your workload. Connection window should accommodate `
 
 ## Registering a Backend
 
-Similar to HTTP frontend, the registered backend will be auto-discovered and added to the frontend list of serving model. To register a backend, the same `register_llm()` API will be used. Currently the frontend support serving of the following model type and model input combination:
+Similar to HTTP frontend, the registered backend will be auto-discovered and added to the frontend list of serving model. To register a backend, the same `register_model()` API will be used. Currently the frontend support serving of the following model type and model input combination:
 
 * `ModelType::Completions` and `ModelInput::Text`: Combination for LLM backend that uses custom preprocessor
 * `ModelType::Completions` and `ModelInput::Token`: Combination for LLM backend that uses Dynamo preprocessor (i.e. Dynamo vLLM / SGLang / TRTLLM backend)
@@ -153,7 +153,7 @@ See [Router Documentation](../router/README.md) for routing configuration detail
 
 ### With Backends
 
-Backends auto-register with the frontend when they call `register_llm()`. Supported backends:
+Backends auto-register with the frontend when they call `register_model()`. Supported backends:
 
 - [vLLM Backend](../../backends/vllm/README.md)
 - [SGLang Backend](../../backends/sglang/README.md)

--- a/docs/pages/components/router/README.md
+++ b/docs/pages/components/router/README.md
@@ -23,7 +23,7 @@ This command:
 - Exposes the service on port 8000 (configurable)
 - Automatically handles all backend workers registered to the Dynamo endpoint
 
-Backend workers register themselves using the `register_llm` API, after which the KV Router automatically tracks worker state and makes routing decisions based on KV cache overlap.
+Backend workers register themselves using the `register_model` API, after which the KV Router automatically tracks worker state and makes routing decisions based on KV cache overlap.
 
 #### CLI Arguments
 
@@ -83,8 +83,8 @@ For more configuration options and tuning guidelines, see the [Router Guide](rou
 ## Prerequisites and Limitations
 
 **Requirements:**
-- **Dynamic endpoints only**: KV router requires `register_llm()` with `model_input=ModelInput.Tokens`. Your backend handler receives pre-tokenized requests with `token_ids` instead of raw text.
-- Backend workers must call `register_llm()` with `model_input=ModelInput.Tokens` (see [Backend Guide](../../development/backend-guide.md))
+- **Dynamic endpoints only**: KV router requires `register_model()` with `model_input=ModelInput.Tokens`. Your backend handler receives pre-tokenized requests with `token_ids` instead of raw text.
+- Backend workers must call `register_model()` with `model_input=ModelInput.Tokens` (see [Backend Guide](../../development/backend-guide.md))
 - You cannot use `--static-endpoint` mode with KV routing (use dynamic discovery instead)
 
 **Multimodal Support:**

--- a/docs/pages/components/router/router-examples.md
+++ b/docs/pages/components/router/router-examples.md
@@ -377,11 +377,11 @@ class CustomEnginePublisher:
 #### Integration with Your Engine
 
 ```python
-from dynamo.llm import register_llm
+from dynamo.llm import register_model
 
 async def main():
     # Register your engine with Dynamo
-    component, endpoint = await register_llm(
+    component, endpoint = await register_model(
         model="my-model",
         generator=my_generate_fn,
     )

--- a/docs/pages/components/router/router-guide.md
+++ b/docs/pages/components/router/router-guide.md
@@ -27,7 +27,7 @@ This command:
 - Exposes the service on port 8000 (configurable)
 - Automatically handles all backend workers registered to the Dynamo endpoint
 
-Backend workers register themselves using the `register_llm` API, after which the KV Router automatically tracks worker state and makes routing decisions based on KV cache overlap.
+Backend workers register themselves using the `register_model` API, after which the KV Router automatically tracks worker state and makes routing decisions based on KV cache overlap.
 
 #### CLI Arguments
 
@@ -267,7 +267,7 @@ Dynamo supports disaggregated serving where prefill (prompt processing) and deco
 ### Automatic Prefill Router Activation
 
 The prefill router is automatically created when:
-1. A decode model is registered (e.g., via `register_llm()` with `ModelType.Chat | ModelType.Completions`)
+1. A decode model is registered (e.g., via `register_model()` with `ModelType.Chat | ModelType.Completions`)
 2. A prefill worker is detected with the same model name and `ModelType.Prefill`
 
 **Key characteristics of the prefill router:**
@@ -283,7 +283,7 @@ When both workers are registered, requests are automatically routed.
 # Decode worker registration (in your decode worker)
 decode_endpoint = runtime.namespace("dynamo").component("decode").endpoint("generate")
 
-await register_llm(
+await register_model(
     model_input=ModelInput.Tokens,
     model_type=ModelType.Chat | ModelType.Completions,
     endpoint=decode_endpoint,
@@ -296,7 +296,7 @@ await decode_endpoint.serve_endpoint(decode_handler.generate)
 # Prefill worker registration (in your prefill worker)
 prefill_endpoint = runtime.namespace("dynamo").component("prefill").endpoint("generate")
 
-await register_llm(
+await register_model(
     model_input=ModelInput.Tokens,
     model_type=ModelType.Prefill,  # <-- Mark as prefill worker
     endpoint=prefill_endpoint,

--- a/docs/pages/development/backend-guide.md
+++ b/docs/pages/development/backend-guide.md
@@ -17,7 +17,7 @@ The Python file must do three things:
 3. Attach a request handler
 
 ```
-from dynamo.llm import ModelInput, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
    # 1. Decorate a function to get the runtime
@@ -32,8 +32,8 @@ from dynamo.runtime import DistributedRuntime, dynamo_worker
     model_input = ModelInput.Tokens # or ModelInput.Text if engine handles pre-processing
     model_type = ModelType.Chat # or ModelType.Chat | ModelType.Completions if model can be deployed on chat and completions endpoints
     endpoint = component.endpoint("endpoint")
-    # Optional last param to register_llm is model_name. If not present derives it from model_path
-    await register_llm(model_input, model_type, endpoint, model_path)
+    # Optional last param to register_model is model_name. If not present derives it from model_path
+    await register_model(model_input, model_type, endpoint, model_path)
 
     # Initialize your engine here
     # engine = ...
@@ -70,7 +70,7 @@ The `model_type` can be:
 - ModelType.Chat. Your `generate` method receives a `request` and must return a response dict of type [OpenAI Chat Completion](https://platform.openai.com/docs/api-reference/chat).
 - ModelType.Completions. Your `generate` method receives a `request` and must return a response dict of the older [Completions](https://platform.openai.com/docs/api-reference/completions).
 
-`register_llm` can also take the following kwargs:
+`register_model` can also take the following kwargs:
 - `model_name`: The name to call the model. Your incoming HTTP requests model name must match this. Defaults to the hugging face repo name or the folder name.
 - `context_length`: Max model length in tokens. Defaults to the model's set max. Only set this if you need to reduce KV cache allocation to fit into VRAM.
 - `kv_cache_block_size`: Size of a KV block for the engine, in tokens. Defaults to 16.

--- a/docs/pages/features/multimodal/multimodal-trtllm.md
+++ b/docs/pages/features/multimodal/multimodal-trtllm.md
@@ -410,7 +410,7 @@ TRT-LLM workers register with Dynamo using:
 
 ```python
 # TRT-LLM Worker - Register with Tokens
-await register_llm(
+await register_model(
     ModelInput.Tokens,      # Rust does minimal preprocessing
     model_type,             # ModelType.Chat or ModelType.Prefill
     generate_endpoint,

--- a/docs/pages/features/multimodal/multimodal-vllm.md
+++ b/docs/pages/features/multimodal/multimodal-vllm.md
@@ -465,7 +465,7 @@ Dynamo's Rust SDK supports two input types that determine how the HTTP frontend 
 
 ```python
 # Processor - Entry point from HTTP frontend
-await register_llm(
+await register_model(
     ModelInput.Text,        # Frontend sends raw text
     ModelType.Chat,
     generate_endpoint,
@@ -474,7 +474,7 @@ await register_llm(
 )
 
 # Workers - Internal components
-await register_llm(
+await register_model(
     ModelInput.Tokens,      # Expect pre-tokenized input
     ModelType.Chat,         # or ModelType.Prefill for prefill workers
     generate_endpoint,

--- a/docs/pages/integrations/kv-events-custom-engines.md
+++ b/docs/pages/integrations/kv-events-custom-engines.md
@@ -115,11 +115,11 @@ class CustomEnginePublisher:
 ### Integration with Your Engine
 
 ```python
-from dynamo.llm import register_llm
+from dynamo.llm import register_model
 
 async def main():
     # Register your engine with Dynamo
-    component, endpoint = await register_llm(
+    component, endpoint = await register_model(
         model="my-model",
         generator=my_generate_fn,
     )

--- a/examples/backends/tritonserver/src/tritonworker.py
+++ b/examples/backends/tritonserver/src/tritonworker.py
@@ -12,7 +12,7 @@ import uvloop
 from google.protobuf import text_format
 from tritonclient.utils import triton_to_np_dtype
 
-from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -147,8 +147,8 @@ async def triton_worker(runtime: DistributedRuntime, args: argparse.Namespace):
     runtime_config.set_tensor_model_config(model_config)
 
     logger.info("Attempting to register model with Dynamo runtime...")
-    # Use register_llm for tensor-based models (skips HuggingFace downloads)
-    await register_llm(
+    # Use register_model for tensor-based models (skips HuggingFace downloads)
+    await register_model(
         ModelInput.Tensor,
         ModelType.TensorBased,
         endpoint,

--- a/examples/multimodal/components/processor.py
+++ b/examples/multimodal/components/processor.py
@@ -20,7 +20,7 @@ from vllm.outputs import RequestOutput
 from vllm.tokenizers import TokenizerLike as AnyTokenizer
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
-from dynamo.llm import ModelInput, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelType, register_model
 from dynamo.runtime import Client, DistributedRuntime, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -318,7 +318,7 @@ async def init(runtime: DistributedRuntime, args: argparse.Namespace, config: Co
     await encode_worker_client.wait_for_instances()
 
     # Register the endpoint as entrypoint to a model
-    await register_llm(
+    await register_model(
         ModelInput.Text,  # Custom processor is used and this type bypasses SDK processor
         ModelType.Chat,
         generate_endpoint,

--- a/lib/bindings/python/examples/hello_world/server_sglang.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang.py
@@ -8,7 +8,7 @@
 # request via NATS to this python script, which runs sglang.
 #
 # The key differences between this and `server_sglang_tok.py` are:
-# - The `register_llm` function registers us a `Chat` and `Completions` model that accepts `Tokens` input
+# - The `register_model` function registers us a `Chat` and `Completions` model that accepts `Tokens` input
 # - The `generate` function receives a pre-tokenized request and must return token_ids in the response.
 #
 # Setup a virtualenv with dynamo.llm, dynamo.runtime and sglang[all] installed
@@ -27,7 +27,7 @@ import sglang
 import uvloop
 from sglang.srt.server_args import ServerArgs
 
-from dynamo.llm import ModelInput, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
@@ -91,7 +91,7 @@ async def init(runtime: DistributedRuntime, config: Config):
     component = runtime.namespace(config.namespace).component(config.component)
 
     endpoint = component.endpoint(config.endpoint)
-    await register_llm(
+    await register_model(
         ModelInput.Tokens,
         ModelType.Chat | ModelType.Completions,
         endpoint,

--- a/lib/bindings/python/examples/hello_world/server_sglang_tok.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang_tok.py
@@ -9,7 +9,7 @@
 # do the pre/post-processing.
 #
 # The key differences between this and `server_sglang.py` are:
-# - The `register_llm` function registers us a `Chat` and `Completions` model that accepts `Text` input
+# - The `register_model` function registers us a `Chat` and `Completions` model that accepts `Text` input
 # - The `generate` function receives a chat completion request and must return matching response
 #
 # Setup a virtualenv with dynamo.llm, dynamo.runtime and sglang[all] installed
@@ -31,7 +31,7 @@ from sglang.srt.openai_api.adapter import v1_chat_generate_request
 from sglang.srt.openai_api.protocol import ChatCompletionRequest
 from sglang.srt.server_args import ServerArgs
 
-from dynamo.llm import ModelInput, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
@@ -104,7 +104,7 @@ async def init(runtime: DistributedRuntime, config: Config):
     component = runtime.namespace(config.namespace).component(config.component)
 
     endpoint = component.endpoint(config.endpoint)
-    await register_llm(
+    await register_model(
         ModelInput.Text, ModelType.Chat | ModelType.Completions, endpoint, config.model
     )
 

--- a/lib/bindings/python/examples/hello_world/server_vllm.py
+++ b/lib/bindings/python/examples/hello_world/server_vllm.py
@@ -27,7 +27,7 @@ from vllm.entrypoints.openai.api_server import (
 )
 from vllm.inputs import TokensPrompt
 
-from dynamo.llm import ModelInput, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 DYN_NAMESPACE = os.environ.get("DYN_NAMESPACE", "dynamo")
@@ -102,7 +102,7 @@ async def init(runtime: DistributedRuntime, config: Config):
     component = runtime.namespace(config.namespace).component(config.component)
 
     endpoint = component.endpoint(config.endpoint)
-    await register_llm(
+    await register_model(
         ModelInput.Tokens,
         ModelType.Chat | ModelType.Completions,
         endpoint,

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -142,9 +142,9 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(llm::kv::compute_block_hash_for_seq_py, m)?)?;
     m.add_function(wrap_pyfunction!(lora_name_to_id, m)?)?;
     m.add_function(wrap_pyfunction!(log_message, m)?)?;
-    m.add_function(wrap_pyfunction!(register_llm, m)?)?;
-    m.add_function(wrap_pyfunction!(unregister_llm, m)?)?;
-    m.add_function(wrap_pyfunction!(fetch_llm, m)?)?;
+    m.add_function(wrap_pyfunction!(register_model, m)?)?;
+    m.add_function(wrap_pyfunction!(unregister_model, m)?)?;
+    m.add_function(wrap_pyfunction!(fetch_model, m)?)?;
     m.add_function(wrap_pyfunction!(llm::entrypoint::make_engine, m)?)?;
     m.add_function(wrap_pyfunction!(llm::entrypoint::run_input, m)?)?;
 
@@ -228,7 +228,7 @@ fn lora_name_to_id(lora_name: &str) -> i32 {
 #[pyfunction]
 #[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_mode=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None))]
 #[allow(clippy::too_many_arguments)]
-fn register_llm<'p>(
+fn register_model<'p>(
     py: Python<'p>,
     model_input: ModelInput,
     model_type: ModelType,
@@ -409,7 +409,7 @@ fn register_llm<'p>(
 /// - LoRA model: `v1/mdc/{namespace}/{component}/{endpoint}/{instance_id}/{lora_slug}`
 #[pyfunction]
 #[pyo3(signature = (endpoint, lora_name=None))]
-fn unregister_llm<'p>(
+fn unregister_model<'p>(
     py: Python<'p>,
     endpoint: Endpoint,
     lora_name: Option<&str>,
@@ -425,11 +425,11 @@ fn unregister_llm<'p>(
     })
 }
 
-/// Download a model from Hugging Face, returning it's local path
-/// Example: `model_path = await fetch_llm("Qwen/Qwen3-0.6B")`
+/// Download a model from Hugging Face, returning its local path
+/// Example: `model_path = await fetch_model("Qwen/Qwen3-0.6B")`
 #[pyfunction]
 #[pyo3(signature = (remote_name, ignore_weights=false))]
-fn fetch_llm<'p>(
+fn fetch_model<'p>(
     py: Python<'p>,
     remote_name: &str,
     ignore_weights: bool,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1063,6 +1063,11 @@ async def fetch_model(remote_name: str, ignore_weights: bool = False) -> str:
     """
     ...
 
+# Backward-compatible aliases (deprecated, use new names)
+fetch_llm = fetch_model
+register_llm = register_model
+unregister_llm = unregister_model
+
 class EngineConfig:
     """Holds internal configuration for a Dynamo engine."""
     ...

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1011,7 +1011,7 @@ class KvRouterConfig:
         """
         ...
 
-async def register_llm(
+async def register_model(
     model_input: ModelInput,
     model_type: ModelType,
     endpoint: Endpoint,
@@ -1040,7 +1040,7 @@ async def register_llm(
     """
     ...
 
-async def unregister_llm(
+async def unregister_model(
     endpoint: Endpoint,
     lora_name: Optional[str] = None,
 ) -> None:
@@ -1055,11 +1055,11 @@ def lora_name_to_id(lora_name: str) -> int:
     """Generate a deterministic integer ID from a LoRA name using blake3 hash."""
     ...
 
-async def fetch_llm(remote_name: str, ignore_weights: bool = False) -> str:
+async def fetch_model(remote_name: str, ignore_weights: bool = False) -> str:
     """
-    Download a model from Hugging Face, returning it's local path.
+    Download a model from Hugging Face, returning its local path.
     If `ignore_weights` is True, only fetches tokenizer and config files.
-    Example: `model_path = await fetch_llm("Qwen/Qwen3-0.6B")`
+    Example: `model_path = await fetch_model("Qwen/Qwen3-0.6B")`
     """
     ...
 

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -29,11 +29,11 @@ from dynamo._core import RouterMode as RouterMode
 from dynamo._core import WorkerMetricsPublisher as WorkerMetricsPublisher
 from dynamo._core import ZmqKvEventListener as ZmqKvEventListener
 from dynamo._core import compute_block_hash_for_seq as compute_block_hash_for_seq
-from dynamo._core import fetch_llm as fetch_llm
+from dynamo._core import fetch_model as fetch_model
 from dynamo._core import lora_name_to_id as lora_name_to_id
 from dynamo._core import make_engine
-from dynamo._core import register_llm as register_llm
+from dynamo._core import register_model as register_model
 from dynamo._core import run_input
-from dynamo._core import unregister_llm as unregister_llm
+from dynamo._core import unregister_model as unregister_model
 
 from .exceptions import HttpError

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -37,3 +37,8 @@ from dynamo._core import run_input
 from dynamo._core import unregister_model as unregister_model
 
 from .exceptions import HttpError
+
+# Backward-compatible aliases
+fetch_llm = fetch_model
+register_llm = register_model
+unregister_llm = unregister_model

--- a/lib/bindings/python/tests/test_tensor.py
+++ b/lib/bindings/python/tests/test_tensor.py
@@ -8,7 +8,7 @@ import os
 import pytest
 import uvloop
 
-from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_model
 from dynamo.runtime import DistributedRuntime
 
 TEST_END_TO_END = os.environ.get("TEST_END_TO_END", 0)
@@ -34,8 +34,8 @@ async def test_register(runtime: DistributedRuntime):
 
     assert model_config == runtime_config.get_tensor_model_config()
 
-    # Use register_llm for tensor-based backends (skips HuggingFace downloads)
-    await register_llm(
+    # Use register_model for tensor-based backends (skips HuggingFace downloads)
+    await register_model(
         ModelInput.Tensor,
         ModelType.TensorBased,
         endpoint,

--- a/lib/llm/src/preprocessor/media/README.md
+++ b/lib/llm/src/preprocessor/media/README.md
@@ -33,7 +33,7 @@ If `enable_image` or `enable_video` are not called, requests containing the corr
 Register the LLM as usual, adding the media configuration:
 
 ```python
-register_llm(
+register_model(
   ...,
   media_decoder=decoder,
   media_fetcher=fetcher,

--- a/tests/frontend/grpc/echo_tensor_worker.py
+++ b/tests/frontend/grpc/echo_tensor_worker.py
@@ -9,7 +9,7 @@
 import tritonclient.grpc.model_config_pb2 as mc
 import uvloop
 
-from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 
@@ -53,8 +53,8 @@ async def echo_tensor_worker(runtime: DistributedRuntime):
     )
     assert model_config == retrieved_model_config
 
-    # Use register_llm for tensor-based backends (skips HuggingFace downloads)
-    await register_llm(
+    # Use register_model for tensor-based backends (skips HuggingFace downloads)
+    await register_model(
         ModelInput.Tensor,
         ModelType.TensorBased,
         endpoint,

--- a/tests/serve/launch/template_verifier.py
+++ b/tests/serve/launch/template_verifier.py
@@ -9,7 +9,7 @@ import uvloop
 from transformers import AutoTokenizer
 
 from dynamo.common.utils.paths import WORKSPACE_DIR
-from dynamo.llm import ModelInput, ModelType, register_llm
+from dynamo.llm import ModelInput, ModelType, register_model
 from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 SERVE_TEST_DIR = os.path.join(WORKSPACE_DIR, "tests/serve")
@@ -54,7 +54,7 @@ async def main(runtime: DistributedRuntime):
 
     # Register model with custom template
     model_name = "Qwen/Qwen3-0.6B"
-    await register_llm(
+    await register_model(
         ModelInput.Tokens,
         ModelType.Chat,
         endpoint,


### PR DESCRIPTION
#### Overview:

Rename `fetch_llm` → `fetch_model`, `register_llm` → `register_model`, and `unregister_llm` → `unregister_model` for better naming consistency. These functions work with various model types (LLMs, embeddings, diffusion models), not just LLMs.

#### Details:

Renamed three core model management functions across Rust bindings and Python components:

- **`fetch_llm` → `fetch_model`**: Downloads models from HuggingFace
- **`register_llm` → `register_model`**: Registers models with Dynamo runtime
- **`unregister_llm` → `unregister_model`**: Unregisters models from Dynamo runtime

Also renamed SGLang wrapper functions:
- `_register_llm_with_runtime_config` → `_register_model_with_runtime_config`
- `register_llm_with_readiness_gate` → `register_model_with_readiness_gate`

**12 files modified** across `lib/bindings/python/rust/` and `components/src/dynamo/` (vllm, sglang, trtllm, frontend, global_router, mocker).

No functional changes - purely a naming refactor.

#### Where should the reviewer start?

Review `lib/bindings/python/rust/lib.rs` (lines 141-143, 229, 409) for core function renames, then check import statements and wrapper functions in `components/src/dynamo/sglang/register.py`.

#### Related Issues:

- Relates to internal naming consistency improvements
https://github.com/ai-dynamo/enhancements/blob/97c2f19692d9c0413d78dd1c62079854a9ed9467/deps/proposal-bindings-v2.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed model fetching API function for improved clarity and consistency across components. The functionality remains unchanged, but applications using this API directly will need to update their function calls accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->