### PR TITLE
fix: reduce pytest-marker-report output noise and move to tests/

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
   hooks:
     - id: pytest-marker-report
       name: Report pytest markers (static + inherited)
-      entry: python3 scripts/report_pytest_markers.py
+      entry: python3 tests/report_pytest_markers.py
       language: python
       pass_filenames: false
       additional_dependencies:

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -356,6 +356,11 @@ def parse_args():
     parser.add_argument(
         "--tests", default="tests", help="Path to test directory (default: tests)"
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print all tests with their markers (default: only failures and summary)",
+    )
     return parser.parse_args()
 
 
@@ -395,14 +400,18 @@ def run_collection(test_path: str, use_stubbing: bool) -> tuple[int, Report]:
     return exitcode, plugin.build_report()
 
 
-def print_human_report(report: Report) -> None:
-    """Print human-readable report to stdout."""
-    print("\n" + "=" * 80)
-    print(f"{'TEST ID':<60} | MARKERS")
-    print("=" * 80)
+def print_human_report(report: Report, *, verbose: bool = False) -> None:
+    """Print human-readable report to stdout.
 
-    for rec in report.tests:
-        print(f"{rec.nodeid:<60} | {', '.join(rec.markers)}")
+    By default only prints tests with missing markers and the summary.
+    Pass verbose=True to print all tests with their markers.
+    """
+    if verbose:
+        print("\n" + "=" * 80)
+        print(f"{'TEST ID':<60} | MARKERS")
+        print("=" * 80)
+        for rec in report.tests:
+            print(f"{rec.nodeid:<60} | {', '.join(rec.markers)}")
 
     # Print tests with missing markers before summary
     missing_tests = [rec for rec in report.tests if rec.missing]
@@ -432,7 +441,7 @@ def main() -> int:
     declared = load_declared_markers(Path("."))
     validate_marker_definitions(report, declared)
 
-    print_human_report(report)
+    print_human_report(report, verbose=args.verbose)
 
     # Strict mode validation
     if args.strict:


### PR DESCRIPTION
## Summary
- Move `report_pytest_markers.py` from `scripts/` to `tests/`, removing the now-empty `scripts/` directory
- Add `--verbose` flag to control output verbosity — by default only tests with missing markers and the summary are printed (~180 lines vs ~980)
- Update `.pre-commit-config.yaml` entry to point to the new path

## Test plan
- [x] `pre-commit run pytest-marker-report --all-files` passes
- [x] Default output reduced from ~980 to ~180 lines
- [x] `--verbose` flag restores full output
- [ ] CI pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--verbose` flag to control pytest marker report output verbosity, allowing users to display expanded or summary-only results

* **Chores**
  * Updated pytest marker report tool location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->