### PR TITLE
fix: wire reasoning parser from worker runtime config into frontend

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -557,11 +557,17 @@ impl ModelManager {
             .and_then(|r| r.value().runtime_config.tool_call_parser.clone())
     }
 
+    pub fn get_model_reasoning_parser(&self, model: &str) -> Option<String> {
+        self.cards
+            .iter()
+            .find(|r| r.value().display_name == model)
+            .and_then(|r| r.value().runtime_config.reasoning_parser.clone())
+    }
+
     /// Creates parsing options with tool call parser and reasoning parser for the specified model.
-    /// Currently reasoning parser is not implemented (returns None).
     pub fn get_parsing_options(&self, model: &str) -> crate::protocols::openai::ParsingOptions {
         let tool_call_parser = self.get_model_tool_call_parser(model);
-        let reasoning_parser = None; // TODO: Implement reasoning parser
+        let reasoning_parser = self.get_model_reasoning_parser(model);
 
         crate::protocols::openai::ParsingOptions::new(tool_call_parser, reasoning_parser)
     }


### PR DESCRIPTION
## Summary

- The frontend's `get_parsing_options()` in `ModelManager` hardcoded `reasoning_parser` to `None` (with a TODO comment), so `reasoning_content` was always null in API responses regardless of the worker's `--dyn-reasoning-parser` setting.
- Added `get_model_reasoning_parser()` method (mirrors existing `get_model_tool_call_parser()`) that reads `reasoning_parser` from the worker's `RuntimeConfig` via service discovery.
- Updated `get_parsing_options()` to call the new method instead of returning `None`.

## Test plan

- Deployed on Nebius with GLM-Z1-0414-A3B (FP8, tp4) using `--dyn-reasoning-parser deepseek_r1`
- Confirmed `reasoning_content` is populated in streaming responses via both OpenAI (`/v1/chat/completions`) and Anthropic (`/v1/messages`) endpoints
- Verified non-reasoning models are unaffected (reasoning_parser remains None when not configured)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to retrieve model reasoning parsers from model configurations.

* **Improvements**
  * Enhanced model parsing options to integrate reasoning parser information for improved AI model handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->