### PR TITLE
fix: Fix dev container build

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -221,7 +221,6 @@ ${NIXL_LIB_DIR}:\
 ${NIXL_PLUGIN_DIR}:\
 /usr/local/ucx/lib:\
 /usr/local/ucx/lib/ucx:\
-/usr/local/cuda/compat/lib.real:\
 ${LD_LIBRARY_PATH}
 
 # Copy shell profile script for framework-specific environment variables

--- a/container/templates/trtllm_framework.Dockerfile
+++ b/container/templates/trtllm_framework.Dockerfile
@@ -105,7 +105,7 @@ ARG GITHUB_TRTLLM_COMMIT
 {% if context.trtllm.has_trtllm_context == "1" %}
 # Copy only wheel files and commit info from trtllm_wheel stage from build_context
 COPY --from=trtllm_wheel / /trtllm_wheel/
-{%- endif -%}
+{%- endif %}
 COPY --from=trtllm_wheel_image /app/tensorrt_llm /trtllm_wheel_image/
 
 # Cache uv downloads; uv handles its own locking for this cache.


### PR DESCRIPTION
#### Overview:

There were 2 bugs prior to this commit when building a TRTLLM dev container:

- template rendering bug
- CUDA compatibility layer

The `nvidia_entrypoint.sh` script should render the second completely unnecessary.

#### Details:

The 1st bug would error out during the wheel copying stage.

The 2nd bug would make it so that, in the container, using any actual GPU functionality would throw an error about compatibility issues.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container's CUDA library path configuration.
  * Fixed template formatting in framework container build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->