### PR TITLE
docs: add blog section with navbar dropdown and landing page

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -213,6 +213,13 @@ jobs:
             cp -r source-checkout/docs/components docs-checkout/fern/components
           fi
 
+          # Sync blogs/ directory
+          if [ -d source-checkout/docs/blogs ]; then
+            echo "Syncing blogs/ to docs-website branch..."
+            rm -rf docs-checkout/fern/blogs
+            cp -r source-checkout/docs/blogs docs-checkout/fern/blogs
+          fi
+
           # Sync main.css
           if [ -f source-checkout/docs/main.css ]; then
             echo "Syncing main.css to docs-website branch..."

--- a/docs/blogs/README.md
+++ b/docs/blogs/README.md
@@ -1,0 +1,96 @@
+# Adding a Blog Post
+
+Follow these three steps to publish a new blog post on the Dynamo docs site.
+
+## Step 1: Write the Blog Post
+
+Create a new Markdown file in this folder (`docs/blogs/`):
+
+```
+docs/blogs/my-post-slug.md
+```
+
+Use kebab-case for the filename. The filename becomes the URL slug
+(e.g., `my-post-slug.md` serves at `/dynamo/blog/my-post-slug`).
+
+Add frontmatter at the top of the file:
+
+```yaml
+---
+title: Your Blog Post Title
+description: A one-sentence summary shown in search results and social previews.
+---
+```
+
+## Step 2: Add the Post to Navigation
+
+Open `docs/versions/dev.yml` and add a page entry under the **Blog** section:
+
+```yaml
+  - section: Blog
+    contents:
+      - page: Blog
+        path: ../blogs/index.mdx
+      - page: Your Blog Post Title
+        path: ../blogs/my-post-slug.md
+```
+
+Each new post gets a `- page:` entry after the landing page. The `page`
+value is the display name in the sidebar; the `path` points to your file.
+
+## Step 3: Add a Card to the Landing Page
+
+Open `docs/blogs/index.mdx` and add a `<Card>` inside the `<CardGroup>`:
+
+Add a summary line below the page heading:
+
+```mdx
+Technical deep dives, announcements, and updates from the Dynamo team.
+
+<Card
+  title="Your Blog Post Title"
+  icon="regular newspaper"
+  href="/dynamo/blog/my-post-slug"
+>
+  A brief summary of what this post covers (1-2 sentences).
+</Card>
+```
+
+### Card Fields
+
+| Field  | Required | Description                                              |
+|--------|----------|----------------------------------------------------------|
+| title  | Yes      | Post title displayed on the card                         |
+| icon   | No       | Font Awesome icon class (e.g., `regular bolt`)           |
+| href   | Yes      | URL path starting with `/dynamo/blog/`                   |
+| (body) | Yes      | Short summary text inside the Card tags                  |
+
+Wrap multiple cards in `<CardGroup cols={2}>...</CardGroup>` for a grid layout.
+
+Browse icons at https://fontawesome.com/icons (Free tier).
+
+## Step 4: Add the Post to the Navbar Dropdown
+
+Open `docs/docs.yml` and add a link under the Blog dropdown in `navbar-links`:
+
+```yaml
+navbar-links:
+  - type: dropdown
+    text: Blog
+    links:
+      - text: All Posts
+        href: /dynamo/blog
+      - text: Your Blog Post Title
+        href: /dynamo/blog/my-post-slug
+```
+
+Only add featured/recent posts here. The dropdown should stay short (5 items max).
+Posts that are no longer featured can be removed from the dropdown while remaining
+accessible from the landing page and sidebar.
+
+## Quick Checklist
+
+- [ ] Blog post `.md` file created in `docs/blogs/`
+- [ ] Page entry added to `docs/versions/dev.yml` under the Blog section
+- [ ] Card added to `docs/blogs/index.mdx`
+- [ ] (Optional) Link added to the Blog dropdown in `docs/docs.yml`

--- a/docs/blogs/README.md
+++ b/docs/blogs/README.md
@@ -1,12 +1,12 @@
 # Adding a Blog Post
 
-Follow these three steps to publish a new blog post on the Dynamo docs site.
+Follow these steps to publish a new blog post on the Dynamo docs site.
 
 ## Step 1: Write the Blog Post
 
 Create a new Markdown file in this folder (`docs/blogs/`):
 
-```
+```text
 docs/blogs/my-post-slug.md
 ```
 
@@ -29,7 +29,7 @@ Open `docs/versions/dev.yml` and add a page entry under the **Blog** section:
 ```yaml
   - section: Blog
     contents:
-      - page: Blog
+      - page: All Posts
         path: ../blogs/index.mdx
       - page: Your Blog Post Title
         path: ../blogs/my-post-slug.md
@@ -40,13 +40,9 @@ value is the display name in the sidebar; the `path` points to your file.
 
 ## Step 3: Add a Card to the Landing Page
 
-Open `docs/blogs/index.mdx` and add a `<Card>` inside the `<CardGroup>`:
-
-Add a summary line below the page heading:
+Open `docs/blogs/index.mdx` and add a `<Card>` inside the existing `<CardGroup>`:
 
 ```mdx
-Technical deep dives, announcements, and updates from the Dynamo team.
-
 <Card
   title="Your Blog Post Title"
   icon="regular newspaper"
@@ -65,11 +61,12 @@ Technical deep dives, announcements, and updates from the Dynamo team.
 | href   | Yes      | URL path starting with `/dynamo/blog/`                   |
 | (body) | Yes      | Short summary text inside the Card tags                  |
 
-Wrap multiple cards in `<CardGroup cols={2}>...</CardGroup>` for a grid layout.
+The `<CardGroup cols={2}>` wrapper is already in `index.mdx`. Just add your
+`<Card>` inside it.
 
 Browse icons at https://fontawesome.com/icons (Free tier).
 
-## Step 4: Add the Post to the Navbar Dropdown
+## Step 4 (Optional): Add the Post to the Navbar Dropdown
 
 Open `docs/docs.yml` and add a link under the Blog dropdown in `navbar-links`:
 

--- a/docs/blogs/index.mdx
+++ b/docs/blogs/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Dynamo Blog
+description: Technical deep dives, announcements, and updates from the Dynamo team.
+---
+
+# Dynamo Blog
+
+Technical deep dives, announcements, and updates from the Dynamo team.
+
+{/* Add blog post cards below. See README.md in this folder for instructions. */}

--- a/docs/blogs/index.mdx
+++ b/docs/blogs/index.mdx
@@ -3,8 +3,8 @@ title: Dynamo Blog
 description: Technical deep dives, announcements, and updates from the Dynamo team.
 ---
 
-# Dynamo Blog
-
 Technical deep dives, announcements, and updates from the Dynamo team.
 
-{/* Add blog post cards below. See README.md in this folder for instructions. */}
+<CardGroup cols={2}>
+  {/* Add blog post cards here. See README.md in this folder for instructions. */}
+</CardGroup>

--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -37,6 +37,11 @@ redirects:
 
 # GitHub repository link in navbar
 navbar-links:
+  - type: dropdown
+    text: Blog
+    links:
+      - text: All Posts
+        href: /dynamo/blog
   - type: github
     value: https://github.com/ai-dynamo/dynamo
 

--- a/docs/versions/dev.yml
+++ b/docs/versions/dev.yml
@@ -212,7 +212,7 @@ navigation:
   # ==================== Blog ====================
   - section: Blog
     contents:
-      - page: Blog
+      - page: All Posts
         path: ../blogs/index.mdx
         slug: blog
 

--- a/docs/versions/dev.yml
+++ b/docs/versions/dev.yml
@@ -209,6 +209,13 @@ navigation:
       - page: Planner Design
         path: ../pages/design-docs/planner-design.md
 
+  # ==================== Blog ====================
+  - section: Blog
+    contents:
+      - page: Blog
+        path: ../blogs/index.mdx
+        slug: blog
+
   # ==================== Hidden Pages ====================
   # Pages accessible via direct URL but not shown in main navigation.
   # Matches Sphinx hidden_toctree.rst -- pages linked from within content


### PR DESCRIPTION
## Summary
- Add a dropdown-type "Blog" navbar link in the docs header
- Create blog landing page at `docs/blogs/index.mdx`
- Add Blog section to sidebar navigation in `docs/versions/dev.yml`
- Add `docs/blogs/README.md` with step-by-step instructions for adding new blog posts

## Details
Adds the scaffolding for a blog section to the Fern docs site. The navbar dropdown currently has an "All Posts" link pointing to the blog landing page. The landing page is ready for `<Card>` components to be added as posts are written. The README documents the full workflow: write post, add to nav, add card, optionally feature in dropdown.

## Where Should the Reviewer Start?
- `docs/docs.yml` (navbar-links change)
- `docs/blogs/README.md` (contributor instructions)

## Test Plan
- [ ] CI passes
- [ ] `fern docs dev` renders the blog landing page at `/dynamo/blog`
- [ ] Blog dropdown appears in navbar with "All Posts" link
- [ ] Blog section appears in sidebar navigation

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched dedicated Blog section in the documentation
  * Blog landing page with card-based post layout
  * Added Blog dropdown menu in the navbar with "All Posts" link

* **Documentation**
  * Added step-by-step guide for publishing blog posts, covering naming conventions, frontmatter requirements, and navigation setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->