### PR TITLE
fix: Docker push retries

### DIFF
--- a/.github/actions/docker-tag-push/action.yml
+++ b/.github/actions/docker-tag-push/action.yml
@@ -51,9 +51,35 @@ runs:
         ECR_HOSTNAME: ${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com
       run: |
         set -euo pipefail
-        if [[ ${CONDITIONAL_TAG} != '' ]]; then
-            docker tag ${LOCAL_IMAGE} ${ECR_HOSTNAME}/${CONDITIONAL_TAG}
-            docker push ${ECR_HOSTNAME}/${CONDITIONAL_TAG}
+        retry_push() {
+          local image="$1"
+          local max_attempts=8
+          local wait_seconds=10
+          local attempt=1
+
+          while true; do
+            if docker push "$image"; then
+              return 0
+            fi
+
+            if (( attempt >= max_attempts )); then
+              echo "Push failed after ${max_attempts} attempts: $image"
+              return 1
+            fi
+
+            echo "Push failed for $image (attempt ${attempt}/${max_attempts}); retrying in ${wait_seconds}s..."
+            sleep "$wait_seconds"
+            attempt=$((attempt + 1))
+            wait_seconds=$((wait_seconds * 2))
+            if (( wait_seconds > 120 )); then
+              wait_seconds=120
+            fi
+          done
+        }
+
+        if [[ -n "${CONDITIONAL_TAG}" ]]; then
+            docker tag "${LOCAL_IMAGE}" "${ECR_HOSTNAME}/${CONDITIONAL_TAG}"
+            retry_push "${ECR_HOSTNAME}/${CONDITIONAL_TAG}"
         fi
         while IFS= read -r TAG; do
           if [ -z "$TAG" ]; then
@@ -61,7 +87,7 @@ runs:
           fi
           echo "Tagging and pushing: ${ECR_HOSTNAME}/${TAG}"
           docker tag "${LOCAL_IMAGE}" "${ECR_HOSTNAME}/${TAG}"
-          docker push "${ECR_HOSTNAME}/${TAG}"
+          retry_push "${ECR_HOSTNAME}/${TAG}"
         done <<< "$PUSH_TAGS"
     - name: ACR Tag and Push
       shell: bash
@@ -72,11 +98,37 @@ runs:
         AZURE_ACR_HOSTNAME: ${{ inputs.azure_acr_hostname }}
       run: |
         set -euo pipefail
+        retry_push() {
+          local image="$1"
+          local max_attempts=8
+          local wait_seconds=10
+          local attempt=1
+
+          while true; do
+            if docker push "$image"; then
+              return 0
+            fi
+
+            if (( attempt >= max_attempts )); then
+              echo "Push failed after ${max_attempts} attempts: $image"
+              return 1
+            fi
+
+            echo "Push failed for $image (attempt ${attempt}/${max_attempts}); retrying in ${wait_seconds}s..."
+            sleep "$wait_seconds"
+            attempt=$((attempt + 1))
+            wait_seconds=$((wait_seconds * 2))
+            if (( wait_seconds > 120 )); then
+              wait_seconds=120
+            fi
+          done
+        }
+
         while IFS= read -r TAG; do
           if [ -z "$TAG" ]; then
             continue
           fi
           echo "Tagging and pushing: ${AZURE_ACR_HOSTNAME}/${TAG}"
           docker tag "${LOCAL_IMAGE}" "${AZURE_ACR_HOSTNAME}/${TAG}"
-          docker push "${AZURE_ACR_HOSTNAME}/${TAG}"
+          retry_push "${AZURE_ACR_HOSTNAME}/${TAG}"
         done <<< "$PUSH_TAGS"

--- a/.github/actions/docker-tag-push/action.yml
+++ b/.github/actions/docker-tag-push/action.yml
@@ -51,31 +51,7 @@ runs:
         ECR_HOSTNAME: ${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com
       run: |
         set -euo pipefail
-        retry_push() {
-          local image="$1"
-          local max_attempts=8
-          local wait_seconds=10
-          local attempt=1
-
-          while true; do
-            if docker push "$image"; then
-              return 0
-            fi
-
-            if (( attempt >= max_attempts )); then
-              echo "Push failed after ${max_attempts} attempts: $image"
-              return 1
-            fi
-
-            echo "Push failed for $image (attempt ${attempt}/${max_attempts}); retrying in ${wait_seconds}s..."
-            sleep "$wait_seconds"
-            attempt=$((attempt + 1))
-            wait_seconds=$((wait_seconds * 2))
-            if (( wait_seconds > 120 )); then
-              wait_seconds=120
-            fi
-          done
-        }
+        source "${{ github.action_path }}/retry_push.sh"
 
         if [[ -n "${CONDITIONAL_TAG}" ]]; then
             docker tag "${LOCAL_IMAGE}" "${ECR_HOSTNAME}/${CONDITIONAL_TAG}"
@@ -98,31 +74,7 @@ runs:
         AZURE_ACR_HOSTNAME: ${{ inputs.azure_acr_hostname }}
       run: |
         set -euo pipefail
-        retry_push() {
-          local image="$1"
-          local max_attempts=8
-          local wait_seconds=10
-          local attempt=1
-
-          while true; do
-            if docker push "$image"; then
-              return 0
-            fi
-
-            if (( attempt >= max_attempts )); then
-              echo "Push failed after ${max_attempts} attempts: $image"
-              return 1
-            fi
-
-            echo "Push failed for $image (attempt ${attempt}/${max_attempts}); retrying in ${wait_seconds}s..."
-            sleep "$wait_seconds"
-            attempt=$((attempt + 1))
-            wait_seconds=$((wait_seconds * 2))
-            if (( wait_seconds > 120 )); then
-              wait_seconds=120
-            fi
-          done
-        }
+        source "${{ github.action_path }}/retry_push.sh"
 
         while IFS= read -r TAG; do
           if [ -z "$TAG" ]; then

--- a/.github/actions/docker-tag-push/retry_push.sh
+++ b/.github/actions/docker-tag-push/retry_push.sh
@@ -1,0 +1,25 @@
+retry_push() {
+  local image="$1"
+  local max_attempts=8
+  local wait_seconds=10
+  local attempt=1
+
+  while true; do
+    if docker push "$image"; then
+      return 0
+    fi
+
+    if (( attempt >= max_attempts )); then
+      echo "Push failed after ${max_attempts} attempts: $image"
+      return 1
+    fi
+
+    echo "Push failed for $image (attempt ${attempt}/${max_attempts}); retrying in ${wait_seconds}s..."
+    sleep "$wait_seconds"
+    attempt=$((attempt + 1))
+    wait_seconds=$((wait_seconds * 2))
+    if (( wait_seconds > 120 )); then
+      wait_seconds=120
+    fi
+  done
+}

--- a/.github/actions/docker-tag-push/retry_push.sh
+++ b/.github/actions/docker-tag-push/retry_push.sh
@@ -1,6 +1,9 @@
+# Retry docker push with exponential backoff.
+# Safe under `set -e`: the `if` conditional context prevents a failed
+# `docker push` from triggering an immediate exit.
 retry_push() {
   local image="$1"
-  local max_attempts=8
+  local max_attempts=3
   local wait_seconds=10
   local attempt=1
 
@@ -8,13 +11,14 @@ retry_push() {
     if docker push "$image"; then
       return 0
     fi
+    echo "Push failed for $image (attempt ${attempt}/${max_attempts})." >&2
 
     if (( attempt >= max_attempts )); then
-      echo "Push failed after ${max_attempts} attempts: $image"
+      echo "Push failed after ${max_attempts} attempts: $image" >&2
       return 1
     fi
 
-    echo "Push failed for $image (attempt ${attempt}/${max_attempts}); retrying in ${wait_seconds}s..."
+    echo "Retrying in ${wait_seconds}s..."
     sleep "$wait_seconds"
     attempt=$((attempt + 1))
     wait_seconds=$((wait_seconds * 2))

--- a/.github/actions/skopeo-copy/action.yml
+++ b/.github/actions/skopeo-copy/action.yml
@@ -109,7 +109,7 @@ runs:
         RETRY_DELAY=10
         for attempt in $(seq 1 $MAX_RETRIES); do
           echo "Attempt ${attempt}/${MAX_RETRIES}..."
-          if skopeo copy --all "${SOURCE_REF}" "${TARGET_REF}"; then
+          if skopeo copy --all --retry-times 3 "${SOURCE_REF}" "${TARGET_REF}"; then
             echo "target_image_ref=${{ inputs.target_registry }}/${TARGET_IMAGE}:${TARGET_TAG}" >> $GITHUB_OUTPUT
             echo "✅ Image copied successfully"
             exit 0

--- a/.github/workflows/build-test-distribute-flavor.yml
+++ b/.github/workflows/build-test-distribute-flavor.yml
@@ -90,7 +90,7 @@ on:
         description: 'Timeout in minutes for the copy to ACR step'
         required: false
         type: number
-        default: 5
+        default: 10
     secrets:
       AWS_DEFAULT_REGION:
         required: true


### PR DESCRIPTION
#### Overview:

docker push now retries with longer waits in both ECR and ACR flows.

- Updated [action.yml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Added retry_push() in each push step:
  - max_attempts=8
  - initial wait 10s
  - exponential backoff (10s, 20s, 40s, …) capped at 120s
- Replaced every direct docker push ... call (including conditional_tag) with retry_push ....
- Kept existing tagging behavior unchanged; only push resilience was modified.
- Validation: no file errors reported by editor diagnostics.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced reliability of Docker image push operations by implementing an automatic retry mechanism with exponential backoff, ensuring more robust deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->