### PR TITLE
feat: expose predicted KV hit rate as Prometheus histogram

### DIFF
--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -6,6 +6,9 @@
 //! This module centralizes all router-side Prometheus metric definitions:
 //! - [`WorkerLoadMetrics`]: Per-worker active decode blocks and prefill tokens gauges.
 //! - [`RoutingOverheadMetrics`]: Per-request routing phase latency histograms.
+//! - [`RouterRequestMetrics`]: Per-request aggregate histograms (TTFT, ITL, tokens, KV hit rate).
+//!
+//! See also: `docs/pages/observability/metrics.md` (Router Metrics section).
 
 use std::sync::{Arc, LazyLock, OnceLock};
 use std::time::Duration;
@@ -214,6 +217,9 @@ impl RouterRequestMetrics {
             kv_hit_rate,
         }
     }
+
+    // TODO: move all `router_*` metric name strings to `prometheus_names.rs` constants
+    // for consistency with the other metric families (routing_overhead, frontend_service).
 
     /// Create from a Component, memoized in a static OnceLock.
     pub fn from_component(component: &Component) -> Arc<Self> {

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -380,6 +380,9 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 overlap_amount as usize * block_size,
             );
             tracker.record_worker_full(instance_id, dp_rank, self.chooser.worker_type());
+            if let Some(hit_rate) = tracker.kv_hit_rate() {
+                request_metrics.kv_hit_rate.observe(hit_rate);
+            }
         }
         request_metrics
             .input_sequence_tokens


### PR DESCRIPTION
Add `router_kv_hit_rate` histogram to `RouterRequestMetrics` so the router-predicted cache hit rate is scrape-able from Prometheus, not just buried in the per-request nvext timing payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system monitoring by adding KV cache hit rate metrics collection for improved observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->