### PR TITLE
feat: Add n>1 support to the frontend and the vLLM backend

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1428,7 +1428,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         else:
             prompt_tokens = None
 
-        completion_tokens = sum(len(output.token_ids) for output in request_output.outputs)
+        completion_tokens = sum(
+            len(output.token_ids) for output in request_output.outputs
+        )
 
         return {
             "prompt_tokens": prompt_tokens,
@@ -1596,7 +1598,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     choice_index = output.index
                     if choice_index in finished_choices:
                         continue
-                    num_output_tokens_so_far = output_tokens_per_choice.get(choice_index, 0)
+                    num_output_tokens_so_far = output_tokens_per_choice.get(
+                        choice_index, 0
+                    )
                     next_total_toks = len(output.token_ids)
                     out: Dict[str, Any] = {
                         "token_ids": output.token_ids[num_output_tokens_so_far:],
@@ -1614,8 +1618,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         out["top_logprobs"] = top_logprobs
 
                     if output.finish_reason:
-                        out["finish_reason"] = normalize_finish_reason(output.finish_reason)
-                        out["completion_usage"] = BaseWorkerHandler._build_completion_usage(
+                        out["finish_reason"] = normalize_finish_reason(
+                            output.finish_reason
+                        )
+                        out[
+                            "completion_usage"
+                        ] = BaseWorkerHandler._build_completion_usage(
                             request_output=res,
                             embedding_sequence_length=embedding_sequence_length,
                         )
@@ -1905,7 +1913,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                             continue
                         previous_text = previous_text_per_choice.get(choice_index, "")
                         # Calculate the delta text (new text since last chunk)
-                        delta_text = output.text[len(previous_text):]
+                        delta_text = output.text[len(previous_text) :]
                         previous_text_per_choice[choice_index] = output.text
 
                         # Skip if no new text and no finish_reason for this choice
@@ -1918,7 +1926,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                                 "role": "assistant",
                                 "content": delta_text,
                             },
-                            "finish_reason": normalize_finish_reason(output.finish_reason),
+                            "finish_reason": normalize_finish_reason(
+                                output.finish_reason
+                            ),
                         }
                         choices.append(choice_data)
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -301,6 +301,7 @@ def build_sampling_params_openai(
         "min_p": "min_p",
         "length_penalty": "length_penalty",
         "use_beam_search": "use_beam_search",
+        "n": "n",
     }
 
     for req_key, param_key in openai_mapping.items():
@@ -1427,7 +1428,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         else:
             prompt_tokens = None
 
-        completion_tokens = len(request_output.outputs[0].token_ids)
+        completion_tokens = sum(len(output.token_ids) for output in request_output.outputs)
 
         return {
             "prompt_tokens": prompt_tokens,
@@ -1571,7 +1572,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 priority=priority,
             )
 
-            num_output_tokens_so_far = 0
+            output_tokens_per_choice: Dict[int, int] = {}
+            finished_choices: set[int] = set()
             async for res in gen:
                 # res is vllm's RequestOutput
 
@@ -1586,42 +1588,52 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     yield {
                         "finish_reason": "error: No outputs from vLLM engine",
                         "token_ids": [],
+                        "index": 0,
                     }
                     break
 
-                output = res.outputs[0]
-                next_total_toks = len(output.token_ids)
-                out = {"token_ids": output.token_ids[num_output_tokens_so_far:]}
+                for output in res.outputs:
+                    choice_index = output.index
+                    if choice_index in finished_choices:
+                        continue
+                    num_output_tokens_so_far = output_tokens_per_choice.get(choice_index, 0)
+                    next_total_toks = len(output.token_ids)
+                    out: Dict[str, Any] = {
+                        "token_ids": output.token_ids[num_output_tokens_so_far:],
+                        "index": choice_index,
+                    }
 
-                # Extract logprobs for new tokens if available
-                tokenizer = getattr(self.engine_client, "tokenizer", None)
-                log_probs, top_logprobs = self._extract_logprobs(
-                    output, num_output_tokens_so_far, tokenizer=tokenizer
-                )
-                if log_probs is not None:
-                    out["log_probs"] = log_probs
-                if top_logprobs is not None:
-                    out["top_logprobs"] = top_logprobs
+                    # Extract logprobs for new tokens if available
+                    tokenizer = getattr(self.engine_client, "tokenizer", None)
+                    log_probs, top_logprobs = self._extract_logprobs(
+                        output, num_output_tokens_so_far, tokenizer=tokenizer
+                    )
+                    if log_probs is not None:
+                        out["log_probs"] = log_probs
+                    if top_logprobs is not None:
+                        out["top_logprobs"] = top_logprobs
 
-                if output.finish_reason:
-                    out["finish_reason"] = normalize_finish_reason(output.finish_reason)
-                    out["completion_usage"] = BaseWorkerHandler._build_completion_usage(
-                        request_output=res,
-                        embedding_sequence_length=embedding_sequence_length,
-                    )
-                    # Log completion with LoRA info (debug level to avoid log spam)
-                    self._log_with_lora_context(
-                        "Completed token generation for request {request_id}{lora_info}: "
-                        "{output_tokens} output tokens, finish_reason={finish_reason}",
-                        request_id,
-                        lora_request,
-                        output_tokens=next_total_toks,
-                        finish_reason=output.finish_reason,
-                    )
-                if output.stop_reason:
-                    out["stop_reason"] = output.stop_reason
-                yield out
-                num_output_tokens_so_far = next_total_toks
+                    if output.finish_reason:
+                        out["finish_reason"] = normalize_finish_reason(output.finish_reason)
+                        out["completion_usage"] = BaseWorkerHandler._build_completion_usage(
+                            request_output=res,
+                            embedding_sequence_length=embedding_sequence_length,
+                        )
+                        # Log completion with LoRA info (debug level to avoid log spam)
+                        self._log_with_lora_context(
+                            "Completed token generation for request {request_id}{lora_info}: "
+                            "{output_tokens} output tokens, finish_reason={finish_reason}",
+                            request_id,
+                            lora_request,
+                            output_tokens=next_total_toks,
+                            finish_reason=output.finish_reason,
+                        )
+                    if output.stop_reason:
+                        out["stop_reason"] = output.stop_reason
+                    yield out
+                    output_tokens_per_choice[choice_index] = next_total_toks
+                    if output.finish_reason:
+                        finished_choices.add(choice_index)
 
         except EngineDeadError as e:
             logger.error(f"vLLM EngineDeadError: {e}")
@@ -1851,7 +1863,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         dp_rank = self._to_local_dp_rank(routing.get("dp_rank"))
         priority = -int(routing.get("priority", 0))
         openai_request_id = request.get("id") or request.get("request_id", request_id)
-        previous_text = ""
+        previous_text_per_choice: Dict[int, str] = {}
 
         trace_headers = build_trace_headers(context)
 
@@ -1865,6 +1877,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     trace_headers=trace_headers,
                     priority=priority,
                 )
+
+                n = getattr(sampling_params, "n", 1) or 1
+                finished_choices: set[int] = set()
 
                 async for res in gen:
                     if not res.outputs:
@@ -1883,29 +1898,45 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         }
                         break
 
-                    output = res.outputs[0]
-                    # Calculate the delta text (new text since last chunk)
-                    delta_text = output.text[len(previous_text) :]
-                    previous_text = output.text
+                    choices = []
+                    for output in res.outputs:
+                        choice_index = output.index
+                        if choice_index in finished_choices:
+                            continue
+                        previous_text = previous_text_per_choice.get(choice_index, "")
+                        # Calculate the delta text (new text since last chunk)
+                        delta_text = output.text[len(previous_text):]
+                        previous_text_per_choice[choice_index] = output.text
 
-                    choice_data = {
-                        "index": 0,
-                        "delta": {
-                            "role": "assistant",
-                            "content": delta_text,
-                        },
-                        "finish_reason": normalize_finish_reason(output.finish_reason),
-                    }
+                        # Skip if no new text and no finish_reason for this choice
+                        if not delta_text and not output.finish_reason:
+                            continue
+
+                        choice_data = {
+                            "index": choice_index,
+                            "delta": {
+                                "role": "assistant",
+                                "content": delta_text,
+                            },
+                            "finish_reason": normalize_finish_reason(output.finish_reason),
+                        }
+                        choices.append(choice_data)
+
+                        if output.finish_reason:
+                            finished_choices.add(choice_index)
+
+                    if not choices:
+                        continue
 
                     chunk = {
                         "id": openai_request_id,
                         "created": int(time.time()),
                         "object": "chat.completion.chunk",
                         "model": "unknown",
-                        "choices": [choice_data],
+                        "choices": choices,
                     }
 
-                    if output.finish_reason:
+                    if len(finished_choices) == n:
                         chunk["usage"] = BaseWorkerHandler._build_completion_usage(
                             request_output=res,
                         )

--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -15,7 +15,11 @@
 //! Further post-processing can happen in the response stream. One example is the jailing mechanism for partial
 //! hidden stop condition matches, which can be handled in the response stream rather than the backend.
 
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Instant,
+};
 
 use anyhow::Result;
 use futures::stream::{self, StreamExt};
@@ -62,9 +66,13 @@ pub struct Backend {
 #[allow(dead_code)]
 struct DecoderUnfoldState {
     stream: ManyOut<ExecutionOutputStream>,
-    decoder: Decoder,
+    decoders: HashMap<u32, Decoder>,
     validate_engine_decode: bool,
-    /// Set to true when a local stop condition is detected, causing the stream to end
+    /// Tracks which choice indices have finished generating
+    finished_choices: HashSet<u32>,
+    /// Number of choices requested (n parameter)
+    n: u32,
+    /// Set to true when all choices are finished, causing the stream to end
     finished: bool,
 }
 
@@ -97,21 +105,29 @@ impl Backend {
         skip_special_tokens: bool,
         include_stop_str_in_output: bool,
         tracker: Option<Arc<RequestTracker>>,
+        n: u32,
     ) -> anyhow::Result<DecoderUnfoldState> {
         let Some(tokenizer) = self.tokenizer.as_ref() else {
             anyhow::bail!("Backend built from blank ModelDeploymentCard, no tokenizer");
         };
-        let decoder = Decoder::new(
-            tokenizer.decode_stream(prompt_token_ids, skip_special_tokens),
-            stop_conditions,
-            include_stop_str_in_output,
-            tracker,
-        );
+
+        let mut decoders = HashMap::new();
+        for i in 0..n {
+            let decoder = Decoder::new(
+                tokenizer.decode_stream(prompt_token_ids, skip_special_tokens),
+                stop_conditions.clone(),
+                include_stop_str_in_output,
+                tracker.as_ref().map(|t| Arc::clone(t)),
+            );
+            decoders.insert(i, decoder);
+        }
 
         Ok(DecoderUnfoldState {
             stream,
-            decoder,
+            decoders,
             validate_engine_decode: self.validate_engine_decode,
+            finished_choices: HashSet::new(),
+            n,
             finished: false,
         })
     }
@@ -145,6 +161,8 @@ impl
             .unwrap_or(false);
         let tracker = request.tracker.clone();
 
+        let n = request.sampling_options.n.unwrap_or(1) as u32;
+
         let next_stream = next.generate(request).await?;
 
         let context = next_stream.context();
@@ -155,35 +173,56 @@ impl
             skip_special_tokens,
             include_stop_str_in_output,
             tracker,
+            n,
         )?;
 
         let processed_stream = stream::unfold(state, |mut state| async move {
-            // If we've already detected a local stop condition, end the stream
+            // If all choices are finished, end the stream
             if state.finished {
                 return None;
             }
 
             match state.stream.next().await {
                 Some(output) => {
-                    // move to state.process_output
-                    // handle any error conditions / unwraps here
-
                     // events are pass thru
                     if output.is_event() || output.data.is_none() {
-                        return Some((output, state));
-                    }
-
-                    // if we have a data field without an event, then we might need to update the data
-                    if let Some(data) = &output.data
-                        && data.text.is_some()
-                        && !state.validate_engine_decode
-                    {
-                        return Some((output, state));
+                        return Some((Some(output), state));
                     }
 
                     let data = output.data.as_ref().unwrap();
+                    let choice_index = data.index.unwrap_or(0);
 
-                    let result = match state.decoder.process_token_ids(&data.token_ids) {
+                    // Skip already-finished choices
+                    if state.finished_choices.contains(&choice_index) {
+                        return Some((None, state));
+                    }
+
+                    // Engine already decoded text; stop condition detection is handled by the engine, not Rust-side Decoder
+                    if data.text.is_some() && !state.validate_engine_decode {
+                        // Check if engine signaled finish for this choice
+                        if data.finish_reason.is_some() {
+                            state.finished_choices.insert(choice_index);
+                            if state.finished_choices.len() as u32 >= state.n {
+                                state.stream.context().stop_generating();
+                                state.finished = true;
+                            }
+                        }
+                        return Some((Some(output), state));
+                    }
+
+                    // Look up the per-choice decoder
+                    let decoder = match state.decoders.get_mut(&choice_index) {
+                        Some(d) => d,
+                        None => {
+                            tracing::warn!(
+                                "No decoder for choice index {}, passing through",
+                                choice_index
+                            );
+                            return Some((Some(output), state));
+                        }
+                    };
+
+                    let result = match decoder.process_token_ids(&data.token_ids) {
                         Ok(result) => result,
                         Err(e) => {
                             tracing::error!("Failed to process token_ids: {e}");
@@ -194,7 +233,7 @@ impl
                                 data.finish_reason =
                                     Some(FinishReason::Error(format!("decode error: {e}")));
                             }
-                            return Some((output, state));
+                            return Some((Some(output), state));
                         }
                     };
 
@@ -228,11 +267,24 @@ impl
                         None => (None, None),
                     };
 
-                    // If we detected a local stop condition, mark stream as finished
-                    // so we stop iterating (upstream may keep generating, but we ignore it)
+                    // Track per-choice finish: either from Rust-side stop detection or engine-signaled
+                    let choice_finished = finish_reason.is_some() || data.finish_reason.is_some();
+
+                    // If we detected a local stop condition not already signaled by engine,
+                    // mark this choice as finished
                     if finish_reason.is_some() && data.finish_reason.is_none() {
-                        state.stream.context().stop_generating();
-                        state.finished = true;
+                        // For n=1 we can stop generating immediately
+                        if state.n <= 1 {
+                            state.stream.context().stop_generating();
+                        }
+                    }
+
+                    if choice_finished {
+                        state.finished_choices.insert(choice_index);
+                        if state.finished_choices.len() as u32 >= state.n {
+                            state.stream.context().stop_generating();
+                            state.finished = true;
+                        }
                     }
 
                     let text = result.text;
@@ -275,12 +327,13 @@ impl
 
                     output.data = Some(data);
 
-                    Some((output, state))
+                    Some((Some(output), state))
                 }
 
                 None => None,
             }
         })
+        .filter_map(|x| async { x })
         .fuse();
 
         // convert stream of processed Annotated<LLMEngineOutput> to Annotated<BackendOutput>

--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -97,6 +97,7 @@ impl Backend {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn decoder(
         &self,
         stream: ManyOut<ExecutionOutputStream>,
@@ -117,7 +118,7 @@ impl Backend {
                 tokenizer.decode_stream(prompt_token_ids, skip_special_tokens),
                 stop_conditions.clone(),
                 include_stop_str_in_output,
-                tracker.as_ref().map(|t| Arc::clone(t)),
+                tracker.as_ref().map(Arc::clone),
             );
             decoders.insert(i, decoder);
         }

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -91,11 +91,22 @@ impl
         let (preprocessed_request, context) = request.transfer(());
         let engine_ctx = context.context();
         let engine_ctx_ = engine_ctx.clone();
+
+        // Disable migration for multi-choice requests (n>1) since migrating
+        // multiple output sequences is not supported
+        let n = preprocessed_request.sampling_options.n.unwrap_or(1);
+        let effective_migration_limit = if n > 1 {
+            tracing::info!("Request migration is not supported with n > 1, disabling migration");
+            0
+        } else {
+            self.migration_limit
+        };
+
         let retry_manager = RetryManager::build(
             engine_ctx,
             preprocessed_request,
             next,
-            self.migration_limit,
+            effective_migration_limit,
             self.max_seq_len,
             self.model_name.clone(),
             self.metrics.clone(),

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -393,7 +393,7 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
         };
 
         // Create the streaming response.
-        let index = 0;
+        let index = delta.index.unwrap_or(0);
         let mut stream_response = self.create_choice(
             index,
             delta.text,

--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -487,16 +487,16 @@ def test_multiple_choices_n5(
         stream=True,
         timeout=180,
     )
-    assert response.status_code == 200, (
-        f"Streaming request failed with status {response.status_code}: {response.text}"
-    )
+    assert (
+        response.status_code == 200
+    ), f"Streaming request failed with status {response.status_code}: {response.text}"
 
     # Parse SSE events
     chunks = []
     for line in response.iter_lines(decode_unicode=True):
         if not line or not line.startswith("data: "):
             continue
-        data_str = line[len("data: "):]
+        data_str = line[len("data: ") :]
         if data_str == "[DONE]":
             break
         chunks.append(json.loads(data_str))
@@ -519,14 +519,22 @@ def test_multiple_choices_n5(
                 finished_indices.add(idx)
 
     # Verify all 5 choice indices appeared
-    assert all_indices == {0, 1, 2, 3, 4}, (
-        f"Expected indices {{0,1,2,3,4}}, got {all_indices}"
-    )
+    assert all_indices == {
+        0,
+        1,
+        2,
+        3,
+        4,
+    }, f"Expected indices {{0,1,2,3,4}}, got {all_indices}"
 
     # Verify all 5 choices finished
-    assert finished_indices == {0, 1, 2, 3, 4}, (
-        f"Expected all 5 choices to finish, only got {finished_indices}"
-    )
+    assert finished_indices == {
+        0,
+        1,
+        2,
+        3,
+        4,
+    }, f"Expected all 5 choices to finish, only got {finished_indices}"
 
     # Verify each choice produced some content
     for i in range(5):

--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -455,3 +455,52 @@ def test_reasoning(request, start_services: ServicePorts, predownload_models) ->
     assert any(
         char.isdigit() for char in content
     ), "Expected response to contain numerical calculations"
+
+
+@pytest.mark.timeout(240)
+@pytest.mark.post_merge
+def test_multiple_choices_n5(
+    request, start_services: ServicePorts, predownload_models
+) -> None:
+    """Test that n=5 returns 5 distinct choices with correct indices and usage."""
+
+    payload = {
+        "model": TEST_MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": "Say a single random word.",
+            }
+        ],
+        "max_tokens": 20,
+        "n": 5,
+        "temperature": 1.0,
+    }
+
+    base_url = f"http://localhost:{start_services.frontend_port}"
+    response = _send_chat_request(payload, base_url=base_url)
+    response_data = _validate_chat_response(response)
+
+    choices = response_data.get("choices", [])
+    assert len(choices) == 5, f"Expected 5 choices, got {len(choices)}"
+
+    # Verify each choice has a unique index 0-4
+    indices = sorted(c["index"] for c in choices)
+    assert indices == [0, 1, 2, 3, 4], f"Expected indices [0,1,2,3,4], got {indices}"
+
+    # Verify each choice has a finish_reason and non-empty content
+    for choice in choices:
+        assert choice.get("finish_reason") is not None, (
+            f"Choice {choice['index']} missing finish_reason"
+        )
+        message = choice.get("message", {})
+        content = message.get("content", "")
+        assert content, f"Choice {choice['index']} has empty content"
+
+    # Verify usage is present and completion_tokens accounts for all choices
+    usage = response_data.get("usage", {})
+    assert usage.get("prompt_tokens", 0) > 0, "Missing prompt_tokens in usage"
+    assert usage.get("completion_tokens", 0) > 0, "Missing completion_tokens in usage"
+    assert usage.get("total_tokens", 0) == (
+        usage["prompt_tokens"] + usage["completion_tokens"]
+    ), "total_tokens should equal prompt_tokens + completion_tokens"

--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -462,7 +462,8 @@ def test_reasoning(request, start_services: ServicePorts, predownload_models) ->
 def test_multiple_choices_n5(
     request, start_services: ServicePorts, predownload_models
 ) -> None:
-    """Test that n=5 returns 5 distinct choices with correct indices and usage."""
+    """Test that n=5 streaming returns 5 distinct choices with correct indices."""
+    import json
 
     payload = {
         "model": TEST_MODEL,
@@ -475,32 +476,58 @@ def test_multiple_choices_n5(
         "max_tokens": 20,
         "n": 5,
         "temperature": 1.0,
+        "stream": True,
     }
 
     base_url = f"http://localhost:{start_services.frontend_port}"
-    response = _send_chat_request(payload, base_url=base_url)
-    response_data = _validate_chat_response(response)
+    response = requests.post(
+        f"{base_url}/v1/chat/completions",
+        headers={"Content-Type": "application/json"},
+        json=payload,
+        stream=True,
+        timeout=180,
+    )
+    assert response.status_code == 200, (
+        f"Streaming request failed with status {response.status_code}: {response.text}"
+    )
 
-    choices = response_data.get("choices", [])
-    assert len(choices) == 5, f"Expected 5 choices, got {len(choices)}"
+    # Parse SSE events
+    chunks = []
+    for line in response.iter_lines(decode_unicode=True):
+        if not line or not line.startswith("data: "):
+            continue
+        data_str = line[len("data: "):]
+        if data_str == "[DONE]":
+            break
+        chunks.append(json.loads(data_str))
 
-    # Verify each choice has a unique index 0-4
-    indices = sorted(c["index"] for c in choices)
-    assert indices == [0, 1, 2, 3, 4], f"Expected indices [0,1,2,3,4], got {indices}"
+    assert len(chunks) > 0, "Expected at least one streaming chunk"
 
-    # Verify each choice has a finish_reason and non-empty content
-    for choice in choices:
-        assert choice.get("finish_reason") is not None, (
-            f"Choice {choice['index']} missing finish_reason"
-        )
-        message = choice.get("message", {})
-        content = message.get("content", "")
-        assert content, f"Choice {choice['index']} has empty content"
+    # Collect all choice indices and finished indices across all chunks
+    all_indices = set()
+    finished_indices = set()
+    content_per_choice: dict = {}
+    for chunk in chunks:
+        for choice in chunk.get("choices", []):
+            idx = choice["index"]
+            all_indices.add(idx)
+            delta_content = choice.get("delta", {}).get("content", "")
+            if delta_content:
+                content_per_choice.setdefault(idx, "")
+                content_per_choice[idx] += delta_content
+            if choice.get("finish_reason") is not None:
+                finished_indices.add(idx)
 
-    # Verify usage is present and completion_tokens accounts for all choices
-    usage = response_data.get("usage", {})
-    assert usage.get("prompt_tokens", 0) > 0, "Missing prompt_tokens in usage"
-    assert usage.get("completion_tokens", 0) > 0, "Missing completion_tokens in usage"
-    assert usage.get("total_tokens", 0) == (
-        usage["prompt_tokens"] + usage["completion_tokens"]
-    ), "total_tokens should equal prompt_tokens + completion_tokens"
+    # Verify all 5 choice indices appeared
+    assert all_indices == {0, 1, 2, 3, 4}, (
+        f"Expected indices {{0,1,2,3,4}}, got {all_indices}"
+    )
+
+    # Verify all 5 choices finished
+    assert finished_indices == {0, 1, 2, 3, 4}, (
+        f"Expected all 5 choices to finish, only got {finished_indices}"
+    )
+
+    # Verify each choice produced some content
+    for i in range(5):
+        assert content_per_choice.get(i), f"Choice {i} has no content"


### PR DESCRIPTION
#### Overview:

Adds support for generating multiple choices (n>1) in chat completions for vLLM.

#### Details:

Pass `n` to vLLM and keep track of each decoder independently, handling stopping. Currently no request migration support.
Report combined usage statistics.

#### Where should the reviewer start?

  - handlers.py — Both token mode and text mode now iterate over all res.outputs instead of just outputs[0]. Tracks per-choice state (`previous_text_per_choice`, `output_tokens_per_choice`, `finished_choices`). Keeps track of finished decoders in `finished_choices`. Usage is attached only when all n
  choices finish. Maps the n parameter through to vLLM's SamplingParams.
  - backend.rs — Creates a separate Decoder per choice index (keyed 0..n in a HashMap). Tracks finished_choices and only calls stop_generating() when all choices are done. Filters out already-finished choices via filter_map.
  - delta.rs — Uses delta.index.unwrap_or(0) instead of hardcoded index = 0, so each choice's index propagates correctly into the streaming response.
  - migration.rs — Request migration is currently out of scope for this PR so it disables request migration when n > 1 (sets migration limit to 0).
  - test_vllm.py — An e2e test that sends a request with `n=5`

Things to review: correctness, performance.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #6116


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for generating multiple completions simultaneously in a single request.
  * Enhanced streaming to properly track and identify each completion independently.
  * Improved token accounting to accurately count tokens across all generated outputs.
  * Disabled automatic retries for multi-completion requests.

* **Tests**
  * Added comprehensive test coverage for multi-completion streaming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->