### PR TITLE
fix(recipes): add ComputeDomain for gpt-oss-120b-trtllm-agg on GB200 …

### DIFF
--- a/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
@@ -16,6 +16,20 @@ data:
     moe_config:
         backend: CUTLASS
 ---
+# NOTE: ComputeDomain provisions the IMEX channel required for MNNVL NVLink shared memory
+# on GB200 nodes. If your cluster uses the Grove operator with autoMNNVLEnabled=true, Grove
+# automatically manages this resource — remove this block in that case to avoid a scheduling
+# conflict. See the "2. GPU Cluster Requirements" note in recipes/README.md for details.
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: trtllm-compute-domain
+spec:
+  numNodes: 1  # Single-node aggregated deployment (4 GPUs on 1 node)
+  channel:
+    resourceClaimTemplate:
+      name: trtllm-compute-domain-channel
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
@@ -70,7 +84,7 @@ spec:
           - |
             python3 -m dynamo.trtllm \
               --model-path "${MODEL_PATH}" \
-              --served-model-name "openai/gpt-oss-120b" \
+              --served-model-name "${SERVED_MODEL_NAME}" \
               --extra-engine-args "${ENGINE_ARGS}" \
               --tensor-parallel-size 4 \
               --expert-parallel-size 4 \
@@ -81,16 +95,16 @@ spec:
           - -c
           image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.0
           env:
-          - name: TRTLLM_ENABLE_PDL
-            value: "1"
-          - name: TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL
-            value: "True"
+          - name: MODEL_PATH
+            value: "openai/gpt-oss-120b"
           - name: SERVED_MODEL_NAME
             value: "openai/gpt-oss-120b"
           - name: ENGINE_ARGS
             value: "/opt/dynamo/configs/config.yaml"
-          - name: MODEL_PATH
-            value: "openai/gpt-oss-120b"
+          - name: TRTLLM_ENABLE_PDL
+            value: "1"
+          - name: TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL
+            value: "True"
           - name: HF_HOME
             value: /opt/models
           volumeMounts:
@@ -98,6 +112,9 @@ spec:
             name: llm-config
             readOnly: true
           workingDir: /workspace/examples/backends/trtllm
+        resourceClaims:
+          - name: compute-domain-channel
+            resourceClaimTemplateName: trtllm-compute-domain-channel
         volumes:
         - configMap:
             name: llm-config
@@ -108,3 +125,5 @@ spec:
           gpu: "4"
         requests:
           gpu: "4"
+        claims:
+          - name: compute-domain-channel


### PR DESCRIPTION
#### Overview:

Fixes the gpt-oss-120b TRT-LLM aggregated recipe for GB200 clusters by adding the
ComputeDomain resource required for MNNVL NVLink shared memory, and documents the
Grove auto-MNNVL interaction that affects all GB200 recipes.

#### Details:

- `deploy.yaml`: add `ComputeDomain` + `resourceClaims` + `resources.claims` for MNNVL
  IMEX channel provisioning (required by CUTLASS MoE EP=4 on GB200; remove if Grove
  `autoMNNVLEnabled=true` is active on your cluster)
- `deploy.yaml`: consolidate `SERVED_MODEL_NAME` as the single source of truth, referenced
  by `--served-model-name` in the Python command; remove the redundant hardcoded string
- `README.md`: add a `[!NOTE]` callout under GPU Cluster Requirements explaining the
  ComputeDomain requirement for GB200 recipes and the Grove auto-MNNVL double-claim conflict

#### Where should the reviewer start?

`recipes/gpt-oss-120b/trtllm/agg/deploy.yaml` — the ComputeDomain block and the env var
ordering. Then `recipes/README.md` lines 80–98 for the new callout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive GB200-specific prerequisite documentation covering ComputeDomain/IMEX requirements, NVLink constraints, and operator interactions.

* **New Features**
  * Introduced ComputeDomain resource enabling IMEX and NVLink support on GB200 nodes for optimized distributed computation.
  * Enabled PDL-based processing capabilities.
  * Model serving configurations are now dynamically manageable instead of hard-coded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->