### PR TITLE
feat: add least-loaded router

### DIFF
--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -189,7 +189,14 @@ class FrontendArgGroup(ArgGroup):
             "routes to the one with fewer in-flight requests. In disaggregated prefill "
             "mode, power-of-two skips bootstrap optimization and falls back to the "
             "synchronous prefill path.",
-            choices=["round-robin", "random", "power-of-two", "kv", "direct", "least-loaded"],
+            choices=[
+                "round-robin",
+                "random",
+                "power-of-two",
+                "kv",
+                "direct",
+                "least-loaded",
+            ],
         )
         add_argument(
             g,

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -189,7 +189,7 @@ class FrontendArgGroup(ArgGroup):
             "routes to the one with fewer in-flight requests. In disaggregated prefill "
             "mode, power-of-two skips bootstrap optimization and falls back to the "
             "synchronous prefill path.",
-            choices=["round-robin", "random", "power-of-two", "kv", "direct"],
+            choices=["round-robin", "random", "power-of-two", "kv", "direct", "least-loaded"],
         )
         add_argument(
             g,

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -186,9 +186,10 @@ class FrontendArgGroup(ArgGroup):
             env_var="DYN_ROUTER_MODE",
             default="round-robin",
             help="How to route the request. power-of-two picks 2 random workers and "
-            "routes to the one with fewer in-flight requests. In disaggregated prefill "
-            "mode, power-of-two skips bootstrap optimization and falls back to the "
-            "synchronous prefill path.",
+            "routes to the one with fewer in-flight requests. least-loaded routes to "
+            "the worker with the fewest active requests. In disaggregated prefill mode, "
+            "both power-of-two and least-loaded skip bootstrap optimization and fall "
+            "back to the synchronous prefill path.",
             choices=[
                 "round-robin",
                 "random",

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -7,7 +7,8 @@
 # - OpenAI HTTP server.
 # - Auto-discovery: Watches etcd for engine/worker registration (via `register_model`).
 # - Pre-processor: Prompt templating and tokenization.
-# - Router, defaulting to round-robin. Use --router-mode to switch (round-robin, random, kv, direct, least-loaded).
+# - Router, defaulting to round-robin. Use --router-mode to switch
+#   (round-robin, random, kv, direct, least-loaded).
 #
 # Pass `--interactive` or `-i` for text chat instead of HTTP server.
 #
@@ -236,9 +237,6 @@ async def async_main():
     else:
         router_mode = RouterMode.RoundRobin
         kv_router_config = None
-
-    if router_mode == RouterMode.LeastLoaded and config.enforce_disagg:
-        raise ValueError("least-loaded routing is not supported in disaggregated mode.")
 
     os.environ[MIN_INITIAL_WORKERS_ENV] = str(config.min_initial_workers)
     router_config = RouterConfig(

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -7,7 +7,7 @@
 # - OpenAI HTTP server.
 # - Auto-discovery: Watches etcd for engine/worker registration (via `register_model`).
 # - Pre-processor: Prompt templating and tokenization.
-# - Router, defaulting to round-robin. Use --router-mode to switch (round-robin, random, kv, direct).
+# - Router, defaulting to round-robin. Use --router-mode to switch (round-robin, random, kv, direct, least-loaded).
 #
 # Pass `--interactive` or `-i` for text chat instead of HTTP server.
 #
@@ -229,6 +229,9 @@ async def async_main():
         kv_router_config = None
     elif config.router_mode == "power-of-two":
         router_mode = RouterMode.PowerOfTwoChoices
+        kv_router_config = None
+    elif config.router_mode == "least-loaded":
+        router_mode = RouterMode.LeastLoaded
         kv_router_config = None
     else:
         router_mode = RouterMode.RoundRobin

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -237,6 +237,9 @@ async def async_main():
         router_mode = RouterMode.RoundRobin
         kv_router_config = None
 
+    if router_mode == RouterMode.LeastLoaded and config.enforce_disagg:
+        raise ValueError("least-loaded routing is not supported in disaggregated mode.")
+
     os.environ[MIN_INITIAL_WORKERS_ENV] = str(config.min_initial_workers)
     router_config = RouterConfig(
         router_mode,

--- a/docs/components/frontend/README.md
+++ b/docs/components/frontend/README.md
@@ -85,7 +85,7 @@ spec:
 |-----------|---------|-------------|
 | `--http-port` | 8000 | HTTP server port |
 | `--kserve-grpc-server` | false | Enable KServe gRPC server |
-| `--router-mode` | `round-robin` | Routing strategy: `round-robin`, `random`, `kv`, `direct`, `least-loaded` |
+| `--router-mode` | `round-robin` | Routing strategy: `round-robin`, `random`, `kv`, `direct`, `least-loaded` (`power-of-two` and `least-loaded` use synchronous prefill fallback in disaggregated prefill mode) |
 
 See the [Frontend Guide](frontend-guide.md) for full configuration options.
 

--- a/docs/components/frontend/README.md
+++ b/docs/components/frontend/README.md
@@ -85,7 +85,7 @@ spec:
 |-----------|---------|-------------|
 | `--http-port` | 8000 | HTTP server port |
 | `--kserve-grpc-server` | false | Enable KServe gRPC server |
-| `--router-mode` | `round-robin` | Routing strategy: `round-robin`, `random`, `kv`, `direct` |
+| `--router-mode` | `round-robin` | Routing strategy: `round-robin`, `random`, `kv`, `direct`, `least-loaded` |
 
 See the [Frontend Guide](frontend-guide.md) for full configuration options.
 

--- a/docs/components/router/README.md
+++ b/docs/components/router/README.md
@@ -46,7 +46,7 @@ For all CLI arguments, environment variables, K8s deployment examples, and tunin
 **Limitations:**
 - Static endpoints not supported—KV router requires dynamic model discovery via etcd to track worker instances and their KV cache states
 
-For basic model registration without KV routing, use `--router-mode round-robin` or `--router-mode random` with both static and dynamic endpoints.
+For basic model registration without KV routing, use `--router-mode round-robin`, `--router-mode random`, or `--router-mode least-loaded` with both static and dynamic endpoints.
 
 ## Next Steps
 

--- a/docs/components/router/router-guide.md
+++ b/docs/components/router/router-guide.md
@@ -20,6 +20,7 @@ The Dynamo router can be deployed in several configurations. The table below sho
 | **Frontend + Random** | `python -m dynamo.frontend --router-mode random` | Random worker selection | None | Aggregated | Stateless load balancing |
 | **Frontend + KV (Aggregated)** | `python -m dynamo.frontend --router-mode kv` | KV cache overlap + load | NATS Core / JetStream / ZMQ / Approx | Aggregated | Production single-pool serving with cache reuse |
 | **Frontend + KV (Disaggregated)** | `python -m dynamo.frontend --router-mode kv` with prefill + decode workers | KV cache overlap + load | NATS Core / JetStream / ZMQ / Approx | Disaggregated (prefill + decode pools) | Separate prefill/decode for large-scale serving |
+| **Frontend + Least-Loaded** | `python -m dynamo.frontend --router-mode least-loaded` | Fewest active connections | None | Aggregated | Simple load-aware balancing without KV awareness |
 | **Frontend + Direct** | `python -m dynamo.frontend --router-mode direct` | Worker ID from request hints | None | Aggregated | External orchestrator (e.g., EPP/GAIE) selects workers |
 | **Standalone Router** | `python -m dynamo.router` | KV cache overlap + load | NATS Core / JetStream / ZMQ | Any | Routing without the HTTP frontend (multi-tier, custom pipelines) |
 
@@ -30,6 +31,7 @@ The Dynamo router can be deployed in several configurations. The table below sho
 | **Round-Robin** | `round-robin` (default) | Cycles through available workers in order |
 | **Random** | `random` | Selects a random worker for each request |
 | **KV** | `kv` | Evaluates KV cache overlap and decode load per worker; picks lowest cost |
+| **Least-Loaded** | `least-loaded` | Routes to the worker with fewest active connections |
 | **Direct** | `direct` | Reads the target `worker_id` from the request's routing hints; no selection logic |
 
 ### KV Event Transport Modes (within `--router-mode kv`)
@@ -214,6 +216,7 @@ We can then use the default routing methods exposed by the client class to send 
 - **Random routing**: Default strategy, available via `client.generate()` or `client.random()`
 - **Round-robin routing**: Cycles through available workers via `client.round_robin()`
 - **Direct routing**: Explicitly targets a specific worker via `client.direct(input, component_id)`
+- **Least-loaded routing**: Routes to the worker with fewest active connections via `--router-mode least-loaded`
 
 KV Cache routing uses direct routing with a special worker selection algorithm.
 

--- a/docs/components/router/router-guide.md
+++ b/docs/components/router/router-guide.md
@@ -20,7 +20,7 @@ The Dynamo router can be deployed in several configurations. The table below sho
 | **Frontend + Random** | `python -m dynamo.frontend --router-mode random` | Random worker selection | None | Aggregated | Stateless load balancing |
 | **Frontend + KV (Aggregated)** | `python -m dynamo.frontend --router-mode kv` | KV cache overlap + load | NATS Core / JetStream / ZMQ / Approx | Aggregated | Production single-pool serving with cache reuse |
 | **Frontend + KV (Disaggregated)** | `python -m dynamo.frontend --router-mode kv` with prefill + decode workers | KV cache overlap + load | NATS Core / JetStream / ZMQ / Approx | Disaggregated (prefill + decode pools) | Separate prefill/decode for large-scale serving |
-| **Frontend + Least-Loaded** | `python -m dynamo.frontend --router-mode least-loaded` | Fewest active connections | None | Aggregated | Simple load-aware balancing without KV awareness |
+| **Frontend + Least-Loaded** | `python -m dynamo.frontend --router-mode least-loaded` | Fewest active connections | None | Aggregated or disaggregated fallback | Simple load-aware balancing without KV awareness |
 | **Frontend + Direct** | `python -m dynamo.frontend --router-mode direct` | Worker ID from request hints | None | Aggregated | External orchestrator (e.g., EPP/GAIE) selects workers |
 | **Standalone Router** | `python -m dynamo.router` | KV cache overlap + load | NATS Core / JetStream / ZMQ | Any | Routing without the HTTP frontend (multi-tier, custom pipelines) |
 
@@ -31,7 +31,7 @@ The Dynamo router can be deployed in several configurations. The table below sho
 | **Round-Robin** | `round-robin` (default) | Cycles through available workers in order |
 | **Random** | `random` | Selects a random worker for each request |
 | **KV** | `kv` | Evaluates KV cache overlap and decode load per worker; picks lowest cost |
-| **Least-Loaded** | `least-loaded` | Routes to the worker with fewest active connections |
+| **Least-Loaded** | `least-loaded` | Routes to the worker with fewest active connections; in disaggregated prefill paths it skips bootstrap optimization and falls back to synchronous prefill |
 | **Direct** | `direct` | Reads the target `worker_id` from the request's routing hints; no selection logic |
 
 ### KV Event Transport Modes (within `--router-mode kv`)
@@ -217,6 +217,7 @@ We can then use the default routing methods exposed by the client class to send 
 - **Round-robin routing**: Cycles through available workers via `client.round_robin()`
 - **Direct routing**: Explicitly targets a specific worker via `client.direct(input, component_id)`
 - **Least-loaded routing**: Routes to the worker with fewest active connections via `--router-mode least-loaded`
+  In disaggregated prefill paths it skips bootstrap optimization and uses the synchronous prefill path, matching power-of-two routing.
 
 KV Cache routing uses direct routing with a special worker selection algorithm.
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -51,6 +51,7 @@ pub enum RouterMode {
     /// Direct routing - reads worker ID from each request's routing hints.
     /// Used when an external orchestrator (e.g., EPP) handles worker selection.
     Direct,
+    LeastLoaded,
 }
 
 impl From<RouterMode> for RsRouterMode {
@@ -61,6 +62,7 @@ impl From<RouterMode> for RsRouterMode {
             RouterMode::PowerOfTwoChoices => Self::PowerOfTwoChoices,
             RouterMode::KV => Self::KV,
             RouterMode::Direct => Self::Direct,
+            RouterMode::LeastLoaded => Self::LeastLoaded,
         }
     }
 }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1150,7 +1150,7 @@ class RouterConfig:
         Create a RouterConfig.
 
         Args:
-            mode: The router mode (RoundRobin, Random, KV, or Direct)
+            mode: The router mode (RoundRobin, Random, KV, Direct, or LeastLoaded)
             config: Optional KV router configuration (used when mode is KV)
             active_decode_blocks_threshold: Threshold percentage (0.0-1.0) for decode blocks busy detection
             active_prefill_tokens_threshold: Literal token count threshold for prefill busy detection

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1129,6 +1129,7 @@ class RouterMode:
     PowerOfTwoChoices: "RouterMode"
     KV: "RouterMode"
     Direct: "RouterMode"
+    LeastLoaded: "RouterMode"
     ...
 
 class RouterConfig:

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -336,7 +336,10 @@ where
         RouterMode::Direct => {
             ServiceBackend::from_engine(Arc::new(DirectRoutingRouter::new(router)))
         }
-        RouterMode::Random | RouterMode::RoundRobin | RouterMode::PowerOfTwoChoices => {
+        RouterMode::Random
+        | RouterMode::RoundRobin
+        | RouterMode::PowerOfTwoChoices
+        | RouterMode::LeastLoaded => {
             ServiceBackend::from_engine(Arc::new(router))
         }
         RouterMode::KV => {

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -339,9 +339,7 @@ where
         RouterMode::Random
         | RouterMode::RoundRobin
         | RouterMode::PowerOfTwoChoices
-        | RouterMode::LeastLoaded => {
-            ServiceBackend::from_engine(Arc::new(router))
-        }
+        | RouterMode::LeastLoaded => ServiceBackend::from_engine(Arc::new(router)),
         RouterMode::KV => {
             let Some(chooser) = chooser else {
                 anyhow::bail!("RouterMode::KV requires KVRouter to not be null");

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -64,8 +64,8 @@ mod registry;
 pub mod service;
 
 pub use client::Client;
-pub(crate) use client::LeastLoadedState;
-pub(crate) use client::get_or_create_least_loaded_state;
+pub(crate) use client::RoutingOccupancyState;
+pub(crate) use client::get_or_create_routing_occupancy_state;
 pub use endpoint::build_transport_type;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -64,6 +64,8 @@ mod registry;
 pub mod service;
 
 pub use client::Client;
+pub(crate) use client::LeastLoadedState;
+pub(crate) use client::get_or_create_least_loaded_state;
 pub use endpoint::build_transport_type;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{collections::HashMap, time::Duration};
 
 use anyhow::Result;

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::{collections::HashMap, time::Duration};
 
 use anyhow::Result;
 use arc_swap::ArcSwap;
+use dashmap::DashMap;
 use futures::StreamExt;
 use tokio::net::unix::pipe::Receiver;
 
@@ -41,6 +43,8 @@ pub struct Client {
     /// Interval for periodic reconciliation of instance_avail with instance_source.
     /// This ensures instances removed via `report_instance_down` are eventually restored.
     reconcile_interval: Duration,
+    /// Active connection count per instance for least-loaded routing: instance_id -> count
+    instance_connections: Arc<DashMap<u64, AtomicU64>>,
 }
 
 impl Client {
@@ -80,6 +84,7 @@ impl Client {
             instance_avail_tx: Arc::new(avail_tx),
             instance_avail_rx: avail_rx,
             reconcile_interval,
+            instance_connections: Arc::new(DashMap::new()),
         };
         client.monitor_instance_source();
         Ok(client)
@@ -157,6 +162,39 @@ impl Client {
         self.instance_free.store(Arc::new(free_ids));
     }
 
+    /// Increment the active connection count for an instance (for least-loaded routing).
+    pub fn increment_connections(&self, instance_id: u64) {
+        self.instance_connections
+            .entry(instance_id)
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Decrement the active connection count for an instance (for least-loaded routing).
+    pub fn decrement_connections(&self, instance_id: u64) {
+        if let Some(count) = self.instance_connections.get(&instance_id) {
+            count.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Get the active connection count for an instance.
+    pub fn connection_count(&self, instance_id: u64) -> u64 {
+        self.instance_connections
+            .get(&instance_id)
+            .map(|c| c.load(Ordering::Relaxed))
+            .unwrap_or(0)
+    }
+
+    /// Get the available instance with the lowest active connection count.
+    /// Returns None if no instances are available.
+    pub fn least_loaded_instance(&self) -> Option<u64> {
+        let instance_ids = self.instance_ids_avail();
+        instance_ids
+            .iter()
+            .min_by_key(|&&id| self.connection_count(id))
+            .copied()
+    }
+
     /// Monitor the key-value instance source and update instance_avail.
     ///
     /// This function also performs periodic reconciliation: if `instance_source` hasn't
@@ -180,6 +218,11 @@ impl Client {
                 // TODO: this resets both tracked available and free instances
                 client.instance_avail.store(Arc::new(instance_ids.clone()));
                 client.instance_free.store(Arc::new(instance_ids.clone()));
+
+                // Clean up stale connection counters for instances that no longer exist
+                client
+                    .instance_connections
+                    .retain(|id, _| instance_ids.contains(id));
 
                 // Send update to watch channel subscribers
                 let _ = client.instance_avail_tx.send(instance_ids);

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -23,6 +23,73 @@ use crate::{
     transports::etcd::Client as EtcdClient,
 };
 
+/// Shared state for least-loaded routing
+#[derive(Debug, Default)]
+pub(crate) struct LeastLoadedState {
+    /// Active connection count per instance: instance_id -> count
+    connections: DashMap<u64, AtomicU64>,
+    lock: std::sync::Mutex<()>,
+}
+
+impl LeastLoadedState {
+    /// Acquire the selection lock, pick the least-loaded instance, and increment its count.
+    /// Returns the selected instance ID, or None if no instances are available.
+    pub(crate) fn select_and_increment(&self, instance_ids: &[u64]) -> Option<u64> {
+        let _guard = self.lock.lock().unwrap();
+        let id = *instance_ids
+            .iter()
+            .min_by_key(|&&id| self.connection_count(id))?;
+        self.increment(id);
+        Some(id)
+    }
+
+    fn increment(&self, instance_id: u64) {
+        self.connections
+            .entry(instance_id)
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn decrement(&self, instance_id: u64) {
+        if let Some(count) = self.connections.get(&instance_id) {
+            let _ = count.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                Some(current.saturating_sub(1))
+            });
+        }
+    }
+
+    pub(crate) fn connection_count(&self, instance_id: u64) -> u64 {
+        self.connections
+            .get(&instance_id)
+            .map(|c| c.load(Ordering::Relaxed))
+            .unwrap_or(0)
+    }
+
+    /// Remove counters for instances that no longer exist.
+    pub(crate) fn retain(&self, instance_ids: &[u64]) {
+        self.connections.retain(|id, _| instance_ids.contains(id));
+    }
+}
+
+/// Get or create the shared least-loaded state for an endpoint.
+pub(crate) async fn get_or_create_least_loaded_state(endpoint: &Endpoint) -> Arc<LeastLoadedState> {
+    let drt = endpoint.drt();
+    let registry = drt.least_loaded_states();
+    let mut registry = registry.lock().await;
+
+    if let Some(weak) = registry.get(endpoint) {
+        if let Some(state) = weak.upgrade() {
+            return state;
+        } else {
+            registry.remove(endpoint);
+        }
+    }
+
+    let state = Arc::new(LeastLoadedState::default());
+    registry.insert(endpoint.clone(), Arc::downgrade(&state));
+    state
+}
+
 /// Default interval for periodic reconciliation of instance_avail with instance_source
 const DEFAULT_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -43,8 +110,6 @@ pub struct Client {
     /// Interval for periodic reconciliation of instance_avail with instance_source.
     /// This ensures instances removed via `report_instance_down` are eventually restored.
     reconcile_interval: Duration,
-    /// Active connection count per instance for least-loaded routing: instance_id -> count
-    instance_connections: Arc<DashMap<u64, AtomicU64>>,
 }
 
 impl Client {
@@ -84,7 +149,6 @@ impl Client {
             instance_avail_tx: Arc::new(avail_tx),
             instance_avail_rx: avail_rx,
             reconcile_interval,
-            instance_connections: Arc::new(DashMap::new()),
         };
         client.monitor_instance_source();
         Ok(client)
@@ -162,41 +226,6 @@ impl Client {
         self.instance_free.store(Arc::new(free_ids));
     }
 
-    /// Increment the active connection count for an instance (for least-loaded routing).
-    pub fn increment_connections(&self, instance_id: u64) {
-        self.instance_connections
-            .entry(instance_id)
-            .or_insert_with(|| AtomicU64::new(0))
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Decrement the active connection count for an instance (for least-loaded routing).
-    pub fn decrement_connections(&self, instance_id: u64) {
-        if let Some(count) = self.instance_connections.get(&instance_id) {
-            let _ = count.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-                Some(current.saturating_sub(1))
-            });
-        }
-    }
-
-    /// Get the active connection count for an instance.
-    pub fn connection_count(&self, instance_id: u64) -> u64 {
-        self.instance_connections
-            .get(&instance_id)
-            .map(|c| c.load(Ordering::Relaxed))
-            .unwrap_or(0)
-    }
-
-    /// Get the available instance with the lowest active connection count.
-    /// Returns None if no instances are available.
-    pub fn least_loaded_instance(&self) -> Option<u64> {
-        let instance_ids = self.instance_ids_avail();
-        instance_ids
-            .iter()
-            .min_by_key(|&&id| self.connection_count(id))
-            .copied()
-    }
-
     /// Monitor the key-value instance source and update instance_avail.
     ///
     /// This function also performs periodic reconciliation: if `instance_source` hasn't
@@ -221,10 +250,14 @@ impl Client {
                 client.instance_avail.store(Arc::new(instance_ids.clone()));
                 client.instance_free.store(Arc::new(instance_ids.clone()));
 
-                // Clean up stale connection counters for instances that no longer exist
-                client
-                    .instance_connections
-                    .retain(|id, _| instance_ids.contains(id));
+                // Clean up stale connection counters for instances that no longer exist.
+                let registry = client.endpoint.drt().least_loaded_states();
+                if let Ok(registry) = registry.try_lock()
+                    && let Some(weak) = registry.get(&client.endpoint)
+                    && let Some(state) = weak.upgrade()
+                {
+                    state.retain(&instance_ids);
+                }
 
                 // Send update to watch channel subscribers
                 let _ = client.instance_avail_tx.send(instance_ids);
@@ -440,5 +473,84 @@ mod tests {
         assert_eq!(current, vec![1, 3]);
 
         rt.shutdown();
+    }
+
+    /// Test that concurrent select_and_increment distributes load correctly.
+    #[tokio::test]
+    async fn test_concurrent_select_and_increment() {
+        let state = Arc::new(LeastLoadedState::default());
+        let instance_ids: Vec<u64> = vec![100, 200, 300];
+        let num_requests = 90;
+
+        let mut handles = Vec::new();
+        for _ in 0..num_requests {
+            let state = state.clone();
+            let ids = instance_ids.clone();
+            handles.push(tokio::spawn(
+                async move { state.select_and_increment(&ids) },
+            ));
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert_eq!(state.connection_count(100), 30);
+        assert_eq!(state.connection_count(200), 30);
+        assert_eq!(state.connection_count(300), 30);
+    }
+
+    #[tokio::test]
+    async fn test_connection_counts() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt.namespace("test_ll_counts".to_string()).unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+
+        let state1 = get_or_create_least_loaded_state(&endpoint).await;
+        let state2 = get_or_create_least_loaded_state(&endpoint).await;
+
+        let picked1 = state1.select_and_increment(&[10, 20, 30]).unwrap();
+        assert_eq!(state1.connection_count(picked1), 1);
+
+        let picked2 = state1.select_and_increment(&[10, 20, 30]).unwrap();
+        assert_ne!(picked1, picked2);
+
+        // state2 should see the same counts (same underlying Arc)
+        assert_eq!(state2.connection_count(10), state1.connection_count(10));
+        assert_eq!(state2.connection_count(20), state1.connection_count(20));
+        assert_eq!(state2.connection_count(30), state1.connection_count(30));
+
+        state2.decrement(picked1);
+        assert_eq!(
+            state1.connection_count(picked1),
+            if picked1 == picked2 { 1 } else { 0 }
+        );
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_least_loaded_state_retain() {
+        let state = LeastLoadedState::default();
+
+        // Add some connections
+        state.select_and_increment(&[1, 2, 3]);
+        state.select_and_increment(&[1, 2, 3]);
+        state.select_and_increment(&[1, 2, 3]);
+        // Each instance should have 1 connection
+        assert_eq!(state.connection_count(1), 1);
+        assert_eq!(state.connection_count(2), 1);
+        assert_eq!(state.connection_count(3), 1);
+
+        // Retain only instances 1 and 3 (instance 2 was removed)
+        state.retain(&[1, 3]);
+
+        assert_eq!(state.connection_count(1), 1);
+        assert_eq!(state.connection_count(2), 0); // cleaned up
+        assert_eq!(state.connection_count(3), 1);
     }
 }

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -3,7 +3,10 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use anyhow::Result;
 use arc_swap::ArcSwap;
@@ -23,58 +26,55 @@ use crate::{
     transports::etcd::Client as EtcdClient,
 };
 
-/// Shared state for least-loaded routing
+/// Shared occupancy state for routing modes that track per-worker in-flight requests.
 #[derive(Debug, Default)]
-pub(crate) struct LeastLoadedState {
-    /// Active connection count per instance: instance_id -> count
-    connections: DashMap<u64, AtomicU64>,
-    lock: std::sync::Mutex<()>,
+pub(crate) struct RoutingOccupancyState {
+    counts: DashMap<u64, AtomicU64>,
+    exact_selection_lock: tokio::sync::Mutex<()>,
 }
 
-impl LeastLoadedState {
-    /// Acquire the selection lock, pick the least-loaded instance, and increment its count.
-    /// Returns the selected instance ID, or None if no instances are available.
-    pub(crate) fn select_and_increment(&self, instance_ids: &[u64]) -> Option<u64> {
-        let _guard = self.lock.lock().unwrap();
-        let id = *instance_ids
-            .iter()
-            .min_by_key(|&&id| self.connection_count(id))?;
-        self.increment(id);
-        Some(id)
-    }
-
-    fn increment(&self, instance_id: u64) {
-        self.connections
+impl RoutingOccupancyState {
+    pub(crate) fn increment(&self, instance_id: u64) {
+        self.counts
             .entry(instance_id)
             .or_insert_with(|| AtomicU64::new(0))
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    pub(crate) async fn select_exact_min_and_increment(&self, instance_ids: &[u64]) -> Option<u64> {
+        let _guard = self.exact_selection_lock.lock().await;
+        let id = *instance_ids.iter().min_by_key(|&&id| self.load(id))?;
+        self.increment(id);
+        Some(id)
+    }
+
     pub(crate) fn decrement(&self, instance_id: u64) {
-        if let Some(count) = self.connections.get(&instance_id) {
+        if let Some(count) = self.counts.get(&instance_id) {
             let _ = count.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
                 Some(current.saturating_sub(1))
             });
         }
     }
 
-    pub(crate) fn connection_count(&self, instance_id: u64) -> u64 {
-        self.connections
+    pub(crate) fn load(&self, instance_id: u64) -> u64 {
+        self.counts
             .get(&instance_id)
             .map(|c| c.load(Ordering::Relaxed))
             .unwrap_or(0)
     }
 
-    /// Remove counters for instances that no longer exist.
     pub(crate) fn retain(&self, instance_ids: &[u64]) {
-        self.connections.retain(|id, _| instance_ids.contains(id));
+        let live: HashSet<u64> = instance_ids.iter().copied().collect();
+        self.counts.retain(|id, _| live.contains(id));
     }
 }
 
-/// Get or create the shared least-loaded state for an endpoint.
-pub(crate) async fn get_or_create_least_loaded_state(endpoint: &Endpoint) -> Arc<LeastLoadedState> {
+/// Get or create the shared routing occupancy state for an endpoint.
+pub(crate) async fn get_or_create_routing_occupancy_state(
+    endpoint: &Endpoint,
+) -> Arc<RoutingOccupancyState> {
     let drt = endpoint.drt();
-    let registry = drt.least_loaded_states();
+    let registry = drt.routing_occupancy_states();
     let mut registry = registry.lock().await;
 
     if let Some(weak) = registry.get(endpoint) {
@@ -85,7 +85,7 @@ pub(crate) async fn get_or_create_least_loaded_state(endpoint: &Endpoint) -> Arc
         }
     }
 
-    let state = Arc::new(LeastLoadedState::default());
+    let state = Arc::new(RoutingOccupancyState::default());
     registry.insert(endpoint.clone(), Arc::downgrade(&state));
     state
 }
@@ -250,8 +250,8 @@ impl Client {
                 client.instance_avail.store(Arc::new(instance_ids.clone()));
                 client.instance_free.store(Arc::new(instance_ids.clone()));
 
-                // Clean up stale connection counters for instances that no longer exist.
-                let registry = client.endpoint.drt().least_loaded_states();
+                // Clean up stale occupancy counters for instances that no longer exist.
+                let registry = client.endpoint.drt().routing_occupancy_states();
                 if let Ok(registry) = registry.try_lock()
                     && let Some(weak) = registry.get(&client.endpoint)
                     && let Some(state) = weak.upgrade()
@@ -478,7 +478,7 @@ mod tests {
     /// Test that concurrent select_and_increment distributes load correctly.
     #[tokio::test]
     async fn test_concurrent_select_and_increment() {
-        let state = Arc::new(LeastLoadedState::default());
+        let state = Arc::new(RoutingOccupancyState::default());
         let instance_ids: Vec<u64> = vec![100, 200, 300];
         let num_requests = 90;
 
@@ -486,18 +486,18 @@ mod tests {
         for _ in 0..num_requests {
             let state = state.clone();
             let ids = instance_ids.clone();
-            handles.push(tokio::spawn(
-                async move { state.select_and_increment(&ids) },
-            ));
+            handles.push(tokio::spawn(async move {
+                state.select_exact_min_and_increment(&ids).await
+            }));
         }
 
         for handle in handles {
             handle.await.unwrap();
         }
 
-        assert_eq!(state.connection_count(100), 30);
-        assert_eq!(state.connection_count(200), 30);
-        assert_eq!(state.connection_count(300), 30);
+        assert_eq!(state.load(100), 30);
+        assert_eq!(state.load(200), 30);
+        assert_eq!(state.load(300), 30);
     }
 
     #[tokio::test]
@@ -510,47 +510,87 @@ mod tests {
         let component = ns.component("test_component".to_string()).unwrap();
         let endpoint = component.endpoint("test_endpoint".to_string());
 
-        let state1 = get_or_create_least_loaded_state(&endpoint).await;
-        let state2 = get_or_create_least_loaded_state(&endpoint).await;
+        let state1 = get_or_create_routing_occupancy_state(&endpoint).await;
+        let state2 = get_or_create_routing_occupancy_state(&endpoint).await;
 
-        let picked1 = state1.select_and_increment(&[10, 20, 30]).unwrap();
-        assert_eq!(state1.connection_count(picked1), 1);
+        let picked1 = state1
+            .select_exact_min_and_increment(&[10, 20, 30])
+            .await
+            .unwrap();
+        assert_eq!(state1.load(picked1), 1);
 
-        let picked2 = state1.select_and_increment(&[10, 20, 30]).unwrap();
+        let picked2 = state1
+            .select_exact_min_and_increment(&[10, 20, 30])
+            .await
+            .unwrap();
         assert_ne!(picked1, picked2);
 
         // state2 should see the same counts (same underlying Arc)
-        assert_eq!(state2.connection_count(10), state1.connection_count(10));
-        assert_eq!(state2.connection_count(20), state1.connection_count(20));
-        assert_eq!(state2.connection_count(30), state1.connection_count(30));
+        assert_eq!(state2.load(10), state1.load(10));
+        assert_eq!(state2.load(20), state1.load(20));
+        assert_eq!(state2.load(30), state1.load(30));
 
         state2.decrement(picked1);
-        assert_eq!(
-            state1.connection_count(picked1),
-            if picked1 == picked2 { 1 } else { 0 }
-        );
+        assert_eq!(state1.load(picked1), if picked1 == picked2 { 1 } else { 0 });
 
         rt.shutdown();
     }
 
     #[tokio::test]
     async fn test_least_loaded_state_retain() {
-        let state = LeastLoadedState::default();
+        let state = RoutingOccupancyState::default();
 
         // Add some connections
-        state.select_and_increment(&[1, 2, 3]);
-        state.select_and_increment(&[1, 2, 3]);
-        state.select_and_increment(&[1, 2, 3]);
+        state.select_exact_min_and_increment(&[1, 2, 3]).await;
+        state.select_exact_min_and_increment(&[1, 2, 3]).await;
+        state.select_exact_min_and_increment(&[1, 2, 3]).await;
         // Each instance should have 1 connection
-        assert_eq!(state.connection_count(1), 1);
-        assert_eq!(state.connection_count(2), 1);
-        assert_eq!(state.connection_count(3), 1);
+        assert_eq!(state.load(1), 1);
+        assert_eq!(state.load(2), 1);
+        assert_eq!(state.load(3), 1);
 
         // Retain only instances 1 and 3 (instance 2 was removed)
         state.retain(&[1, 3]);
 
-        assert_eq!(state.connection_count(1), 1);
-        assert_eq!(state.connection_count(2), 0); // cleaned up
-        assert_eq!(state.connection_count(3), 1);
+        assert_eq!(state.load(1), 1);
+        assert_eq!(state.load(2), 0);
+        assert_eq!(state.load(3), 1);
+    }
+
+    #[tokio::test]
+    async fn test_monitor_instance_source_cleans_up_removed_worker_counts() {
+        const TEST_RECONCILE_INTERVAL: Duration = Duration::from_millis(50);
+
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt.namespace("test_occupancy_cleanup".to_string()).unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+
+        let client = Client::with_reconcile_interval(endpoint.clone(), TEST_RECONCILE_INTERVAL)
+            .await
+            .unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        client.wait_for_instances().await.unwrap();
+
+        let worker_id = client.instance_ids_avail()[0];
+        let state = get_or_create_routing_occupancy_state(&endpoint).await;
+        state.increment(worker_id);
+        assert_eq!(state.load(worker_id), 1);
+
+        endpoint.unregister_endpoint_instance().await.unwrap();
+
+        for _ in 0..10 {
+            if state.load(worker_id) == 0 {
+                break;
+            }
+            tokio::time::sleep(TEST_RECONCILE_INTERVAL).await;
+        }
+
+        assert_eq!(state.load(worker_id), 0);
+
+        rt.shutdown();
     }
 }

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -173,7 +173,9 @@ impl Client {
     /// Decrement the active connection count for an instance (for least-loaded routing).
     pub fn decrement_connections(&self, instance_id: u64) {
         if let Some(count) = self.instance_connections.get(&instance_id) {
-            count.fetch_sub(1, Ordering::Relaxed);
+            let _ = count.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                Some(current.saturating_sub(1))
+            });
         }
     }
 

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::component::{
-    self, Component, ComponentBuilder, Endpoint, Instance, LeastLoadedState, Namespace,
+    self, Component, ComponentBuilder, Endpoint, Instance, Namespace, RoutingOccupancyState,
 };
 use crate::pipeline::PipelineError;
 use crate::pipeline::network::manager::NetworkManager;
@@ -36,7 +36,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 type InstanceMap = HashMap<Endpoint, Weak<Receiver<Vec<Instance>>>>;
-type LeastLoadedMap = HashMap<Endpoint, Weak<LeastLoadedState>>;
+type RoutingOccupancyMap = HashMap<Endpoint, Weak<RoutingOccupancyState>>;
 
 /// Distributed [Runtime] which provides access to shared resources across the cluster, this includes
 /// communication protocols and transports.
@@ -66,7 +66,7 @@ pub struct DistributedRuntime {
     component_registry: component::Registry,
 
     instance_sources: Arc<tokio::sync::Mutex<InstanceMap>>,
-    least_loaded_states: Arc<tokio::sync::Mutex<LeastLoadedMap>>,
+    routing_occupancy_states: Arc<tokio::sync::Mutex<RoutingOccupancyMap>>,
 
     // Health Status
     system_health: Arc<parking_lot::Mutex<SystemHealth>>,
@@ -188,7 +188,7 @@ impl DistributedRuntime {
             discovery_metadata,
             component_registry,
             instance_sources: Arc::new(Mutex::new(HashMap::new())),
-            least_loaded_states: Arc::new(Mutex::new(HashMap::new())),
+            routing_occupancy_states: Arc::new(Mutex::new(HashMap::new())),
             metrics_registry: crate::MetricsRegistry::new(),
             system_health,
             request_plane,
@@ -394,8 +394,8 @@ impl DistributedRuntime {
         self.instance_sources.clone()
     }
 
-    pub(crate) fn least_loaded_states(&self) -> Arc<Mutex<LeastLoadedMap>> {
-        self.least_loaded_states.clone()
+    pub(crate) fn routing_occupancy_states(&self) -> Arc<Mutex<RoutingOccupancyMap>> {
+        self.routing_occupancy_states.clone()
     }
 
     /// TODO: This is a temporary KV router measure for component/component.rs EventPublisher impl for

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -1,19 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::component::{Component, Instance};
+use crate::component::{
+    self, Component, ComponentBuilder, Endpoint, Instance, LeastLoadedState, Namespace,
+};
 use crate::pipeline::PipelineError;
 use crate::pipeline::network::manager::NetworkManager;
 use crate::service::{ServiceClient, ServiceSet};
 use crate::storage::kv;
+use crate::{discovery, system_status_server, transports};
 use crate::{
-    component::{self, ComponentBuilder, Endpoint, Namespace},
     discovery::Discovery,
     metrics::PrometheusUpdateCallback,
     metrics::{MetricsHierarchy, MetricsRegistry},
     transports::{etcd, nats, tcp},
 };
-use crate::{discovery, system_status_server, transports};
 
 use super::utils::GracefulShutdownTracker;
 use crate::SystemHealth;
@@ -35,6 +36,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 type InstanceMap = HashMap<Endpoint, Weak<Receiver<Vec<Instance>>>>;
+type LeastLoadedMap = HashMap<Endpoint, Weak<LeastLoadedState>>;
 
 /// Distributed [Runtime] which provides access to shared resources across the cluster, this includes
 /// communication protocols and transports.
@@ -64,6 +66,7 @@ pub struct DistributedRuntime {
     component_registry: component::Registry,
 
     instance_sources: Arc<tokio::sync::Mutex<InstanceMap>>,
+    least_loaded_states: Arc<tokio::sync::Mutex<LeastLoadedMap>>,
 
     // Health Status
     system_health: Arc<parking_lot::Mutex<SystemHealth>>,
@@ -185,6 +188,7 @@ impl DistributedRuntime {
             discovery_metadata,
             component_registry,
             instance_sources: Arc::new(Mutex::new(HashMap::new())),
+            least_loaded_states: Arc::new(Mutex::new(HashMap::new())),
             metrics_registry: crate::MetricsRegistry::new(),
             system_health,
             request_plane,
@@ -388,6 +392,10 @@ impl DistributedRuntime {
 
     pub fn instance_sources(&self) -> Arc<Mutex<InstanceMap>> {
         self.instance_sources.clone()
+    }
+
+    pub(crate) fn least_loaded_states(&self) -> Arc<Mutex<LeastLoadedMap>> {
+        self.least_loaded_states.clone()
     }
 
     /// TODO: This is a temporary KV router measure for component/component.rs EventPublisher impl for

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -346,15 +346,12 @@ where
 
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
-        let instance_id = self
-            .client
-            .least_loaded_instance()
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no instances found for endpoint {}",
-                    self.client.endpoint.id()
-                )
-            })?;
+        let instance_id = self.client.least_loaded_instance().ok_or_else(|| {
+            anyhow::anyhow!(
+                "no instances found for endpoint {}",
+                self.client.endpoint.id()
+            )
+        })?;
         tracing::trace!(
             "least loaded router selected {instance_id} (connections: {})",
             self.client.connection_count(instance_id)
@@ -362,7 +359,10 @@ where
 
         self.client.increment_connections(instance_id);
 
-        match self.generate_with_fault_detection(instance_id, request).await {
+        match self
+            .generate_with_fault_detection(instance_id, request)
+            .await
+        {
             Ok(stream) => {
                 let engine_ctx = stream.context();
                 let counted = ConnectionCountedStream {

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -17,7 +17,7 @@ fn is_inhibited(err: &(dyn std::error::Error + 'static)) -> bool {
 use crate::{
     component::{Client, Endpoint},
     dynamo_nvtx_range,
-    engine::{AsyncEngine, Data},
+    engine::{AsyncEngine, AsyncEngineContext, Data},
     metrics::frontend_perf::STAGE_DURATION_SECONDS,
     pipeline::{
         AddressedPushRouter, AddressedRequest, Error, ManyOut, SingleIn,
@@ -28,15 +28,17 @@ use crate::{
 };
 use async_trait::async_trait;
 use dashmap::DashMap;
+use futures::Stream;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::{
-    future::Future,
     marker::PhantomData,
+    pin::Pin,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
+    task::Poll,
     time::Instant,
 };
 use tokio_stream::StreamExt;
@@ -118,6 +120,9 @@ pub enum RouterMode {
     PowerOfTwoChoices,
     KV,
     Direct,
+    /// Route to the instance with the fewest active connections.
+    /// Prevents imbalanced backends by tracking per-instance inflight counts in the router.
+    LeastLoaded,
 }
 
 impl RouterMode {
@@ -339,6 +344,41 @@ where
             .await
     }
 
+    /// Issue a request to the instance with the fewest active connections.
+    pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        let instance_id = self
+            .client
+            .least_loaded_instance()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no instances found for endpoint {}",
+                    self.client.endpoint.id()
+                )
+            })?;
+        tracing::trace!(
+            "least loaded router selected {instance_id} (connections: {})",
+            self.client.connection_count(instance_id)
+        );
+
+        self.client.increment_connections(instance_id);
+
+        match self.generate_with_fault_detection(instance_id, request).await {
+            Ok(stream) => {
+                let engine_ctx = stream.context();
+                let counted = ConnectionCountedStream {
+                    inner: stream,
+                    client: self.client.clone(),
+                    instance_id,
+                };
+                Ok(ResponseStream::new(Box::pin(counted), engine_ctx))
+            }
+            Err(e) => {
+                self.client.decrement_connections(instance_id);
+                Err(e)
+            }
+        }
+    }
+
     /// Select the next worker according to the routing mode.
     /// Increments round-robin counter if applicable.
     /// Returns None for Direct mode - requires explicit worker IDs via routing hints
@@ -555,9 +595,51 @@ where
                     "Direct routing should not call generate on PushRouter directly; use DirectRoutingRouter wrapper"
                 );
             }
+            RouterMode::LeastLoaded => self.least_loaded(request).await,
         }
     }
 }
+
+/// A stream wrapper that decrements the per-instance connection counter when
+/// the stream completes or is dropped. Used by least-loaded routing.
+struct ConnectionCountedStream<U: Data> {
+    inner: ManyOut<U>,
+    client: Client,
+    instance_id: u64,
+}
+
+impl<U: Data> Drop for ConnectionCountedStream<U> {
+    fn drop(&mut self) {
+        self.client.decrement_connections(self.instance_id);
+    }
+}
+
+impl<U: Data> std::fmt::Debug for ConnectionCountedStream<U> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnectionCountedStream")
+            .field("instance_id", &self.instance_id)
+            .finish()
+    }
+}
+
+impl<U: Data> Stream for ConnectionCountedStream<U> {
+    type Item = U;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+impl<U: Data> AsyncEngineContextProvider for ConnectionCountedStream<U> {
+    fn context(&self) -> Arc<dyn AsyncEngineContext> {
+        self.inner.context()
+    }
+}
+
+impl<U: Data> crate::engine::AsyncEngineStream<U> for ConnectionCountedStream<U> {}
 
 #[cfg(test)]
 mod tests {

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -15,7 +15,7 @@ fn is_inhibited(err: &(dyn std::error::Error + 'static)) -> bool {
     match_error_chain(err, INHIBITED, &[])
 }
 use crate::{
-    component::{Client, Endpoint},
+    component::{Client, Endpoint, LeastLoadedState, get_or_create_least_loaded_state},
     dynamo_nvtx_range,
     engine::{AsyncEngine, AsyncEngineContext, Data},
     metrics::frontend_perf::STAGE_DURATION_SECONDS,
@@ -35,7 +35,7 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicU64, Ordering},
     },
     task::Poll,
@@ -106,8 +106,8 @@ where
     /// where transient failures are expected.
     fault_detection_enabled: bool,
 
-    /// Lock for least-loaded routing, ensures atomic selection + increment of connection count.
-    least_loaded_lock: Arc<Mutex<()>>,
+    /// Shared least-loaded routing state (None when not using least-loaded mode).
+    least_loaded_state: Option<Arc<LeastLoadedState>>,
 
     /// An internal Rust type. This says that PushRouter is generic over the T and U types,
     /// which are the input and output types of it's `generate` function. It allows the
@@ -203,15 +203,21 @@ where
     ) -> anyhow::Result<Self> {
         let addressed = addressed_router(&client.endpoint).await?;
 
+        let least_loaded_state = if router_mode == RouterMode::LeastLoaded {
+            Some(get_or_create_least_loaded_state(&client.endpoint).await)
+        } else {
+            None
+        };
+
         Ok(PushRouter {
-            client: client.clone(),
+            client,
             addressed,
             router_mode,
             round_robin_counter: Arc::new(AtomicU64::new(0)),
             in_flight_counts: Arc::new(DashMap::new()),
             busy_threshold: None,
             fault_detection_enabled: false,
-            least_loaded_lock: Arc::new(Mutex::new(())),
+            least_loaded_state,
             _phantom: PhantomData,
         })
     }
@@ -230,15 +236,21 @@ where
             monitor.start_monitoring().await?;
         }
 
+        let least_loaded_state = if router_mode == RouterMode::LeastLoaded {
+            Some(get_or_create_least_loaded_state(&client.endpoint).await)
+        } else {
+            None
+        };
+
         let router = PushRouter {
-            client: client.clone(),
+            client,
             addressed,
             router_mode,
             round_robin_counter: Arc::new(AtomicU64::new(0)),
             in_flight_counts: Arc::new(DashMap::new()),
             busy_threshold,
             fault_detection_enabled: true,
-            least_loaded_lock: Arc::new(Mutex::new(())),
+            least_loaded_state,
             _phantom: PhantomData,
         };
 
@@ -349,20 +361,22 @@ where
 
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
-        let instance_id = {
-            let _guard = self.least_loaded_lock.lock().unwrap();
-            let id = self.client.least_loaded_instance().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no instances found for endpoint {}",
-                    self.client.endpoint.id()
-                )
-            })?;
-            self.client.increment_connections(id);
-            id
-        };
+        let state = self.least_loaded_state.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "least-loaded state not initialized for endpoint {}",
+                self.client.endpoint.id()
+            )
+        })?;
+        let instance_ids = self.client.instance_ids_avail();
+        let instance_id = state.select_and_increment(&instance_ids).ok_or_else(|| {
+            anyhow::anyhow!(
+                "no instances found for endpoint {}",
+                self.client.endpoint.id()
+            )
+        })?;
         tracing::trace!(
             "least loaded router selected {instance_id} (connections: {})",
-            self.client.connection_count(instance_id)
+            state.connection_count(instance_id)
         );
 
         match self
@@ -373,13 +387,13 @@ where
                 let engine_ctx = stream.context();
                 let counted = ConnectionCountedStream {
                     inner: stream,
-                    client: self.client.clone(),
+                    state: state.clone(),
                     instance_id,
                 };
                 Ok(ResponseStream::new(Box::pin(counted), engine_ctx))
             }
             Err(e) => {
-                self.client.decrement_connections(instance_id);
+                state.decrement(instance_id);
                 Err(e)
             }
         }
@@ -609,13 +623,13 @@ where
 /// the stream completes or is dropped. Used by least-loaded routing.
 struct ConnectionCountedStream<U: Data> {
     inner: ManyOut<U>,
-    client: Client,
+    state: Arc<LeastLoadedState>,
     instance_id: u64,
 }
 
 impl<U: Data> Drop for ConnectionCountedStream<U> {
     fn drop(&mut self) {
-        self.client.decrement_connections(self.instance_id);
+        self.state.decrement(self.instance_id);
     }
 }
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -35,7 +35,7 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
     task::Poll,
@@ -106,6 +106,9 @@ where
     /// where transient failures are expected.
     fault_detection_enabled: bool,
 
+    /// Lock for least-loaded routing, ensures atomic selection + increment of connection count.
+    least_loaded_lock: Arc<Mutex<()>>,
+
     /// An internal Rust type. This says that PushRouter is generic over the T and U types,
     /// which are the input and output types of it's `generate` function. It allows the
     /// compiler to specialize us at compile time.
@@ -120,8 +123,6 @@ pub enum RouterMode {
     PowerOfTwoChoices,
     KV,
     Direct,
-    /// Route to the instance with the fewest active connections.
-    /// Prevents imbalanced backends by tracking per-instance inflight counts in the router.
     LeastLoaded,
 }
 
@@ -210,6 +211,7 @@ where
             in_flight_counts: Arc::new(DashMap::new()),
             busy_threshold: None,
             fault_detection_enabled: false,
+            least_loaded_lock: Arc::new(Mutex::new(())),
             _phantom: PhantomData,
         })
     }
@@ -236,6 +238,7 @@ where
             in_flight_counts: Arc::new(DashMap::new()),
             busy_threshold,
             fault_detection_enabled: true,
+            least_loaded_lock: Arc::new(Mutex::new(())),
             _phantom: PhantomData,
         };
 
@@ -346,18 +349,21 @@ where
 
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
-        let instance_id = self.client.least_loaded_instance().ok_or_else(|| {
-            anyhow::anyhow!(
-                "no instances found for endpoint {}",
-                self.client.endpoint.id()
-            )
-        })?;
+        let instance_id = {
+            let _guard = self.least_loaded_lock.lock().unwrap();
+            let id = self.client.least_loaded_instance().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no instances found for endpoint {}",
+                    self.client.endpoint.id()
+                )
+            })?;
+            self.client.increment_connections(id);
+            id
+        };
         tracing::trace!(
             "least loaded router selected {instance_id} (connections: {})",
             self.client.connection_count(instance_id)
         );
-
-        self.client.increment_connections(instance_id);
 
         match self
             .generate_with_fault_detection(instance_id, request)

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -680,8 +680,29 @@ mod tests {
     use crate::{
         DistributedRuntime, Runtime,
         distributed::DistributedConfig,
+        error::DynamoError,
         pipeline::{ResponseStream, context::Controller},
     };
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    struct TestResponse {
+        error: Option<DynamoError>,
+    }
+
+    impl MaybeError for TestResponse {
+        fn from_err(err: impl std::error::Error + 'static) -> Self {
+            Self {
+                error: Some(DynamoError::from(
+                    Box::new(err) as Box<dyn std::error::Error + 'static>
+                )),
+            }
+        }
+
+        fn err(&self) -> Option<DynamoError> {
+            self.error.clone()
+        }
+    }
 
     #[test]
     fn p2c_selects_lower_load_worker() {
@@ -829,7 +850,7 @@ mod tests {
         endpoint.register_endpoint_instance().await.unwrap();
         client.wait_for_instances().await.unwrap();
 
-        let router = PushRouter::<u64, u64>::from_client(client, RouterMode::LeastLoaded)
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::LeastLoaded)
             .await
             .unwrap();
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -387,8 +387,7 @@ where
 
     /// Select the next worker according to the routing mode.
     /// Increments round-robin counter if applicable.
-    /// Returns None for Direct mode - requires explicit worker IDs via routing hints
-    /// Panics for KV mode which has its own selection via find_best_match.
+    /// Panics if called on Direct, KV, or LeastLoaded mode - those have their own selection mechanisms.
     pub fn select_next_worker(&self) -> Option<u64> {
         let instance_ids = self.client.instance_ids_avail();
         let count = instance_ids.len();
@@ -418,7 +417,7 @@ where
 
     /// Peek the next worker according to the routing mode without incrementing the counter.
     /// Useful for checking if a worker is suitable before committing to it.
-    /// Returns None for Direct mode - requires explicit worker IDs via routing hints.
+    /// Panics if called on Direct, KV, or LeastLoaded mode - those have their own selection mechanisms.
     pub fn peek_next_worker(&self) -> Option<u64> {
         let instance_ids = self.client.instance_ids_avail();
         let count = instance_ids.len();

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -15,7 +15,7 @@ fn is_inhibited(err: &(dyn std::error::Error + 'static)) -> bool {
     match_error_chain(err, INHIBITED, &[])
 }
 use crate::{
-    component::{Client, Endpoint, LeastLoadedState, get_or_create_least_loaded_state},
+    component::{Client, Endpoint, RoutingOccupancyState, get_or_create_routing_occupancy_state},
     dynamo_nvtx_range,
     engine::{AsyncEngine, AsyncEngineContext, Data},
     metrics::frontend_perf::STAGE_DURATION_SECONDS,
@@ -27,7 +27,6 @@ use crate::{
     traits::DistributedRuntimeProvider,
 };
 use async_trait::async_trait;
-use dashmap::DashMap;
 use futures::Stream;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -44,17 +43,43 @@ use std::{
 use tokio_stream::StreamExt;
 use tracing::Instrument;
 
-/// RAII guard that decrements a per-instance in-flight counter on drop.
-/// Used by PowerOfTwoChoices routing to track request occupancy.
-struct P2CGuard {
-    in_flight_counts: Arc<DashMap<u64, AtomicU64>>,
+struct OccupancyPermit {
+    state: Arc<RoutingOccupancyState>,
     instance_id: u64,
+    armed: bool,
 }
 
-impl Drop for P2CGuard {
+impl OccupancyPermit {
+    fn new(state: Arc<RoutingOccupancyState>, instance_id: u64) -> Self {
+        Self {
+            state,
+            instance_id,
+            armed: true,
+        }
+    }
+
+    fn into_tracked_stream<U: Data>(mut self, stream: ManyOut<U>) -> ManyOut<U> {
+        self.armed = false;
+        let engine_ctx = stream.context();
+        ResponseStream::new(
+            Box::pin(OccupancyTrackedStream {
+                inner: stream,
+                state: self.state.clone(),
+                instance_id: self.instance_id,
+            }),
+            engine_ctx,
+        )
+    }
+
+    fn instance_id(&self) -> u64 {
+        self.instance_id
+    }
+}
+
+impl Drop for OccupancyPermit {
     fn drop(&mut self) {
-        if let Some(counter) = self.in_flight_counts.get(&self.instance_id) {
-            counter.value().fetch_sub(1, Ordering::Relaxed);
+        if self.armed {
+            self.state.decrement(self.instance_id);
         }
     }
 }
@@ -89,9 +114,6 @@ where
     /// Number of round robin requests handled. Used to decide which server is next.
     round_robin_counter: Arc<AtomicU64>,
 
-    /// Per-instance in-flight request counts for PowerOfTwoChoices routing.
-    in_flight_counts: Arc<DashMap<u64, AtomicU64>>,
-
     /// The next step in the chain. PushRouter (this object) picks an instances,
     /// addresses it, then passes it to AddressedPushRouter which does the network traffic.
     addressed: Arc<AddressedPushRouter>,
@@ -106,8 +128,8 @@ where
     /// where transient failures are expected.
     fault_detection_enabled: bool,
 
-    /// Shared least-loaded routing state (None when not using least-loaded mode).
-    least_loaded_state: Option<Arc<LeastLoadedState>>,
+    /// Shared request occupancy state for tracked routing modes.
+    occupancy_state: Option<Arc<RoutingOccupancyState>>,
 
     /// An internal Rust type. This says that PushRouter is generic over the T and U types,
     /// which are the input and output types of it's `generate` function. It allows the
@@ -138,7 +160,7 @@ impl RouterMode {
 
 /// Pick the instance with lower in-flight count from two random candidates.
 /// Returns the single instance if only one is available.
-fn p2c_select_from(in_flight_counts: &DashMap<u64, AtomicU64>, instance_ids: &[u64]) -> u64 {
+fn p2c_select_from(occupancy_state: &RoutingOccupancyState, instance_ids: &[u64]) -> u64 {
     let count = instance_ids.len();
     if count == 1 {
         return instance_ids[0];
@@ -148,14 +170,8 @@ fn p2c_select_from(in_flight_counts: &DashMap<u64, AtomicU64>, instance_ids: &[u
     let idx2 = (idx1 + 1 + rng.random_range(0..count - 1)) % count;
     let id1 = instance_ids[idx1];
     let id2 = instance_ids[idx2];
-    let load1 = in_flight_counts
-        .get(&id1)
-        .map(|c| c.value().load(Ordering::Relaxed))
-        .unwrap_or(0);
-    let load2 = in_flight_counts
-        .get(&id2)
-        .map(|c| c.value().load(Ordering::Relaxed))
-        .unwrap_or(0);
+    let load1 = occupancy_state.load(id1);
+    let load2 = occupancy_state.load(id2);
     let selected = if load1 <= load2 { id1 } else { id2 };
     tracing::debug!(
         candidate_a = id1,
@@ -203,8 +219,11 @@ where
     ) -> anyhow::Result<Self> {
         let addressed = addressed_router(&client.endpoint).await?;
 
-        let least_loaded_state = if router_mode == RouterMode::LeastLoaded {
-            Some(get_or_create_least_loaded_state(&client.endpoint).await)
+        let occupancy_state = if matches!(
+            router_mode,
+            RouterMode::PowerOfTwoChoices | RouterMode::LeastLoaded
+        ) {
+            Some(get_or_create_routing_occupancy_state(&client.endpoint).await)
         } else {
             None
         };
@@ -214,10 +233,9 @@ where
             addressed,
             router_mode,
             round_robin_counter: Arc::new(AtomicU64::new(0)),
-            in_flight_counts: Arc::new(DashMap::new()),
             busy_threshold: None,
             fault_detection_enabled: false,
-            least_loaded_state,
+            occupancy_state,
             _phantom: PhantomData,
         })
     }
@@ -236,8 +254,11 @@ where
             monitor.start_monitoring().await?;
         }
 
-        let least_loaded_state = if router_mode == RouterMode::LeastLoaded {
-            Some(get_or_create_least_loaded_state(&client.endpoint).await)
+        let occupancy_state = if matches!(
+            router_mode,
+            RouterMode::PowerOfTwoChoices | RouterMode::LeastLoaded
+        ) {
+            Some(get_or_create_routing_occupancy_state(&client.endpoint).await)
         } else {
             None
         };
@@ -247,10 +268,9 @@ where
             addressed,
             router_mode,
             round_robin_counter: Arc::new(AtomicU64::new(0)),
-            in_flight_counts: Arc::new(DashMap::new()),
             busy_threshold,
             fault_detection_enabled: true,
-            least_loaded_state,
+            occupancy_state,
             _phantom: PhantomData,
         };
 
@@ -301,36 +321,32 @@ where
     /// Issue a request using power-of-two-choices: pick 2 random healthy workers,
     /// route to the one with fewer in-flight requests.
     pub async fn power_of_two_choices(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        let state = self.occupancy_state()?;
         let instance_id = {
-            let instance_ids = self.client.instance_ids_avail();
+            let instance_ids = self
+                .client
+                .instance_ids_avail()
+                .iter()
+                .copied()
+                .collect::<Vec<_>>();
             if instance_ids.is_empty() {
                 return Err(anyhow::anyhow!(
                     "no instances found for endpoint {}",
                     self.client.endpoint.id()
                 ));
             }
-            p2c_select_from(&self.in_flight_counts, &instance_ids)
+            p2c_select_from(state.as_ref(), &instance_ids)
         };
-        // Guard created before the await so error paths also decrement.
-        self.in_flight_counts
-            .entry(instance_id)
-            .or_insert_with(|| AtomicU64::new(0))
-            .value()
-            .fetch_add(1, Ordering::Relaxed);
-        let guard = P2CGuard {
-            in_flight_counts: self.in_flight_counts.clone(),
-            instance_id,
-        };
+        state.increment(instance_id);
+        let permit = OccupancyPermit::new(state, instance_id);
 
-        let stream = self
+        match self
             .generate_with_fault_detection(instance_id, request)
-            .await?;
-        let engine_ctx = stream.context();
-        let stream = stream.map(move |res| {
-            let _guard = &guard;
-            res
-        });
-        Ok(ResponseStream::new(Box::pin(stream), engine_ctx))
+            .await
+        {
+            Ok(stream) => Ok(permit.into_tracked_stream(stream)),
+            Err(err) => Err(err),
+        }
     }
 
     /// Issue a request to a specific endpoint
@@ -361,47 +377,40 @@ where
 
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
-        let state = self.least_loaded_state.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "least-loaded state not initialized for endpoint {}",
-                self.client.endpoint.id()
-            )
-        })?;
-        let instance_ids = self.client.instance_ids_avail();
-        let instance_id = state.select_and_increment(&instance_ids).ok_or_else(|| {
-            anyhow::anyhow!(
-                "no instances found for endpoint {}",
-                self.client.endpoint.id()
-            )
-        })?;
+        let state = self.occupancy_state()?;
+        let instance_ids = self
+            .client
+            .instance_ids_avail()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+        let instance_id = state
+            .select_exact_min_and_increment(&instance_ids)
+            .await
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no instances found for endpoint {}",
+                    self.client.endpoint.id()
+                )
+            })?;
+        let permit = OccupancyPermit::new(state.clone(), instance_id);
         tracing::trace!(
             "least loaded router selected {instance_id} (connections: {})",
-            state.connection_count(instance_id)
+            state.load(instance_id)
         );
 
         match self
             .generate_with_fault_detection(instance_id, request)
             .await
         {
-            Ok(stream) => {
-                let engine_ctx = stream.context();
-                let counted = ConnectionCountedStream {
-                    inner: stream,
-                    state: state.clone(),
-                    instance_id,
-                };
-                Ok(ResponseStream::new(Box::pin(counted), engine_ctx))
-            }
-            Err(e) => {
-                state.decrement(instance_id);
-                Err(e)
-            }
+            Ok(stream) => Ok(permit.into_tracked_stream(stream)),
+            Err(err) => Err(err),
         }
     }
 
     /// Select the next worker according to the routing mode.
     /// Increments round-robin counter if applicable.
-    /// Panics if called on Direct, KV, or LeastLoaded mode - those have their own selection mechanisms.
+    /// Returns None for modes that require request lifecycle tracking or explicit routing hints.
     pub fn select_next_worker(&self) -> Option<u64> {
         let instance_ids = self.client.instance_ids_avail();
         let count = instance_ids.len();
@@ -418,9 +427,8 @@ where
                 let counter = rand::rng().random::<u64>() as usize;
                 Some(instance_ids[counter % count])
             }
-            // P2C needs lifecycle tracking (P2CGuard); use generate() instead.
-            RouterMode::PowerOfTwoChoices | RouterMode::Direct => None,
-            _ => {
+            RouterMode::PowerOfTwoChoices | RouterMode::Direct | RouterMode::LeastLoaded => None,
+            RouterMode::KV => {
                 panic!(
                     "select_next_worker should not be called for {:?} routing mode",
                     self.router_mode
@@ -431,7 +439,7 @@ where
 
     /// Peek the next worker according to the routing mode without incrementing the counter.
     /// Useful for checking if a worker is suitable before committing to it.
-    /// Panics if called on Direct, KV, or LeastLoaded mode - those have their own selection mechanisms.
+    /// Returns None for modes that require request lifecycle tracking or explicit routing hints.
     pub fn peek_next_worker(&self) -> Option<u64> {
         let instance_ids = self.client.instance_ids_avail();
         let count = instance_ids.len();
@@ -451,15 +459,23 @@ where
                 let counter = rand::rng().random::<u64>() as usize;
                 Some(instance_ids[counter % count])
             }
-            // P2C needs lifecycle tracking (P2CGuard); use generate() instead.
-            RouterMode::PowerOfTwoChoices | RouterMode::Direct => None,
-            _ => {
+            RouterMode::PowerOfTwoChoices | RouterMode::Direct | RouterMode::LeastLoaded => None,
+            RouterMode::KV => {
                 panic!(
                     "peek_next_worker should not be called for {:?} routing mode",
                     self.router_mode
                 )
             }
         }
+    }
+
+    fn occupancy_state(&self) -> anyhow::Result<Arc<RoutingOccupancyState>> {
+        self.occupancy_state.clone().ok_or_else(|| {
+            anyhow::anyhow!(
+                "routing occupancy state not initialized for endpoint {}",
+                self.client.endpoint.id()
+            )
+        })
     }
 
     /*
@@ -619,29 +635,27 @@ where
     }
 }
 
-/// A stream wrapper that decrements the per-instance connection counter when
-/// the stream completes or is dropped. Used by least-loaded routing.
-struct ConnectionCountedStream<U: Data> {
+struct OccupancyTrackedStream<U: Data> {
     inner: ManyOut<U>,
-    state: Arc<LeastLoadedState>,
+    state: Arc<RoutingOccupancyState>,
     instance_id: u64,
 }
 
-impl<U: Data> Drop for ConnectionCountedStream<U> {
+impl<U: Data> Drop for OccupancyTrackedStream<U> {
     fn drop(&mut self) {
         self.state.decrement(self.instance_id);
     }
 }
 
-impl<U: Data> std::fmt::Debug for ConnectionCountedStream<U> {
+impl<U: Data> std::fmt::Debug for OccupancyTrackedStream<U> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ConnectionCountedStream")
+        f.debug_struct("OccupancyTrackedStream")
             .field("instance_id", &self.instance_id)
             .finish()
     }
 }
 
-impl<U: Data> Stream for ConnectionCountedStream<U> {
+impl<U: Data> Stream for OccupancyTrackedStream<U> {
     type Item = U;
 
     fn poll_next(
@@ -652,105 +666,120 @@ impl<U: Data> Stream for ConnectionCountedStream<U> {
     }
 }
 
-impl<U: Data> AsyncEngineContextProvider for ConnectionCountedStream<U> {
+impl<U: Data> AsyncEngineContextProvider for OccupancyTrackedStream<U> {
     fn context(&self) -> Arc<dyn AsyncEngineContext> {
         self.inner.context()
     }
 }
 
-impl<U: Data> crate::engine::AsyncEngineStream<U> for ConnectionCountedStream<U> {}
+impl<U: Data> crate::engine::AsyncEngineStream<U> for OccupancyTrackedStream<U> {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        DistributedRuntime, Runtime,
+        distributed::DistributedConfig,
+        pipeline::{ResponseStream, context::Controller},
+    };
 
     #[test]
     fn p2c_selects_lower_load_worker() {
-        let counts = DashMap::new();
-        counts.insert(1, AtomicU64::new(10));
-        counts.insert(2, AtomicU64::new(1));
+        let state = RoutingOccupancyState::default();
+        for _ in 0..10 {
+            state.increment(1);
+        }
+        state.increment(2);
 
         // With only two workers, p2c_select_from must pick both and choose id=2 (lower load).
-        let result = p2c_select_from(&counts, &[1, 2]);
+        let result = p2c_select_from(&state, &[1, 2]);
         assert_eq!(result, 2);
     }
 
     #[test]
     fn p2c_selects_single_worker() {
-        let counts = DashMap::new();
-        assert_eq!(p2c_select_from(&counts, &[42]), 42);
+        let state = RoutingOccupancyState::default();
+        assert_eq!(p2c_select_from(&state, &[42]), 42);
     }
 
     #[test]
     fn p2c_treats_missing_counts_as_zero() {
-        let counts = DashMap::new();
-        counts.insert(1, AtomicU64::new(5));
+        let state = RoutingOccupancyState::default();
+        for _ in 0..5 {
+            state.increment(1);
+        }
         // Worker 2 has no entry — should be treated as 0, so it wins.
-        let result = p2c_select_from(&counts, &[1, 2]);
+        let result = p2c_select_from(&state, &[1, 2]);
         assert_eq!(result, 2);
     }
 
     #[test]
     fn p2c_returns_valid_worker_on_tie() {
-        let counts = DashMap::new();
-        counts.insert(1, AtomicU64::new(3));
-        counts.insert(2, AtomicU64::new(3));
+        let state = RoutingOccupancyState::default();
+        for _ in 0..3 {
+            state.increment(1);
+            state.increment(2);
+        }
 
         for _ in 0..100 {
-            let result = p2c_select_from(&counts, &[1, 2]);
+            let result = p2c_select_from(&state, &[1, 2]);
             assert!(result == 1 || result == 2);
         }
     }
 
     #[test]
-    fn p2c_lifecycle_tracks_inflight_counts() {
-        let counts = Arc::new(DashMap::new());
-        let mut guards = Vec::new();
+    fn occupancy_permit_decrements_before_stream_creation() {
+        let state = Arc::new(RoutingOccupancyState::default());
+        state.increment(42);
+        let permit = OccupancyPermit::new(state.clone(), 42);
+        assert_eq!(state.load(42), 1);
+        drop(permit);
+        assert_eq!(state.load(42), 0);
+    }
+
+    #[test]
+    fn occupancy_tracked_stream_decrements_on_drop() {
+        let state = Arc::new(RoutingOccupancyState::default());
+        state.increment(7);
+        let permit = OccupancyPermit::new(state.clone(), 7);
+        let ctx: Arc<dyn AsyncEngineContext> = Arc::new(Controller::default());
+        let stream = permit.into_tracked_stream(ResponseStream::new(
+            Box::pin(tokio_stream::iter(vec![1u64])),
+            ctx,
+        ));
+        assert_eq!(state.load(7), 1);
+        drop(stream);
+        assert_eq!(state.load(7), 0);
+    }
+
+    #[test]
+    fn p2c_lifecycle_tracks_inflight_counts_with_shared_tracker() {
+        let state = Arc::new(RoutingOccupancyState::default());
+        let mut permits = Vec::new();
         for _ in 0..5 {
-            let selected = p2c_select_from(&counts, &[1, 2]);
-            counts
-                .entry(selected)
-                .or_insert_with(|| AtomicU64::new(0))
-                .value()
-                .fetch_add(1, Ordering::Relaxed);
-            guards.push(P2CGuard {
-                in_flight_counts: counts.clone(),
-                instance_id: selected,
-            });
+            let selected = p2c_select_from(&state, &[1, 2]);
+            state.increment(selected);
+            permits.push(OccupancyPermit::new(state.clone(), selected));
         }
 
-        let total = counts
-            .get(&1)
-            .map(|c| c.value().load(Ordering::Relaxed))
-            .unwrap_or(0)
-            + counts
-                .get(&2)
-                .map(|c| c.value().load(Ordering::Relaxed))
-                .unwrap_or(0);
+        let total = state.load(1) + state.load(2);
         assert_eq!(total, 5, "5 in-flight requests should be tracked");
 
-        drop(guards);
-        let total = counts
-            .get(&1)
-            .map(|c| c.value().load(Ordering::Relaxed))
-            .unwrap_or(0)
-            + counts
-                .get(&2)
-                .map(|c| c.value().load(Ordering::Relaxed))
-                .unwrap_or(0);
+        drop(permits);
+        let total = state.load(1) + state.load(2);
         assert_eq!(total, 0, "All guards dropped, counts should be 0");
     }
 
     #[test]
     fn p2c_never_selects_dominated_worker() {
-        let counts = DashMap::new();
-        counts.insert(1, AtomicU64::new(0));
-        counts.insert(2, AtomicU64::new(0));
-        counts.insert(3, AtomicU64::new(100));
+        let state = RoutingOccupancyState::default();
+        for _ in 0..100 {
+            state.increment(3);
+        }
 
         let mut selected = [0u32; 3];
         for _ in 0..1000 {
-            let result = p2c_select_from(&counts, &[1, 2, 3]);
+            let result = p2c_select_from(&state, &[1, 2, 3]);
             match result {
                 1 => selected[0] += 1,
                 2 => selected[1] += 1,
@@ -763,5 +792,50 @@ mod tests {
             "Worker 3 (load=100) should never be selected against load=0 workers, but got {} times",
             selected[2]
         );
+    }
+
+    #[tokio::test]
+    async fn least_loaded_selects_exact_min_and_tracks_counts() {
+        let state = Arc::new(RoutingOccupancyState::default());
+        state.increment(1);
+        state.increment(1);
+        state.increment(2);
+
+        let selected = state
+            .select_exact_min_and_increment(&[1, 2, 3])
+            .await
+            .unwrap();
+        assert_eq!(selected, 3);
+
+        let permit = OccupancyPermit::new(state.clone(), selected);
+        assert_eq!(state.load(selected), 1);
+        drop(permit);
+        assert_eq!(state.load(selected), 0);
+    }
+
+    #[tokio::test]
+    async fn least_loaded_select_and_peek_return_none_with_available_worker() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt
+            .namespace("test_least_loaded_router".to_string())
+            .unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+
+        endpoint.register_endpoint_instance().await.unwrap();
+        client.wait_for_instances().await.unwrap();
+
+        let router = PushRouter::<u64, u64>::from_client(client, RouterMode::LeastLoaded)
+            .await
+            .unwrap();
+
+        assert_eq!(router.select_next_worker(), None);
+        assert_eq!(router.peek_next_worker(), None);
+
+        rt.shutdown();
     }
 }


### PR DESCRIPTION
#### Overview:

Add a least-loaded router option, based on the connection counts from backends to the current router.

#### Details:

Uses a DashMap to keep track of incoming stream. When streams are completed or dropped, the counter is decremented. The router will choose the backend with the fewest connections.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #6312 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added least-loaded routing mode, enabling intelligent request distribution to workers with the fewest active connections via `--router-mode least_loaded` CLI flag.

* **Documentation**
  * Updated router configuration documentation to include the new least-loaded routing strategy alongside existing routing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->