### PR TITLE
chore: allow frontend + mockers to run on macos

### DIFF
--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -26,7 +26,6 @@ default = []
 media-ffmpeg = ["dynamo-llm/media-ffmpeg"]
 
 [dependencies]
-dynamo-llm = { path = "../../llm", default-features = false }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-parsers = { path = "../../parsers" }
 
@@ -75,7 +74,10 @@ prometheus = "0.14.0"
 
 
 [target.'cfg(target_os = "linux")'.dependencies]
-dynamo-llm = { path = "../../llm", features = ["block-manager"] }
+dynamo-llm = { path = "../../llm" }
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+dynamo-llm = { path = "../../llm", default-features = false }
 
 [dev-dependencies]
 rstest = "0.25"

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -26,7 +26,7 @@ default = []
 media-ffmpeg = ["dynamo-llm/media-ffmpeg"]
 
 [dependencies]
-dynamo-llm = { path = "../../llm" }
+dynamo-llm = { path = "../../llm", default-features = false }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-parsers = { path = "../../parsers" }
 
@@ -73,6 +73,9 @@ dlpark = { version = "0.5", features = ["pyo3", "half"], optional = true }
 cudarc = { version = "0.17.1", features = ["cuda-12020"], optional = true }
 prometheus = "0.14.0"
 
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dynamo-llm = { path = "../../llm", features = ["block-manager"] }
 
 [dev-dependencies]
 rstest = "0.25"

--- a/lib/bindings/python/build.rs
+++ b/lib/bindings/python/build.rs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Build script for dynamo-py3.
+//!
+//! On macOS, nixl-sys unconditionally links `-lstdc++` which doesn't exist
+//! (macOS uses libc++). We create an empty static archive to satisfy the
+//! linker since libc++ is already linked.
+
+fn main() {
+    #[cfg(target_os = "macos")]
+    {
+        let out_dir = std::env::var("OUT_DIR").unwrap();
+        let lib_path = format!("{}/libstdc++.a", out_dir);
+
+        // Write a minimal valid static archive (just the magic header).
+        // macOS `ar` refuses to create an empty archive, so write it directly.
+        std::fs::write(&lib_path, b"!<arch>\n")
+            .expect("failed to create empty libstdc++.a");
+
+        println!("cargo:rustc-link-search=native={}", out_dir);
+    }
+}

--- a/lib/bindings/python/build.rs
+++ b/lib/bindings/python/build.rs
@@ -15,8 +15,7 @@ fn main() {
 
         // Write a minimal valid static archive (just the magic header).
         // macOS `ar` refuses to create an empty archive, so write it directly.
-        std::fs::write(&lib_path, b"!<arch>\n")
-            .expect("failed to create empty libstdc++.a");
+        std::fs::write(&lib_path, b"!<arch>\n").expect("failed to create empty libstdc++.a");
 
         println!("cargo:rustc-link-search=native={}", out_dir);
     }

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -17,7 +17,7 @@ use crate::entrypoint::RouterConfig;
 use crate::mocker::protocols::{MockEngineArgs, WorkerType};
 use crate::model_card::ModelDeploymentCard;
 use crate::model_type::{ModelInput, ModelType};
-use crate::preprocessor::media::{ImageDecoder, MediaDecoder, MediaFetcher};
+use crate::preprocessor::media::{MediaDecoder, MediaFetcher};
 use crate::request_template::RequestTemplate;
 
 pub mod runtime_config;
@@ -245,12 +245,6 @@ impl LocalModelBuilder {
             self.runtime_config.enable_local_indexer = mocker_engine_args.enable_local_indexer
                 && mocker_engine_args.worker_type != WorkerType::Decode;
             self.runtime_config.data_parallel_size = mocker_engine_args.dp_size;
-            self.media_decoder = Some(MediaDecoder {
-                image: Some(ImageDecoder::default()),
-                #[cfg(feature = "media-ffmpeg")]
-                video: None,
-            });
-            self.media_fetcher = Some(MediaFetcher::default());
 
             // Set bootstrap endpoint for prefill workers with bootstrap_port configured
             if mocker_engine_args.worker_type == WorkerType::Prefill

--- a/lib/mocker/src/perf_model.rs
+++ b/lib/mocker/src/perf_model.rs
@@ -204,7 +204,7 @@ impl PerfModel {
         };
         // Ensure non-negative timing
         let result = time.max(0.0);
-        tracing::debug!("Prefill time prediction: new_tokens={new_tokens}, time={result:.2}ms");
+        tracing::trace!("Prefill time prediction: new_tokens={new_tokens}, time={result:.2}ms");
         result
     }
 
@@ -229,7 +229,7 @@ impl PerfModel {
         };
         // Ensure non-negative timing
         let result = time.max(0.0);
-        tracing::debug!(
+        tracing::trace!(
             "Decode time prediction: active_kv_tokens={active_kv_tokens}, context_length={context_length}, time={result:.2}ms"
         );
         result


### PR DESCRIPTION
## Branch Summary

### 1. macOS build support for Python bindings
**Files:** `lib/bindings/python/Cargo.toml`, `lib/bindings/python/build.rs` (new)

- Disables `dynamo-llm`'s default `block-manager` feature on non-Linux to avoid pulling in Linux-only dependencies (`nixl-sys`, `cudarc`, `nix`, `aligned-vec`)
- Re-enables `block-manager` on Linux via `[target.'cfg(target_os = "linux")'.dependencies]` so the Linux build is unchanged
- New `build.rs` creates an empty `libstdc++.a` archive on macOS to work around `nixl-sys` unconditionally emitting `-lstdc++` (macOS uses `libc++`)

### 2. Remove unnecessary media decoder setup from mocker
**File:** `lib/llm/src/local_model.rs`

- Removes `MediaDecoder` and `MediaFetcher` initialization from the mocker engine path in `LocalModelBuilder`
- Drops the now-unused `ImageDecoder` import



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved macOS-specific compilation issue for Python bindings.

* **Refactor**
  * Simplified internal model initialization and improved dependency configuration for better platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->