### PR TITLE
docs: Fix Dockerfile path in README for vLLM dev image

### DIFF
--- a/container/README.md
+++ b/container/README.md
@@ -227,7 +227,7 @@ Note: `uv` commands set `UV_CACHE_DIR` per `RUN` so `uv` always uses the same pa
 ```bash
 # Build vLLM dev image called dynamo:latest-vllm (default). This runs as root and is for development.
 python container/render.py --framework=vllm --target=dev --output-short-filename
-docker build -t dynamo:latest-vllm-dev -f rendered.Dockerfile .
+docker build -t dynamo:latest-vllm-dev -f container/rendered.Dockerfile .
 
 # Build a local-dev image. The local-dev image will run as `dynamo` with UID/GID matched to your host user,
 # which is useful when mounting partitions for development.


### PR DESCRIPTION
python build command assumes we are at the project root, but docker build command assumes we are in `dynamo/container` folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker build path reference in development documentation to reflect the correct location for the development image build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->