### PR TITLE
feat: replace Prometheus traffic metrics with RouterRequestMetrics in SLA Planner

### DIFF
--- a/components/src/dynamo/planner/utils/planner_argparse.py
+++ b/components/src/dynamo/planner/utils/planner_argparse.py
@@ -156,8 +156,9 @@ def create_sla_planner_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--metric-pulling-prometheus-endpoint",
         type=str,
-        default=SLAPlannerDefaults.metric_pulling_prometheus_endpoint,
-        help="Prometheus endpoint URL for pulling dynamo deployment metrics",
+        default=None,
+        help="Prometheus endpoint URL for pulling dynamo deployment metrics (optional; "
+             "used as fallback when --loadbased-router-metrics-url is not set)",
     )
     parser.add_argument(
         "--metric-reporting-prometheus-port",


### PR DESCRIPTION
… SLA planner

Poll the router's /metrics endpoint directly for TTFT/ITL/ISL/OSL/request-count instead of querying a Prometheus server. This eliminates the Prometheus scrape-interval delay and makes the router the single source of truth for all traffic metrics.

- Add RouterTrafficSnapshot dataclass and _parse_router_metrics / fetch_router_traffic_snapshot to DirectRouterMetricsClient; computes per-interval deltas from cumulative histograms
- Decouple prometheus_engine_client creation from enable_loadbased: client is now created whenever --loadbased-router-metrics-url is provided, enabling router-based traffic metrics in throughput-only mode
- observe_traffic_stats uses router snapshot when available, falls back to PrometheusAPIClient for backwards compatibility
- run_sampling_loop now started whenever prometheus_engine_client exists (not only when enable_loadbased=True)
- Make --metric-pulling-prometheus-endpoint optional (default None); Prometheus client is now a fallback only
- Add unit tests for histogram parsing, delta computation, namespace filtering, and the router snapshot path in observe_traffic_stats

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
