### PR TITLE
docs: fix 14 broken links detected by lychee CI

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -3,3 +3,7 @@
 
 # Ignore URLs in test data files
 .*tests/data.*
+
+# Ignore placeholder URLs in docs templates
+^https://\.\.\./
+^https://github\.com/\.\.\.

--- a/docs/pages/api/nixl-connect/README.md
+++ b/docs/pages/api/nixl-connect/README.md
@@ -167,5 +167,5 @@ and the worker awaits for the data transfer to complete for yielding a response.
 
   - [NVIDIA Dynamo](https://developer.nvidia.com/dynamo) @ [GitHub](https://github.com/ai-dynamo/dynamo)
   - [NVIDIA Inference Transfer Library (NIXL)](https://developer.nvidia.com/blog/introducing-nvidia-dynamo-a-low-latency-distributed-inference-framework-for-scaling-reasoning-ai-models/#nvidia_inference_transfer_library_nixl_low-latency_hardware-agnostic_communication%C2%A0) @ [GitHub](https://github.com/ai-dynamo/nixl)
-  - [Dynamo Multimodal Example](https://github.com/ai-dynamo/dynamo/tree/main/examples/multimodal.md)
+  - [Dynamo Multimodal Example](https://github.com/ai-dynamo/dynamo/tree/main/examples/multimodal)
   - [NVIDIA GPU Direct](https://developer.nvidia.com/gpudirect)

--- a/docs/pages/backends/sglang/README.md
+++ b/docs/pages/backends/sglang/README.md
@@ -261,4 +261,4 @@ We currently provide deployment examples for Kubernetes and SLURM.
 - **[Deploying Dynamo with SGLang on Kubernetes](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/sglang/deploy/README.md)**
 
 ## SLURM
-- **[Deploying Dynamo with SGLang on SLURM](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/sglang/slurm-jobs/README.md)**
+- **[Deploying Dynamo with SGLang on SLURM](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/sglang/slurm_jobs/README.md)**

--- a/docs/pages/backends/sglang/diffusion-lm.md
+++ b/docs/pages/backends/sglang/diffusion-lm.md
@@ -47,7 +47,7 @@ python -m dynamo.sglang \
 
 The diffusion worker uses the **LowConfidence** algorithm for the iterative refinement process. This algorithm refines tokens with low confidence scores, progressively replacing masked tokens with the model's predictions until confidence thresholds are met.
 
-For more details on diffusion algorithms and configuration options, refer to the [SGLang Diffusion Language Models documentation](https://github.com/sgl-project/sglang/blob/main/docs/supported_models/diffusion_language_models.md).
+For more details on diffusion algorithms and configuration options, refer to the [SGLang Diffusion Language Models documentation](https://github.com/sgl-project/sglang/blob/main/docs/supported_models/text_generation/diffusion_language_models.md).
 
 
 ## Testing the Deployment

--- a/docs/pages/backends/trtllm/README.md
+++ b/docs/pages/backends/trtllm/README.md
@@ -364,7 +364,7 @@ The `--enable-attention-dp` flag sets `attention_dp_size = tensor_parallel_size`
 
 ## Performance Sweep
 
-For detailed instructions on running comprehensive performance sweeps across both aggregated and disaggregated serving configurations, see the [TensorRT-LLM Benchmark Scripts for DeepSeek R1 model](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/trtllm/performance-sweeps/README.md). This guide covers recommended benchmarking setups, usage of provided scripts, and best practices for evaluating system performance.
+For detailed instructions on running comprehensive performance sweeps across both aggregated and disaggregated serving configurations, see the [TensorRT-LLM Benchmark Scripts for DeepSeek R1 model](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/trtllm/performance_sweeps/README.md). This guide covers recommended benchmarking setups, usage of provided scripts, and best practices for evaluating system performance.
 
 ## Dynamo KV Block Manager Integration
 

--- a/docs/pages/benchmarks/kv-router-ab-testing.md
+++ b/docs/pages/benchmarks/kv-router-ab-testing.md
@@ -98,7 +98,7 @@ kubectl create secret generic hf-token-secret \
 
 ### Step 1.3: Install Dynamo Platform (Per-Namespace)
 
-If your cluster uses namespace-restricted Dynamo operators, you'll need to install the Dynamo platform in each namespace. Follow the [Dynamo Kubernetes Installation Guide](https://github.com/ai-dynamo/dynamo/blob/main/docs/kubernetes/installation-guide.md) to install the platform in both namespaces:
+If your cluster uses namespace-restricted Dynamo operators, you'll need to install the Dynamo platform in each namespace. Follow the [Dynamo Kubernetes Installation Guide](https://github.com/ai-dynamo/dynamo/blob/main/docs/pages/kubernetes/installation-guide.md) to install the platform in both namespaces:
 
 - `router-off-test`
 - `router-on-test`

--- a/docs/pages/fault-tolerance/request-cancellation.md
+++ b/docs/pages/fault-tolerance/request-cancellation.md
@@ -49,7 +49,7 @@ The Python `Context` class wraps the Rust `AsyncEngineContext` and exposes the f
 - **`stop_generating()`**: Issues a stop generating signal, equivalent to the Rust method
 - **`async_killed_or_stopped()`**: An async method that completes when the context becomes either killed or stopped, whichever happens first. This combines the functionality of the Rust `killed()` and `stopped()` async methods using `tokio::select!`.
 
-For a working example of request cancellation, see the [cancellation demo](https://github.com/ai-dynamo/dynamo/tree/main/examples/custom-backend/cancellation/README.md).
+For a working example of request cancellation, see the [cancellation demo](https://github.com/ai-dynamo/dynamo/tree/main/examples/custom_backend/cancellation/README.md).
 
 ### Context Usage in Python
 

--- a/docs/pages/getting-started/examples.md
+++ b/docs/pages/getting-started/examples.md
@@ -10,7 +10,7 @@ The examples below assume you build the latest image yourself from source. If us
 
 Demonstrates the basic concepts of Dynamo by creating a simple GPU-unaware graph.
 
-[View Hello World Example](https://github.com/ai-dynamo/dynamo/tree/main/examples/runtime/hello_world)
+[View Hello World Example](https://github.com/ai-dynamo/dynamo/tree/main/examples/custom_backend/hello_world)
 
 ## vLLM
 

--- a/docs/pages/kubernetes/README.md
+++ b/docs/pages/kubernetes/README.md
@@ -46,7 +46,7 @@ Before deploying the platform, run the pre-deployment checks to ensure the clust
 ./deploy/pre-deployment/pre-deployment-check.sh
 ```
 
-This validates kubectl connectivity, StorageClass configuration, and GPU availability. See [pre-deployment checks](https://github.com/ai-dynamo/dynamo/tree/main/deploy/pre-deployment/README) for more details.
+This validates kubectl connectivity, StorageClass configuration, and GPU availability. See [pre-deployment checks](https://github.com/ai-dynamo/dynamo/tree/main/deploy/pre-deployment/README.md) for more details.
 
 ## 1. Install Platform First
 
@@ -79,9 +79,9 @@ Each backend has deployment examples and configuration options:
 
 | Backend      | Aggregated | Aggregated + Router | Disaggregated | Disaggregated + Router | Disaggregated + Planner | Disaggregated Multi-node |
 |--------------|:----------:|:-------------------:|:-------------:|:----------------------:|:-----------------------:|:------------------------:|
-| **[SGLang](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/sglang/deploy/README)**       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **[TensorRT-LLM](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/trtllm/deploy/README)** | ✅ | ✅ | ✅ | ✅ | 🚧 | ✅ |
-| **[vLLM](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/vllm/deploy/README)**           | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **[SGLang](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/sglang/deploy/README.md)**       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **[TensorRT-LLM](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/trtllm/deploy/README.md)** | ✅ | ✅ | ✅ | ✅ | 🚧 | ✅ |
+| **[vLLM](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/vllm/deploy/README.md)**           | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ## 3. Deploy Your First Model
 
@@ -232,7 +232,7 @@ Key customization points include:
 - **[Managing Models with DynamoModel](deployment/dynamomodel-guide.md)** - Deploy LoRA adapters and manage models
 - **[Operator Documentation](dynamo-operator.md)** - How the platform works
 - **[Service Discovery](service-discovery.md)** - Discovery backends and configuration
-- **[Helm Charts](https://github.com/ai-dynamo/dynamo/tree/main/deploy/helm/README)** - For advanced users
+- **[Helm Charts](https://github.com/ai-dynamo/dynamo/tree/main/deploy/helm/README.md)** - For advanced users
 - **[Checkpointing](chrek/README.md)** - Fast pod startup with checkpoint/restore
 - **[GitOps Deployment with FluxCD](fluxcd.md)** - For advanced users
 - **[Logging](observability/logging.md)** - For logging setup

--- a/docs/pages/kubernetes/chrek/standalone.md
+++ b/docs/pages/kubernetes/chrek/standalone.md
@@ -679,9 +679,9 @@ securityContext:
 ## Additional Resources
 
 - [ChReK Helm Chart Values](https://github.com/ai-dynamo/dynamo/tree/main/deploy/helm/charts/chrek/values.yaml)
-- [Smart Entrypoint Script](https://github.com/ai-dynamo/dynamo/tree/main/deploy/chrek/scripts/smart-entrypoint.sh)
+- [ChReK Dockerfile](https://github.com/ai-dynamo/dynamo/tree/main/deploy/chrek/Dockerfile)
 - [CRIU Documentation](https://criu.org/Main_Page)
-- [CUDA Checkpoint Plugin](https://docs.nvidia.com/cuda/cuda-checkpoint-plugin/)
+- [CUDA Checkpoint Utility](https://github.com/NVIDIA/cuda-checkpoint)
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes all 14 broken links causing the [lychee CI check](https://github.com/ai-dynamo/dynamo/actions/runs/22201127602/job/64214015086) to fail.

**Changes across 10 files:**

| Category | Count | Fix |
|---|---|---|
| Missing `.md` extension | 5 | `deploy/helm/README` -> `README.md`, etc. |
| Underscore vs hyphen | 3 | `slurm-jobs` -> `slurm_jobs`, `performance-sweeps` -> `performance_sweeps`, `custom-backend` -> `custom_backend` |
| Wrong directory path | 2 | `docs/kubernetes/` -> `docs/pages/kubernetes/`, `examples/runtime/hello_world` -> `examples/custom_backend/hello_world` |
| Spurious `.md` on directory | 1 | `examples/multimodal.md` -> `examples/multimodal` |
| External URL moved | 1 | SGLang diffusion docs moved to `text_generation/` subdirectory |
| External URL removed | 2 | CUDA checkpoint plugin docs -> GitHub repo, dead `smart-entrypoint.sh` -> ChReK Dockerfile |

Also adds `.lycheeignore` entries for intentional placeholder URLs in `docs/pages/templates/integration-readme.md`.

## Test Plan

- [ ] Lychee CI check passes (0 errors)
- [ ] Spot-check fixed links resolve to correct targets

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed multiple broken and outdated links across API, backend, and Kubernetes deployment documentation to ensure proper navigation.
  * Updated resource references and path corrections in getting-started guides and additional resources sections.

* **Chores**
  * Updated URL validation patterns to improve documentation quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->