### PR TITLE
fix: Remove --retry-delay flag from skopeo

### DIFF
--- a/.github/actions/skopeo-copy/action.yml
+++ b/.github/actions/skopeo-copy/action.yml
@@ -109,7 +109,7 @@ runs:
         RETRY_DELAY=10
         for attempt in $(seq 1 $MAX_RETRIES); do
           echo "Attempt ${attempt}/${MAX_RETRIES}..."
-          if skopeo copy --all --retry-times 4 --retry-delay 5s "${SOURCE_REF}" "${TARGET_REF}"; then
+          if skopeo copy --all --retry-times 4 "${SOURCE_REF}" "${TARGET_REF}"; then
             echo "target_image_ref=${{ inputs.target_registry }}/${TARGET_IMAGE}:${TARGET_TAG}" >> $GITHUB_OUTPUT
             echo "✅ Image copied successfully"
             exit 0


### PR DESCRIPTION
#### Overview:

Will put it back once we upgrade skopeo

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated retry mechanism in image copy operations to rely on exponential backoff timing rather than fixed per-call delays, improving overall retry behavior and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->