### PR TITLE
feat: Remove public uses of CancellationToken

### DIFF
--- a/lib/bindings/python/examples/kserve_grpc_service/server.py
+++ b/lib/bindings/python/examples/kserve_grpc_service/server.py
@@ -72,7 +72,7 @@ async def worker(runtime: DistributedRuntime):
     service.add_completions_model(model_name, checksum, engine)
 
     print("Starting KServe gRPC service...")
-    shutdown_signal = service.run(runtime.child_token())
+    shutdown_signal = service.run(runtime)
 
     try:
         print(
@@ -86,6 +86,7 @@ async def worker(runtime: DistributedRuntime):
         print(f"Unexpected error occurred: {err}")
     finally:
         print("Shutting down worker...")
+        service.shutdown()  # Shutdown service first
         runtime.shutdown()
 
 

--- a/lib/bindings/python/examples/openai_service/server.py
+++ b/lib/bindings/python/examples/openai_service/server.py
@@ -72,7 +72,7 @@ async def worker(runtime: DistributedRuntime):
     service.add_chat_completions_model(served_model_name, "mdcsum", engine)
 
     print("Starting service...")
-    shutdown_signal = service.run(runtime.child_token())
+    shutdown_signal = service.run(runtime)
 
     try:
         print(f"Serving endpoint: {host}:{port}/v1/models")
@@ -88,6 +88,7 @@ async def worker(runtime: DistributedRuntime):
         print(f"Unexpected error occurred: {e}")
     finally:
         print("Shutting down worker...")
+        service.shutdown()  # Shutdown service first
         runtime.shutdown()
 
 

--- a/lib/bindings/python/rust/http.rs
+++ b/lib/bindings/python/rust/http.rs
@@ -87,7 +87,7 @@ impl HttpService {
         // Check if run() was already called to avoid creating unnecessary token
         if self.cancel_token.get().is_some() {
             return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                "HttpService.run() has already been called on this instance"
+                "HttpService.run() has already been called on this instance",
             ));
         }
 
@@ -97,10 +97,12 @@ impl HttpService {
 
         // Store the token for shutdown - should always succeed after the check above
         self.cancel_token
-            .set(CancellationToken { inner: token.clone() })
+            .set(CancellationToken {
+                inner: token.clone(),
+            })
             .map_err(|_| {
                 PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                    "Race condition detected in HttpService.run()"
+                    "Race condition detected in HttpService.run()",
                 )
             })?;
 

--- a/lib/bindings/python/rust/http.rs
+++ b/lib/bindings/python/rust/http.rs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use anyhow::{Error, Result, anyhow as error};
 use pyo3::prelude::*;
 
-use crate::{CancellationToken, engine::*, to_pyerr};
+use crate::{CancellationToken, DistributedRuntime, engine::*, to_pyerr};
 
 pub use dynamo_llm::endpoint_type::EndpointType;
 pub use dynamo_llm::http::service::{error as http_error, service_v2};
@@ -18,6 +18,8 @@ pub use dynamo_runtime::{
 #[pyclass]
 pub struct HttpService {
     inner: service_v2::HttpService,
+    // CancellationToken is already Send + Sync + Clone, no Mutex needed
+    cancel_token: Arc<OnceLock<CancellationToken>>,
 }
 
 #[pymethods]
@@ -27,7 +29,10 @@ impl HttpService {
     pub fn new(port: Option<u16>) -> PyResult<Self> {
         let builder = service_v2::HttpService::builder().port(port.unwrap_or(8080));
         let inner = builder.build().map_err(to_pyerr)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            cancel_token: Arc::new(OnceLock::new()),
+        })
     }
 
     pub fn add_completions_model(
@@ -78,12 +83,25 @@ impl HttpService {
         Ok(self.inner.model_manager().list_completions_models())
     }
 
-    fn run<'p>(&self, py: Python<'p>, token: CancellationToken) -> PyResult<Bound<'p, PyAny>> {
+    fn run<'p>(&self, py: Python<'p>, runtime: &DistributedRuntime) -> PyResult<Bound<'p, PyAny>> {
         let service = self.inner.clone();
+        // Create a child token from the runtime
+        let token = runtime.inner().child_token();
+
+        // Store the token for shutdown (OnceLock ensures it's only set once)
+        let _ = self.cancel_token.set(CancellationToken { inner: token.clone() });
+
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            service.run(token.inner).await.map_err(to_pyerr)?;
+            service.run(token).await.map_err(to_pyerr)?;
             Ok(())
         })
+    }
+
+    fn shutdown(&self) {
+        // CancellationToken.cancel() is thread-safe, no lock needed
+        if let Some(token) = self.cancel_token.get() {
+            token.inner.cancel();
+        }
     }
 
     fn enable_endpoint(&self, endpoint_type: String, enabled: bool) -> PyResult<()> {

--- a/lib/bindings/python/rust/kserve_grpc.rs
+++ b/lib/bindings/python/rust/kserve_grpc.rs
@@ -8,7 +8,10 @@ use llm_rs::model_card::ModelDeploymentCard as RsModelDeploymentCard;
 use llm_rs::model_type::{ModelInput, ModelType};
 use pyo3::prelude::*;
 
-use crate::{CancellationToken, DistributedRuntime, engine::*, llm::local_model::ModelRuntimeConfig, to_pyerr};
+use crate::{
+    CancellationToken, DistributedRuntime, engine::*, llm::local_model::ModelRuntimeConfig,
+    to_pyerr,
+};
 
 pub use dynamo_llm::grpc::service::kserve;
 
@@ -137,7 +140,7 @@ impl KserveGrpcService {
         // Check if run() was already called to avoid creating unnecessary token
         if self.cancel_token.get().is_some() {
             return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                "KserveGrpcService.run() has already been called on this instance"
+                "KserveGrpcService.run() has already been called on this instance",
             ));
         }
 
@@ -147,10 +150,12 @@ impl KserveGrpcService {
 
         // Store the token for shutdown - should always succeed after the check above
         self.cancel_token
-            .set(CancellationToken { inner: token.clone() })
+            .set(CancellationToken {
+                inner: token.clone(),
+            })
             .map_err(|_| {
                 PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                    "Race condition detected in KserveGrpcService.run()"
+                    "Race condition detected in KserveGrpcService.run()",
                 )
             })?;
 

--- a/lib/bindings/python/rust/kserve_grpc.rs
+++ b/lib/bindings/python/rust/kserve_grpc.rs
@@ -1,20 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use dynamo_llm::{self as llm_rs};
 use llm_rs::model_card::ModelDeploymentCard as RsModelDeploymentCard;
 use llm_rs::model_type::{ModelInput, ModelType};
 use pyo3::prelude::*;
 
-use crate::{CancellationToken, engine::*, llm::local_model::ModelRuntimeConfig, to_pyerr};
+use crate::{CancellationToken, DistributedRuntime, engine::*, llm::local_model::ModelRuntimeConfig, to_pyerr};
 
 pub use dynamo_llm::grpc::service::kserve;
 
 #[pyclass]
 pub struct KserveGrpcService {
     inner: kserve::KserveService,
+    // CancellationToken is already Send + Sync + Clone, no Mutex needed
+    cancel_token: Arc<OnceLock<CancellationToken>>,
 }
 
 #[pymethods]
@@ -30,7 +32,10 @@ impl KserveGrpcService {
             builder = builder.host(host);
         }
         let inner = builder.build().map_err(to_pyerr)?;
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            cancel_token: Arc::new(OnceLock::new()),
+        })
     }
 
     pub fn add_completions_model(
@@ -128,11 +133,24 @@ impl KserveGrpcService {
         Ok(self.inner.model_manager().list_tensor_models())
     }
 
-    fn run<'p>(&self, py: Python<'p>, token: CancellationToken) -> PyResult<Bound<'p, PyAny>> {
+    fn run<'p>(&self, py: Python<'p>, runtime: &DistributedRuntime) -> PyResult<Bound<'p, PyAny>> {
         let service = self.inner.clone();
+        // Create a child token from the runtime
+        let token = runtime.inner().child_token();
+
+        // Store the token for shutdown (OnceLock ensures it's only set once)
+        let _ = self.cancel_token.set(CancellationToken { inner: token.clone() });
+
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            service.run(token.inner).await.map_err(to_pyerr)?;
+            service.run(token).await.map_err(to_pyerr)?;
             Ok(())
         })
+    }
+
+    fn shutdown(&self) {
+        // CancellationToken.cancel() is thread-safe, no lock needed
+        if let Some(token) = self.cancel_token.get() {
+            token.inner.cancel();
+        }
     }
 }

--- a/lib/bindings/python/rust/kserve_grpc.rs
+++ b/lib/bindings/python/rust/kserve_grpc.rs
@@ -134,12 +134,25 @@ impl KserveGrpcService {
     }
 
     fn run<'p>(&self, py: Python<'p>, runtime: &DistributedRuntime) -> PyResult<Bound<'p, PyAny>> {
+        // Check if run() was already called to avoid creating unnecessary token
+        if self.cancel_token.get().is_some() {
+            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "KserveGrpcService.run() has already been called on this instance"
+            ));
+        }
+
         let service = self.inner.clone();
-        // Create a child token from the runtime
+        // Only create token if we passed the check above
         let token = runtime.inner().child_token();
 
-        // Store the token for shutdown (OnceLock ensures it's only set once)
-        let _ = self.cancel_token.set(CancellationToken { inner: token.clone() });
+        // Store the token for shutdown - should always succeed after the check above
+        self.cancel_token
+            .set(CancellationToken { inner: token.clone() })
+            .map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                    "Race condition detected in KserveGrpcService.run()"
+                )
+            })?;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             service.run(token).await.map_err(to_pyerr)?;

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -149,7 +149,6 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(llm::entrypoint::run_input, m)?)?;
 
     m.add_class::<DistributedRuntime>()?;
-    m.add_class::<Namespace>()?;
     m.add_class::<Component>()?;
     m.add_class::<Endpoint>()?;
     m.add_class::<ModelCardInstanceId>()?;

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -773,7 +773,6 @@ impl DistributedRuntime {
     }
 }
 
-
 #[pymethods]
 impl Component {
     fn endpoint(&self, name: String) -> PyResult<Endpoint> {

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -149,7 +149,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(llm::entrypoint::run_input, m)?)?;
 
     m.add_class::<DistributedRuntime>()?;
-    m.add_class::<CancellationToken>()?;
+    m.add_class::<Namespace>()?;
     m.add_class::<Component>()?;
     m.add_class::<Endpoint>()?;
     m.add_class::<ModelCardInstanceId>()?;
@@ -680,11 +680,6 @@ impl DistributedRuntime {
         self.event_loop.clone()
     }
 
-    fn child_token(&self) -> CancellationToken {
-        let inner = self.inner.runtime().child_token();
-        CancellationToken { inner }
-    }
-
     /// Register an async Python callback for /engine/{route_name}
     ///
     /// Args:
@@ -779,20 +774,6 @@ impl DistributedRuntime {
     }
 }
 
-#[pymethods]
-impl CancellationToken {
-    fn cancel(&self) {
-        self.inner.cancel();
-    }
-
-    fn cancelled<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
-        let token = self.inner.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            token.cancelled().await;
-            Ok(())
-        })
-    }
-}
 
 #[pymethods]
 impl Component {

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -85,12 +85,6 @@ class DistributedRuntime:
         """
         ...
 
-    def child_token(self) -> CancellationToken:
-        """
-        Get a child cancellation token that can be passed to async tasks
-        """
-        ...
-
     def register_engine_route(
         self,
         route_name: str,
@@ -117,19 +111,18 @@ class DistributedRuntime:
         """
         ...
 
-class CancellationToken:
-    def cancel(self) -> None:
+class Namespace:
+    """
+    A namespace is a collection of components
+    """
+
+    ...
+
+    def component(self, name: str) -> Component:
         """
-        Cancel the token and all its children
+        Create a `Component` object
         """
         ...
-
-    async def cancelled(self) -> None:
-        """
-        Await until the token is cancelled
-        """
-        ...
-
 
 class Component:
     """
@@ -780,7 +773,29 @@ class HttpService:
     It is a OpenAI compatible http ingress into the Dynamo Distributed Runtime.
     """
 
-    ...
+    def __init__(self, port: Optional[int] = None) -> None:
+        """
+        Create a new HTTP service.
+
+        Args:
+            port: Optional port number to bind the service to (default: 8080)
+        """
+        ...
+
+    async def run(self, runtime: DistributedRuntime) -> None:
+        """
+        Run the HTTP service.
+
+        Args:
+            runtime: DistributedRuntime instance for token management
+        """
+        ...
+
+    def shutdown(self) -> None:
+        """
+        Shutdown the HTTP service by cancelling its internal token.
+        """
+        ...
 
 class PythonAsyncEngine:
     """
@@ -921,12 +936,18 @@ class KserveGrpcService:
         """
         ...
 
-    async def run(self, token: CancellationToken) -> None:
+    async def run(self, runtime: DistributedRuntime) -> None:
         """
         Run the KServe gRPC service.
 
         Args:
-            token: Cancellation token to stop the service
+            runtime: DistributedRuntime instance for token management
+        """
+        ...
+
+    def shutdown(self) -> None:
+        """
+        Shutdown the KServe gRPC service by cancelling its internal token.
         """
         ...
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -111,19 +111,6 @@ class DistributedRuntime:
         """
         ...
 
-class Namespace:
-    """
-    A namespace is a collection of components
-    """
-
-    ...
-
-    def component(self, name: str) -> Component:
-        """
-        Create a `Component` object
-        """
-        ...
-
 class Component:
     """
     A component is a collection of endpoints

--- a/lib/bindings/python/tests/test_kserve_grpc.py
+++ b/lib/bindings/python/tests/test_kserve_grpc.py
@@ -68,17 +68,15 @@ def tensor_service(runtime):
             model_name, checksum, engine, runtime_config=runtime_config
         )
 
-        cancel_token = runtime.child_token()
-
         async def _serve():
-            await tensor_model_service.run(cancel_token)
+            await tensor_model_service.run(runtime)
 
         server_task = asyncio.create_task(_serve())
         try:
             await asyncio.sleep(1)  # wait service to start
             yield host, port
         finally:
-            cancel_token.cancel()
+            tensor_model_service.shutdown()
             with contextlib.suppress(asyncio.TimeoutError, asyncio.CancelledError):
                 await asyncio.wait_for(server_task, timeout=5)
 


### PR DESCRIPTION
#### Overview:

Refactor cancellation token management to be internal to services, removing CancellationToken from the public API. Services now manage tokens internally and expose shutdown() for graceful termination.

#### Details:

- Removed CancellationToken from public API
- Services (HttpService, KserveGrpcService) now accept DistributedRuntime and create child tokens internally
- Added shutdown() methods to both services for graceful cancellation
- Updated run() signatures to accept DistributedRuntime instead of CancellationToken
- Updated examples and tests to use new API

#### Where should the reviewer start?

- lib/bindings/python/rust/http.rs - HttpService cancellation implementation
- lib/bindings/python/rust/kserve_grpc.rs - KserveGrpcService cancellation implementation
- lib/bindings/python/src/dynamo/_core.pyi - Public API changes

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-1485
https://github.com/ai-dynamo/enhancements/blob/97c2f19692d9c0413d78dd1c62079854a9ed9467/deps/proposal-bindings-v2.md#move-internal-bindings-meaning-used-by-components-but-not-intended-for-public-use-otherwise-under-new-_internal-module


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit shutdown() methods to HTTP and KServe services for controlled cleanup.
  * Services now validate and prevent multiple concurrent run invocations.

* **Refactor**
  * Services now accept the runtime directly rather than a separate child cancellation token.
  * Removed the separate CancellationToken from the public API to simplify cancellation handling.
  * Improved service lifecycle sequencing to ensure service shutdown before runtime shutdown.

* **Tests**
  * Updated service tests to reflect new initialization and shutdown patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->