### PR TITLE
fix: use force_reasoning parser for nemotron_nano

### DIFF
--- a/docs/pages/agents/tool-calling.md
+++ b/docs/pages/agents/tool-calling.md
@@ -39,6 +39,7 @@ Parser to Model Mapping
 | llama3_json | meta-llama/Llama-3.1-*, meta-llama/Llama-3.2-* |
 | harmony | openai/gpt-oss-* |
 | nemotron_deci | nvidia/nemotron-* |
+| nemotron_nano | nvidia/NVIDIA-Nemotron-3-Nano-* |
 | phi4 | Phi-4-* |
 | deepseek_v3 | deepseek-ai/DeepSeek-V3, deepseek-ai/DeepSeek-R1, deepseek-ai/DeepSeek-R1-0528 |
 | deepseek_v3_1 | deepseek-ai/DeepSeek-V3.1 |

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -30,7 +30,7 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
         map.insert("step3", ReasoningParserType::Step3);
         map.insert("mistral", ReasoningParserType::Mistral);
         map.insert("granite", ReasoningParserType::Granite);
-        map.insert("nemotron_nano", ReasoningParserType::NemotronDeci); // nemotron nano is <think>...</think>
+        map.insert("nemotron_nano", ReasoningParserType::DeepseekR1); // nemotron nano is ...</think>
         map.insert("glm45", ReasoningParserType::NemotronDeci); // GLM-4.5/5 is <think>...</think>, no force_reasoning
         map.insert(
             "minimax_append_think",


### PR DESCRIPTION
#### Overview:

Nemotron nano should use the force_reasoning parser by default. However, nemotron_nano also supports setting `enable_thinking=false` in the chat template, so we should _not_ force reasoning if that argument is passed. 

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added toggle option to control reasoning processing behavior in chat requests, enabling users to enable or disable advanced reasoning features as needed.

* **Improvements**
  * Updated reasoning parser configuration for enhanced compatibility and better support across different model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->