### PR TITLE
fix: Forward stream_options through multimodal request pipeline

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/protocol.py
+++ b/components/src/dynamo/vllm/multimodal_utils/protocol.py
@@ -157,6 +157,7 @@ class MultiModalRequest(BaseModel):
     max_tokens: Optional[int] = None
     temperature: Optional[float] = None
     stream: Optional[bool] = True
+    stream_options: Optional[dict] = None
 
 
 class MultiModalInput(BaseModel):

--- a/examples/multimodal/components/processor.py
+++ b/examples/multimodal/components/processor.py
@@ -221,6 +221,7 @@ class Processor(ProcessMixIn):
             model=raw_request.model,
             messages=[msg],
             stream=True,
+            stream_options=raw_request.stream_options,
             max_tokens=raw_request.max_tokens,
             temperature=raw_request.temperature,
             request_id=str(uuid.uuid4()),

--- a/examples/multimodal/utils/protocol.py
+++ b/examples/multimodal/utils/protocol.py
@@ -146,6 +146,7 @@ class MultiModalRequest(BaseModel):
     max_tokens: Optional[int] = None
     temperature: Optional[float] = None
     stream: Optional[bool] = True
+    stream_options: Optional[dict] = None
 
 
 class MultiModalInput(BaseModel):


### PR DESCRIPTION
## Summary

- Added `stream_options` field to `MultiModalRequest` Pydantic model so the value from incoming HTTP requests is no longer silently dropped
- Forward `stream_options` when constructing `ChatCompletionRequest` in the multimodal processor
- Applied the same fix to the example copy of the protocol

## Root cause

`MultiModalRequest` didn't include a `stream_options` field, so Pydantic silently discarded it during request parsing. When the downstream `ChatCompletionRequest` was constructed, `stream_options` was never forwarded, causing `usage: None` in the final streaming chunk even when `"stream_options": {"include_usage": true}` was set in the request body.

## Validation

I traced through the full request path to confirm the fix:

1. **`MultiModalRequest` (protocol.py)** — previously had only `model`, `messages`, `max_tokens`, `temperature`, `stream`. Any `stream_options` in the JSON body was silently dropped by Pydantic since the field didn't exist on the model. After the fix, it's captured as `Optional[dict]`.

2. **`Processor.generate()` (processor.py)** — previously constructed `ChatCompletionRequest` without `stream_options`. After the fix, `raw_request.stream_options` is passed through. vLLM's `ChatCompletionRequest` accepts this and coerces the dict into its `StreamOptions` model.

3. Verified there are no other code paths that construct `ChatCompletionRequest` from `MultiModalRequest` (grepped the full repo).

Using `Optional[dict]` for the field type keeps the protocol model backend-agnostic and avoids tight coupling to vLLM's specific `StreamOptions` class.

## Test plan

- [ ] Send a streaming multimodal request with `"stream_options": {"include_usage": true}` and verify the final chunk includes `usage` with token counts
- [ ] Send a streaming multimodal request without `stream_options` and verify behavior is unchanged (usage is None)

Fixes #6251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming configuration options support. Users can now pass additional streaming settings through the API to enable enhanced stream customization and more flexible streaming behavior control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->