### PR TITLE
feat: Remove Namespace from public

### DIFF
--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -438,10 +438,8 @@ class EngineFactory:
             reasoning_parser_class = None
 
         (namespace_name, component_name, endpoint_name) = instance_id.triple()
-        generate_endpoint = (
-            self.runtime.namespace(namespace_name)
-            .component(component_name)
-            .endpoint(endpoint_name)
+        generate_endpoint = self.runtime.endpoint(
+            f"{namespace_name}.{component_name}.{endpoint_name}"
         )
 
         if self.router_config.router_mode == RouterMode.KV:

--- a/components/src/dynamo/global_planner/__main__.py
+++ b/components/src/dynamo/global_planner/__main__.py
@@ -71,8 +71,8 @@ async def main(runtime: DistributedRuntime, args):
 
     logger.info("=" * 60)
 
-    # Create the GlobalPlanner component
-    component = runtime.namespace(namespace).component("GlobalPlanner")
+    # Create the GlobalPlanner component (get from first endpoint)
+    component = runtime.endpoint(f"{namespace}.GlobalPlanner.scale_request").component()
 
     # Get K8s namespace (where GlobalPlanner pod is running)
     k8s_namespace = os.environ.get("POD_NAMESPACE", "default")

--- a/components/src/dynamo/global_router/__main__.py
+++ b/components/src/dynamo/global_router/__main__.py
@@ -69,12 +69,12 @@ async def worker(runtime: DistributedRuntime):
     # Initialize connections to local routers
     await handler.initialize()
 
-    # Create component in the global router namespace
-    component = runtime.namespace(config.namespace).component(config.component_name)
-
     # Create endpoints for prefill and decode
     # Note: We use separate endpoints so we can register them with different ModelTypes
-    prefill_endpoint = component.endpoint("prefill_generate")
+    prefill_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component_name}.prefill_generate"
+    )
+    component = prefill_endpoint.component()
     decode_endpoint = component.endpoint("decode_generate")
 
     logger.info("Registering as prefill worker...")

--- a/components/src/dynamo/global_router/handler.py
+++ b/components/src/dynamo/global_router/handler.py
@@ -79,11 +79,7 @@ class GlobalRouterHandler:
         # Connect to prefill pool local routers
         for idx, namespace in enumerate(self.config.prefill_pool_dynamo_namespaces):
             try:
-                endpoint = (
-                    self.runtime.namespace(namespace)
-                    .component("router")
-                    .endpoint("generate")
-                )
+                endpoint = self.runtime.endpoint(f"{namespace}.router.generate")
                 client = await endpoint.client()
                 self.prefill_clients[namespace] = client
                 logger.info(
@@ -98,11 +94,7 @@ class GlobalRouterHandler:
         # Connect to decode pool local routers
         for idx, namespace in enumerate(self.config.decode_pool_dynamo_namespaces):
             try:
-                endpoint = (
-                    self.runtime.namespace(namespace)
-                    .component("router")
-                    .endpoint("generate")
-                )
+                endpoint = self.runtime.endpoint(f"{namespace}.router.generate")
                 client = await endpoint.client()
                 self.decode_clients[namespace] = client
                 logger.info(

--- a/components/src/dynamo/planner/__main__.py
+++ b/components/src/dynamo/planner/__main__.py
@@ -58,13 +58,11 @@ async def init_planner(runtime: DistributedRuntime, config: PlannerConfig):
 
     await start_planner(runtime, config)
 
-    component = runtime.namespace(config.namespace).component("Planner")
-
     async def generate(request: RequestType):
         """Dummy endpoint to satisfy that each component has an endpoint"""
         yield "mock endpoint"
 
-    generate_endpoint = component.endpoint("generate")
+    generate_endpoint = runtime.endpoint(f"{config.namespace}.Planner.generate")
     await generate_endpoint.serve_endpoint(generate)  # type: ignore[arg-type]
 
 

--- a/components/src/dynamo/planner/remote_planner_client.py
+++ b/components/src/dynamo/planner/remote_planner_client.py
@@ -34,10 +34,8 @@ class RemotePlannerClient:
     async def _ensure_client(self):
         """Lazy initialization of endpoint client with retry mechanism"""
         if self._client is None:
-            endpoint = (
-                self.runtime.namespace(self.central_namespace)
-                .component(self.central_component)
-                .endpoint("scale_request")
+            endpoint = self.runtime.endpoint(
+                f"{self.central_namespace}.{self.central_component}.scale_request"
             )
 
             # Retry logic with exponential backoff

--- a/components/src/dynamo/planner/utils/planner_core.py
+++ b/components/src/dynamo/planner/utils/planner_core.py
@@ -486,12 +486,9 @@ class BasePlanner:
 
     async def _get_or_create_client(self, component_name: str, endpoint_name: str):
         """Create a client for the given component and endpoint, with a brief sleep for state sync."""
-        client = (
-            await self.runtime.namespace(self.namespace)
-            .component(component_name)
-            .endpoint(endpoint_name)
-            .client()
-        )
+        client = await self.runtime.endpoint(
+            f"{self.namespace}.{component_name}.{endpoint_name}"
+        ).client()
         # TODO: remove this sleep after rust client() is blocking until watching state
         await asyncio.sleep(0.1)
         return client

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -59,12 +59,9 @@ class StandaloneRouterHandler:
             namespace, component, endpoint = parts
 
             # Get worker endpoint
-            worker_endpoint = (
-                self.runtime.namespace(namespace)
-                .component(component)
-                .endpoint(endpoint)
+            worker_endpoint = self.runtime.endpoint(
+                f"{namespace}.{component}.{endpoint}"
             )
-
             self.worker_client = await worker_endpoint.client()
 
             self.kv_router = KvRouter(
@@ -182,17 +179,15 @@ async def worker(runtime: DistributedRuntime):
 
     kv_router_config = build_kv_router_config(config)
 
-    # Create service component - use "router" as component name
-    component = runtime.namespace(config.namespace).component("router")
-
     # Create handler
     handler = StandaloneRouterHandler(
         runtime, config.endpoint, config.router_block_size, kv_router_config
     )
     await handler.initialize()
 
-    # Expose endpoints
-    generate_endpoint = component.endpoint("generate")
+    # Create endpoints (get component from first endpoint to avoid duplicate metrics registries)
+    generate_endpoint = runtime.endpoint(f"{config.namespace}.router.generate")
+    component = generate_endpoint.component()
     best_worker_endpoint = component.endpoint("best_worker_id")
 
     logger.debug("Starting to serve endpoints...")

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -251,11 +251,10 @@ async def init(
     engine = sgl.Engine(server_args=server_args)
     load_time = time.time() - start_time
 
-    component = runtime.namespace(dynamo_args.namespace).component(
-        dynamo_args.component
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
-
-    generate_endpoint = component.endpoint(dynamo_args.endpoint)
+    component = generate_endpoint.component()
 
     # Setup metrics and KV events for ALL nodes (including non-leader)
     # Non-leader nodes need KV event publishing for their local DP ranks
@@ -338,11 +337,10 @@ async def init_prefill(
 
     engine = sgl.Engine(server_args=server_args)
 
-    component = runtime.namespace(dynamo_args.namespace).component(
-        dynamo_args.component
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
-
-    generate_endpoint = component.endpoint(dynamo_args.endpoint)
+    component = generate_endpoint.component()
 
     # Setup metrics and KV events for ALL nodes (including non-leader)
     # Non-leader nodes need KV event publishing for their local DP ranks
@@ -426,11 +424,10 @@ async def init_diffusion(
 
     engine = sgl.Engine(server_args=server_args)
 
-    component = runtime.namespace(dynamo_args.namespace).component(
-        dynamo_args.component
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
-
-    generate_endpoint = component.endpoint(dynamo_args.endpoint)
+    component = generate_endpoint.component()
 
     # Setup metrics and KV events for ALL nodes (including non-leader)
     # Non-leader nodes need KV event publishing for their local DP ranks
@@ -502,11 +499,10 @@ async def init_embedding(
 
     engine = sgl.Engine(server_args=server_args)
 
-    component = runtime.namespace(dynamo_args.namespace).component(
-        dynamo_args.component
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
-
-    generate_endpoint = component.endpoint(dynamo_args.endpoint)
+    component = generate_endpoint.component()
 
     # publisher instantiates the metrics and kv event publishers
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
@@ -594,11 +590,10 @@ async def init_image_diffusion(runtime: DistributedRuntime, config: Config):
     if not fs_url:
         raise ValueError("--image-diffusion-fs-url is required for diffusion workers")
 
-    component = runtime.namespace(dynamo_args.namespace).component(
-        dynamo_args.component
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
-
-    generate_endpoint = component.endpoint(dynamo_args.endpoint)
+    component = generate_endpoint.component()
 
     # Image diffusion doesn't have metrics publisher like LLM
     # Could add custom metrics for images/sec, steps/sec later
@@ -681,11 +676,10 @@ async def init_video_generation(runtime: DistributedRuntime, config: Config):
             "--video-generation-fs-url is required for video generation workers"
         )
 
-    component = runtime.namespace(dynamo_args.namespace).component(
-        dynamo_args.component
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
-
-    generate_endpoint = component.endpoint(dynamo_args.endpoint)
+    component = generate_endpoint.component()
 
     handler = VideoGenerationWorkerHandler(
         component,
@@ -729,19 +723,15 @@ async def init_multimodal_processor(
 ):
     """Initialize multimodal processor component"""
     server_args, dynamo_args = config.server_args, config.dynamo_args
-    component = runtime.namespace(dynamo_args.namespace).component(
-        dynamo_args.component
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
-
-    generate_endpoint = component.endpoint(dynamo_args.endpoint)
+    component = generate_endpoint.component()
 
     # For processor, we need to connect to the encode worker
-    encode_worker_client = (
-        await runtime.namespace(dynamo_args.namespace)
-        .component("encoder")
-        .endpoint("generate")
-        .client()
-    )
+    encode_worker_client = await runtime.endpoint(
+        f"{dynamo_args.namespace}.encoder.generate"
+    ).client()
 
     ready_event = asyncio.Event()
 
@@ -787,19 +777,15 @@ async def init_multimodal_encode_worker(
     """Initialize multimodal encode worker component"""
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
-    component = runtime.namespace(dynamo_args.namespace).component(
-        dynamo_args.component
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
-
-    generate_endpoint = component.endpoint(dynamo_args.endpoint)
+    component = generate_endpoint.component()
 
     # For encode worker, we need to connect to the downstream LLM worker
-    pd_worker_client = (
-        await runtime.namespace(dynamo_args.namespace)
-        .component("backend")
-        .endpoint("generate")
-        .client()
-    )
+    pd_worker_client = await runtime.endpoint(
+        f"{dynamo_args.namespace}.backend.generate"
+    ).client()
 
     handler = MultimodalEncodeWorkerHandler(
         component, config, pd_worker_client, shutdown_event
@@ -840,22 +826,18 @@ async def init_multimodal_worker(
     """
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
-    component = runtime.namespace(dynamo_args.namespace).component(
-        dynamo_args.component
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
-
-    generate_endpoint = component.endpoint(dynamo_args.endpoint)
+    component = generate_endpoint.component()
 
     engine = sgl.Engine(server_args=server_args)
 
     if config.serving_mode == DisaggregationMode.DECODE:
         logging.info("Initializing prefill client for multimodal decode worker")
-        prefill_client = (
-            await runtime.namespace(dynamo_args.namespace)
-            .component("prefill")
-            .endpoint("generate")
-            .client()
-        )
+        prefill_client = await runtime.endpoint(
+            f"{dynamo_args.namespace}.prefill.generate"
+        ).client()
         handler = MultimodalWorkerHandler(
             component, engine, config, prefill_client, shutdown_event
         )
@@ -895,11 +877,10 @@ async def init_multimodal_prefill_worker(
 
     engine = sgl.Engine(server_args=server_args)
 
-    component = runtime.namespace(dynamo_args.namespace).component(
-        dynamo_args.component
+    generate_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.{dynamo_args.endpoint}"
     )
-
-    generate_endpoint = component.endpoint(dynamo_args.endpoint)
+    component = generate_endpoint.component()
 
     handler = MultimodalPrefillWorkerHandler(component, engine, config, shutdown_event)
     await handler.async_init()

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -129,14 +129,9 @@ async def init_llm_worker(
         parsed_namespace, parsed_component_name, parsed_endpoint_name = parse_endpoint(
             config.encode_endpoint
         )
-        encode_client = (
-            await runtime.namespace(parsed_namespace)
-            .component(parsed_component_name)
-            .endpoint(parsed_endpoint_name)
-            .client()
-        )
-
-    component = runtime.namespace(config.namespace).component(config.component)
+        encode_client = await runtime.endpoint(
+            f"{parsed_namespace}.{parsed_component_name}.{parsed_endpoint_name}"
+        ).client()
 
     # Convert model path to Path object if it's a local path, otherwise keep as string
     model_path = str(config.model)
@@ -334,7 +329,10 @@ async def init_llm_worker(
         config.disaggregation_mode,
         component_gauges=component_gauges,
     ) as engine:
-        endpoint = component.endpoint(config.endpoint)
+        endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.{config.endpoint}"
+        )
+        component = endpoint.component()
 
         # should ideally call get_engine_runtime_config
         # this is because we don't have a good way to
@@ -451,9 +449,7 @@ async def init_llm_worker(
         if config.publish_events_and_metrics:
             # Initialize and pass in the publisher to the request handler to
             # publish events and metrics.
-            kv_listener = runtime.namespace(config.namespace).component(
-                config.component
-            )
+            kv_listener = endpoint.component()
             # Use model as fallback if served_model_name is not provided
             model_name_for_metrics = config.served_model_name or config.model
             metrics_labels = [

--- a/components/src/dynamo/trtllm/workers/video_diffusion_worker.py
+++ b/components/src/dynamo/trtllm/workers/video_diffusion_worker.py
@@ -81,9 +81,11 @@ async def init_video_diffusion_worker(
         enable_async_cpu_offload=config.enable_async_cpu_offload,
     )
 
-    # Get the component and endpoint from the runtime
-    component = runtime.namespace(config.namespace).component(config.component)
-    endpoint = component.endpoint(config.endpoint)
+    # Get the endpoint from the runtime
+    endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
+    component = endpoint.component()
 
     # Initialize the diffusion engine (auto-detects pipeline from model_index.json)
     engine = DiffusionEngine(diffusion_config)

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -921,7 +921,6 @@ def get_engine_cache_info(engine: AsyncLLM):
         raise
 
 
-
 async def init_omni(
     runtime: DistributedRuntime, config: Config, shutdown_event: asyncio.Event
 ):

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -539,9 +539,10 @@ async def init_prefill(
     """
     Instantiate and serve
     """
-    component = runtime.namespace(config.namespace).component(config.component)
-
-    generate_endpoint = component.endpoint(config.endpoint)
+    generate_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
+    component = generate_endpoint.component()
     clear_endpoint = component.endpoint("clear_kv_blocks")
 
     # Use pre-created engine if provided (checkpoint mode), otherwise create new
@@ -681,9 +682,10 @@ async def init(
     Instantiate and serve
     """
 
-    component = runtime.namespace(config.namespace).component(config.component)
-
-    generate_endpoint = component.endpoint(config.endpoint)
+    generate_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
+    component = generate_endpoint.component()
     clear_endpoint = component.endpoint("clear_kv_blocks")
     load_lora_endpoint = component.endpoint("load_lora")
     unload_lora_endpoint = component.endpoint("unload_lora")
@@ -919,6 +921,7 @@ def get_engine_cache_info(engine: AsyncLLM):
         raise
 
 
+
 async def init_omni(
     runtime: DistributedRuntime, config: Config, shutdown_event: asyncio.Event
 ):
@@ -931,8 +934,10 @@ async def init_omni(
     # Lazy import to avoid loading vllm-omni unless explicitly needed
     from dynamo.vllm.omni import OmniHandler
 
-    component = runtime.namespace(config.namespace).component(config.component)
-    generate_endpoint = component.endpoint(config.endpoint)
+    generate_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
+    component = generate_endpoint.component()
 
     # Initialize OmniHandler with Omni orchestrator
     handler = OmniHandler(

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -21,8 +21,8 @@ from .multimodal_handlers import (
 
 logger = logging.getLogger(__name__)
 
-# (engine_client, vllm_config, default_sampling_params, prometheus_temp_dir)
-EngineSetupResult = tuple[Any, Any, Any, Any]
+# (engine_client, vllm_config, default_sampling_params, prometheus_temp_dir, component_gauges)
+EngineSetupResult = tuple[Any, Any, Any, Any, Any]
 
 SetupVllmEngineFn = Callable[..., EngineSetupResult]
 SetupKvEventPublisherFn = Callable[..., Optional[Any]]
@@ -88,9 +88,10 @@ class WorkerFactory:
         - Aggregated (P+D): Prefill and decode on same worker
         - Disaggregated (P→D): Prefill forwards to separate decode worker
         """
-        component = runtime.namespace(config.namespace).component(config.component)
-
-        generate_endpoint = component.endpoint(config.endpoint)
+        generate_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.{config.endpoint}"
+        )
+        component = generate_endpoint.component()
         clear_endpoint = component.endpoint("clear_kv_blocks")
 
         # Use pre-created engine if provided (checkpoint mode), otherwise create new
@@ -114,12 +115,9 @@ class WorkerFactory:
         # Set up encode worker client when routing to encoder is enabled
         encode_worker_client = None
         if config.route_to_encoder:
-            encode_worker_client = (
-                await runtime.namespace(config.namespace)
-                .component("encoder")
-                .endpoint("generate")
-                .client()
-            )
+            encode_worker_client = await runtime.endpoint(
+                f"{config.namespace}.encoder.generate"
+            ).client()
             logger.info("Waiting for Encoder Worker Instances ...")
             await encode_worker_client.wait_for_instances()
             logger.info("Connected to encoder workers")
@@ -127,12 +125,9 @@ class WorkerFactory:
         # Set up decode worker client for disaggregated mode
         decode_worker_client = None
         if config.is_prefill_worker:
-            decode_worker_client = (
-                await runtime.namespace(config.namespace)
-                .component("decoder")
-                .endpoint("generate")
-                .client()
-            )
+            decode_worker_client = await runtime.endpoint(
+                f"{config.namespace}.decoder.generate"
+            ).client()
             await decode_worker_client.wait_for_instances()
             logger.info("Connected to decode worker for disaggregated mode")
 
@@ -201,8 +196,9 @@ class WorkerFactory:
         shutdown_event: asyncio.Event,
     ) -> None:
         """Initialize standalone multimodal encode worker."""
-        component = runtime.namespace(config.namespace).component(config.component)
-        generate_endpoint = component.endpoint(config.endpoint)
+        generate_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.{config.endpoint}"
+        )
 
         handler = EncodeWorkerHandler(config.engine_args)
         await handler.async_init(runtime)

--- a/examples/backends/tritonserver/src/tritonworker.py
+++ b/examples/backends/tritonserver/src/tritonworker.py
@@ -102,10 +102,7 @@ async def triton_worker(runtime: DistributedRuntime, args: argparse.Namespace):
         f"Environment: DYN_DISCOVERY_BACKEND={os.environ.get('DYN_DISCOVERY_BACKEND', 'NOT SET')}"
     )
 
-    component = runtime.namespace("triton").component("tritonserver")
-    logger.info("✓ Created component: triton/tritonserver")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint("triton.tritonserver.generate")
     logger.info("✓ Created endpoint: triton/tritonserver/generate")
 
     model_repository = args.model_repository

--- a/examples/backends/vllm/mm_router_worker/mm_router_worker.py
+++ b/examples/backends/vllm/mm_router_worker/mm_router_worker.py
@@ -125,10 +125,8 @@ async def worker(runtime: DistributedRuntime) -> None:
     )
 
     # Connect to downstream vLLM workers
-    downstream_endpoint = (
-        runtime.namespace(args.namespace)
-        .component(args.downstream_component)
-        .endpoint(args.downstream_endpoint)
+    downstream_endpoint = runtime.endpoint(
+        f"{args.namespace}.{args.downstream_component}.{args.downstream_endpoint}"
     )
     downstream_client = await downstream_endpoint.client()
 
@@ -162,8 +160,7 @@ async def worker(runtime: DistributedRuntime) -> None:
     )
 
     # Register this worker's endpoint
-    component = runtime.namespace(args.namespace).component(args.component)
-    endpoint = component.endpoint(args.endpoint)
+    endpoint = runtime.endpoint(f"{args.namespace}.{args.component}.{args.endpoint}")
 
     # Use ModelInput.Tokens so Frontend preprocesses the request
     # Request format: {token_ids, sampling_options, stop_conditions, extra_args: {messages}}

--- a/examples/custom_backend/cancellation/client.py
+++ b/examples/custom_backend/cancellation/client.py
@@ -54,10 +54,10 @@ async def main():
 
     # Connect to middle server or direct server based on argument
     if use_middle_server:
-        endpoint = runtime.namespace("demo").component("middle").endpoint("generate")
+        endpoint = runtime.endpoint("demo.middle.generate")
         print("Client connecting to middle server...")
     else:
-        endpoint = runtime.namespace("demo").component("server").endpoint("generate")
+        endpoint = runtime.endpoint("demo.server.generate")
         print("Client connecting directly to backend server...")
 
     client = await endpoint.client()

--- a/examples/custom_backend/cancellation/middle_server.py
+++ b/examples/custom_backend/cancellation/middle_server.py
@@ -21,9 +21,7 @@ class MiddleServer:
     async def initialize(self):
         """Initialize connection to backend servers"""
         # Connect to backend servers
-        endpoint = (
-            self.runtime.namespace("demo").component("server").endpoint("generate")
-        )
+        endpoint = self.runtime.endpoint("demo.server.generate")
         self.backend_client = await endpoint.client()
         await self.backend_client.wait_for_instances()
         print("Middle server: Connected to backend servers")
@@ -56,10 +54,8 @@ async def main():
     handler = MiddleServer(runtime)
     await handler.initialize()
 
-    # Create middle server component
-    component = runtime.namespace("demo").component("middle")
-
-    endpoint = component.endpoint("generate")
+    # Create middle server endpoint
+    endpoint = runtime.endpoint("demo.middle.generate")
 
     print("Middle server started")
     print("Forwarding requests to backend servers...")

--- a/examples/custom_backend/cancellation/server.py
+++ b/examples/custom_backend/cancellation/server.py
@@ -33,10 +33,8 @@ async def main():
     loop = asyncio.get_running_loop()
     runtime = DistributedRuntime(loop, "file", "nats")
 
-    # Create server component
-    component = runtime.namespace("demo").component("server")
-
-    endpoint = component.endpoint("generate")
+    # Create server endpoint
+    endpoint = runtime.endpoint("demo.server.generate")
     handler = DemoServer()
 
     print("Demo server started")

--- a/examples/custom_backend/hello_world/client.py
+++ b/examples/custom_backend/hello_world/client.py
@@ -23,9 +23,7 @@ from dynamo.runtime import DistributedRuntime, dynamo_worker
 @dynamo_worker()
 async def worker(runtime: DistributedRuntime):
     # Get endpoint
-    endpoint = (
-        runtime.namespace("hello_world").component("backend").endpoint("generate")
-    )
+    endpoint = runtime.endpoint("hello_world.backend.generate")
 
     # Create client and wait for service to be ready
     client = await endpoint.client()

--- a/examples/custom_backend/hello_world/hello_world.py
+++ b/examples/custom_backend/hello_world/hello_world.py
@@ -27,13 +27,9 @@ async def worker(runtime: DistributedRuntime):
     component_name = "backend"
     endpoint_name = "generate"
 
-    component = runtime.namespace(namespace_name).component(component_name)
+    endpoint = runtime.endpoint(f"{namespace_name}.{component_name}.{endpoint_name}")
 
-    logger.info(f"Created service {namespace_name}/{component_name}")
-
-    endpoint = component.endpoint(endpoint_name)
-
-    logger.info(f"Serving endpoint {endpoint_name}")
+    logger.info(f"Serving endpoint {namespace_name}/{component_name}/{endpoint_name}")
     await endpoint.serve_endpoint(content_generator)
 
 

--- a/examples/multimodal/components/audio_encode_worker.py
+++ b/examples/multimodal/components/audio_encode_worker.py
@@ -267,19 +267,16 @@ async def init(runtime: DistributedRuntime, args: argparse.Namespace, config: Co
     Instantiate and serve
     """
 
-    component = runtime.namespace(config.namespace).component(config.component)
-
-    generate_endpoint = component.endpoint(config.endpoint)
+    generate_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
 
     parsed_namespace, parsed_component_name, parsed_endpoint_name = parse_endpoint(
         args.downstream_endpoint
     )
-    pd_worker_client = (
-        await runtime.namespace(parsed_namespace)
-        .component(parsed_component_name)
-        .endpoint(parsed_endpoint_name)
-        .client()
-    )
+    pd_worker_client = await runtime.endpoint(
+        f"{parsed_namespace}.{parsed_component_name}.{parsed_endpoint_name}"
+    ).client()
 
     handler = VllmEncodeWorker(args, config.engine_args, pd_worker_client)
     await handler.async_init(runtime)

--- a/examples/multimodal/components/encode_worker.py
+++ b/examples/multimodal/components/encode_worker.py
@@ -224,19 +224,16 @@ async def init(runtime: DistributedRuntime, args: argparse.Namespace, config: Co
     Instantiate and serve
     """
 
-    component = runtime.namespace(config.namespace).component(config.component)
-
-    generate_endpoint = component.endpoint(config.endpoint)
+    generate_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
 
     parsed_namespace, parsed_component_name, parsed_endpoint_name = parse_endpoint(
         args.downstream_endpoint
     )
-    pd_worker_client = (
-        await runtime.namespace(parsed_namespace)
-        .component(parsed_component_name)
-        .endpoint(parsed_endpoint_name)
-        .client()
-    )
+    pd_worker_client = await runtime.endpoint(
+        f"{parsed_namespace}.{parsed_component_name}.{parsed_endpoint_name}"
+    ).client()
 
     handler = VllmEncodeWorker(args, config.engine_args, pd_worker_client)
     await handler.async_init(runtime)

--- a/examples/multimodal/components/processor.py
+++ b/examples/multimodal/components/processor.py
@@ -298,19 +298,16 @@ async def init(runtime: DistributedRuntime, args: argparse.Namespace, config: Co
     Instantiate and serve
     """
 
-    component = runtime.namespace(config.namespace).component(config.component)
-
-    generate_endpoint = component.endpoint(config.endpoint)
+    generate_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
 
     parsed_namespace, parsed_component_name, parsed_endpoint_name = parse_endpoint(
         args.downstream_endpoint
     )
-    encode_worker_client = (
-        await runtime.namespace(parsed_namespace)
-        .component(parsed_component_name)
-        .endpoint(parsed_endpoint_name)
-        .client()
-    )
+    encode_worker_client = await runtime.endpoint(
+        f"{parsed_namespace}.{parsed_component_name}.{parsed_endpoint_name}"
+    ).client()
 
     handler = Processor(args, config.engine_args, encode_worker_client)
 

--- a/examples/multimodal/components/video_encode_worker.py
+++ b/examples/multimodal/components/video_encode_worker.py
@@ -271,19 +271,16 @@ async def init(runtime: DistributedRuntime, args: argparse.Namespace, config: Co
     Instantiate and serve
     """
 
-    component = runtime.namespace(config.namespace).component(config.component)
-
-    generate_endpoint = component.endpoint(config.endpoint)
+    generate_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
 
     parsed_namespace, parsed_component_name, parsed_endpoint_name = parse_endpoint(
         args.downstream_endpoint
     )
-    pd_worker_client = (
-        await runtime.namespace(parsed_namespace)
-        .component(parsed_component_name)
-        .endpoint(parsed_endpoint_name)
-        .client()
-    )
+    pd_worker_client = await runtime.endpoint(
+        f"{parsed_namespace}.{parsed_component_name}.{parsed_endpoint_name}"
+    ).client()
 
     handler = VllmEncodeWorker(args, config.engine_args, pd_worker_client)
     await handler.async_init(runtime)

--- a/examples/multimodal/components/worker.py
+++ b/examples/multimodal/components/worker.py
@@ -233,12 +233,9 @@ class VllmPDWorker(VllmBaseWorker):
                 parsed_component_name,
                 parsed_endpoint_name,
             ) = parse_endpoint(self.downstream_endpoint)
-            self.decode_worker_client = (
-                await runtime.namespace(parsed_namespace)
-                .component(parsed_component_name)
-                .endpoint(parsed_endpoint_name)
-                .client()
-            )
+            self.decode_worker_client = await runtime.endpoint(
+                f"{parsed_namespace}.{parsed_component_name}.{parsed_endpoint_name}"
+            ).client()
 
         if "video" in self.engine_args.model.lower():
             self.EMBEDDINGS_DTYPE = torch.uint8

--- a/examples/multimodal/components/worker.py
+++ b/examples/multimodal/components/worker.py
@@ -435,10 +435,13 @@ async def init(runtime: DistributedRuntime, args: argparse.Namespace, config: Co
     Instantiate and serve
     """
 
-    component = runtime.namespace(config.namespace).component(config.component)
-
-    generate_endpoint = component.endpoint(config.endpoint)
-    clear_endpoint = component.endpoint("clear_kv_blocks")
+    generate_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
+    clear_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.clear_kv_blocks"
+    )
+    component = generate_endpoint.component()
 
     if args.worker_type in ["prefill", "encode_prefill"]:
         handler: VllmBaseWorker = VllmPDWorker(

--- a/examples/multimodal/components/worker.py
+++ b/examples/multimodal/components/worker.py
@@ -438,10 +438,8 @@ async def init(runtime: DistributedRuntime, args: argparse.Namespace, config: Co
     generate_endpoint = runtime.endpoint(
         f"{config.namespace}.{config.component}.{config.endpoint}"
     )
-    clear_endpoint = runtime.endpoint(
-        f"{config.namespace}.{config.component}.clear_kv_blocks"
-    )
     component = generate_endpoint.component()
+    clear_endpoint = component.endpoint("clear_kv_blocks")
 
     if args.worker_type in ["prefill", "encode_prefill"]:
         handler: VllmBaseWorker = VllmPDWorker(

--- a/lib/bindings/python/examples/bls/bar.py
+++ b/lib/bindings/python/examples/bls/bar.py
@@ -31,9 +31,7 @@ class RequestHandler:
 
 @dynamo_worker()
 async def worker(runtime: DistributedRuntime):
-    component = runtime.namespace("examples/bls").component("bar")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint("examples/bls.bar.generate")
     await endpoint.serve_endpoint(RequestHandler().generate)
 
 

--- a/lib/bindings/python/examples/bls/bls.py
+++ b/lib/bindings/python/examples/bls/bls.py
@@ -24,18 +24,8 @@ uvloop.install()
 
 @dynamo_worker()
 async def worker(runtime: DistributedRuntime):
-    foo = (
-        await runtime.namespace("examples/bls")
-        .component("foo")
-        .endpoint("generate")
-        .client()
-    )
-    bar = (
-        await runtime.namespace("examples/bls")
-        .component("bar")
-        .endpoint("generate")
-        .client()
-    )
+    foo = await runtime.endpoint("examples/bls.foo.generate").client()
+    bar = await runtime.endpoint("examples/bls.bar.generate").client()
 
     # hello world showed us the client has a .generate, which uses the default load balancer
     # however, you can explicitly opt-in to client side load balancing by using the `round_robin`

--- a/lib/bindings/python/examples/bls/foo.py
+++ b/lib/bindings/python/examples/bls/foo.py
@@ -30,9 +30,7 @@ class RequestHandler:
 
 @dynamo_worker()
 async def worker(runtime: DistributedRuntime):
-    component = runtime.namespace("examples/bls").component("foo")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint("examples/bls.foo.generate")
     await endpoint.serve_endpoint(RequestHandler().generate)
 
 

--- a/lib/bindings/python/examples/error_handling/client.py
+++ b/lib/bindings/python/examples/error_handling/client.py
@@ -30,7 +30,7 @@ async def init(runtime: DistributedRuntime, ns: str):
     Instantiate a `backend` client and call the `generate` endpoint
     """
     # get endpoint
-    endpoint = runtime.namespace(ns).component("backend").endpoint("generate")
+    endpoint = runtime.endpoint(f"{ns}.backend.generate")
 
     # create client
     client = await endpoint.client()

--- a/lib/bindings/python/examples/error_handling/server.py
+++ b/lib/bindings/python/examples/error_handling/server.py
@@ -43,9 +43,7 @@ async def init(runtime: DistributedRuntime, ns: str):
     Instantiate a `backend` component and serve the `generate` endpoint
     A `Component` can serve multiple endpoints
     """
-    component = runtime.namespace(ns).component("backend")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint(f"{ns}.backend.generate")
     print("Started server instance")
     await endpoint.serve_endpoint(RequestHandler().generate)
 

--- a/lib/bindings/python/examples/hello_world/client.py
+++ b/lib/bindings/python/examples/hello_world/client.py
@@ -30,7 +30,7 @@ async def init(runtime: DistributedRuntime, ns: str):
     Instantiate a `backend` client and call the `generate` endpoint
     """
     # get endpoint
-    endpoint = runtime.namespace(ns).component("backend").endpoint("generate")
+    endpoint = runtime.endpoint(f"{ns}.backend.generate")
 
     # create client
     client = await endpoint.client()

--- a/lib/bindings/python/examples/hello_world/server.py
+++ b/lib/bindings/python/examples/hello_world/server.py
@@ -48,9 +48,7 @@ async def init(runtime: DistributedRuntime, ns: str):
     Instantiate a `backend` component and serve the `generate` endpoint
     A `Component` can serve multiple endpoints
     """
-    component = runtime.namespace(ns).component("backend")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint(f"{ns}.backend.generate")
     print("Started server instance")
 
     # the server will gracefully shutdown (i.e., keep opened TCP streams finishes)

--- a/lib/bindings/python/examples/hello_world/server_sglang.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang.py
@@ -88,9 +88,9 @@ async def init(runtime: DistributedRuntime, config: Config):
     """
     Instantiate and serve
     """
-    component = runtime.namespace(config.namespace).component(config.component)
-
-    endpoint = component.endpoint(config.endpoint)
+    endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
     await register_model(
         ModelInput.Tokens,
         ModelType.Chat | ModelType.Completions,

--- a/lib/bindings/python/examples/hello_world/server_sglang_tok.py
+++ b/lib/bindings/python/examples/hello_world/server_sglang_tok.py
@@ -101,9 +101,9 @@ async def init(runtime: DistributedRuntime, config: Config):
     """
     Instantiate and serve
     """
-    component = runtime.namespace(config.namespace).component(config.component)
-
-    endpoint = component.endpoint(config.endpoint)
+    endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
     await register_model(
         ModelInput.Text, ModelType.Chat | ModelType.Completions, endpoint, config.model
     )

--- a/lib/bindings/python/examples/hello_world/server_vllm.py
+++ b/lib/bindings/python/examples/hello_world/server_vllm.py
@@ -99,9 +99,9 @@ async def init(runtime: DistributedRuntime, config: Config):
     """
     Instantiate and serve
     """
-    component = runtime.namespace(config.namespace).component(config.component)
-
-    endpoint = component.endpoint(config.endpoint)
+    endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
     await register_model(
         ModelInput.Tokens,
         ModelType.Chat | ModelType.Completions,

--- a/lib/bindings/python/examples/pipeline/backend.py
+++ b/lib/bindings/python/examples/pipeline/backend.py
@@ -31,9 +31,7 @@ class RequestHandler:
 
 @dynamo_worker()
 async def worker(runtime: DistributedRuntime):
-    component = runtime.namespace("examples/pipeline").component("backend")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint("examples/pipeline.backend.generate")
     await endpoint.serve_endpoint(RequestHandler().generate)
 
 

--- a/lib/bindings/python/examples/pipeline/frontend.py
+++ b/lib/bindings/python/examples/pipeline/frontend.py
@@ -35,17 +35,10 @@ class RequestHandler:
 @dynamo_worker()
 async def worker(runtime: DistributedRuntime):
     # client to the next component - in this case the middle component
-    next = (
-        await runtime.namespace("examples/pipeline")
-        .component("middle")
-        .endpoint("generate")
-        .client()
-    )
+    next = await runtime.endpoint("examples/pipeline.middle.generate").client()
 
     # create endpoint service for frontend component
-    component = runtime.namespace("examples/pipeline").component("frontend")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint("examples/pipeline.frontend.generate")
 
     handler = RequestHandler(next)
     await endpoint.serve_endpoint(handler.generate)

--- a/lib/bindings/python/examples/pipeline/middle.py
+++ b/lib/bindings/python/examples/pipeline/middle.py
@@ -35,17 +35,10 @@ class RequestHandler:
 @dynamo_worker()
 async def worker(runtime: DistributedRuntime):
     # client to backend
-    backend = (
-        await runtime.namespace("examples/pipeline")
-        .component("backend")
-        .endpoint("generate")
-        .client()
-    )
+    backend = await runtime.endpoint("examples/pipeline.backend.generate").client()
 
     # create endpoint service for middle component
-    component = runtime.namespace("examples/pipeline").component("middle")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint("examples/pipeline.middle.generate")
     await endpoint.serve_endpoint(RequestHandler(backend).generate)
 
 

--- a/lib/bindings/python/examples/pipeline/pipeline.py
+++ b/lib/bindings/python/examples/pipeline/pipeline.py
@@ -31,12 +31,7 @@ async def worker(runtime: DistributedRuntime):
     - `frontend` call `middle` which calls `backend`
     - each component transforms the request before passing it to the backend
     """
-    pipeline = (
-        await runtime.namespace("examples/pipeline")
-        .component("frontend")
-        .endpoint("generate")
-        .client()
-    )
+    pipeline = await runtime.endpoint("examples/pipeline.frontend.generate").client()
 
     async for char in await pipeline.round_robin("hello from"):
         print(char)

--- a/lib/bindings/python/examples/typed/client.py
+++ b/lib/bindings/python/examples/typed/client.py
@@ -26,7 +26,7 @@ async def worker(runtime: DistributedRuntime):
     Instantiate a `backend` client and call the `generate` endpoint
     """
     # get endpoint
-    endpoint = runtime.namespace("dynamo").component("backend").endpoint("generate")
+    endpoint = runtime.endpoint("dynamo.backend.generate")
 
     # create client
     client = await endpoint.client()

--- a/lib/bindings/python/examples/typed/server.py
+++ b/lib/bindings/python/examples/typed/server.py
@@ -41,9 +41,7 @@ async def worker(runtime: DistributedRuntime):
     Instantiate a `backend` component and serve the `generate` endpoint
     A `Component` can serve multiple endpoints
     """
-    component = runtime.namespace("dynamo").component("backend")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint("dynamo.backend.generate")
     await endpoint.serve_endpoint(RequestHandler().generate)
 
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -657,8 +657,13 @@ impl DistributedRuntime {
         let endpoint_name = parts[2];
 
         // Get endpoint using existing chain
-        let namespace = self.inner.namespace(namespace_name.to_string()).map_err(to_pyerr)?;
-        let component = namespace.component(component_name.to_string()).map_err(to_pyerr)?;
+        let namespace = self
+            .inner
+            .namespace(namespace_name.to_string())
+            .map_err(to_pyerr)?;
+        let component = namespace
+            .component(component_name.to_string())
+            .map_err(to_pyerr)?;
         let endpoint = component.endpoint(endpoint_name.to_string());
 
         Ok(Endpoint {

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -150,7 +150,6 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_class::<DistributedRuntime>()?;
     m.add_class::<CancellationToken>()?;
-    m.add_class::<Namespace>()?;
     m.add_class::<Component>()?;
     m.add_class::<Endpoint>()?;
     m.add_class::<ModelCardInstanceId>()?;
@@ -463,13 +462,6 @@ struct CancellationToken {
 
 #[pyclass]
 #[derive(Clone)]
-struct Namespace {
-    inner: rs::component::Namespace,
-    event_loop: PyObject,
-}
-
-#[pyclass]
-#[derive(Clone)]
 struct Component {
     inner: rs::component::Component,
     event_loop: PyObject,
@@ -645,13 +637,6 @@ impl DistributedRuntime {
         Ok(DistributedRuntime {
             inner,
             event_loop: py.None(),
-        })
-    }
-
-    fn namespace(&self, name: String) -> PyResult<Namespace> {
-        Ok(Namespace {
-            inner: self.inner.namespace(name).map_err(to_pyerr)?,
-            event_loop: self.event_loop.clone(),
         })
     }
 
@@ -947,17 +932,6 @@ impl Endpoint {
             inner: self.inner.component().clone(),
             event_loop: self.event_loop.clone(),
         }
-    }
-}
-
-#[pymethods]
-impl Namespace {
-    fn component(&self, name: String) -> PyResult<Component> {
-        let inner = self.inner.component(name).map_err(to_pyerr)?;
-        Ok(Component {
-            inner,
-            event_loop: self.event_loop.clone(),
-        })
     }
 }
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -655,6 +655,33 @@ impl DistributedRuntime {
         })
     }
 
+    /// Get an endpoint directly by path (e.g., "namespace.component.endpoint" or "dyn://...").
+    fn endpoint(&self, path: String) -> PyResult<Endpoint> {
+        let path = path.trim_start_matches("dyn://");
+        let parts: Vec<&str> = path.split('.').collect();
+
+        if parts.len() != 3 {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Invalid endpoint path '{}'. Expected format: 'namespace.component.endpoint' or 'dyn://namespace.component.endpoint'",
+                path
+            )));
+        }
+
+        let namespace_name = parts[0];
+        let component_name = parts[1];
+        let endpoint_name = parts[2];
+
+        // Get endpoint using existing chain
+        let namespace = self.inner.namespace(namespace_name.to_string()).map_err(to_pyerr)?;
+        let component = namespace.component(component_name.to_string()).map_err(to_pyerr)?;
+        let endpoint = component.endpoint(endpoint_name.to_string());
+
+        Ok(Endpoint {
+            inner: endpoint,
+            event_loop: self.event_loop.clone(),
+        })
+    }
+
     fn shutdown(&self) {
         self.inner.shutdown();
     }
@@ -909,6 +936,14 @@ impl Endpoint {
             inner.register_endpoint_instance().await.map_err(to_pyerr)?;
             Ok(())
         })
+    }
+
+    /// Get the parent Component.
+    fn component(&self) -> Component {
+        Component {
+            inner: self.inner.component().clone(),
+            event_loop: self.event_loop.clone(),
+        }
     }
 }
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -657,8 +657,8 @@ impl DistributedRuntime {
 
     /// Get an endpoint directly by path (e.g., "namespace.component.endpoint" or "dyn://...").
     fn endpoint(&self, path: String) -> PyResult<Endpoint> {
-        let path = path.trim_start_matches("dyn://");
-        let parts: Vec<&str> = path.split('.').collect();
+        let trimmed_path = path.trim_start_matches("dyn://");
+        let parts: Vec<&str> = trimmed_path.split('.').collect();
 
         if parts.len() != 3 {
             return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
@@ -939,6 +939,9 @@ impl Endpoint {
     }
 
     /// Get the parent Component.
+    ///
+    /// Note: To avoid duplicate metrics registries, reuse the returned Component for
+    /// multiple endpoints: `component.endpoint("ep1")`, `component.endpoint("ep2")`.
     fn component(&self) -> Component {
         Component {
             inner: self.inner.component().clone(),

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -76,7 +76,8 @@ class DistributedRuntime:
             Endpoint: The requested endpoint
 
         Raises:
-            ValueError: If path format is invalid
+            ValueError: If path format is invalid (not 3 parts separated by dots)
+            Exception: If namespace or component creation fails
 
         Example:
             endpoint = runtime.endpoint("demo.backend.generate")
@@ -235,9 +236,14 @@ class Endpoint:
         Returns:
             Component: The parent component
 
+        Note:
+            To avoid duplicate metrics registries, reuse the returned Component for
+            multiple endpoints: component.endpoint("ep1"), component.endpoint("ep2")
+
         Example:
             endpoint = runtime.endpoint("demo.backend.generate")
-            component = endpoint.component()  # Get parent component
+            component = endpoint.component()
+            health_endpoint = component.endpoint("health")  # Reuse component
         """
         ...
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -58,12 +58,6 @@ class DistributedRuntime:
         """
         ...
 
-    def namespace(self, name: str) -> Namespace:
-        """
-        Create a `Namespace` object
-        """
-        ...
-
     def endpoint(self, path: str) -> Endpoint:
         """
         Get an endpoint directly by path.
@@ -136,19 +130,6 @@ class CancellationToken:
         """
         ...
 
-
-class Namespace:
-    """
-    A namespace is a collection of components
-    """
-
-    ...
-
-    def component(self, name: str) -> Component:
-        """
-        Create a `Component` object
-        """
-        ...
 
 class Component:
     """

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -64,6 +64,26 @@ class DistributedRuntime:
         """
         ...
 
+    def endpoint(self, path: str) -> Endpoint:
+        """
+        Get an endpoint directly by path.
+
+        Args:
+            path: Endpoint path in format 'namespace.component.endpoint'
+                  or 'dyn://namespace.component.endpoint'
+
+        Returns:
+            Endpoint: The requested endpoint
+
+        Raises:
+            ValueError: If path format is invalid
+
+        Example:
+            endpoint = runtime.endpoint("demo.backend.generate")
+            endpoint = runtime.endpoint("dyn://demo.backend.generate")
+        """
+        ...
+
     def shutdown(self) -> None:
         """
         Shutdown the runtime by triggering the cancellation token
@@ -205,6 +225,19 @@ class Endpoint:
         This adds the endpoint back to the instances bucket, allowing the router
         to send requests to this worker again. Use this when a worker wakes up
         and should start receiving requests.
+        """
+        ...
+
+    def component(self) -> Component:
+        """
+        Get the parent Component that this endpoint belongs to.
+
+        Returns:
+            Component: The parent component
+
+        Example:
+            endpoint = runtime.endpoint("demo.backend.generate")
+            component = endpoint.component()  # Get parent component
         """
         ...
 

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -15,7 +15,7 @@ from dynamo._core import Component as Component
 from dynamo._core import Context as Context
 from dynamo._core import DistributedRuntime as DistributedRuntime
 from dynamo._core import Endpoint as Endpoint
-from dynamo._core import Namespace as Namespace
+from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
 
 
 def dynamo_worker(enable_nats: bool = True):

--- a/lib/bindings/python/tests/cancellation/test_cancellation.py
+++ b/lib/bindings/python/tests/cancellation/test_cancellation.py
@@ -128,8 +128,7 @@ async def server(runtime, namespace):
 
     async def init_server():
         """Initialize the test server component and serve the generate endpoint"""
-        component = runtime.namespace(namespace).component("backend")
-        endpoint = component.endpoint("generate")
+        endpoint = runtime.endpoint(f"{namespace}.backend.generate")
         print("Started test server instance")
 
         # Serve the endpoint - this will block until shutdown
@@ -156,7 +155,7 @@ async def server(runtime, namespace):
 async def client(runtime, namespace):
     """Create a client connected to the test server"""
     # Create client
-    endpoint = runtime.namespace(namespace).component("backend").endpoint("generate")
+    endpoint = runtime.endpoint(f"{namespace}.backend.generate")
     client = await endpoint.client()
     await client.wait_for_instances()
 

--- a/lib/bindings/python/tests/test_tensor.py
+++ b/lib/bindings/python/tests/test_tensor.py
@@ -16,9 +16,7 @@ TEST_END_TO_END = os.environ.get("TEST_END_TO_END", 0)
 
 @pytest.mark.asyncio
 async def test_register(runtime: DistributedRuntime):
-    component = runtime.namespace("test").component("tensor")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint("test.tensor.generate")
 
     model_config = {
         "name": "tensor",

--- a/tests/frontend/grpc/echo_tensor_worker.py
+++ b/tests/frontend/grpc/echo_tensor_worker.py
@@ -15,9 +15,7 @@ from dynamo.runtime import DistributedRuntime, dynamo_worker
 
 @dynamo_worker()
 async def echo_tensor_worker(runtime: DistributedRuntime):
-    component = runtime.namespace("tensor").component("echo")
-
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint("tensor.echo.generate")
 
     triton_model_config = mc.ModelConfig()
     triton_model_config.name = "echo"

--- a/tests/planner/unit/test_remote_planner.py
+++ b/tests/planner/unit/test_remote_planner.py
@@ -30,14 +30,10 @@ pytestmark = [
 def mock_runtime():
     """Create a mock DistributedRuntime."""
     runtime = MagicMock()
-    namespace_mock = MagicMock()
-    component_mock = MagicMock()
     endpoint_mock = MagicMock()
     client_mock = AsyncMock()
 
-    runtime.namespace.return_value = namespace_mock
-    namespace_mock.component.return_value = component_mock
-    component_mock.endpoint.return_value = endpoint_mock
+    runtime.endpoint.return_value = endpoint_mock
     endpoint_mock.client = AsyncMock(return_value=client_mock)
     client_mock.wait_for_instances = AsyncMock()
 
@@ -82,21 +78,17 @@ async def test_send_scale_request_success(mock_runtime):
     assert response.current_replicas["decode"] == 5
     # Verify lazy init happened
     assert client._client is not None
-    runtime.namespace.assert_called_once_with("central-ns")
+    runtime.endpoint.assert_called_once_with("central-ns.Planner.scale_request")
 
 
 @pytest.mark.asyncio
 async def test_send_scale_request_error():
     """Test scale request error handling."""
     runtime = MagicMock()
-    namespace_mock = MagicMock()
-    component_mock = MagicMock()
     endpoint_mock = MagicMock()
     client_mock = AsyncMock()
 
-    runtime.namespace.return_value = namespace_mock
-    namespace_mock.component.return_value = component_mock
-    component_mock.endpoint.return_value = endpoint_mock
+    runtime.endpoint.return_value = endpoint_mock
     endpoint_mock.client = AsyncMock(return_value=client_mock)
     client_mock.wait_for_instances = AsyncMock()
 
@@ -132,14 +124,10 @@ async def test_send_scale_request_error():
 async def test_send_scale_request_no_response():
     """Test scale request when no response is received."""
     runtime = MagicMock()
-    namespace_mock = MagicMock()
-    component_mock = MagicMock()
     endpoint_mock = MagicMock()
     client_mock = AsyncMock()
 
-    runtime.namespace.return_value = namespace_mock
-    namespace_mock.component.return_value = component_mock
-    component_mock.endpoint.return_value = endpoint_mock
+    runtime.endpoint.return_value = endpoint_mock
     endpoint_mock.client = AsyncMock(return_value=client_mock)
     client_mock.wait_for_instances = AsyncMock()
 

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1389,9 +1389,9 @@ def _test_router_indexers_sync(
         # Create first runtime and endpoint for router 1
         logger.info("Creating first KV router with its own runtime")
         runtime1 = get_runtime(store_backend, request_plane)
-        namespace1 = runtime1.namespace(engine_workers.namespace)
-        component1 = namespace1.component(engine_workers.component_name)
-        endpoint1 = component1.endpoint("generate")
+        endpoint1 = runtime1.endpoint(
+            f"{engine_workers.namespace}.{engine_workers.component_name}.generate"
+        )
 
         kv_router1 = KvRouter(
             endpoint=endpoint1,
@@ -1442,9 +1442,9 @@ def _test_router_indexers_sync(
         # Create second runtime and endpoint for router 2
         logger.info("Creating second KV router with its own runtime")
         runtime2 = get_runtime(store_backend, request_plane)
-        namespace2 = runtime2.namespace(engine_workers.namespace)
-        component2 = namespace2.component(engine_workers.component_name)
-        endpoint2 = component2.endpoint("generate")
+        endpoint2 = runtime2.endpoint(
+            f"{engine_workers.namespace}.{engine_workers.component_name}.generate"
+        )
 
         kv_router2 = KvRouter(
             endpoint=endpoint2,

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -507,9 +507,9 @@ def test_kv_router_bindings(
 
         # Get runtime and create endpoint
         runtime = get_runtime(request_plane=request_plane)
-        namespace = runtime.namespace(mockers.namespace)
-        component = namespace.component(mockers.component_name)
-        endpoint = component.endpoint("generate")
+        endpoint = runtime.endpoint(
+            f"{mockers.namespace}.{mockers.component_name}.generate"
+        )
 
         # Run Python router bindings test
         _test_python_router_bindings(
@@ -697,9 +697,7 @@ def test_router_decisions(
         # Get runtime and create endpoint
         runtime = get_runtime(request_plane=request_plane)
         # Use the namespace from the mockers
-        namespace = runtime.namespace(mockers.namespace)
-        component = namespace.component("mocker")
-        endpoint = component.endpoint("generate")
+        endpoint = runtime.endpoint(f"{mockers.namespace}.mocker.generate")
 
         _test_router_decisions(
             mockers,

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -416,9 +416,7 @@ def test_router_decisions_sglang_multiple_workers(
         logger.info(f"All SGLang workers using namespace: {sglang_workers.namespace}")
 
         runtime = get_runtime(request_plane=request_plane)
-        namespace = runtime.namespace(sglang_workers.namespace)
-        component = namespace.component("backend")
-        endpoint = component.endpoint("generate")
+        endpoint = runtime.endpoint(f"{sglang_workers.namespace}.backend.generate")
 
         _test_router_decisions(
             sglang_workers,
@@ -465,9 +463,7 @@ def test_router_decisions_sglang_dp(
         # Get runtime and create endpoint
         runtime = get_runtime(request_plane=request_plane)
         # Use the namespace from the SGLang workers
-        namespace = runtime.namespace(sglang_workers.namespace)
-        component = namespace.component("backend")  # endpoint is backend.generate
-        endpoint = component.endpoint("generate")
+        endpoint = runtime.endpoint(f"{sglang_workers.namespace}.backend.generate")
 
         _test_router_decisions(
             sglang_workers, endpoint, MODEL_NAME, request, test_dp_rank=True

--- a/tests/router/test_router_e2e_with_trtllm.py
+++ b/tests/router/test_router_e2e_with_trtllm.py
@@ -408,9 +408,7 @@ def test_router_decisions_trtllm_attention_dp(
         # Get runtime and create endpoint
         runtime = get_runtime(request_plane=request_plane)
         # Use the namespace from the vLLM workers
-        namespace = runtime.namespace(trtllm_workers.namespace)
-        component = namespace.component("tensorrt_llm")
-        endpoint = component.endpoint("generate")
+        endpoint = runtime.endpoint(f"{trtllm_workers.namespace}.tensorrt_llm.generate")
 
         _test_router_decisions(
             trtllm_workers,
@@ -457,9 +455,7 @@ def test_router_decisions_trtllm_multiple_workers(
         logger.info(f"All TRT-LLM workers using namespace: {trtllm_workers.namespace}")
 
         runtime = get_runtime(request_plane=request_plane)
-        namespace = runtime.namespace(trtllm_workers.namespace)
-        component = namespace.component("tensorrt_llm")
-        endpoint = component.endpoint("generate")
+        endpoint = runtime.endpoint(f"{trtllm_workers.namespace}.tensorrt_llm.generate")
 
         _test_router_decisions(
             trtllm_workers,

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -434,9 +434,7 @@ def test_router_decisions_vllm_multiple_workers(
 
         # Get runtime and create endpoint
         runtime = get_runtime(request_plane=request_plane)
-        namespace = runtime.namespace(vllm_workers.namespace)
-        component = namespace.component("backend")
-        endpoint = component.endpoint("generate")
+        endpoint = runtime.endpoint(f"{vllm_workers.namespace}.backend.generate")
 
         _test_router_decisions(
             vllm_workers,
@@ -483,9 +481,9 @@ def test_router_decisions_vllm_dp(
         # Get runtime and create endpoint
         runtime = get_runtime(request_plane=request_plane)
         # Use the namespace from the vLLM workers
-        namespace = runtime.namespace(vllm_workers.namespace)
-        component = namespace.component("backend")  # endpoint is backend.generate
-        endpoint = component.endpoint("generate")
+        endpoint = runtime.endpoint(
+            f"{vllm_workers.namespace}.backend.generate"
+        )  # endpoint is backend.generate
 
         _test_router_decisions(
             vllm_workers, endpoint, MODEL_NAME, request, test_dp_rank=True

--- a/tests/serve/launch/template_verifier.py
+++ b/tests/serve/launch/template_verifier.py
@@ -43,8 +43,7 @@ async def main(runtime: DistributedRuntime):
     """Main worker function for template verification."""
 
     # Create service
-    component = runtime.namespace("test").component("backend")
-    endpoint = component.endpoint("generate")
+    endpoint = runtime.endpoint("test.backend.generate")
 
     # Use the existing custom template from fixtures
     template_path = Path(SERVE_TEST_DIR) / "fixtures" / "custom_template.jinja"


### PR DESCRIPTION
#### Overview:

Add `runtime.endpoint(path)` and `endpoint.component()` methods to simplify endpoint access from a 3-step chain to a single call to remove runtime.namespace() usage.

#### Details:

**New methods:**
- `runtime.endpoint("namespace.component.endpoint")` - Direct endpoint access
- `endpoint.component()` - Get parent Component when needed

**Before:**
component = runtime.namespace("demo").component("backend")
endpoint = component.endpoint("generate")

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-1474
https://github.com/ai-dynamo/enhancements/blob/97c2f19692d9c0413d78dd1c62079854a9ed9467/deps/proposal-bindings-v2.md#move-internal-bindings-meaning-used-by-components-but-not-intended-for-public-use-otherwise-under-new-_internal-module


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct endpoint access via path lookup on the runtime.
  * Added ability to retrieve parent component from an endpoint.

* **Refactor**
  * Simplified endpoint resolution pattern throughout example implementations for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->