### PR TITLE
feat: add --endpoint flag support to dynamo.vllm

### DIFF
--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -58,7 +58,7 @@ class DynamoRuntimeArgGroup(ArgGroup):
             flag_name="--endpoint",
             env_var="DYN_ENDPOINT",
             default=None,
-            help="Dynamo endpoint string in 'dyn://namespace.component.endpoint' format. Example: dyn://dynamo.backend.generate. Currently used only by TRT-LLM and SGLang backends.",
+            help="Dynamo endpoint string in 'dyn://namespace.component.endpoint' format. Example: dyn://dynamo.backend.generate.",
         )
         add_argument(
             g,

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -21,6 +21,7 @@ from dynamo.common.configuration.groups.runtime_args import (
     DynamoRuntimeArgGroup,
     DynamoRuntimeConfig,
 )
+from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.vllm.backend_args import DynamoVllmArgGroup, DynamoVllmConfig
 
 from . import envs
@@ -152,6 +153,9 @@ def update_dynamo_config_with_engine(
     else:
         dynamo_config.served_model_name = None
 
+    # Capture user-provided --endpoint before defaults overwrite it
+    user_endpoint = dynamo_config.endpoint
+
     # TODO: move to "disaggregation_mode" as the other engines.
     if dynamo_config.route_to_encoder:
         dynamo_config.component = "processor"
@@ -177,6 +181,13 @@ def update_dynamo_config_with_engine(
     else:
         dynamo_config.component = "backend"
         dynamo_config.endpoint = "generate"
+
+    # If user provided --endpoint, override namespace/component/endpoint
+    if user_endpoint is not None:
+        parsed_ns, parsed_comp, parsed_ep = parse_endpoint(user_endpoint)
+        dynamo_config.namespace = parsed_ns
+        dynamo_config.component = parsed_comp
+        dynamo_config.endpoint = parsed_ep
 
     if dynamo_config.custom_jinja_template is not None:
         expanded_template_path = os.path.expanduser(


### PR DESCRIPTION
## Summary
- Adds `--endpoint dyn://namespace.component.endpoint` support to the vLLM backend, matching sglang/trtllm behavior
- When `--endpoint` is provided, the parsed namespace, component, and endpoint override defaults set by worker-type flags (e.g. `--is-prefill-worker`)
- Updates `--endpoint` help text to remove backend-specific restriction note
- Adds 4 unit tests covering override, defaults preserved, override with worker flags, and invalid format

Closes DGH-577

## Test plan
- [x] `test_endpoint_overrides_defaults` — verifies `--endpoint` sets all three fields
- [x] `test_endpoint_not_provided_preserves_defaults` — verifies defaults unchanged without flag
- [x] `test_endpoint_overrides_with_prefill_worker` — verifies `--endpoint` wins over `--is-prefill-worker`
- [x] `test_endpoint_invalid_format_raises` — verifies `ValueError` on bad format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User-specified endpoint configurations now take precedence over automatically assigned routing defaults, providing enhanced control over backend selection.

* **Documentation**
  * Simplified the help message for the --endpoint argument with improved clarity.

* **Tests**
  * Added unit tests validating endpoint override behavior and error handling for invalid endpoint formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->