### PR TITLE
feat: Remove Context from public

### DIFF
--- a/components/src/dynamo/common/utils/otel_tracing.py
+++ b/components/src/dynamo/common/utils/otel_tracing.py
@@ -6,7 +6,7 @@ OpenTelemetry tracing header utilities for Dynamo components.
 """
 
 
-from dynamo._core import Context
+from dynamo._internal import Context
 
 
 def build_trace_headers(context: Context) -> dict[str, str] | None:

--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -7,7 +7,8 @@ from typing import Optional
 
 import sglang as sgl
 
-from dynamo._core import Component, Context
+from dynamo._core import Component
+from dynamo._internal import Context
 from dynamo.sglang.args import Config
 from dynamo.sglang.protocol import EmbeddingRequest
 from dynamo.sglang.publisher import DynamoSglangPublisher

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -13,7 +13,8 @@ from typing import Any, AsyncGenerator, Dict, Optional, Tuple
 import sglang as sgl
 from sglang.srt.utils import get_local_ip_auto
 
-from dynamo._core import Component, Context
+from dynamo._core import Component
+from dynamo._internal import Context
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher

--- a/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
@@ -13,7 +13,8 @@ from typing import Any, AsyncGenerator, Optional
 import torch
 from PIL import Image
 
-from dynamo._core import Component, Context
+from dynamo._core import Component
+from dynamo._internal import Context
 from dynamo.sglang.args import Config
 from dynamo.sglang.protocol import CreateImageRequest, ImageData, ImagesResponse, NvExt
 from dynamo.sglang.publisher import DynamoSglangPublisher

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -8,7 +8,8 @@ from typing import Any, AsyncGenerator, Dict, Optional
 
 import sglang as sgl
 
-from dynamo._core import Component, Context
+from dynamo._core import Component
+from dynamo._internal import Context
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.sglang.args import Config, DisaggregationMode
 from dynamo.sglang.publisher import DynamoSglangPublisher

--- a/components/src/dynamo/sglang/request_handlers/llm/diffusion_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/diffusion_handler.py
@@ -6,7 +6,8 @@ from typing import Any, AsyncGenerator, Dict, Optional
 
 import sglang as sgl
 
-from dynamo._core import Component, Context
+from dynamo._core import Component
+from dynamo._internal import Context
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -7,7 +7,8 @@ from typing import Any, AsyncGenerator, Dict, Optional
 
 import sglang as sgl
 
-from dynamo._core import Component, Context
+from dynamo._core import Component
+from dynamo._internal import Context
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -16,7 +16,8 @@ from sglang.srt.parser.conversation import chat_templates
 from transformers import AutoTokenizer
 
 import dynamo.nixl_connect as connect
-from dynamo._core import Client, Component, Context
+from dynamo._core import Client, Component
+from dynamo._internal import Context
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
 from dynamo.sglang.protocol import SglangMultimodalRequest

--- a/components/src/dynamo/sglang/request_handlers/multimodal/processor_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/processor_handler.py
@@ -10,7 +10,8 @@ from typing import Any, Dict, Optional
 
 from transformers import AutoTokenizer
 
-from dynamo._core import Client, Component, Context
+from dynamo._core import Client, Component
+from dynamo._internal import Context
 from dynamo.sglang.args import Config
 from dynamo.sglang.multimodal_utils import (
     multimodal_request_to_sglang,

--- a/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/worker_handler.py
@@ -10,7 +10,8 @@ import sglang as sgl
 import torch
 
 import dynamo.nixl_connect as connect
-from dynamo._core import Client, Component, Context
+from dynamo._core import Client, Component
+from dynamo._internal import Context
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.sglang.args import Config, DisaggregationMode
 from dynamo.sglang.protocol import (

--- a/components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/video_generation/video_generation_handler.py
@@ -11,7 +11,8 @@ from typing import Any, AsyncGenerator, Optional
 
 import torch
 
-from dynamo._core import Component, Context
+from dynamo._core import Component
+from dynamo._internal import Context
 from dynamo.sglang.args import Config
 from dynamo.sglang.protocol import (
     CreateVideoRequest,

--- a/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
@@ -6,7 +6,7 @@
 import logging
 from typing import Optional
 
-from dynamo._core import Context
+from dynamo._internal import Context
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )

--- a/components/src/dynamo/trtllm/request_handlers/base_generative_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/base_generative_handler.py
@@ -10,7 +10,7 @@ It provides a common base class for LLM, video diffusion, and image diffusion ha
 from abc import ABC, abstractmethod
 from typing import Any, AsyncGenerator
 
-from dynamo._core import Context
+from dynamo._internal import Context
 
 
 class BaseGenerativeHandler(ABC):

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -29,7 +29,7 @@ from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.sampling_params import GuidedDecodingParams
 from tensorrt_llm.scheduling_params import SchedulingParams
 
-from dynamo._core import Context
+from dynamo._internal import Context
 from dynamo.common.utils.otel_tracing import build_trace_headers
 from dynamo.logits_processing.examples import HelloWorldLogitsProcessor
 from dynamo.nixl_connect import Connector

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -4,7 +4,7 @@
 import logging
 from typing import Optional
 
-from dynamo._core import Context
+from dynamo._internal import Context
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )

--- a/components/src/dynamo/trtllm/request_handlers/video_diffusion/video_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/video_diffusion/video_handler.py
@@ -13,7 +13,8 @@ import time
 import uuid
 from typing import Any, AsyncGenerator, Optional
 
-from dynamo._core import Component, Context
+from dynamo._core import Component
+from dynamo._internal import Context
 from dynamo.trtllm.configs.diffusion_config import DiffusionConfig
 from dynamo.trtllm.engines.diffusion_engine import DiffusionEngine
 from dynamo.trtllm.protocols.video_protocol import (

--- a/examples/custom_backend/cancellation/client.py
+++ b/examples/custom_backend/cancellation/client.py
@@ -2,23 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Simple client demonstration of request cancellation using context.stop_generating()
+Simple client demonstration of request cancellation using stream.cancel()
 """
 
 import asyncio
 import sys
 
-from dynamo._core import Context, DistributedRuntime
+from dynamo.runtime import DistributedRuntime
 
 
 async def demo_cancellation(client):
     """Perform the generation request with cancellation demonstration"""
-    # Create context for cancellation control
-    context = Context()
-
     # Start streaming request
     print("Starting streaming request...")
-    stream = await client.generate("dummy_request", context=context)
+    stream = await client.generate("dummy_request")
 
     iteration_count = 0
     async for response in stream:
@@ -28,7 +25,7 @@ async def demo_cancellation(client):
         # Cancel after receiving 3 responses
         if iteration_count >= 2:
             print("Client: Cancelling after 3 responses...")
-            context.stop_generating()
+            stream.cancel()
             break
 
         iteration_count += 1

--- a/lib/bindings/python/rust/context.rs
+++ b/lib/bindings/python/rust/context.rs
@@ -44,7 +44,7 @@ impl Context {
 impl Context {
     #[new]
     #[pyo3(signature = (id=None))]
-    fn py_new(id: Option<String>) -> Self {
+    pub fn py_new(id: Option<String>) -> Self {
         let controller = match id {
             Some(id) => Controller::new(id),
             None => Controller::default(),

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -104,10 +104,7 @@ fn get_span_for_direct_context(
 
 // Helper to create request context with proper linking and cancellation handling.
 // Works with any request type (not just JSON) to enable proper cancellation propagation.
-fn create_request_context<T>(
-    request: T,
-    parent_ctx: &Option<context::Context>,
-) -> RsContext<T>
+fn create_request_context<T>(request: T, parent_ctx: &Option<context::Context>) -> RsContext<T>
 where
     T: Send + Sync + 'static,
 {
@@ -1046,7 +1043,8 @@ impl Client {
         let client = self.router.clone();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let span = get_span_for_direct_context(&internal_context, "direct", &instance_id.to_string());
+            let span =
+                get_span_for_direct_context(&internal_context, "direct", &instance_id.to_string());
             let stream = client
                 .direct(request_ctx, instance_id)
                 .instrument(span)
@@ -1250,8 +1248,10 @@ mod tests {
         parent.inner().stop_generating();
 
         // Verify cancellation propagated to child
-        assert!(child_ctx.context().is_stopped(),
-            "Child context should be stopped after parent.stop_generating()");
+        assert!(
+            child_ctx.context().is_stopped(),
+            "Child context should be stopped after parent.stop_generating()"
+        );
     }
 
     #[test]
@@ -1297,8 +1297,10 @@ mod tests {
         let child_ctx = create_request_context(request, &Some(parent.clone()));
 
         // Child should immediately be stopped
-        assert!(child_ctx.context().is_stopped(),
-            "Child should be stopped if created from already-stopped parent");
+        assert!(
+            child_ctx.context().is_stopped(),
+            "Child should be stopped if created from already-stopped parent"
+        );
     }
 
     #[derive(Debug, Clone, PartialEq)]

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -620,10 +620,8 @@ impl KvRouter {
 
             // Create child context linked to parent - enables cancellation to propagate from
             // client (parent) to backend (child) when stream.cancel() is called
-            let request_ctx = crate::create_request_context(
-                request,
-                &Some(internal_context.clone())
-            );
+            let request_ctx =
+                crate::create_request_context(request, &Some(internal_context.clone()));
 
             // Pass linked child context to backend so it can observe cancellation
             let stream = inner.generate(request_ctx).await.map_err(to_pyerr)?;

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -670,7 +670,8 @@ impl KvRouter {
                 }
             });
 
-            Ok(crate::AsyncResponseStream::new(rx, false))
+            let internal_context = crate::context::Context::py_new(None);
+            Ok(crate::AsyncResponseStream::new(rx, false, internal_context))
         })
     }
 }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -309,6 +309,11 @@ class Context:
     """
     Context wrapper around AsyncEngineContext for Python bindings.
     Provides tracing and cancellation capabilities for request handling.
+
+    .. warning::
+        This class is internal API and should only be imported from ``dynamo._internal``.
+        It is used by Dynamo handler implementations and is not part of the stable public API.
+        For request cancellation in client code, use the ``cancel()`` method on the stream object.
     """
 
     def __init__(self, id: Optional[str] = None) -> None:

--- a/lib/bindings/python/src/dynamo/_internal/__init__.py
+++ b/lib/bindings/python/src/dynamo/_internal/__init__.py
@@ -11,8 +11,10 @@ For public APIs, use dynamo.runtime and dynamo.llm.
 """
 
 # Re-export from _core
+from dynamo._core import Context as Context
 from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
 
 __all__ = [
+    "Context",
     "ModelDeploymentCard",
 ]

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel, ValidationError
 # import * causes "unable to detect undefined names"
 from dynamo._core import Client as Client
 from dynamo._core import Component as Component
-from dynamo._core import Context as Context
 from dynamo._core import DistributedRuntime as DistributedRuntime
 from dynamo._core import Endpoint as Endpoint
 from dynamo._core import Namespace as Namespace


### PR DESCRIPTION
#### Overview:

Remove `Context` from public Python API. Context is now internal-only, accessible via `dynamo._internal`. Client-side cancellation simplified to `stream.cancel()` instead of requiring explicit Context construction. Additionally, proper cancellation support is now enabled for KvRouter streams (suggested by coderabbit).

#### Details:

**API Changes:**
- **Removed** `context` parameter from `Client.generate()`, `round_robin()`, `random()`, `direct()`
- Context now created internally in each Client method
- **Added** cancellation methods to `AsyncResponseStream`: `cancel()`, `is_cancelled()`, `request_id()`
- **Moved** Context export from `dynamo.runtime` → `dynamo._internal`

**KvRouter Cancellation Support:**
- **Fixed** KvRouter streams to properly propagate client-initiated cancellation to backend
- Made `create_request_context()` generic to support any request type (not just JSON)
- Child contexts now properly linked to parent contexts via `link_child()` for cancellation propagation
- When `stream.cancel()` is called on KvRouter streams, backend now observes the cancellation
- Added 5 unit tests to verify cancellation propagation correctness

**Client API (before → after):**

**Before**
```
from dynamo.core import Context
context = Context()
stream = await client.generate(request, context=context)
context.stop_generating()
```

**After**
```
stream = await client.generate(request)
stream.cancel()
```

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DIS-1486

https://github.com/ai-dynamo/enhancements/blob/97c2f19692d9c0413d78dd1c62079854a9ed9467/deps/proposal-bindings-v2.md#move-internal-bindings-meaning-used-by-components-but-not-intended-for-public-use-otherwise-under-new-_internal-module


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `cancel()`, `is_cancelled()`, and `request_id()` methods to response streams for enhanced request management and cancellation control.

* **Improvements**
  * Simplified cancellation mechanism: use `stream.cancel()` directly instead of context-based cancellation.

* **Documentation**
  * Clarified that Context is an internal API; use stream methods for request cancellation instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->