### PR TITLE
fix: add pre_merge markers to vLLM unit tests

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_kv_events_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_kv_events_api.py
@@ -32,6 +32,8 @@ KVCacheEvent = _kv_events.KVCacheEvent
 pytestmark = [
     pytest.mark.vllm,
     pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
 ]
 
 
@@ -49,7 +51,6 @@ class TestVllmKvEventsApi:
         5. lora_id
         6. medium
         7. lora_name (added in vLLM 0.14.0)
-        8. extra_keys (contains MM info, cache_salt, etc.)
 
         If vLLM adds/removes/reorders fields, this test will fail.
         """
@@ -61,7 +62,6 @@ class TestVllmKvEventsApi:
             "lora_id",
             "medium",
             "lora_name",
-            "extra_keys",
         )
 
         actual_fields = BlockStored.__struct_fields__
@@ -148,7 +148,6 @@ class TestVllmKvEventsApi:
             lora_id=None,
             medium="GPU",
             lora_name=None,
-            extra_keys=None,
         )
 
         encoded = msgspec.msgpack.encode(event)
@@ -160,9 +159,9 @@ class TestVllmKvEventsApi:
             decoded[0] == "BlockStored"
         ), f"Expected tag 'BlockStored', got {decoded[0]}"
 
-        # Verify field count (tag + 8 fields = 9 elements)
-        assert len(decoded) == 9, (
-            f"Expected 9 elements (tag + 8 fields), got {len(decoded)}.\n"
+        # Verify field count (tag + 7 fields = 8 elements)
+        assert len(decoded) == 8, (
+            f"Expected 8 elements (tag + 7 fields), got {len(decoded)}.\n"
             f"Decoded: {decoded}\n"
             f"If field count changed, update Rust deserializers."
         )
@@ -175,4 +174,3 @@ class TestVllmKvEventsApi:
         assert decoded[5] is None, f"lora_id at wrong position: {decoded[5]}"
         assert decoded[6] == "GPU", f"medium at wrong position: {decoded[6]}"
         assert decoded[7] is None, f"lora_name at wrong position: {decoded[7]}"
-        assert decoded[8] is None, f"extra_keys at wrong position: {decoded[8]}"

--- a/components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
@@ -16,6 +16,8 @@ from dynamo.vllm.handlers import BaseWorkerHandler
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
 ]
 
 

--- a/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
@@ -51,6 +51,8 @@ OutputProcessorOutput = _output_processor_mod.OutputProcessorOutput
 pytestmark = [
     pytest.mark.vllm,
     pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
 ]
 
 


### PR DESCRIPTION
## Summary
- Add `pytest.mark.pre_merge` and `pytest.mark.gpu_0` to 3 vLLM test files (`test_vllm_kv_events_api.py`, `test_vllm_prompt_embeds.py`, `test_vllm_renderer_api.py`) so CI collects them via `unit and (post_merge or pre_merge)`
- Remove `extra_keys` from `BlockStored` test expectations to match vLLM 0.15.1 (field was removed upstream; Rust deserializers already handle this gracefully via `unwrap_or(None)` and `#[serde(default)]`)

## Test plan
- [x] All 49 unit tests pass across the 3 modified files
- [x] `test_kvbm.py` integration tests pass (validates KV event publish/subscribe with no `extra_keys`)
- [x] CI marker collection now picks up 76 tests (previously ~28 from files that already had markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test categorization for improved test management and execution.
  * Refined internal test data structures for better alignment with current specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->