### PR TITLE
fix: clean up completed webhook Jobs after helm install/upgrade

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/webhook-ca-inject-job.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-ca-inject-job.yaml
@@ -149,7 +149,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  ttlSecondsAfterFinished: 600
   backoffLimit: 5
   template:
     metadata:

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-ca-inject-job.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-ca-inject-job.yaml
@@ -147,8 +147,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 600
   backoffLimit: 5
   template:
     metadata:

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-cert-gen-job.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-cert-gen-job.yaml
@@ -88,8 +88,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-4"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 600
   backoffLimit: 3
   template:
     metadata:

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-cert-gen-job.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-cert-gen-job.yaml
@@ -90,7 +90,6 @@ metadata:
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  ttlSecondsAfterFinished: 600
   backoffLimit: 3
   template:
     metadata:

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-crd-conversion-certmanager.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-crd-conversion-certmanager.yaml
@@ -89,8 +89,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 600
   backoffLimit: 5
   template:
     metadata:

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-crd-conversion-certmanager.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-crd-conversion-certmanager.yaml
@@ -91,7 +91,6 @@ metadata:
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  ttlSecondsAfterFinished: 600
   backoffLimit: 5
   template:
     metadata:


### PR DESCRIPTION
## Summary

- Webhook hook Jobs (`cert-gen`, `ca-inject`, `crd-conversion-patch`) accumulate indefinitely in `Completed` state after every `helm install`/`upgrade`. They're never garbage-collected.
- Root cause: the Jobs only use `before-hook-creation` as their `hook-delete-policy`, but each Job name includes `{{ .Release.Revision }}` (e.g., `webhook-cert-gen-1`, `webhook-cert-gen-2`). Helm treats each revision as a distinct resource and never matches the previous one for deletion.
- Fix: add `hook-succeeded` to the delete policy (Helm deletes the Job immediately on success) and set `ttlSecondsAfterFinished: 600` as a fallback so the Kubernetes TTL controller cleans up anything Helm misses (e.g., interrupted upgrades). This matches what `mpi-run-ssh-keygen` and `gpu-discovery-preflight` already do.

Fixes #6395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automatic cleanup of completed platform jobs after 10 minutes.
  * Enhanced Helm hook cleanup policies to remove temporary resources after successful execution, improving resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->