### PR TITLE
fix: derive kv-router discovery name from target worker component

### DIFF
--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -419,9 +419,9 @@ impl ModelManager {
         let instance_id = discovery.instance_id();
 
         // Build transport for router endpoint based on request plane mode
-        // Derive the router's discovery component name from the target worker component
+        // Use the worker's component name so each target pool gets its own router discovery group
         let router_endpoint_id =
-            router_endpoint_id(endpoint.id().namespace, &endpoint.id().component);
+            router_endpoint_id(endpoint.id().namespace, endpoint.id().component);
         let transport = build_transport_type(endpoint, &router_endpoint_id, instance_id).await?;
 
         let discovery_spec = DiscoverySpec::Endpoint {

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -419,8 +419,9 @@ impl ModelManager {
         let instance_id = discovery.instance_id();
 
         // Build transport for router endpoint based on request plane mode
-        // Use KV_ROUTER_COMPONENT as the component name to distinguish from the generate endpoint's component
-        let router_endpoint_id = router_endpoint_id(endpoint.id().namespace);
+        // Derive the router's discovery component name from the target worker component
+        let router_endpoint_id =
+            router_endpoint_id(endpoint.id().namespace, &endpoint.id().component);
         let transport = build_transport_type(endpoint, &router_endpoint_id, instance_id).await?;
 
         let discovery_spec = DiscoverySpec::Endpoint {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -88,26 +88,22 @@ pub fn worker_kv_indexer_query_endpoint(dp_rank: DpRank) -> String {
 }
 
 // for router discovery registration
-pub const KV_ROUTER_ENDPOINT: &str = "generate";
-
-fn kv_router_component_name(target_component: &str) -> String {
-    format!("{target_component}-kv-router")
-}
+pub const KV_ROUTER_ENDPOINT: &str = "router-discovery";
 
 /// Creates an EndpointId for the KV router in the given namespace.
-pub fn router_endpoint_id(namespace: String, target_component: &str) -> EndpointId {
+pub fn router_endpoint_id(namespace: String, component: String) -> EndpointId {
     EndpointId {
         namespace,
-        component: kv_router_component_name(target_component),
+        component,
         name: KV_ROUTER_ENDPOINT.to_string(),
     }
 }
 
 /// Creates a DiscoveryQuery for the KV router in the given namespace.
-pub fn router_discovery_query(namespace: String, target_component: &str) -> DiscoveryQuery {
+pub fn router_discovery_query(namespace: String, component: String) -> DiscoveryQuery {
     DiscoveryQuery::Endpoint {
         namespace,
-        component: kv_router_component_name(target_component),
+        component,
         endpoint: KV_ROUTER_ENDPOINT.to_string(),
     }
 }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -88,23 +88,26 @@ pub fn worker_kv_indexer_query_endpoint(dp_rank: DpRank) -> String {
 }
 
 // for router discovery registration
-pub const KV_ROUTER_COMPONENT: &str = "kv-router";
 pub const KV_ROUTER_ENDPOINT: &str = "generate";
 
+fn kv_router_component_name(target_component: &str) -> String {
+    format!("{target_component}-kv-router")
+}
+
 /// Creates an EndpointId for the KV router in the given namespace.
-pub fn router_endpoint_id(namespace: String) -> EndpointId {
+pub fn router_endpoint_id(namespace: String, target_component: &str) -> EndpointId {
     EndpointId {
         namespace,
-        component: KV_ROUTER_COMPONENT.to_string(),
+        component: kv_router_component_name(target_component),
         name: KV_ROUTER_ENDPOINT.to_string(),
     }
 }
 
 /// Creates a DiscoveryQuery for the KV router in the given namespace.
-pub fn router_discovery_query(namespace: String) -> DiscoveryQuery {
+pub fn router_discovery_query(namespace: String, target_component: &str) -> DiscoveryQuery {
     DiscoveryQuery::Endpoint {
         namespace,
-        component: KV_ROUTER_COMPONENT.to_string(),
+        component: kv_router_component_name(target_component),
         endpoint: KV_ROUTER_ENDPOINT.to_string(),
     }
 }

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -283,7 +283,7 @@ pub async fn start_kv_router_background(
     let generate_endpoint = component.endpoint("generate");
     let discovery_client = component.drt().discovery();
     let router_discovery_key =
-        router_discovery_query(component.namespace().name(), component.name());
+        router_discovery_query(component.namespace().name(), component.name().to_string());
     let mut router_event_stream = discovery_client
         .list_and_watch(router_discovery_key, Some(cancellation_token.clone()))
         .await?;
@@ -575,7 +575,7 @@ async fn cleanup_orphaned_consumers(
     let Ok(router_instances) = discovery
         .list(router_discovery_query(
             component.namespace().name(),
-            component.name(),
+            component.name().to_string(),
         ))
         .await
     else {

--- a/lib/llm/src/kv_router/subscriber.rs
+++ b/lib/llm/src/kv_router/subscriber.rs
@@ -282,7 +282,8 @@ pub async fn start_kv_router_background(
     // Watch for router deletions to clean up orphaned consumers via discovery
     let generate_endpoint = component.endpoint("generate");
     let discovery_client = component.drt().discovery();
-    let router_discovery_key = router_discovery_query(component.namespace().name());
+    let router_discovery_key =
+        router_discovery_query(component.namespace().name(), component.name());
     let mut router_event_stream = discovery_client
         .list_and_watch(router_discovery_key, Some(cancellation_token.clone()))
         .await?;
@@ -572,7 +573,10 @@ async fn cleanup_orphaned_consumers(
     // Get active routers from discovery
     let discovery = component.drt().discovery();
     let Ok(router_instances) = discovery
-        .list(router_discovery_query(component.namespace().name()))
+        .list(router_discovery_query(
+            component.namespace().name(),
+            component.name(),
+        ))
         .await
     else {
         tracing::debug!("Failed to list router instances from discovery, skipping cleanup");


### PR DESCRIPTION
## Summary

Replaces the hardcoded `"kv-router"` discovery component name with `"{target_component}-kv-router"` (e.g. `"prefill-kv-router"`, `"decode-kv-router"`). In disagg mode with prefill and decode workers in the same namespace, this prevents cross-stream consumer cleanup where prefill routers would try to clean decode router consumers and vice versa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced KV router service discovery to incorporate target component information alongside namespace when deriving service endpoints, improving endpoint identification accuracy during registration and transport initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->