### PR TITLE
test: deploy-test stress run 4/5

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -347,11 +347,12 @@ jobs:
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
     runs-on: prod-default-small-v2
     needs: [deploy-operator, vllm-pipeline]
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         profile:
           - agg
@@ -381,11 +382,12 @@ jobs:
     # Run if core, sglang, or deploy is changed
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true'
     needs: [changed-files, deploy-operator, sglang-pipeline]
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         profile:
           - agg
@@ -413,17 +415,20 @@ jobs:
     # Run if core, trtllm, or deploy is changed
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.deploy == 'true'
     needs: [changed-files, deploy-operator, trtllm-pipeline]
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         profile:
           - agg
           - agg_router
-          - disagg
-          - disagg_router
+          # Disabled: trtllm disagg profiles consistently timeout (~32 min) with 0% success rate.
+          # Re-enable once the underlying disagg deployment issue is resolved.
+          # - disagg
+          # - disagg_router
     name: deploy-test-trtllm (${{ matrix.profile }})
     env:
       FRAMEWORK: trtllm

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -352,7 +352,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
       matrix:
         profile:
           - agg

--- a/tests/deploy/test_deploy.py
+++ b/tests/deploy/test_deploy.py
@@ -104,6 +104,7 @@ def validate_chat_response(
 @pytest.mark.deploy
 @pytest.mark.post_merge
 @pytest.mark.e2e
+@pytest.mark.timeout(600)
 async def test_deployment(
     deployment_target: DeploymentTarget,
     deployment_spec: DeploymentSpec,


### PR DESCRIPTION
Stress test run 4 of 5 — testing concurrent deploy-test pipeline capacity. Will be closed after test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline timeouts and parallelization settings for deployment tests to improve overall efficiency and reliability.
  * Extended the maximum execution duration for end-to-end deployment testing to accommodate longer test runs and reduce timeouts.
  * Temporarily disabled specific test profiles experiencing persistent timeout issues; these will be re-enabled once the underlying problems are resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->