### PR TITLE
fix: add imagepullsecrets to gpu discovery preflight yaml

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/gpu-discovery-preflight.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/gpu-discovery-preflight.yaml
@@ -82,6 +82,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "dynamo-operator.fullname" . }}-gpu-discovery-preflight
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.controllerManager.tolerations }}
       tolerations:
         {{- toYaml .Values.controllerManager.tolerations | nindent 8 }}


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU discovery operations now support configurable image pull secrets. This enables authentication with private container registries and provides flexibility for deployments requiring credential-based access to container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->