### PR TITLE
chore: Upgrade to tensorrt-llm==1.3.0rc3

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "pydantic>=2",
     "tabulate",
     "types-tabulate",
-    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.3.0rc1 (==4.57.1), SGLang 0.5.8 (==4.57.1)
+    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.3.0rc3 (==4.57.1), SGLang 0.5.8 (==4.57.1)
     "transformers>=4.56.0",
     "pytest-mypy",
 ]

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -41,6 +41,7 @@ prometheus_client==0.23.1
 prophet==1.2.1
 protobuf>=5.29.5,<7.0.0
 pydantic>=2.11.4,<2.13  # vllm==0.12.0 depends on pydantic>=2.12.0
+pydantic-settings<2.13.0  # TRT-LLM DynamicYamlWithDeepMergeSettingsSource incompatible with 2.13.0 _read_files(deep_merge=)
 pyright==1.1.407
 PyYAML==6.0.3
 scikit-learn==1.7.2

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -53,7 +53,7 @@ tensorboard>=2.19.0,<2.21.0
 tensorboardX==2.6.2.2
 # Transformers version constraint for container builds
 # - vLLM 0.11.0: >=4.55.2, vLLM 0.11.2: >=4.56.0,<5
-# - TensorRT-LLM 1.3.0rc1: ==4.57.1
+# - TensorRT-LLM 1.3.0rc3: ==4.57.1
 # - SGLang 0.5.8: ==4.57.1
 # Using >=4.56.0 to satisfy all frameworks
 transformers>=4.56.0

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -18,7 +18,7 @@ The following table shows the backend framework versions included with each Dyna
 | :------------- | :------------- | :--------------- | :------------------ | :--------- | :--------- | :--------------- | :--------- |
 | vLLM           | `0.14.1`       | `0.12.0`         | `0.12.0`            | `0.12.0`   | `0.11.0`   | `0.11.0`         | `0.11.0`   |
 | SGLang         | `0.5.8`        | `0.5.6.post2`    | `0.5.6.post2`       | `0.5.6.post2` | `0.5.3.post4` | `0.5.3.post4` | `0.5.3.post4` |
-| TensorRT-LLM   | `1.3.0rc1`     | `1.2.0rc6.post2` | `1.2.0rc6.post1`  | `1.2.0rc6.post1` | `1.2.0rc3` | `1.2.0rc3`     | `1.2.0rc2` |
+| TensorRT-LLM   | `1.3.0rc3`     | `1.2.0rc6.post2` | `1.2.0rc6.post1`  | `1.2.0rc6.post1` | `1.2.0rc3` | `1.2.0rc3`     | `1.2.0rc2` |
 | NIXL           | `0.9.0`        | `0.8.0`          | `0.8.0`             | `0.8.0`    | `0.8.0`    | `0.8.0`          | `0.8.0`    |
 
 **main (ToT)** reflects the current development branch. **v0.8.1.post1** is a patch release for PyPI wheels and TRT-LLM container only (no GitHub release).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 trtllm =[
     "uvloop",
     "msgpack==1.1.2",
-    "tensorrt-llm==1.3.0rc1",
+    "tensorrt-llm==1.3.0rc3",
 ]
 
 vllm = [


### PR DESCRIPTION
## Summary
- Cherry-pick of #6402 to release/0.9.1
- Upgrade TensorRT-LLM from 1.3.0rc1 to 1.3.0rc3 across version pins
- Pin `pydantic-settings<2.13.0` to fix TRT-LLM autodeploy test compatibility

## Changes
- `pyproject.toml`: `tensorrt-llm==1.3.0rc1` → `1.3.0rc3`
- `benchmarks/pyproject.toml`: comment update
- `container/deps/requirements.txt`: comment update + `pydantic-settings<2.13.0` pin
- `docs/reference/support-matrix.md`: main (ToT) row updated

**Skipped:** `container/context.yaml` (file does not exist on release/0.9.1 branch)

## pydantic-settings pin rationale

pydantic-settings v2.13.0 (released Feb 16) added a `deep_merge` parameter to the base `_read_files()` method ([PR #698](https://github.com/pydantic/pydantic-settings/pull/698)). TRT-LLM 1.3.0rc3 defines `DynamicYamlWithDeepMergeSettingsSource` which overrides `_read_files()` without this parameter, causing:

```
TypeError: DynamicYamlWithDeepMergeSettingsSource._read_files() got an unexpected keyword argument 'deep_merge'
```

This affects release/0.9.1 but not main because:
- **main** uses the new `trtllm-pipeline` workflow with `context.yaml`-driven builds, where dependency resolution avoids installing pydantic-settings 2.13.0
- **release/0.9.1** uses the legacy `Dockerfile.trtllm`, which installs `requirements.txt` after TRT-LLM, allowing `uv` to resolve `pydantic-settings==2.13.0` independently

Dynamo code has zero `pydantic-settings` imports — only TRT-LLM uses it internally.

## Original PR
- Main PR: #6402
- Merge commit: 9a15730a7f4f4d733414926f32d9cc165e0ed2c5

## Test plan
- [ ] CI passes
- [ ] TRT-LLM autodeploy tests pass with pydantic-settings<2.13.0
- [ ] Verified fix works on release branch