### PR TITLE
ci: add cargo-machete check for unused Rust dependencies

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -106,6 +106,11 @@ jobs:
       run: |
         cargo-deny --version || cargo install cargo-deny@0.19.0
         cargo-deny -L error --all-features check licenses bans --config ${{ github.workspace }}/deny.toml
+    - name: Install and Run cargo-machete
+      working-directory: ${{ matrix.dir }}
+      run: |
+        cargo-machete --version || cargo install cargo-machete@0.9.1
+        cargo machete --with-metadata
     # Have an explicit step to build tests first to separate time spent on build vs execution.
     - name: Compile Tests
       working-directory: ${{ matrix.dir }}

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -106,11 +106,6 @@ jobs:
       run: |
         cargo-deny --version || cargo install cargo-deny@0.19.0
         cargo-deny -L error --all-features check licenses bans --config ${{ github.workspace }}/deny.toml
-    - name: Install and Run cargo-machete
-      working-directory: ${{ matrix.dir }}
-      run: |
-        cargo-machete --version || cargo install cargo-machete@0.9.1
-        cargo machete --with-metadata
     # Have an explicit step to build tests first to separate time spent on build vs execution.
     - name: Compile Tests
       working-directory: ${{ matrix.dir }}
@@ -165,3 +160,8 @@ jobs:
     - name: Run Clippy Checks
       working-directory: ${{ matrix.dir }}
       run: cargo clippy --no-deps --all-targets -- -D warnings
+    - name: Install and Run cargo-machete
+      working-directory: ${{ matrix.dir }}
+      run: |
+        cargo-machete --version || cargo install cargo-machete@0.9.1
+        cargo machete --with-metadata

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -164,4 +164,4 @@ jobs:
       working-directory: ${{ matrix.dir }}
       run: |
         cargo-machete --version || cargo install cargo-machete@0.9.1
-        cargo machete --with-metadata
+        cargo machete


### PR DESCRIPTION
add cargo-machete check for unused Rust dependencies

closes: OPS-3408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened automated quality assurance by adding supplementary code analysis checks to the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->