### PR TITLE
chore: use config.modality directly for multimodal init and remove incorrect fallback value

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -161,7 +161,6 @@ async def init_llm_worker(
     )
     kv_connector_config = build_kv_connector_config(config)
 
-    modality = getattr(config, "modality", None) or "text"
     arg_map = {
         "model": model_path,
         "scheduler_config": scheduler_config,
@@ -290,7 +289,7 @@ async def init_llm_worker(
         # This overrides the skip_tokenizer_init=True set earlier
         engine_args["skip_tokenizer_init"] = False
 
-    if modality == Modality.MULTIMODAL:
+    if config.modality == Modality.MULTIMODAL:
         engine_args["skip_tokenizer_init"] = False
         model_config = AutoConfig.from_pretrained(config.model, trust_remote_code=True)
         multimodal_processor = MultimodalRequestProcessor(


### PR DESCRIPTION

#### Overview:

Clean up the modality config check.

#### Details:

Removed redundant local variable with incorrect fallback value, use config.modality directly. 

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified modality configuration handling by directly accessing configuration settings instead of using local processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->