### PR TITLE
chore: remove mechanism to disable webhooks

### DIFF
--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -19,7 +19,7 @@ limitations under the License.
 
 A Helm chart for NVIDIA Dynamo Platform.
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.0-dev](https://img.shields.io/badge/Version-1.0.0--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## 🚀 Overview
 
@@ -37,6 +37,17 @@ The Dynamo Platform Helm chart deploys the complete Dynamo Kubernetes Platform i
 - Helm 3.8+
 - Sufficient cluster resources for your deployment scale
 - Container registry access (if using private images)
+- TLS certificate infrastructure for admission webhooks (auto-generated via Helm hooks by default, or [cert-manager](https://cert-manager.io/), or externally managed)
+
+## 🔄 Upgrading Notes
+
+### Webhooks are now mandatory (v1.0.0+)
+
+The `webhook.enabled` Helm value has been removed. Admission webhooks are now a required component of the operator and cannot be disabled. This change aligns with the upcoming addition of CRD conversion webhooks, which are mandatory for multi-version API support.
+
+No action is required for most upgrades — Helm hooks automatically generate TLS certificates and inject the CA bundle during `helm upgrade`. If you use cert-manager or externally managed certificates, ensure your existing configuration is correct before upgrading.
+
+---
 
 ## ⚠️ Important: Cluster-Wide vs Namespace-Scoped Deployment
 
@@ -86,7 +97,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://components/operator | dynamo-operator | 0.7.1 |
+| file://components/operator | dynamo-operator | 1.0.0-dev |
 | https://charts.bitnami.com/bitnami | etcd | 12.0.18 |
 | https://nats-io.github.io/k8s/helm/charts/ | nats | 1.3.2 |
 | oci://ghcr.io/ai-dynamo/grove | grove(grove-charts) | v0.1.0-alpha.6 |
@@ -96,6 +107,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| global.etcd.install | bool | `false` | Whether this chart should install the bundled etcd subchart. When true, deploys etcd and auto-configures the operator with its address. When false, etcd is not deployed. Use dynamo-operator.etcdAddr to point at an external instance if you are bringing your own etcd. |
 | dynamo-operator.enabled | bool | `true` | Whether to enable the Dynamo Kubernetes operator deployment |
 | dynamo-operator.natsAddr | string | `""` | NATS server address for operator communication (leave empty to use the bundled NATS chart). Format: "nats://hostname:port" |
 | dynamo-operator.etcdAddr | string | `""` | etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: "http://hostname:port" or "https://hostname:port" |
@@ -104,6 +116,8 @@ The chart includes built-in validation to prevent all operator conflicts:
 | dynamo-operator.namespaceRestriction | object | `{"enabled":false,"lease":{"duration":"30s","renewInterval":"10s"},"targetNamespace":null}` | Namespace access controls for the operator |
 | dynamo-operator.namespaceRestriction.enabled | bool | `false` | Whether to restrict operator to specific namespaces. By default, the operator will run with cluster-wide permissions. Only 1 instance of the operator should be deployed in the cluster. If you want to deploy multiple operator instances, you can set this to true and specify the target namespace (by default, the target namespace is the helm release namespace). |
 | dynamo-operator.namespaceRestriction.targetNamespace | string | `nil` | Target namespace for operator deployment (leave empty for current namespace) |
+| dynamo-operator.gpuDiscovery | object | `{"enabled":true}` | GPU discovery configuration (only applies when namespaceRestriction.enabled=true) |
+| dynamo-operator.gpuDiscovery.enabled | bool | `true` | Whether to provision a ClusterRole for the namespace-scoped operator to read GPU node labels. When true (default), Helm creates a ClusterRole/ClusterRoleBinding granting node read access. Set to false if your installer lacks ClusterRole creation permissions. |
 | dynamo-operator.controllerManager.tolerations | list | `[]` | Node tolerations for controller manager pods |
 | dynamo-operator.controllerManager.affinity | object | `{}` | Affinity for controller manager pods |
 | dynamo-operator.controllerManager.leaderElection.id | string | `""` | Leader election ID for cluster-wide coordination. WARNING: All cluster-wide operators must use the SAME ID to prevent split-brain. Different IDs would allow multiple leaders simultaneously. |
@@ -131,7 +145,6 @@ The chart includes built-in validation to prevent all operator conflicts:
 | dynamo-operator.dynamo.metrics.prometheusEndpoint | string | `""` | Endpoint that services can use to retrieve metrics. If set, dynamo operator will automatically inject the PROMETHEUS_ENDPOINT environment variable into services it manages. Users can override the value of the PROMETHEUS_ENDPOINT environment variable by modifying the corresponding deployment's environment variables |
 | dynamo-operator.dynamo.mpiRun.secretName | string | `"mpi-run-ssh-secret"` | Name of the secret containing the SSH key for MPI Run |
 | dynamo-operator.dynamo.mpiRun.sshKeygen.enabled | bool | `true` | Whether to enable SSH key generation for MPI Run |
-| dynamo-operator.webhook.enabled | bool | `true` | Whether to enable admission webhooks for resource validation. When enabled, the operator will validate DynamoComponentDeployment and DynamoGraphDeployment resources before they are created or updated in the cluster. Enabled by default for production-ready validation and better error reporting. |
 | dynamo-operator.webhook.certificateSecret.name | string | `"webhook-server-cert"` | Name of the Kubernetes secret containing webhook TLS certificates. The secret must contain three keys: tls.crt (server certificate), tls.key (server private key), and ca.crt (Certificate Authority certificate). |
 | dynamo-operator.webhook.certificateSecret.external | bool | `false` | Whether to manage the certificate secret externally. When false (default), certificates are automatically generated via Helm hooks during installation. When true, you must create the secret manually before installing the chart. |
 | dynamo-operator.webhook.certificateValidity | int | `365` | Certificate validity duration in days for auto-generated certificates. Only used when certManager.enabled=false and certificateSecret.external=false. After this duration, certificates will expire and need to be regenerated. |
@@ -148,6 +161,9 @@ The chart includes built-in validation to prevent all operator conflicts:
 | dynamo-operator.webhook.certManager.certificate.rootCA.duration | string | `"87600h"` | Duration for the root CA certificate (e.g., "87600h" for 10 years). The root CA typically has a much longer lifetime than the leaf certificates it signs. |
 | dynamo-operator.webhook.certManager.certificate.rootCA.renewBefore | string | `"720h"` | Time before root CA expiration to trigger renewal (e.g., "720h" for 30 days). Renewing a CA can be disruptive as all signed certificates must be reissued. |
 | dynamo-operator.checkpoint.enabled | bool | `false` | Whether to enable checkpoint/restore functionality |
+| dynamo-operator.checkpoint.initContainerImage | string | `"busybox:latest"` | Image used for init containers in checkpoint jobs (e.g., signal file cleanup) |
+| dynamo-operator.checkpoint.readyForCheckpointFilePath | string | `"/tmp/ready-for-checkpoint"` | Path written by worker when model is loaded and ready for checkpointing |
+| dynamo-operator.checkpoint.restoreMarkerFilePath | string | `"/tmp/dynamo-restored"` | Path written by restore-entrypoint after successful CRIU restore |
 | dynamo-operator.checkpoint.storage.type | string | `"pvc"` | Storage backend type: pvc, s3, or oci |
 | dynamo-operator.checkpoint.storage.signalHostPath | string | `"/var/lib/chrek/signals"` | Host path for signal files (communication between checkpoint pod and DaemonSet) |
 | dynamo-operator.checkpoint.storage.pvc.pvcName | string | `"chrek-pvc"` | Name of the PVC created by the chrek chart |
@@ -156,14 +172,12 @@ The chart includes built-in validation to prevent all operator conflicts:
 | dynamo-operator.checkpoint.storage.s3.credentialsSecretRef | string | `""` | Reference to a secret containing AWS credentials |
 | dynamo-operator.checkpoint.storage.oci.uri | string | `""` | OCI URI in format: oci://registry/repository |
 | dynamo-operator.checkpoint.storage.oci.credentialsSecretRef | string | `""` | Reference to a docker config secret for registry authentication |
-| dynamo-operator.checkpoint.criu.timeout | string | `"21600"` | CRIU operation timeout in seconds. Default: 21600 (6 hours) |
 | grove.enabled | bool | `false` | Whether to enable Grove for multi-node inference coordination, if enabled, the Grove operator will be deployed cluster-wide |
 | grove.tolerations | list | `[]` | Node tolerations for Grove pods |
 | grove.affinity | object | `{}` | Affinity for Grove pods |
 | kai-scheduler.enabled | bool | `false` | Whether to enable Kai Scheduler for intelligent resource allocation, if enabled, the Kai Scheduler operator will be deployed cluster-wide |
 | kai-scheduler.global.tolerations | list | `[]` | Node tolerations for kai-scheduler pods |
 | kai-scheduler.global.affinity | object | `{}` | Affinity for kai-scheduler pods |
-| global.etcd.install | bool | `false` | Whether to install the bundled etcd subchart. When true, deploys etcd and auto-configures the operator with its address. Use dynamo-operator.etcdAddr to point at an external instance instead. |
 | etcd.image.repository | string | `"bitnamilegacy/etcd"` | following bitnami announcement for brownout - https://github.com/bitnami/charts/tree/main/bitnami/etcd#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog, we need to use the legacy repository until we migrate to the new "secure" repository |
 | nats.enabled | bool | `true` | Whether to enable NATS deployment, disable if you want to use an external NATS instance. For complete configuration options, see: https://github.com/nats-io/k8s/tree/main/helm/charts/nats , all nats settings should be prefixed with "nats." |
 

--- a/deploy/helm/charts/platform/README.md.gotmpl
+++ b/deploy/helm/charts/platform/README.md.gotmpl
@@ -37,6 +37,17 @@ The Dynamo Platform Helm chart deploys the complete Dynamo Kubernetes Platform i
 - Helm 3.8+
 - Sufficient cluster resources for your deployment scale
 - Container registry access (if using private images)
+- TLS certificate infrastructure for admission webhooks (auto-generated via Helm hooks by default, or [cert-manager](https://cert-manager.io/), or externally managed)
+
+## 🔄 Upgrading Notes
+
+### Webhooks are now mandatory (v1.0.0+)
+
+The `webhook.enabled` Helm value has been removed. Admission webhooks are now a required component of the operator and cannot be disabled. This change aligns with the upcoming addition of CRD conversion webhooks, which are mandatory for multi-version API support.
+
+No action is required for most upgrades — Helm hooks automatically generate TLS certificates and inject the CA bundle during `helm upgrade`. If you use cert-manager or externally managed certificates, ensure your existing configuration is correct before upgrading.
+
+---
 
 ## ⚠️ Important: Cluster-Wide vs Namespace-Scoped Deployment
 

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -145,9 +145,6 @@ spec:
           - --gpu-discovery-enabled={{ .Values.gpuDiscovery.enabled }}
         {{- end }}
           - --operator-version={{ .Chart.AppVersion }}
-        {{- if .Values.webhook.enabled }}
-          - --enable-webhooks=true
-        {{- end }}
         {{- if .Values.checkpoint.enabled }}
           - --checkpoint-enabled=true
           - --checkpoint-storage-type={{ .Values.checkpoint.storage.type }}
@@ -187,12 +184,10 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
-        {{- if .Values.webhook.enabled }}
         ports:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        {{- end }}
         readinessProbe:
           httpGet:
             path: /readyz
@@ -203,20 +198,16 @@ spec:
           10 }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
-        {{- if .Values.webhook.enabled }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-        {{- end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "dynamo-operator.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 30
-      {{- if .Values.webhook.enabled }}
       volumes:
       - name: cert
         secret:
           defaultMode: 420
           secretName: {{ .Values.webhook.certificateSecret.name }}
-      {{- end }}

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-ca-inject-job.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-ca-inject-job.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if and .Values.webhook.enabled (not .Values.webhook.certManager.enabled) (not .Values.webhook.certificateSecret.external) }}
+{{- if and (not .Values.webhook.certManager.enabled) (not .Values.webhook.certificateSecret.external) }}
 ---
 # ServiceAccount for CA bundle injection job
 apiVersion: v1

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-cert-gen-job.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-cert-gen-job.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if and .Values.webhook.enabled (not .Values.webhook.certManager.enabled) (not .Values.webhook.certificateSecret.external) }}
+{{- if and (not .Values.webhook.certManager.enabled) (not .Values.webhook.certificateSecret.external) }}
 ---
 # ServiceAccount for certificate generation job
 apiVersion: v1

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-certificates.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-certificates.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if and .Values.webhook.enabled .Values.webhook.certManager.enabled }}
+{{- if .Values.webhook.certManager.enabled }}
 ---
 # Self-signed issuer to bootstrap the CA
 apiVersion: cert-manager.io/v1

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.webhook.enabled }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -221,5 +220,4 @@ webhooks:
     - dynamographdeployments
   sideEffects: None
   timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
-{{- end }}
 

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-crd-conversion-certmanager.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-crd-conversion-certmanager.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if and .Values.webhook.enabled .Values.webhook.certManager.enabled }}
+{{- if .Values.webhook.certManager.enabled }}
 ---
 # ServiceAccount for the CRD conversion patch job
 apiVersion: v1

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.webhook.enabled }}
 ---
 # Role to read the webhook certificate secret
 apiVersion: rbac.authorization.k8s.io/v1
@@ -56,5 +55,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "dynamo-operator.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
-{{- end }}
 

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-service.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-service.yaml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.webhook.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -34,5 +33,4 @@ spec:
   selector:
     control-plane: controller-manager
   {{- include "dynamo-operator.selectorLabels" . | nindent 4 }}
-{{- end }}
 

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -208,10 +208,6 @@ checkpoint:
 
 # Webhook configuration
 webhook:
-  # Enable admission webhooks for validation
-  # Enabled by default for production-ready validation and better error reporting
-  enabled: true
-
   # Certificate configuration
   certificateSecret:
     # Name of the secret containing webhook TLS certificates

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -156,9 +156,6 @@ dynamo-operator:
 
   # Webhook configuration for admission control and validation
   webhook:
-    # -- Whether to enable admission webhooks for resource validation. When enabled, the operator will validate DynamoComponentDeployment and DynamoGraphDeployment resources before they are created or updated in the cluster. Enabled by default for production-ready validation and better error reporting.
-    enabled: true
-
     # Certificate configuration for webhook TLS
     certificateSecret:
       # -- Name of the Kubernetes secret containing webhook TLS certificates. The secret must contain three keys: tls.crt (server certificate), tls.key (server private key), and ca.crt (Certificate Authority certificate).

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -157,7 +157,6 @@ func main() {
 	var namespaceScopeLeaseRenewInterval time.Duration
 	var operatorVersion string
 	var discoveryBackend string
-	var enableWebhooks bool
 	var gpuDiscoveryEnabled bool
 	// Checkpoint configuration
 	var checkpointEnabled bool
@@ -181,9 +180,6 @@ func main() {
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	flag.BoolVar(&enableWebhooks, "enable-webhooks", false,
-		"Enable admission webhooks for validation. When enabled, controllers skip validation "+
-			"(webhooks handle it). When disabled, controllers perform validation.")
 	flag.BoolVar(&gpuDiscoveryEnabled, "gpu-discovery-enabled", true,
 		"Whether GPU discovery is enabled for namespace-scoped operators. When true (default), "+
 			"the Helm chart has provisioned a ClusterRole granting node read access for GPU hardware discovery.")
@@ -692,80 +688,68 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set webhooks enabled flag in config
-	ctrlConfig.WebhooksEnabled = enableWebhooks
 	ctrlConfig.GPUDiscoveryEnabled = gpuDiscoveryEnabled
 
-	if enableWebhooks {
-		setupLog.Info("Webhooks are enabled - webhooks will validate, controllers will skip validation")
-	} else {
-		setupLog.Info("Webhooks are disabled - controllers will validate (defense in depth)")
-	}
-
-	// Configure webhooks with lease-based namespace exclusion (only if enabled)
+	// Configure webhooks with lease-based namespace exclusion
 	// In cluster-wide mode, inject ctrlConfig.ExcludedNamespaces (leaseWatcher) so webhooks can defer
 	// to namespace-restricted operators. In namespace-restricted mode, webhooks validate without checking
 	// leases (ExcludedNamespaces is nil). The webhooks use LeaseAwareValidator wrapper to add coordination.
-	if enableWebhooks {
-		if ctrlConfig.RestrictedNamespace == "" {
-			// Cluster-wide mode: inject the same ExcludedNamespaces used by controllers
-			setupLog.Info("Configuring webhooks with lease-based namespace exclusion for cluster-wide mode")
-			internalwebhook.SetExcludedNamespaces(ctrlConfig.ExcludedNamespaces)
-		} else {
-			// Namespace-restricted mode: no exclusion checking needed (validators not wrapped)
-			setupLog.Info("Configuring webhooks for namespace-restricted mode (no lease checking)",
-				"restrictedNamespace", ctrlConfig.RestrictedNamespace)
-			internalwebhook.SetExcludedNamespaces(nil)
-		}
-
-		// Register validation webhook handlers
-		setupLog.Info("Registering validation webhooks")
-
-		dcdHandler := webhookvalidation.NewDynamoComponentDeploymentHandler()
-		if err = dcdHandler.RegisterWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to register webhook", "webhook", "DynamoComponentDeployment")
-			os.Exit(1)
-		}
-
-		dgdHandler := webhookvalidation.NewDynamoGraphDeploymentHandler(mgr)
-		if err = dgdHandler.RegisterWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to register webhook", "webhook", "DynamoGraphDeployment")
-			os.Exit(1)
-		}
-
-		dmHandler := webhookvalidation.NewDynamoModelHandler()
-		if err = dmHandler.RegisterWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to register webhook", "webhook", "DynamoModel")
-			os.Exit(1)
-		}
-
-		isClusterWide := ctrlConfig.RestrictedNamespace == ""
-		dgdrHandler := webhookvalidation.NewDynamoGraphDeploymentRequestHandler(isClusterWide, gpuDiscoveryEnabled)
-		if err = dgdrHandler.RegisterWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to register webhook", "webhook", "DynamoGraphDeploymentRequest")
-			os.Exit(1)
-		}
-
-		if err = ctrl.NewWebhookManagedBy(mgr).
-			For(&nvidiacomv1alpha1.DynamoGraphDeploymentRequest{}).
-			Complete(); err != nil {
-			setupLog.Error(err, "unable to register conversion webhook", "webhook", "DynamoGraphDeploymentRequest-conversion")
-			os.Exit(1)
-		}
-
-		setupLog.Info("Validation webhooks registered successfully")
-
-		// Register defaulting (mutating) webhook handlers
-		setupLog.Info("Registering defaulting webhooks")
-
-		dgdDefaulter := webhookdefaulting.NewDGDDefaulter(operatorVersion)
-		if err = dgdDefaulter.RegisterWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to register webhook", "webhook", "DynamoGraphDeployment-defaulting")
-			os.Exit(1)
-		}
-
-		setupLog.Info("Defaulting webhooks registered successfully")
+	isClusterWide := ctrlConfig.RestrictedNamespace == ""
+	if isClusterWide {
+		setupLog.Info("Configuring webhooks with lease-based namespace exclusion for cluster-wide mode")
+		internalwebhook.SetExcludedNamespaces(ctrlConfig.ExcludedNamespaces)
+	} else {
+		setupLog.Info("Configuring webhooks for namespace-restricted mode (no lease checking)",
+			"restrictedNamespace", ctrlConfig.RestrictedNamespace)
+		internalwebhook.SetExcludedNamespaces(nil)
 	}
+
+	// Register validation webhook handlers
+	setupLog.Info("Registering validation webhooks")
+
+	dcdHandler := webhookvalidation.NewDynamoComponentDeploymentHandler()
+	if err = dcdHandler.RegisterWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to register webhook", "webhook", "DynamoComponentDeployment")
+		os.Exit(1)
+	}
+
+	dgdHandler := webhookvalidation.NewDynamoGraphDeploymentHandler(mgr)
+	if err = dgdHandler.RegisterWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to register webhook", "webhook", "DynamoGraphDeployment")
+		os.Exit(1)
+	}
+
+	dmHandler := webhookvalidation.NewDynamoModelHandler()
+	if err = dmHandler.RegisterWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to register webhook", "webhook", "DynamoModel")
+		os.Exit(1)
+	}
+
+	dgdrHandler := webhookvalidation.NewDynamoGraphDeploymentRequestHandler(isClusterWide, gpuDiscoveryEnabled)
+	if err = dgdrHandler.RegisterWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to register webhook", "webhook", "DynamoGraphDeploymentRequest")
+		os.Exit(1)
+	}
+
+	if err = ctrl.NewWebhookManagedBy(mgr).
+		For(&nvidiacomv1alpha1.DynamoGraphDeploymentRequest{}).
+		Complete(); err != nil {
+		setupLog.Error(err, "unable to register conversion webhook", "webhook", "DynamoGraphDeploymentRequest-conversion")
+		os.Exit(1)
+	}
+
+	setupLog.Info("Validation webhooks registered successfully")
+
+	// Register defaulting (mutating) webhook handlers
+	setupLog.Info("Registering defaulting webhooks")
+
+	dgdDefaulter := webhookdefaulting.NewDGDDefaulter(operatorVersion)
+	if err = dgdDefaulter.RegisterWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to register webhook", "webhook", "DynamoGraphDeployment-defaulting")
+		os.Exit(1)
+	}
+
+	setupLog.Info("Defaulting webhooks registered successfully")
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/deploy/operator/internal/controller_common/predicate.go
+++ b/deploy/operator/internal/controller_common/predicate.go
@@ -80,11 +80,6 @@ type Config struct {
 	// DiscoveryBackend is the discovery backend to use. Default is "kubernetes" for Kubernetes API service discovery. Set to "etcd" to use ETCD for discovery.
 	DiscoveryBackend string
 
-	// WebhooksEnabled indicates whether admission webhooks are enabled
-	// When true, controllers skip validation (webhooks handle it)
-	// When false, controllers perform validation (defense in depth)
-	WebhooksEnabled bool
-
 	// GPUDiscoveryEnabled indicates whether Helm provisioned node read access for the namespace-scoped operator.
 	// Only relevant for namespace-scoped operators (RestrictedNamespace != "").
 	GPUDiscoveryEnabled bool

--- a/docs/pages/kubernetes/dynamo-operator.md
+++ b/docs/pages/kubernetes/dynamo-operator.md
@@ -122,7 +122,7 @@ For a user-focused guide on deploying and managing models with DynamoModel, see:
 
 ## Webhooks
 
-The Dynamo Operator uses **Kubernetes admission webhooks** for real-time validation of custom resources before they are persisted to the cluster. Webhooks are **enabled by default** and ensure that invalid configurations are rejected immediately at the API server level.
+The Dynamo Operator uses **Kubernetes admission webhooks** for real-time validation and mutation of custom resources before they are persisted to the cluster. Webhooks are a required component of the operator and ensure that invalid configurations are rejected immediately at the API server level.
 
 **Key Features:**
 - ✅ Shared certificate infrastructure across all webhook types

--- a/docs/pages/kubernetes/webhooks.md
+++ b/docs/pages/kubernetes/webhooks.md
@@ -11,7 +11,6 @@ This document describes the webhook functionality in the Dynamo Operator, includ
 - [Overview](#overview)
 - [Architecture](#architecture)
 - [Configuration](#configuration)
-  - [Enabling/Disabling Webhooks](#enablingdisabling-webhooks)
   - [Certificate Management Options](#certificate-management-options)
   - [Advanced Configuration](#advanced-configuration)
 - [Certificate Management](#certificate-management)
@@ -31,10 +30,9 @@ All webhook types (validating, mutating, conversion, etc.) share the same **webh
 
 ### Key Features
 
-- ✅ **Enabled by default** - Zero-touch validation out of the box
+- ✅ **Always enabled** - Webhooks are a required component of the operator
 - ✅ **Shared certificate infrastructure** - All webhook types use the same TLS certificates
 - ✅ **Automatic certificate generation** - No manual certificate management required
-- ✅ **Defense in depth** - Controllers validate when webhooks are disabled
 - ✅ **cert-manager integration** - Optional integration for automated certificate lifecycle
 - ✅ **Multi-operator support** - Lease-based coordination for cluster-wide and namespace-restricted deployments
 - ✅ **Immutability enforcement** - Critical fields protected via CEL validation rules
@@ -45,8 +43,11 @@ All webhook types (validating, mutating, conversion, etc.) share the same **webh
   - `DynamoComponentDeployment` validation
   - `DynamoGraphDeployment` validation
   - `DynamoModel` validation
+  - `DynamoGraphDeploymentRequest` validation
+- **Mutating Webhooks**: Apply default values to resources on creation
+  - `DynamoGraphDeployment` defaulting
 
-**Note:** Future releases may add mutating webhooks (for defaults/transformations) and conversion webhooks (for CRD version migrations). All will use the same certificate infrastructure described in this document.
+**Note:** All webhook types use the same certificate infrastructure described in this document.
 
 ---
 
@@ -56,53 +57,56 @@ All webhook types (validating, mutating, conversion, etc.) share the same **webh
 ┌─────────────────────────────────────────────────────────────────┐
 │                         API Server                               │
 │  1. User submits CR (kubectl apply)                             │
-│  2. API server calls ValidatingWebhookConfiguration             │
+│  2. API server calls MutatingWebhookConfiguration               │
 └────────────────────────┬────────────────────────────────────────┘
                          │ HTTPS (TLS required)
                          ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                  Webhook Server (in Operator Pod)                │
-│  3. Validates CR against business rules                         │
-│  4. Returns admit/deny decision + warnings                      │
-└─────────────────────────────────────────────────────────────────┘
+│  3. Applies defaults (e.g., operator version annotation)        │
+│  4. Returns mutated CR                                          │
+└────────────────────────┬────────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                         API Server                               │
+│  5. API server calls ValidatingWebhookConfiguration             │
+└────────────────────────┬────────────────────────────────────────┘
+                         │ HTTPS (TLS required)
+                         ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                  Webhook Server (in Operator Pod)                │
+│  6. Validates CR against business rules                         │
+│  7. Returns admit/deny decision + warnings                      │
+└────────────────────────┬────────────────────────────────────────┘
                          │
                          ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                      API Server                                  │
-│  5. If admitted: Persist CR to etcd                             │
-│  6. If denied: Return error to user                             │
+│  8. If admitted: Persist CR to etcd                             │
+│  9. If denied: Return error to user                             │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Validation Flow
+### Admission Flow
 
-1. **Webhook validation** (if enabled): Validates at API server level
-2. **CEL validation**: Kubernetes-native immutability checks (always active)
-3. **Controller validation** (if webhooks disabled): Defense-in-depth validation during reconciliation
+1. **Mutating webhooks**: Apply defaults and transformations before validation
+2. **Validating webhooks**: Validate the (possibly mutated) CR against business rules
+3. **CEL validation**: Kubernetes-native immutability checks (always active)
+
+---
+
+## Upgrading from versions with `webhook.enabled: false`
+
+The `webhook.enabled` Helm value has been removed. Webhooks are now a required component of the operator and are always active. If you previously ran with `webhook.enabled: false`, take the following steps before upgrading:
+
+1. **Remove `webhook.enabled`** from any custom values files. Helm will ignore the unknown key, but it should be cleaned up to avoid confusion.
+2. **Ensure port 9443 is reachable** from the Kubernetes API server to the operator pod. If you have `NetworkPolicy` rules or firewall configurations restricting traffic, add an ingress rule allowing the API server to reach the webhook server on port 9443.
+3. **Ensure webhook TLS certificates are available.** By default, Helm hooks generate self-signed certificates automatically during `helm upgrade` — no action needed. If you use cert-manager or externally managed certificates, verify your configuration is in place before upgrading.
 
 ---
 
 ## Configuration
-
-### Enabling/Disabling Webhooks
-
-Webhooks are **enabled by default**. To disable them:
-
-```yaml
-# Platform-level values.yaml
-dynamo-operator:
-  webhook:
-    enabled: false
-```
-
-**When to disable webhooks:**
-- During development/testing when rapid iteration is needed
-- In environments where admission webhooks are not supported
-- When troubleshooting validation issues
-
-**Note:** When webhooks are disabled, controllers perform validation during reconciliation (defense in depth).
-
----
 
 ### Certificate Management Options
 
@@ -123,9 +127,6 @@ The operator supports three certificate management modes:
 ```yaml
 dynamo-operator:
   webhook:
-    # Enable/disable validation webhooks
-    enabled: true
-
     # Certificate management
     certManager:
       enabled: false
@@ -455,7 +456,7 @@ If the namespace-restricted operator is deleted or becomes unhealthy:
 
 **Checks:**
 
-1. **Verify webhook is enabled**:
+1. **Verify webhook configuration exists**:
 ```bash
 kubectl get validatingwebhookconfiguration | grep dynamo
 ```
@@ -477,7 +478,7 @@ kubectl get service -n <namespace> | grep webhook
 4. **Check operator logs for webhook startup**:
 ```bash
 kubectl logs -n <namespace> deployment/<release>-dynamo-operator | grep webhook
-# Should see: "Webhooks are enabled - webhooks will validate, controllers will skip validation"
+# Should see: "Registering validation webhooks"
 # Should see: "Starting webhook server"
 ```
 
@@ -636,15 +637,15 @@ kubectl describe <resource-type> <name> -n <namespace>
 # Look for events mentioning webhook errors
 ```
 
-2. **Temporarily disable webhook**:
+2. **Temporarily work around the webhook**:
 ```bash
-# Option 1: Delete ValidatingWebhookConfiguration
-kubectl delete validatingwebhookconfiguration <name>
-
-# Option 2: Set failurePolicy to Ignore
+# Option 1: Set failurePolicy to Ignore
 kubectl patch validatingwebhookconfiguration <name> \
   --type='json' \
   -p='[{"op": "replace", "path": "/webhooks/0/failurePolicy", "value": "Ignore"}]'
+
+# Option 2 (last resort): Delete ValidatingWebhookConfiguration
+kubectl delete validatingwebhookconfiguration <name>
 ```
 
 3. **Delete resource again**:
@@ -652,7 +653,7 @@ kubectl patch validatingwebhookconfiguration <name> \
 kubectl delete <resource-type> <name> -n <namespace>
 ```
 
-4. **Re-enable webhook**:
+4. **Restore webhook configuration**:
 ```bash
 helm upgrade <release> dynamo-platform -n <namespace>
 ```
@@ -663,17 +664,15 @@ helm upgrade <release> dynamo-platform -n <namespace>
 
 ### Production Deployments
 
-1. ✅ **Keep webhooks enabled** (default) for real-time validation
-2. ✅ **Use `failurePolicy: Fail`** (default) to ensure validation is enforced
-3. ✅ **Monitor webhook latency** - Validation adds ~10-50ms per resource operation
-4. ✅ **Use cert-manager** for automated certificate lifecycle in large deployments
-5. ✅ **Test webhook configuration** in staging before production
+1. ✅ **Use `failurePolicy: Fail`** (default) to ensure validation is enforced
+2. ✅ **Monitor webhook latency** - Validation adds ~10-50ms per resource operation
+3. ✅ **Use cert-manager** for automated certificate lifecycle in large deployments
+4. ✅ **Test webhook configuration** in staging before production
 
 ### Development Deployments
 
-1. ✅ **Disable webhooks** for rapid iteration if needed
-2. ✅ **Use `failurePolicy: Ignore`** if webhook availability is problematic
-3. ✅ **Keep automatic certificates** (simpler than cert-manager for dev)
+1. ✅ **Use `failurePolicy: Ignore`** if webhook availability is problematic during development
+2. ✅ **Keep automatic certificates** (simpler than cert-manager for dev)
 
 ### Multi-Tenant Deployments
 


### PR DESCRIPTION
#### Overview:

remove mechanism to disable webhooks.

with the introduction of conversion webhooks, webhooks infrastructure (SSL certificate, ...) is now mandatory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Webhooks are now always enabled and cannot be disabled; removed webhook.enabled configuration option.

* **Documentation**
  * Updated documentation to reflect webhooks are a required, always-enabled component of the operator.
  * Clarified webhook functionality includes both validation and mutation of custom resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->