### PR TITLE
feat(operator): add observedGeneration to DGD status

### DIFF
--- a/deploy/helm/charts/crds/templates/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/helm/charts/crds/templates/nvidia.com_dynamographdeployments.yaml
@@ -11369,6 +11369,10 @@ spec:
                       - type
                     type: object
                   type: array
+                observedGeneration:
+                  description: ObservedGeneration is the most recent generation observed by the controller.
+                  format: int64
+                  type: integer
                 restart:
                   description: Restart contains the status of the restart of the graph deployment.
                   properties:

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_types.go
@@ -110,6 +110,9 @@ const (
 
 // DynamoGraphDeploymentStatus defines the observed state of DynamoGraphDeployment.
 type DynamoGraphDeploymentStatus struct {
+	// ObservedGeneration is the most recent generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// State is a high-level textual status of the graph deployment lifecycle.
 	// +kubebuilder:default=initializing
 	State DGDState `json:"state"`

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -11369,6 +11369,10 @@ spec:
                       - type
                     type: object
                   type: array
+                observedGeneration:
+                  description: ObservedGeneration is the most recent generation observed by the controller.
+                  format: int64
+                  type: integer
                 restart:
                   description: Restart contains the status of the restart of the graph deployment.
                   properties:

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -136,6 +136,12 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 			LastTransitionTime: metav1.Now(),
 		})
 
+		// Only set ObservedGeneration when reconciliation succeeded (no error),
+		// so it accurately reflects the last successfully processed generation.
+		if err == nil {
+			dynamoDeployment.Status.ObservedGeneration = dynamoDeployment.Generation
+		}
+
 		updateErr := r.Status().Update(ctx, dynamoDeployment)
 		if updateErr != nil {
 			logger.Error(updateErr, "Unable to update the CRD status", "crd", req.NamespacedName, "state", state, "reason", reason, "message", message)

--- a/docs/pages/kubernetes/api-reference.md
+++ b/docs/pages/kubernetes/api-reference.md
@@ -645,6 +645,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed by the controller. |  | Optional: \{\} <br /> |
 | `state` _[DGDState](#dgdstate)_ | State is a high-level textual status of the graph deployment lifecycle. | initializing | Enum: [initializing pending successful failed] <br /> |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions contains the latest observed conditions of the graph deployment.<br />The slice is merged by type on patch updates. |  |  |
 | `services` _object (keys:string, values:[ServiceReplicaStatus](#servicereplicastatus))_ | Services contains per-service replica status information.<br />The map key is the service name from spec.services. |  | Optional: \{\} <br /> |


### PR DESCRIPTION
#### Overview:

Add `observedGeneration` field to `DynamoGraphDeploymentStatus`, matching the existing pattern in DynamoComponentDeployment. This lets consumers detect whether the controller has successfully reconciled the latest spec.

#### Details:

- Added `ObservedGeneration int64` field to `DynamoGraphDeploymentStatus`
- Set `ObservedGeneration` in the DGD controller's defer status-update block, only when reconciliation succeeds (`err == nil`), so it accurately reflects the last successfully processed generation
- Ran `make generate`, `make manifests`, and `make generate-api-docs`

#### Where should the reviewer start?

- `internal/controller/dynamographdeployment_controller.go` — the defer block where `ObservedGeneration` is set
- `api/v1alpha1/dynamographdeployment_types.go` — the new status field

#### Related Issues:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observedGeneration field to deployment status, allowing users to track which resource generation the controller has most recently observed and processed.

* **Documentation**
  * Updated API reference documentation to reflect the new observedGeneration field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->