### PR TITLE
docs: remove duplicate H1 headings from Fern pages

### DIFF
--- a/docs/pages/api/nixl-connect/README.md
+++ b/docs/pages/api/nixl-connect/README.md
@@ -4,8 +4,6 @@
 title: NIXL Connect API
 ---
 
-# Dynamo NIXL Connect
-
 Dynamo NIXL Connect specializes in moving data between models/workers in a Dynamo Graph, and for the use cases where registration and memory regions need to be dynamic.
 Dynamo connect provides utilities for such use cases, using the NIXL-based I/O subsystem via a set of Python classes.
 The relaxed registration comes with some performance overheads, but simplifies the integration process.

--- a/docs/pages/api/nixl-connect/connector.md
+++ b/docs/pages/api/nixl-connect/connector.md
@@ -4,8 +4,6 @@
 title: Connector
 ---
 
-# dynamo.nixl_connect.Connector
-
 Core class for managing the connection between workers in a distributed environment.
 Use this class to create readable and writable operations, or read and write data to remote workers.
 

--- a/docs/pages/api/nixl-connect/descriptor.md
+++ b/docs/pages/api/nixl-connect/descriptor.md
@@ -4,8 +4,6 @@
 title: Descriptor
 ---
 
-# dynamo.nixl_connect.Descriptor
-
 Memory descriptor that ensures memory is registered with the NIXL-base I/O subsystem.
 Memory must be registered with the NIXL subsystem to enable interaction with the memory.
 

--- a/docs/pages/api/nixl-connect/device-kind.md
+++ b/docs/pages/api/nixl-connect/device-kind.md
@@ -4,8 +4,6 @@
 title: Device Kind
 ---
 
-# dynamo.nixl_connect.DeviceKind(IntEnum)
-
 Represents the kind of device a [`Device`](device.md) object represents.
 
 

--- a/docs/pages/api/nixl-connect/device.md
+++ b/docs/pages/api/nixl-connect/device.md
@@ -4,8 +4,6 @@
 title: Device
 ---
 
-# dynamo.nixl_connect.Device
-
 `Device` class describes the device a given allocation resides in.
 Usually host (`"cpu"`) or GPU (`"cuda"`) memory.
 

--- a/docs/pages/api/nixl-connect/operation-status.md
+++ b/docs/pages/api/nixl-connect/operation-status.md
@@ -4,8 +4,6 @@
 title: Operation Status
 ---
 
-# dynamo.nixl_connect.OperationStatus(IntEnum)
-
 Represents the current state or status of an operation.
 
 

--- a/docs/pages/api/nixl-connect/rdma-metadata.md
+++ b/docs/pages/api/nixl-connect/rdma-metadata.md
@@ -4,8 +4,6 @@
 title: RDMA Metadata
 ---
 
-# dynamo.nixl_connect.RdmaMetadata
-
 A Pydantic type intended to provide JSON serialized NIXL metadata about a [`ReadableOperation`](readable-operation.md) or [`WritableOperation`](writable-operation.md) object.
 NIXL metadata contains detailed information about a worker process and how to access memory regions registered with the corresponding agent.
 This data is required to perform data transfers using the NIXL-based I/O subsystem.

--- a/docs/pages/api/nixl-connect/read-operation.md
+++ b/docs/pages/api/nixl-connect/read-operation.md
@@ -4,8 +4,6 @@
 title: Read Operation
 ---
 
-# dynamo.nixl_connect.ReadOperation
-
 An operation which transfers data from a remote worker to the local worker.
 
 To create the operation, NIXL metadata ([RdmaMetadata](rdma-metadata.md)) from a remote worker's [`ReadableOperation`](readable-operation.md)

--- a/docs/pages/api/nixl-connect/readable-operation.md
+++ b/docs/pages/api/nixl-connect/readable-operation.md
@@ -4,8 +4,6 @@
 title: Readable Operation
 ---
 
-# dynamo.nixl_connect.ReadableOperation
-
 An operation which enables a remote worker to read data from the local worker.
 
 To create the operation, a set of local [`Descriptor`](descriptor.md) objects must be provided that reference memory intended to be transferred to a remote worker.

--- a/docs/pages/api/nixl-connect/writable-operation.md
+++ b/docs/pages/api/nixl-connect/writable-operation.md
@@ -4,8 +4,6 @@
 title: Writable Operation
 ---
 
-# dynamo.nixl_connect.WritableOperation
-
 An operation which enables a remote worker to write data to the local worker.
 
 To create the operation, a set of local [`Descriptor`](descriptor.md) objects must be provided which reference memory intended to receive data from a remote worker.

--- a/docs/pages/api/nixl-connect/write-operation.md
+++ b/docs/pages/api/nixl-connect/write-operation.md
@@ -4,8 +4,6 @@
 title: Write Operation
 ---
 
-# dynamo.nixl_connect.WriteOperation
-
 An operation which transfers data from the local worker to a remote worker.
 
 To create the operation, NIXL metadata ([RdmaMetadata](rdma-metadata.md)) from a remote worker's [`WritableOperation`](writable-operation.md)

--- a/docs/pages/backends/sglang/README.md
+++ b/docs/pages/backends/sglang/README.md
@@ -4,8 +4,6 @@
 title: SGLang
 ---
 
-# Running SGLang with Dynamo
-
 ## Use the Latest Release
 
 We recommend using the latest stable release of Dynamo to avoid breaking changes:

--- a/docs/pages/backends/sglang/sglang-diffusion.md
+++ b/docs/pages/backends/sglang/sglang-diffusion.md
@@ -4,8 +4,6 @@
 title: Diffusion
 ---
 
-# Diffusion Models
-
 Dynamo SGLang supports three types of diffusion-based generation: **LLM diffusion** (text generation via iterative refinement), **image diffusion** (text-to-image), and **video generation** (text-to-video). Each uses a different worker flag and handler, but all integrate with SGLang's `DiffGenerator`.
 
 ## Overview

--- a/docs/pages/backends/sglang/sglang-disaggregation.md
+++ b/docs/pages/backends/sglang/sglang-disaggregation.md
@@ -4,8 +4,6 @@
 title: Disaggregation
 ---
 
-# SGLang Disaggregated Serving
-
 This document explains how SGLang's disaggregated prefill-decode architecture works, both standalone and within Dynamo.
 
 ## Overview

--- a/docs/pages/backends/sglang/sglang-examples.md
+++ b/docs/pages/backends/sglang/sglang-examples.md
@@ -4,8 +4,6 @@
 title: Examples
 ---
 
-# SGLang Examples
-
 For quick start instructions, see the [SGLang README](README.md). This document provides all deployment patterns for running SGLang with Dynamo, including LLMs, multimodal, and diffusion models, and Kubernetes deployment.
 
 ## Table of Contents

--- a/docs/pages/backends/sglang/sglang-observability.md
+++ b/docs/pages/backends/sglang/sglang-observability.md
@@ -4,8 +4,6 @@
 title: Observability
 ---
 
-# SGLang Observability
-
 This guide covers metrics, tracing, and visualization for SGLang deployments running through Dynamo.
 
 ## Prometheus Metrics

--- a/docs/pages/backends/sglang/sglang-reference-guide.md
+++ b/docs/pages/backends/sglang/sglang-reference-guide.md
@@ -5,8 +5,6 @@ title: Reference Guide
 subtitle: Architecture, configuration, and operational details for the SGLang backend
 ---
 
-# Reference Guide
-
 ## Overview
 
 The SGLang backend in Dynamo uses a modular architecture where `main.py` dispatches to specialized initialization modules based on the worker type. Each worker type has its own init module, request handler, health check, and registration logic.

--- a/docs/pages/backends/trtllm/README.md
+++ b/docs/pages/backends/trtllm/README.md
@@ -4,8 +4,6 @@
 title: TensorRT-LLM
 ---
 
-# LLM Deployment using TensorRT-LLM
-
 This directory contains examples and reference implementations for deploying Large Language Models (LLMs) in various configurations using TensorRT-LLM.
 
 ## Use the Latest Release

--- a/docs/pages/backends/trtllm/gemma3-sliding-window-attention.md
+++ b/docs/pages/backends/trtllm/gemma3-sliding-window-attention.md
@@ -4,8 +4,6 @@
 title: Gemma3 Sliding Window
 ---
 
-# Gemma 3 with Variable Sliding Window Attention
-
 This guide demonstrates how to deploy google/gemma-3-1b-it with Variable Sliding Window Attention (VSWA) using Dynamo. Since google/gemma-3-1b-it is a small model, each aggregated, decode, or prefill worker only requires one H100 GPU or one GB200 GPU.
 VSWA is a mechanism in which a model’s layers alternate between multiple sliding window sizes. An example of this is Gemma 3, which incorporates both global attention layers and sliding window layers.
 

--- a/docs/pages/backends/trtllm/gpt-oss.md
+++ b/docs/pages/backends/trtllm/gpt-oss.md
@@ -4,8 +4,6 @@
 title: GPT-OSS
 ---
 
-# Running gpt-oss-120b Disaggregated with TensorRT-LLM
-
 Dynamo supports disaggregated serving of gpt-oss-120b with TensorRT-LLM. This guide demonstrates how to deploy gpt-oss-120b using disaggregated prefill/decode serving on a single B200 node with 8 GPUs, running 1 prefill worker on 4 GPUs and 1 decode worker on 4 GPUs.
 
 ## Overview

--- a/docs/pages/backends/trtllm/kv-cache-transfer.md
+++ b/docs/pages/backends/trtllm/kv-cache-transfer.md
@@ -4,8 +4,6 @@
 title: KV Cache Transfer
 ---
 
-# KV Cache Transfer in Disaggregated Serving
-
 In disaggregated serving architectures, KV cache must be transferred between prefill and decode workers. TensorRT-LLM supports two methods for this transfer:
 
 ## Using NIXL for KV Cache Transfer

--- a/docs/pages/backends/trtllm/llama4-plus-eagle.md
+++ b/docs/pages/backends/trtllm/llama4-plus-eagle.md
@@ -4,8 +4,6 @@
 title: Llama4 + Eagle
 ---
 
-# Llama 4 Maverick Instruct with Eagle Speculative Decoding on SLURM
-
 This guide demonstrates how to deploy Llama 4 Maverick Instruct with Eagle Speculative Decoding on GB200x4 nodes. We will be following the [multi-node deployment instructions](./multinode/multinode-examples.md) to set up the environment for the following scenarios:
 
 - **Aggregated Serving:**

--- a/docs/pages/backends/trtllm/multinode/multinode-examples.md
+++ b/docs/pages/backends/trtllm/multinode/multinode-examples.md
@@ -4,8 +4,6 @@
 title: Multinode Examples
 ---
 
-# Example: Multi-node TRTLLM Workers with Dynamo on Slurm
-
 > **Note:** The scripts referenced in this example (such as `srun_aggregated.sh` and `srun_disaggregated.sh`) can be found in [`examples/basics/multinode/trtllm/`](https://github.com/ai-dynamo/dynamo/tree/main/examples/basics/multinode/trtllm/).
 
 To run a single Dynamo+TRTLLM Worker that spans multiple nodes (ex: TP16),

--- a/docs/pages/backends/trtllm/prometheus.md
+++ b/docs/pages/backends/trtllm/prometheus.md
@@ -4,8 +4,6 @@
 title: Prometheus
 ---
 
-# TensorRT-LLM Prometheus Metrics
-
 ## Overview
 
 When running TensorRT-LLM through Dynamo, TensorRT-LLM's Prometheus metrics are automatically passed through and exposed on Dynamo's `/metrics` endpoint (default port 8081). This allows you to access both TensorRT-LLM engine metrics (prefixed with `trtllm_`) and Dynamo runtime metrics (prefixed with `dynamo_*`) from a single worker backend endpoint.

--- a/docs/pages/backends/vllm/README.md
+++ b/docs/pages/backends/vllm/README.md
@@ -4,8 +4,6 @@
 title: vLLM
 ---
 
-# LLM Deployment using vLLM
-
 This directory contains reference implementations for deploying Large Language Models (LLMs) in various configurations using vLLM. For Dynamo integration, we leverage vLLM's native KV cache events, NIXL based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
 ## Use the Latest Release

--- a/docs/pages/backends/vllm/deepseek-r1.md
+++ b/docs/pages/backends/vllm/deepseek-r1.md
@@ -4,8 +4,6 @@
 title: DeepSeek-R1
 ---
 
-# Running Deepseek R1 with Wide EP
-
 Dynamo supports running Deepseek R1 with data parallel attention and wide expert parallelism. Each data parallel attention rank is a separate dynamo component that will emit its own KV Events and Metrics. vLLM controls the expert parallelism using the flag `--enable-expert-parallel`
 
 ## Instructions

--- a/docs/pages/backends/vllm/gpt-oss.md
+++ b/docs/pages/backends/vllm/gpt-oss.md
@@ -4,8 +4,6 @@
 title: GPT-OSS
 ---
 
-# Running gpt-oss-120b Disaggregated with vLLM
-
 Dynamo supports disaggregated serving of gpt-oss-120b with vLLM. This guide demonstrates how to deploy gpt-oss-120b using disaggregated prefill/decode serving on a single H100 node with 8 GPUs, running 1 prefill worker on 4 GPUs and 1 decode worker on 4 GPUs.
 
 ## Overview

--- a/docs/pages/backends/vllm/multi-node.md
+++ b/docs/pages/backends/vllm/multi-node.md
@@ -4,8 +4,6 @@
 title: Multi-Node
 ---
 
-# Multi-node Examples
-
 This guide covers deploying vLLM across multiple nodes using Dynamo's distributed capabilities.
 
 ## Prerequisites

--- a/docs/pages/backends/vllm/prometheus.md
+++ b/docs/pages/backends/vllm/prometheus.md
@@ -4,8 +4,6 @@
 title: Prometheus
 ---
 
-# vLLM Prometheus Metrics
-
 ## Overview
 
 When running vLLM through Dynamo, vLLM engine metrics are automatically passed through and exposed on Dynamo's `/metrics` endpoint (default port 8081). This allows you to access both vLLM engine metrics (prefixed with `vllm:`) and Dynamo runtime metrics (prefixed with `dynamo_*`) from a single worker backend endpoint.

--- a/docs/pages/backends/vllm/prompt-embeddings.md
+++ b/docs/pages/backends/vllm/prompt-embeddings.md
@@ -4,8 +4,6 @@
 title: Prompt Embeddings
 ---
 
-# Prompt Embeddings
-
 Dynamo supports prompt embeddings (also known as prompt embeds) as a secure alternative input method to traditional text prompts. By allowing applications to use pre-computed embeddings for inference, this feature not only offers greater flexibility in prompt engineering but also significantly enhances privacy and data security. With prompt embeddings, sensitive user data can be transformed into embeddings before ever reaching the inference server, reducing the risk of exposing confidential information during the AI workflow.
 
 

--- a/docs/pages/backends/vllm/vllm-omni.md
+++ b/docs/pages/backends/vllm/vllm-omni.md
@@ -4,8 +4,6 @@
 title: vLLM-Omni
 ---
 
-# [Experimental] Omni Models with vLLM
-
 Dynamo supports multimodal generation through the [vLLM-Omni](https://github.com/vllm-project/vllm-omni) backend. This integration exposes text-to-text, text-to-image, and text-to-video capabilities via OpenAI-compatible API endpoints.
 
 ## Prerequisites

--- a/docs/pages/benchmarks/benchmarking.md
+++ b/docs/pages/benchmarks/benchmarking.md
@@ -5,9 +5,6 @@ title: Dynamo Benchmarking
 subtitle: Benchmark and compare performance across Dynamo deployment configurations
 ---
 
-
-# Dynamo Benchmarking Guide
-
 This benchmarking framework lets you compare performance across any combination of:
 - **DynamoGraphDeployments**
 - **External HTTP endpoints** (existing services deployed following standard documentation from vLLM, llm-d, AIBrix, etc.)

--- a/docs/pages/components/frontend/README.md
+++ b/docs/pages/components/frontend/README.md
@@ -4,8 +4,6 @@
 title: Frontend
 ---
 
-# Frontend
-
 The Dynamo Frontend is the API gateway for serving LLM inference requests. It provides OpenAI-compatible HTTP endpoints and KServe gRPC endpoints, handling request preprocessing, routing, and response formatting.
 
 ## Feature Matrix

--- a/docs/pages/components/frontend/frontend-guide.md
+++ b/docs/pages/components/frontend/frontend-guide.md
@@ -4,8 +4,6 @@
 title: Frontend Guide
 ---
 
-# Frontend Guide
-
 This guide covers the KServe gRPC frontend configuration and integration for the Dynamo Frontend.
 
 ## KServe gRPC Frontend

--- a/docs/pages/components/frontend/nvext.md
+++ b/docs/pages/components/frontend/nvext.md
@@ -4,8 +4,6 @@
 title: NVIDIA Request Extensions (nvext)
 ---
 
-# NVIDIA Request Extensions (`nvext`)
-
 `nvext` is a top-level JSON object on the request body that provides NVIDIA-specific extensions to the OpenAI-compatible API. `nvext` fields are consumed by the Dynamo frontend, preprocessor, router, and backend workers to control routing, preprocessing, response metadata, scheduling, and engine-level priority.
 
 ## Usage

--- a/docs/pages/components/kvbm/README.md
+++ b/docs/pages/components/kvbm/README.md
@@ -4,8 +4,6 @@
 title: KVBM
 ---
 
-# KV Block Manager (KVBM)
-
 The Dynamo KV Block Manager (KVBM) is a scalable runtime component designed to handle memory allocation, management, and remote sharing of Key-Value (KV) blocks for inference tasks across heterogeneous and distributed environments. It acts as a unified memory layer and write-through cache for frameworks like vLLM and TensorRT-LLM.
 
 KVBM offers:

--- a/docs/pages/components/kvbm/kvbm-guide.md
+++ b/docs/pages/components/kvbm/kvbm-guide.md
@@ -5,7 +5,6 @@ title: KVBM Guide
 subtitle: Enable KV offloading using KV Block Manager (KVBM) for Dynamo deployments
 ---
 
-# KVBM Guide
 The Dynamo KV Block Manager (KVBM) is a scalable runtime component designed to handle memory allocation, management, and remote sharing of Key-Value (KV) blocks for inference tasks across heterogeneous and distributed environments. It acts as a unified memory layer and write-through cache for frameworks like vLLM and TensorRT-LLM.
 
 KVBM is modular and can be used standalone via `pip install kvbm` or as the memory management component in the full Dynamo stack. This guide covers installation, configuration, and deployment of the Dynamo KV Block Manager (KVBM) and other KV cache management systems.

--- a/docs/pages/components/planner/README.md
+++ b/docs/pages/components/planner/README.md
@@ -4,8 +4,6 @@
 title: Planner
 ---
 
-# Planner
-
 The Planner monitors system performance and automatically scales prefill/decode workers to meet latency SLAs. It runs as a component inside the Dynamo inference graph on Kubernetes.
 
 The SLA Planner supports two scaling modes:

--- a/docs/pages/components/planner/planner-examples.md
+++ b/docs/pages/components/planner/planner-examples.md
@@ -4,8 +4,6 @@
 title: Planner Examples
 ---
 
-# Planner Examples: Throughput-Based Scaling
-
 Practical examples for deploying the SLA Planner with throughput-based scaling. All examples below use the DGDR workflow with pre-deployment profiling. For deployment concepts, see the [Planner Guide](planner-guide.md). For a quick overview, see the [Planner README](README.md).
 
 ## Basic Examples

--- a/docs/pages/components/planner/planner-guide.md
+++ b/docs/pages/components/planner/planner-guide.md
@@ -4,8 +4,6 @@
 title: Planner Guide
 ---
 
-# Planner Guide
-
 The Dynamo SLA Planner is an autoscaling controller that adjusts prefill and decode engine replica counts at runtime to meet latency SLAs. It reads traffic signals (Prometheus metrics or load predictor output) and engine performance profiles to decide when to scale up or down.
 
 For a quick overview, see the [Planner README](README.md). For architecture internals, see [Planner Design](../../design-docs/planner-design.md).

--- a/docs/pages/components/profiler/README.md
+++ b/docs/pages/components/profiler/README.md
@@ -4,8 +4,6 @@
 title: Profiler
 ---
 
-# Profiler
-
 The Dynamo Profiler is an automated performance analysis tool that measures model inference characteristics to optimize deployment configurations. It determines optimal tensor parallelism (TP) settings for prefill and decode phases, generates performance interpolation data, and enables SLA-driven autoscaling through the Planner.
 
 ## Feature Matrix

--- a/docs/pages/components/profiler/profiler-examples.md
+++ b/docs/pages/components/profiler/profiler-examples.md
@@ -4,8 +4,6 @@
 title: Profiler Examples
 ---
 
-# Profiler Examples
-
 Complete examples for profiling with DGDRs, the interactive WebUI, and direct script usage.
 
 ## DGDR Examples

--- a/docs/pages/components/profiler/profiler-guide.md
+++ b/docs/pages/components/profiler/profiler-guide.md
@@ -4,8 +4,6 @@
 title: Profiler Guide
 ---
 
-# Profiler Guide
-
 ## Overview
 
 The Dynamo Profiler analyzes model inference performance and generates optimized deployment configurations (DynamoGraphDeployments). Given a model, hardware, and SLA targets, it determines the best parallelization strategy, selects optimal prefill and decode engine configurations, and produces a ready-to-deploy DGD YAML.

--- a/docs/pages/components/router/README.md
+++ b/docs/pages/components/router/README.md
@@ -4,8 +4,6 @@
 title: Router
 ---
 
-# Router
-
 The Dynamo KV Router intelligently routes requests by evaluating their computational costs across different workers. It considers both decoding costs (from active blocks) and prefill costs (from newly computed blocks), using KV cache overlap to minimize redundant computation. Optimizing the KV Router is critical for achieving maximum throughput and minimum latency in distributed inference setups.
 
 ## Quick Start

--- a/docs/pages/components/router/agent-hints.md
+++ b/docs/pages/components/router/agent-hints.md
@@ -5,8 +5,6 @@ title: Agent Hints
 subtitle: Per-request hints for scheduling, load balancing, and KV cache optimization
 ---
 
-# Agent Hints
-
 Agent hints are optional per-request hints passed via the `nvext.agent_hints` field in the request body. They allow the calling agent or application to communicate request-level metadata that the router uses to improve scheduling, load balancing, and KV cache utilization.
 
 ```json

--- a/docs/pages/components/router/router-examples.md
+++ b/docs/pages/components/router/router-examples.md
@@ -4,8 +4,6 @@
 title: Router Examples
 ---
 
-# Router Examples
-
 For quick start instructions, see the [Router README](README.md). This document provides further examples for using the Dynamo Router, including Python API usage, Kubernetes deployments, and custom routing patterns.
 
 ## Table of Contents

--- a/docs/pages/components/router/router-guide.md
+++ b/docs/pages/components/router/router-guide.md
@@ -5,8 +5,6 @@ title: Router Guide
 subtitle: Enable KV-aware routing using Router for Dynamo deployments
 ---
 
-# Router Guide
-
 ## Overview
 
 The Dynamo KV Router intelligently routes requests by evaluating their computational costs across different workers. It considers both decoding costs (from active blocks) and prefill costs (from newly computed blocks), using KV cache overlap to minimize redundant computation. Optimizing the KV Router is critical for achieving maximum throughput and minimum latency in distributed inference setups.

--- a/docs/pages/components/router/standalone-indexer.md
+++ b/docs/pages/components/router/standalone-indexer.md
@@ -5,8 +5,6 @@ title: Standalone KV Indexer
 subtitle: Run the KV cache indexer as an independent service for querying block state
 ---
 
-# Standalone KV Indexer
-
 ## Overview
 
 The standalone KV indexer runs the KV cache radix tree as an independent service, separate from the router. It subscribes to KV events from workers, maintains a radix tree of cached blocks, and exposes a query endpoint (`kv_indexer_query`) that external clients can use to inspect or query KV cache state.

--- a/docs/pages/design-docs/architecture.md
+++ b/docs/pages/design-docs/architecture.md
@@ -4,8 +4,6 @@
 title: Overall Architecture
 ---
 
-# High Level Architecture
-
 Dynamo is NVIDIA's high-throughput, low-latency inference framework that's designed to serve generative AI and reasoning models in multi-node distributed environments. It's inference engine agnostic, supporting SGLang, TRT-LLM, vLLM and others, while capturing essential LLM capabilities:
 
 - **Disaggregated prefill & decode inference**: Maximizes GPU throughput and helps you balance throughput and latency

--- a/docs/pages/design-docs/disagg-serving.md
+++ b/docs/pages/design-docs/disagg-serving.md
@@ -4,8 +4,6 @@
 title: Disaggregated Serving
 ---
 
-# Dynamo Disaggregation: Separating Prefill and Decode for Enhanced Performance
-
 The prefill and decode phases of LLM requests have different computation characteristics and memory footprints. Disaggregating these phases into specialized llm engines allows for better hardware allocation, improved scalability, and overall enhanced performance. For example, using a larger TP for the memory-bound decoding phase while a smaller TP for the computation-bound prefill phase allows both phases to be computed efficiently. In addition, for requests with long context, separating their prefill phase into dedicated prefill engines allows the ongoing decoding requests to be efficiently processed without being blocked by these long prefills.
 
 Disaggregated execution of a request has three main steps:

--- a/docs/pages/design-docs/discovery-plane.md
+++ b/docs/pages/design-docs/discovery-plane.md
@@ -4,8 +4,6 @@
 title: Discovery Plane
 ---
 
-# Discovery Plane
-
 Dynamo's service discovery layer lets components find each other at runtime. Workers register their endpoints when they start, and frontends discover them automatically.
 The discovery backend adapts to the deployment environment.
 

--- a/docs/pages/design-docs/distributed-runtime.md
+++ b/docs/pages/design-docs/distributed-runtime.md
@@ -4,8 +4,6 @@
 title: Distributed Runtime
 ---
 
-# Dynamo Distributed Runtime
-
 ## Overview
 
 Dynamo's `DistributedRuntime` is the core infrastructure in the framework that enables distributed communication and coordination between different Dynamo components. It is implemented in Rust (`/lib/runtime`) and exposed to other programming languages via bindings (i.e., Python bindings can be found in `/lib/bindings/python`). The runtime supports multiple discovery backends (Kubernetes-native or etcd) and request planes (TCP, HTTP, or NATS). `DistributedRuntime` follows a hierarchical structure:

--- a/docs/pages/design-docs/dynamo-flow.md
+++ b/docs/pages/design-docs/dynamo-flow.md
@@ -4,8 +4,6 @@
 title: Architecture Flow
 ---
 
-# Dynamo Architecture Flow
-
 This diagram shows the NVIDIA Dynamo disaggregated inference system. Color-coded flows indicate different types of operations.
 
 ## 🔵 Main Request Flow (Blue)

--- a/docs/pages/design-docs/event-plane.md
+++ b/docs/pages/design-docs/event-plane.md
@@ -4,8 +4,6 @@
 title: Event Plane
 ---
 
-# Dynamo Event Plane
-
 The event plane provides Dynamo with a pub/sub layer for near real-time event exchange between components. It delivers KV cache updates, worker load metrics, and sequence tracking events, enabling features like KV-aware routing and disaggregated serving.
 
 ## When Is the Event Plane Used?

--- a/docs/pages/design-docs/kvbm-design.md
+++ b/docs/pages/design-docs/kvbm-design.md
@@ -4,8 +4,6 @@
 title: KVBM Design
 ---
 
-# KVBM Design
-
 This document provides an in-depth look at the architecture, components, framework integrations via the connector API, and the detailed workings of the Dynamo KV Block Manager (KVBM). The design of KVBM takes inspiration from the KV block managers used in SGLang and vLLM, with added influence from historical memory tiering strategies common in general GPU programming. For more details, see [Further Reading](#further-reading).
 
 ## KVBM Components

--- a/docs/pages/design-docs/planner-design.md
+++ b/docs/pages/design-docs/planner-design.md
@@ -4,8 +4,6 @@
 title: Planner Design
 ---
 
-# Planner Design
-
 > **Tier 3 design documentation** for contributors and architects. For user-facing docs, see [docs/components/planner/](../components/planner/README.md).
 
 ## Overview

--- a/docs/pages/design-docs/request-plane.md
+++ b/docs/pages/design-docs/request-plane.md
@@ -4,8 +4,6 @@
 title: Request Plane
 ---
 
-# Dynamo Request Planes User Guide
-
 ## Overview
 
 Dynamo supports multiple transport mechanisms for its request plane (the communication layer between services). You can choose from three different request plane modes based on your deployment requirements:

--- a/docs/pages/design-docs/router-design.md
+++ b/docs/pages/design-docs/router-design.md
@@ -4,8 +4,6 @@
 title: Router Design
 ---
 
-# Router Design
-
 This document describes the internal architecture of the Dynamo KV Router, including block tracking mechanisms, the KV cache optimization system, event handling, and transport modes.
 
 ## KV Router Architecture

--- a/docs/pages/development/backend-guide.md
+++ b/docs/pages/development/backend-guide.md
@@ -5,8 +5,6 @@ title: Writing Python Workers in Dynamo
 subtitle: Create custom Python workers and engines for Dynamo
 ---
 
-# Writing Python Workers in Dynamo
-
 This guide explains how to create your own Python worker in Dynamo.
 
 The [dynamo](https://pypi.org/project/ai-dynamo/) Python library allows you to build your own engine and attach it to Dynamo.

--- a/docs/pages/development/jail-stream.md
+++ b/docs/pages/development/jail-stream.md
@@ -4,8 +4,6 @@
 title: Jail Stream
 ---
 
-# JailedStream Implementation
-
 ## Overview
 
 The `JailedStream` is a standalone implementation for handling "jail" detection in token streams. It provides a clean, builder-based API for accumulating tokens when certain sequences are detected, then releasing them as a single chunk when the jail ends.

--- a/docs/pages/development/runtime-guide.md
+++ b/docs/pages/development/runtime-guide.md
@@ -4,8 +4,6 @@
 title: Runtime Guide
 ---
 
-# Dynamo Runtime
-
 <h4>A Datacenter Scale Distributed Inference Serving Framework</h4>
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/docs/pages/fault-tolerance/README.md
+++ b/docs/pages/fault-tolerance/README.md
@@ -5,8 +5,6 @@ title: Fault Tolerance
 subtitle: Handle failures gracefully with request migration, cancellation, and graceful shutdown
 ---
 
-# Fault Tolerance
-
 Dynamo provides comprehensive fault tolerance mechanisms to ensure reliable LLM inference in production deployments. This section covers the various strategies and features that enable Dynamo to handle failures gracefully and maintain service availability.
 
 ## Overview

--- a/docs/pages/fault-tolerance/graceful-shutdown.md
+++ b/docs/pages/fault-tolerance/graceful-shutdown.md
@@ -4,8 +4,6 @@
 title: Graceful Shutdown
 ---
 
-# Graceful Shutdown
-
 This document describes how Dynamo components handle shutdown signals to ensure in-flight requests complete successfully and resources are properly cleaned up.
 
 ## Overview

--- a/docs/pages/fault-tolerance/request-rejection.md
+++ b/docs/pages/fault-tolerance/request-rejection.md
@@ -4,8 +4,6 @@
 title: Request Rejection
 ---
 
-# Request Rejection (Load Shedding)
-
 This document describes how Dynamo implements request rejection to prevent system overload and maintain service stability under high load conditions.
 
 ## Overview

--- a/docs/pages/fault-tolerance/testing.md
+++ b/docs/pages/fault-tolerance/testing.md
@@ -4,8 +4,6 @@
 title: Testing
 ---
 
-# Fault Tolerance Testing
-
 This document describes the test infrastructure for validating Dynamo's fault tolerance mechanisms. The testing framework supports request cancellation, migration, etcd HA, and hardware fault injection scenarios.
 
 ## Overview

--- a/docs/pages/features/disaggregated-serving/README.md
+++ b/docs/pages/features/disaggregated-serving/README.md
@@ -5,8 +5,6 @@ title: Disaggregated Serving
 subtitle: Find optimal prefill/decode configuration for disaggregated serving deployments
 ---
 
-# Disaggregated Serving Guide
-
 [AIConfigurator](https://github.com/ai-dynamo/aiconfigurator/tree/main) is a performance optimization tool that helps you find the optimal configuration for deploying LLMs with Dynamo. It automatically determines the best number of prefill and decode workers, parallelism settings, and deployment parameters to meet your SLA targets while maximizing throughput.
 
 ## Why Use AIConfigurator?

--- a/docs/pages/features/lora/README.md
+++ b/docs/pages/features/lora/README.md
@@ -5,8 +5,6 @@ title: LoRA Adapters
 subtitle: Serve fine-tuned LoRA adapters with dynamic loading and routing in Dynamo
 ---
 
-# LoRA Adapters
-
 LoRA (Low-Rank Adaptation) enables efficient fine-tuning and serving of specialized model variants without duplicating full model weights. Dynamo provides built-in support for dynamic LoRA adapter loading, caching, and inference routing.
 
 ## Backend Support

--- a/docs/pages/features/multimodal/README.md
+++ b/docs/pages/features/multimodal/README.md
@@ -5,8 +5,6 @@ title: Multimodality Support
 subtitle: Deploy multimodal models with image, video, and audio support in Dynamo
 ---
 
-# Multimodal Inference in Dynamo
-
 Dynamo supports multimodal inference across multiple LLM backends, enabling models to process images, video, and audio alongside text. This section provides comprehensive documentation for deploying multimodal models.
 
 > [!IMPORTANT]

--- a/docs/pages/features/multimodal/multimodal-sglang.md
+++ b/docs/pages/features/multimodal/multimodal-sglang.md
@@ -4,8 +4,6 @@
 title: SGLang Multimodal
 ---
 
-# SGLang Multimodal
-
 This document provides a comprehensive guide for multimodal inference using SGLang backend in Dynamo. SGLang multimodal supports **EPD**, **E/PD**, and **E/P/D** flows, with NIXL (RDMA) for zero-copy tensor transfer in disaggregated modes.
 
 ## Support Matrix

--- a/docs/pages/features/multimodal/multimodal-trtllm.md
+++ b/docs/pages/features/multimodal/multimodal-trtllm.md
@@ -4,8 +4,6 @@
 title: TensorRT-LLM Multimodal
 ---
 
-# TensorRT-LLM Multimodal
-
 This document provides a comprehensive guide for multimodal inference using TensorRT-LLM backend in Dynamo.
 
 You can provide multimodal inputs in the following ways:

--- a/docs/pages/features/multimodal/multimodal-vllm.md
+++ b/docs/pages/features/multimodal/multimodal-vllm.md
@@ -4,8 +4,6 @@
 title: vLLM Multimodal
 ---
 
-# vLLM Multimodal
-
 This document provides a comprehensive guide for multimodal inference using vLLM backend in Dynamo.
 
 > [!IMPORTANT]

--- a/docs/pages/features/speculative-decoding/README.md
+++ b/docs/pages/features/speculative-decoding/README.md
@@ -4,8 +4,6 @@
 title: Speculative Decoding
 ---
 
-# Speculative Decoding
-
 Speculative decoding is an optimization technique that uses a smaller "draft" model to predict multiple tokens, which are then verified by the main model in parallel. This can significantly reduce latency for autoregressive generation.
 
 ## Backend Support

--- a/docs/pages/features/speculative-decoding/speculative-decoding-vllm.md
+++ b/docs/pages/features/speculative-decoding/speculative-decoding-vllm.md
@@ -4,8 +4,6 @@
 title: Speculative Decoding with vLLM
 ---
 
-# Speculative Decoding with vLLM
-
 Using Speculative Decoding with the vLLM backend.
 
 > **See also**: [Speculative Decoding Overview](./README.md) for cross-backend documentation.

--- a/docs/pages/integrations/flexkv-integration.md
+++ b/docs/pages/integrations/flexkv-integration.md
@@ -4,8 +4,6 @@
 title: FlexKV
 ---
 
-# FlexKV Integration in Dynamo
-
 ## Introduction
 
 [FlexKV](https://github.com/taco-project/FlexKV) is a scalable, distributed runtime for KV cache offloading developed by Tencent Cloud's TACO team in collaboration with the community. It acts as a unified KV caching layer for inference engines like SGLang, TensorRT-LLM, and vLLM.

--- a/docs/pages/integrations/kv-events-custom-engines.md
+++ b/docs/pages/integrations/kv-events-custom-engines.md
@@ -4,8 +4,6 @@
 title: KV Events for Custom Engines
 ---
 
-# KV Event Publishing for Custom Engines
-
 This document explains how to implement KV event publishing for custom inference engines, enabling them to participate in Dynamo's KV cache-aware routing.
 
 ## Overview

--- a/docs/pages/integrations/lmcache-integration.md
+++ b/docs/pages/integrations/lmcache-integration.md
@@ -4,8 +4,6 @@
 title: LMCache
 ---
 
-# LMCache Integration in Dynamo
-
 ## Introduction
 
 LMCache is a high-performance KV cache layer that supercharges LLM serving by enabling **prefill-once, reuse-everywhere** semantics. As described in the [official documentation](https://docs.lmcache.ai/index.html), LMCache lets LLMs prefill each text only once by storing the KV caches of all reusable texts, allowing reuse of KV caches for any reused text (not necessarily prefix) across any serving engine instance.

--- a/docs/pages/integrations/sglang-hicache.md
+++ b/docs/pages/integrations/sglang-hicache.md
@@ -4,8 +4,6 @@
 title: SGLang HiCache
 ---
 
-# Enable SGLang Hierarchical Cache (HiCache)
-
 This guide shows how to enable SGLang's Hierarchical Cache (HiCache) inside Dynamo.
 
 ## 1) Start the SGLang worker with HiCache enabled

--- a/docs/pages/kubernetes/README.md
+++ b/docs/pages/kubernetes/README.md
@@ -4,8 +4,6 @@
 title: Deployment Guide
 ---
 
-# Deploying Dynamo on Kubernetes
-
 High-level guide to Dynamo Kubernetes deployments. Start here, then dive into specific guides.
 
 ## Important Terminology

--- a/docs/pages/kubernetes/chrek/dynamo.md
+++ b/docs/pages/kubernetes/chrek/dynamo.md
@@ -4,8 +4,6 @@
 title: Integration with Dynamo
 ---
 
-# Checkpoint/Restore for Fast Pod Startup
-
 > ⚠️ **Experimental Feature**: ChReK is currently in **beta/preview**. The ChReK DaemonSet runs in privileged mode to perform CRIU operations. See [Limitations](#limitations) for details.
 
 Checkpointing captures the complete state of a running worker pod (including GPU memory) and saves it to storage. New pods can restore from this checkpoint instead of performing a full cold start.

--- a/docs/pages/kubernetes/deployment/minikube.md
+++ b/docs/pages/kubernetes/deployment/minikube.md
@@ -4,8 +4,6 @@
 title: Minikube Setup
 ---
 
-# Minikube Setup Guide
-
 Don't have a Kubernetes cluster? No problem! You can set up a local development environment using Minikube. This guide walks through the set up of everything you need to run Dynamo Kubernetes Platform locally.
 
 ## 1. Install Minikube

--- a/docs/pages/kubernetes/installation-guide.md
+++ b/docs/pages/kubernetes/installation-guide.md
@@ -4,8 +4,6 @@
 title: Detailed Installation Guide
 ---
 
-# Installation Guide for Dynamo Kubernetes Platform
-
 Deploy and manage Dynamo inference graphs on Kubernetes with automated orchestration and scaling, using the Dynamo Kubernetes Platform.
 
 ## Before You Start

--- a/docs/pages/kubernetes/rolling-update.md
+++ b/docs/pages/kubernetes/rolling-update.md
@@ -4,8 +4,6 @@
 title: Rolling Updates
 ---
 
-# Rolling Updates for DynamoGraphDeployments
-
 This guide covers how rolling updates work for `DynamoGraphDeployment` (DGD) resources. Rolling updates allow you to update worker configurations (images, resources, environment variables, etc.) with minimal downtime by gradually replacing old pods with new ones.
 
 The behavior of rolling updates depends on the backing resource type of your deployment. DGDs backed by Kubernetes Deployments benefit from **managed rolling updates** with namespace isolation, while Grove and LWS-backed deployments use their native update mechanisms.

--- a/docs/pages/kubernetes/service-discovery.md
+++ b/docs/pages/kubernetes/service-discovery.md
@@ -4,8 +4,6 @@
 title: Service Discovery
 ---
 
-# Service Discovery
-
 Dynamo components (frontends, workers, planner) need to be able to discover each other and their capabilities at runtime. We refer to this as service discovery. There are 2 kinds of service discovery backends supported on Kubernetes.
 
 ## Discovery Backends

--- a/docs/pages/mocker/mocker.md
+++ b/docs/pages/mocker/mocker.md
@@ -4,8 +4,6 @@
 title: Mocker
 ---
 
-# Mocker: LLM Engine Simulation in Rust
-
 The Mocker is a lightweight, high-fidelity simulation of an LLM inference engine, implemented entirely in Rust. It replicates the core scheduling, memory management, and timing behaviors of production engines without requiring a GPU, making it invaluable for testing Dynamo's routing, KV cache events, disaggregated serving, and planner components.
 
 ## Overview

--- a/docs/pages/observability/README.md
+++ b/docs/pages/observability/README.md
@@ -5,8 +5,6 @@ title: Observability (Local)
 subtitle: Monitor Dynamo deployments with metrics, logging, and tracing
 ---
 
-# Dynamo Observability
-
 ## Getting Started Quickly
 
 This is an example to get started quickly on a single machine.

--- a/docs/pages/observability/health-checks.md
+++ b/docs/pages/observability/health-checks.md
@@ -4,8 +4,6 @@
 title: Health Checks
 ---
 
-# Dynamo Health Checks
-
 ## Overview
 
 Dynamo provides health check and liveness HTTP endpoints for each component which

--- a/docs/pages/observability/logging.md
+++ b/docs/pages/observability/logging.md
@@ -4,8 +4,6 @@
 title: Logging
 ---
 
-# Dynamo Logging
-
 ## Overview
 
 Dynamo provides structured logging in both text as well as JSONL. When

--- a/docs/pages/observability/metrics-developer-guide.md
+++ b/docs/pages/observability/metrics-developer-guide.md
@@ -4,8 +4,6 @@
 title: Metrics Developer Guide
 ---
 
-# Metrics Developer Guide
-
 This guide explains how to create and use custom metrics in Dynamo components using the Dynamo metrics API.
 
 ## Metrics Exposure

--- a/docs/pages/observability/metrics.md
+++ b/docs/pages/observability/metrics.md
@@ -4,8 +4,6 @@
 title: Metrics
 ---
 
-# Dynamo Metrics
-
 ## Overview
 
 Dynamo provides built-in metrics capabilities through the Dynamo metrics API, which is automatically available whenever you use the `DistributedRuntime` framework. This document serves as a reference for all available metrics in Dynamo.

--- a/docs/pages/observability/prometheus-grafana.md
+++ b/docs/pages/observability/prometheus-grafana.md
@@ -4,8 +4,6 @@
 title: Prometheus + Grafana Setup
 ---
 
-# Metrics Visualization with Prometheus and Grafana
-
 ## Overview
 
 This guide shows how to set up Prometheus and Grafana for visualizing Dynamo metrics on a single machine for demo purposes.

--- a/docs/pages/observability/tracing.md
+++ b/docs/pages/observability/tracing.md
@@ -4,8 +4,6 @@
 title: Tracing
 ---
 
-# Distributed Tracing with Tempo
-
 ## Overview
 
 Dynamo supports OpenTelemetry-based distributed tracing for visualizing request flows across Frontend and Worker components. Traces are exported to Tempo via OTLP (OpenTelemetry Protocol) and visualized in Grafana.

--- a/docs/pages/performance/tuning.md
+++ b/docs/pages/performance/tuning.md
@@ -4,8 +4,6 @@
 title: Tuning Disaggregated Performance
 ---
 
-# Disaggregation and Performance Tuning
-
 Disaggregation gains performance by separating the prefill and decode into different engines to reduce interferences between the two.
 However, performant disaggregation requires careful tuning of the inference parameters.
 Specifically, there are three sets of parameters that needs to be tuned:

--- a/docs/pages/reference/feature-matrix.md
+++ b/docs/pages/reference/feature-matrix.md
@@ -4,8 +4,6 @@
 title: Feature Matrix
 ---
 
-# Dynamo Feature Compatibility Matrices
-
 This document provides a comprehensive compatibility matrix for key Dynamo features across the supported backends.
 
 *Updated for Dynamo v0.9.0*

--- a/docs/pages/reference/release-artifacts.md
+++ b/docs/pages/reference/release-artifacts.md
@@ -4,8 +4,6 @@
 title: Release Artifacts
 ---
 
-# Dynamo Release Artifacts
-
 This document provides a comprehensive inventory of all Dynamo release artifacts including container images, Python wheels, Helm charts, and Rust crates.
 
 > **See also:** [Support Matrix](support-matrix.md) for hardware and platform compatibility | [Feature Matrix](feature-matrix.md) for backend feature support

--- a/docs/pages/reference/support-matrix.md
+++ b/docs/pages/reference/support-matrix.md
@@ -4,8 +4,6 @@
 title: Support Matrix
 ---
 
-# Dynamo Support Matrix
-
 This document provides the support matrix for Dynamo, including hardware, software and build instructions.
 
 **See also:** [Release Artifacts](release-artifacts.md) for container images, wheels, Helm charts, and crates | [Feature Matrix](feature-matrix.md) for backend feature support


### PR DESCRIPTION
## Summary

- Remove redundant body `# H1` headings from 94 documentation pages in `docs/pages/`
- Fern renders the frontmatter `title:` as the page H1, so body `# headings` create duplicate H1 elements
- Duplicate H1s are bad for accessibility, SEO, and visual consistency

## Details

Detected by the `docs_visual_inspector` tool's `duplicate-heading` check, which found 94 pages on `dev` with two H1 elements. Each fix removes only the body `# H1` line (and trailing blank line), leaving all other content intact.

Examples of removed headings:
- `title: "Disaggregated Serving"` + body `# Disaggregated Serving Guide` (near-duplicate)
- `title: "Router"` + body `# Router` (exact duplicate)
- `title: "vLLM"` + body `# LLM Deployment using vLLM` (verbose duplicate)

## Test plan

- [x] Verified with 4 parallel review agents that only the correct H1 lines were removed
- [x] No content lost, no code blocks touched, all frontmatter intact
- [ ] Fern preview build passes
- [ ] Visual spot-check of a few pages on preview

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed top-level markdown headers from numerous documentation files across API references, backend guides, design docs, components, integrations, Kubernetes, and observability sections to streamline documentation structure without altering content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->