### PR TITLE
ci: add known_third_party to avoid pre-commit isort failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,13 @@ balanced_wrapping = true
 indent = "    "
 skip = ["build"]
 known_first_party = ["dynamo"]
+# isort may confuse what is 1st or 3rd library. e.g.
+# when dynamo/vllm/omni/xx.py import vllm, local isort may treat this `vllm` as first
+# party heuristically. This causes local sort differs from GitHub sort and pre-commit
+# failure. To mitigate 1) one can install 3rd party lib so that isort is aware of it,
+# 2) hardcode 3rd party lib here, 3) add "# isort: skip_file" to problematic files
+# as the last resort.
+known_third_party = ["vllm", "tensorrt_llm", "sglang"]
 
 [tool.pytest.ini_options]
 minversion = "8.0"


### PR DESCRIPTION
## Why

  Local `isort` may treat imports like `vllm` as first-party when running inside
  a similarly-named package (e.g. `dynamo/vllm/omni/`). This causes local sort
  to differ from GitHub's pre-commit sort, leading to spurious CI failures.

  ## What Changed

  - Added `known_third_party = ["vllm", "tensorrt_llm", "sglang"]` to
    `pyproject.toml` so isort consistently classifies these as third-party

  ## Test Plan

  - Verify pre-commit `isort` passes locally and on CI without `--no-verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated import sorting configuration to ensure consistency across development tooling and build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->