### PR TITLE
chore: exclude docs/ Python files from CODEOWNERS review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,9 @@ Cargo.toml @ai-dynamo/dynamo-rust-codeowners
 # Python Libraries
 *.py @ai-dynamo/python-codeowners @ai-dynamo/Devops
 
+# Docs utility scripts (diagram generators, conversion tools — not production code)
+/docs/**/*.py
+
 # Container/Environments
 /container/ @ai-dynamo/Devops @ai-dynamo/dynamo-rust-codeowners @ai-dynamo/python-codeowners @ai-dynamo/dynamo-deploy-codeowners
 


### PR DESCRIPTION
## Summary

- Add a no-owner CODEOWNERS override for `/docs/**/*.py` so Python utility scripts in `docs/` (diagram generators, callout converters, etc.) don't trigger `@ai-dynamo/python-codeowners` and `@ai-dynamo/Devops` review
- The global `*.py` catch-all currently matches all Python files regardless of location, requiring unnecessary reviews for non-production Python scripts. 

## Context

Discovered while putting another PR that triggered full Python codeowner review despite being docs-only utility scripts.

## Test Plan

- [ ] Verify CODEOWNERS syntax is valid (GitHub parses it on push)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership and review assignments for documentation-related scripts to ensure appropriate team oversight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->