### PR TITLE
docs: fix broken links and unconverted callouts in v0.9.0 docs

### DIFF
--- a/fern/pages-v0.9.0/agents/tool-calling.md
+++ b/fern/pages-v0.9.0/agents/tool-calling.md
@@ -21,12 +21,14 @@ To enable this feature, you should set the following flag while launching the ba
 python -m dynamo.<backend> --help"
 ```
 
-> [!NOTE]
-> If no tool call parser is provided by the user, Dynamo will try to use default tool call parsing based on `<TOOLCALL>` and `<|python_tag|>` tool tags.
+<Note>
+If no tool call parser is provided by the user, Dynamo will try to use default tool call parsing based on `<TOOLCALL>` and `<|python_tag|>` tool tags.
+</Note>
 
-> [!TIP]
-> If your model's default chat template doesn't support tool calling, but the model itself does, you can specify a custom chat template per worker
-> with `python -m dynamo.<backend> --custom-jinja-template </path/to/template.jinja>`.
+<Tip>
+If your model's default chat template doesn't support tool calling, but the model itself does, you can specify a custom chat template per worker
+with `python -m dynamo.<backend> --custom-jinja-template </path/to/template.jinja>`.
+</Tip>
 
 
 Parser to Model Mapping

--- a/fern/pages-v0.9.0/backends/sglang/README.md
+++ b/fern/pages-v0.9.0/backends/sglang/README.md
@@ -66,8 +66,9 @@ Dynamo SGLang uses SGLang's native argument parser, so **most SGLang engine argu
 - **Default (`--use-sglang-tokenizer` not set)**: Dynamo handles tokenization/detokenization via our blazing fast frontend and passes `input_ids` to SGLang
 - **With `--use-sglang-tokenizer`**: SGLang handles tokenization/detokenization, Dynamo passes raw prompts
 
-> [!NOTE]
-> When using `--use-sglang-tokenizer`, only `v1/chat/completions` is available through Dynamo's frontend.
+<Note>
+When using `--use-sglang-tokenizer`, only `v1/chat/completions` is available through Dynamo's frontend.
+</Note>
 
 ### Request Cancellation
 
@@ -80,8 +81,9 @@ When a user cancels a request (e.g., by disconnecting from the frontend), the re
 | **Aggregated** | ✅ | ✅ |
 | **Disaggregated** | ⚠️ | ✅ |
 
-> [!WARNING]
-> ⚠️ SGLang backend currently does not support cancellation during remote prefill phase in disaggregated mode.
+<Warning>
+⚠️ SGLang backend currently does not support cancellation during remote prefill phase in disaggregated mode.
+</Warning>
 
 For more details, see the [Request Cancellation Architecture](../../fault-tolerance/request-cancellation.md) documentation.
 
@@ -162,15 +164,17 @@ For local/bare-metal development, start etcd and optionally NATS using [Docker C
 docker compose -f deploy/docker-compose.yml up -d
 ```
 
-> [!NOTE]
-> - **etcd** is optional but is the default local discovery backend. You can also use `--kv_store file` to use file system based discovery.
-> - **NATS** is optional - only needed if using KV routing with events (default). You can disable it with `--no-kv-events` flag for prediction-based routing
-> - **On Kubernetes**, neither is required when using the Dynamo operator, which explicitly sets `DYN_DISCOVERY_BACKEND=kubernetes` to enable native K8s service discovery (DynamoWorkerMetadata CRD)
+<Note>
+- **etcd** is optional but is the default local discovery backend. You can also use `--kv_store file` to use file system based discovery.
+- **NATS** is optional - only needed if using KV routing with events (default). You can disable it with `--no-kv-events` flag for prediction-based routing
+- **On Kubernetes**, neither is required when using the Dynamo operator, which explicitly sets `DYN_DISCOVERY_BACKEND=kubernetes` to enable native K8s service discovery (DynamoWorkerMetadata CRD)
+</Note>
 
-> [!TIP]
-> Each example corresponds to a simple bash script that runs the OpenAI compatible server, processor, and optional router (written in Rust) and LLM engine (written in Python) in a single terminal. You can easily take each command and run them in separate terminals.
->
-> Additionally - because we use sglang's argument parser, you can pass in any argument that sglang supports to the worker!
+<Tip>
+Each example corresponds to a simple bash script that runs the OpenAI compatible server, processor, and optional router (written in Rust) and LLM engine (written in Python) in a single terminal. You can easily take each command and run them in separate terminals.
+
+Additionally - because we use sglang's argument parser, you can pass in any argument that sglang supports to the worker!
+</Tip>
 
 
 ### Aggregated Serving

--- a/fern/pages-v0.9.0/backends/sglang/profiling.md
+++ b/fern/pages-v0.9.0/backends/sglang/profiling.md
@@ -5,8 +5,9 @@
 
 # Profiling SGLang Workers in Dynamo
 
-> [!NOTE]
-> **See also**: [Profiler Component Overview](../../components/profiler/README.md) for SLA-driven profiling and deployment optimization.
+<Note>
+**See also**: [Profiler Component Overview](../../components/profiler/README.md) for SLA-driven profiling and deployment optimization.
+</Note>
 
 Dynamo exposes profiling endpoints for SGLang workers via the system server's `/engine/*` routes. This allows you to start and stop PyTorch profiling on running inference workers without restarting them.
 

--- a/fern/pages-v0.9.0/backends/trtllm/README.md
+++ b/fern/pages-v0.9.0/backends/trtllm/README.md
@@ -65,10 +65,11 @@ For local/bare-metal development, start etcd and optionally NATS using [Docker C
 docker compose -f deploy/docker-compose.yml up -d
 ```
 
-> [!NOTE]
-> - **etcd** is optional but is the default local discovery backend. You can also use `--kv_store file` to use file system based discovery.
-> - **NATS** is optional - only needed if using KV routing with events (default). You can disable it with `--no-kv-events` flag for prediction-based routing
-> - **On Kubernetes**, neither is required when using the Dynamo operator, which explicitly sets `DYN_DISCOVERY_BACKEND=kubernetes` to enable native K8s service discovery (DynamoWorkerMetadata CRD)
+<Note>
+- **etcd** is optional but is the default local discovery backend. You can also use `--kv_store file` to use file system based discovery.
+- **NATS** is optional - only needed if using KV routing with events (default). You can disable it with `--no-kv-events` flag for prediction-based routing
+- **On Kubernetes**, neither is required when using the Dynamo operator, which explicitly sets `DYN_DISCOVERY_BACKEND=kubernetes` to enable native K8s service discovery (DynamoWorkerMetadata CRD)
+</Note>
 
 ### Build container
 
@@ -96,8 +97,9 @@ apt-get update && apt-get -y install git git-lfs
 
 ## Single Node Examples
 
-> [!IMPORTANT]
-> Below we provide some simple shell scripts that run the components for each configuration. Each shell script is simply running the `python3 -m dynamo.frontend <args>` to start up the ingress and using `python3 -m dynamo.trtllm <args>` to start up the workers. You can easily take each command and run them in separate terminals.
+<Info>
+Below we provide some simple shell scripts that run the components for each configuration. Each shell script is simply running the `python3 -m dynamo.frontend <args>` to start up the ingress and using `python3 -m dynamo.trtllm <args>` to start up the workers. You can easily take each command and run them in separate terminals.
+</Info>
 
 For detailed information about the architecture and how KV-aware routing works, see the [Router Guide](../../components/router/router-guide.md).
 
@@ -122,8 +124,7 @@ cd $DYNAMO_HOME/examples/backends/trtllm
 
 ### Disaggregated with KV Routing
 
-> [!IMPORTANT]
-> In disaggregated workflow, requests are routed to the prefill worker to maximize KV cache reuse.
+<Info>In disaggregated workflow, requests are routed to the prefill worker to maximize KV cache reuse.</Info>
 
 ```bash
 cd $DYNAMO_HOME/examples/backends/trtllm
@@ -185,8 +186,9 @@ You can enable [request migration](../../fault-tolerance/request-migration.md) t
 python3 -m dynamo.trtllm ... --migration-limit=3
 ```
 
-> [!IMPORTANT]
-> **Prefill workers do not support request migration** and must use `--migration-limit=0` (the default). Prefill workers only process prompts and return KV cache state - they don't maintain long-running generation requests that would benefit from migration.
+<Info>
+**Prefill workers do not support request migration** and must use `--migration-limit=0` (the default). Prefill workers only process prompts and return KV cache state - they don't maintain long-running generation requests that would benefit from migration.
+</Info>
 
 See the [Request Migration Architecture](../../fault-tolerance/request-migration.md) documentation for details on how this works.
 

--- a/fern/pages-v0.9.0/backends/vllm/README.md
+++ b/fern/pages-v0.9.0/backends/vllm/README.md
@@ -64,10 +64,11 @@ For local/bare-metal development, start etcd and optionally NATS using [Docker C
 docker compose -f deploy/docker-compose.yml up -d
 ```
 
-> [!NOTE]
-> - **etcd** is optional but is the default local discovery backend. You can also use `--kv_store file` to use file system based discovery.
-> - **NATS** is optional - only needed if using KV routing with events (default). You can disable it with `--no-kv-events` flag for prediction-based routing
-> - **On Kubernetes**, neither is required when using the Dynamo operator, which explicitly sets `DYN_DISCOVERY_BACKEND=kubernetes` to enable native K8s service discovery (DynamoWorkerMetadata CRD)
+<Note>
+- **etcd** is optional but is the default local discovery backend. You can also use `--kv_store file` to use file system based discovery.
+- **NATS** is optional - only needed if using KV routing with events (default). You can disable it with `--no-kv-events` flag for prediction-based routing
+- **On Kubernetes**, neither is required when using the Dynamo operator, which explicitly sets `DYN_DISCOVERY_BACKEND=kubernetes` to enable native K8s service discovery (DynamoWorkerMetadata CRD)
+</Note>
 
 ### Pull or build container
 
@@ -87,8 +88,9 @@ This includes the specific commit [vllm-project/vllm#19790](https://github.com/v
 
 ## Run Single Node Examples
 
-> [!IMPORTANT]
-> Below we provide simple shell scripts that run the components for each configuration. Each shell script runs `python3 -m dynamo.frontend` to start the ingress and uses `python3 -m dynamo.vllm` to start the vLLM workers. You can also run each command in separate terminals for better log visibility.
+<Info>
+Below we provide simple shell scripts that run the components for each configuration. Each shell script runs `python3 -m dynamo.frontend` to start the ingress and uses `python3 -m dynamo.vllm` to start the vLLM workers. You can also run each command in separate terminals for better log visibility.
+</Info>
 
 ### Aggregated Serving
 
@@ -132,8 +134,9 @@ cd examples/backends/vllm
 bash launch/dep.sh
 ```
 
-> [!TIP]
-> Run a disaggregated example and try adding another prefill worker once the setup is running! The system will automatically discover and utilize the new worker.
+<Tip>
+Run a disaggregated example and try adding another prefill worker once the setup is running! The system will automatically discover and utilize the new worker.
+</Tip>
 
 ## Advanced Examples
 

--- a/fern/pages-v0.9.0/backends/vllm/gpt-oss.md
+++ b/fern/pages-v0.9.0/backends/vllm/gpt-oss.md
@@ -16,7 +16,7 @@ This deployment uses disaggregated serving in vLLM where:
 
 ## Prerequisites
 
-This guide assumes readers already knows how to deploy Dynamo disaggregated serving with vLLM as illustrated in [README.md](README.md)
+This guide assumes readers already knows how to deploy Dynamo disaggregated serving with vLLM as illustrated in [the vLLM backend guide](/dynamo/v-0-9-0/components/backends/v-llm)
 
 ## Instructions
 

--- a/fern/pages-v0.9.0/components/kvbm/kvbm-guide.md
+++ b/fern/pages-v0.9.0/components/kvbm/kvbm-guide.md
@@ -84,12 +84,13 @@ vllm serve --kv-transfer-config '{"kv_connector":"DynamoConnector","kv_role":"kv
 
 ## Run KVBM in Dynamo with TensorRT-LLM
 
-> [!NOTE]
-> **Prerequisites:**
-> - Ensure `etcd` and `nats` are running before starting
-> - KVBM only supports TensorRT-LLM's PyTorch backend
-> - Disable partial reuse (`enable_partial_reuse: false`) to increase offloading cache hits
-> - KVBM requires TensorRT-LLM v1.2.0rc2 or newer
+<Note>
+**Prerequisites:**
+- Ensure `etcd` and `nats` are running before starting
+- KVBM only supports TensorRT-LLM's PyTorch backend
+- Disable partial reuse (`enable_partial_reuse: false`) to increase offloading cache hits
+- KVBM requires TensorRT-LLM v1.2.0rc2 or newer
+</Note>
 
 ### Docker Setup
 
@@ -201,9 +202,10 @@ cd $DYNAMO_HOME/examples/backends/vllm
 
 ### Disaggregated Serving with TRT-LLM
 
-> [!NOTE]
-> The latest TensorRT-LLM release (1.3.0rc1) is currently experiencing a request hang when running disaggregated serving with KVBM.
-> Please include the TensorRT-LLM commit id `18e611da773026a55d187870ebcfa95ff00c8482` when building the Dynamo TensorRT-LLM runtime image to test the KVBM + disaggregated serving feature.
+<Note>
+The latest TensorRT-LLM release (1.3.0rc1) is currently experiencing a request hang when running disaggregated serving with KVBM.
+Please include the TensorRT-LLM commit id `18e611da773026a55d187870ebcfa95ff00c8482` when building the Dynamo TensorRT-LLM runtime image to test the KVBM + disaggregated serving feature.
+</Note>
 
 ```bash
 # Build the Dynamo TensorRT-LLM container using commit ID 18e611da773026a55d187870ebcfa95ff00c8482. Note: This build can take a long time.
@@ -213,8 +215,9 @@ cd $DYNAMO_HOME/examples/backends/vllm
 ./container/run.sh --framework trtllm -it --mount-workspace --use-nixl-gds
 ```
 
-> [!NOTE]
-> Important: After logging into the Dynamo TensorRT-LLM runtime container, copy the Triton kernels into the container's virtual environment as a separate Python module.
+<Note>
+Important: After logging into the Dynamo TensorRT-LLM runtime container, copy the Triton kernels into the container's virtual environment as a separate Python module.
+</Note>
 
 ```bash
 # Clone the TensorRT-LLM repo and copy the triton_kernels folder into the container as a Python module.

--- a/fern/pages-v0.9.0/components/profiler/profiler-guide.md
+++ b/fern/pages-v0.9.0/components/profiler/profiler-guide.md
@@ -43,8 +43,9 @@ The profiler sweeps over the following parallelization mappings for prefill and 
 | GQA+MoE (Qwen3MoeForCausalLM) | TP, TEP, DEP | TP, TEP, DEP |
 | Other Models | TP | TP |
 
-> [!NOTE]
-> Exact model x parallelization mapping support is dependent on the backend. The profiler does not guarantee that the recommended P/D engine configuration is supported and bug-free by the backend.
+<Note>
+Exact model x parallelization mapping support is dependent on the backend. The profiler does not guarantee that the recommended P/D engine configuration is supported and bug-free by the backend.
+</Note>
 
 ## Deployment
 
@@ -140,8 +141,9 @@ kubectl port-forward svc/<deployment>-frontend 8000:8000 -n $NAMESPACE
 curl http://localhost:8000/v1/models
 ```
 
-> [!NOTE]
-> DGDRs are **immutable**. To update SLAs or configuration, delete the existing DGDR and create a new one.
+<Note>
+DGDRs are **immutable**. To update SLAs or configuration, delete the existing DGDR and create a new one.
+</Note>
 
 ### Direct Script Execution
 
@@ -214,8 +216,9 @@ profilingConfig:
       aicBackendVersion: "0.20.0"      # TRT-LLM version simulated by AIC
 ```
 
-> [!NOTE]
-> `aicBackendVersion` specifies the TensorRT-LLM version that AI Configurator simulates. See the [AI Configurator supported features](https://github.com/ai-dynamo/aiconfigurator#supported-features) for available versions.
+<Note>
+`aicBackendVersion` specifies the TensorRT-LLM version that AI Configurator simulates. See the [AI Configurator supported features](https://github.com/ai-dynamo/aiconfigurator#supported-features) for available versions.
+</Note>
 
 **Currently supports:**
 - **Backends**: TensorRT-LLM (versions 0.20.0, 1.0.0rc3, 1.0.0rc6)
@@ -296,8 +299,9 @@ hardware:
 - **numGpusPerNode**: Determine the upper bound of GPUs per node for dense models and configure Grove for multi-node MoE engines
 - **gpuType**: Informational only, auto-detected by the controller. For AI Configurator, use `aicSystem` in the [sweep configuration](#ai-configurator-configuration) instead
 
-> [!TIP]
-> If you don't specify hardware constraints, the controller auto-detects based on your model size and available cluster resources.
+<Tip>
+If you don't specify hardware constraints, the controller auto-detects based on your model size and available cluster resources.
+</Tip>
 
 ### Sweep Configuration (Optional)
 
@@ -335,8 +339,9 @@ planner:
   planner_load_predictor: linear             # Load prediction method
 ```
 
-> [!NOTE]
-> Planner arguments use `planner_` prefix. See [SLA Planner documentation](../planner/planner-guide.md) for full list.
+<Note>
+Planner arguments use `planner_` prefix. See [SLA Planner documentation](../planner/planner-guide.md) for full list.
+</Note>
 
 ### Model Cache PVC (Advanced)
 
@@ -413,8 +418,9 @@ The profiler uses the DGD config as a **base template**, then optimizes it based
 | `--pick-with-webui` | flag | false | Launch interactive WebUI |
 | `--webui-port` | int | 8000 | Port for WebUI |
 
-> [!NOTE]
-> CLI arguments map to DGDR config fields: `--min-num-gpus` = `hardware.minNumGpusPerEngine`, `--max-num-gpus` = `hardware.maxNumGpusPerEngine`, `--use-ai-configurator` = `sweep.useAiConfigurator`. See [DGDR Configuration Structure](#dgdr-configuration-structure) for all field mappings.
+<Note>
+CLI arguments map to DGDR config fields: `--min-num-gpus` = `hardware.minNumGpusPerEngine`, `--max-num-gpus` = `hardware.maxNumGpusPerEngine`, `--use-ai-configurator` = `sweep.useAiConfigurator`. See [DGDR Configuration Structure](#dgdr-configuration-structure) for all field mappings.
+</Note>
 
 ## Integration
 
@@ -604,8 +610,7 @@ hardware:
 
 **Calculate Max TP**: `max_tp = num_attention_heads / 4`
 
-> [!NOTE]
-> This is an AI Configurator limitation. Online profiling doesn't have this constraint.
+<Note>This is an AI Configurator limitation. Online profiling doesn't have this constraint.</Note>
 
 ### Image Pull Errors
 

--- a/fern/pages-v0.9.0/development/backend-guide.md
+++ b/fern/pages-v0.9.0/development/backend-guide.md
@@ -117,8 +117,9 @@ A Python worker may need to be shut down promptly, for example when the node run
 
 In such cases, you can signal incomplete responses by raising a `GeneratorExit` exception in your generate loop. This will immediately close the response stream, signaling to the frontend that the stream is incomplete. With request migration enabled (see the [`migration_limit`](../fault-tolerance/request-migration.md) parameter), the frontend will automatically migrate the partially completed request to another worker instance, if available, to be completed.
 
-> [!WARNING]
-> We will update the `GeneratorExit` exception to a new Dynamo exception. Please expect minor code breaking change in the near future.
+<Warning>
+We will update the `GeneratorExit` exception to a new Dynamo exception. Please expect minor code breaking change in the near future.
+</Warning>
 
 Here's an example of how to implement this in your `RequestHandler`:
 

--- a/fern/pages-v0.9.0/features/multimodal/README.md
+++ b/fern/pages-v0.9.0/features/multimodal/README.md
@@ -8,11 +8,12 @@ subtitle: Deploy multimodal models with image, video, and audio support in Dynam
 
 Dynamo supports multimodal inference across multiple LLM backends, enabling models to process images, video, and audio alongside text. This section provides comprehensive documentation for deploying multimodal models.
 
-> [!IMPORTANT]
-> **Security Requirement**: Multimodal processing must be explicitly enabled at startup.
-> See the relevant documentation for each backend for the necessary flags.
->
-> This prevents unintended processing of multimodal data from untrusted sources.
+<Info>
+**Security Requirement**: Multimodal processing must be explicitly enabled at startup.
+See the relevant documentation for each backend for the necessary flags.
+
+This prevents unintended processing of multimodal data from untrusted sources.
+</Info>
 
 ## Backend Documentation
 ## Support Matrix

--- a/fern/pages-v0.9.0/features/multimodal/multimodal-vllm.md
+++ b/fern/pages-v0.9.0/features/multimodal/multimodal-vllm.md
@@ -7,9 +7,10 @@
 
 This document provides a comprehensive guide for multimodal inference using vLLM backend in Dynamo.
 
-> [!IMPORTANT]
-> **Security Requirement**: All multimodal workers require the `--enable-multimodal` flag to be explicitly set at startup. This is a security feature to prevent unintended processing of multimodal data from untrusted sources. Workers will fail at startup if multimodal flags (e.g., `--multimodal-worker`, `--multimodal-processor`) are used without `--enable-multimodal`.
-> This flag is analogous to `--enable-mm-embeds` in vllm serve but also extends it to all multimodal content (url, embeddings, b64).
+<Info>
+**Security Requirement**: All multimodal workers require the `--enable-multimodal` flag to be explicitly set at startup. This is a security feature to prevent unintended processing of multimodal data from untrusted sources. Workers will fail at startup if multimodal flags (e.g., `--multimodal-worker`, `--multimodal-processor`) are used without `--enable-multimodal`.
+This flag is analogous to `--enable-mm-embeds` in vllm serve but also extends it to all multimodal content (url, embeddings, b64).
+</Info>
 
 ## Support Matrix
 
@@ -160,7 +161,7 @@ cd $DYNAMO_HOME/examples/backends/vllm
 bash launch/disagg_multimodal_epd.sh --model llava-hf/llava-1.5-7b-hf
 ```
 
-> [!NOTE] Disaggregation is currently only confirmed to work with LLaVA. Qwen2.5-VL is not confirmed to be supported.
+<Note>Disaggregation is currently only confirmed to work with LLaVA. Qwen2.5-VL is not confirmed to be supported.</Note>
 
 ## ECConnector Serving
 

--- a/fern/pages-v0.9.0/kubernetes/deployment/minikube.md
+++ b/fern/pages-v0.9.0/kubernetes/deployment/minikube.md
@@ -13,8 +13,7 @@ First things first! Start by installing Minikube. Follow the official [Minikube 
 ## 2. Configure GPU Support (Optional)
 Planning to use GPU-accelerated workloads? You'll need to configure GPU support in Minikube. Follow the [Minikube GPU guide](https://minikube.sigs.k8s.io/docs/tutorials/nvidia/) to set up NVIDIA GPU support before proceeding.
 
-> [!TIP]
-> Make sure to configure GPU support before starting Minikube if you plan to use GPU workloads!
+<Tip>Make sure to configure GPU support before starting Minikube if you plan to use GPU workloads!</Tip>
 
 
 ## 3. Start Minikube

--- a/fern/pages-v0.9.0/kubernetes/installation-guide.md
+++ b/fern/pages-v0.9.0/kubernetes/installation-guide.md
@@ -153,38 +153,41 @@ VALIDATION ERROR: Cannot install cluster-wide Dynamo operator.
 Found existing namespace-restricted Dynamo operators in namespaces: ...
 ```
 
-> [!TIP]
-> For multinode deployments, you need to install multinode orchestration components:
->
-> **Option 1 (Recommended): Grove + KAI Scheduler**
-> - Grove and KAI Scheduler can be installed manually or through the dynamo-platform helm install command.
-> - When using the dynamo-platform helm install command, Grove and KAI Scheduler are NOT installed by default. You can enable their installation by setting the following flags:
->
-> ```bash
-> --set "grove.enabled=true"
-> --set "kai-scheduler.enabled=true"
-> ```
->
-> **Option 2: LeaderWorkerSet (LWS) + Volcano**
-> - If using LWS for multinode deployments, you must also install Volcano (required dependency):
->   - [LWS Installation](https://github.com/kubernetes-sigs/lws#installation)
->   - [Volcano Installation](https://volcano.sh/en/docs/installation/) (required for gang scheduling with LWS)
-> - These must be installed manually before deploying multinode workloads with LWS.
->
-> See the [Multinode Deployment Guide](./deployment/multinode-deployment.md) for details on orchestrator selection.
+<Tip>
+For multinode deployments, you need to install multinode orchestration components:
 
-> [!TIP]
-> By default, Model Express Server is not used.
-> If you wish to use an existing Model Express Server, you can set the modelExpressURL to the existing server's URL in the helm install command:
+**Option 1 (Recommended): Grove + KAI Scheduler**
+- Grove and KAI Scheduler can be installed manually or through the dynamo-platform helm install command.
+- When using the dynamo-platform helm install command, Grove and KAI Scheduler are NOT installed by default. You can enable their installation by setting the following flags:
+
+```bash
+--set "grove.enabled=true"
+--set "kai-scheduler.enabled=true"
+```
+
+**Option 2: LeaderWorkerSet (LWS) + Volcano**
+- If using LWS for multinode deployments, you must also install Volcano (required dependency):
+  - [LWS Installation](https://github.com/kubernetes-sigs/lws#installation)
+  - [Volcano Installation](https://volcano.sh/en/docs/installation/) (required for gang scheduling with LWS)
+- These must be installed manually before deploying multinode workloads with LWS.
+
+See the [Multinode Deployment Guide](./deployment/multinode-deployment.md) for details on orchestrator selection.
+</Tip>
+
+<Tip>
+By default, Model Express Server is not used.
+If you wish to use an existing Model Express Server, you can set the modelExpressURL to the existing server's URL in the helm install command:
+</Tip>
 
 ```bash
 --set "dynamo-operator.modelExpressURL=http://model-express-server.model-express.svc.cluster.local:8080"
 ```
 
-> [!TIP]
-> By default, Dynamo Operator is installed cluster-wide and will monitor all namespaces.
-> If you wish to restrict the operator to monitor only a specific namespace (the helm release namespace by default), you can set the namespaceRestriction.enabled to true.
-> You can also change the restricted namespace by setting the targetNamespace property.
+<Tip>
+By default, Dynamo Operator is installed cluster-wide and will monitor all namespaces.
+If you wish to restrict the operator to monitor only a specific namespace (the helm release namespace by default), you can set the namespaceRestriction.enabled to true.
+You can also change the restricted namespace by setting the targetNamespace property.
+</Tip>
 
 ```bash
 --set "dynamo-operator.namespaceRestriction.enabled=true"

--- a/fern/pages-v0.9.0/reference/feature-matrix.md
+++ b/fern/pages-v0.9.0/reference/feature-matrix.md
@@ -108,25 +108,25 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 > 5. **Request Cancellation**: Due to known issues, the TensorRT-LLM engine is temporarily not notified of request cancellations, meaning allocated resources for cancelled requests are not freed.
 
 {/* Backend READMEs */}
-[vllm-readme]: docs/backends/vllm/README.md
-[sglang-readme]: docs/backends/sglang/README.md
-[trtllm-readme]: docs/backends/trtllm/README.md
+[vllm-readme]: /dynamo/v-0-9-0/components/backends/v-llm
+[sglang-readme]: /dynamo/v-0-9-0/components/backends/sg-lang
+[trtllm-readme]: /dynamo/v-0-9-0/components/backends/tensor-rt-llm
 
 {/* Design Docs */}
-[disagg]: docs/design_docs/disagg_serving.md
-[kv-routing]: docs/components/router/router_guide.md
-[planner]: docs/components/planner/README.md
-[kvbm]: docs/components/kvbm/README.md
-[migration]: docs/fault_tolerance/request_migration.md
-[tools]: docs/agents/tool-calling.md
+[disagg]: /dynamo/v-0-9-0/design-docs/disaggregated-serving
+[kv-routing]: /dynamo/v-0-9-0/user-guides/kv-cache-aware-routing
+[planner]: /dynamo/v-0-9-0/components/planner
+[kvbm]: /dynamo/v-0-9-0/components/kvbm
+[migration]: /dynamo/v-0-9-0/user-guides/fault-tolerance/request-migration
+[tools]: /dynamo/v-0-9-0/user-guides/tool-calling
 
 {/* Multimodal */}
-[mm]: docs/features/multimodal/README.md
-[mm-vllm]: docs/features/multimodal/multimodal_vllm.md
-[mm-trtllm]: docs/features/multimodal/multimodal_trtllm.md
-[mm-sglang]: docs/features/multimodal/multimodal_sglang.md
+[mm]: /dynamo/v-0-9-0/user-guides/multimodality-support
+[mm-vllm]: /dynamo/v-0-9-0/user-guides/multimodality-support/v-llm-multimodal
+[mm-trtllm]: /dynamo/v-0-9-0/user-guides/multimodality-support/tensor-rt-llm-multimodal
+[mm-sglang]: /dynamo/v-0-9-0/user-guides/multimodality-support/sg-lang-multimodal
 
 {/* Feature-specific */}
-[lora]: docs/kubernetes/deployment/dynamomodel-guide.md
-[vllm-spec]: docs/features/speculative_decoding/speculative_decoding_vllm.md
-[trtllm-eagle]: docs/backends/trtllm/llama4_plus_eagle.md
+[lora]: /dynamo/v-0-9-0/kubernetes-deployment/deployment-guide/managing-models-with-dynamo-model
+[vllm-spec]: /dynamo/v-0-9-0/additional-resources/speculative-decoding/speculative-decoding-with-v-llm
+[trtllm-eagle]: /dynamo/v-0-9-0/additional-resources/tensor-rt-llm-details/llama-4-eagle


### PR DESCRIPTION
## Summary
- Fix 16 broken `.md` reference-style links in `feature-matrix.md` to use correct Fern absolute paths
- Fix `README.md` link in `backends/vllm/gpt-oss.md`
- Convert 31 GitHub-style callouts (`[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`) to Fern components across 12 files

## Details

The v0.9.0 frozen docs contain links with `.md` extensions that result in 404s on the Fern site, and GitHub-style callouts that render as raw blockquotes instead of styled admonitions.

This PR fixes all `md-link-404` and `unconverted-callout` issues in the v0.9.0 versioned pages. Callouts are converted using `fern/convert_callouts.py` with manual fixups for edge cases.

Identified via automated docs inspection (`tools/docs_visual_inspector.py`).

## Where Should the Reviewer Start?
- `fern/pages-v0.9.0/reference/feature-matrix.md` — link fixes
- `fern/pages-v0.9.0/components/profiler/profiler-guide.md` — largest callout conversion (7 callouts)

## Test Plan
- [ ] Verify links in feature matrix resolve correctly on v0.9.0 docs
- [ ] Spot-check callout rendering on 2-3 pages

Made with [Cursor](https://cursor.com)