### PR TITLE
ci: switch container-validation-dynamo to runtime target

### DIFF
--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -88,15 +88,15 @@ jobs:
           ECR_HOSTNAME: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
         run: |
           CUDA_MAJOR=${CUDA_VERSION%%.*}
-          IMAGE_TAG_SUFFIX="${{ github.sha }}-dynamo-dev-cuda${CUDA_MAJOR}-amd64"
+          IMAGE_TAG_SUFFIX="${{ github.sha }}-dynamo-runtime-cuda${CUDA_MAJOR}-amd64"
           echo "image_tag_suffix=${IMAGE_TAG_SUFFIX}" >> $GITHUB_OUTPUT
           echo "remote_tag=${ECR_HOSTNAME}/ai-dynamo/dynamo:${IMAGE_TAG_SUFFIX}" >> $GITHUB_OUTPUT
       - name: Generate Dockerfile
         shell: bash
         run: |
-          echo "Generating Dockerfile for target: dev and framework: dynamo"
+          echo "Generating Dockerfile for target: runtime and framework: dynamo"
           python ./container/render.py \
-              --target=dev \
+              --target=runtime \
               --framework=dynamo \
               --platform=amd64 \
               --cuda-version=${{ env.CUDA_VERSION }} \
@@ -107,7 +107,7 @@ jobs:
         with:
           image_tag: ${{ steps.define_image_tag.outputs.remote_tag }}
           framework: dynamo
-          target: dev
+          target: runtime
           platform: amd64
           cuda_version: ${{ env.CUDA_VERSION }}
           ci_token: ${{ secrets.CI_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
         run: docker pull ${{ env.IMAGE_TAG }}
       - name: Run Rust checks (block-manager + media-ffmpeg + integration tests)
         run: |
-          docker run --rm -w /workspace/lib/llm \
+          docker run --rm --user root -w /workspace/lib/llm \
             --name ${{ env.CONTAINER_ID }}_rust_checks \
             -e SCCACHE_BUCKET=${{ secrets.SCCACHE_S3_BUCKET }} \
             -e SCCACHE_REGION=${{ secrets.AWS_DEFAULT_REGION }} \

--- a/container/Dockerfile.template
+++ b/container/Dockerfile.template
@@ -12,7 +12,6 @@
     {% if target == "frontend" %}
         {% include "templates/dynamo_base.Dockerfile" %}
         {% include "templates/wheel_builder.Dockerfile" %}
-        {% include "templates/dynamo_runtime.Dockerfile" %}
         {% include "templates/frontend.Dockerfile" %}
     {% elif target == "runtime" or target == "dev" or target == "local-dev" %}
         {% include "templates/dynamo_base.Dockerfile" %}

--- a/container/templates/dynamo_runtime.Dockerfile
+++ b/container/templates/dynamo_runtime.Dockerfile
@@ -30,6 +30,13 @@ ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
     NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib/${ARCH_ALT}-linux-gnu/plugins \
     CARGO_TARGET_DIR=/opt/dynamo/target
 
+ENV LD_LIBRARY_PATH=\
+${NIXL_LIB_DIR}:\
+${NIXL_PLUGIN_DIR}:\
+/usr/local/ucx/lib:\
+/usr/local/ucx/lib/ucx:\
+${LD_LIBRARY_PATH}
+
 # Copy ucx and nixl libs
 COPY --chown=dynamo: --from=wheel_builder /usr/local/ucx/ /usr/local/ucx/
 COPY --chown=dynamo: --from=wheel_builder ${NIXL_PREFIX}/ ${NIXL_PREFIX}/

--- a/container/templates/dynamo_runtime.Dockerfile
+++ b/container/templates/dynamo_runtime.Dockerfile
@@ -59,7 +59,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         python${PYTHON_VERSION}-dev \
-        python${PYTHON_VERSION}-venv && \
+        python${PYTHON_VERSION}-venv \
+        build-essential \
+        cmake \
+        protobuf-compiler \
+        pkg-config \
+        clang \
+        libclang-dev \
+        patchelf \
+        git \
+        git-lfs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3
@@ -105,6 +114,26 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
         fi; \
         uv pip install "$KVBM_WHEEL"; \
     fi
+
+# Initialize Git LFS (required for git+https dependencies with LFS artifacts)
+RUN git lfs install
+
+# Install test and common dependencies
+RUN --mount=type=bind,source=./container/deps/requirements.txt,target=/tmp/requirements.txt \
+    --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.test.txt \
+    --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
+    export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
+    uv pip install \
+        --index-strategy unsafe-best-match \
+        --extra-index-url https://download.pytorch.org/whl/cu130 \
+        --requirement /tmp/requirements.txt \
+        --requirement /tmp/requirements.test.txt
+
+# Copy workspace source code
+ARG WORKSPACE_DIR=/workspace
+WORKDIR ${WORKSPACE_DIR}
+COPY --chmod=775 --chown=dynamo:0 ./ ${WORKSPACE_DIR}/
+RUN chmod g+w ${WORKSPACE_DIR}
 
 ARG DYNAMO_COMMIT_SHA
 ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -60,9 +60,11 @@ COPY --chown=dynamo: ATTRIBUTION* LICENSE /workspace/
 ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="/opt/dynamo/venv/bin:$PATH"
 
-# Copy uv and wheelhouse from runtime stage
-COPY --chown=dynamo: --from=runtime /bin/uv /bin/uvx /bin/
-COPY --chown=dynamo: --from=runtime /opt/dynamo/wheelhouse/ /opt/dynamo/wheelhouse/
+# Copy uv from base stage and wheels from wheel_builder (no runtime stage dependency)
+COPY --chown=dynamo: --from=dynamo_base /bin/uv /bin/uvx /bin/
+COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
+COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
+COPY --chown=dynamo: --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
 
 # Create virtual environment
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \


### PR DESCRIPTION
Switch the dynamo CI validation workflow from the dev target to runtime, removing heavy developer tools (vim, gdb, valgrind, nsight-systems, etc.) that are unnecessary for CI and also avoid editable install of dynamo wheels in CI container. The runtime image now includes build tools, test dependencies, and workspace source needed by CI job.

Decouple the frontend image from the runtime stage by copying uv and wheels directly from dynamo_base and wheel_builder stages.

closes: OPS-3412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build infrastructure to use runtime targets instead of development targets.
  * Enhanced runtime container image with improved library path configuration, expanded system dependencies, Git LFS support, and Python package management.
  * Refactored container artifact sourcing to use explicit build-time stages for more efficient builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->