### PR TITLE
fix: pin pydantic-settings<2.13.0 for trtllm compatibility

### DIFF
--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -41,6 +41,7 @@ prometheus_client==0.23.1
 prophet==1.2.1
 protobuf>=5.29.5,<7.0.0
 pydantic>=2.11.4,<2.13  # vllm==0.12.0 depends on pydantic>=2.12.0
+pydantic-settings<2.13.0  # tensorrt_llm DynamicYamlWithDeepMergeSettingsSource incompatible with 2.13.0+ deep_merge param
 pyright==1.1.407
 PyYAML==6.0.3
 scikit-learn==1.7.2

--- a/container/render.py
+++ b/container/render.py
@@ -58,25 +58,55 @@ def parse_args():
 def validate_args(args):
     valid_inputs = {
         "vllm": {
-            "target": ["runtime", "dev", "local-dev", "framework", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "framework",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["12.9", "13.0"],
         },
         "trtllm": {
-            "target": ["runtime", "dev", "local-dev", "framework", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "framework",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["13.1"],
         },
         "sglang": {
-            "target": ["runtime", "dev", "local-dev", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["12.9", "13.0"],
         },
         "dynamo": {
-            "target": ["runtime", "dev", "local-dev", "frontend", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "frontend",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["12.9", "13.0"],
         },
     }
 
     if args.framework in valid_inputs:
-        if args.target in valid_inputs[args.framework]["target"] and args.cuda_version in valid_inputs[args.framework]["cuda_version"]:
+        if (
+            args.target in valid_inputs[args.framework]["target"]
+            and args.cuda_version in valid_inputs[args.framework]["cuda_version"]
+        ):
             return
         else:
             raise ValueError(


### PR DESCRIPTION
## Summary
- Pin `pydantic-settings<2.13.0` in `container/deps/requirements.txt` to fix trtllm autodeploy test failures
- `pydantic-settings` 2.13.0 added a `deep_merge` param to `YamlConfigSettingsSource._read_files()` that is incompatible with `tensorrt_llm`'s `DynamicYamlWithDeepMergeSettingsSource` override: https://github.com/pydantic/pydantic-settings/releases
- This caused all 10 parameterized cases of `test_unsupported_args_get_pruned_for_autodeploy` to fail with `TypeError`

## Root Cause
[Failed CI run](https://github.com/ai-dynamo/dynamo/actions/runs/22078844933/job/63802076977): `pydantic-settings` 2.13.0 (released Feb 13) changed the `YamlConfigSettingsSource.__init__` to pass `deep_merge=...` to `_read_files()`. TensorRT-LLM's subclass `DynamicYamlWithDeepMergeSettingsSource` overrides `_read_files()` without accepting this kwarg, causing a `TypeError` on every `ADLlmArgs()` instantiation.

## Test plan
- [ ] Verify trtllm CI pipeline passes (specifically `test_unsupported_args_get_pruned_for_autodeploy`)
- [ ] Verify no other frameworks are affected by the pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python package dependencies: Added version constraint on pydantic-settings to versions below 2.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->