### PR TITLE
feat: Remove Component from public

### DIFF
--- a/components/src/dynamo/global_planner/__main__.py
+++ b/components/src/dynamo/global_planner/__main__.py
@@ -71,9 +71,6 @@ async def main(runtime: DistributedRuntime, args):
 
     logger.info("=" * 60)
 
-    # Create the GlobalPlanner component (get from first endpoint)
-    component = runtime.endpoint(f"{namespace}.GlobalPlanner.scale_request").component()
-
     # Get K8s namespace (where GlobalPlanner pod is running)
     k8s_namespace = os.environ.get("POD_NAMESPACE", "default")
     logger.info(f"Running in Kubernetes namespace: {k8s_namespace}")
@@ -87,7 +84,7 @@ async def main(runtime: DistributedRuntime, args):
 
     # Serve scale_request endpoint
     logger.info("Serving endpoints...")
-    scale_endpoint = component.endpoint("scale_request")
+    scale_endpoint = runtime.endpoint(f"{namespace}.GlobalPlanner.scale_request")
     await scale_endpoint.serve_endpoint(handler.scale_request)
     logger.info("  ✓ scale_request - Receives scaling requests from Planners")
 
@@ -101,7 +98,7 @@ async def main(runtime: DistributedRuntime, args):
             "managed_namespaces": args.managed_namespaces or "all",
         }
 
-    health_endpoint = component.endpoint("health")
+    health_endpoint = runtime.endpoint(f"{namespace}.GlobalPlanner.health")
     await health_endpoint.serve_endpoint(health_check)
     logger.info("  ✓ health - Health check endpoint")
 

--- a/components/src/dynamo/global_router/__main__.py
+++ b/components/src/dynamo/global_router/__main__.py
@@ -74,8 +74,9 @@ async def worker(runtime: DistributedRuntime):
     prefill_endpoint = runtime.endpoint(
         f"{config.namespace}.{config.component_name}.prefill_generate"
     )
-    component = prefill_endpoint.component()
-    decode_endpoint = component.endpoint("decode_generate")
+    decode_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component_name}.decode_generate"
+    )
 
     logger.info("Registering as prefill worker...")
     # Register as prefill worker - frontend will send prefill requests here

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -185,10 +185,9 @@ async def worker(runtime: DistributedRuntime):
     )
     await handler.initialize()
 
-    # Create endpoints (get component from first endpoint to avoid duplicate metrics registries)
+    # Create endpoints
     generate_endpoint = runtime.endpoint(f"{config.namespace}.router.generate")
-    component = generate_endpoint.component()
-    best_worker_endpoint = component.endpoint("best_worker_id")
+    best_worker_endpoint = runtime.endpoint(f"{config.namespace}.router.best_worker_id")
 
     logger.debug("Starting to serve endpoints...")
 

--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import sglang as sgl
 
-from dynamo._core import Component, Context
+from dynamo._core import Context
 from dynamo.sglang.args import Config
 from dynamo.sglang.protocol import EmbeddingRequest
 from dynamo.sglang.publisher import DynamoSglangPublisher
@@ -17,13 +17,12 @@ from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 class EmbeddingWorkerHandler(BaseWorkerHandler):
     def __init__(
         self,
-        component: Component,
         engine: sgl.Engine,
         config: Config,
         publisher: Optional[DynamoSglangPublisher] = None,
         shutdown_event: Optional[asyncio.Event] = None,
     ):
-        super().__init__(component, engine, config, publisher, None, shutdown_event)
+        super().__init__(engine, config, publisher, None, shutdown_event)
         logging.info("Embedding worker handler initialized")
 
     def cleanup(self):

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -13,7 +13,7 @@ from typing import Any, AsyncGenerator, Dict, Optional, Tuple
 import sglang as sgl
 from sglang.srt.utils import get_local_ip_auto
 
-from dynamo._core import Component, Context
+from dynamo._core import Context
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
@@ -30,18 +30,15 @@ class BaseGenerativeHandler(ABC):
 
     def __init__(
         self,
-        component: Component,
         config: Config,
         publisher: Optional[DynamoSglangPublisher] = None,
     ) -> None:
         """Initialize base generative handler.
 
         Args:
-            component: The Dynamo runtime component.
             config: SGLang and Dynamo configuration.
             publisher: Optional metrics publisher for the worker.
         """
-        self.component = component
         self.config = config
 
         # Set up metrics and KV publishers
@@ -98,7 +95,6 @@ class BaseWorkerHandler(BaseGenerativeHandler):
 
     def __init__(
         self,
-        component: Component,
         engine: sgl.Engine,
         config: Config,
         publisher: Optional[DynamoSglangPublisher] = None,
@@ -108,7 +104,6 @@ class BaseWorkerHandler(BaseGenerativeHandler):
         """Initialize base worker handler.
 
         Args:
-            component: The Dynamo runtime component.
             engine: The SGLang engine instance.
             config: SGLang and Dynamo configuration.
             publisher: Optional metrics publisher for the worker.
@@ -116,7 +111,7 @@ class BaseWorkerHandler(BaseGenerativeHandler):
             shutdown_event: Optional event to signal shutdown.
         """
         # Call parent constructor
-        super().__init__(component, config, publisher)
+        super().__init__(config, publisher)
 
         # LLM-specific initialization
         self.engine = engine

--- a/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
@@ -13,7 +13,7 @@ from typing import Any, AsyncGenerator, Optional
 import torch
 from PIL import Image
 
-from dynamo._core import Component, Context
+from dynamo._core import Context
 from dynamo.common.storage import upload_to_fs
 from dynamo.sglang.args import Config
 from dynamo.sglang.protocol import CreateImageRequest, ImageData, ImagesResponse, NvExt
@@ -34,7 +34,6 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
 
     def __init__(
         self,
-        component: Component,
         generator: Any,  # DiffGenerator, not sgl.Engine
         config: Config,
         publisher: Optional[DynamoSglangPublisher] = None,
@@ -43,13 +42,12 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
         """Initialize diffusion worker handler.
 
         Args:
-            component: The Dynamo runtime component.
             generator: The SGLang DiffGenerator instance.
             config: SGLang and Dynamo configuration.
             publisher: Optional metrics publisher (not used for diffusion currently).
             fs: Optional fsspec filesystem for primary image storage.
         """
-        super().__init__(component, config, publisher)
+        super().__init__(config, publisher)
 
         self.generator = generator  # DiffGenerator, not Engine
         self.fs = fs

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -8,7 +8,7 @@ from typing import Any, AsyncGenerator, Dict, Optional
 
 import sglang as sgl
 
-from dynamo._core import Component, Context
+from dynamo._core import Context
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.sglang.args import Config, DisaggregationMode
 from dynamo.sglang.publisher import DynamoSglangPublisher
@@ -20,7 +20,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
     def __init__(
         self,
-        component: Component,
         engine: sgl.Engine,
         config: Config,
         publisher: DynamoSglangPublisher,
@@ -30,7 +29,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         """Initialize decode worker handler.
 
         Args:
-            component: The Dynamo runtime component.
             engine: The SGLang engine instance.
             config: SGLang and Dynamo configuration.
             publisher: Metrics publisher for the worker.
@@ -38,7 +36,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             generate_endpoint: The endpoint handle for discovery registration.
         """
         super().__init__(
-            component,
             engine,
             config,
             publisher,

--- a/components/src/dynamo/sglang/request_handlers/llm/diffusion_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/diffusion_handler.py
@@ -6,7 +6,7 @@ from typing import Any, AsyncGenerator, Dict, Optional
 
 import sglang as sgl
 
-from dynamo._core import Component, Context
+from dynamo._core import Context
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
@@ -19,7 +19,6 @@ class DiffusionWorkerHandler(DecodeWorkerHandler):
 
     def __init__(
         self,
-        component: Component,
         engine: sgl.Engine,
         config: Config,
         publisher: DynamoSglangPublisher = None,
@@ -29,16 +28,13 @@ class DiffusionWorkerHandler(DecodeWorkerHandler):
         """Initialize diffusion worker handler.
 
         Args:
-            component: The Dynamo runtime component.
             engine: SGLang engine with diffusion algorithm configured.
             config: SGLang and Dynamo configuration.
             publisher: Optional metrics publisher.
             generate_endpoint: The endpoint handle for discovery.
             shutdown_event: Optional event to signal shutdown.
         """
-        super().__init__(
-            component, engine, config, publisher, generate_endpoint, shutdown_event
-        )
+        super().__init__(engine, config, publisher, generate_endpoint, shutdown_event)
 
         # Validate that diffusion algorithm is configured
         if (

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -7,7 +7,7 @@ from typing import Any, AsyncGenerator, Dict, Optional
 
 import sglang as sgl
 
-from dynamo._core import Component, Context
+from dynamo._core import Context
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
@@ -18,7 +18,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
     def __init__(
         self,
-        component: Component,
         engine: sgl.Engine,
         config: Config,
         publisher: DynamoSglangPublisher,
@@ -28,7 +27,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         """Initialize prefill worker handler.
 
         Args:
-            component: The Dynamo runtime component.
             engine: The SGLang engine instance.
             config: SGLang and Dynamo configuration.
             publisher: The SGLang publisher instance.
@@ -37,9 +35,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         """
         self.engine = engine
         self.bootstrap_host, self.bootstrap_port = self._get_bootstrap_info(self.engine)
-        super().__init__(
-            component, engine, config, publisher, generate_endpoint, shutdown_event
-        )
+        super().__init__(engine, config, publisher, generate_endpoint, shutdown_event)
         self._consume_tasks = set()
         logging.info(
             f"Prefill worker handler initialized - bootstrap host: {self.bootstrap_host}, bootstrap port: {self.bootstrap_port}"

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -16,7 +16,7 @@ from sglang.srt.parser.conversation import chat_templates
 from transformers import AutoTokenizer
 
 import dynamo.nixl_connect as connect
-from dynamo._core import Client, Component, Context
+from dynamo._core import Client, Context
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
 from dynamo.sglang.protocol import SglangMultimodalRequest
@@ -46,14 +46,11 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler):
 
     def __init__(
         self,
-        component: Component,
         config: Config,
         pd_worker_client: Client,
         shutdown_event: Optional[asyncio.Event] = None,
     ) -> None:
-        super().__init__(
-            component, engine=None, config=config, shutdown_event=shutdown_event
-        )
+        super().__init__(engine=None, config=config, shutdown_event=shutdown_event)
         self.pd_worker_client = pd_worker_client
         self.model = config.server_args.model_path
 

--- a/components/src/dynamo/sglang/request_handlers/multimodal/processor_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/processor_handler.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 
 from transformers import AutoTokenizer
 
-from dynamo._core import Client, Component, Context
+from dynamo._core import Client, Context
 from dynamo.sglang.args import Config
 from dynamo.sglang.multimodal_utils import (
     multimodal_request_to_sglang,
@@ -34,14 +34,11 @@ class MultimodalProcessorHandler(BaseWorkerHandler):
 
     def __init__(
         self,
-        component: Component,
         config: Config,
         encode_worker_client: Client,
         shutdown_event: Optional[asyncio.Event] = None,
     ):
-        super().__init__(
-            component, engine=None, config=config, shutdown_event=shutdown_event
-        )
+        super().__init__(engine=None, config=config, shutdown_event=shutdown_event)
         self.encode_worker_client = encode_worker_client
         self.chat_template = getattr(config.server_args, "chat_template", "qwen2-vl")
         self.model = config.server_args.model_path

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -10,7 +10,7 @@ import sglang as sgl
 import torch
 
 import dynamo.nixl_connect as connect
-from dynamo._core import Client, Component, Context
+from dynamo._core import Client, Context
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.sglang.args import Config, DisaggregationMode
 from dynamo.sglang.protocol import (
@@ -253,13 +253,12 @@ class MultimodalWorkerHandler(BaseWorkerHandler):
 
     def __init__(
         self,
-        component: Component,
         engine: sgl.Engine,
         config: Config,
         prefill_client: Client = None,
         shutdown_event: Optional[asyncio.Event] = None,
     ):
-        super().__init__(component, engine, config, None, None, shutdown_event)
+        super().__init__(engine, config, None, None, shutdown_event)
 
         # Initialize processors
         self.embeddings_processor = EmbeddingsProcessor()
@@ -435,12 +434,11 @@ class MultimodalPrefillWorkerHandler(BaseWorkerHandler):
 
     def __init__(
         self,
-        component: Component,
         engine: sgl.Engine,
         config: Config,
         shutdown_event: Optional[asyncio.Event] = None,
     ):
-        super().__init__(component, engine, config, None, None, shutdown_event)
+        super().__init__(engine, config, None, None, shutdown_event)
 
         # Initialize processors
         self.embeddings_processor = EmbeddingsProcessor()

--- a/components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py
@@ -11,7 +11,7 @@ from typing import Any, AsyncGenerator, Optional
 
 import torch
 
-from dynamo._core import Component, Context
+from dynamo._core import Context
 from dynamo.common.storage import upload_to_fs
 from dynamo.sglang.args import Config
 from dynamo.sglang.protocol import (
@@ -35,7 +35,6 @@ class VideoGenerationWorkerHandler(BaseGenerativeHandler):
 
     def __init__(
         self,
-        component: Component,
         generator: Any,  # DiffGenerator, not sgl.Engine
         config: Config,
         publisher: Optional[DynamoSglangPublisher] = None,
@@ -44,14 +43,13 @@ class VideoGenerationWorkerHandler(BaseGenerativeHandler):
         """Initialize video generation worker handler.
 
         Args:
-            component: The Dynamo runtime component.
             generator: The SGLang DiffGenerator instance.
             config: SGLang and Dynamo configuration.
             publisher: Optional metrics publisher (not used for video currently).
             fs: Optional fsspec filesystem for primary video storage.
         """
         # Call parent constructor for common setup
-        super().__init__(component, config, publisher)
+        super().__init__(config, publisher)
 
         # Video generation-specific initialization
         self.generator = generator  # DiffGenerator, not Engine

--- a/components/src/dynamo/sglang/tests/test_sglang_image_diffusion_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_image_diffusion_handler.py
@@ -24,12 +24,6 @@ pytestmark = [
 
 
 @pytest.fixture
-def mock_component():
-    """Mock Dynamo Component."""
-    return MagicMock()
-
-
-@pytest.fixture
 def mock_generator():
     """Mock SGLang DiffGenerator."""
     generator = MagicMock()
@@ -67,12 +61,9 @@ def mock_context():
 
 
 @pytest.fixture
-def handler(
-    mock_component, mock_generator, mock_config, mock_fs
-) -> ImageDiffusionWorkerHandler:
+def handler(mock_generator, mock_config, mock_fs) -> ImageDiffusionWorkerHandler:
     """Create ImageDiffusionWorkerHandler instance."""
     return ImageDiffusionWorkerHandler(
-        component=mock_component,
         generator=mock_generator,
         config=mock_config,
         publisher=None,
@@ -90,9 +81,7 @@ class TestImageDiffusionWorkerHandler:
         assert handler.fs_url == "file:///tmp/images"
         assert handler.base_url == "file:///tmp/images"
 
-    def test_initialization_with_url_base(
-        self, mock_component, mock_generator, mock_fs
-    ):
+    def test_initialization_with_url_base(self, mock_generator, mock_fs):
         """Test handler initialization with URL base."""
         config = MagicMock()
         config.dynamo_args = MagicMock()
@@ -100,7 +89,6 @@ class TestImageDiffusionWorkerHandler:
         config.dynamo_args.media_output_http_url = "http://localhost:8008/images"
 
         handler = ImageDiffusionWorkerHandler(
-            component=mock_component,
             generator=mock_generator,
             config=config,
             publisher=None,

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -296,9 +296,8 @@ class Publisher:
 
     def __init__(
         self,
-        component,
+        endpoint,
         engine,
-        kv_listener,
         worker_id,
         kv_block_size,
         metrics_labels,
@@ -306,9 +305,8 @@ class Publisher:
         zmq_endpoint: Optional[str] = None,
         enable_local_indexer: bool = False,
     ):
-        self.component = component
+        self.endpoint = endpoint
         self.engine = engine
-        self.kv_listener = kv_listener
         self.worker_id = worker_id
         self.kv_block_size = kv_block_size
         self.max_window_size = None
@@ -356,7 +354,7 @@ class Publisher:
         if self.metrics_publisher is None:
             logging.error("KV metrics publisher not initialized!")
             return
-        await self.metrics_publisher.create_endpoint(self.component)
+        await self.metrics_publisher.create_endpoint(self.endpoint)
 
     def initialize(self):
         # Setup the metrics publisher
@@ -385,9 +383,9 @@ class Publisher:
             self.kv_event_publishers = {}
             for rank in range(self.attention_dp_size):
                 self.kv_event_publishers[rank] = KvEventPublisher(
-                    self.kv_listener,
-                    self.worker_id,
-                    self.kv_block_size,
+                    endpoint=self.endpoint,
+                    worker_id=self.worker_id,
+                    kv_block_size=self.kv_block_size,
                     dp_rank=rank,
                     enable_local_indexer=self.enable_local_indexer,
                 )
@@ -760,9 +758,8 @@ class Publisher:
 
 @asynccontextmanager
 async def get_publisher(
-    component,
+    endpoint,
     engine,
-    kv_listener,
     worker_id,
     kv_block_size,
     metrics_labels,
@@ -771,9 +768,8 @@ async def get_publisher(
     enable_local_indexer: bool = False,
 ):
     publisher = Publisher(
-        component,
+        endpoint,
         engine,
-        kv_listener,
         worker_id,
         kv_block_size,
         metrics_labels,

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -55,7 +55,6 @@ class RequestHandlerConfig:
     Configuration for the request handler
     """
 
-    component: object
     engine: TensorRTLLMEngine
     default_sampling_params: SamplingParams
     publisher: Publisher
@@ -89,7 +88,6 @@ class HandlerBase(BaseGenerativeHandler):
 
     def __init__(self, config: RequestHandlerConfig):
         self.engine = config.engine
-        self.component = config.component
         self.default_sampling_params = config.default_sampling_params
         self.publisher = config.publisher
         self.metrics_collector = config.metrics_collector

--- a/components/src/dynamo/trtllm/request_handlers/video_diffusion/video_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/video_diffusion/video_handler.py
@@ -13,7 +13,7 @@ import time
 import uuid
 from typing import Any, AsyncGenerator, Optional
 
-from dynamo._core import Component, Context
+from dynamo._core import Context
 from dynamo.common.protocols.video_protocol import (
     NvCreateVideoRequest,
     NvVideosResponse,
@@ -42,18 +42,15 @@ class VideoGenerationHandler(BaseGenerativeHandler):
 
     def __init__(
         self,
-        component: Component,
         engine: DiffusionEngine,
         config: DiffusionConfig,
     ):
         """Initialize the handler.
 
         Args:
-            component: The Dynamo runtime component.
             engine: The DiffusionEngine instance.
             config: Diffusion generation configuration.
         """
-        self.component = component
         self.engine = engine
         self.config = config
         if not config.media_output_fs_url:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_video_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_video_diffusion.py
@@ -597,7 +597,6 @@ class TestVideoHandlerConcurrency:
             return_value=MagicMock(),
         ):
             handler = VideoGenerationHandler(
-                component=MagicMock(),
                 engine=mock_engine,
                 config=config,
             )
@@ -684,7 +683,6 @@ class TestVideoHandlerResponseFormats:
             return_value=MagicMock(),
         ):
             handler = VideoGenerationHandler(
-                component=MagicMock(),
                 engine=mock_engine,
                 config=config,
             )

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -336,7 +336,7 @@ async def init_llm_worker(
         endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"
         )
-        component = endpoint.component()
+
         if shutdown_endpoints is not None:
             shutdown_endpoints[:] = [endpoint]
 
@@ -419,7 +419,6 @@ async def init_llm_worker(
 
         # publisher will be set later if publishing is enabled.
         handler_config = RequestHandlerConfig(
-            component=component,
             engine=engine,
             default_sampling_params=default_sampling_params,
             publisher=None,
@@ -456,7 +455,6 @@ async def init_llm_worker(
         if config.publish_events_and_metrics:
             # Initialize and pass in the publisher to the request handler to
             # publish events and metrics.
-            kv_listener = endpoint.component()
             # Use model as fallback if served_model_name is not provided
             model_name_for_metrics = config.served_model_name or config.model
             metrics_labels = [
@@ -476,7 +474,7 @@ async def init_llm_worker(
             if consolidator_output_endpoint:
                 # Use the connect endpoint directly (already provided by get_consolidator_endpoints)
                 consolidator_publisher = KvEventPublisher(
-                    component,
+                    endpoint=endpoint,
                     kv_block_size=config.kv_block_size,
                     zmq_endpoint=consolidator_output_connect_endpoint,
                     zmq_topic="",
@@ -487,9 +485,8 @@ async def init_llm_worker(
                 )
 
             async with get_publisher(
-                component,
+                endpoint,
                 engine,
-                kv_listener,
                 int(endpoint.connection_id()),
                 config.kv_block_size,
                 metrics_labels,

--- a/components/src/dynamo/trtllm/workers/video_diffusion_worker.py
+++ b/components/src/dynamo/trtllm/workers/video_diffusion_worker.py
@@ -91,7 +91,7 @@ async def init_video_diffusion_worker(
     endpoint = runtime.endpoint(
         f"{config.namespace}.{config.component}.{config.endpoint}"
     )
-    component = endpoint.component()
+
     if shutdown_endpoints is not None:
         shutdown_endpoints[:] = [endpoint]
 
@@ -100,7 +100,7 @@ async def init_video_diffusion_worker(
     await engine.initialize()
 
     # Create the request handler
-    handler = VideoGenerationHandler(component, engine, diffusion_config)
+    handler = VideoGenerationHandler(engine, diffusion_config)
 
     # Register the model with Dynamo's discovery system
     model_name = config.served_model_name or config.model

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -268,7 +268,6 @@ class BaseWorkerHandler(ABC):
     def __init__(
         self,
         runtime,
-        component,
         engine,
         default_sampling_params,
         model_max_len: int | None = None,
@@ -280,7 +279,6 @@ class BaseWorkerHandler(ABC):
         enable_frontend_decoding: bool = False,
     ):
         self.runtime = runtime
-        self.component = component
         self.engine_client = engine
         self.default_sampling_params = default_sampling_params
         self.kv_publishers: list[KvEventPublisher] | None = None
@@ -1233,7 +1231,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
     def __init__(
         self,
         runtime,
-        component,
         engine,
         default_sampling_params,
         model_max_len: int | None = None,
@@ -1246,7 +1243,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
     ):
         super().__init__(
             runtime,
-            component,
             engine,
             default_sampling_params,
             model_max_len,
@@ -1443,7 +1439,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
     def __init__(
         self,
         runtime,
-        component,
         engine,
         default_sampling_params,
         model_max_len: int | None = None,
@@ -1456,7 +1451,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
     ):
         super().__init__(
             runtime,
-            component,
             engine,
             default_sampling_params,
             model_max_len,

--- a/components/src/dynamo/vllm/multimodal_handlers/multimodal_pd_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/multimodal_pd_worker_handler.py
@@ -20,7 +20,7 @@ from dynamo.common.multimodal.embedding_transfer import (
     LocalEmbeddingReceiver,
     NixlPersistentEmbeddingReceiver,
 )
-from dynamo.runtime import Client, Component, DistributedRuntime
+from dynamo.runtime import Client, DistributedRuntime
 
 from ..args import Config
 from ..handlers import BaseWorkerHandler, build_sampling_params
@@ -44,7 +44,6 @@ class MultimodalPDWorkerHandler(BaseWorkerHandler):
     def __init__(
         self,
         runtime,
-        component: Component,
         engine_client: AsyncLLM,
         config: Config,
         encode_worker_client: Client | None = None,
@@ -60,7 +59,6 @@ class MultimodalPDWorkerHandler(BaseWorkerHandler):
         # Call BaseWorkerHandler.__init__ with proper parameters
         super().__init__(
             runtime,
-            component,
             engine_client,
             default_sampling_params,
             enable_multimodal=config.enable_multimodal,

--- a/components/src/dynamo/vllm/multimodal_handlers/worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/worker_handler.py
@@ -22,7 +22,6 @@ class MultimodalDecodeWorkerHandler(BaseWorkerHandler):
     def __init__(
         self,
         runtime,
-        component,
         engine_client,
         config: Config,
         shutdown_event=None,
@@ -36,7 +35,6 @@ class MultimodalDecodeWorkerHandler(BaseWorkerHandler):
         # Call BaseWorkerHandler.__init__ with proper parameters
         super().__init__(
             runtime,
-            component,
             engine_client,
             default_sampling_params,
             enable_multimodal=config.enable_multimodal,

--- a/components/src/dynamo/vllm/omni/omni_handler.py
+++ b/components/src/dynamo/vllm/omni/omni_handler.py
@@ -68,7 +68,6 @@ class OmniHandler(BaseOmniHandler):
     def __init__(
         self,
         runtime,
-        component,
         config,
         default_sampling_params: Dict[str, Any],
         shutdown_event: asyncio.Event | None = None,
@@ -88,7 +87,6 @@ class OmniHandler(BaseOmniHandler):
         """
         super().__init__(
             runtime=runtime,
-            component=component,
             config=config,
             default_sampling_params=default_sampling_params,
             shutdown_event=shutdown_event,

--- a/components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_multimodal_pd_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/multimodal_handlers/test_vllm_multimodal_pd_worker_handler.py
@@ -62,7 +62,6 @@ def _make_handler(
     with patch.object(mod.BaseWorkerHandler, "__init__", return_value=None):
         return mod.MultimodalPDWorkerHandler(
             runtime=MagicMock(),
-            component=MagicMock(),
             engine_client=MagicMock(),
             config=config,
             encode_worker_client=encode_worker_client,

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -105,6 +105,7 @@ class TestCreate:
             Mock(),
             Mock(),
             "/tmp/prometheus",
+            Mock(),
         )
 
         await factory.create(

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -103,6 +103,7 @@ class WorkerFactory:
         clear_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.clear_kv_blocks"
         )
+        shutdown_endpoints[:] = [generate_endpoint, clear_endpoint]
 
         lora_enabled = config.engine_args.enable_lora
         if lora_enabled:

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -100,14 +100,21 @@ class WorkerFactory:
         generate_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"
         )
-        component = generate_endpoint.component()
-        clear_endpoint = component.endpoint("clear_kv_blocks")
-        shutdown_endpoints[:] = [generate_endpoint, clear_endpoint]
+        clear_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.clear_kv_blocks"
+        )
+
         lora_enabled = config.engine_args.enable_lora
         if lora_enabled:
-            load_lora_endpoint = component.endpoint("load_lora")
-            unload_lora_endpoint = component.endpoint("unload_lora")
-            list_loras_endpoint = component.endpoint("list_loras")
+            load_lora_endpoint = runtime.endpoint(
+                f"{config.namespace}.{config.component}.load_lora"
+            )
+            unload_lora_endpoint = runtime.endpoint(
+                f"{config.namespace}.{config.component}.unload_lora"
+            )
+            list_loras_endpoint = runtime.endpoint(
+                f"{config.namespace}.{config.component}.list_loras"
+            )
             shutdown_endpoints.extend(
                 [load_lora_endpoint, unload_lora_endpoint, list_loras_endpoint]
             )
@@ -152,7 +159,6 @@ class WorkerFactory:
         if config.multimodal_decode_worker:
             handler = MultimodalDecodeWorkerHandler(
                 runtime,
-                component,
                 engine_client,
                 config,
                 shutdown_event,
@@ -161,7 +167,6 @@ class WorkerFactory:
         else:
             handler = MultimodalPDWorkerHandler(
                 runtime,
-                component,
                 engine_client,
                 config,
                 encode_worker_client,
@@ -175,7 +180,7 @@ class WorkerFactory:
 
         # Set up KV event publisher for prefix caching if enabled
         kv_publisher = self.setup_kv_event_publisher(
-            config, component, generate_endpoint, vllm_config
+            config, generate_endpoint, vllm_config
         )
         if kv_publisher:
             handler.kv_publisher = kv_publisher

--- a/examples/multimodal/components/worker.py
+++ b/examples/multimodal/components/worker.py
@@ -24,7 +24,7 @@ from vllm.v1.engine.async_llm import AsyncLLM
 
 import dynamo.nixl_connect as connect
 from dynamo.llm import KvEventPublisher
-from dynamo.runtime import Component, DistributedRuntime, Endpoint, dynamo_worker
+from dynamo.runtime import DistributedRuntime, Endpoint, dynamo_worker
 from dynamo.runtime.logging import configure_dynamo_logging
 
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
@@ -104,7 +104,6 @@ class VllmBaseWorker:
     def __init__(
         self,
         args: argparse.Namespace,
-        component: Component,
         endpoint: Endpoint,
         config: Config,
     ):
@@ -113,15 +112,15 @@ class VllmBaseWorker:
         self.downstream_endpoint = args.downstream_endpoint
         self.engine_args = config.engine_args
         self.config = config
-        self.setup_vllm_engine(component, endpoint)
+        self.setup_vllm_engine(endpoint)
 
     async def async_init(self, runtime: DistributedRuntime):
         pass
 
-    def setup_vllm_engine(self, component: Component, endpoint: Endpoint):
+    def setup_vllm_engine(self, endpoint: Endpoint):
         """Initialize the vLLM engine.
         This method sets up the vLLM engine client, and configures the dynamo-aware KV
-        event publisher and metrics stats logger based on component and endpoint.
+        event publisher and metrics stats logger based on endpoint.
         """
 
         os.environ["VLLM_NO_USAGE_STATS"] = "1"  # Avoid internal HTTP requests
@@ -138,9 +137,8 @@ class VllmBaseWorker:
 
         # Create vLLM engine with metrics logger and KV event publisher attached
         self.stats_logger = StatLoggerFactory(
-            component,
-            self.engine_args.data_parallel_rank or 0,
-            metrics_labels=[("model", self.config.model)],
+            endpoint=endpoint,
+            dp_rank=self.engine_args.data_parallel_rank or 0,
         )
         self.engine_client = AsyncLLM.from_vllm_config(
             vllm_config=vllm_config,
@@ -164,7 +162,7 @@ class VllmBaseWorker:
         ).replace("*", "127.0.0.1")
 
         self.kv_publisher = KvEventPublisher(
-            component=component,
+            endpoint=endpoint,
             kv_block_size=vllm_config.cache_config.block_size,
             zmq_endpoint=zmq_endpoint,
         )
@@ -435,15 +433,14 @@ async def init(runtime: DistributedRuntime, args: argparse.Namespace, config: Co
     generate_endpoint = runtime.endpoint(
         f"{config.namespace}.{config.component}.{config.endpoint}"
     )
-    component = generate_endpoint.component()
-    clear_endpoint = component.endpoint("clear_kv_blocks")
+    clear_endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.clear_kv_blocks"
+    )
 
     if args.worker_type in ["prefill", "encode_prefill"]:
-        handler: VllmBaseWorker = VllmPDWorker(
-            args, component, generate_endpoint, config
-        )
+        handler: VllmBaseWorker = VllmPDWorker(args, generate_endpoint, config)
     elif args.worker_type == "decode":
-        handler = VllmDecodeWorker(args, component, generate_endpoint, config)
+        handler = VllmDecodeWorker(args, generate_endpoint, config)
     await handler.async_init(runtime)
 
     logger.info(f"Starting to serve the {args.endpoint} endpoint...")

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3244,7 +3244,6 @@ dependencies = [
  "dlpark",
  "dynamo-llm",
  "dynamo-runtime",
- "prometheus",
  "pyo3",
  "pyo3-async-runtimes",
  "serde",

--- a/lib/bindings/kvbm/Cargo.toml
+++ b/lib/bindings/kvbm/Cargo.toml
@@ -57,6 +57,5 @@ pyo3-async-runtimes = { version = "0.23.0", default-features = false, features =
 
 dlpark = { version = "0.5", features = ["pyo3", "half"], optional = true }
 cudarc = { version = "0.19.2", features = ["cuda-12020"], optional = true }
-prometheus = "0.14.0"
 
 [dev-dependencies]

--- a/lib/bindings/python/examples/error_handling/server.py
+++ b/lib/bindings/python/examples/error_handling/server.py
@@ -40,8 +40,8 @@ async def worker(runtime: DistributedRuntime):
 
 async def init(runtime: DistributedRuntime, ns: str):
     """
-    Instantiate a `backend` component and serve the `generate` endpoint
-    A `Component` can serve multiple endpoints
+    Create and serve the `generate` endpoint using the distributed runtime.
+    Multiple endpoints can be served from a single worker.
     """
     endpoint = runtime.endpoint(f"{ns}.backend.generate")
     print("Started server instance")

--- a/lib/bindings/python/examples/hello_world/server.py
+++ b/lib/bindings/python/examples/hello_world/server.py
@@ -45,8 +45,8 @@ async def graceful_shutdown(runtime: DistributedRuntime):
 
 async def init(runtime: DistributedRuntime, ns: str):
     """
-    Instantiate a `backend` component and serve the `generate` endpoint
-    A `Component` can serve multiple endpoints
+    Create and serve the `generate` endpoint using the distributed runtime.
+    Multiple endpoints can be served from a single worker.
     """
     endpoint = runtime.endpoint(f"{ns}.backend.generate")
     print("Started server instance")

--- a/lib/bindings/python/examples/typed/server.py
+++ b/lib/bindings/python/examples/typed/server.py
@@ -38,8 +38,8 @@ class RequestHandler:
 @dynamo_worker()
 async def worker(runtime: DistributedRuntime):
     """
-    Instantiate a `backend` component and serve the `generate` endpoint
-    A `Component` can serve multiple endpoints
+    Create and serve the `generate` endpoint using the distributed runtime.
+    Multiple endpoints can be served from a single worker.
     """
     endpoint = runtime.endpoint("dynamo.backend.generate")
     await endpoint.serve_endpoint(RequestHandler().generate)

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -9,7 +9,7 @@ use std::sync::mpsc;
 use tokio_stream::StreamExt;
 
 use super::*;
-use crate::Component;
+use crate::Endpoint;
 use llm_rs::kv_router::protocols::compute_block_hash_for_seq;
 use rs::pipeline::{AsyncEngine, SingleIn};
 use rs::protocols::annotated::Annotated as RsAnnotated;
@@ -86,14 +86,14 @@ impl WorkerMetricsPublisher {
         })
     }
 
-    #[pyo3(signature = (component))]
+    #[pyo3(signature = (endpoint))]
     fn create_endpoint<'p>(
         &self,
         py: Python<'p>,
-        component: Component,
+        endpoint: Endpoint,
     ) -> PyResult<Bound<'p, PyAny>> {
         let rs_publisher = self.inner.clone();
-        let rs_component = component.inner.clone();
+        let rs_component = endpoint.inner.component().clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             rs_publisher
                 .create_endpoint(rs_component)
@@ -127,9 +127,9 @@ pub(crate) struct KvEventPublisher {
 #[pymethods]
 impl KvEventPublisher {
     #[new]
-    #[pyo3(signature = (component, worker_id=0, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None))]
+    #[pyo3(signature = (endpoint, worker_id=0, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None))]
     fn new(
-        component: Component,
+        endpoint: Endpoint,
         worker_id: WorkerId,
         kv_block_size: usize,
         dp_rank: DpRank,
@@ -139,8 +139,8 @@ impl KvEventPublisher {
     ) -> PyResult<Self> {
         let _ = worker_id;
 
-        let source_config = zmq_endpoint.map(|endpoint| KvEventSourceConfig::Zmq {
-            endpoint,
+        let source_config = zmq_endpoint.map(|ep| KvEventSourceConfig::Zmq {
+            endpoint: ep,
             topic: zmq_topic.unwrap_or_default(),
         });
 
@@ -148,8 +148,11 @@ impl KvEventPublisher {
             return Err(to_pyerr(anyhow::anyhow!("kv_block_size cannot be 0")));
         }
 
+        // Extract component from endpoint
+        let component = endpoint.inner.component().clone();
+
         let inner = llm_rs::kv_router::publisher::KvEventPublisher::new_with_local_indexer(
-            component.inner,
+            component,
             kv_block_size as u32,
             source_config,
             enable_local_indexer,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -111,19 +111,6 @@ class DistributedRuntime:
         """
         ...
 
-class Component:
-    """
-    A component is a collection of endpoints
-    """
-
-    ...
-
-    def endpoint(self, name: str) -> Endpoint:
-        """
-        Create an endpoint
-        """
-        ...
-
 
 class Endpoint:
     """
@@ -189,25 +176,6 @@ class Endpoint:
         and should start receiving requests.
         """
         ...
-
-    def component(self) -> Component:
-        """
-        Get the parent Component that this endpoint belongs to.
-
-        Returns:
-            Component: The parent component
-
-        Note:
-            To avoid duplicate metrics registries, reuse the returned Component for
-            multiple endpoints: component.endpoint("ep1"), component.endpoint("ep2")
-
-        Example:
-            endpoint = runtime.endpoint("demo.backend.generate")
-            component = endpoint.component()
-            health_endpoint = component.endpoint("health")  # Reuse component
-        """
-        ...
-
 
 class Client:
     """
@@ -404,14 +372,15 @@ class WorkerMetricsPublisher:
         Create a `WorkerMetricsPublisher` object
         """
 
-    async def create_endpoint(self, component: Component) -> None:
+    async def create_endpoint(self, endpoint: Endpoint) -> None:
         """
-        Create the NATS endpoint for metrics publishing. Must be awaited.
+        Initialize the NATS endpoint for publishing worker metrics. Must be awaited.
 
-        Only service created through this method will interact with KV router of the same component.
+        Extracts component information from the endpoint to set up metrics publishing
+        on the correct NATS subject for routing decisions.
 
         Args:
-            component: The component to create the endpoint for
+            endpoint: The endpoint to extract component information from for metrics publishing
         """
 
     def publish(
@@ -575,7 +544,7 @@ class KvIndexer:
 
     ...
 
-    def __init__(self, component: Component, block_size: int) -> None:
+    def __init__(self, endpoint: Endpoint, block_size: int) -> None:
         """
         Create a `KvIndexer` object
         """
@@ -622,7 +591,7 @@ class ApproxKvIndexer:
 
     def __init__(
         self,
-        component: Component,
+        endpoint: Endpoint,
         kv_block_size: int,
         router_ttl_secs: float = 120.0,
         router_max_tree_size: int = 1048576,
@@ -689,7 +658,7 @@ class KvEventPublisher:
 
     def __init__(
         self,
-        component: Component,
+        endpoint: Endpoint,
         worker_id: int = 0,
         kv_block_size: int = 0,
         dp_rank: int = 0,
@@ -706,8 +675,8 @@ class KvEventPublisher:
         When zmq_endpoint is None, events are pushed manually via publish_stored/publish_removed.
 
         Args:
-            component: The component to publish events for
-            worker_id: The worker ID (unused, inferred from component)
+            endpoint: The endpoint to extract component information from for event publishing
+            worker_id: The worker ID (unused, inferred from endpoint)
             kv_block_size: The KV block size (must be > 0)
             dp_rank: The data parallel rank (defaults to 0)
             enable_local_indexer: Enable worker-local KV indexer
@@ -1612,7 +1581,6 @@ class VirtualConnectorClient:
 
 __all__ = [
     "Client",
-    "Component",
     "Context",
     "KserveGrpcService",
     "ModelDeploymentCard",

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -11,11 +11,9 @@ from pydantic import BaseModel, ValidationError
 # List all the classes in the _core module for re-export
 # import * causes "unable to detect undefined names"
 from dynamo._core import Client as Client
-from dynamo._core import Component as Component
 from dynamo._core import Context as Context
 from dynamo._core import DistributedRuntime as DistributedRuntime
 from dynamo._core import Endpoint as Endpoint
-from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
 
 
 def dynamo_worker(enable_nats: bool = True):

--- a/tests/router/test_router_e2e_with_trtllm.py
+++ b/tests/router/test_router_e2e_with_trtllm.py
@@ -407,7 +407,7 @@ def test_router_decisions_trtllm_attention_dp(
 
         # Get runtime and create endpoint
         runtime = get_runtime(request_plane=request_plane)
-        # Use the namespace from the vLLM workers
+        # Use the namespace from the TRT-LLM workers
         endpoint = runtime.endpoint(f"{trtllm_workers.namespace}.tensorrt_llm.generate")
 
         _test_router_decisions(


### PR DESCRIPTION
## Overview

Complete removal of `Component` from the Python API, building on PR #6386. Component is now an internal Rust implementation detail with caching to prevent duplicate MetricsRegistry instances. All Python code uses `runtime.endpoint()` directly.

**Based on:** #6386 (which added `runtime.endpoint()` and removed `namespace()` usage)

**Remove unused metric_labels to cleanup the APIs**

## Details

This PR removes the `Component` class entirely from the Python API surface, completing the endpoint API simplification effort.

### Core Changes

**Rust Bindings (`lib/bindings/python/rust/lib.rs`):**
- Removed `Component` struct, `#[pymethods]`, and class registration
- Removed `Endpoint.component()` method from Python API
- Component now exists only in Rust internally

**Component Caching (`lib/runtime/src/component.rs`):**
- Added `component_cache: Arc<RwLock<HashMap<String, Component>>>` to `Namespace`
- Multiple `runtime.endpoint()` calls with same component name now share the same Component instance
- Prevents duplicate `MetricsRegistry` objects (fixes metrics duplication issue)
- Thread-safe with read-lock fast path and write-lock slow path

**Publisher APIs (`lib/bindings/python/rust/llm/kv.rs`, `lib/llm/src/kv_router/publisher.rs`):**
- `KvEventPublisher(endpoint=...)` - accepts Endpoint, extracts Component internally
- `WorkerMetricsPublisher.create_endpoint(endpoint)` - accepts Endpoint instead of Component
- `KvEventPublisher.from_endpoint()` - new Rust constructor that extracts Component from Endpoint

**Type Stubs (`lib/bindings/python/src/dynamo/_core.pyi`):**
- Removed `Component` class definition
- Removed `Namespace` class definition (from PR #6386)
- Updated `WorkerMetricsPublisher.create_endpoint()` docstring for clarity

## Where should the reviewer start?

1. **Rust bindings changes**: `lib/bindings/python/rust/lib.rs` - Component removal, `lib/runtime/src/component.rs` - Component caching implementation
2. **Publisher API changes**: `lib/bindings/python/rust/llm/kv.rs` - How Endpoint replaces Component
3. **Example usage**: `components/src/dynamo/vllm/main.py` or `components/src/dynamo/vllm/worker_factory.py` - See the pattern in action
4. **Type stubs**: `lib/bindings/python/src/dynamo/_core.pyi` - Updated API signatures

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-1478

https://github.com/ai-dynamo/enhancements/blob/97c2f19692d9c0413d78dd1c62079854a9ed9467/deps/proposal-bindings-v2.md#move-internal-bindings-meaning-used-by-components-but-not-intended-for-public-use-otherwise-under-new-_internal-module


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified endpoint resolution mechanism across the system by replacing multi-step object hierarchy lookups with direct fully-qualified string-based endpoint access, reducing boilerplate and improving code clarity throughout the codebase.

* **Chores**
  * Updated internal API surfaces to remove intermediate component/namespace abstractions, streamlining service initialization and request handling patterns across multiple backend implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->