### PR TITLE
style: fix pre-commit formatting in container/render.py

### DIFF
--- a/container/render.py
+++ b/container/render.py
@@ -58,25 +58,55 @@ def parse_args():
 def validate_args(args):
     valid_inputs = {
         "vllm": {
-            "target": ["runtime", "dev", "local-dev", "framework", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "framework",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["12.9", "13.0"],
         },
         "trtllm": {
-            "target": ["runtime", "dev", "local-dev", "framework", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "framework",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["13.1"],
         },
         "sglang": {
-            "target": ["runtime", "dev", "local-dev", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["12.9", "13.0"],
         },
         "dynamo": {
-            "target": ["runtime", "dev", "local-dev", "frontend", "wheel_builder", "base"],
+            "target": [
+                "runtime",
+                "dev",
+                "local-dev",
+                "frontend",
+                "wheel_builder",
+                "base",
+            ],
             "cuda_version": ["12.9", "13.0"],
         },
     }
 
     if args.framework in valid_inputs:
-        if args.target in valid_inputs[args.framework]["target"] and args.cuda_version in valid_inputs[args.framework]["cuda_version"]:
+        if (
+            args.target in valid_inputs[args.framework]["target"]
+            and args.cuda_version in valid_inputs[args.framework]["cuda_version"]
+        ):
             return
         else:
             raise ValueError(


### PR DESCRIPTION
## Summary
- Fix ruff line-length violations in `container/render.py` introduced by #6290
- Break long target lists and if-condition into multi-line format

## Test plan
- [ ] Pre-commit check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code reformatting for improved readability. No functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->