### PR TITLE
feat: interleaved thinking support in reasoning parser

### DIFF
--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -794,8 +794,8 @@ mod tests {
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, false);
 
         // Forced reasoning without open tag, flushed on </think>
-        let r1 = parser
-            .parse_reasoning_streaming_incremental("initial reasoning</think> normal1 ", &[]);
+        let r1 =
+            parser.parse_reasoning_streaming_incremental("initial reasoning</think> normal1 ", &[]);
         assert_eq!(r1.reasoning_text, "initial reasoning");
         assert_eq!(r1.normal_text, " normal1 ");
 
@@ -844,8 +844,7 @@ mod tests {
         assert_eq!(r1.reasoning_text, "T1");
         assert_eq!(r1.normal_text, "");
 
-        let r2 =
-            parser.parse_reasoning_streaming_incremental("<tool_call>A</tool_call>", &[]);
+        let r2 = parser.parse_reasoning_streaming_incremental("<tool_call>A</tool_call>", &[]);
         assert_eq!(r2.normal_text, "<tool_call>A</tool_call>");
         assert_eq!(r2.reasoning_text, "");
 
@@ -853,8 +852,7 @@ mod tests {
         assert_eq!(r3.reasoning_text, "T2");
         assert_eq!(r3.normal_text, "");
 
-        let r4 =
-            parser.parse_reasoning_streaming_incremental("<tool_call>B</tool_call>", &[]);
+        let r4 = parser.parse_reasoning_streaming_incremental("<tool_call>B</tool_call>", &[]);
         assert_eq!(r4.normal_text, "<tool_call>B</tool_call>");
         assert_eq!(r4.reasoning_text, "");
     }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -30,6 +30,7 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
         map.insert("mistral", ReasoningParserType::Mistral);
         map.insert("granite", ReasoningParserType::Granite);
         map.insert("nemotron_nano", ReasoningParserType::NemotronDeci); // nemotron nano is <think>...</think>
+        map.insert("glm45", ReasoningParserType::NemotronDeci); // GLM-4.5/5 is <think>...</think>, no force_reasoning
         map.insert(
             "minimax_append_think",
             ReasoningParserType::MiniMaxAppendThink,
@@ -225,6 +226,7 @@ mod tests {
             "mistral",
             "granite",
             "nemotron_nano",
+            "glm45",
             "minimax_append_think",
         ];
         for parser in available_parsers {


### PR DESCRIPTION
## Summary

- Enable multiple `<think>...</think>` blocks per stream for models like GLM-4.5/5 and Qwen3 that produce multi-turn reasoning interleaved with normal content
- **Streaming path:** reset `stripped_think_start` after each `</think>` so the state machine cycles `normal→reasoning→normal`. Handle mid-chunk transitions where `</think>text<think>` arrives in one chunk. Require partial prefix length >= 2 to avoid buffering lone `<` (needed for tool call XML tags like `<invoke>`)
- **Non-streaming path:** replace single-split logic with cursor-based loop that extracts all `<think>...</think>` pairs
- Register `glm45` reasoning parser for GLM-4.5/5 models (`--dyn-reasoning-parser glm45`)

## Test plan

- [x] 311 parser tests pass (6 new interleaved tests, 5 updated existing tests)
- [x] Clippy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for multiple reasoning blocks within single inputs with improved streaming capability.
  * Added forced reasoning mode for flexible text processing.

* **Improvements**
  * Better handling of partial tokens across data chunks for more reliable streaming.
  * Improved parsing robustness for interleaved reasoning and text blocks.
  * Expanded parser compatibility with additional model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->