### PR TITLE
Add DGD .status.state enum

### DIFF
--- a/deploy/helm/charts/crds/templates/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/helm/charts/crds/templates/nvidia.com_dynamographdeployments.yaml
@@ -11445,8 +11445,16 @@ spec:
                     The map key is the service name from spec.services.
                   type: object
                 state:
+                  default: initializing
                   description: State is a high-level textual status of the graph deployment lifecycle.
+                  enum:
+                    - initializing
+                    - pending
+                    - successful
+                    - failed
                   type: string
+              required:
+                - state
               type: object
           type: object
       served: true

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_types.go
@@ -44,6 +44,16 @@ const (
 	ComponentKindLeaderWorkerSet ComponentKind = "LeaderWorkerSet"
 )
 
+// +kubebuilder:validation:Enum=initializing;pending;successful;failed
+type DGDState string
+
+const (
+	DGDStateInitializing DGDState = "initializing"
+	DGDStatePending      DGDState = "pending"
+	DGDStateReady        DGDState = "successful"
+	DGDStateFailed       DGDState = "failed"
+)
+
 // DynamoGraphDeploymentSpec defines the desired state of DynamoGraphDeployment.
 type DynamoGraphDeploymentSpec struct {
 	// PVCs defines a list of persistent volume claims that can be referenced by components.
@@ -101,7 +111,8 @@ const (
 // DynamoGraphDeploymentStatus defines the observed state of DynamoGraphDeployment.
 type DynamoGraphDeploymentStatus struct {
 	// State is a high-level textual status of the graph deployment lifecycle.
-	State string `json:"state,omitempty"`
+	// +kubebuilder:default=initializing
+	State DGDState `json:"state"`
 	// Conditions contains the latest observed conditions of the graph deployment.
 	// The slice is merged by type on patch updates.
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
@@ -205,16 +216,13 @@ type DynamoGraphDeployment struct {
 	Status DynamoGraphDeploymentStatus `json:"status,omitempty"`
 }
 
-func (s *DynamoGraphDeployment) SetState(state string) {
+func (s *DynamoGraphDeployment) SetState(state DGDState) {
 	s.Status.State = state
 }
 
 // GetState returns the current lifecycle state
 func (d *DynamoGraphDeployment) GetState() string {
-	if d.Status.State == "" {
-		return consts.ResourceStateUnknown
-	}
-	return d.Status.State
+	return string(d.Status.State)
 }
 
 // +kubebuilder:object:root=true

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -11445,8 +11445,16 @@ spec:
                     The map key is the service name from spec.services.
                   type: object
                 state:
+                  default: initializing
                   description: State is a high-level textual status of the graph deployment lifecycle.
+                  enum:
+                    - initializing
+                    - pending
+                    - successful
+                    - failed
                   type: string
+              required:
+                - state
               type: object
           type: object
       served: true

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -405,7 +405,7 @@ func Test_reconcileGroveResources(t *testing.T) {
 				},
 			},
 			wantReconcileResult: ReconcileResult{
-				State:   DGDStateReady,
+				State:   v1alpha1.DGDStateReady,
 				Reason:  "all_resources_are_ready",
 				Message: "All resources are ready",
 				ServiceStatus: map[string]v1alpha1.ServiceReplicaStatus{
@@ -467,7 +467,7 @@ func Test_reconcileGroveResources(t *testing.T) {
 				},
 			},
 			wantReconcileResult: ReconcileResult{
-				State:   DGDStatePending,
+				State:   v1alpha1.DGDStatePending,
 				Reason:  "some_resources_are_not_ready",
 				Message: Message("Resources not ready: test-dgd: podclique/test-dgd-0-decode: desired=2, ready=1"),
 				ServiceStatus: map[string]v1alpha1.ServiceReplicaStatus{
@@ -542,7 +542,7 @@ func Test_reconcileGroveResources(t *testing.T) {
 				},
 			},
 			wantReconcileResult: ReconcileResult{
-				State:   DGDStateReady,
+				State:   v1alpha1.DGDStateReady,
 				Reason:  "all_resources_are_ready",
 				Message: "All resources are ready",
 				ServiceStatus: map[string]v1alpha1.ServiceReplicaStatus{
@@ -614,7 +614,7 @@ func Test_reconcileGroveResources(t *testing.T) {
 				},
 			},
 			wantReconcileResult: ReconcileResult{
-				State:   DGDStatePending,
+				State:   v1alpha1.DGDStatePending,
 				Reason:  "some_resources_are_not_ready",
 				Message: Message("Resources not ready: test-dgd: pcsg/test-dgd-0-aggregated: desired=2, available=1"),
 				ServiceStatus: map[string]v1alpha1.ServiceReplicaStatus{
@@ -1445,7 +1445,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				},
 			},
 			wantReconcileResult: ReconcileResult{
-				State:   DGDStateReady,
+				State:   v1alpha1.DGDStateReady,
 				Reason:  "all_resources_are_ready",
 				Message: "All resources are ready",
 				ServiceStatus: map[string]v1alpha1.ServiceReplicaStatus{
@@ -1505,7 +1505,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				},
 			},
 			wantReconcileResult: ReconcileResult{
-				State:   DGDStatePending,
+				State:   v1alpha1.DGDStatePending,
 				Reason:  "some_resources_are_not_ready",
 				Message: "Resources not ready: test-dgd-frontend: Component deployment not ready - Available condition not true",
 				ServiceStatus: map[string]v1alpha1.ServiceReplicaStatus{
@@ -1635,7 +1635,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				},
 			},
 			wantReconcileResult: ReconcileResult{
-				State:   DGDStateReady,
+				State:   v1alpha1.DGDStateReady,
 				Reason:  "all_resources_are_ready",
 				Message: "All resources are ready",
 				ServiceStatus: map[string]v1alpha1.ServiceReplicaStatus{
@@ -1781,7 +1781,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				},
 			},
 			wantReconcileResult: ReconcileResult{
-				State:   DGDStatePending,
+				State:   v1alpha1.DGDStatePending,
 				Reason:  "some_resources_are_not_ready",
 				Message: "Resources not ready: test-dgd-decode: Component deployment not ready - Available condition not true",
 				ServiceStatus: map[string]v1alpha1.ServiceReplicaStatus{
@@ -1892,7 +1892,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				},
 			},
 			wantReconcileResult: ReconcileResult{
-				State:   DGDStatePending,
+				State:   v1alpha1.DGDStatePending,
 				Reason:  "some_resources_are_not_ready",
 				Message: "Resources not ready: test-dgd-decode: Component deployment not ready - Available condition not true; test-dgd-frontend: Component deployment not ready - Available condition not true",
 				ServiceStatus: map[string]v1alpha1.ServiceReplicaStatus{

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -542,23 +542,23 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleReadyState(ctx context.Co
 	}
 
 	// Update deployment status
-	dgdr.Status.Deployment.State = dgd.Status.State
+	dgdr.Status.Deployment.State = string(dgd.Status.State)
 
 	// Check if DGD degraded from Ready
-	if dgd.Status.State != string(DGDStateReady) {
+	if dgd.Status.State != nvidiacomv1alpha1.DGDStateReady {
 		logger.Info("DGD degraded, transitioning back to Deploying",
 			"dgdState", dgd.Status.State)
 
 		dgdr.Status.State = DGDRStateDeploying
 
 		r.Recorder.Event(dgdr, corev1.EventTypeWarning, EventReasonDeploymentDegraded,
-			fmt.Sprintf(MessageDeploymentDegraded, dgd.Name, dgd.Status.State))
+			fmt.Sprintf(MessageDeploymentDegraded, dgd.Name, string(dgd.Status.State)))
 
 		meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
 			Type:    ConditionTypeDeploymentReady,
 			Status:  metav1.ConditionFalse,
 			Reason:  EventReasonDeploymentDegraded,
-			Message: fmt.Sprintf("Deployment degraded to %s", dgd.Status.State),
+			Message: fmt.Sprintf("Deployment degraded to %s", string(dgd.Status.State)),
 		})
 	}
 
@@ -599,10 +599,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingState(ctx contex
 	}
 
 	// Update deployment status
-	dgdr.Status.Deployment.State = dgd.Status.State
+	dgdr.Status.Deployment.State = string(dgd.Status.State)
 
 	// Check if DGD is Ready
-	if dgd.Status.State == string(DGDStateReady) {
+	if dgd.Status.State == nvidiacomv1alpha1.DGDStateReady {
 		logger.Info("DGD is Ready, transitioning to Ready state")
 		dgdr.Status.State = DGDRStateReady
 
@@ -745,7 +745,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 			dgdr.Status.Deployment = &nvidiacomv1alpha1.DeploymentStatus{
 				Name:      dgdName,
 				Namespace: dgdNamespace,
-				State:     string(DGDStatePending),
+				State:     string(nvidiacomv1alpha1.DGDStatePending),
 				Created:   true,
 			}
 			return ctrl.Result{}, r.Status().Update(ctx, dgdr)
@@ -758,7 +758,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	dgdr.Status.Deployment = &nvidiacomv1alpha1.DeploymentStatus{
 		Name:      dgdName,
 		Namespace: dgdNamespace,
-		State:     string(DGDStatePending),
+		State:     string(nvidiacomv1alpha1.DGDStatePending),
 		Created:   true,
 	}
 


### PR DESCRIPTION
#### Overview:

Promote DGD lifecycle state from untyped string to a first-class DGDState enum in api/v1alpha1, adding a new initializing state as the CRD default. This establishes a stable, schema-validated state contract for external automation consuming DGD status.

#### Details:

New type DGDState in api/v1alpha1/dynamographdeployment_types.go ( ex type State from deploy/operator/api/v1alpha1/dynamographdeployment_types.go):
- initializing — CRD default, set by API server on creation before the controller's first reconcile
- pending — controller is actively reconciling, sub-resources not yet ready
- successful — all resources ready
- failed — reconciliation error
Removed `omitempty`, added default `initializing`

#### Where should the reviewer start?

deploy/operator/api/v1alpha1/dynamographdeployment_types.go — the DGDState type, constants, default, and SetState/GetState changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced standardized deployment state tracking with four defined states: initializing, pending, successful, and failed.
  * Enhanced status reporting to ensure deployment state is always present and clearly defined throughout the deployment lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->