### PR TITLE
ci: remove unused event_file job

### DIFF
--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -213,14 +213,3 @@ jobs:
           enable_mypy: 'false'
           parallel_mode: 'none'
           dind_as_sidecar: 'false'
-
-  event_file:
-    name: "Event File"
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Upload
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: Event File
-          path: ${{ github.event_path }}


### PR DESCRIPTION
- Remove event_file job (no downstream workflow_run consumer)

closes: OPS-3404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed artifact upload step from pull request validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->