### PR TITLE
fix: add missing nvlink binary to vLLM and TRT-LLM runtime/dev/local-dev Dockerfiles

### DIFF
--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -9,6 +9,9 @@
 
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
 
+# NOTE: Unlike vLLM/TRTLLM, the SGLang upstream runtime image already ships with the full CUDA
+# toolkit (nvcc, nvlink, ptxas, etc.), so no selective COPY of CUDA binaries is needed here.
+
 # cleanup unnecessary libs (python3-blinker conflicts with pip-installed blinker from Flask/dash)
 RUN apt remove -y python3-apt python3-blinker && \
     pip uninstall -y termplotlib

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -34,6 +34,7 @@ ENV OMPI_MCA_coll_ucc_enable=0
 
 # Copy CUDA development tools (nvcc, headers, dependencies, etc.) from PyTorch base image
 COPY --from=pytorch_base /usr/local/cuda/bin/nvcc /usr/local/cuda/bin/nvcc
+COPY --from=pytorch_base /usr/local/cuda/bin/nvlink /usr/local/cuda/bin/nvlink
 COPY --from=pytorch_base /usr/local/cuda/bin/cudafe++ /usr/local/cuda/bin/cudafe++
 COPY --from=pytorch_base /usr/local/cuda/bin/ptxas /usr/local/cuda/bin/ptxas
 COPY --from=pytorch_base /usr/local/cuda/bin/fatbinary /usr/local/cuda/bin/fatbinary

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -34,6 +34,7 @@ ENV CUDA_DEVICE_ORDER=PCI_BUS_ID
 
 # Copy CUDA development tools (nvcc, headers, dependencies, etc.) from base devel image
 COPY --from=dynamo_base /usr/local/cuda/bin/nvcc /usr/local/cuda/bin/nvcc
+COPY --from=dynamo_base /usr/local/cuda/bin/nvlink /usr/local/cuda/bin/nvlink
 COPY --from=dynamo_base /usr/local/cuda/bin/cudafe++ /usr/local/cuda/bin/cudafe++
 COPY --from=dynamo_base /usr/local/cuda/bin/ptxas /usr/local/cuda/bin/ptxas
 COPY --from=dynamo_base /usr/local/cuda/bin/fatbinary /usr/local/cuda/bin/fatbinary


### PR DESCRIPTION
#### Overview:

Adds the missing `nvlink` CUDA linker binary to the vLLM and TRT-LLM runtime Dockerfile templates. The `kvbm-kernels` build system now (as of 2026-02-23) uses `nvcc -shared` which internally invokes `nvlink` to link CUDA shared libraries, but `nvlink` was never included in the selective CUDA binary copies from the base/devel images, causing build failures in dev containers.

#### Details:

- Add `COPY --from=dynamo_base /usr/local/cuda/bin/nvlink` to `vllm_runtime.Dockerfile`
- Add `COPY --from=pytorch_base /usr/local/cuda/bin/nvlink` to `trtllm_runtime.Dockerfile`
- Add clarifying comment to `sglang_runtime.Dockerfile` noting the upstream image already includes the full CUDA toolkit
- SGLang needs no change since `lmsysorg/sglang` runtime image ships with all CUDA tools

#### Where should the reviewer start?

- `container/templates/vllm_runtime.Dockerfile` and `container/templates/trtllm_runtime.Dockerfile` — the one-line COPY additions
- Verify the source stages (`dynamo_base` for vLLM, `pytorch_base` for TRT-LLM) contain `/usr/local/cuda/bin/nvlink`

#### Related Issues:

Relates to DIS-1508


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container runtime Dockerfiles to improve CUDA toolkit configuration across SGLang, TensorRT-LLM, and vLLM runtime images.
  * Enhanced documentation in build files regarding CUDA tool availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->