### PR TITLE
fix: add Docker Compose for disaggregated serving with unique hostnames

### DIFF
--- a/container/render.py
+++ b/container/render.py
@@ -58,11 +58,25 @@ def parse_args():
 def validate_args(args):
     valid_inputs = {
         "vllm": {
-            "target": ["runtime", "dev", "local-dev", "framework", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "framework",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["12.9", "13.0"],
         },
         "trtllm": {
-            "target": ["runtime", "dev", "local-dev", "framework", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "framework",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["13.1"],
         },
         "sglang": {
@@ -70,13 +84,23 @@ def validate_args(args):
             "cuda_version": ["12.9", "13.0"],
         },
         "dynamo": {
-            "target": ["runtime", "dev", "local-dev", "frontend", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "frontend",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["12.9", "13.0"],
         },
     }
 
     if args.framework in valid_inputs:
-        if args.target in valid_inputs[args.framework]["target"] and args.cuda_version in valid_inputs[args.framework]["cuda_version"]:
+        if (
+            args.target in valid_inputs[args.framework]["target"]
+            and args.cuda_version in valid_inputs[args.framework]["cuda_version"]
+        ):
             return
         else:
             raise ValueError(

--- a/examples/backends/trtllm/deploy/docker-compose-disagg.yml
+++ b/examples/backends/trtllm/deploy/docker-compose-disagg.yml
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Disaggregated TensorRT-LLM serving with Docker Compose.
+#
+# This deploys separate prefill and decode workers with NIXL-based KV cache transfer.
+# Requires a machine with at least 2 GPUs.
+#
+# Prerequisites:
+#   - Start infrastructure first:
+#       docker compose -f deploy/docker-compose.yml up -d
+#   - Set CONTAINER_IMAGE to a tensorrtllm-runtime image (NGC or custom-built)
+#   - Set MODEL_PATH to the model directory on the host
+#
+# Usage (minimal - 1 prefill + 1 decode):
+#   export CONTAINER_IMAGE=nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1
+#   export MODEL_PATH=/path/to/Qwen3-4B
+#   docker compose -f examples/backends/trtllm/deploy/docker-compose-disagg.yml up
+#
+# Scaling:
+#   Docker Compose `--scale` does NOT work with network_mode: host because all
+#   replicas would share ports, GPUs, and hostnames. To add more workers, define
+#   additional services (see prefill-1 example below). For dynamic scaling, use
+#   the Kubernetes DynamoGraphDeployment (see disagg_router.yaml).
+#
+# IMPORTANT: Each worker MUST have a globally unique hostname. When using
+# network_mode: host, containers share the host's network namespace and inherit
+# its hostname. TensorRT-LLM uses hostname+PID to identify NIXL agents for KV
+# cache transfer. Identical hostnames cause agents to skip connecting to each
+# other, silently breaking KV cache transfer.
+
+x-worker-common: &worker-common
+  image: ${CONTAINER_IMAGE:?Set CONTAINER_IMAGE to a tensorrtllm-runtime image}
+  network_mode: host
+  ipc: host
+  shm_size: "10g"
+  ulimits:
+    memlock: -1
+    stack: 67108864
+    nofile:
+      soft: 65536
+      hard: 65536
+  cap_add:
+    - SYS_PTRACE
+  volumes:
+    - ${MODEL_PATH:?Set MODEL_PATH to the model directory}:/model
+  environment:
+    - CUDA_VISIBLE_DEVICES=0
+
+services:
+  frontend:
+    image: ${CONTAINER_IMAGE}
+    hostname: dynamo-frontend
+    network_mode: host
+    command: >
+      python3 -m dynamo.frontend
+      --router-mode kv
+      --http-port ${HTTP_PORT:-8000}
+
+  prefill-0:
+    <<: *worker-common
+    hostname: dynamo-prefill-0
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${PREFILL_0_GPU:-0}"]
+              capabilities: [gpu]
+    command: >
+      python3 -m dynamo.trtllm
+      --model-path /model
+      --served-model-name ${SERVED_MODEL_NAME:-model}
+      --disaggregation-mode prefill
+      --publish-events-and-metrics
+      --extra-engine-args /workspace/examples/backends/trtllm/engine_configs/qwen3/prefill.yaml
+
+  decode-0:
+    <<: *worker-common
+    hostname: dynamo-decode-0
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${DECODE_0_GPU:-1}"]
+              capabilities: [gpu]
+    command: >
+      python3 -m dynamo.trtllm
+      --model-path /model
+      --served-model-name ${SERVED_MODEL_NAME:-model}
+      --disaggregation-mode decode
+      --extra-engine-args /workspace/examples/backends/trtllm/engine_configs/qwen3/decode.yaml
+
+  # To scale, add more services with unique hostnames, GPUs, and ports.
+  # Do NOT use `docker compose up --scale` — it does not work with network_mode: host.
+  #
+  # prefill-1:
+  #   <<: *worker-common
+  #   hostname: dynamo-prefill-1
+  #   environment:
+  #     - CUDA_VISIBLE_DEVICES=0
+  #     - DYN_SYSTEM_PORT=8082
+  #   deploy:
+  #     resources:
+  #       reservations:
+  #         devices:
+  #           - driver: nvidia
+  #             device_ids: ["2"]
+  #             capabilities: [gpu]
+  #   command: >
+  #     python3 -m dynamo.trtllm
+  #     --model-path /model
+  #     --served-model-name ${SERVED_MODEL_NAME:-model}
+  #     --disaggregation-mode prefill
+  #     --publish-events-and-metrics
+  #     --extra-engine-args /workspace/examples/backends/trtllm/engine_configs/qwen3/prefill.yaml


### PR DESCRIPTION
## Summary

- Add `docker-compose-disagg.yml` for single-host disaggregated TRT-LLM serving with Docker
- Set explicit `hostname:` per worker to prevent NIXL agent name collisions
- Document the hostname requirement and add troubleshooting entry

## Problem

TensorRT-LLM generates NIXL agent names as `hostname_pid_counter`. When prefill and decode workers run in separate Docker containers with `network_mode: host`, they share the host's hostname and have similar PIDs (separate PID namespaces), producing identical agent names. This causes the NIXL self-detection logic to skip connection setup between workers, silently breaking KV cache transfer.

There was no Docker Compose example for disaggregated serving, so users constructed their own `docker run` commands without knowing about the hostname requirement.

## Changes

1. **`examples/backends/trtllm/deploy/docker-compose-disagg.yml`** (new)
   - Docker Compose for disaggregated prefill/decode with infrastructure prerequisites
   - Sets `hostname: dynamo-prefill` and `hostname: dynamo-decode` to ensure unique NIXL agent names
   - Uses YAML anchors for shared worker config
   - Configurable via env vars (CONTAINER_IMAGE, MODEL_PATH, PREFILL_GPU, DECODE_GPU)

2. **`examples/backends/trtllm/deploy/README.md`** (updated)
   - Added Section 7 documenting the Docker Compose deployment option
   - Added troubleshooting entry for the NIXL hostname issue with symptoms and fix

## Test plan

- [ ] Deploy disaggregated serving using the new Docker Compose file on a 2-GPU host
- [ ] Verify KV cache transfer works with NIXL (DEFAULT backend)
- [ ] Verify `curl` to the frontend returns streaming completions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide for Docker Compose disaggregated TensorRT-LLM deployment, including architecture overview, configuration instructions, and solutions for common issues like KV cache transfer failures.

* **New Features**
  * Introduced Docker Compose configuration for deploying TensorRT-LLM with separate prefill and decode workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->