### PR TITLE
fix(sglang): handle idle ticks in streaming instead of erroring

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -232,11 +232,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
                 # With stream_output=True, output_ids contains only new tokens (disjoint)
                 output_ids = res.get("output_ids", [])
-                # If request is not finished yet, but there are no outputs, return an error.
+                # Empty output_ids without finish_reason is a normal idle tick in
+                # continuous batching — this request wasn't scheduled this decode step.
                 if not output_ids and not finish_reason:
-                    if not context.is_stopped():
-                        yield {"finish_reason": "error", "token_ids": []}
-                    break
+                    continue
 
                 # Pass through disjoint token segments directly
                 out["token_ids"] = output_ids

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -154,14 +154,20 @@ class StreamProcessor:
             async for res in stream_source:
                 try:
                     # With stream_output=True, output_ids contains only new tokens (disjoint)
+                    output_ids = res.get("output_ids", [])
+                    # Empty output_ids without finish is a normal idle tick
+                    # in continuous batching — skip it.
+                    finish_reason = res.get("meta_info", {}).get("finish_reason")
+                    if not output_ids and not finish_reason:
+                        continue
+
                     output = {
-                        "token_ids": res["output_ids"],
+                        "token_ids": output_ids,
                         "text": res.get("text", ""),
                         "finished": False,
                     }
 
                     # Check for finish reason
-                    finish_reason = res.get("meta_info", {}).get("finish_reason")
                     if finish_reason:
                         output.update(
                             {


### PR DESCRIPTION
## Summary

- With `stream_output=True`, SGLang sends disjoint output segments. When a request produces no new tokens in a decode step, the disjoint slice is empty — `output_ids=[]` without `finish_reason`.
- The existing handler treated this as a fatal error, yielding `{"finish_reason": "error"}` and breaking the stream. This was safe under `stream_output=False` (where `.copy()` always returns the full cumulative history, so empty was unreachable), but became a correctness bug when `stream_output=True` was forced.
- Real engine errors propagate through SGLang's `FINISH_ABORT` mechanism which always sets `finish_reason` — empty `output_ids` without `finish_reason` is not an error condition.
- Fix: `continue` instead of error+break. Same fix applied to the multimodal worker handler.