### PR TITLE
feat: Remove Namespace and CancellationToken from lib.rs

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -149,8 +149,6 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(llm::entrypoint::run_input, m)?)?;
 
     m.add_class::<DistributedRuntime>()?;
-    m.add_class::<CancellationToken>()?;
-    m.add_class::<Namespace>()?;
     m.add_class::<Component>()?;
     m.add_class::<Endpoint>()?;
     m.add_class::<ModelCardInstanceId>()?;

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -16,7 +16,6 @@ from dynamo._core import Context as Context
 from dynamo._core import DistributedRuntime as DistributedRuntime
 from dynamo._core import Endpoint as Endpoint
 from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
-from dynamo._core import Namespace as Namespace
 
 
 def dynamo_worker(enable_nats: bool = True):


### PR DESCRIPTION
### Overview:

Remove unused Python bindings for `Namespace` and `CancellationToken` classes. Analysis revealed these classes are not imported or used anywhere in Python code (components/, examples/, or tests/), making them unnecessary bindings that clutter the public API.

#### Details:

**Removed from Python bindings:**
- `Namespace` - Not imported or used in any Python code
- `CancellationToken` - Not imported or used in any Python code

**Changes made:**
1. `lib/bindings/python/rust/lib.rs` - Removed `m.add_class::<Namespace>()?;` and `m.add_class::<CancellationToken>()?;`
2. `lib/bindings/python/src/dynamo/runtime/__init__.py` - Removed `Namespace` import
3. 
#### Where should the reviewer start?

lib/bindings/python/rust/lib.rs

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

[DIS-1460](https://linear.app/nvidia-dynamo/issue/DIS-1460)

https://github.com/ai-dynamo/enhancements/blob/97c2f19692d9c0413d78dd1c62079854a9ed9467/deps/proposal-bindings-v2.md#move-internal-bindings-meaning-used-by-components-but-not-intended-for-public-use-otherwise-under-new-_internal-module
