### PR TITLE
fix: remove unnecessary cuda synchronize calls in GMS adapters

### DIFF
--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -403,11 +403,6 @@ class GMSClientMemoryManager:
         self._unmap_preserving_va()
         self._va_preserved = True
 
-        # Ensure all CUDA VMM unmap operations complete before releasing the lock.
-        # This prevents race conditions where remap() may be called before
-        # physical memory is fully released.
-        synchronize()
-
         self._client_rpc.close()
         self._client = None
         self._unmapped = True

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -119,11 +119,6 @@ class GMSWorker(Worker):
         allocator = CuMemAllocator.get_instance()
         allocator.sleep(offload_tags=tuple())
 
-        # Ensure all CUDA VMM unmap operations complete before returning.
-        # Without this sync, wake_up() may race with pending unmaps, causing OOM
-        # when it tries to allocate new memory while old memory is still mapped.
-        torch.cuda.synchronize()
-
         free_bytes_after, total = torch.cuda.mem_get_info()
         freed_bytes = free_bytes_after - free_bytes_before
         used_bytes = total - free_bytes_after
@@ -145,15 +140,10 @@ class GMSWorker(Worker):
             assert manager is not None, "GMS client is not initialized"
             assert manager.is_unmapped, "GMS weights are not unmapped"
             manager.remap()
-            torch.cuda.synchronize()
 
         if "kv_cache" in tags:
             allocator = CuMemAllocator.get_instance()
             allocator.wake_up(tags=["kv_cache"])
-
-            # Ensure KV cache mappings are complete before returning.
-            # Without this sync, inference may start before mappings are ready.
-            torch.cuda.synchronize()
 
             # Reinitialize FP8 KV scales if needed
             if self.cache_config.cache_dtype.startswith("fp8") and hasattr(


### PR DESCRIPTION
## Summary
- Remove 8 redundant `torch.cuda.synchronize()` / `cuCtxSynchronize()` calls from GMS vLLM worker, SGLang memory saver, and client memory manager. CUDA VMM operations (`cuMemMap`, `cuMemUnmap`, `cuMemSetAccess`) are synchronous driver API calls — syncing after them is a no-op.
- Add `pause_generation()` / `resume_generation()` to vLLM handler's sleep/wake path to properly abort and drain in-flight requests before unmapping GPU memory. Previously vLLM did not quiesce the GPU before sleep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal GPU memory management and request handling operations to improve system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->