### PR TITLE
fix: Fix MultimodalPDWorkerHandler instantiation

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -1249,12 +1249,12 @@ async def init_multimodal_worker(
         )
     else:
         handler = MultimodalPDWorkerHandler(
-            runtime,
-            component,
-            engine_client,
-            config,
-            decode_worker_client,
-            shutdown_event,
+            runtime=runtime,
+            component=component,
+            engine_client=engine_client,
+            config=config,
+            decode_worker_client=decode_worker_client,
+            shutdown_event=shutdown_event,
         )
     handler.add_temp_dir(prometheus_temp_dir)
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Fix `MultimodalPDWorkerHandler` instantiation which does not provide `encode_worker_client` value added from recent commits.

#### Details:

<!-- Describe the changes made in this PR. -->
While running EPD disaggregated Qwen-VL model with `disagg_multimodal_epd.sh`, `MultimodalPDWorkerHandler` requires `encode_worker_client` parameter, but it is not provided while creating a prefill worker handler.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-visible changes to report. This release includes internal code maintenance that does not affect end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->