### PR TITLE
feat: add model field to multimodal protocol to identity LoRA model

### DIFF
--- a/components/src/dynamo/vllm/multimodal_handlers/multimodal_pd_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/multimodal_pd_worker_handler.py
@@ -140,6 +140,7 @@ class MultimodalPDWorkerHandler(BaseWorkerHandler):
             ),
             sampling_params=sampling_params,
             request_id=request_id,
+            model=raw_request.get("model"),
             multimodal_inputs=multimodal_groups,
         )
 

--- a/components/src/dynamo/vllm/multimodal_utils/protocol.py
+++ b/components/src/dynamo/vllm/multimodal_utils/protocol.py
@@ -175,6 +175,8 @@ class MultiModalGroup(BaseModel):
 
 class vLLMMultimodalRequest(vLLMGenerateRequest):
     model_config = ConfigDict(arbitrary_types_allowed=True)
+    # LoRA adapter name (matches the name used in load_lora)
+    model: Optional[str] = None
     # Decode-only worker can have None for multimodal_inputs
     multimodal_inputs: Optional[List[MultiModalGroup]] = Field(default_factory=list)
     # Add these fields for Qwen VL (mRoPE) decode-only worker

--- a/examples/multimodal/components/processor.py
+++ b/examples/multimodal/components/processor.py
@@ -143,6 +143,7 @@ class Processor(ProcessMixIn):
             engine_prompt=engine_prompt,
             sampling_params=sampling_params,
             request_id=request_id,
+            model=raw_request.model,
             multimodal_input=multimodal_input,
         )
 

--- a/examples/multimodal/utils/protocol.py
+++ b/examples/multimodal/utils/protocol.py
@@ -156,6 +156,8 @@ class MultiModalInput(BaseModel):
 
 class vLLMMultimodalRequest(vLLMGenerateRequest):
     model_config = ConfigDict(arbitrary_types_allowed=True)
+    # LoRA adapter name (matches the name used in load_lora)
+    model: Optional[str] = None
     multimodal_input: Optional[MultiModalInput] = Field(default_factory=MultiModalInput)
     image_grid_thw: Optional[List[Any]] = None
     embeddings_shape: Optional[


### PR DESCRIPTION
#### Overview:

Add `model: Optional[str] = None` to vLLMMultimodalRequest in both components and examples protocol files, and propagate from raw requests through the pipeline. This carries the LoRA adapter name  from the frontend to the worker without behavioral changes.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes DIS-1480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multimodal requests now support explicit model field specification throughout the entire processing pipeline. Model information is properly propagated to all downstream components, enabling comprehensive request metadata handling. This enhancement improves model-specific configurations and ensures consistent context information is available across all processing stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->