### PR TITLE
fix: frontend crash when using TRTLLM runtime image

### DIFF
--- a/components/src/dynamo/common/config_dump/config_dumper.py
+++ b/components/src/dynamo/common/config_dump/config_dumper.py
@@ -45,14 +45,17 @@ def _get_package_version(dist_name: str) -> Optional[str]:
 
 
 def _get_sglang_version() -> Optional[str]:
+    """Get SGLang version if installed, without importing the module."""
     return _get_package_version("sglang")
 
 
 def _get_trtllm_version() -> Optional[str]:
+    """Get TensorRT-LLM version if installed, without importing the module."""
     return _get_package_version("tensorrt-llm")
 
 
 def _get_vllm_version() -> Optional[str]:
+    """Get vLLM version if installed, without importing the module."""
     return _get_package_version("vllm")
 
 

--- a/components/src/dynamo/common/config_dump/config_dumper.py
+++ b/components/src/dynamo/common/config_dump/config_dumper.py
@@ -4,6 +4,7 @@
 import argparse
 import dataclasses
 import functools
+import importlib.metadata
 import json
 import logging
 import pathlib
@@ -21,58 +22,38 @@ from .system_info import (
 logger = logging.getLogger(__name__)
 
 
-def _get_sglang_version() -> Optional[str]:
-    """Get SGLang version if available.
+def _get_package_version(dist_name: str) -> Optional[str]:
+    """Get installed package version via metadata, without importing the module.
+
+    Uses importlib.metadata to avoid module-level side effects. Importing
+    framework packages (tensorrt_llm, vllm, sglang) triggers heavy native
+    initialization (CUDA context, TensorRT bindings, torch extensions) that
+    can crash the process when the runtime environment doesn't match—e.g.,
+    importing tensorrt_llm in a frontend pod that has no GPU allocation.
+
+    Args:
+        dist_name: Distribution name (e.g., "tensorrt-llm", "vllm", "sglang").
 
     Returns:
-        Version string if SGLang is installed, None otherwise.
+        Version string if the package is installed, None otherwise.
     """
     try:
-        import sglang as sgl
+        return importlib.metadata.version(dist_name)
+    except importlib.metadata.PackageNotFoundError:
+        logger.debug(f"{dist_name} not installed")
+        return None
 
-        return sgl.__version__
-    except ImportError:
-        logger.debug("SGLang not available")
-        return None
-    except AttributeError:
-        logger.warning("SGLang installed but version not available")
-        return None
+
+def _get_sglang_version() -> Optional[str]:
+    return _get_package_version("sglang")
 
 
 def _get_trtllm_version() -> Optional[str]:
-    """Get TensorRT-LLM version if available.
-
-    Returns:
-        Version string if TensorRT-LLM is installed, None otherwise.
-    """
-    try:
-        import tensorrt_llm
-
-        return tensorrt_llm.__version__
-    except ImportError:
-        logger.debug("TensorRT-LLM not available")
-        return None
-    except AttributeError:
-        logger.warning("TensorRT-LLM installed but version not available")
-        return None
+    return _get_package_version("tensorrt-llm")
 
 
 def _get_vllm_version() -> Optional[str]:
-    """Get vLLM version if available.
-
-    Returns:
-        Version string if vLLM is installed, None otherwise.
-    """
-    try:
-        import vllm
-
-        return vllm.__version__
-    except ImportError:
-        logger.debug("vLLM not available")
-        return None
-    except AttributeError:
-        logger.warning("vLLM installed but version not available")
-        return None
+    return _get_package_version("vllm")
 
 
 def _get_dynamo_version() -> str:


### PR DESCRIPTION
#### Overview:

- Frontend crashes silently (no traceback, no log output) when deployed in a TRTLLM runtime container image. Works fine with vLLM runtime or frontend-only images.
- Root cause: `_get_trtllm_version()` in `config_dumper.py` does `import tensorrt_llm` to read the version. In the TRTLLM container the package is installed, so the import triggers CUDA context init and TensorRT native binding loads. The frontend pod has no GPU allocation → native init segfaults before Python can catch anything.
- The import always executes because `configure_dynamo_logging()` sets the root logger to DEBUG unconditionally, making the `getEffectiveLevel() <= DEBUG` guard in `dump_config()` always true.
- Fix: replace `import tensorrt_llm` / `import vllm` / `import sglang` with `importlib.metadata.version()` which reads version from installed package metadata on disk — no native code, no module-level side effects.

#### Details:

The frontend process crashes silently—no traceback, no log output even at DYN_LOG=debug—when deployed using a TRTLLM runtime container image. The crash doesn't happen with vLLM runtime or frontend-only images.

The root cause is in config_dumper.py. The three version-detection functions (_get_trtllm_version, _get_vllm_version, _get_sglang_version) import the framework modules directly to read __version__. In the TRTLLM container, tensorrt_llm is installed, so the import succeeds—but it triggers CUDA context initialization and TensorRT native binding loads at import time. The frontend pod has no GPU allocation, so this native init segfaults before Python gets a chance to catch anything.

This code path always executes because configure_dynamo_logging() sets the root logger to DEBUG unconditionally, which means the getEffectiveLevel() <= DEBUG guard in dump_config() is always true, and get_config_dump() always calls the version functions.

The fix replaces all three framework imports with importlib.metadata.version(), which reads the version string from the installed package's dist-info/METADATA file on disk. No module __init__.py execution, no native extension loading, no CUDA context.

#### Where should the reviewer start?

The entire change is in components/src/dynamo/common/config_dump/config_dumper.py. Look at the new _get_package_version() helper (line 25) and the three one-liner delegates that replaced the old import-based functions. The call sites in get_config_dump() are unchanged.

For context on why the old code always ran, see lib/bindings/python/src/dynamo/runtime/logging.py:53 where the root logger level is set to DEBUG.


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #6408


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved version detection mechanism for third-party packages (sglang, tensorrt-llm, vllm) in the config dumper utility with enhanced error handling for missing packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->