### PR TITLE
feat: make GMS lock mode configurable via model_loader_extra_config

### DIFF
--- a/lib/gpu_memory_service/integrations/common/__init__.py
+++ b/lib/gpu_memory_service/integrations/common/__init__.py
@@ -6,6 +6,7 @@
 from gpu_memory_service.integrations.common.patches import patch_empty_cache
 from gpu_memory_service.integrations.common.utils import (
     finalize_gms_write,
+    get_requested_lock_type,
     setup_meta_tensor_workaround,
 )
 
@@ -13,4 +14,5 @@ __all__ = [
     "patch_empty_cache",
     "setup_meta_tensor_workaround",
     "finalize_gms_write",
+    "get_requested_lock_type",
 ]

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -9,6 +9,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import torch
+from gpu_memory_service.common.types import RequestedLockType
 
 if TYPE_CHECKING:
     from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
@@ -64,3 +65,14 @@ def finalize_gms_write(
     )
 
     return int(total_bytes)
+
+
+def get_requested_lock_type(extra_config: dict) -> RequestedLockType:
+    """Determine the GMS lock mode from model_loader_extra_config.
+
+    When extra_config["gms_weights_import_only"] is true, returns RO so the
+    client blocks until weights are committed.  Otherwise returns RW_OR_RO.
+    """
+    if (extra_config or {}).get("gms_weights_import_only", False):
+        return RequestedLockType.RO
+    return RequestedLockType.RW_OR_RO

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -152,6 +152,25 @@ def patch_model_runner() -> None:
         return original_init_memory_pool(self, *args, **kwargs)
 
     ModelRunner.init_memory_pool = patched_init_memory_pool
+
+    # Wrap load_model so that model_loader_extra_config is available to
+    # GMSMemorySaverImpl before TorchMemorySaver._ensure_initialized runs.
+    original_load_model = ModelRunner.load_model
+
+    def patched_load_model(self, *args, **kwargs):
+        import json
+
+        import gpu_memory_service.integrations.sglang.memory_saver as ms_mod
+
+        raw = getattr(self.server_args, "model_loader_extra_config", None) or {}
+        if isinstance(raw, str):
+            raw = json.loads(raw)
+        ms_mod._model_loader_extra_config = raw
+
+        return original_load_model(self, *args, **kwargs)
+
+    ModelRunner.load_model = patched_load_model
+
     ModelRunner._gms_patched = True
     _model_runner_patched = True
-    logger.info("[GMS] Patched ModelRunner.init_memory_pool")
+    logger.info("[GMS] Patched ModelRunner.init_memory_pool and load_model")

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -164,7 +164,13 @@ def patch_model_runner() -> None:
 
         raw = getattr(self.server_args, "model_loader_extra_config", None) or {}
         if isinstance(raw, str):
-            raw = json.loads(raw)
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "[GMS] Failed to parse model_loader_extra_config, using defaults"
+                )
+                raw = {}
         ms_mod._model_loader_extra_config = raw
 
         return original_load_model(self, *args, **kwargs)

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -68,7 +68,9 @@ def register_gms_loader(load_format: str = "gms") -> None:
             gms_client, pool = get_or_create_gms_client_memory_manager(
                 get_socket_path(device),
                 device,
-                mode=get_requested_lock_type(self.load_config.model_loader_extra_config),
+                mode=get_requested_lock_type(
+                    self.load_config.model_loader_extra_config
+                ),
                 tag="weights",
             )
 

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -4,8 +4,10 @@
 """vLLM model loader for GPU Memory Service integration.
 
 Provides a model loader that loads weights via GMS for cross-process sharing.
-The loader uses RW_OR_RO mode: first process loads from disk (RW), subsequent
-processes import from GMS metadata (RO).
+By default the loader uses RW_OR_RO mode: first process loads from disk (RW),
+subsequent processes import from GMS metadata (RO).  Set
+``gms_weights_import_only: true`` in ``--model-loader-extra-config`` to force
+RO mode, which blocks until weights are committed.
 """
 
 from __future__ import annotations
@@ -17,10 +19,11 @@ from typing import TYPE_CHECKING
 import torch
 from gpu_memory_service import get_or_create_gms_client_memory_manager
 from gpu_memory_service.client.torch.module import materialize_module_from_gms
-from gpu_memory_service.common.types import GrantedLockType, RequestedLockType
+from gpu_memory_service.common.types import GrantedLockType
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.integrations.common.utils import (
     finalize_gms_write,
+    get_requested_lock_type,
     setup_meta_tensor_workaround,
 )
 
@@ -65,7 +68,7 @@ def register_gms_loader(load_format: str = "gms") -> None:
             gms_client, pool = get_or_create_gms_client_memory_manager(
                 get_socket_path(device),
                 device,
-                mode=RequestedLockType.RW_OR_RO,
+                mode=get_requested_lock_type(self.load_config.model_loader_extra_config),
                 tag="weights",
             )
 

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -21,8 +21,8 @@ from gpu_memory_service import (
     get_gms_client_memory_manager,
     get_or_create_gms_client_memory_manager,
 )
-from gpu_memory_service.common.types import RequestedLockType
 from gpu_memory_service.common.utils import get_socket_path
+from gpu_memory_service.integrations.common.utils import get_requested_lock_type
 from gpu_memory_service.integrations.common import patch_empty_cache
 from gpu_memory_service.integrations.vllm.model_loader import register_gms_loader
 from gpu_memory_service.integrations.vllm.patches import patch_memory_snapshot
@@ -59,8 +59,9 @@ class GMSWorker(Worker):
 
         # Establish GMS connection (so MemorySnapshot can query committed bytes)
         socket_path = get_socket_path(device)
+        extra_config = self.load_config.model_loader_extra_config
         get_or_create_gms_client_memory_manager(
-            socket_path, device, mode=RequestedLockType.RW_OR_RO, tag="weights"
+            socket_path, device, mode=get_requested_lock_type(extra_config), tag="weights"
         )
 
         # Parent will set device again (harmless) and do memory checks

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -22,8 +22,8 @@ from gpu_memory_service import (
     get_or_create_gms_client_memory_manager,
 )
 from gpu_memory_service.common.utils import get_socket_path
-from gpu_memory_service.integrations.common.utils import get_requested_lock_type
 from gpu_memory_service.integrations.common import patch_empty_cache
+from gpu_memory_service.integrations.common.utils import get_requested_lock_type
 from gpu_memory_service.integrations.vllm.model_loader import register_gms_loader
 from gpu_memory_service.integrations.vllm.patches import patch_memory_snapshot
 
@@ -61,7 +61,10 @@ class GMSWorker(Worker):
         socket_path = get_socket_path(device)
         extra_config = self.load_config.model_loader_extra_config
         get_or_create_gms_client_memory_manager(
-            socket_path, device, mode=get_requested_lock_type(extra_config), tag="weights"
+            socket_path,
+            device,
+            mode=get_requested_lock_type(extra_config),
+            tag="weights",
         )
 
         # Parent will set device again (harmless) and do memory checks


### PR DESCRIPTION
## Summary
- Adds `gms_weights_import_only` option to `--model-loader-extra-config` for both vLLM and SGLang integrations
- When set to `true`, forces RO lock acquisition instead of the default `RW_OR_RO`, causing the engine to block until GMS weights are committed
- For SGLang, patches `ModelRunner.load_model` to extract the extra config from `server_args` before `TorchMemorySaver._ensure_initialized` runs, since the lock is acquired before the model loader sees `load_config`

### Usage
```bash
--model-loader-extra-config '{"gms_weights_import_only": true}'
```

## Test plan
- [ ] Verify default behavior (no config) still uses `RW_OR_RO` for both vLLM and SGLang
- [ ] Verify `gms_weights_import_only: true` causes RO lock acquisition that blocks until committed
- [ ] Verify SGLang config extraction from `server_args` happens before `_ensure_initialized`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU memory service lock mode is now dynamically configurable. Control lock behavior via the `--model-loader-extra-config` parameter with the `gms_weights_import_only` flag. Default remains read-write or read-only; enable the flag to enforce read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->