### PR TITLE
fix: Batch KV events in Mocker

### DIFF
--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -181,6 +181,7 @@ impl KvManager {
         match event {
             MoveBlock::Use(hashes, local_hashes) => {
                 let mut blocks_stored = Vec::<u64>::new();
+                let mut blocks_evicted = Vec::<u64>::new();
 
                 let mut parent_block: Option<&UniqueBlock> = None;
                 for hash in hashes {
@@ -208,7 +209,7 @@ impl KvManager {
                             self.dp_rank
                         );
                         if let UniqueBlock::FullBlock(evicted_full_block) = evicted {
-                            self.publish_kv_event(vec![evicted_full_block], &[], None, false);
+                            blocks_evicted.push(evicted_full_block);
                         }
                     }
 
@@ -225,6 +226,7 @@ impl KvManager {
                     Some(UniqueBlock::FullBlock(block)) => Some(*block),
                     Some(UniqueBlock::PartialBlock(_)) => panic!("parent block cannot be partial"),
                 };
+                self.publish_kv_event(blocks_evicted, &[], None, false);
                 self.publish_kv_event(blocks_stored, local_hashes, parent_hash, true);
             }
 


### PR DESCRIPTION
Instead of emitting individual remove events for each block, batch them together. This more closely matches what the inference frameworks do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized KV cache event batching to aggregate multiple block evictions into a single event, reducing event publishing overhead.

* **Tests**
  * Added comprehensive test coverage for KV cache event batching behavior to validate correct event aggregation and ordering during cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->