### PR TITLE
feat: remove --connector flag for vLLM backend (LLM-90)

### DIFF
--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -110,8 +110,8 @@ class DynamoRuntimeArgGroup(ArgGroup):
             g,
             flag_name="--connector",
             env_var="DYN_CONNECTOR",
-            default=["nixl"],
-            help="List of connectors to use in order (e.g., --connector nixl lmcache). Options: nixl, lmcache, kvbm, null, none. Order will be preserved in MultiConnector.",
+            default=[],
+            help="[Deprecated for vLLM] Use --kv-transfer-config instead. For TRT-LLM, options: nixl, lmcache, kvbm, null, none.",
             nargs="*",
         )
 

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import json
 import logging
 import os
 import socket
 import warnings
 from typing import Any, Dict, Optional
 
-from vllm.config import KVTransferConfig
 from vllm.distributed.kv_events import KVEventsConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
 
@@ -30,7 +30,6 @@ from . import envs
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
-VALID_CONNECTORS = {"nixl", "lmcache", "kvbm", "null", "none"}
 
 
 class Config(DynamoRuntimeConfig, DynamoVllmConfig):
@@ -54,18 +53,6 @@ class Config(DynamoRuntimeConfig, DynamoVllmConfig):
     def validate(self) -> None:
         DynamoRuntimeConfig.validate(self)
         DynamoVllmConfig.validate(self)
-
-    def has_connector(self, connector_name: str) -> bool:
-        """
-        Check if a specific connector is enabled.
-
-        Args:
-            connector_name: Name of the connector to check (e.g., "kvbm", "nixl")
-
-        Returns:
-            True if the connector is in the connector list, False otherwise
-        """
-        return self.connector is not None and connector_name in self.connector
 
 
 @register_encoder(Config)
@@ -198,30 +185,25 @@ def update_dynamo_config_with_engine(
                 "Please ensure the file exists and the path is correct."
             )
 
-    normalized = [c.lower() for c in (dynamo_config.connector or [])]
-    invalid = [c for c in normalized if c not in VALID_CONNECTORS]
-    if invalid:
-        raise ValueError(
-            f"Invalid connector(s): {', '.join(invalid)}. "
-            f"Valid options are: {', '.join(sorted(VALID_CONNECTORS))}"
-        )
+    # --connector is no longer supported for vLLM. Raise hard error if explicitly set.
+    _reject_connector_flag(dynamo_config)
 
+    # If --is-prefill-worker is set, require explicit --kv-transfer-config
     has_kv_transfer_config = (
         hasattr(engine_config, "kv_transfer_config")
         and engine_config.kv_transfer_config is not None
     )
-    if not normalized or "none" in normalized or "null" in normalized:
-        if len(normalized) > 1:
-            raise ValueError(
-                "'none' and 'null' cannot be combined with other connectors"
-            )
-        dynamo_config.connector = []  # type: ignore[assignment]
-    else:
-        if has_kv_transfer_config:
-            raise ValueError(
-                "Cannot specify both --kv-transfer-config and --connector flags"
-            )
-        dynamo_config.connector = normalized  # type: ignore[assignment]
+    if dynamo_config.is_prefill_worker and not has_kv_transfer_config:
+        raise ValueError(
+            "--connector is no longer supported for the vLLM backend. "
+            "When using --is-prefill-worker, you must explicitly provide "
+            "--kv-transfer-config. Example:\n"
+            "  --kv-transfer-config "
+            '\'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\''
+        )
+
+    # Clear connector list (no longer used for vLLM)
+    dynamo_config.connector = []  # type: ignore[assignment]
 
     # Validate ModelExpress P2P server URL
     if getattr(engine_config, "load_format", None) in ("mx-source", "mx-target"):
@@ -235,7 +217,7 @@ def update_dynamo_config_with_engine(
 def update_engine_config_with_dynamo(
     dynamo_config: Config, engine_config: AsyncEngineArgs
 ) -> None:
-    """Update engine config base on Dynamo config."""
+    """Update engine config based on Dynamo config."""
     # Workaround for vLLM GIL contention bug with NIXL connector when using UniProcExecutor.
     # With TP=1, vLLM defaults to UniProcExecutor which runs scheduler and worker in the same
     # process. This causes a hot loop in _process_engine_step that doesn't release the GIL,
@@ -244,21 +226,17 @@ def update_engine_config_with_dynamo(
     # Note: Only apply for NIXL - other connectors (kvbm, lmcache) work fine with UniProcExecutor
     # and forcing mp can expose race conditions in vLLM's scheduler.
     # See: https://github.com/vllm-project/vllm/issues/29369
-    connector_list = (
-        [c.lower() for c in dynamo_config.connector] if dynamo_config.connector else []
-    )
-    uses_nixl = "nixl" in connector_list
-    tp_size = getattr(engine_config, "tensor_parallel_size", None) or 1
-    if (
-        uses_nixl
-        and tp_size == 1
-        and getattr(engine_config, "distributed_executor_backend", None) is None
-    ):
-        logger.info(
-            "Setting --distributed-executor-backend=mp for TP=1 to avoid "
-            "UniProcExecutor GIL contention with NIXL connector"
-        )
-        engine_config.distributed_executor_backend = "mp"
+    if _uses_nixl_connector(engine_config):
+        tp_size = getattr(engine_config, "tensor_parallel_size", None) or 1
+        if (
+            tp_size == 1
+            and getattr(engine_config, "distributed_executor_backend", None) is None
+        ):
+            logger.info(
+                "Setting --distributed-executor-backend=mp for TP=1 to avoid "
+                "UniProcExecutor GIL contention with NIXL connector"
+            )
+            engine_config.distributed_executor_backend = "mp"
 
     if engine_config.enable_prefix_caching is None:
         logger.debug(
@@ -273,12 +251,7 @@ def update_engine_config_with_dynamo(
             f"Setting reasonable default of {engine_config.block_size} for block_size"
         )
 
-    if dynamo_config.has_connector("nixl") or (
-        # Check if the user provided their own kv_transfer_config
-        getattr(engine_config, "kv_transfer_config", None) is not None
-        # and the connector is NixlConnector
-        and engine_config.kv_transfer_config.kv_connector == "NixlConnector"
-    ):
+    if _uses_nixl_connector(engine_config):
         ensure_side_channel_host()
 
     defaults = {
@@ -293,9 +266,6 @@ def update_engine_config_with_dynamo(
         "disable_log_stats": False,
     }
 
-    kv_transfer_config = create_kv_transfer_config(dynamo_config, engine_config)
-    if kv_transfer_config:
-        defaults["kv_transfer_config"] = kv_transfer_config
     kv_cfg = create_kv_events_config(dynamo_config, engine_config)
     defaults["kv_events_config"] = kv_cfg
     dynamo_config.use_kv_events = kv_cfg is not None and kv_cfg.enable_kv_cache_events
@@ -366,54 +336,98 @@ def create_kv_events_config(
     )
 
 
-def create_kv_transfer_config(
-    dynamo_config: Config, engine_config: AsyncEngineArgs
-) -> Optional[KVTransferConfig]:
-    """Create KVTransferConfig based on user config or connector list.
+def _uses_nixl_connector(engine_config: AsyncEngineArgs) -> bool:
+    """Check if the user-provided --kv-transfer-config uses NixlConnector."""
+    kv_cfg = getattr(engine_config, "kv_transfer_config", None)
+    return kv_cfg is not None and kv_cfg.kv_connector == "NixlConnector"
 
-    Handles logging and returns the appropriate config or None.
+
+def _uses_dynamo_connector(engine_config: AsyncEngineArgs) -> bool:
+    """Check if the user-provided --kv-transfer-config uses DynamoConnector (KVBM)."""
+    kv_cfg = getattr(engine_config, "kv_transfer_config", None)
+    return kv_cfg is not None and kv_cfg.kv_connector == "DynamoConnector"
+
+
+def _connector_to_kv_transfer_json(connectors: list[str]) -> str:
+    """Convert a legacy --connector list to the equivalent --kv-transfer-config JSON.
+
+    Used in error messages to help users migrate.
     """
-    has_user_kv_config = (
-        hasattr(engine_config, "kv_transfer_config")
-        and engine_config.kv_transfer_config is not None
-    )
-    if has_user_kv_config:
-        logger.info("Using user-provided kv_transfer_config from --kv-transfer-config")
-        return None
-    if not dynamo_config.connector:
-        logger.info("Using vLLM defaults for kv_transfer_config")
-        return None
-    logger.info(
-        f"Creating kv_transfer_config from --connector {dynamo_config.connector}"
-    )
     multi_connectors = []
-    for conn in dynamo_config.connector:
-        if conn == "lmcache":
-            connector_cfg = {"kv_connector": "LMCacheConnectorV1", "kv_role": "kv_both"}
-        elif conn == "nixl":
-            connector_cfg = {"kv_connector": "NixlConnector", "kv_role": "kv_both"}
-        elif conn == "kvbm":
-            connector_cfg = {
-                "kv_connector": "DynamoConnector",
-                "kv_connector_module_path": "kvbm.vllm_integration.connector",
-                "kv_role": "kv_both",
-            }
-        else:
-            continue
-        multi_connectors.append(connector_cfg)
+    for conn in connectors:
+        c = conn.lower()
+        if c == "lmcache":
+            multi_connectors.append(
+                {"kv_connector": "LMCacheConnectorV1", "kv_role": "kv_both"}
+            )
+        elif c == "nixl":
+            multi_connectors.append(
+                {"kv_connector": "NixlConnector", "kv_role": "kv_both"}
+            )
+        elif c == "kvbm":
+            multi_connectors.append(
+                {
+                    "kv_connector": "DynamoConnector",
+                    "kv_connector_module_path": "kvbm.vllm_integration.connector",
+                    "kv_role": "kv_both",
+                }
+            )
 
-    # For single connector, return direct config
     if len(multi_connectors) == 1:
-        cfg = multi_connectors[0]
-        return KVTransferConfig(**cfg)
+        return json.dumps(multi_connectors[0])
 
-    # For multiple connectors, use PdConnector
-    return KVTransferConfig(
-        kv_connector="PdConnector",
-        kv_role="kv_both",
-        kv_connector_extra_config={"connectors": multi_connectors},
-        kv_connector_module_path="kvbm.vllm_integration.connector",
+    return json.dumps(
+        {
+            "kv_connector": "PdConnector",
+            "kv_role": "kv_both",
+            "kv_connector_extra_config": {"connectors": multi_connectors},
+            "kv_connector_module_path": "kvbm.vllm_integration.connector",
+        }
     )
+
+
+def _reject_connector_flag(dynamo_config: Config) -> None:
+    """Raise ValueError if --connector was explicitly set (CLI or DYN_CONNECTOR env var).
+
+    The --connector flag is no longer supported for the vLLM backend.
+    Users must use --kv-transfer-config instead.
+    """
+    connector_list = dynamo_config.connector or []
+
+    # Check if --connector was explicitly provided via CLI or DYN_CONNECTOR env var
+    env_connector = os.environ.get("DYN_CONNECTOR")
+    explicitly_set = bool(connector_list) or (env_connector is not None)
+
+    if not explicitly_set:
+        return
+
+    # Normalize: "none"/"null" means no connector
+    normalized = [c.lower() for c in connector_list]
+    if normalized and all(c in ("none", "null") for c in normalized):
+        # --connector none/null: tell user it's no longer needed
+        raise ValueError(
+            "--connector is no longer supported for the vLLM backend. "
+            "'--connector none' is no longer needed — the default is already "
+            "no connector. Simply remove the --connector flag."
+        )
+
+    # Active connectors: show migration path
+    if normalized:
+        equiv = _connector_to_kv_transfer_json(normalized)
+        raise ValueError(
+            "--connector is no longer supported for the vLLM backend. "
+            "Use --kv-transfer-config instead.\n"
+            f"  Equivalent: --kv-transfer-config '{equiv}'\n"
+            "See: https://linear.app/nvidia-dynamo/issue/LLM-90"
+        )
+
+    # DYN_CONNECTOR env var set but parsed to empty list
+    if env_connector is not None:
+        raise ValueError(
+            "The DYN_CONNECTOR environment variable is no longer supported "
+            "for the vLLM backend. Use --kv-transfer-config instead.\n"
+            "See: https://linear.app/nvidia-dynamo/issue/LLM-90"
+        )
 
 
 def get_host_ip() -> str:

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -52,7 +52,7 @@ from dynamo.runtime import DistributedRuntime, Endpoint
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.vllm.worker_factory import WorkerFactory
 
-from .args import Config, parse_args
+from .args import Config, _uses_dynamo_connector, parse_args
 from .checkpoint_restore import get_checkpoint_config
 from .handlers import DecodeWorkerHandler, PrefillWorkerHandler
 from .health_check import (
@@ -439,9 +439,9 @@ def setup_vllm_engine(config, stat_logger=None):
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
 
-    # Set up consolidator endpoints if KVBM is enabled
+    # Set up consolidator endpoints if KVBM (DynamoConnector) is enabled
     consolidator_endpoints = None
-    if config.has_connector("kvbm"):
+    if _uses_dynamo_connector(config.engine_args):
         try:
             from kvbm.vllm_integration.consolidator_config import (
                 get_consolidator_endpoints,

--- a/docs/pages/backends/vllm/README.md
+++ b/docs/pages/backends/vllm/README.md
@@ -161,7 +161,7 @@ vLLM workers are configured through command-line arguments. Key parameters inclu
 - `--model`: Model to serve (e.g., `Qwen/Qwen3-0.6B`)
 - `--is-prefill-worker`: Enable prefill-only mode for disaggregated serving
 - `--metrics-endpoint-port`: Port for publishing KV metrics to Dynamo
-- `--connector`: Specify which kv_transfer_config you want vllm to use `[nixl, lmcache, kvbm, none]`. This is a helper flag which overwrites the engines KVTransferConfig.
+- `--kv-transfer-config`: JSON string specifying the vLLM KVTransferConfig (e.g., `--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'`). See vLLM documentation for details.
 - `--enable-prompt-embeds`: **Enable prompt embeddings feature** (opt-in, default: disabled)
   - **Required for:** Accepting pre-computed prompt embeddings via API
   - **Default behavior:** Prompt embeddings DISABLED - requests with `prompt_embeds` will fail

--- a/docs/pages/backends/vllm/prometheus.md
+++ b/docs/pages/backends/vllm/prometheus.md
@@ -23,7 +23,7 @@ When running vLLM through Dynamo, vLLM engine metrics are automatically passed t
 | Variable/Flag | Description | Default | Example |
 |---------------|-------------|---------|---------|
 | `DYN_SYSTEM_PORT` | System metrics/health port. Required to expose `/metrics` endpoint. | `-1` (disabled) | `8081` |
-| `--connector` | KV connector to use. Use `lmcache` to enable LMCache metrics. | `nixl` | `--connector lmcache` |
+| `--kv-transfer-config` | KV transfer configuration JSON. Use LMCache connector to enable LMCache metrics. | - | `--kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'` |
 
 ## Getting Started Quickly
 
@@ -109,18 +109,18 @@ For the complete and authoritative list of all vLLM metrics, see the [official v
 
 ## LMCache Metrics
 
-When LMCache is enabled with `--connector lmcache` and `DYN_SYSTEM_PORT` is set, LMCache metrics (prefixed with `lmcache:`) are automatically exposed via Dynamo's `/metrics` endpoint alongside vLLM and Dynamo metrics.
+When LMCache is enabled with `--kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'` and `DYN_SYSTEM_PORT` is set, LMCache metrics (prefixed with `lmcache:`) are automatically exposed via Dynamo's `/metrics` endpoint alongside vLLM and Dynamo metrics.
 
 ### Minimum Requirements
 
 To access LMCache metrics, both of these are required:
-1. `--connector lmcache` - Enables LMCache in vLLM
+1. `--kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'` - Enables LMCache in vLLM
 2. `DYN_SYSTEM_PORT=8081` - Enables Dynamo's metrics HTTP endpoint
 
 **Example:**
 ```bash
 DYN_SYSTEM_PORT=8081 \
-python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector lmcache
+python -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
 ```
 
 ### Viewing LMCache Metrics

--- a/docs/pages/backends/vllm/vllm-omni.md
+++ b/docs/pages/backends/vllm/vllm-omni.md
@@ -161,7 +161,7 @@ The `/v1/videos` endpoint also accepts NVIDIA extensions via the `nvext` field f
 | `--omni` | Enable the vLLM-Omni orchestrator (required for all omni workloads) |
 | `--output-modalities <modality>` | Output modality: `text`, `image`, or `video` |
 | `--stage-configs-path <path>` | Path to stage config YAML (optional; vLLM-Omni uses model defaults if omitted) |
-| `--connector none` | Disable KV connector (recommended for omni workers) |
+| _(no `--kv-transfer-config`)_ | KV connector is disabled by default; omit the flag for omni workers |
 | `--media-output-fs-url <url>` | Filesystem URL for storing generated media (default: `file:///tmp/dynamo_media`) |
 | `--media-output-http-url <url>` | Base URL for rewriting media paths in responses (optional) |
 

--- a/docs/pages/components/kvbm/kvbm-guide.md
+++ b/docs/pages/components/kvbm/kvbm-guide.md
@@ -264,7 +264,7 @@ DYN_KVBM_CPU_CACHE_GB=20 \
 python -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \
     --enforce-eager \
-    --connector kvbm
+    --kv-transfer-config '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}'
 ```
 
 ### Enable Metrics for TensorRT-LLM
@@ -420,7 +420,7 @@ python -m dynamo.frontend &
 
 DYN_KVBM_CPU_CACHE_GB=10 \
 nsys profile -o /tmp/kvbm-nsys --trace-fork-before-exec=true --cuda-graph-trace=node --delay 30 --duration 60 \
-python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector kvbm
+python -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}'
 ```
 
 ## See Also

--- a/docs/pages/features/lora/README.md
+++ b/docs/pages/features/lora/README.md
@@ -81,7 +81,6 @@ The LoRA system consists of:
 # Start vLLM worker with LoRA flags
 DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=8081 \
     python -m dynamo.vllm --model Qwen/Qwen3-0.6B --enforce-eager \
-    --connector none \
     --enable-lora \
     --max-lora-rank 64
 ```

--- a/docs/pages/integrations/flexkv-integration.md
+++ b/docs/pages/integrations/flexkv-integration.md
@@ -34,11 +34,11 @@ title: FlexKV
 
 ### Enable FlexKV
 
-Set the `DYNAMO_USE_FLEXKV` environment variable and use the `--connector flexkv` flag:
+Set the `DYNAMO_USE_FLEXKV` environment variable and use the `--kv-transfer-config` flag:
 
 ```bash
 export DYNAMO_USE_FLEXKV=1
-python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector flexkv
+python -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"FlexKVConnector","kv_role":"kv_both"}'
 ```
 
 ## Aggregated Serving
@@ -52,7 +52,7 @@ python -m dynamo.frontend &
 # Terminal 2: Start vLLM worker with FlexKV
 DYNAMO_USE_FLEXKV=1 \
 FLEXKV_CPU_CACHE_GB=32 \
-  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector flexkv
+  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"FlexKVConnector","kv_role":"kv_both"}'
 ```
 
 ### With KV-Aware Routing
@@ -72,7 +72,7 @@ FLEXKV_SERVER_RECV_PORT="ipc:///tmp/flexkv_server_0" \
 CUDA_VISIBLE_DEVICES=0 \
 python -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \
-    --connector flexkv \
+    --kv-transfer-config '{"kv_connector":"FlexKVConnector","kv_role":"kv_both"}' \
     --gpu-memory-utilization 0.2 \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
 
@@ -83,7 +83,7 @@ FLEXKV_SERVER_RECV_PORT="ipc:///tmp/flexkv_server_1" \
 CUDA_VISIBLE_DEVICES=1 \
 python -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \
-    --connector flexkv \
+    --kv-transfer-config '{"kv_connector":"FlexKVConnector","kv_role":"kv_both"}' \
     --gpu-memory-utilization 0.2 \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'
 ```
@@ -97,7 +97,7 @@ FlexKV can be used with disaggregated prefill/decode serving. The prefill worker
 python -m dynamo.frontend &
 
 # Terminal 2: Decode worker (without FlexKV)
-CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector nixl &
+CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
 
 # Terminal 3: Prefill worker (with FlexKV)
 DYN_VLLM_KV_EVENT_PORT=20081 \
@@ -108,7 +108,7 @@ CUDA_VISIBLE_DEVICES=1 \
   python -m dynamo.vllm \
   --model Qwen/Qwen3-0.6B \
   --is-prefill-worker \
-  --connector nixl flexkv
+  --kv-transfer-config '{"kv_connector":"FlexKVConnector","kv_role":"kv_both"}'
 ```
 
 ## Configuration

--- a/docs/pages/integrations/lmcache-integration.md
+++ b/docs/pages/integrations/lmcache-integration.md
@@ -20,10 +20,10 @@ This document describes how LMCache is integrated into Dynamo's vLLM backend to 
 
 ### Configuration
 
-LMCache is enabled using the `--connector lmcache` flag:
+LMCache is enabled using the `--kv-transfer-config` flag:
 
 ```bash
-python -m dynamo.vllm --model <model_name> --connector lmcache
+python -m dynamo.vllm --model <model_name> --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
 ```
 
 ### Customization
@@ -157,11 +157,11 @@ kv_transfer_config = KVTransferConfig(
 
 ## Metrics and Monitoring
 
-When LMCache is enabled with `--connector lmcache` and `DYN_SYSTEM_PORT` is set, LMCache metrics are automatically exposed via Dynamo's `/metrics` endpoint alongside vLLM and Dynamo metrics.
+When LMCache is enabled with `--kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'` and `DYN_SYSTEM_PORT` is set, LMCache metrics are automatically exposed via Dynamo's `/metrics` endpoint alongside vLLM and Dynamo metrics.
 
 **Requirements to access LMCache metrics:**
 
-- `--connector lmcache` - Enables LMCache
+- `--kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'` - Enables LMCache
 - `DYN_SYSTEM_PORT=8081` - Enables metrics HTTP endpoint
 - `PROMETHEUS_MULTIPROC_DIR` (optional) - If not set, Dynamo manages it internally
 

--- a/docs/pages/templates/integration-readme.md
+++ b/docs/pages/templates/integration-readme.md
@@ -26,7 +26,7 @@ title: Integration README
 ```bash
 # Add installation and usage from existing integration docs
 # Example pattern (LMCache):
-# python -m dynamo.vllm --model <model> --connector lmcache
+# python -m dynamo.vllm --model <model> --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
 ```
 
 ## Configuration

--- a/examples/backends/vllm/deploy/README.md
+++ b/examples/backends/vllm/deploy/README.md
@@ -86,7 +86,7 @@ extraPodSpec:
 - `--enable-prompt-embeds`: Enable prompt embeddings feature
 - `--enable-multimodal`: Enable multimodal (vision) support
 - `--is-prefill-worker`: Prefill-only mode for disaggregated serving
-- `--connector [nixl|lmcache|kvbm|none]`: KV transfer backend selection
+- `--kv-transfer-config '<json>'`: KV transfer backend configuration (e.g., `'{"kv_connector":"NixlConnector","kv_role":"kv_both"}'`)
 
 ## Prerequisites
 

--- a/examples/backends/vllm/deploy/agg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/agg_kvbm.yaml
@@ -41,5 +41,5 @@ spec:
             - --max-model-len
             - "32000"
             - --enforce-eager
-            - --connector
-            - kvbm
+            - --kv-transfer-config
+            - '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}'

--- a/examples/backends/vllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/disagg-multinode.yaml
@@ -44,8 +44,6 @@ spec:
           - --tensor-parallel-size
           - "2"
           - --is-decode-worker
-          - --connector
-          - none
           - --kv-transfer-config
           - '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "engine_id":
             "vllm-disagg-decode-engine-0abc123"}'
@@ -72,8 +70,6 @@ spec:
           - --tensor-parallel-size
           - "2"
           - --is-prefill-worker
-          - --connector
-          - none
           - --kv-transfer-config
           - '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "engine_id":
             "vllm-disagg-prefill-engine-0abc123"}'

--- a/examples/backends/vllm/deploy/disagg_kvbm.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm.yaml
@@ -63,6 +63,5 @@ spec:
             - --max-model-len
             - "32000"
             - --enforce-eager
-            - --connector
-            - kvbm
-            - nixl
+            - --kv-transfer-config
+            - '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}'

--- a/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_2p2d.yaml
@@ -63,6 +63,5 @@ spec:
             - --max-model-len
             - "32000"
             - --enforce-eager
-            - --connector
-            - kvbm
-            - nixl
+            - --kv-transfer-config
+            - '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}'

--- a/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
+++ b/examples/backends/vllm/deploy/disagg_kvbm_tp2.yaml
@@ -71,8 +71,7 @@ spec:
             - --max-model-len
             - "32000"
             - --enforce-eager
-            - --connector
-            - kvbm
-            - nixl
+            - --kv-transfer-config
+            - '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}'
             - --tensor-parallel-size
             - "2"

--- a/examples/backends/vllm/deploy/lora/agg_lora.yaml
+++ b/examples/backends/vllm/deploy/lora/agg_lora.yaml
@@ -60,8 +60,6 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-0.6B
-            - --connector
-            - none
             - --enable-lora
             - --max-lora-rank
             - "64"

--- a/examples/backends/vllm/launch/agg.sh
+++ b/examples/backends/vllm/launch/agg.sh
@@ -29,4 +29,4 @@ python -m dynamo.frontend &
 # run worker
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
-    python -m dynamo.vllm --model "$MODEL" --enforce-eager --connector none "${EXTRA_ARGS[@]}"
+    python -m dynamo.vllm --model "$MODEL" --enforce-eager "${EXTRA_ARGS[@]}"

--- a/examples/backends/vllm/launch/agg_kvbm.sh
+++ b/examples/backends/vllm/launch/agg_kvbm.sh
@@ -11,4 +11,4 @@ python -m dynamo.frontend &
 # run worker with KVBM enabled
 # NOTE: remove --enforce-eager for production use
 DYN_KVBM_CPU_CACHE_GB=20 \
-  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector kvbm --enforce-eager
+  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}' --enforce-eager

--- a/examples/backends/vllm/launch/agg_kvbm_router.sh
+++ b/examples/backends/vllm/launch/agg_kvbm_router.sh
@@ -25,7 +25,7 @@ CUDA_VISIBLE_DEVICES=0 DYN_KVBM_CPU_CACHE_GB=2 \
     python3 -m dynamo.vllm \
     --model $MODEL \
     --enforce-eager \
-    --connector kvbm \
+    --kv-transfer-config '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}' \
     --gpu-memory-utilization 0.4 \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
 
@@ -36,6 +36,6 @@ CUDA_VISIBLE_DEVICES=1 DYN_KVBM_CPU_CACHE_GB=2 \
     python3 -m dynamo.vllm \
     --model $MODEL \
     --enforce-eager \
-    --connector kvbm \
+    --kv-transfer-config '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}' \
     --gpu-memory-utilization 0.4 \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'

--- a/examples/backends/vllm/launch/agg_lmcache.sh
+++ b/examples/backends/vllm/launch/agg_lmcache.sh
@@ -13,4 +13,4 @@ python -m dynamo.frontend &
 
 # run worker with LMCache enabled (without PROMETHEUS_MULTIPROC_DIR set externally)
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
-  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector lmcache
+  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'

--- a/examples/backends/vllm/launch/agg_lmcache_multiproc.sh
+++ b/examples/backends/vllm/launch/agg_lmcache_multiproc.sh
@@ -24,5 +24,5 @@ python -m dynamo.frontend &
 # run worker with LMCache enabled and PROMETHEUS_MULTIPROC_DIR explicitly set
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
   PROMETHEUS_MULTIPROC_DIR="$PROMETHEUS_MULTIPROC_DIR" \
-  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector lmcache
+  python -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
 

--- a/examples/backends/vllm/launch/agg_multimodal.sh
+++ b/examples/backends/vllm/launch/agg_multimodal.sh
@@ -65,11 +65,10 @@ fi
 # Start vLLM worker with vision model
 # Multimodal data (images) are decoded in the backend worker using ImageLoader
 # --enforce-eager: Quick deployment (remove for production)
-# --connector none: No KV transfer needed for aggregated serving
 # Extra args from command line come last to allow overrides
 CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0} \
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
-    python -m dynamo.vllm --enable-multimodal --model $MODEL_NAME --connector none $MODEL_SPECIFIC_ARGS "${EXTRA_ARGS[@]}"
+    python -m dynamo.vllm --enable-multimodal --model $MODEL_NAME $MODEL_SPECIFIC_ARGS "${EXTRA_ARGS[@]}"
 
 # Wait for all background processes to complete
 wait

--- a/examples/backends/vllm/launch/agg_omni.sh
+++ b/examples/backends/vllm/launch/agg_omni.sh
@@ -50,5 +50,4 @@ DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
     --model "$MODEL" \
     --omni \
     --stage-configs-path "$STAGE_CONFIG" \
-    --connector none \
     "${EXTRA_ARGS[@]}"

--- a/examples/backends/vllm/launch/agg_omni_image.sh
+++ b/examples/backends/vllm/launch/agg_omni_image.sh
@@ -38,7 +38,6 @@ DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
     python -m dynamo.vllm \
     --model "$MODEL" \
     --omni \
-    --connector none \
     --output-modalities image \
     --media-output-fs-url file:///tmp/dynamo_media \
     "${EXTRA_ARGS[@]}"

--- a/examples/backends/vllm/launch/agg_omni_video.sh
+++ b/examples/backends/vllm/launch/agg_omni_video.sh
@@ -40,7 +40,6 @@ DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
     python -m dynamo.vllm \
     --model "$MODEL" \
     --omni \
-    --connector none \
     --output-modalities video \
     --media-output-fs-url file:///tmp/dynamo_media \
     "${EXTRA_ARGS[@]}"

--- a/examples/backends/vllm/launch/agg_request_planes.sh
+++ b/examples/backends/vllm/launch/agg_request_planes.sh
@@ -46,4 +46,4 @@ python -m dynamo.frontend &
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
 DYN_HEALTH_CHECK_ENABLED=true \
-    python -m dynamo.vllm --model Qwen/Qwen3-0.6B --enforce-eager --connector none
+    python -m dynamo.vllm --model Qwen/Qwen3-0.6B --enforce-eager

--- a/examples/backends/vllm/launch/agg_router.sh
+++ b/examples/backends/vllm/launch/agg_router.sh
@@ -28,7 +28,6 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --enforce-eager \
-    --connector none \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
@@ -37,5 +36,4 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --enforce-eager \
-    --connector none \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'

--- a/examples/backends/vllm/launch/agg_router_replicas.sh
+++ b/examples/backends/vllm/launch/agg_router_replicas.sh
@@ -30,7 +30,6 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --enforce-eager \
-    --connector none \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
@@ -39,5 +38,4 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --enforce-eager \
-    --connector none \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'

--- a/examples/backends/vllm/launch/agg_spec_decoding.sh
+++ b/examples/backends/vllm/launch/agg_spec_decoding.sh
@@ -25,5 +25,4 @@ CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm \
         "num_speculative_tokens": 2,
         "method": "eagle"
     }' \
-    --connector none \
     --gpu-memory-utilization 0.8

--- a/examples/backends/vllm/launch/disagg_kvbm.sh
+++ b/examples/backends/vllm/launch/disagg_kvbm.sh
@@ -10,7 +10,7 @@ python -m dynamo.frontend &
 
 # run decode worker on GPU 0, without enabling KVBM
 # NOTE: remove --enforce-eager for production use
-CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector nixl --enforce-eager &
+CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --enforce-eager &
 
 # run prefill worker on GPU 1 with KVBM enabled using 20GB of CPU cache
 # NOTE: remove --enforce-eager for production use
@@ -20,6 +20,6 @@ CUDA_VISIBLE_DEVICES=1 \
   python3 -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \
     --is-prefill-worker \
-    --connector kvbm nixl \
+    --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
     --enforce-eager \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'

--- a/examples/backends/vllm/launch/disagg_kvbm_2p2d.sh
+++ b/examples/backends/vllm/launch/disagg_kvbm_2p2d.sh
@@ -10,9 +10,9 @@ python -m dynamo.frontend --router-mode kv &
 
 # run decode workers on GPU 0 and 1, without enabling KVBM
 # NOTE: remove --enforce-eager for production use
-CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector nixl --enforce-eager --is-decode-worker &
+CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --enforce-eager --is-decode-worker &
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
-CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --connector nixl --enforce-eager --is-decode-worker &
+CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --enforce-eager --is-decode-worker &
 
 # run prefill workers on GPU 2 and 3 with KVBM enabled using 20GB of CPU cache
 # NOTE: use different barrier id prefixes for each prefill worker to avoid conflicts
@@ -23,7 +23,7 @@ CUDA_VISIBLE_DEVICES=2 \
   python3 -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \
     --is-prefill-worker \
-    --connector kvbm nixl \
+    --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
     --enforce-eager \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20082","enable_kv_cache_events":true}' &
 
@@ -35,6 +35,6 @@ CUDA_VISIBLE_DEVICES=3 \
   python3 -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \
     --is-prefill-worker \
-    --connector kvbm nixl \
+    --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
     --enforce-eager \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20083","enable_kv_cache_events":true}'

--- a/examples/backends/vllm/launch/disagg_kvbm_router.sh
+++ b/examples/backends/vllm/launch/disagg_kvbm_router.sh
@@ -38,7 +38,7 @@ CUDA_VISIBLE_DEVICES=2 DYN_KVBM_CPU_CACHE_GB=20 \
     --model $MODEL \
     --enforce-eager \
     --is-prefill-worker \
-    --connector kvbm nixl \
+    --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081"}' &
 
 VLLM_NIXL_SIDE_CHANNEL_PORT=20098 \
@@ -49,5 +49,5 @@ CUDA_VISIBLE_DEVICES=3 DYN_KVBM_CPU_CACHE_GB=20 \
     --model $MODEL \
     --enforce-eager \
     --is-prefill-worker \
-    --connector kvbm nixl \
+    --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20082"}'

--- a/examples/backends/vllm/launch/disagg_lmcache.sh
+++ b/examples/backends/vllm/launch/disagg_lmcache.sh
@@ -20,5 +20,5 @@ CUDA_VISIBLE_DEVICES=1 \
   python3 -m dynamo.vllm \
     --model Qwen/Qwen3-0.6B \
     --is-prefill-worker \
-    --connector lmcache nixl \
+    --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'

--- a/examples/backends/vllm/launch/disagg_router_gaudi.sh
+++ b/examples/backends/vllm/launch/disagg_router_gaudi.sh
@@ -32,7 +32,6 @@ HABANA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --kv-transfer-config "{\"kv_connector\": \"NixlConnector\", \"kv_role\": \"kv_both\", \"kv_buffer_device\": \"${NIXL_BUFFER_DEVICE}\", \"kv_connector_extra_config\": {\"backends\": [\"${VLLM_NIXL_BACKEND}\"]}}" \
-    --connector none \
     --is-decode-worker &
 
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
@@ -40,7 +39,6 @@ HABANA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --kv-transfer-config "{\"kv_connector\": \"NixlConnector\", \"kv_role\": \"kv_both\", \"kv_buffer_device\": \"${NIXL_BUFFER_DEVICE}\", \"kv_connector_extra_config\": {\"backends\": [\"${VLLM_NIXL_BACKEND}\"]}}" \
-    --connector none \
     --is-decode-worker &
 
 # two prefill workers
@@ -51,7 +49,6 @@ HABANA_VISIBLE_DEVICES=2 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --kv-transfer-config "{\"kv_connector\": \"NixlConnector\", \"kv_role\": \"kv_both\", \"kv_buffer_device\": \"${NIXL_BUFFER_DEVICE}\", \"kv_connector_extra_config\": {\"backends\": [\"${VLLM_NIXL_BACKEND}\"]}}" \
-    --connector none \
     --is-prefill-worker \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5558", "enable_kv_cache_events":true}'&
 
@@ -60,6 +57,5 @@ HABANA_VISIBLE_DEVICES=3 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --kv-transfer-config "{\"kv_connector\": \"NixlConnector\", \"kv_role\": \"kv_both\", \"kv_buffer_device\": \"${NIXL_BUFFER_DEVICE}\", \"kv_connector_extra_config\": {\"backends\": [\"${VLLM_NIXL_BACKEND}\"]}}" \
-    --connector none \
     --is-prefill-worker \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5559", "enable_kv_cache_events":true}'

--- a/examples/backends/vllm/launch/lora/agg_lora.sh
+++ b/examples/backends/vllm/launch/lora/agg_lora.sh
@@ -24,7 +24,6 @@ python -m dynamo.frontend &
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag
 DYN_SYSTEM_ENABLED=true DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
     python -m dynamo.vllm --model Qwen/Qwen3-0.6B --enforce-eager  \
-    --connector none  \
     --enable-lora  \
     --max-lora-rank 64
 

--- a/examples/backends/vllm/launch/lora/agg_lora_router.sh
+++ b/examples/backends/vllm/launch/lora/agg_lora_router.sh
@@ -36,7 +36,6 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --enforce-eager \
-    --connector none \
     --enable-lora \
     --max-lora-rank 64 \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
@@ -47,7 +46,6 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --enforce-eager \
-    --connector none \
     --enable-lora \
     --max-lora-rank 64 \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'

--- a/examples/multimodal/deploy/lora/agg_qwen_lora.yaml
+++ b/examples/multimodal/deploy/lora/agg_qwen_lora.yaml
@@ -83,8 +83,6 @@ spec:
             - --enable-multimodal
             - --model
             - Qwen/Qwen3-VL-2B-Instruct
-            - --connector
-            - none
             - --enable-lora
             - --max-lora-rank
             - "64"

--- a/examples/multimodal/launch/lora/lora_agg.sh
+++ b/examples/multimodal/launch/lora/lora_agg.sh
@@ -140,13 +140,11 @@ echo "Starting vLLM worker..."
 
 # --enable-lora: Enable LoRA adapter support in vLLM engine
 # --max-lora-rank: Maximum LoRA rank (increase if your adapters have higher rank)
-# --connector none: No KV transfer needed for aggregated serving
 CUDA_VISIBLE_DEVICES="$GPU_DEVICE" \
 DYN_SYSTEM_PORT="$SYSTEM_PORT" \
     python -m dynamo.vllm \
         --enable-multimodal \
         --model "$MODEL_NAME" \
-        --connector none \
         --enable-lora \
         --max-lora-rank "$MAX_LORA_RANK" \
         "${MODEL_SPECIFIC_ARGS[@]}" \

--- a/tests/frontend/test_prompt_embeds.py
+++ b/tests/frontend/test_prompt_embeds.py
@@ -73,8 +73,6 @@ class VllmPromptEmbedsWorkerProcess(ManagedProcess):
             "dynamo.vllm",
             "--model",
             TEST_MODEL,
-            "--connector",
-            "none",
             "--max-model-len",
             "4096",
             "--discovery-backend",

--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -93,8 +93,6 @@ class VllmWorkerProcess(ManagedProcess):
             "harmony",
             "--dyn-reasoning-parser",
             "gpt_oss",
-            "--connector",
-            "none",
         ]
 
         env = os.environ.copy()

--- a/tests/kvbm_integration/test_consolidator_router_e2e.py
+++ b/tests/kvbm_integration/test_consolidator_router_e2e.py
@@ -354,8 +354,8 @@ def llm_worker(frontend_server, test_directory, runtime_services, engine_type):
             "dynamo.vllm",
             "--model",
             model_id,
-            "--connector",
-            "kvbm",
+            "--kv-transfer-config",
+            '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}',
             "--enforce-eager",  # For faster startup in tests
         ]
     else:  # trtllm
@@ -777,8 +777,8 @@ class TestConsolidatorRouterE2E:
                     "dynamo.vllm",
                     "--model",
                     model_id,
-                    "--connector",
-                    "kvbm",
+                    "--kv-transfer-config",
+                    '{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"}',
                     "--enforce-eager",
                     "--enable-prefix-caching",
                     "--num-gpu-blocks-override",

--- a/tests/kvbm_integration/test_determinism_disagg.py
+++ b/tests/kvbm_integration/test_determinism_disagg.py
@@ -143,8 +143,8 @@ class LLMServerManager:
             "16",
             "--max-model-len",
             "8000",  # required to fit on L4 GPU when using 8b model
-            "--connector",
-            "nixl",
+            "--kv-transfer-config",
+            '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
         ]
 
         # Construct prefiller command
@@ -159,9 +159,8 @@ class LLMServerManager:
             "16",
             "--max-model-len",
             "8000",  # required to fit on L4 GPU when using 8b model
-            "--connector",
-            "kvbm",
-            "nixl",
+            "--kv-transfer-config",
+            '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"kvbm.vllm_integration.connector","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}',
         ]
 
         # GPU blocks override

--- a/tests/lmcache/deploy-lmcache_enabled-dynamo.sh
+++ b/tests/lmcache/deploy-lmcache_enabled-dynamo.sh
@@ -27,4 +27,4 @@ echo "🔧 Starting dynamo worker with LMCache enabled..."
 
 python -m dynamo.frontend &
 
-python3 -m dynamo.vllm --model $MODEL_URL --connector lmcache
+python3 -m dynamo.vllm --model $MODEL_URL --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'

--- a/tests/mm_router/test_vllm_mm_router_e2e.py
+++ b/tests/mm_router/test_vllm_mm_router_e2e.py
@@ -109,8 +109,6 @@ class VLLMWorkerProcess(ManagedProcess):
                 "0.85",
                 "--max-model-len",
                 "8192",
-                "--connector",
-                "none",
                 "--served-model-name",
                 f"{VLLM_MM_MODEL}__internal",
             ],

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -148,7 +148,7 @@ class VLLMProcess:
         # - When data_parallel_size is set, launch one process per DP rank
         # - Each process gets --data-parallel-rank and --data-parallel-size
         # - Each process runs on its own GPU via CUDA_VISIBLE_DEVICES
-        # - --connector nixl enables KV cache transfer between ranks
+        # - --kv-transfer-config enables KV cache transfer between ranks
 
         for worker_idx in range(num_workers):
             # Calculate GPU device for this process
@@ -207,7 +207,7 @@ class VLLMProcess:
                         str(data_parallel_size),
                         # "--data-parallel-address", "127.0.0.1",  # Required for DP coordination
                         # "--data-parallel-rpc-port", "13345",  # RPC port for DP coordination
-                        # "--connector", "nixl",  # Required for KV transfer between DP ranks
+                        # "--kv-transfer-config", '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',  # Required for KV transfer between DP ranks
                     ]
                 )
 


### PR DESCRIPTION
## Summary

- Hard-remove the `--connector` flag for the vLLM backend — using it now raises a `ValueError` with a migration hint showing the equivalent `--kv-transfer-config` JSON
- Change default connector from `["nixl"]` to `[]` so aggregated serving works without any connector flag
- Require explicit `--kv-transfer-config` when using `--is-prefill-worker` (no more implicit nixl)
- Migrate all 33+ launch scripts, YAML deploys, tests, and docs from `--connector` to `--kv-transfer-config`
- TRT-LLM connector support is unchanged (separate ticket)

## Test plan

- [ ] `PYTHONPATH=... python3 -m pytest -xvv components/src/dynamo/vllm/tests/test_vllm_unit.py` — new error tests pass
- [ ] `python3 -m pytest -xvv components/src/dynamo/trtllm/tests/test_trtllm_unit.py` — TRT-LLM unaffected
- [ ] `grep -r '\-\-connector' examples/ tests/ docs/` shows zero vLLM-related hits (only TRT-LLM remains)
- [ ] `aggregated_lmcache` and `aggregated_lmcache_multiproc` CI tests pass (root cause: default `["nixl"]` conflicted with `--kv-transfer-config`)

Closes LLM-90
Closes LLM-95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * The `--connector` CLI flag has been deprecated and replaced with `--kv-transfer-config` for vLLM KV transfer configuration
  * Users must now provide KV transfer settings as a JSON configuration string instead of selecting connector types
  * Clear error messages guide users through migration with examples

* **New Features**
  * Introduced `--kv-transfer-config` flag that accepts JSON-based configuration for flexible KV transfer backend setup

* **Documentation**
  * All configuration examples and integration guides updated to reflect new flag usage and JSON format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->