### PR TITLE
fix: correct blog URL from /blog/blog to /blog

### DIFF
--- a/docs/blogs/README.md
+++ b/docs/blogs/README.md
@@ -11,7 +11,7 @@ docs/blogs/my-post-slug.md
 ```
 
 Use kebab-case for the filename. The filename becomes the URL slug
-(e.g., `my-post-slug.md` serves at `/dynamo/blog/my-post-slug`).
+(e.g., `my-post-slug.md` serves at `/dynamo/dev/blog/my-post-slug`).
 
 Add frontmatter at the top of the file:
 
@@ -28,14 +28,14 @@ Open `docs/versions/dev.yml` and add a page entry under the **Blog** section:
 
 ```yaml
   - section: Blog
+    path: ../blogs/index.mdx
+    slug: blog
     contents:
-      - page: All Posts
-        path: ../blogs/index.mdx
       - page: Your Blog Post Title
         path: ../blogs/my-post-slug.md
 ```
 
-Each new post gets a `- page:` entry after the landing page. The `page`
+Each new post gets a `- page:` entry in the `contents` list. The `page`
 value is the display name in the sidebar; the `path` points to your file.
 
 ## Step 3: Add a Card to the Landing Page
@@ -46,7 +46,7 @@ Open `docs/blogs/index.mdx` and add a `<Card>` inside the existing `<CardGroup>`
 <Card
   title="Your Blog Post Title"
   icon="regular newspaper"
-  href="/dynamo/blog/my-post-slug"
+  href="/dynamo/dev/blog/my-post-slug"
 >
   A brief summary of what this post covers (1-2 sentences).
 </Card>
@@ -58,7 +58,7 @@ Open `docs/blogs/index.mdx` and add a `<Card>` inside the existing `<CardGroup>`
 |--------|----------|----------------------------------------------------------|
 | title  | Yes      | Post title displayed on the card                         |
 | icon   | No       | Font Awesome icon class (e.g., `regular bolt`)           |
-| href   | Yes      | URL path starting with `/dynamo/blog/`                   |
+| href   | Yes      | URL path starting with `/dynamo/dev/blog/`               |
 | (body) | Yes      | Short summary text inside the Card tags                  |
 
 The `<CardGroup cols={2}>` wrapper is already in `index.mdx`. Just add your
@@ -76,9 +76,9 @@ navbar-links:
     text: Blog
     links:
       - text: All Posts
-        href: /dynamo/blog
+        href: /dynamo/dev/blog
       - text: Your Blog Post Title
-        href: /dynamo/blog/my-post-slug
+        href: /dynamo/dev/blog/my-post-slug
 ```
 
 Only add featured/recent posts here. The dropdown should stay short (5 items max).

--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -41,7 +41,7 @@ navbar-links:
     text: Blog
     links:
       - text: All Posts
-        href: /dynamo/blog
+        href: /dynamo/dev/blog
   - type: github
     value: https://github.com/ai-dynamo/dynamo
 

--- a/docs/versions/dev.yml
+++ b/docs/versions/dev.yml
@@ -211,10 +211,9 @@ navigation:
 
   # ==================== Blog ====================
   - section: Blog
-    contents:
-      - page: All Posts
-        path: ../blogs/index.mdx
-        slug: blog
+    path: ../blogs/index.mdx
+    slug: blog
+    contents: []
 
   # ==================== Hidden Pages ====================
   # Pages accessible via direct URL but not shown in main navigation.


### PR DESCRIPTION
## Summary
- Fix blog page URL from `/dynamo/dev/blog/blog` to `/dynamo/dev/blog`
- Update navbar dropdown href to include `/dev/` version prefix

## Details
Follow-up to #6409. The blog section had a nested slug issue: section "Blog" generated `/blog/` and the child page slug `blog` added another `/blog`. This moves the landing page `path` to the section level so the section itself serves the page, and updates all hrefs to include the `/dev/` version prefix.

## Where Should the Reviewer Start?
- `docs/versions/dev.yml` (section-level path change)

## Test Plan
- [ ] CI passes
- [ ] Blog page renders at `/dynamo/dev/blog` (not `/dynamo/dev/blog/blog`)
- [ ] Navbar dropdown "All Posts" link works

Made with [Cursor](https://cursor.com)