### PR TITLE
feat: Configurable Request Cancellation abort passage to TRT-LLM 

### DIFF
--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -156,7 +156,7 @@ class DynamoTrtllmArgGroup(ArgGroup):
             g,
             flag_name="--disable-request-abort",
             env_var="DYN_TRTLLM_DISABLE_REQUEST_ABORT",
-            default=False,
+            default=True,
             help="Disable calling abort() on the TRT-LLM engine when a request is cancelled.",
         )
         add_argument(

--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -152,6 +152,13 @@ class DynamoTrtllmArgGroup(ArgGroup):
             default=False,
             help="If set, publish events and metrics to Dynamo components.",
         )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--disable-request-abort",
+            env_var="DYN_TRTLLM_DISABLE_REQUEST_ABORT",
+            default=False,
+            help="Disable calling abort() on the TRT-LLM engine when a request is cancelled.",
+        )
         add_argument(
             g,
             flag_name="--disaggregation-mode",
@@ -370,6 +377,7 @@ class DynamoTrtllmConfig(ConfigBase):
     extra_engine_args: str
     override_engine_args: str
     publish_events_and_metrics: bool
+    disable_request_abort: bool
 
     disaggregation_mode: DisaggregationMode
     modality: Modality

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -72,6 +72,7 @@ class RequestHandlerConfig:
     kv_block_size: int = 32
     shutdown_event: Optional[asyncio.Event] = None
     encoder_cache_capacity_gb: float = 0  # Encoder cache capacity in GB
+    disable_request_abort: bool = False
 
 
 class HandlerBase(BaseGenerativeHandler):
@@ -101,6 +102,7 @@ class HandlerBase(BaseGenerativeHandler):
         self.runtime = config.runtime
         self.kv_block_size: int = config.kv_block_size
         self.shutdown_event = config.shutdown_event
+        self.disable_request_abort = config.disable_request_abort
 
     def check_error(self, result: dict):
         """
@@ -208,13 +210,15 @@ class HandlerBase(BaseGenerativeHandler):
                 return_when=asyncio.FIRST_COMPLETED,
             )
 
-            # Abort the generation
-            # Temporary:
-            #   Disable calling abort() on the engine, which may get stuck if a
-            #   sufficiently large number of concurrent requests is cancelled.
-            # Note to restore:
-            #   call `generation_result.abort()`; and then
-            #   log `logging.debug(f"Aborted Request ID: {context.id()}")`
+            # Abort the generation unless disabled
+            if self.disable_request_abort:
+                logging.debug(
+                    f"Request ID {context.id()} cancelled but abort() skipped "
+                    "(DYN_TRTLLM_DISABLE_REQUEST_ABORT=true)"
+                )
+            else:
+                generation_result.abort()
+                logging.debug(f"Aborted Request ID: {context.id()}")
 
             # Clean up any remaining background task
             for task in pending:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -72,7 +72,7 @@ class RequestHandlerConfig:
     kv_block_size: int = 32
     shutdown_event: Optional[asyncio.Event] = None
     encoder_cache_capacity_gb: float = 0  # Encoder cache capacity in GB
-    disable_request_abort: bool = False
+    disable_request_abort: bool = True
 
 
 class HandlerBase(BaseGenerativeHandler):

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -428,6 +428,7 @@ async def init_llm_worker(
             kv_block_size=config.kv_block_size,
             shutdown_event=shutdown_event,
             encoder_cache_capacity_gb=config.multimodal_embedding_cache_capacity_gb,
+            disable_request_abort=config.disable_request_abort,
         )
 
         # Register the model with runtime config

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -187,8 +187,7 @@ def test_request_cancellation_trtllm_aggregated(
     with DynamoFrontendProcess(request) as frontend:
         logger.info("Frontend started successfully")
 
-        # Step 2: Start an aggregated worker
-        # Step 2: Start a single worker (allocates its own system_port)
+        # Step 2: Start an aggregated worker (allocates its own system_port)
         with DynamoWorkerProcess(
             request, frontend.frontend_port, mode="prefill_and_decode"
         ) as worker:
@@ -217,10 +216,10 @@ def test_request_cancellation_trtllm_aggregated(
                     frontend.frontend_port, request_type
                 )
 
-                # Poll for "New Request ID" pattern
+                # Poll for "AggregatedHandler Request ID" pattern
                 request_id, worker_log_offset = poll_for_pattern(
                     process=worker,
-                    pattern="New Request ID: ",
+                    pattern="AggregatedHandler Request ID: ",
                     log_offset=worker_log_offset,
                     match_type="contains",
                 )

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -38,6 +38,7 @@ pytestmark = [
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.post_merge,  # post_merge to pinpoint failure commit
     pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
+    pytest.mark.xfail(reason="Cancellation is temporarily disabled", strict=True),
 ]
 
 

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -38,7 +38,6 @@ pytestmark = [
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.post_merge,  # post_merge to pinpoint failure commit
     pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
-    pytest.mark.xfail(reason="Cancellation is temporarily disabled", strict=True),
 ]
 
 

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -236,7 +236,7 @@ def test_request_migration_trtllm_aggregated(
                     frontend,
                     worker1,
                     worker2,
-                    receiving_pattern="New Request ID: ",
+                    receiving_pattern="AggregatedHandler Request ID: ",
                     migration_limit=migration_limit,
                     immediate_kill=immediate_kill,
                     use_chat_completion=(request_api == "chat"),


### PR DESCRIPTION
#### Overview:

User may config whether the TRT-LLM engine will receive the abort signal, when the request is cancelled at Dynamo.

#### Details:

Add a new flag `--disable-request-abort` that is defaulted to `True`. The flag may also be set by environment variable `DYN_TRTLLM_DISABLE_REQUEST_ABORT`.

The passage of abort signal to TRT-LLM engine is disabled by default. It can be moved to enabled by default in the future.

Note: The original `New Request ID: ` pattern logged by TRT-LLM backend has been changed to `AggregatedHandler Request ID: `. The test case has been updated accounting for this change.

#### Where should the reviewer start?

Start with the `backend_args.py` on the new flag and environment variable, and then `handler_base.py` to see where the flag is checked and abort is issued.

Finally, the unit test at `test_trtllm_handler_base.py` testing the correct calls to `generation_result.abort()` with different `disable_request_abort` flags set.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes DIS-1490


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to control request abort behavior during cancellations, enabling better control over fault tolerance handling.
  * New environment variable available for configuration.

* **Tests**
  * Added test suite verifying cancellation behavior with the new configuration flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->