### PR TITLE
fix(chrek): fix CI errors and replace SIGUSR2 with SIGKILL on checkpoint failure

### DIFF
--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -161,9 +161,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 | dynamo-operator.webhook.certManager.certificate.rootCA.duration | string | `"87600h"` | Duration for the root CA certificate (e.g., "87600h" for 10 years). The root CA typically has a much longer lifetime than the leaf certificates it signs. |
 | dynamo-operator.webhook.certManager.certificate.rootCA.renewBefore | string | `"720h"` | Time before root CA expiration to trigger renewal (e.g., "720h" for 30 days). Renewing a CA can be disruptive as all signed certificates must be reissued. |
 | dynamo-operator.checkpoint.enabled | bool | `false` | Whether to enable checkpoint/restore functionality |
-| dynamo-operator.checkpoint.initContainerImage | string | `"busybox:latest"` | Image used for init containers in checkpoint jobs (e.g., signal file cleanup) |
 | dynamo-operator.checkpoint.readyForCheckpointFilePath | string | `"/tmp/ready-for-checkpoint"` | Path written by worker when model is loaded and ready for checkpointing |
-| dynamo-operator.checkpoint.restoreMarkerFilePath | string | `"/tmp/dynamo-restored"` | Path written by restore-entrypoint after successful CRIU restore |
 | dynamo-operator.checkpoint.storage.type | string | `"pvc"` | Storage backend type: pvc, s3, or oci |
 | dynamo-operator.checkpoint.storage.pvc.pvcName | string | `"chrek-pvc"` | Name of the PVC created by the chrek chart |
 | dynamo-operator.checkpoint.storage.pvc.basePath | string | `"/checkpoints"` | Base path within the PVC for storing checkpoints |


### PR DESCRIPTION
## Summary

- Remove stale `initContainerImage` and `restoreMarkerFilePath` entries from the platform helm chart README that were removed from the operator values.yaml in #6286 but not regenerated
- Fix broken `chrek.py` link in standalone docs (renamed to `checkpoint_restore.py` in #6286)
- Fix race condition in the docs code example: install signal handlers **before** writing the ready file (matching the actual `checkpoint_restore.py` implementation)
- Replace SIGUSR2 with SIGKILL for checkpoint failure signal: after a failed checkpoint, the process is unrecoverable (CUDA is locked with no cleanup path), so the watcher now sends SIGKILL to terminate immediately instead of SIGUSR2 which required application-side handling
- Remove all SIGUSR2 failure-handling code from `checkpoint_restore.py` (signal handler, asyncio event, wait branch, RuntimeError) since SIGKILL cannot be caught
- Update all signal documentation in standalone.md (bullet list, code example, important notes, reference table) and watcher.go comments to reflect the SIGUSR2 → SIGKILL change

## Test plan

- [ ] CI `check` job passes (helm README matches generated output)
- [ ] CI `lychee` link checker passes (no more 404 for `chrek.py`)
- [ ] `go build ./...` passes in `deploy/chrek/` (verified locally)
- [ ] Checkpoint success path unaffected (SIGUSR1 handling unchanged)
- [ ] Checkpoint failure terminates pod with exit code 137 (SIGKILL)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated checkpoint and restore process documentation to reflect revised signal handling behavior.
  * Updated reference implementation paths in documentation.
  * Removed deprecated checkpoint configuration entries from platform chart values.

* **Changes**
  * Modified checkpoint failure handling to use immediate process termination.
  * Simplified signal coordination logic for checkpoint/restore operations with reordered initialization sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->