### PR TITLE
fix: remove etcd entirely from operator go code

### DIFF
--- a/deploy/helm/charts/platform/Chart.yaml
+++ b/deploy/helm/charts/platform/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
   - name: etcd
     version: 12.0.18
     repository: "https://charts.bitnami.com/bitnami"
-    condition: etcd.enabled
+    condition: global.etcd.install
   - name: kai-scheduler
     version: v0.9.4
     repository: oci://ghcr.io/nvidia/kai-scheduler

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -27,7 +27,7 @@ The Dynamo Platform Helm chart deploys the complete Dynamo Kubernetes Platform i
 
 - **Dynamo Operator**: Kubernetes operator for managing Dynamo deployments
 - **NATS**: High-performance messaging system for component communication
-- **etcd**: Distributed key-value store for operator state management
+- **etcd**: Distributed key-value store for service discovery (optional, disabled by default)
 - **Grove**: Multi-node inference orchestration (optional)
 - **Kai Scheduler**: Advanced workload scheduling (optional)
 
@@ -98,7 +98,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 |-----|------|---------|-------------|
 | dynamo-operator.enabled | bool | `true` | Whether to enable the Dynamo Kubernetes operator deployment |
 | dynamo-operator.natsAddr | string | `""` | NATS server address for operator communication (leave empty to use the bundled NATS chart). Format: "nats://hostname:port" |
-| dynamo-operator.etcdAddr | string | `""` | etcd server address for operator state storage (leave empty to use the bundled etcd chart). Format: "http://hostname:port" or "https://hostname:port" |
+| dynamo-operator.etcdAddr | string | `""` | etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: "http://hostname:port" or "https://hostname:port" |
 | dynamo-operator.nats.enabled | bool | `true` | Whether the NATS is enabled |
 | dynamo-operator.modelExpressURL | string | `""` | URL for the Model Express server if not deployed by this helm chart. This is ignored if Model Express server is installed by this helm chart (global.model-express.enabled is true). |
 | dynamo-operator.namespaceRestriction | object | `{"enabled":false,"lease":{"duration":"30s","renewInterval":"10s"},"targetNamespace":null}` | Namespace access controls for the operator |
@@ -165,7 +165,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 | kai-scheduler.enabled | bool | `false` | Whether to enable Kai Scheduler for intelligent resource allocation, if enabled, the Kai Scheduler operator will be deployed cluster-wide |
 | kai-scheduler.global.tolerations | list | `[]` | Node tolerations for kai-scheduler pods |
 | kai-scheduler.global.affinity | object | `{}` | Affinity for kai-scheduler pods |
-| etcd.enabled | bool | `true` | Whether to enable etcd deployment, disable if you want to use an external etcd instance. For complete configuration options, see: https://github.com/bitnami/charts/tree/main/bitnami/etcd , all etcd settings should be prefixed with "etcd." |
+| global.etcd.install | bool | `false` | Whether to install the bundled etcd subchart. When true, deploys etcd and auto-configures the operator with its address. Use dynamo-operator.etcdAddr to point at an external instance instead. |
 | etcd.image.repository | string | `"bitnamilegacy/etcd"` | following bitnami announcement for brownout - https://github.com/bitnami/charts/tree/main/bitnami/etcd#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog, we need to use the legacy repository until we migrate to the new "secure" repository |
 | nats.enabled | bool | `true` | Whether to enable NATS deployment, disable if you want to use an external NATS instance. For complete configuration options, see: https://github.com/nats-io/k8s/tree/main/helm/charts/nats , all nats settings should be prefixed with "nats." |
 
@@ -176,7 +176,24 @@ For detailed NATS configuration options beyond `nats.enabled`, please refer to t
 
 ### etcd Configuration
 
-For detailed etcd configuration options beyond `etcd.enabled`, please refer to the official Bitnami etcd Helm chart documentation:
+etcd is **no longer required** for the Dynamo platform. The operator uses Kubernetes-native service discovery by default, and the bundled etcd subchart is **disabled by default**.
+
+To enable the bundled etcd subchart (e.g., for etcd-based service discovery):
+
+```yaml
+global:
+  etcd:
+    install: true
+```
+
+To use an external etcd instance instead:
+
+```yaml
+dynamo-operator:
+  etcdAddr: "http://my-external-etcd:2379"
+```
+
+For detailed etcd configuration options, please refer to the official Bitnami etcd Helm chart documentation:
 **[etcd Helm Chart Documentation](https://github.com/bitnami/charts/tree/main/bitnami/etcd)**
 
 ## 📚 Additional Resources

--- a/deploy/helm/charts/platform/README.md.gotmpl
+++ b/deploy/helm/charts/platform/README.md.gotmpl
@@ -27,7 +27,7 @@ The Dynamo Platform Helm chart deploys the complete Dynamo Kubernetes Platform i
 
 - **Dynamo Operator**: Kubernetes operator for managing Dynamo deployments
 - **NATS**: High-performance messaging system for component communication
-- **etcd**: Distributed key-value store for operator state management
+- **etcd**: Distributed key-value store for service discovery (optional, disabled by default)
 - **Grove**: Multi-node inference orchestration (optional)
 - **Kai Scheduler**: Advanced workload scheduling (optional)
 
@@ -93,7 +93,24 @@ For detailed NATS configuration options beyond `nats.enabled`, please refer to t
 
 ### etcd Configuration
 
-For detailed etcd configuration options beyond `etcd.enabled`, please refer to the official Bitnami etcd Helm chart documentation:
+etcd is **no longer required** for the Dynamo platform. The operator uses Kubernetes-native service discovery by default, and the bundled etcd subchart is **disabled by default**.
+
+To enable the bundled etcd subchart (e.g., for etcd-based service discovery):
+
+```yaml
+global:
+  etcd:
+    install: true
+```
+
+To use an external etcd instance instead:
+
+```yaml
+dynamo-operator:
+  etcdAddr: "http://my-external-etcd:2379"
+```
+
+For detailed etcd configuration options, please refer to the official Bitnami etcd Helm chart documentation:
 **[etcd Helm Chart Documentation](https://github.com/bitnami/charts/tree/main/bitnami/etcd)**
 
 

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
         {{- end }}
         {{- if .Values.etcdAddr }}
           - --etcdAddr={{ .Values.etcdAddr }}
-        {{- else }}
+        {{- else if and .Values.global .Values.global.etcd .Values.global.etcd.install }}
           - --etcdAddr={{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.cluster.local:2379
         {{- end }}
         {{- if and .Values.dynamo.istio.enabled .Values.dynamo.istio.gateway }}

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -14,6 +14,13 @@
 # limitations under the License.
 # Used to generate top-level secrets (overridden by custom-values.yaml)
 
+global:
+  etcd:
+    # -- Whether this chart should install the bundled etcd subchart.
+    # When true, deploys etcd and auto-configures the operator with its address.
+    # When false, etcd is not deployed. Use dynamo-operator.etcdAddr to point at an external instance if you are bringing your own etcd.
+    install: false
+
 # Subcharts configuration
 
 # Dynamo operator configuration
@@ -24,7 +31,7 @@ dynamo-operator:
   # -- NATS server address for operator communication (leave empty to use the bundled NATS chart). Format: "nats://hostname:port"
   natsAddr: ""
 
-  # -- etcd server address for operator state storage (leave empty to use the bundled etcd chart). Format: "http://hostname:port" or "https://hostname:port"
+  # -- etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: "http://hostname:port" or "https://hostname:port"
   etcdAddr: ""
 
   nats:
@@ -276,12 +283,9 @@ kai-scheduler:
     # -- Affinity for kai-scheduler pods
     affinity: {}
 
-# etcd configuration - distributed key-value store for operator state
+# etcd configuration - distributed key-value store
+# Installation is controlled by global.etcd.install above.
 etcd:
-
-  # -- Whether to enable etcd deployment, disable if you want to use an external etcd instance. For complete configuration options, see: https://github.com/bitnami/charts/tree/main/bitnami/etcd , all etcd settings should be prefixed with "etcd."
-  enabled: true
-
   image:
     # -- following bitnami announcement for brownout - https://github.com/bitnami/charts/tree/main/bitnami/etcd#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog, we need to use the legacy repository until we migrate to the new "secure" repository
     repository: bitnamilegacy/etcd

--- a/docs/pages/kubernetes/dynamo-operator.md
+++ b/docs/pages/kubernetes/dynamo-operator.md
@@ -201,7 +201,6 @@ helm install dynamo-platform ./platform/ \
   --create-namespace \
   --set "dynamo-operator.controllerManager.manager.image.repository=${DOCKER_SERVER}/dynamo-operator" \
   --set "dynamo-operator.controllerManager.manager.image.tag=${IMAGE_TAG}" \
-  --set etcd.enabled=false \
   --set dynamo-operator.imagePullSecrets[0].name=docker-imagepullsecret
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed ETCD discovery backend support; Kubernetes discovery is now the exclusive service discovery mechanism.
  * Simplified operator configuration by eliminating ETCD-related settings.

* **Chores**
  * Removed unnecessary dependencies from the operator module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->