### PR TITLE
ci: add automated version bump workflows for releases

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,0 +1,903 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Dynamo Release Version Bump Script.
+
+Discovery-based version bumper that scans the entire repo for Dynamo version
+references and updates them to the new release version. Used by both Phase 1
+(release branch prep) and Phase 2 (port to main) workflows.
+
+Usage:
+    # Full release: bump all versions to 1.0.0 with backend metadata
+    python3 .github/scripts/bump_version.py \\
+        --new-version 1.0.0 \\
+        --vllm-version 0.15.1 \\
+        --sglang-version 0.5.7 \\
+        --trtllm-version 1.3.0rc1 \\
+        --nixl-version 0.9.0 \\
+        --cuda-versions-vllm 12.9,13.0 \\
+        --cuda-versions-sglang 12.9,13.0 \\
+        --cuda-versions-trtllm 13.0 \\
+        --release-date "Feb 15, 2026"
+
+    # Post-release: Helm-only patch (skip containers, wheels, etc.)
+    python3 .github/scripts/bump_version.py \\
+        --new-version 0.9.0.post1 \\
+        --skip-core --skip-containers --skip-docs
+
+    # Dry run (print changes without writing)
+    python3 .github/scripts/bump_version.py --new-version 1.0.0 --dry-run
+
+    # Check for stale versions (CI mode)
+    python3 .github/scripts/bump_version.py --check --expected-version 0.9.0
+
+Version format conventions:
+    Python / container tags / git:  0.9.0.post1  (PEP 440, dot separator)
+    Rust crates / Helm charts:      0.9.0-post1  (semver, hyphen separator)
+    The script accepts the Python format and auto-converts for Cargo/Helm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator
+
+# ---------------------------------------------------------------------------
+# Version format helpers
+# ---------------------------------------------------------------------------
+
+
+def to_semver(version: str) -> str:
+    """Convert Python PEP 440 post-release to semver format for Cargo/Helm.
+
+    0.9.0.post1 -> 0.9.0-post1
+    1.0.0       -> 1.0.0       (no change for non-post versions)
+    """
+    return re.sub(r"\.post(\d+)$", r"-post\1", version)
+
+
+def is_post_release(version: str) -> bool:
+    """Check if version is a post-release (e.g., 0.9.0.post1)."""
+    return bool(re.search(r"\.post\d+$", version))
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns that identify Dynamo version references
+# ---------------------------------------------------------------------------
+# Version number pattern: X.Y.Z with optional .postN or -postN suffix
+_VER = r"\d+\.\d+\.\d+(?:[.-]post\d+)?"
+
+# Container image tags: ai-dynamo/<any-image>:X.Y.Z
+# Broad match — catches any image name under ai-dynamo/ so new images
+# (epp-image, snapshot-agent, etc.) are picked up automatically.
+IMAGE_TAG_RE = re.compile(
+    r"((?:nvcr\.io/nvidia/)?ai-dynamo/[a-z][a-z0-9-]*)" rf":({_VER})"
+)
+
+# Wheel filenames and pip install specs:
+#   ai_dynamo_runtime-0.7.0-cp310-..., ai-dynamo==0.8.1, ai-dynamo[vllm]==0.8.1.post1
+WHEEL_FILE_RE = re.compile(
+    r"(ai[_-]dynamo(?:[_-]runtime)?(?:\[[^\]]*\])?)" rf"(==|-)({_VER})"
+)
+
+# dynamoVersion: "0.6.0" or "0.9.0.post1" in operator samples
+DYNAMO_VERSION_FIELD_RE = re.compile(rf'(dynamoVersion:\s*")({_VER})(")')
+
+# git checkout release/X.Y.Z or release/X.Y.Z.post1
+GIT_CHECKOUT_RE = re.compile(rf"(git checkout release/)({_VER})")
+
+# git+https://...@release/X.Y.Z (pip git install URLs)
+GIT_REF_RE = re.compile(rf"(@release/)({_VER})")
+
+# DYNAMO_VERSION=X.Y.Z in shell snippets and docs
+DYNAMO_VERSION_ENV_RE = re.compile(rf"(DYNAMO_VERSION=)({_VER})")
+
+# Standalone Dynamo image tags without full registry path (e.g., vllm-runtime:0.8.0)
+# Kept as an explicit list (unlike IMAGE_TAG_RE) to avoid false positives
+# without the ai-dynamo/ prefix as a disambiguator.
+SHORT_IMAGE_TAG_RE = re.compile(
+    r"((?:vllm|sglang|tensorrtllm)-runtime"
+    r"|dynamo-frontend|kubernetes-operator|frontend"
+    r"|epp-image|snapshot-agent)"
+    rf":({_VER})"
+)
+
+# Unified pattern table used by both scan_and_replace and check_stale_versions.
+# (regex, replacement_template, version_group_index, track_spans_for_dedup)
+_VERSION_PATTERNS: list[tuple[re.Pattern, str, int, bool]] = [
+    (IMAGE_TAG_RE, r"\1:{ver}", 2, True),
+    (SHORT_IMAGE_TAG_RE, r"\1:{ver}", 2, True),
+    (WHEEL_FILE_RE, r"\1\g<2>{ver}", 3, False),
+    (DYNAMO_VERSION_FIELD_RE, r"\g<1>{ver}\3", 2, False),
+    (GIT_CHECKOUT_RE, r"\g<1>{ver}", 2, False),
+    (GIT_REF_RE, r"\g<1>{ver}", 2, False),
+    (DYNAMO_VERSION_ENV_RE, r"\g<1>{ver}", 2, False),
+]
+
+# ---------------------------------------------------------------------------
+# Paths excluded from the catch-all discovery scan
+# ---------------------------------------------------------------------------
+EXCLUDE_PATTERNS = [
+    "**/*.lock",
+    "**/go.sum",
+    "**/go.mod",
+    ".git/**",
+    "**/__pycache__/**",
+    "**/node_modules/**",
+    "**/.venv/**",
+    "**/*.pyc",
+    "**/*.png",
+    "**/*.jpg",
+    "**/*.gif",
+    "**/*.woff*",
+    "**/*.ttf",
+    "**/*.ico",
+    "**/*.pdf",
+    # Auto-generated files handled by regen steps
+    "deploy/operator/config/crd/bases/**",
+    "deploy/helm/charts/crds/templates/**",
+    "deploy/helm/charts/platform/README.md",
+    "docs/kubernetes/api-reference.md",
+    "deploy/operator/api/v1alpha1/zz_generated.deepcopy.go",
+    # Test fixtures with intentional old versions
+    "deploy/operator/internal/**/*_test.go",
+    "deploy/operator/internal/checkpoint/**",
+    "deploy/operator/internal/dynamo/graph_test.go",
+    "tests/**",
+    # The bump script itself
+    ".github/scripts/bump_version.py",
+    # Error classification (separate package, has its own version)
+    "error_classification/**",
+]
+
+# Files that get targeted edits (not catch-all replacement).
+# The catch-all scanner skips these; dedicated functions handle them.
+TARGETED_EDIT_FILES = frozenset(
+    {
+        "docs/reference/release-artifacts.md",
+        "docs/reference/support-matrix.md",
+        "docs/reference/feature-matrix.md",
+        "pyproject.toml",
+        "Cargo.toml",
+        "lib/bindings/python/Cargo.toml",
+        "lib/gpu_memory_service/setup.py",
+        "deploy/helm/charts/crds/Chart.yaml",
+        "deploy/helm/charts/platform/Chart.yaml",
+        "deploy/helm/charts/platform/components/operator/Chart.yaml",
+        "deploy/helm/charts/snapshot/Chart.yaml",
+        "deploy/helm/charts/snapshot/values.yaml",
+        # Operator Go source and samples are handled by update_operator_source()
+        "deploy/operator/api/v1alpha1/dynamographdeploymentrequest_types.go",
+        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamographdeploymentrequest.yaml",
+        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml",
+    }
+)
+
+
+def _matches_exclude(rel_path: str) -> bool:
+    """Robust exclusion check using pathlib-style matching."""
+    p = Path(rel_path)
+    for pattern in EXCLUDE_PATTERNS:
+        if p.match(pattern):
+            return True
+        # Handle ** prefix patterns
+        if pattern.startswith("**/"):
+            suffix = pattern[3:]
+            if fnmatch.fnmatch(rel_path, f"*{suffix}") or fnmatch.fnmatch(
+                p.name, suffix
+            ):
+                return True
+        if fnmatch.fnmatch(rel_path, pattern):
+            return True
+    return False
+
+
+def is_binary(filepath: Path) -> bool:
+    """Quick check if a file is binary."""
+    try:
+        with open(filepath, "rb") as f:
+            chunk = f.read(8192)
+            return b"\x00" in chunk
+    except (OSError, PermissionError):
+        return True
+
+
+def _iter_version_files(
+    repo: Path,
+    extra_skip: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, Path, str]]:
+    """Yield (rel_path, filepath, content) for all version-relevant files."""
+    for dirpath, dirnames, filenames in os.walk(repo):
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if not d.startswith(".")
+            and d not in ("node_modules", "__pycache__", ".venv")
+        ]
+        for filename in filenames:
+            filepath = Path(dirpath) / filename
+            rel_path = str(filepath.relative_to(repo))
+            if _matches_exclude(rel_path) or rel_path in extra_skip:
+                continue
+            if is_binary(filepath):
+                continue
+            try:
+                content = filepath.read_text(encoding="utf-8", errors="surrogateescape")
+            except (OSError, UnicodeDecodeError):
+                continue
+            yield rel_path, filepath, content
+
+
+# ===================================================================
+# Category 1: Core version files (targeted edits)
+# ===================================================================
+
+
+def update_pyproject_toml(
+    repo: Path, old_ver: str, new_ver: str, dry_run: bool
+) -> list[str]:
+    """Update version in pyproject.toml."""
+    filepath = repo / "pyproject.toml"
+    changes = []
+    content = filepath.read_text()
+    new_content = content
+
+    # version = "X.Y.Z"
+    new_content = re.sub(
+        rf'(version\s*=\s*"){re.escape(old_ver)}"',
+        rf'\g<1>{new_ver}"',
+        new_content,
+    )
+    # ai-dynamo-runtime==X.Y.Z
+    new_content = re.sub(
+        rf"(ai-dynamo-runtime==){re.escape(old_ver)}",
+        rf"\g<1>{new_ver}",
+        new_content,
+    )
+
+    if new_content != content:
+        changes.append(f"pyproject.toml: version {old_ver} -> {new_ver}")
+        if not dry_run:
+            filepath.write_text(new_content)
+    return changes
+
+
+def update_cargo_toml(
+    repo: Path, old_ver: str, new_ver: str, dry_run: bool
+) -> list[str]:
+    """Auto-discover and update Cargo.toml files containing the old version.
+
+    Scans all Cargo.toml files in the repo (excluding target/ and vendored
+    directories) so newly added workspaces are picked up automatically.
+    Uses semver format (0.9.0-post1) for Cargo files.
+    """
+    changes = []
+    old_semver = to_semver(old_ver)
+    new_semver = to_semver(new_ver)
+
+    skip_dirs = {"target", ".git", "node_modules", "__pycache__", ".venv"}
+    for dirpath, dirnames, filenames in os.walk(repo):
+        dirnames[:] = [d for d in dirnames if d not in skip_dirs]
+        if "Cargo.toml" not in filenames:
+            continue
+        filepath = Path(dirpath) / "Cargo.toml"
+        rel_path = str(filepath.relative_to(repo))
+        content = filepath.read_text()
+        new_content = re.sub(
+            rf'(version\s*=\s*"){re.escape(old_semver)}"',
+            rf'\g<1>{new_semver}"',
+            content,
+        )
+        if new_content != content:
+            changes.append(f"{rel_path}: version {old_semver} -> {new_semver}")
+            if not dry_run:
+                filepath.write_text(new_content)
+    return changes
+
+
+def update_gpu_memory_setup(
+    repo: Path, old_ver: str, new_ver: str, dry_run: bool
+) -> list[str]:
+    """Update version in lib/gpu_memory_service/setup.py."""
+    filepath = repo / "lib/gpu_memory_service/setup.py"
+    if not filepath.exists():
+        return []
+    content = filepath.read_text()
+    new_content = re.sub(
+        rf'(version\s*=\s*"){re.escape(old_ver)}"',
+        rf'\g<1>{new_ver}"',
+        content,
+    )
+    if new_content != content:
+        if not dry_run:
+            filepath.write_text(new_content)
+        return [f"lib/gpu_memory_service/setup.py: version {old_ver} -> {new_ver}"]
+    return []
+
+
+# ===================================================================
+# Category 2: Helm charts (targeted edits)
+# ===================================================================
+
+
+def update_helm_charts(
+    repo: Path, old_ver: str, new_ver: str, dry_run: bool
+) -> list[str]:
+    """Update version fields in Helm Chart.yaml files.
+
+    Handles exact old version, dev-suffixed versions (1.0.0-dev), and
+    post-release versions (0.9.0-post1). Uses semver format for Helm.
+    """
+    changes = []
+    new_semver = to_semver(new_ver)
+    ver_pattern = r"\d+\.\d+\.\d+(?:-(?:dev|post\d+))?"
+
+    # Chart.yaml files: (relative_path, update_appVersion)
+    chart_configs = [
+        ("deploy/helm/charts/crds/Chart.yaml", False),
+        ("deploy/helm/charts/platform/Chart.yaml", False),
+        ("deploy/helm/charts/platform/components/operator/Chart.yaml", True),
+        ("deploy/helm/charts/snapshot/Chart.yaml", True),
+    ]
+
+    for rel_path, update_app_version in chart_configs:
+        filepath = repo / rel_path
+        if not filepath.exists():
+            continue
+        content = filepath.read_text()
+        new_content = re.sub(
+            rf"(^version:\s*){ver_pattern}",
+            rf"\g<1>{new_semver}",
+            content,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        if update_app_version:
+            new_content = re.sub(
+                rf'(^appVersion:\s*"){ver_pattern}"',
+                rf'\g<1>{new_semver}"',
+                new_content,
+                flags=re.MULTILINE,
+            )
+        if new_content != content:
+            changes.append(f"{rel_path}: version -> {new_semver}")
+            if not dry_run:
+                filepath.write_text(new_content)
+
+    # Platform chart: dynamo-operator dependency version
+    platform_chart = repo / "deploy/helm/charts/platform/Chart.yaml"
+    if platform_chart.exists():
+        content = platform_chart.read_text()
+        new_content = re.sub(
+            rf"(  - name: dynamo-operator\n    version:\s*){ver_pattern}",
+            rf"\g<1>{new_semver}",
+            content,
+        )
+        if new_content != content and not dry_run:
+            platform_chart.write_text(new_content)
+
+    # Snapshot values.yaml: image tag
+    snapshot_values = repo / "deploy/helm/charts/snapshot/values.yaml"
+    if snapshot_values.exists():
+        content = snapshot_values.read_text()
+        new_content = re.sub(
+            rf"(repository:\s*nvcr\.io/nvidia/ai-dynamo/snapshot-agent\n\s*tag:\s*){ver_pattern}",
+            rf"\g<1>{new_semver}",
+            content,
+        )
+        if new_content != content:
+            changes.append(
+                "deploy/helm/charts/snapshot/values.yaml: tag -> " + new_semver
+            )
+            if not dry_run:
+                snapshot_values.write_text(new_content)
+
+    return changes
+
+
+# ===================================================================
+# Category 2b: Operator Go source and samples (targeted edits)
+# ===================================================================
+
+
+def update_operator_source(repo: Path, new_ver: str, dry_run: bool) -> list[str]:
+    """Update version references in operator Go source and sample files."""
+    changes = []
+
+    targets = [
+        "deploy/operator/api/v1alpha1/dynamographdeploymentrequest_types.go",
+        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamographdeploymentrequest.yaml",
+        "deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml",
+    ]
+
+    for rel in targets:
+        filepath = repo / rel
+        if not filepath.exists():
+            continue
+        content = filepath.read_text()
+        new_content = content
+
+        # Replace any Dynamo image tags
+        new_content = IMAGE_TAG_RE.sub(rf"\1:{new_ver}", new_content)
+        new_content = SHORT_IMAGE_TAG_RE.sub(rf"\1:{new_ver}", new_content)
+        # Replace dynamoVersion: "X.Y.Z"
+        new_content = DYNAMO_VERSION_FIELD_RE.sub(rf"\g<1>{new_ver}\3", new_content)
+
+        if new_content != content:
+            changes.append(f"{rel}: updated version references -> {new_ver}")
+            if not dry_run:
+                filepath.write_text(new_content)
+
+    return changes
+
+
+# ===================================================================
+# Category 3: Reference documentation (targeted edits)
+# ===================================================================
+
+
+def update_feature_matrix(repo: Path, new_ver: str, dry_run: bool) -> list[str]:
+    """Update the 'Updated for Dynamo vX.Y.Z' line in feature-matrix.md."""
+    filepath = repo / "docs/reference/feature-matrix.md"
+    if not filepath.exists():
+        return []
+    content = filepath.read_text()
+    new_content = re.sub(
+        r"\*Updated for Dynamo v[\d.]+(?:\.post\d+)?\*",
+        f"*Updated for Dynamo v{new_ver}*",
+        content,
+    )
+    if new_content != content:
+        if not dry_run:
+            filepath.write_text(new_content)
+        return [f"feature-matrix.md: updated version tag -> v{new_ver}"]
+    return []
+
+
+def update_support_matrix(
+    repo: Path,
+    new_ver: str,
+    dry_run: bool,
+    backend_versions: dict[str, str | None] | None = None,
+) -> list[str]:
+    """Update support-matrix.md for a new release.
+
+    - Removes '*(in progress)*' from the version row
+    - Updates the "At a Glance" latest stable release line
+    - Adds a new row to the Backend Dependencies table
+    """
+    filepath = repo / "docs/reference/support-matrix.md"
+    if not filepath.exists():
+        return []
+    content = filepath.read_text()
+    original = content
+    changes = []
+    bv = backend_versions or {}
+
+    # Remove "*(in progress)*" from the released version row
+    content = re.sub(
+        rf"(\*\*v{re.escape(new_ver)}\*\*)\s*\*\(in progress\)\*",
+        r"\1",
+        content,
+    )
+
+    if all(bv.get(k) for k in ("sglang", "trtllm", "vllm", "nixl")):
+        # Update "At a Glance" latest stable release line
+        content = re.sub(
+            r"(\*\*Latest stable release:\*\* \[v)[\d.]+\S*"
+            r"(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v)[\d.]+\S*"
+            r"(\) --).*",
+            rf"\g<1>{new_ver}\g<2>{new_ver}\3"
+            rf' SGLang `{bv["sglang"]}` |'
+            rf' TensorRT-LLM `{bv["trtllm"]}` |'
+            rf' vLLM `{bv["vllm"]}` |'
+            rf' NIXL `{bv["nixl"]}`',
+            content,
+        )
+        changes.append(f"support-matrix.md: updated At a Glance for v{new_ver}")
+
+        # Add new row to Backend Dependencies table (after main ToT row)
+        if f"| **v{new_ver}**" not in content:
+            new_row = (
+                f"| **v{new_ver}** "
+                f'| `{bv["sglang"]}` '
+                f'| `{bv["trtllm"]}` '
+                f'| `{bv["vllm"]}` '
+                f'| `{bv["nixl"]}` |'
+            )
+            content = re.sub(
+                r"(\| \*\*main \(ToT\)\*\* \|[^\n]+\n)",
+                rf"\1{new_row}\n",
+                content,
+            )
+            changes.append(
+                f"support-matrix.md: added v{new_ver} to Backend Dependencies"
+            )
+
+    if content != original:
+        if not dry_run:
+            filepath.write_text(content)
+    return changes
+
+
+def update_release_artifacts(
+    repo: Path,
+    new_ver: str,
+    release_date: str | None,
+    dry_run: bool,
+    backend_versions: dict[str, str | None] | None = None,
+) -> list[str]:
+    """Update the Current Release section and add history rows in release-artifacts.md."""
+    filepath = repo / "docs/reference/release-artifacts.md"
+    if not filepath.exists():
+        return []
+    content = filepath.read_text()
+    original = content
+    changes = []
+
+    # Update "Current Release: Dynamo vX.Y.Z" header
+    content = re.sub(
+        r"(## Current Release: Dynamo v)[\d.]+\S*",
+        rf"\g<1>{new_ver}",
+        content,
+    )
+
+    # Update GitHub Release link in current release section
+    content = re.sub(
+        r"(\*\*GitHub Release:\*\* \[v)[\d.]+\S*(\]\(https://github\.com/ai-dynamo/dynamo/releases/tag/v)[\d.]+\S*(\))",
+        rf"\g<1>{new_ver}\g<2>{new_ver}\3",
+        content,
+    )
+
+    # Update Docs link in current release section
+    ver_dashed = new_ver.replace(".", "-")
+    content = re.sub(
+        r"(\*\*Docs:\*\* \[v)[\d.]+\S*(\]\(https://docs\.nvidia\.com/dynamo/v-)[\d-]+\S*(/?\))",
+        rf"\g<1>{new_ver}\g<2>{ver_dashed}\3",
+        content,
+    )
+
+    # Add row to GitHub Releases table if not already present
+    if f"| `v{new_ver}`" not in content:
+        date_str = release_date or datetime.now().strftime("%b %d, %Y")
+        new_row = (
+            f"| `v{new_ver}` | {date_str} "
+            f"| [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v{new_ver}) "
+            f"| [Docs](https://docs.nvidia.com/dynamo/v-{ver_dashed}/) |"
+        )
+        # Insert after the table header row
+        table_pattern = r"(### GitHub Releases\n\n\| Version \|.*\n\|[-| ]+\n)"
+        if re.search(table_pattern, content):
+            content = re.sub(
+                table_pattern,
+                rf"\1{new_row}\n",
+                content,
+            )
+            changes.append(
+                f"release-artifacts.md: added v{new_ver} to GitHub Releases table"
+            )
+        else:
+            print(
+                "WARNING: Could not find GitHub Releases table pattern in "
+                "release-artifacts.md. Skipping table row insertion.",
+                file=sys.stderr,
+            )
+
+    # Update backend versions in Current Release Container Images table
+    # Scoped to "## Current Release" section to avoid touching history tables
+    bv = backend_versions or {}
+    backend_labels = {"vllm": "vLLM", "sglang": "SGLang", "trtllm": "TRT-LLM"}
+    cr_start = content.find("## Current Release")
+    if cr_start >= 0:
+        # Find the next H2 section after Current Release
+        next_h2 = content.find("\n## ", cr_start + 1)
+        if next_h2 < 0:
+            next_h2 = len(content)
+        section = content[cr_start:next_h2]
+        for key, label in backend_labels.items():
+            ver = bv.get(key)
+            if ver:
+                section = re.sub(rf"({label} `)v[^`]+(`)", rf"\g<1>v{ver}\2", section)
+        content = content[:cr_start] + section + content[next_h2:]
+        if bv:
+            changes.append(
+                "release-artifacts.md: updated backend versions in Current Release"
+            )
+
+    if content != original:
+        changes.append(f"release-artifacts.md: updated Current Release to v{new_ver}")
+        if not dry_run:
+            filepath.write_text(content)
+
+    return changes
+
+
+# ===================================================================
+# Category 4: Discovery-based catch-all scan
+# ===================================================================
+
+
+def scan_and_replace(repo: Path, new_ver: str, dry_run: bool) -> list[str]:
+    """Walk the repo and replace all Dynamo version patterns with new_ver."""
+    changes = []
+    for rel_path, filepath, content in _iter_version_files(
+        repo, extra_skip=TARGETED_EDIT_FILES
+    ):
+        new_content = content
+        for regex, repl_template, _, _ in _VERSION_PATTERNS:
+            new_content = regex.sub(repl_template.format(ver=new_ver), new_content)
+        if new_content != content:
+            changes.append(f"{rel_path}: updated version references -> {new_ver}")
+            if not dry_run:
+                filepath.write_text(
+                    new_content, encoding="utf-8", errors="surrogateescape"
+                )
+    return changes
+
+
+# ===================================================================
+# --check mode: scan for stale versions
+# ===================================================================
+
+
+def check_stale_versions(repo: Path, expected_ver: str) -> list[str]:
+    """Scan repo for Dynamo version patterns that don't match expected_ver.
+
+    Returns list of stale reference descriptions. Empty list = all clean.
+    """
+    stale = []
+    skip_files = frozenset(
+        {
+            "docs/reference/release-artifacts.md",
+            "docs/reference/support-matrix.md",
+        }
+    )
+    for rel_path, _, content in _iter_version_files(repo, extra_skip=skip_files):
+        for lineno, line in enumerate(content.splitlines(), 1):
+            reported_spans: set[tuple[int, int]] = set()
+            for regex, _, ver_group, track_spans in _VERSION_PATTERNS:
+                for m in regex.finditer(line):
+                    if track_spans and any(
+                        m.start() >= s and m.end() <= e for s, e in reported_spans
+                    ):
+                        continue
+                    ver = m.group(ver_group)
+                    if ver != expected_ver and not ver.startswith(expected_ver + "."):
+                        stale.append(
+                            f"STALE: {rel_path}:{lineno} -- {m.group(0)} (expected {expected_ver})"
+                        )
+                    if track_spans:
+                        reported_spans.add((m.start(), m.end()))
+    return stale
+
+
+# ===================================================================
+# Auto-detect current version from pyproject.toml
+# ===================================================================
+
+
+def detect_current_version(repo: Path) -> str:
+    """Read the current version from pyproject.toml."""
+    pyproject = repo / "pyproject.toml"
+    content = pyproject.read_text()
+    m = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    if not m:
+        print("ERROR: Could not detect version from pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return m.group(1)
+
+
+# ===================================================================
+# Main
+# ===================================================================
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Dynamo release version bump script",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--new-version", help="Target version (e.g., 1.0.0 or 0.9.0.post1)"
+    )
+    parser.add_argument(
+        "--old-version", help="Current version to replace (auto-detected if omitted)"
+    )
+    parser.add_argument(
+        "--repo-root", default=".", help="Repository root (default: cwd)"
+    )
+
+    # Backend metadata — accepted for forward-compatibility with the release
+    # workflow (which always passes them) but not yet consumed by this script.
+    # Future work: auto-populate support-matrix rows from these values.
+    parser.add_argument("--vllm-version", help="vLLM version (reserved, not yet used)")
+    parser.add_argument(
+        "--sglang-version", help="SGLang version (reserved, not yet used)"
+    )
+    parser.add_argument(
+        "--trtllm-version", help="TRT-LLM version (reserved, not yet used)"
+    )
+    parser.add_argument("--nixl-version", help="NIXL version (reserved, not yet used)")
+    parser.add_argument(
+        "--cuda-versions-vllm", help="CUDA versions for vLLM (reserved, not yet used)"
+    )
+    parser.add_argument(
+        "--cuda-versions-sglang",
+        help="CUDA versions for SGLang (reserved, not yet used)",
+    )
+    parser.add_argument(
+        "--cuda-versions-trtllm",
+        help="CUDA versions for TRT-LLM (reserved, not yet used)",
+    )
+    parser.add_argument("--release-date", help="Release date (e.g., 'Feb 15, 2026')")
+
+    # Modes
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print changes without writing"
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="Check for stale versions (CI mode)"
+    )
+    parser.add_argument("--expected-version", help="Expected version for --check mode")
+
+    # Scope controls (for post-releases or selective bumps)
+    parser.add_argument(
+        "--skip-core",
+        action="store_true",
+        help="Skip core version files (pyproject.toml, Cargo.toml, setup.py)",
+    )
+    parser.add_argument(
+        "--skip-containers",
+        action="store_true",
+        help="Skip discovery-based container image tag scan (docs, recipes, examples)",
+    )
+    parser.add_argument(
+        "--skip-helm",
+        action="store_true",
+        help="Skip Helm Chart.yaml version updates",
+    )
+    parser.add_argument(
+        "--skip-docs",
+        action="store_true",
+        help="Skip reference doc updates (support-matrix, feature-matrix, release-artifacts)",
+    )
+
+    args = parser.parse_args()
+    repo = Path(args.repo_root).resolve()
+
+    # --check mode
+    if args.check:
+        expected = args.expected_version
+        if not expected:
+            expected = detect_current_version(repo)
+        print(f"Checking for stale version references (expected: {expected})...")
+        stale = check_stale_versions(repo, expected)
+        if stale:
+            for s in stale:
+                print(s)
+            print(f"\nFound {len(stale)} stale version reference(s).")
+            sys.exit(1)
+        else:
+            print("All version references are up to date.")
+            sys.exit(0)
+
+    # Bump mode
+    if not args.new_version:
+        parser.error("--new-version is required (unless using --check)")
+
+    new_ver = args.new_version
+    old_ver = args.old_version or detect_current_version(repo)
+
+    if old_ver == new_ver:
+        print(
+            f"WARNING: old version ({old_ver}) == new version ({new_ver}). "
+            "Nothing to bump.",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    if args.dry_run:
+        print(f"DRY RUN: Would bump {old_ver} -> {new_ver}")
+    else:
+        print(f"Bumping version: {old_ver} -> {new_ver}")
+
+    if is_post_release(new_ver):
+        print(f"  Post-release detected: Python={new_ver}, Semver={to_semver(new_ver)}")
+
+    skip_flags = []
+    if args.skip_core:
+        skip_flags.append("core")
+    if args.skip_containers:
+        skip_flags.append("containers")
+    if args.skip_helm:
+        skip_flags.append("helm")
+    if args.skip_docs:
+        skip_flags.append("docs")
+    if skip_flags:
+        print(f"  Skipping: {', '.join(skip_flags)}")
+
+    backend_versions = {
+        "vllm": args.vllm_version,
+        "sglang": args.sglang_version,
+        "trtllm": args.trtllm_version,
+        "nixl": args.nixl_version,
+    }
+
+    all_changes: list[str] = []
+
+    # Category 1: Core version files
+    if not args.skip_core:
+        print("\n=== Category 1: Core version files ===")
+        all_changes.extend(update_pyproject_toml(repo, old_ver, new_ver, args.dry_run))
+        all_changes.extend(update_cargo_toml(repo, old_ver, new_ver, args.dry_run))
+        all_changes.extend(
+            update_gpu_memory_setup(repo, old_ver, new_ver, args.dry_run)
+        )
+    else:
+        print("\n=== Category 1: Core version files [SKIPPED] ===")
+
+    # Category 2: Helm charts
+    if not args.skip_helm:
+        print("\n=== Category 2: Helm charts ===")
+        all_changes.extend(update_helm_charts(repo, old_ver, new_ver, args.dry_run))
+    else:
+        print("\n=== Category 2: Helm charts [SKIPPED] ===")
+
+    # Category 2b: Operator Go source and samples
+    # Part of the CRD regen chain -- update image tags and dynamoVersion fields
+    # in Go doc comments and sample YAMLs before CRD regeneration.
+    if not args.skip_containers:
+        print("\n=== Category 2b: Operator Go source and samples ===")
+        all_changes.extend(update_operator_source(repo, new_ver, args.dry_run))
+    else:
+        print("\n=== Category 2b: Operator Go source and samples [SKIPPED] ===")
+
+    # Category 3: Reference documentation
+    if not args.skip_docs:
+        print("\n=== Category 3: Reference documentation ===")
+        all_changes.extend(update_feature_matrix(repo, new_ver, args.dry_run))
+        all_changes.extend(
+            update_support_matrix(repo, new_ver, args.dry_run, backend_versions)
+        )
+        all_changes.extend(
+            update_release_artifacts(
+                repo, new_ver, args.release_date, args.dry_run, backend_versions
+            )
+        )
+    else:
+        print("\n=== Category 3: Reference documentation [SKIPPED] ===")
+
+    # Category 4: Discovery-based catch-all scan
+    if not args.skip_containers:
+        print("\n=== Category 4: Discovery-based scan (docs, recipes, examples) ===")
+        all_changes.extend(scan_and_replace(repo, new_ver, args.dry_run))
+    else:
+        print("\n=== Category 4: Discovery-based scan [SKIPPED] ===")
+
+    # Summary
+    print(f"\n{'=' * 60}")
+    print(
+        f"{'DRY RUN ' if args.dry_run else ''}Summary: {len(all_changes)} file(s) changed"
+    )
+    print(f"{'=' * 60}")
+    for change in all_changes:
+        print(f"  {'[DRY] ' if args.dry_run else '✅ '}{change}")
+
+    if not all_changes:
+        print(
+            "WARNING: No files were changed. This may indicate the old version "
+            f"({old_ver}) was not found in any target files, or all categories "
+            "were skipped.",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -1,0 +1,451 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Phase 2: Port version bump to main after a GitHub release is published.
+#
+# Full releases (vX.Y.Z):
+#   Auto-triggered on release:published. Updates all version references and
+#   opens a PR to main.
+#
+# Post-releases (vX.Y.Z.postN):
+#   Two options controlled by `post_release_behavior` input:
+#   - "fail" (default): Auto-trigger fails with instructions to use manual trigger
+#   - "skip": Auto-trigger silently skips, no PR created
+#   To bump a post-release, use workflow_dispatch with component checkboxes.
+#
+# Phase 1 (release branch prep) is integrated into release.yml.
+
+name: Release Version Bump
+
+on:
+  release:
+    types: [published]
+
+  # Manual trigger for post-releases or re-runs
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v1.0.0 or v0.9.0.post1)'
+        required: true
+        type: string
+      post_release_behavior:
+        description: 'How auto-trigger handles post-release tags (fail = red X with instructions, skip = silent green check)'
+        required: false
+        type: choice
+        options:
+          - fail
+          - skip
+        default: fail
+      update_core:
+        description: 'Update core version files (pyproject.toml, Cargo.toml, setup.py)'
+        required: false
+        type: boolean
+        default: true
+      update_containers:
+        description: 'Update container image tags across docs, recipes, examples'
+        required: false
+        type: boolean
+        default: true
+      update_helm:
+        description: 'Update Helm Chart.yaml versions'
+        required: false
+        type: boolean
+        default: true
+      update_docs:
+        description: 'Update reference docs (support-matrix, feature-matrix, release-artifacts)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  version-bump-to-main:
+    name: Open PR to main
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Determine tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="$RELEASE_TAG"
+          else
+            TAG="$INPUT_TAG"
+          fi
+
+          # Validate tag format: vX.Y.Z or vX.Y.Z.postN
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$ ]]; then
+            echo "::error::Invalid tag format: $TAG. Must be vX.Y.Z or vX.Y.Z.postN"
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          IS_POST="false"
+          if [[ "$TAG" =~ \.post[0-9]+$ ]]; then
+            IS_POST="true"
+          fi
+
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "is_post=$IS_POST" >> $GITHUB_OUTPUT
+          echo "Tag: $TAG, Version: $VERSION, Post-release: $IS_POST"
+
+      # Post-release gate: fail or skip based on behavior setting
+      - name: Post-release gate
+        if: steps.tag.outputs.is_post == 'true' && github.event_name == 'release'
+        env:
+          BEHAVIOR: ${{ inputs.post_release_behavior || 'fail' }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$BEHAVIOR" = "skip" ]; then
+            echo "::notice::Post-release $TAG detected. Skipping auto version bump (post_release_behavior=skip)."
+            echo "To bump this post-release, run this workflow manually via Actions > workflow_dispatch with component checkboxes."
+            echo "SKIP_REST=true" >> $GITHUB_ENV
+            exit 0
+          else
+            echo "## Post-release detected" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Tag \`$TAG\` is a post-release. Post-releases require manual scope selection." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### How to proceed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "1. Go to **Actions** > **Release Version Bump** > **Run workflow**" >> $GITHUB_STEP_SUMMARY
+            echo "2. Enter tag: \`$TAG\`" >> $GITHUB_STEP_SUMMARY
+            echo "3. Select which components to update:" >> $GITHUB_STEP_SUMMARY
+            echo "   - **update_core**: pyproject.toml, Cargo.toml, setup.py" >> $GITHUB_STEP_SUMMARY
+            echo "   - **update_containers**: Image tags in docs, recipes, examples" >> $GITHUB_STEP_SUMMARY
+            echo "   - **update_helm**: Helm Chart.yaml versions" >> $GITHUB_STEP_SUMMARY
+            echo "   - **update_docs**: support-matrix, feature-matrix, release-artifacts" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Post-release $TAG detected. Post-releases require manual scope selection. Run this workflow via Actions > workflow_dispatch with the component checkboxes."
+            exit 1
+          fi
+
+      # Note: When SKIP_REST=true, all subsequent steps are guarded by
+      # `if: env.SKIP_REST != 'true'` and will be individually skipped.
+      - name: Post-release skip notice
+        if: env.SKIP_REST == 'true'
+        run: echo "Post-release skip is active. All subsequent steps will be individually skipped."
+
+      # Step 1: Checkout the release tag to read context.yaml
+      - name: Checkout release tag
+        if: env.SKIP_REST != 'true'
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          path: release-ref
+
+      # Step 2: Parse backend metadata from container/context.yaml
+      - name: Extract backend metadata
+        if: env.SKIP_REST != 'true'
+        id: metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_CREATED_AT: ${{ github.event.release.created_at }}
+        run: |
+          set -euo pipefail
+          CTX="release-ref/container/context.yaml"
+
+          # Install yq (pinned version for reproducibility)
+          YQ_VERSION="4.52.2"
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+
+          # vLLM version: strip 'v' prefix
+          VLLM_VER=$(yq '.vllm.vllm_ref' "$CTX" | sed 's/^v//')
+          echo "vllm_version=$VLLM_VER" >> $GITHUB_OUTPUT
+
+          # SGLang version: from runtime_image_tag, strip 'v' prefix and '-runtime'/'-cu*-runtime' suffix
+          SGLANG_TAG=$(yq '.sglang."cuda12.9".runtime_image_tag // .sglang.runtime_image_tag // ""' "$CTX")
+          SGLANG_VER=$(echo "$SGLANG_TAG" | sed 's/^v//; s/-cu[0-9]*-runtime$//; s/-runtime$//')
+          echo "sglang_version=$SGLANG_VER" >> $GITHUB_OUTPUT
+
+          # TRT-LLM version: from pip_wheel, extract version after ==
+          TRTLLM_WHEEL=$(yq '.trtllm.pip_wheel' "$CTX")
+          TRTLLM_VER=$(echo "$TRTLLM_WHEEL" | sed 's/.*==//')
+          echo "trtllm_version=$TRTLLM_VER" >> $GITHUB_OUTPUT
+
+          # NIXL version
+          NIXL_VER=$(yq '.dynamo.nixl_ref' "$CTX")
+          echo "nixl_version=$NIXL_VER" >> $GITHUB_OUTPUT
+
+          # CUDA versions for vLLM
+          CUDA_VLLM=$(yq '[.vllm | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
+          echo "cuda_versions_vllm=$CUDA_VLLM" >> $GITHUB_OUTPUT
+
+          # CUDA versions for SGLang
+          CUDA_SGLANG=$(yq '[.sglang | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
+          echo "cuda_versions_sglang=$CUDA_SGLANG" >> $GITHUB_OUTPUT
+
+          # CUDA versions for TRT-LLM (from runtime_image_tag)
+          TRTLLM_RUNTIME_TAG=$(yq '.trtllm.runtime_image_tag' "$CTX")
+          CUDA_TRTLLM=$(echo "$TRTLLM_RUNTIME_TAG" | grep -oP 'cuda\K[\d.]+')
+          echo "cuda_versions_trtllm=$CUDA_TRTLLM" >> $GITHUB_OUTPUT
+
+          # Release date
+          if [ "$EVENT_NAME" = "release" ]; then
+            RELEASE_DATE=$(date -d "$RELEASE_CREATED_AT" "+%b %d, %Y" 2>/dev/null || date "+%b %d, %Y")
+          else
+            RELEASE_DATE=$(date "+%b %d, %Y")
+          fi
+          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
+
+          # Print summary
+          echo "=== Extracted Metadata ==="
+          echo "  vLLM: $VLLM_VER"
+          echo "  SGLang: $SGLANG_VER"
+          echo "  TRT-LLM: $TRTLLM_VER"
+          echo "  NIXL: $NIXL_VER"
+          echo "  CUDA (vLLM): $CUDA_VLLM"
+          echo "  CUDA (SGLang): $CUDA_SGLANG"
+          echo "  CUDA (TRT-LLM): $CUDA_TRTLLM"
+          echo "  Release date: $RELEASE_DATE"
+
+      # Step 3: Checkout main branch
+      - name: Checkout main
+        if: env.SKIP_REST != 'true'
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        with:
+          ref: main
+          fetch-depth: 0
+          path: main-checkout
+
+      # Step 4: Set up tools
+      - name: Set up Python
+        if: env.SKIP_REST != 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Set up Go
+        if: env.SKIP_REST != 'true'
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        with:
+          go-version-file: main-checkout/deploy/operator/go.mod
+
+      - name: Set up Rust
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        run: |
+          set -euo pipefail
+          rustup show active-toolchain
+
+      - name: Install controller-gen
+        if: env.SKIP_REST != 'true'
+        run: |
+          set -euo pipefail
+          cd main-checkout/deploy/operator
+          make controller-gen
+
+      - name: Install helm-docs
+        if: env.SKIP_REST != 'true'
+        run: |
+          set -euo pipefail
+          HELM_DOCS_VERSION="1.14.2"
+          curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xzf - helm-docs
+          sudo mv helm-docs /usr/local/bin/
+
+      # Step 5: Create branch and run version bump
+      - name: Create version-bump branch
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/bump-version-to-${VERSION}"
+          git checkout -b "$BRANCH"
+          echo "branch=$BRANCH" >> $GITHUB_ENV
+
+      - name: Build skip flags
+        if: env.SKIP_REST != 'true'
+        id: flags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          UPDATE_CORE: ${{ inputs.update_core }}
+          UPDATE_CONTAINERS: ${{ inputs.update_containers }}
+          UPDATE_HELM: ${{ inputs.update_helm }}
+          UPDATE_DOCS: ${{ inputs.update_docs }}
+        run: |
+          set -euo pipefail
+          SKIP_FLAGS=""
+
+          # For auto-triggered full releases, all components are updated.
+          # For manual triggers, respect the checkbox inputs.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$UPDATE_CORE" != "true" ]; then
+              SKIP_FLAGS="$SKIP_FLAGS --skip-core"
+            fi
+            if [ "$UPDATE_CONTAINERS" != "true" ]; then
+              SKIP_FLAGS="$SKIP_FLAGS --skip-containers"
+            fi
+            if [ "$UPDATE_HELM" != "true" ]; then
+              SKIP_FLAGS="$SKIP_FLAGS --skip-helm"
+            fi
+            if [ "$UPDATE_DOCS" != "true" ]; then
+              SKIP_FLAGS="$SKIP_FLAGS --skip-docs"
+            fi
+          fi
+
+          echo "skip_flags=$SKIP_FLAGS" >> $GITHUB_OUTPUT
+
+          # Expose individual flags for conditional regen steps
+          echo "skip_core=$( [[ "$SKIP_FLAGS" == *--skip-core* ]] && echo true || echo false )" >> $GITHUB_OUTPUT
+          echo "skip_containers=$( [[ "$SKIP_FLAGS" == *--skip-containers* ]] && echo true || echo false )" >> $GITHUB_OUTPUT
+          echo "skip_helm=$( [[ "$SKIP_FLAGS" == *--skip-helm* ]] && echo true || echo false )" >> $GITHUB_OUTPUT
+          echo "Skip flags: ${SKIP_FLAGS:-none}"
+
+      - name: Run version bump script
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        env:
+          BUMP_VERSION: ${{ steps.tag.outputs.version }}
+          BUMP_VLLM: ${{ steps.metadata.outputs.vllm_version }}
+          BUMP_SGLANG: ${{ steps.metadata.outputs.sglang_version }}
+          BUMP_TRTLLM: ${{ steps.metadata.outputs.trtllm_version }}
+          BUMP_NIXL: ${{ steps.metadata.outputs.nixl_version }}
+          BUMP_CUDA_VLLM: ${{ steps.metadata.outputs.cuda_versions_vllm }}
+          BUMP_CUDA_SGLANG: ${{ steps.metadata.outputs.cuda_versions_sglang }}
+          BUMP_CUDA_TRTLLM: ${{ steps.metadata.outputs.cuda_versions_trtllm }}
+          BUMP_RELEASE_DATE: ${{ steps.metadata.outputs.release_date }}
+          BUMP_SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/bump_version.py \
+            --new-version "$BUMP_VERSION" \
+            --vllm-version "$BUMP_VLLM" \
+            --sglang-version "$BUMP_SGLANG" \
+            --trtllm-version "$BUMP_TRTLLM" \
+            --nixl-version "$BUMP_NIXL" \
+            --cuda-versions-vllm "$BUMP_CUDA_VLLM" \
+            --cuda-versions-sglang "$BUMP_CUDA_SGLANG" \
+            --cuda-versions-trtllm "$BUMP_CUDA_TRTLLM" \
+            --release-date "$BUMP_RELEASE_DATE" \
+            $BUMP_SKIP_FLAGS
+
+      # Step 6: Regenerate Cargo.lock (only if core version files were updated)
+      - name: Regenerate Cargo.lock
+        if: env.SKIP_REST != 'true' && steps.flags.outputs.skip_core != 'true'
+        working-directory: main-checkout
+        run: |
+          set -euo pipefail
+          cargo update --workspace
+
+      # Step 7: Regenerate CRDs (only if operator source was updated, i.e. containers not skipped)
+      - name: Regenerate CRDs
+        if: env.SKIP_REST != 'true' && steps.flags.outputs.skip_containers != 'true'
+        working-directory: main-checkout/deploy/operator
+        run: |
+          set -euo pipefail
+          make generate
+          make manifests
+
+      # Step 8: Regenerate Helm docs (only if Helm charts were updated)
+      - name: Regenerate Helm docs
+        if: env.SKIP_REST != 'true' && steps.flags.outputs.skip_helm != 'true'
+        working-directory: main-checkout/deploy/helm/charts/platform
+        run: |
+          set -euo pipefail
+          helm-docs
+
+      # Step 9: Commit and create PR
+      - name: Commit changes
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          printf -v MSG '%s\n' \
+            "Automated version bump from release v${VERSION}." \
+            "" \
+            "Updates:" \
+            "- Core version files (pyproject.toml, Cargo.toml, setup.py)" \
+            "- Helm chart versions" \
+            "- Operator CRD source and regenerated files" \
+            "- Documentation (support matrix, feature matrix, release artifacts)" \
+            "- Container image tags across docs, recipes, and examples" \
+            "- Cargo.lock files"
+          git commit -s -m "chore: bump version to ${VERSION}" -m "$MSG"
+
+      - name: Push branch
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        env:
+          BRANCH: ${{ env.branch }}
+        run: |
+          set -euo pipefail
+          # Delete remote branch if it already exists (stale from a previous run)
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Remote branch $BRANCH already exists, deleting stale branch..."
+            git push origin --delete "$BRANCH"
+          fi
+          git push -u origin "$BRANCH"
+
+      - name: Create PR
+        if: env.SKIP_REST != 'true'
+        working-directory: main-checkout
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.tag.outputs.version }}
+          IS_POST: ${{ steps.tag.outputs.is_post }}
+          SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
+          VLLM_VER: ${{ steps.metadata.outputs.vllm_version }}
+          SGLANG_VER: ${{ steps.metadata.outputs.sglang_version }}
+          TRTLLM_VER: ${{ steps.metadata.outputs.trtllm_version }}
+          NIXL_VER: ${{ steps.metadata.outputs.nixl_version }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_POST" = "true" ]; then
+            TITLE="chore: bump version to ${VERSION} (post-release)"
+          else
+            TITLE="chore: bump version to ${VERSION}"
+          fi
+
+          printf -v BODY '%s\n' \
+            "## Summary" \
+            "" \
+            "Automated version bump from release v${VERSION}." \
+            "" \
+            "**Backend versions** (derived from \`container/context.yaml\` on the release tag):" \
+            "- vLLM: \`${VLLM_VER}\`" \
+            "- SGLang: \`${SGLANG_VER}\`" \
+            "- TRT-LLM: \`${TRTLLM_VER}\`" \
+            "- NIXL: \`${NIXL_VER}\`" \
+            "" \
+            "**Scope flags**: \`${SKIP_FLAGS:-all components updated}\`" \
+            "" \
+            "### Changes" \
+            "" \
+            "- **Core version files**: pyproject.toml, Cargo.toml, lib/bindings/python/Cargo.toml, lib/gpu_memory_service/setup.py" \
+            "- **Helm charts**: CRDs, platform, operator Chart.yaml + regenerated README" \
+            "- **Operator CRDs**: Go source doc comments updated, CRDs regenerated via \`make generate && make manifests\`" \
+            "- **Reference docs**: support-matrix.md, feature-matrix.md, release-artifacts.md" \
+            "- **Image tags**: Updated across README, docs, recipes, and examples (discovery-based scan)" \
+            "- **Cargo.lock**: Regenerated" \
+            "" \
+            "## Test plan" \
+            "" \
+            "- [ ] Verify version strings are correct in key files" \
+            "- [ ] Verify CRD files pass \`make check\` in deploy/operator/" \
+            "- [ ] Verify no stale version references remain (\`python3 .github/scripts/bump_version.py --check\`)"
+
+          gh pr create \
+            --base main \
+            --title "$TITLE" \
+            --body "$BODY" \
+            --label "release" \
+            --label "chore"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,43 @@ name: Release Pipeline
 on:
   workflow_dispatch:
     inputs:
-      commit_sha:
-        description: 'Git commit SHA whose post-merge CI images to publish (full 40-char SHA).'
+      action:
+        description: 'Action to perform: release-publish (default) runs RC tag + NGC publish; version-bump runs the version bump script only.'
         required: true
-        type: string
-      rc_number:
-        description: 'RC number (e.g., 0 for rc0). Leave empty to auto-increment.'
+        type: choice
+        options:
+          - release-publish
+          - version-bump
+        default: release-publish
+      commit_sha:
+        description: 'Git commit SHA whose post-merge CI images to publish (full 40-char SHA). Only used with release-publish action.'
         required: false
         type: string
+      rc_number:
+        description: 'RC number (e.g., 0 for rc0). Leave empty to auto-increment. Only used with release-publish action.'
+        required: false
+        type: string
+      # Component scope controls for version-bump action (post-releases)
+      update_core:
+        description: 'Update core version files (pyproject.toml, Cargo.toml, setup.py). Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
+      update_containers:
+        description: 'Update container image tags across docs, recipes, examples. Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
+      update_helm:
+        description: 'Update Helm Chart.yaml versions. Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
+      update_docs:
+        description: 'Update reference docs (support-matrix, feature-matrix, release-artifacts). Only used with version-bump action.'
+        required: false
+        type: boolean
+        default: true
 
 # Note: workflow_dispatch can only be triggered from release/* branches
 # This is enforced in the prepare-release job via branch validation
@@ -26,11 +55,176 @@ env:
 
 jobs:
   # ============================================================================
+  # VERSION BUMP (Phase 1): Bump all version references on the release branch
+  # Only runs on workflow_dispatch with action=version-bump.
+  # Uses automated-release environment to bypass branch protection.
+  # ============================================================================
+  version-bump:
+    name: Version Bump (Release Branch Prep)
+    if: inputs.action == 'version-bump'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: automated-release
+    steps:
+      - name: Validate branch
+        run: |
+          set -euo pipefail
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          if [[ ! "$BRANCH_NAME" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$ ]]; then
+            echo "::error::version-bump can only run on release/* branches (current: $BRANCH_NAME)"
+            exit 1
+          fi
+          VERSION="${BRANCH_NAME#release/}"
+          echo "version=$VERSION" >> $GITHUB_ENV
+          echo "branch=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "Version: $VERSION, Branch: $BRANCH_NAME"
+
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: deploy/operator/go.mod
+
+      - name: Install tools (yq, controller-gen, helm-docs)
+        run: |
+          set -euo pipefail
+          # yq
+          YQ_VERSION="4.52.2"
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
+
+          # controller-gen
+          cd deploy/operator && make controller-gen && cd ../..
+
+          # helm-docs
+          HELM_DOCS_VERSION="1.14.2"
+          curl -sSL "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" \
+            | tar -xzf - helm-docs
+          sudo mv helm-docs /usr/local/bin/
+
+      - name: Extract backend metadata from context.yaml
+        id: metadata
+        run: |
+          set -euo pipefail
+          CTX="container/context.yaml"
+
+          VLLM_VER=$(yq '.vllm.vllm_ref' "$CTX" | sed 's/^v//')
+          echo "vllm_version=$VLLM_VER" >> $GITHUB_OUTPUT
+
+          SGLANG_TAG=$(yq '.sglang."cuda12.9".runtime_image_tag // .sglang.runtime_image_tag // ""' "$CTX")
+          SGLANG_VER=$(echo "$SGLANG_TAG" | sed 's/^v//; s/-cu[0-9]*-runtime$//; s/-runtime$//')
+          echo "sglang_version=$SGLANG_VER" >> $GITHUB_OUTPUT
+
+          TRTLLM_WHEEL=$(yq '.trtllm.pip_wheel' "$CTX")
+          TRTLLM_VER=$(echo "$TRTLLM_WHEEL" | sed 's/.*==//')
+          echo "trtllm_version=$TRTLLM_VER" >> $GITHUB_OUTPUT
+
+          NIXL_VER=$(yq '.dynamo.nixl_ref' "$CTX")
+          echo "nixl_version=$NIXL_VER" >> $GITHUB_OUTPUT
+
+          CUDA_VLLM=$(yq '[.vllm | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
+          echo "cuda_versions_vllm=$CUDA_VLLM" >> $GITHUB_OUTPUT
+
+          CUDA_SGLANG=$(yq '[.sglang | keys | .[] | select(test("^cuda"))] | map(sub("^cuda"; "")) | join(",")' "$CTX")
+          echo "cuda_versions_sglang=$CUDA_SGLANG" >> $GITHUB_OUTPUT
+
+          TRTLLM_RUNTIME_TAG=$(yq '.trtllm.runtime_image_tag' "$CTX")
+          CUDA_TRTLLM=$(echo "$TRTLLM_RUNTIME_TAG" | grep -oP 'cuda\K[\d.]+')
+          echo "cuda_versions_trtllm=$CUDA_TRTLLM" >> $GITHUB_OUTPUT
+
+          RELEASE_DATE=$(date "+%b %d, %Y")
+          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
+
+          echo "=== Backend Metadata ==="
+          echo "  vLLM: $VLLM_VER | SGLang: $SGLANG_VER | TRT-LLM: $TRTLLM_VER | NIXL: $NIXL_VER"
+
+      - name: Build skip flags
+        id: flags
+        env:
+          UPDATE_CORE: ${{ inputs.update_core }}
+          UPDATE_CONTAINERS: ${{ inputs.update_containers }}
+          UPDATE_HELM: ${{ inputs.update_helm }}
+          UPDATE_DOCS: ${{ inputs.update_docs }}
+        run: |
+          set -euo pipefail
+          SKIP_FLAGS=""
+          if [ "$UPDATE_CORE" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-core"; fi
+          if [ "$UPDATE_CONTAINERS" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-containers"; fi
+          if [ "$UPDATE_HELM" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-helm"; fi
+          if [ "$UPDATE_DOCS" = "false" ]; then SKIP_FLAGS="$SKIP_FLAGS --skip-docs"; fi
+          echo "skip_flags=$SKIP_FLAGS" >> $GITHUB_OUTPUT
+          echo "Skip flags: ${SKIP_FLAGS:-none (full update)}"
+
+      - name: Run version bump script
+        env:
+          BUMP_SKIP_FLAGS: ${{ steps.flags.outputs.skip_flags }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/bump_version.py \
+            --new-version "${{ env.version }}" \
+            --vllm-version "${{ steps.metadata.outputs.vllm_version }}" \
+            --sglang-version "${{ steps.metadata.outputs.sglang_version }}" \
+            --trtllm-version "${{ steps.metadata.outputs.trtllm_version }}" \
+            --nixl-version "${{ steps.metadata.outputs.nixl_version }}" \
+            --cuda-versions-vllm "${{ steps.metadata.outputs.cuda_versions_vllm }}" \
+            --cuda-versions-sglang "${{ steps.metadata.outputs.cuda_versions_sglang }}" \
+            --cuda-versions-trtllm "${{ steps.metadata.outputs.cuda_versions_trtllm }}" \
+            --release-date "${{ steps.metadata.outputs.release_date }}" \
+            $BUMP_SKIP_FLAGS
+
+      - name: Set up Rust
+        run: |
+          set -euo pipefail
+          rustup show active-toolchain
+
+      - name: Regenerate Cargo.lock
+        run: |
+          set -euo pipefail
+          cargo update --workspace
+
+      - name: Regenerate CRDs
+        working-directory: deploy/operator
+        run: |
+          set -euo pipefail
+          make generate
+          make manifests
+
+      - name: Regenerate Helm docs
+        working-directory: deploy/helm/charts/platform
+        run: |
+          set -euo pipefail
+          helm-docs
+
+      - name: Commit and push
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -s -m "chore: bump version references to ${{ env.version }}"
+            git push
+            echo "Version bump committed to ${{ env.branch }}"
+          fi
+
+  # ============================================================================
   # GATE: Version Extraction
   # ============================================================================
 
   prepare-release:
     name: Prepare Release
+    if: inputs.action != 'version-bump'
     runs-on: prod-default-small-v2
     outputs:
       version: ${{ steps.extract.outputs.version }}


### PR DESCRIPTION
## Summary

- Adds two-phase automated version bump system for Dynamo releases
- Phase 1 (release branch prep) integrates into existing `release.yml`; Phase 2 (port to main) is a new `release-version-bump.yml` workflow
- Shared `bump_version.py` script uses discovery-based scanning to find and update all Dynamo version references across the repo
- Supports both full releases (`vX.Y.Z`) and post-releases (`vX.Y.Z.postN`) with component-level scope control

### Workflow Diagram

```mermaid
flowchart TD
    subgraph phase1 ["Phase 1: Release Branch Prep"]
        A1["workflow_dispatch action: version-bump"] --> B1["Read context.yaml from release branch"]
        B1 --> C1["Run bump_version.py + skip flags"]
        C1 --> D1["Regen CRDs + Cargo.lock + Helm docs"]
        D1 --> E1["Commit to release branch"]
    end

    subgraph existing ["Existing release.yml"]
        E1 --> F1["CI + Build + RC tag + NGC"]
    end

    subgraph tagging ["Tag and Release"]
        F1 --> G1["Manual: create GitHub release vX.Y.Z"]
    end

    subgraph phase2 ["Phase 2: Port to Main"]
        G1 --> H1{"Post-release tag?"}
        H1 -->|No| I1["Read context.yaml from tag"]
        H1 -->|Yes| J1["Fail with instructions to use manual trigger"]
        I1 --> K1["Checkout main, create branch"]
        K1 --> L1["Run bump_version.py"]
        L1 --> M1["Regen CRDs + Cargo.lock + Helm docs"]
        M1 --> N1["Open PR to main"]
    end

    subgraph manual ["Manual Post-Release"]
        J1 -.-> O1["workflow_dispatch with component checkboxes"]
        O1 --> P1["Run bump_version.py + skip flags"]
        P1 --> N1
    end
```

## Details

### Phase 1: Release Branch Prep (`release.yml`)
- New `workflow_dispatch` action `version-bump` added alongside existing `release-publish`
- Runs on `release/*` branches using the `automated-release` environment
- Reads backend metadata from `container/context.yaml`, runs `bump_version.py`, regenerates CRDs, Cargo.lock, and Helm docs, commits to the release branch

### Phase 2: Port to Main (`release-version-bump.yml`)
- Auto-triggers on `release: published` for full releases
- For post-releases: fails with clear instructions to use manual `workflow_dispatch` with component checkboxes
- Creates a branch `chore/bump-version-to-X.Y.Z` and opens a PR to `main`

### Shared Script (`.github/scripts/bump_version.py`)
- **Discovery-based scanning**: Walks the entire repo matching Dynamo-specific version patterns (image tags, wheel refs, git checkout refs, dynamoVersion fields, env vars)
- **Self-healing image matching**: Broad `ai-dynamo/*` regex catches any image name automatically -- no hardcoded list to maintain
- **Auto-discovers Cargo.toml files**: Scans all workspaces instead of hardcoding paths, so new crates are picked up automatically
- **Targeted edits**: Core version files (pyproject.toml, Cargo.toml, setup.py), Helm charts (platform, operator, CRDs, snapshot), operator Go source (before CRD regen), reference docs
- **Post-release support**: `to_semver()` converts `.postN` to `-postN` for Cargo/Helm; `--skip-core`, `--skip-containers`, `--skip-helm`, `--skip-docs` flags for selective scope
- **CI modes**: `--check` scans for stale versions (exit 1 if found), `--dry-run` previews all changes

### Version Format Handling

| Context | Format | Example |
|---------|--------|---------|
| Python, containers, git | .postN | 0.9.0.post1 |
| Rust crates, Helm charts | -postN | 0.9.0-post1 |

### Robustness vs Previous Version

This is a rewrite of the original PR, rebased on current main with these improvements:

| Area | Before | After |
|------|--------|-------|
| Image names | Hardcoded list (missed epp-image, snapshot-agent) | Broad `ai-dynamo/*` regex |
| Cargo.toml | Hardcoded 2 paths (missed kvbm, runtime/examples) | Auto-discovers all workspaces |
| Docs paths | `docs/pages/reference/` (wrong -- targeted edits silently failed) | `docs/reference/` (correct) |
| Git refs | Only `git checkout release/` | Also `@release/` (pip git URLs) |
| Env vars | Not handled | `DYNAMO_VERSION=X.Y.Z` pattern |
| Helm charts | Platform + operator only | Also snapshot Chart.yaml + values.yaml |
| K8s API ref | Wrong exclude paths (api_reference vs api-reference) | Correct exclude; handled via CRD regen chain |
| Phase 1 Cargo.lock | Not regenerated | `cargo update --workspace` after Cargo.toml bump |
| release.yml | Complete rewrite (caused merge conflicts) | Minimal additive changes (version-bump job + inputs) |

## Where Should the Reviewer Start?

- `.github/scripts/bump_version.py` -- the core logic
- `.github/workflows/release-version-bump.yml` -- Phase 2 workflow
- `.github/workflows/release.yml` -- Phase 1 additions (search for `version-bump`)

## Test Plan

- [x] `--dry-run` tested against current main: 67 files correctly identified for full release bump
- [x] `--check` mode tested: correctly flags stale version references with line numbers
- [x] Post-release `--skip-*` flags tested: selective scope works
- [x] Pre-commit hooks pass (black, isort, ruff, flake8, codespell, yaml check)
- [ ] CI passes
- [ ] Manual test of Phase 1 on a release branch
- [ ] Manual test of Phase 2 via workflow_dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated version bump script and new GitHub Actions workflow for release version management
  * Extended release workflow with configurable scope inputs to control which components are updated (core, containers, Helm, docs)
  * Introduced post-release variant support and dry-run capabilities in version updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->