### PR TITLE
feat(mocker): add KV cache transfer latency for disagg serving

### DIFF
--- a/components/src/dynamo/mocker/README.md
+++ b/components/src/dynamo/mocker/README.md
@@ -27,6 +27,9 @@ The mocker engine now supports a vLLM-style CLI interface with individual argume
 - `--num-workers`: Number of mocker workers to launch in the same process (default: 1). All workers share the same tokio runtime and thread pool
 - `--stagger-delay`: Delay in seconds between launching each worker to avoid overwhelming etcd/NATS/frontend. Set to 0 to disable staggering. Use -1 for auto mode (stagger dependent on number of workers). Default: -1 (auto)
 - `--disaggregation-mode prefill` / `--disaggregation-mode decode`: Whether the worker is a prefill or decode worker for disaggregated deployment. If not specified, mocker will be in aggregated mode.
+- `--kv-transfer-bandwidth`: KV cache transfer bandwidth in GB/s for disaggregated serving latency simulation (default: 64.0, inter-node InfiniBand). Set to 0 to disable. For intra-node NVLink, typical value is ~450.
+- `--kv-cache-dtype`: Data type for KV cache, used to compute kv_bytes_per_token. "auto" uses the model's torch dtype (default).
+- `--kv-bytes-per-token`: KV cache bytes per token. If not specified, auto-computed from model config.
 
 **Environment variables:**
 

--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -404,9 +404,17 @@ def parse_args():
         "--kv-cache-dtype",
         type=str,
         default="auto",
+        choices=[
+            "auto",
+            "bfloat16",
+            "fp8",
+            "fp8_ds_mla",
+            "fp8_e4m3",
+            "fp8_e5m2",
+            "fp8_inc",
+        ],
         help="Data type for KV cache, used to compute kv_bytes_per_token. "
-        "'auto' uses the model's torch_dtype (default). "
-        "Options: auto, float16, bfloat16, float32, float8_e4m3fn, float8_e5m2.",
+        "'auto' uses the model's dtype (default).",
     )
     parser.add_argument(
         "--kv-bytes-per-token",

--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from dynamo.common.utils.namespace import get_worker_namespace
 
 from . import __version__
+from .utils.kv_cache import DEFAULT_KV_TRANSFER_BANDWIDTH_GBPS
 from .utils.planner_profiler_perf_data_converter import (
     convert_profile_results_to_npz,
     is_mocker_format_npz,
@@ -395,7 +396,7 @@ def parse_args():
     parser.add_argument(
         "--kv-transfer-bandwidth",
         type=float,
-        default=64.0,
+        default=DEFAULT_KV_TRANSFER_BANDWIDTH_GBPS,
         help="KV cache transfer bandwidth in GB/s for disaggregated serving latency simulation. "
         "Default: 64.0 (inter-node InfiniBand). Set to 0 to disable KV transfer delay. "
         "For intra-node NVLink, typical value is ~450.",

--- a/components/src/dynamo/mocker/utils/kv_cache.py
+++ b/components/src/dynamo/mocker/utils/kv_cache.py
@@ -1,0 +1,73 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+from transformers import AutoConfig
+
+from dynamo.profiler.utils.model_info import get_model_info
+
+logger = logging.getLogger(__name__)
+
+# Mapping from torch dtype strings to byte sizes for KV cache.
+# Used when --kv-cache-dtype is "auto" to infer from model config's dtype.
+TORCH_DTYPE_BYTES = {
+    "float16": 2,
+    "bfloat16": 2,
+    "float32": 4,
+    "float8_e4m3fn": 1,
+    "float8_e5m2": 1,
+}
+
+# Default KV transfer bandwidth in GB/s.
+# 64 GB/s corresponds to inter-node InfiniBand.
+# For intra-node NVLink, typical value is ~450 GB/s.
+DEFAULT_KV_TRANSFER_BANDWIDTH_GBPS = 64.0
+
+
+def get_kv_cache_dtype_bytes(config, kv_cache_dtype: str = "auto") -> int:
+    """Get the byte size per element for KV cache based on dtype.
+
+    When kv_cache_dtype is "auto", uses the model's dtype from config.
+    Follows vLLM's --kv-cache-dtype convention.
+    """
+    if kv_cache_dtype == "auto":
+        dtype = str(getattr(config, "dtype", "float16"))
+        return TORCH_DTYPE_BYTES.get(dtype, 2)
+    return TORCH_DTYPE_BYTES.get(kv_cache_dtype, 2)
+
+
+def compute_kv_bytes_per_token(
+    model_path: str, kv_cache_dtype: str = "auto"
+) -> int | None:
+    """Compute KV cache bytes per token from model config.
+
+    Formula: num_layers * 2 (K+V) * num_kv_heads * head_dim * dtype_bytes
+
+    Uses get_model_info from dynamo.profiler for robust detection of num_kv_heads
+    across different model architectures.
+
+    Args:
+        model_path: Path to model directory or HuggingFace model ID.
+        kv_cache_dtype: KV cache dtype. "auto" uses model's torch_dtype.
+
+    Returns:
+        KV bytes per token, or None if model config cannot be parsed.
+    """
+    try:
+        info = get_model_info(model_path)
+        config = AutoConfig.from_pretrained(model_path, trust_remote_code=False)
+        num_layers = config.num_hidden_layers
+        num_kv_heads = info.num_kv_heads
+        head_dim = config.hidden_size // config.num_attention_heads
+        dtype_bytes = get_kv_cache_dtype_bytes(config, kv_cache_dtype)
+        kv_bytes = num_layers * 2 * num_kv_heads * head_dim * dtype_bytes
+        logger.debug(
+            f"Auto-computed kv_bytes_per_token={kv_bytes} "
+            f"({num_layers} layers, {num_kv_heads} kv_heads, {head_dim} head_dim, "
+            f"{dtype_bytes} dtype_bytes)"
+        )
+        return kv_bytes
+    except Exception as e:
+        logger.warning(f"Could not compute kv_bytes_per_token from model config: {e}")
+        return None

--- a/docs/pages/mocker/mocker.md
+++ b/docs/pages/mocker/mocker.md
@@ -91,6 +91,9 @@ python -m dynamo.mocker \
 | `--disaggregation-mode` | `agg` | Worker mode: `agg` (aggregated), `prefill`, or `decode` |
 | `--durable-kv-events` | False | Enable durable KV events via JetStream (disables local indexer) |
 | `--bootstrap-ports` | None | Ports for P/D rendezvous |
+| `--kv-transfer-bandwidth` | 64.0 | KV cache transfer bandwidth in GB/s. Set to 0 to disable |
+| `--kv-cache-dtype` | auto | KV cache dtype for bytes-per-token computation |
+| `--kv-bytes-per-token` | Auto-computed | KV cache bytes per token (override auto-computation) |
 
 ## Architecture
 
@@ -160,6 +163,16 @@ The mocker supports two timing prediction modes:
 
 For disaggregated prefill/decode deployments, prefill and decode workers coordinate via a simple TCP-based rendezvous protocol. The decode worker connects to the prefill worker's bootstrap port and waits until the prefill phase completes and KV cache is ready. Either side can arrive first—the rendezvous completes when both are ready.
 
+### KV Transfer Latency Simulation
+
+The mocker simulates KV cache transfer time between prefill and decode workers. Before the prefill worker emits its first (and only) token, it sleeps for a duration based on:
+
+- **kv_bytes_per_token** (auto-computed from model config): `num_layers * 2 * num_kv_heads * head_dim * dtype_bytes`. The `dtype_bytes` is determined by `--kv-cache-dtype`: when set to `auto` (default), it uses the model's `dtype` from config; when explicitly set (e.g., `fp8`), it uses the specified dtype instead. Can also be overridden directly with `--kv-bytes-per-token`.
+- **kv_transfer_bandwidth** (default: 64.0 GB/s, inter-node InfiniBand)
+- **Transfer time**: `num_input_tokens * kv_bytes_per_token / bandwidth`
+
+This delay is injected after the scheduler's prefill compute simulation completes, modeling the sequential flow: prefill computation → KV transfer → decode begins. Set `--kv-transfer-bandwidth 0` to disable.
+
 ## Integration with Dynamo
 
 ### KV Event Publishing
@@ -199,7 +212,6 @@ The mocker is particularly useful for:
 
 The following features are not yet supported by the mocker:
 
-- **KV transfer latency simulation** - Disaggregated serving simulates the rendezvous handshake but does not model the actual KV cache transfer time between prefill and decode workers
 - **Multi-tier memory** - No support for offloading KV cache to CPU/disk or onboarding back to GPU; potential future integration with KVBM
 - **Multimodal support** - Currently only simulates text token processing; no vision encoder or cross-attention simulation
 - **Native Rust reference counting** - Work in progress to use native Rc/Arc for block reference counting, enabling natural RAII patterns for simpler tracking

--- a/docs/pages/mocker/mocker.md
+++ b/docs/pages/mocker/mocker.md
@@ -167,7 +167,7 @@ For disaggregated prefill/decode deployments, prefill and decode workers coordin
 
 The mocker simulates KV cache transfer time between prefill and decode workers. Before the prefill worker emits its first (and only) token, it sleeps for a duration based on:
 
-- **kv_bytes_per_token** (auto-computed from model config): `num_layers * 2 * num_kv_heads * head_dim * dtype_bytes`. The `dtype_bytes` is determined by `--kv-cache-dtype`: when set to `auto` (default), it uses the model's `dtype` from config; when explicitly set (e.g., `fp8`), it uses the specified dtype instead. Can also be overridden directly with `--kv-bytes-per-token`.
+- **kv_bytes_per_token** (auto-computed from model config): `num_layers * 2 * num_kv_heads * head_dim * dtype_bytes`. The `dtype_bytes` is determined by `--kv-cache-dtype`: when set to `auto` (default), it uses the model's `dtype` from config; when explicitly set (e.g., `fp8`), it uses the specified dtype instead. It can also be overridden directly with `--kv-bytes-per-token`.
 - **kv_transfer_bandwidth** (default: 64.0 GB/s, inter-node InfiniBand)
 - **Transfer time**: `num_input_tokens * kv_bytes_per_token / bandwidth`
 

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -565,10 +565,10 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
 
                         // Simulate KV transfer delay before prefill's first (and only) token.
                         // This models the time to transfer KV cache to the decode worker.
-                        if token_count == 0 {
-                            if let Some(delay) = kv_transfer_delay {
-                                sleep_precise(delay).await;
-                            }
+                        if token_count == 0
+                            && let Some(delay) = kv_transfer_delay
+                        {
+                            sleep_precise(delay).await;
                         }
 
                         // Generate a token (with thinking boundaries if configured)

--- a/lib/mocker/src/common/mod.rs
+++ b/lib/mocker/src/common/mod.rs
@@ -9,3 +9,4 @@ pub mod perf_model;
 pub mod protocols;
 pub mod running_mean;
 pub mod sequence;
+pub mod utils;

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -192,6 +192,7 @@ pub struct MockEngineArgs {
     /// Default: 64.0 (inter-node InfiniBand). Set to 0 to disable KV transfer delay.
     /// For intra-node NVLink, typical value is ~450.
     #[builder(default = "None")]
+    #[validate(range(min = 0.0))]
     pub kv_transfer_bandwidth: Option<f64>,
 
     /// Reasoning/thinking token configuration.

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -183,6 +183,17 @@ pub struct MockEngineArgs {
     #[builder(default = "None")]
     pub bootstrap_port: Option<u16>,
 
+    /// KV cache bytes per token, auto-computed from model config by Python CLI.
+    /// Formula: num_layers * 2 * num_kv_heads * head_dim * dtype_bytes
+    #[builder(default = "None")]
+    pub kv_bytes_per_token: Option<usize>,
+
+    /// KV cache transfer bandwidth in GB/s for disaggregated serving latency simulation.
+    /// Default: 64.0 (inter-node InfiniBand). Set to 0 to disable KV transfer delay.
+    /// For intra-node NVLink, typical value is ~450.
+    #[builder(default = "None")]
+    pub kv_transfer_bandwidth: Option<f64>,
+
     /// Reasoning/thinking token configuration.
     /// When set, the mocker wraps output in thinking boundary tokens.
     #[builder(default = "None")]
@@ -245,6 +256,8 @@ impl MockEngineArgs {
             "planner_profile_data",
             "enable_local_indexer",
             "bootstrap_port",
+            "kv_bytes_per_token",
+            "kv_transfer_bandwidth",
             "reasoning",
             "zmq_kv_events_port",
         ]
@@ -338,6 +351,18 @@ impl MockEngineArgs {
             && let Some(port) = value.as_u64()
         {
             builder = builder.bootstrap_port(Some(port as u16));
+        }
+
+        if let Some(value) = extra_args.get("kv_bytes_per_token")
+            && let Some(num) = value.as_u64()
+        {
+            builder = builder.kv_bytes_per_token(Some(num as usize));
+        }
+
+        if let Some(value) = extra_args.get("kv_transfer_bandwidth")
+            && let Some(num) = value.as_f64()
+        {
+            builder = builder.kv_transfer_bandwidth(Some(num));
         }
 
         if let Some(value) = extra_args.get("reasoning") {

--- a/lib/mocker/src/common/utils.rs
+++ b/lib/mocker/src/common/utils.rs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::{Duration, Instant};
+
+use crate::common::protocols::MockEngineArgs;
+
+/// Compute the KV transfer delay duration for a given number of input tokens.
+///
+/// Returns `None` if KV transfer simulation is disabled (bandwidth is 0 or not configured).
+pub fn compute_kv_transfer_delay(
+    args: &MockEngineArgs,
+    num_input_tokens: usize,
+) -> Option<Duration> {
+    match (args.kv_transfer_bandwidth, args.kv_bytes_per_token) {
+        (Some(bw), Some(bpt)) if bw > 0.0 => {
+            let kv_bytes = num_input_tokens as f64 * bpt as f64;
+            let delay = Duration::from_secs_f64(kv_bytes / (bw * 1e9));
+            tracing::debug!(
+                num_input_tokens,
+                kv_bytes,
+                bandwidth_gb_s = bw,
+                delay_ms = format!("{:.2}", delay.as_secs_f64() * 1000.0),
+                "KV transfer delay for prefill"
+            );
+            Some(delay)
+        }
+        _ => None,
+    }
+}
+
+/// Sleep for the specified duration using timerfd on Linux for precision.
+pub async fn sleep_precise(duration: Duration) {
+    sleep_until_precise(Instant::now() + duration).await;
+}
+
+/// Sleep until the specified deadline using timerfd on Linux for precision.
+///
+/// Unlike `sleep_precise`, this accounts for time already elapsed since the
+/// deadline's reference point, making it suitable for simulation loops where
+/// computation time should be subtracted from the sleep.
+pub async fn sleep_until_precise(deadline: Instant) {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(delay) = tokio_timerfd::Delay::new(deadline) {
+            let _ = delay.await;
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+    }
+}

--- a/lib/mocker/src/common/utils.rs
+++ b/lib/mocker/src/common/utils.rs
@@ -44,6 +44,8 @@ pub async fn sleep_until_precise(deadline: Instant) {
     {
         if let Ok(delay) = tokio_timerfd::Delay::new(deadline) {
             let _ = delay.await;
+        } else {
+            tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
         }
     }
     #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
#### Overview:

- Add KV cache transfer latency simulation to the mocker for disaggregated serving
- Add CLI args: `--kv-transfer-bandwidth` (default 64 GB/s), `--kv-cache-dtype `(default auto), `--kv-bytes-per-token `(default auto-compute from model config, can be overrided)
- Refactor timerfd sleep into shared `sleep_precise/sleep_until_precise` in `common/utils.rs`

#### Details:

This uses a simple synchronous model: prefill → KV transfer delay → decode begins. This matches the vLLM/TRTLLM disagg execution model where "prefill runs synchronously; decode waits for prefill to complete." in https://github.com/ai-dynamo/dynamo/blob/main/docs/pages/design-docs/disagg-serving.md#backend-specific-transfer-metadata

For SGLang's disagg model, KV transfer runs in parallel with decode. Supporting this would require injecting the delay on the decode side rather than the prefill side. Left as a future TODO since the mocker currently only has a vLLM-style scheduler.



#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- relates to https://github.com/ai-dynamo/dynamo/issues/6383


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KV transfer latency simulation added to disaggregated serving flow (introduces an optional prefill delay based on transfer sizing and bandwidth).
  * Three new CLI options: --kv-transfer-bandwidth, --kv-cache-dtype, --kv-bytes-per-token to control transfer timing and KV cache sizing.

* **Documentation**
  * Mocker docs and README updated with usage, timing model, and examples for the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->