### PR TITLE
fix(api): preserve interleaved reasoning order for KV cache correctness

### DIFF
--- a/lib/llm/src/entrypoint/input/text.rs
+++ b/lib/llm/src/entrypoint/input/text.rs
@@ -187,7 +187,9 @@ async fn main_loop(
         let assistant_message = dynamo_async_openai::types::ChatCompletionRequestMessage::Assistant(
             dynamo_async_openai::types::ChatCompletionRequestAssistantMessage {
                 content: Some(assistant_content),
-                reasoning_content: (!assistant_reasoning.is_empty()).then_some(assistant_reasoning),
+                reasoning_content: (!assistant_reasoning.is_empty()).then_some(
+                    dynamo_async_openai::types::ReasoningContent::Text(assistant_reasoning),
+                ),
                 ..Default::default()
             },
         );

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -1751,10 +1751,7 @@ mod tests {
         // Must be Segments, not Text.  Text("A\nB") is the old (broken) behaviour:
         // it loses which reasoning block preceded which tool call.
         assert!(
-            !matches!(
-                msg.reasoning_content,
-                Some(ReasoningContent::Text(_))
-            ),
+            !matches!(msg.reasoning_content, Some(ReasoningContent::Text(_))),
             "reasoning_content must NOT be flat Text when tool calls are interleaved; \
              Text loses positional info and forces a KV cache miss on every multi-tool turn"
         );

--- a/lib/llm/tests/deepseek_v32_encoding.rs
+++ b/lib/llm/tests/deepseek_v32_encoding.rs
@@ -321,6 +321,70 @@ fn test_reasoning_content_survives_chat_request_parsing_and_rendering() {
     assert!(rendered.contains("</think>"));
 }
 
+// Regression test for the KV-cache flattening bug.
+//
+// Models like GLM-5 and Qwen3 (Pattern A) emit interleaved thinking:
+//
+//   <think>A</think> <call>t1</call> <think>B</think> <call>t2</call>
+//
+// `convert_assistant_blocks` now serialises this as a JSON *array*:
+//
+//   "reasoning_content": ["A", "B", ""]
+//
+// OLD CODE stored `reasoning_content: Option<String>` — a JSON array would fail
+// to deserialise into that type, so this test panics at `.unwrap()` on old code.
+// NEW CODE stores `Option<ReasoningContent>` which accepts both string and array,
+// and round-trips the array form faithfully.
+#[test]
+fn test_reasoning_segments_roundtrip_through_parse_and_render() {
+    // Simulate what convert_assistant_blocks produces for an interleaved GLM-5 turn:
+    //   [Think("A"), Tool(t1), Think("B"), Tool(t2)]  →  segments = ["A", "B", ""]
+    let json = r#"{
+        "model": "glm-5",
+        "messages": [
+            {"role": "user", "content": "call two tools"},
+            {
+                "role": "assistant",
+                "reasoning_content": ["A", "B", ""],
+                "tool_calls": [
+                    {"id": "t1", "type": "function", "function": {"name": "f1", "arguments": "{}"}},
+                    {"id": "t2", "type": "function", "function": {"name": "f2", "arguments": "{}"}}
+                ]
+            },
+            {"role": "tool", "tool_call_id": "t1", "content": "r1"},
+            {"role": "tool", "tool_call_id": "t2", "content": "r2"}
+        ]
+    }"#;
+
+    // OLD CODE: serde_json::from_str fails here because Option<String> can't
+    // deserialise a JSON array.  NEW CODE: succeeds.
+    let request: NvCreateChatCompletionRequest = serde_json::from_str(json).unwrap();
+
+    // Segments must survive the round-trip through serde_json
+    let messages_json = serde_json::to_value(request.messages()).unwrap();
+    assert!(
+        messages_json[1]["reasoning_content"].is_array(),
+        "reasoning_content must serialise as a JSON array to preserve positional info; \
+         a string would lose which reasoning preceded which tool call"
+    );
+    let segs = messages_json[1]["reasoning_content"].as_array().unwrap();
+    assert_eq!(segs.len(), 3);
+    assert_eq!(segs[0].as_str().unwrap(), "A"); // precedes t1
+    assert_eq!(segs[1].as_str().unwrap(), "B"); // precedes t2
+    assert_eq!(segs[2].as_str().unwrap(), ""); // no trailing reasoning
+
+    // The formatter must not drop the reasoning content when segments are used.
+    // (DeepSeek V3.2 joins segments into one <think> block; this confirms the
+    // content is not silently discarded.)
+    let formatter =
+        dynamo_llm::preprocessor::prompt::deepseek_v32::DeepSeekV32Formatter::new_thinking();
+    let rendered = formatter.render(&request).unwrap();
+    assert!(rendered.contains("A"), "segment A must appear in rendered output");
+    assert!(rendered.contains("B"), "segment B must appear in rendered output");
+    assert!(rendered.contains("<think>"));
+    assert!(rendered.contains("</think>"));
+}
+
 #[test]
 fn test_tool_call_formatting() {
     let messages = serde_json::json!([

--- a/lib/llm/tests/deepseek_v32_encoding.rs
+++ b/lib/llm/tests/deepseek_v32_encoding.rs
@@ -379,8 +379,14 @@ fn test_reasoning_segments_roundtrip_through_parse_and_render() {
     let formatter =
         dynamo_llm::preprocessor::prompt::deepseek_v32::DeepSeekV32Formatter::new_thinking();
     let rendered = formatter.render(&request).unwrap();
-    assert!(rendered.contains("A"), "segment A must appear in rendered output");
-    assert!(rendered.contains("B"), "segment B must appear in rendered output");
+    assert!(
+        rendered.contains("A"),
+        "segment A must appear in rendered output"
+    );
+    assert!(
+        rendered.contains("B"),
+        "segment B must appear in rendered output"
+    );
     assert!(rendered.contains("<think>"));
     assert!(rendered.contains("</think>"));
 }


### PR DESCRIPTION
## Summary

- Add `reasoning_segments: Option<Vec<String>>` to `ChatCompletionRequestAssistantMessage` — positionally aligned so `segments[i]` is the reasoning that preceded `tool_calls[i]`
- Rewrite `convert_assistant_blocks` (Anthropic API input path) to collect per-tool-call reasoning via `pending_reasoning + std::mem::take`, preserving the interleaved order across `[Thinking, ToolUse, Thinking, ToolUse, …]` block sequences
- Set both `reasoning_segments` (structured, for templates that support it) and `reasoning_content` (flat join, backward-compatible)
- Update `deepseek_v32.rs` Rust renderer to prefer `reasoning_segments` joined when present, fall back to `reasoning_content`

## Problem

For **Pattern A models** (GLM-5, Qwen3) that produce interleaved thinking between parallel tool calls:

```
<think>reasoning for tool 1</think><tool_call>A</tool_call><think>reasoning for tool 2</think><tool_call>B</tool_call>
```

The Anthropic API input path receives these as `[Thinking(r1), ToolUse(A), Thinking(r2), ToolUse(B)]` blocks. The old `convert_assistant_blocks` concatenated all thinking blocks into one flat `reasoning_content = "r1\nr2"` and emitted all tool calls together:

```
<think>r1
r2</think><tool_call>A</tool_call><tool_call>B</tool_call>   ← reconstructed (wrong)
```

This is token-for-token different from what the model produced. On Turn N+1, the engine sees the reconstructed prefix, it doesn't match the KV cache from Turn N, and **every multi-tool exchange gets a full cache miss on the assistant turn**.

## Fix

`reasoning_segments` preserves the original order. A chat template that reads `reasoning_segments` can reconstruct:

```
<think>segments[0]</think><call>tool_calls[0]</call><think>segments[1]</think><call>tool_calls[1]</call>
```

matching the original token sequence → **cache hit**.

## Notes

- `reasoning_content` is still populated (flat join) for backward compatibility with existing templates
- The Jinja template path (GLM-5 served via `tokenizer_config.json`) needs a custom template override that reads `reasoning_segments` — the field is now present in the serialized message context automatically; template update is a follow-up
- Depends on / companion to PR #6422 (interleaved reasoning parser)

## Test plan

- [ ] `cargo check -p dynamo-llm -p dynamo-async-openai` on Linux (macOS build fails on pre-existing Linux-only `fallocate`/`O_DIRECT` disk APIs)
- [ ] Serve GLM-5 via Anthropic API, run 2-turn multi-tool exchange, verify `reasoning_segments` is populated in the converted message
- [ ] Verify DeepSeek V3.2 (single think block) still renders correctly with joined `reasoning_segments` fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended chat completion messages to support reasoning segments, enabling improved representation of multi-segment reasoning content across supported protocols.
  * Enhanced reasoning content handling to maintain backward compatibility while supporting interleaved reasoning structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->