### PR TITLE
fix: vllm omni image perf fix

### DIFF
--- a/components/src/dynamo/vllm/omni/omni_handler.py
+++ b/components/src/dynamo/vllm/omni/omni_handler.py
@@ -239,7 +239,9 @@ class OmniHandler(BaseOmniHandler):
 
         prompt = OmniTextPrompt(
             prompt=req.prompt,
-            negative_prompt=nvext.negative_prompt or "" if nvext else "",
+            negative_prompt=nvext.negative_prompt
+            if nvext and nvext.negative_prompt
+            else None,
         )
 
         sp = OmniDiffusionSamplingParams(
@@ -281,7 +283,9 @@ class OmniHandler(BaseOmniHandler):
 
         prompt = OmniTextPrompt(
             prompt=req.prompt,
-            negative_prompt=nvext.negative_prompt or "" if nvext else "",
+            negative_prompt=nvext.negative_prompt
+            if nvext and nvext.negative_prompt
+            else None,
         )
 
         sp = OmniDiffusionSamplingParams(


### PR DESCRIPTION
#### Overview:

Fix a bug where Dynamo's omni handler always set `negative_prompt=""` (empty string) instead of `None` when the user didn't provide one. This inadvertently enabled Classifier-Free Guidance (CFG) in diffusion pipelines (e.g. Qwen-Image), causing **2x the expected latency** by running two forward passes per denoising step instead of one.

#### Details:

In `_engine_inputs_from_image` and `_engine_inputs_from_video`, the previous code was:

```python
negative_prompt=nvext.negative_prompt or "" if nvext else "",
```

This always produced `""` when no negative prompt was provided. Downstream in the Qwen-Image pipeline, the check `has_neg_prompt = negative_prompt is not None` treats `""` as a valid negative prompt. Combined with `true_cfg_scale` defaulting to 4.0 (> 1), this enables `do_true_cfg = True`, which runs the transformer **twice per step** (once conditional, once unconditional).

Native vLLM-Omni avoids this by only setting `negative_prompt` when explicitly provided, leaving it as `None` otherwise.

The fix changes both image and video paths to:

```python
negative_prompt=nvext.negative_prompt if nvext and nvext.negative_prompt else None,
```

**Benchmark results (Qwen/Qwen-Image, 1 GPU, concurrency=1, vllm==0.14.0):**

| Image Size | Native vLLM-Omni | Dynamo (before) | Dynamo (after) |
|---|---|---|---|
| 1024x1024 (r=5) | 12,705 ms | 25,518 ms | 12,786 ms |
| 256x256 (r=10) | 2,207 ms | 4,291 ms | 2,237 ms |

#### Where should the reviewer start?

- `components/src/dynamo/vllm/omni/omni_handler.py` — lines 242 and 284

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes omni diffusion 2x performance regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of negative prompts for image and video requests. The system now correctly distinguishes between explicitly absent and empty negative prompts, providing more accurate data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->