### PR TITLE
fix: prevent operator deployment when framework builds fail

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -236,14 +236,13 @@ jobs:
     runs-on: prod-default-small-v2
     # Run when any deploy test will run: if core, any framework, or deploy files changed
     if: |
-      always() &&
       (needs.changed-files.outputs.core == 'true' ||
        needs.changed-files.outputs.vllm == 'true' ||
        needs.changed-files.outputs.sglang == 'true' ||
        needs.changed-files.outputs.trtllm == 'true' ||
        needs.changed-files.outputs.deploy == 'true') &&
-      (needs.operator.result == 'success' || needs.operator.result == 'skipped')
-    needs: [changed-files, operator]
+      needs.backend-status-check.result == 'success'
+    needs: [changed-files, operator, backend-status-check]
     outputs:
       NAMESPACE: ${{ steps.deploy-operator-step.outputs.namespace }}
     steps:


### PR DESCRIPTION
## Summary
- Make deploy-operator job depend on backend-status-check to prevent namespace creation when framework builds fail
- Simplifies condition logic by reusing backend-status-check validation instead of duplicating operator checks

## Context
Previously, deploy-operator only depended on [changed-files, operator], which meant it would create a Kubernetes namespace even if framework pipelines (vllm/sglang/trtllm) failed. This polluted the cluster with unused namespaces since deploy tests wouldn't run without successful framework builds.

By adding backend-status-check as a dependency, deploy-operator now waits for all framework pipelines to complete successfully (or be skipped) before creating the namespace. This prevents resource waste while maintaining parallel execution where possible.

## Testing
- [ ] Verify deploy-operator skips when a framework build fails
- [ ] Verify deploy-operator runs when all frameworks succeed or are skipped
- [ ] Verify no Kubernetes namespace is created on framework build failures

## Checklist
- [ ] Human has reviewed AI code
- [ ] Relevant context for this fix has been tracked in this issue and/or in associated linear ticket for future debugging
- [ ] Code follows project conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to add backend status validation as a prerequisite for deployments, ensuring only deployments with successful backend checks proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->