### PR TITLE
Bis/bis/lora kv events int test

### DIFF
--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -116,10 +116,10 @@ class ZmqKvEventPublisher:
         token_ids: list[int],
         num_block_tokens: list[int],
         block_hashes: list[int],
-        lora_id: int = 0,
         parent_hash: Optional[int] = None,
         block_mm_infos: Optional[list[dict | None]] = None,
         attention_dp_rank: int = 0,
+        lora_name: Optional[str] = None,
     ):
         """Publish a BlockStored event.
 
@@ -139,8 +139,9 @@ class ZmqKvEventPublisher:
             "parent_block_hash": parent_hash_signed,
             "token_ids": token_ids,
             "block_size": self.kv_block_size,
-            "lora_id": lora_id if lora_id != 0 else None,
         }
+        if lora_name is not None:
+            event["lora_name"] = lora_name
 
         # Add multimodal info if present
         if block_mm_infos is not None:
@@ -597,17 +598,14 @@ class Publisher:
                 else:
                     block_mm_infos.append(None)
 
-            # Note: Currently data does not have lora_id.
-            # Using 0 as default value. If later data has
-            # lora_id, we need to verify if this is correct.
-            lora_id = data.get("lora_id", 0)
+            lora_name = data.get("lora_name")
 
             # Get attention_dp_rank from event (TRT-LLM includes this in KVCacheEvent)
             # Default to 0 for backwards compatibility with older TRT-LLM versions
             attention_dp_rank = event.get("attention_dp_rank", 0)
 
             logging.debug(
-                f"publish stored event: engine_event_id: {event_id}, attention_dp_rank: {attention_dp_rank}, token_ids: {token_ids}, num_block_tokens: {num_block_tokens}, block_hashes: {block_hashes}, lora_id: {lora_id}, parent_hash: {parent_hash}"
+                f"publish stored event: engine_event_id: {event_id}, attention_dp_rank: {attention_dp_rank}, token_ids: {token_ids}, num_block_tokens: {num_block_tokens}, block_hashes: {block_hashes}, lora_name: {lora_name}, parent_hash: {parent_hash}"
             )
             # Publish to ZMQ if consolidator is enabled, otherwise publish to NATS
             # Note: event_id is managed internally by the publisher (monotonic counter per dp_rank)
@@ -617,10 +615,10 @@ class Publisher:
                     token_ids,
                     num_block_tokens,
                     block_hashes,
-                    lora_id,
                     parent_hash,
                     block_mm_infos,
                     attention_dp_rank,
+                    lora_name,
                 )
             elif self.kv_event_publishers:
                 # No consolidator: publish to NATS (router subscribes directly)
@@ -631,9 +629,9 @@ class Publisher:
                         token_ids,
                         num_block_tokens,
                         block_hashes,
-                        lora_id,
                         parent_hash,
                         block_mm_infos,
+                        lora_name=lora_name,
                     )
                 else:
                     logging.warning(

--- a/docs/pages/design-docs/router-design.md
+++ b/docs/pages/design-docs/router-design.md
@@ -88,7 +88,7 @@ To get a feel for how KV Cache management works on a single worker with KV Cache
 
 1. **Request tokenization**: The incoming prompt is converted into tokens
 2. **Block partitioning**: The token sequence is divided into fixed-size blocks (e.g., 16 or 64 tokens per block)
-3. **Block hashing**: Each block of tokens is hashed to create a unique identifier
+3. **Block hashing**: Each block of tokens is hashed to create a unique identifier. When a LoRA adapter is active, the adapter name is incorporated into the hash so that blocks cached under different adapters produce distinct identifiers.
 4. **Cache lookup**:
     - For each block, the system checks if a matching block already exists in the KV cache
     - If a match is found, the existing KV cache block is reused

--- a/docs/pages/features/lora/README.md
+++ b/docs/pages/features/lora/README.md
@@ -307,9 +307,20 @@ kubectl logs deployment/my-worker | grep -i lora
 - Check that the LoRA is loaded on the worker handling your request
 - For disaggregated serving, ensure both prefill and decode workers have the LoRA
 
+## KV Cache-Aware LoRA Routing
+
+When KV-aware routing is enabled, the router automatically accounts for LoRA adapter identity when computing block hashes. This means:
+
+- **Distinct hash spaces per adapter**: Blocks cached under adapter `A` will never be confused with blocks cached under adapter `B` or the base model, even if the token sequences are identical. The adapter name is mixed into the `LocalBlockHash` computation.
+- **Automatic prefix sharing within the same adapter**: Requests targeting the same LoRA adapter benefit from KV cache prefix matching just like base model requests do.
+- **No configuration required**: The LoRA name is propagated automatically through KV events (`BlockStored`) from the engine to the router. The router uses the `lora_name` field on events to route LoRA requests to workers that have matching cached blocks.
+
+This works end-to-end across the publisher pipeline, the KV consolidator (for deduplication), and the routing query path.
+
 ## See Also
 
 - [Feature Matrix](../../reference/feature-matrix.md) - Backend compatibility overview
 - [vLLM Backend](../../backends/vllm/README.md) - vLLM-specific configuration
 - [Dynamo Operator](../../kubernetes/dynamo-operator.md) - Kubernetes operator overview
 - [KV-Aware Routing](../../components/router/router-guide.md) - LoRA-aware request routing
+- [KV Events for Custom Engines](../../integrations/kv-events-custom-engines.md) - Publishing LoRA-aware KV events

--- a/docs/pages/integrations/kv-events-custom-engines.md
+++ b/docs/pages/integrations/kv-events-custom-engines.md
@@ -42,7 +42,6 @@ For `BlockStored` events:
 - **`num_block_tokens`**: Number of tokens per block (should all equal `kv_block_size`)
 - **`parent_hash`**: Hash of the parent block. Required for all blocks except the first block in a sequence (which has no parent).
 - **`lora_name`**: LoRA adapter name string (omit or `None` for base model). When set, the adapter name is incorporated into block hash computation so that blocks for different LoRA adapters (or the base model) are never conflated.
-- **`lora_id`**: *(Deprecated)* Numeric LoRA adapter ID. Use `lora_name` instead.
 
 For `BlockRemoved` events:
 - **`block_hashes`**: List of sequence block hashes being evicted
@@ -211,7 +210,6 @@ For `BlockStored`:
     "parent_block_hash": signed_i64 | None,  # Parent hash
     "token_ids": [int, ...],                 # Token IDs
     "block_size": int,                       # Tokens per block
-    "lora_id": int | None,                   # LoRA adapter ID (deprecated, use lora_name)
     "lora_name": str | None,                 # LoRA adapter name
 }
 ```
@@ -260,14 +258,13 @@ publish_stored(
     token_ids: list[int],
     num_block_tokens: list[int],
     block_hashes: list[int],
-    lora_id: int = 0,
     parent_hash: int | None = None,
     block_mm_infos: list[dict | None] | None = None,
     lora_name: str | None = None,
 )
 ```
 
-Publish a block-stored event. Event IDs are managed internally. When `lora_name` is provided, the adapter name is mixed into block hash computation so blocks cached under different adapters produce distinct hashes. The `lora_id` parameter is deprecated; use `lora_name` instead.
+Publish a block-stored event. Event IDs are managed internally. When `lora_name` is provided, the adapter name is mixed into block hash computation so blocks cached under different adapters produce distinct hashes.
 
 #### `publish_removed()`
 

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -335,11 +335,13 @@ pub unsafe extern "C" fn dynamo_kv_event_publish_stored(
     let lora_name = if lora_name.is_null() {
         None
     } else {
-        Some(
-            unsafe { CStr::from_ptr(lora_name) }
-                .to_string_lossy()
-                .into_owned(),
-        )
+        match unsafe { CStr::from_ptr(lora_name) }.to_str() {
+            Ok(s) => Some(s.to_owned()),
+            Err(e) => {
+                tracing::error!(error = ?e, "Failed to convert C string to Rust string (lora_name)");
+                return DynamoLlmResult::ERR;
+            }
+        }
     };
     let kv_params = DynamoKvStoredEventParams {
         event_id,

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -212,7 +212,6 @@ fn kv_event_create_stored_block_from_parts(
     token_ids: *const u32,
     num_tokens: usize,
     kv_block_size: u32,
-    _lora_id: u64,
     lora_name: Option<&str>,
 ) -> KvCacheStoredBlockData {
     let tokens_hash = compute_block_hash_for_seq(
@@ -266,7 +265,6 @@ fn kv_event_create_stored_from_parts(
             tokens,
             num_toks,
             kv_block_size,
-            kv_params.lora_id,
             kv_params.lora_name.as_deref(),
         ));
     }
@@ -306,7 +304,6 @@ pub struct DynamoKvStoredEventParams {
     pub block_ids: *const u64,
     pub num_blocks: usize,
     pub parent_hash: Option<u64>,
-    pub lora_id: u64,
     pub lora_name: Option<String>,
 }
 
@@ -322,7 +319,6 @@ pub unsafe extern "C" fn dynamo_kv_event_publish_stored(
     block_ids: *const u64,
     num_blocks: usize,
     parent_hash: *const u64,
-    lora_id: u64,
     lora_name: *const c_char,
 ) -> DynamoLlmResult {
     let parent_hash = {
@@ -350,7 +346,6 @@ pub unsafe extern "C" fn dynamo_kv_event_publish_stored(
         block_ids,
         num_blocks,
         parent_hash,
-        lora_id,
         lora_name,
     };
     let publisher = KV_PUB.get().unwrap();

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -335,7 +335,11 @@ pub unsafe extern "C" fn dynamo_kv_event_publish_stored(
     let lora_name = if lora_name.is_null() {
         None
     } else {
-        Some(unsafe { CStr::from_ptr(lora_name) }.to_string_lossy().into_owned())
+        Some(
+            unsafe { CStr::from_ptr(lora_name) }
+                .to_string_lossy()
+                .into_owned(),
+        )
     };
     let kv_params = DynamoKvStoredEventParams {
         event_id,
@@ -799,7 +803,10 @@ pub unsafe extern "C" fn add_request(
             let worker = WorkerWithDpRank::new(worker_id, dp_rank);
 
             // Compute overlap_blocks using the public method
-            let overlap_blocks = match decode_router.get_overlap_blocks(&tokens, worker, None).await {
+            let overlap_blocks = match decode_router
+                .get_overlap_blocks(&tokens, worker, None)
+                .await
+            {
                 Ok(overlap) => overlap,
                 Err(e) => {
                     tracing::warn!(error = ?e, "Failed to compute overlap, using 0");

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -66,8 +66,12 @@ pub fn compute_block_hash_for_seq_py(
         .map(depythonize_block_mm_infos)
         .transpose()?;
 
-    let hashes =
-        compute_block_hash_for_seq(&tokens, kv_block_size as u32, mm_infos.as_deref(), lora_name.as_deref());
+    let hashes = compute_block_hash_for_seq(
+        &tokens,
+        kv_block_size as u32,
+        mm_infos.as_deref(),
+        lora_name.as_deref(),
+    );
 
     Ok(hashes.into_iter().map(|h| h.0).collect())
 }

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -47,12 +47,13 @@ pub fn start_kv_block_indexer_py<'p>(
 }
 
 #[pyfunction]
-#[pyo3(name = "compute_block_hash_for_seq", signature = (tokens, kv_block_size, block_mm_infos=None))]
+#[pyo3(name = "compute_block_hash_for_seq", signature = (tokens, kv_block_size, block_mm_infos=None, lora_name=None))]
 pub fn compute_block_hash_for_seq_py(
     _py: Python,
     tokens: Vec<u32>,
     kv_block_size: usize,
     block_mm_infos: Option<Bound<PyAny>>,
+    lora_name: Option<String>,
 ) -> PyResult<Vec<u64>> {
     if kv_block_size == 0 {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
@@ -65,7 +66,8 @@ pub fn compute_block_hash_for_seq_py(
         .map(depythonize_block_mm_infos)
         .transpose()?;
 
-    let hashes = compute_block_hash_for_seq(&tokens, kv_block_size as u32, mm_infos.as_deref());
+    let hashes =
+        compute_block_hash_for_seq(&tokens, kv_block_size as u32, mm_infos.as_deref(), lora_name.as_deref());
 
     Ok(hashes.into_iter().map(|h| h.0).collect())
 }
@@ -169,23 +171,23 @@ impl KvEventPublisher {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (token_ids, num_block_tokens, block_hashes, lora_id, parent_hash=None, block_mm_infos=None))]
+    #[pyo3(signature = (token_ids, num_block_tokens, block_hashes, lora_id=0, parent_hash=None, block_mm_infos=None, lora_name=None))]
     fn publish_stored(
         &self,
         py: Python,
         token_ids: Vec<u32>,
         num_block_tokens: Vec<u64>,
         block_hashes: Vec<i64>,
-        lora_id: u64,
+        #[allow(unused_variables)] lora_id: u64,
         parent_hash: Option<i64>,
         block_mm_infos: Option<Bound<PyAny>>,
+        lora_name: Option<String>,
     ) -> PyResult<()> {
         let kv_block_size = self.kv_block_size as u32;
         let dp_rank = self.dp_rank;
         let warning_count = self.warning_count.clone();
         let inner = self.inner.clone();
 
-        // Use shared monotonic event_id counter from the inner publisher
         let event_id = inner.next_event_id();
 
         let mm_infos = block_mm_infos
@@ -204,7 +206,7 @@ impl KvEventPublisher {
                         &token_ids,
                         &num_block_tokens,
                         &block_hashes_u64,
-                        lora_id,
+                        lora_name.as_deref(),
                         &warning_count,
                         mm_infos.as_deref(),
                     ),
@@ -879,7 +881,7 @@ impl KvRouter {
         Self::process_request_to_stream(py, self.inner.clone(), request, Some(tracker))
     }
 
-    #[pyo3(signature = (token_ids, router_config_override=None, request_id=None, block_mm_infos=None))]
+    #[pyo3(signature = (token_ids, router_config_override=None, request_id=None, block_mm_infos=None, lora_name=None))]
     fn best_worker<'p>(
         &self,
         py: Python<'p>,
@@ -887,6 +889,7 @@ impl KvRouter {
         router_config_override: Option<PyObject>,
         request_id: Option<String>,
         block_mm_infos: Option<PyObject>,
+        lora_name: Option<String>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let router_config_override = if let Some(obj) = router_config_override {
             let override_config: llm_rs::kv_router::RouterConfigOverride =
@@ -911,7 +914,7 @@ impl KvRouter {
                     block_mm_infos.as_deref(),
                     router_config_override.as_ref(),
                     update_states,
-                    None, // lora_name not exposed in Python API yet
+                    lora_name,
                     0.0,
                 )
                 .await
@@ -948,16 +951,18 @@ impl KvRouter {
         })
     }
 
+    #[pyo3(signature = (token_ids, lora_name=None))]
     fn get_potential_loads<'p>(
         &self,
         py: Python<'p>,
         token_ids: Vec<u32>,
+        lora_name: Option<String>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let chooser = self.inner.chooser.clone();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let loads = chooser
-                .get_potential_loads(&token_ids, None)
+                .get_potential_loads(&token_ids, None, lora_name.as_deref())
                 .await
                 .map_err(to_pyerr)?;
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -175,14 +175,13 @@ impl KvEventPublisher {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (token_ids, num_block_tokens, block_hashes, lora_id=0, parent_hash=None, block_mm_infos=None, lora_name=None))]
+    #[pyo3(signature = (token_ids, num_block_tokens, block_hashes, parent_hash=None, block_mm_infos=None, lora_name=None))]
     fn publish_stored(
         &self,
         py: Python,
         token_ids: Vec<u32>,
         num_block_tokens: Vec<u64>,
         block_hashes: Vec<i64>,
-        #[allow(unused_variables)] lora_id: u64,
         parent_hash: Option<i64>,
         block_mm_infos: Option<Bound<PyAny>>,
         lora_name: Option<String>,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -563,7 +563,7 @@ class KvIndexer:
         ...
 
     def find_matches_for_request(
-        self, token_ids: List[int], lora_id: int
+        self, token_ids: List[int], lora_name: Optional[str] = None
     ) -> OverlapScores:
         """
         Return the overlapping scores of workers for the given token ids.
@@ -611,13 +611,14 @@ class ApproxKvIndexer:
         ...
 
     def find_matches_for_request(
-        self, token_ids: List[int]
+        self, token_ids: List[int], lora_name: Optional[str] = None
     ) -> OverlapScores:
         """
         Return the overlapping scores of workers for the given token ids.
 
         Args:
             token_ids: List of token IDs to find matches for
+            lora_name: Optional LoRA adapter name for adapter-aware matching
 
         Returns:
             OverlapScores containing worker matching scores and frequencies
@@ -690,7 +691,6 @@ class KvEventPublisher:
         token_ids: List[int],
         num_block_tokens: List[int],
         block_hashes: List[int],
-        lora_id: int = 0,
         parent_hash: Optional[int] = None,
         block_mm_infos: Optional[List[Optional[Dict[str, Any]]]] = None,
         lora_name: Optional[str] = None,
@@ -704,11 +704,11 @@ class KvEventPublisher:
             token_ids: List of token IDs
             num_block_tokens: Number of tokens per block
             block_hashes: List of block hashes (signed 64-bit integers)
-            lora_id: The LoRA ID
             parent_hash: Optional parent hash (signed 64-bit integer)
             block_mm_infos: Optional list of multimodal info for each block.
                 Each item is either None or a dict with "mm_objects" key containing
                 a list of {"mm_hash": int, "offsets": [[start, end], ...]} dicts.
+            lora_name: Optional LoRA adapter name for adapter-aware block hashing.
         """
         ...
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -236,7 +236,8 @@ class ModelCardInstanceId:
 def compute_block_hash_for_seq(
     tokens: List[int],
     kv_block_size: int,
-    block_mm_infos: Optional[List[Optional[Dict[str, Any]]]] = None
+    block_mm_infos: Optional[List[Optional[Dict[str, Any]]]] = None,
+    lora_name: Optional[str] = None,
 ) -> List[int]:
     """
     Compute block hashes for a sequence of tokens, optionally including multimodal metadata.
@@ -689,9 +690,10 @@ class KvEventPublisher:
         token_ids: List[int],
         num_block_tokens: List[int],
         block_hashes: List[int],
-        lora_id: int,
+        lora_id: int = 0,
         parent_hash: Optional[int] = None,
         block_mm_infos: Optional[List[Optional[Dict[str, Any]]]] = None,
+        lora_name: Optional[str] = None,
     ) -> None:
         """
         Publish a KV stored event.
@@ -1388,6 +1390,7 @@ class KvRouter:
         router_config_override: Optional[JsonLike] = None,
         request_id: Optional[str] = None,
         block_mm_infos: Optional[List[Optional[Dict[str, Any]]]] = None,
+        lora_name: Optional[str] = None,
     ) -> Tuple[int, int, int]:
         """
         Find the best matching worker for the given tokens.
@@ -1413,6 +1416,7 @@ class KvRouter:
     async def get_potential_loads(
         self,
         token_ids: List[int],
+        lora_name: Optional[str] = None,
     ) -> List[Dict[str, int]]:
         """
         Get potential prefill and decode loads for all workers.

--- a/lib/kv-router/README.md
+++ b/lib/kv-router/README.md
@@ -10,13 +10,14 @@ Every cached KV block in a distributed LLM system needs four pieces of informati
 
 ### 1. Local Block Hash (`LocalBlockHash`, u64)
 
-**What**: Hash of the tokens *within* a single block (e.g., 64 tokens).
+**What**: Hash of the tokens *within* a single block (e.g., 64 tokens), optionally including LoRA adapter name and multimodal metadata.
 
-**Why**: Identifies the content of this specific block, independent of context. Two blocks with the same tokens have the same local hash.
+**Why**: Identifies the content of this specific block, independent of context. Two blocks with the same tokens (and same LoRA adapter) have the same local hash. When a LoRA adapter name is provided, it is length-prefixed and appended to the byte buffer before hashing, ensuring that blocks under different adapters (or the base model) always produce distinct hashes.
 
 ```
 Block at position 5: tokens [101, 102, 103, ...]
-LocalBlockHash = hash(tokens) = 0xABCD1234
+LocalBlockHash = hash(tokens)                          = 0xABCD1234  (base model)
+LocalBlockHash = hash(tokens || len("my-lora") || "my-lora") = 0xDEAD5678  (LoRA adapter)
 ```
 
 ### 2. External Sequence Block Hash (`ExternalSequenceBlockHash`, u64)

--- a/lib/kv-router/README.md
+++ b/lib/kv-router/README.md
@@ -14,7 +14,7 @@ Every cached KV block in a distributed LLM system needs four pieces of informati
 
 **Why**: Identifies the content of this specific block, independent of context. Two blocks with the same tokens (and same LoRA adapter) have the same local hash. When a LoRA adapter name is provided, it is length-prefixed and appended to the byte buffer before hashing, ensuring that blocks under different adapters (or the base model) always produce distinct hashes.
 
-```
+```text
 Block at position 5: tokens [101, 102, 103, ...]
 LocalBlockHash = hash(tokens)                          = 0xABCD1234  (base model)
 LocalBlockHash = hash(tokens || len("my-lora") || "my-lora") = 0xDEAD5678  (LoRA adapter)

--- a/lib/kv-router/benches/radix_tree_microbench.rs
+++ b/lib/kv-router/benches/radix_tree_microbench.rs
@@ -302,7 +302,7 @@ fn bench_hash(args: &Args) {
 
     for (i, tokens) in token_sequences.iter().enumerate() {
         let start = Instant::now();
-        let _ = compute_block_hash_for_seq(tokens, args.block_size, None);
+        let _ = compute_block_hash_for_seq(tokens, args.block_size, None, None);
         let elapsed = start.elapsed();
 
         if i >= warmup_iters {

--- a/lib/kv-router/src/approx.rs
+++ b/lib/kv-router/src/approx.rs
@@ -349,7 +349,7 @@ mod tests {
 
         // 1. Before routing decision there should be no matches
         let pre_scores = indexer
-            .find_matches_for_request(&tokens)
+            .find_matches_for_request(&tokens, None)
             .await
             .expect("indexer offline");
         assert!(pre_scores.scores.is_empty());
@@ -366,7 +366,7 @@ mod tests {
 
         // Poll until we observe the match being registered
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens).await.unwrap();
+            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
             s.scores
                 .get(&WorkerWithDpRank::from_worker_id(worker_id))
                 .copied()
@@ -376,7 +376,7 @@ mod tests {
 
         // 3. After the TTL has passed the entry should expire automatically
         time::sleep(TTL + Duration::from_millis(50)).await;
-        let post_scores = indexer.find_matches_for_request(&tokens).await.unwrap();
+        let post_scores = indexer.find_matches_for_request(&tokens, None).await.unwrap();
         assert!(post_scores.scores.is_empty());
     }
 
@@ -413,7 +413,7 @@ mod tests {
 
         // Wait until the worker is registered
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens).await.unwrap();
+            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
             s.scores
                 .contains_key(&WorkerWithDpRank::from_worker_id(worker_id))
         })
@@ -424,7 +424,7 @@ mod tests {
 
         // Ensure the worker's entries are gone
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens).await.unwrap();
+            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
             !s.scores
                 .contains_key(&WorkerWithDpRank::from_worker_id(worker_id))
         })
@@ -475,7 +475,7 @@ mod tests {
 
         // Ensure both workers are registered
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens).await.unwrap();
+            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
             s.scores
                 .get(&WorkerWithDpRank::from_worker_id(worker_0))
                 .copied()
@@ -492,7 +492,7 @@ mod tests {
 
         // Confirm the removed worker is gone, and the other remains.
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens).await.unwrap();
+            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
             !s.scores
                 .contains_key(&WorkerWithDpRank::from_worker_id(worker_0))
                 && s.scores
@@ -539,7 +539,7 @@ mod tests {
 
         // Ensure the indexer has registered the block
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&seq_a).await.unwrap();
+            let s = indexer.find_matches_for_request(&seq_a, None).await.unwrap();
             s.scores
                 .get(&WorkerWithDpRank::from_worker_id(worker_a))
                 .copied()
@@ -551,7 +551,7 @@ mod tests {
         let seq_b: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8];
 
         // Query the indexer for overlaps of Sequence B (before it has been routed anywhere)
-        let overlap = indexer.find_matches_for_request(&seq_b).await.unwrap();
+        let overlap = indexer.find_matches_for_request(&seq_b, None).await.unwrap();
 
         // Expect worker A to have an overlap score of 1 (shared first block)
         assert_eq!(
@@ -606,7 +606,7 @@ mod tests {
 
         // Wait until both workers are reflected in overlap scores
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens).await.unwrap();
+            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
             s.scores
                 .get(&WorkerWithDpRank::from_worker_id(worker_0))
                 .copied()
@@ -618,7 +618,7 @@ mod tests {
         })
         .await;
 
-        let scores = indexer.find_matches_for_request(&tokens).await.unwrap();
+        let scores = indexer.find_matches_for_request(&tokens, None).await.unwrap();
 
         assert_eq!(
             scores
@@ -777,7 +777,7 @@ mod tests {
         // Verify all 5 blocks are present (no pruning yet)
         for i in 0..5 {
             let tokens: Vec<u32> = vec![i * 10, i * 10 + 1, i * 10 + 2, i * 10 + 3];
-            let scores = indexer.find_matches_for_request(&tokens).await.unwrap();
+            let scores = indexer.find_matches_for_request(&tokens, None).await.unwrap();
             assert_eq!(
                 scores.scores.get(&worker).copied(),
                 Some(1),
@@ -803,7 +803,7 @@ mod tests {
         // Verify that the 4 oldest blocks are pruned
         for i in 0..4 {
             let tokens: Vec<u32> = vec![i * 10, i * 10 + 1, i * 10 + 2, i * 10 + 3];
-            let scores = indexer.find_matches_for_request(&tokens).await.unwrap();
+            let scores = indexer.find_matches_for_request(&tokens, None).await.unwrap();
             assert!(
                 scores.scores.get(&worker).copied().unwrap_or(0) == 0,
                 "Block {} should have been pruned but is still present",
@@ -814,7 +814,7 @@ mod tests {
         // Verify the 2 newest blocks are present
         for i in 4..6 {
             let tokens: Vec<u32> = vec![i * 10, i * 10 + 1, i * 10 + 2, i * 10 + 3];
-            let scores = indexer.find_matches_for_request(&tokens).await.unwrap();
+            let scores = indexer.find_matches_for_request(&tokens, None).await.unwrap();
             assert_eq!(
                 scores.scores.get(&worker).copied(),
                 Some(1),

--- a/lib/kv-router/src/approx.rs
+++ b/lib/kv-router/src/approx.rs
@@ -366,7 +366,10 @@ mod tests {
 
         // Poll until we observe the match being registered
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+            let s = indexer
+                .find_matches_for_request(&tokens, None)
+                .await
+                .unwrap();
             s.scores
                 .get(&WorkerWithDpRank::from_worker_id(worker_id))
                 .copied()
@@ -376,7 +379,10 @@ mod tests {
 
         // 3. After the TTL has passed the entry should expire automatically
         time::sleep(TTL + Duration::from_millis(50)).await;
-        let post_scores = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+        let post_scores = indexer
+            .find_matches_for_request(&tokens, None)
+            .await
+            .unwrap();
         assert!(post_scores.scores.is_empty());
     }
 
@@ -413,7 +419,10 @@ mod tests {
 
         // Wait until the worker is registered
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+            let s = indexer
+                .find_matches_for_request(&tokens, None)
+                .await
+                .unwrap();
             s.scores
                 .contains_key(&WorkerWithDpRank::from_worker_id(worker_id))
         })
@@ -424,7 +433,10 @@ mod tests {
 
         // Ensure the worker's entries are gone
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+            let s = indexer
+                .find_matches_for_request(&tokens, None)
+                .await
+                .unwrap();
             !s.scores
                 .contains_key(&WorkerWithDpRank::from_worker_id(worker_id))
         })
@@ -475,7 +487,10 @@ mod tests {
 
         // Ensure both workers are registered
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+            let s = indexer
+                .find_matches_for_request(&tokens, None)
+                .await
+                .unwrap();
             s.scores
                 .get(&WorkerWithDpRank::from_worker_id(worker_0))
                 .copied()
@@ -492,7 +507,10 @@ mod tests {
 
         // Confirm the removed worker is gone, and the other remains.
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+            let s = indexer
+                .find_matches_for_request(&tokens, None)
+                .await
+                .unwrap();
             !s.scores
                 .contains_key(&WorkerWithDpRank::from_worker_id(worker_0))
                 && s.scores
@@ -539,7 +557,10 @@ mod tests {
 
         // Ensure the indexer has registered the block
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&seq_a, None).await.unwrap();
+            let s = indexer
+                .find_matches_for_request(&seq_a, None)
+                .await
+                .unwrap();
             s.scores
                 .get(&WorkerWithDpRank::from_worker_id(worker_a))
                 .copied()
@@ -551,7 +572,10 @@ mod tests {
         let seq_b: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8];
 
         // Query the indexer for overlaps of Sequence B (before it has been routed anywhere)
-        let overlap = indexer.find_matches_for_request(&seq_b, None).await.unwrap();
+        let overlap = indexer
+            .find_matches_for_request(&seq_b, None)
+            .await
+            .unwrap();
 
         // Expect worker A to have an overlap score of 1 (shared first block)
         assert_eq!(
@@ -606,7 +630,10 @@ mod tests {
 
         // Wait until both workers are reflected in overlap scores
         spin_until(Duration::from_millis(100), || async {
-            let s = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+            let s = indexer
+                .find_matches_for_request(&tokens, None)
+                .await
+                .unwrap();
             s.scores
                 .get(&WorkerWithDpRank::from_worker_id(worker_0))
                 .copied()
@@ -618,7 +645,10 @@ mod tests {
         })
         .await;
 
-        let scores = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+        let scores = indexer
+            .find_matches_for_request(&tokens, None)
+            .await
+            .unwrap();
 
         assert_eq!(
             scores
@@ -777,7 +807,10 @@ mod tests {
         // Verify all 5 blocks are present (no pruning yet)
         for i in 0..5 {
             let tokens: Vec<u32> = vec![i * 10, i * 10 + 1, i * 10 + 2, i * 10 + 3];
-            let scores = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+            let scores = indexer
+                .find_matches_for_request(&tokens, None)
+                .await
+                .unwrap();
             assert_eq!(
                 scores.scores.get(&worker).copied(),
                 Some(1),
@@ -803,7 +836,10 @@ mod tests {
         // Verify that the 4 oldest blocks are pruned
         for i in 0..4 {
             let tokens: Vec<u32> = vec![i * 10, i * 10 + 1, i * 10 + 2, i * 10 + 3];
-            let scores = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+            let scores = indexer
+                .find_matches_for_request(&tokens, None)
+                .await
+                .unwrap();
             assert!(
                 scores.scores.get(&worker).copied().unwrap_or(0) == 0,
                 "Block {} should have been pruned but is still present",
@@ -814,7 +850,10 @@ mod tests {
         // Verify the 2 newest blocks are present
         for i in 4..6 {
             let tokens: Vec<u32> = vec![i * 10, i * 10 + 1, i * 10 + 2, i * 10 + 3];
-            let scores = indexer.find_matches_for_request(&tokens, None).await.unwrap();
+            let scores = indexer
+                .find_matches_for_request(&tokens, None)
+                .await
+                .unwrap();
             assert_eq!(
                 scores.scores.get(&worker).copied(),
                 Some(1),

--- a/lib/kv-router/src/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/concurrent_radix_tree.rs
@@ -1122,7 +1122,7 @@ mod tests {
 
             tokio::time::sleep(Duration::from_millis(100)).await;
 
-            let scores = indexer.find_matches_for_request(&[100, 200, 300]).await;
+            let scores = indexer.find_matches_for_request(&[100, 200, 300], None).await;
             assert!(scores.is_ok());
 
             indexer.shutdown();

--- a/lib/kv-router/src/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/concurrent_radix_tree.rs
@@ -1122,7 +1122,9 @@ mod tests {
 
             tokio::time::sleep(Duration::from_millis(100)).await;
 
-            let scores = indexer.find_matches_for_request(&[100, 200, 300], None).await;
+            let scores = indexer
+                .find_matches_for_request(&[100, 200, 300], None)
+                .await;
             assert!(scores.is_ok());
 
             indexer.shutdown();

--- a/lib/kv-router/src/indexer.rs
+++ b/lib/kv-router/src/indexer.rs
@@ -511,7 +511,7 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
         &self,
         tokens: &[u32],
     ) -> Result<OverlapScores, KvRouterError> {
-        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None);
+        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None, None);
         Ok(self.backend.find_matches(&sequence, false))
     }
 
@@ -978,7 +978,7 @@ impl KvIndexerInterface for KvIndexer {
             tokens,
             tokens.len()
         );
-        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None);
+        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None, None);
         tracing::debug!("Computed sequence: {:?}", sequence);
         self.find_matches(sequence).await
     }
@@ -1761,7 +1761,7 @@ impl KvIndexerInterface for KvIndexerSharded {
         &self,
         tokens: &[u32],
     ) -> Result<OverlapScores, KvRouterError> {
-        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None);
+        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None, None);
         self.find_matches(sequence).await
     }
 

--- a/lib/kv-router/src/indexer.rs
+++ b/lib/kv-router/src/indexer.rs
@@ -302,6 +302,7 @@ pub trait KvIndexerInterface {
     /// ### Arguments
     ///
     /// * `tokens` - A vector of `u32` tokens.
+    /// * `lora_name` - Optional LoRA adapter name to include in block hash computation.
     ///
     /// ### Returns
     ///
@@ -309,6 +310,7 @@ pub trait KvIndexerInterface {
     async fn find_matches_for_request(
         &self,
         tokens: &[u32],
+        lora_name: Option<&str>,
     ) -> Result<OverlapScores, KvRouterError>;
 
     /// Apply a `RouterEvent` to the KV store.
@@ -510,8 +512,9 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
     async fn find_matches_for_request(
         &self,
         tokens: &[u32],
+        lora_name: Option<&str>,
     ) -> Result<OverlapScores, KvRouterError> {
-        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None, None);
+        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None, lora_name);
         Ok(self.backend.find_matches(&sequence, false))
     }
 
@@ -972,13 +975,14 @@ impl KvIndexerInterface for KvIndexer {
     async fn find_matches_for_request(
         &self,
         tokens: &[u32],
+        lora_name: Option<&str>,
     ) -> Result<OverlapScores, KvRouterError> {
         tracing::debug!(
             "Finding matches for request tokens: {:?} / len: {}",
             tokens,
             tokens.len()
         );
-        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None, None);
+        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None, lora_name);
         tracing::debug!("Computed sequence: {:?}", sequence);
         self.find_matches(sequence).await
     }
@@ -1307,8 +1311,9 @@ impl KvIndexerInterface for LocalKvIndexer {
     async fn find_matches_for_request(
         &self,
         tokens: &[u32],
+        lora_name: Option<&str>,
     ) -> Result<OverlapScores, KvRouterError> {
-        self.indexer.find_matches_for_request(tokens).await
+        self.indexer.find_matches_for_request(tokens, lora_name).await
     }
 
     async fn apply_event(&self, event: RouterEvent) {
@@ -1760,8 +1765,9 @@ impl KvIndexerInterface for KvIndexerSharded {
     async fn find_matches_for_request(
         &self,
         tokens: &[u32],
+        lora_name: Option<&str>,
     ) -> Result<OverlapScores, KvRouterError> {
-        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None, None);
+        let sequence = compute_block_hash_for_seq(tokens, self.kv_block_size, None, lora_name);
         self.find_matches(sequence).await
     }
 
@@ -2350,7 +2356,7 @@ mod tests {
 
         // Empty index should return no matches
         let tokens = vec![1, 2, 3, 4];
-        let scores = index.find_matches_for_request(&tokens).await.unwrap();
+        let scores = index.find_matches_for_request(&tokens, None).await.unwrap();
         assert!(scores.scores.is_empty());
 
         // Store some data and verify we can find it via tokens
@@ -2362,7 +2368,7 @@ mod tests {
         // Note: find_matches_for_request computes block hashes from tokens,
         // so we need tokens that hash to the same LocalBlockHash values.
         // For this test, we just verify the method works without error.
-        let scores = index.find_matches_for_request(&tokens).await.unwrap();
+        let scores = index.find_matches_for_request(&tokens, None).await.unwrap();
         // The tokens [1,2,3,4] won't match our stored [1,2,3] local hashes
         // because find_matches_for_request computes different hashes from raw tokens
         assert!(scores.scores.is_empty() || !scores.scores.is_empty());

--- a/lib/kv-router/src/indexer.rs
+++ b/lib/kv-router/src/indexer.rs
@@ -1911,7 +1911,10 @@ mod tests {
     use super::*;
     use crate::concurrent_radix_tree::ConcurrentRadixTree;
     use crate::nested_map::PositionalIndexer;
-    use crate::protocols::{ExternalSequenceBlockHash, LocalBlockHash, compute_seq_hash_for_block};
+    use crate::protocols::{
+        ExternalSequenceBlockHash, LocalBlockHash, compute_block_hash_for_seq,
+        compute_seq_hash_for_block,
+    };
     use rstest::rstest;
     use rstest_reuse::{self, *};
     use std::time::Instant;
@@ -2629,6 +2632,296 @@ mod tests {
             scores.scores.is_empty(),
             "Cleared event should clear all dp_ranks for a worker"
         );
+    }
+
+    // ============================================================================
+    // LoRA isolation tests
+    // ============================================================================
+
+    #[tokio::test]
+    #[apply(indexer_template)]
+    async fn test_lora_and_base_model_blocks_do_not_conflict(variant: &str) {
+        let index = make_indexer(variant);
+        let kv_block_size: u32 = 32;
+
+        // Same token sequence for both base model and LoRA adapter
+        let tokens: Vec<u32> = (0..kv_block_size * 3).collect();
+
+        let base_hashes = compute_block_hash_for_seq(&tokens, kv_block_size, None, None);
+        let lora_hashes =
+            compute_block_hash_for_seq(&tokens, kv_block_size, None, Some("my-adapter"));
+
+        // Hashes must differ despite identical tokens
+        assert_ne!(
+            base_hashes, lora_hashes,
+            "Base and LoRA hashes must differ for the same tokens"
+        );
+
+        let base_seq = compute_seq_hash_for_block(&base_hashes);
+        let lora_seq = compute_seq_hash_for_block(&lora_hashes);
+
+        // Store base-model blocks on worker 0
+        let base_event = RouterEvent {
+            worker_id: 0,
+            event: KvCacheEvent {
+                event_id: 0,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    blocks: base_hashes
+                        .iter()
+                        .zip(base_seq.iter())
+                        .map(|(&local, &seq)| KvCacheStoredBlockData {
+                            tokens_hash: local,
+                            block_hash: ExternalSequenceBlockHash(seq),
+                            mm_extra_info: None,
+                        })
+                        .collect(),
+                }),
+                dp_rank: 0,
+            },
+        };
+        index.apply_event(base_event).await;
+
+        // Store LoRA blocks on worker 1
+        let lora_event = RouterEvent {
+            worker_id: 1,
+            event: KvCacheEvent {
+                event_id: 0,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    blocks: lora_hashes
+                        .iter()
+                        .zip(lora_seq.iter())
+                        .map(|(&local, &seq)| KvCacheStoredBlockData {
+                            tokens_hash: local,
+                            block_hash: ExternalSequenceBlockHash(seq),
+                            mm_extra_info: None,
+                        })
+                        .collect(),
+                }),
+                dp_rank: 0,
+            },
+        };
+        index.apply_event(lora_event).await;
+
+        // flush + settle time for thread-pool variants
+        index.flush().await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Query with base-model hashes → only worker 0
+        let base_scores = index.find_matches(base_hashes.clone()).await.unwrap();
+        assert_eq!(
+            base_scores.scores.len(),
+            1,
+            "Only base-model worker should match"
+        );
+        assert_eq!(
+            *base_scores
+                .scores
+                .get(&WorkerWithDpRank::new(0, 0))
+                .unwrap(),
+            3
+        );
+
+        // Query with LoRA hashes → only worker 1
+        let lora_scores = index.find_matches(lora_hashes.clone()).await.unwrap();
+        assert_eq!(lora_scores.scores.len(), 1, "Only LoRA worker should match");
+        assert_eq!(
+            *lora_scores
+                .scores
+                .get(&WorkerWithDpRank::new(1, 0))
+                .unwrap(),
+            3
+        );
+    }
+
+    /// Reproduces the "block_hash mismatch: sequence hashes should be uniform
+    /// across workers" warning seen when the same prompt is sent to both a base
+    /// model worker and a LoRA worker.
+    ///
+    /// On main (without LoRA-aware hashing), both workers compute the same
+    /// LocalBlockHash for identical tokens.  But vLLM's engine includes the
+    /// adapter in its rolling ExternalSequenceBlockHash, so the radix tree
+    /// sees conflicting sequence hashes at the same tree node.
+    ///
+    /// With LoRA-aware hashing, compute_block_hash_for_seq produces distinct
+    /// LocalBlockHash values for different adapters, so the blocks land on
+    /// separate tree paths and no mismatch occurs.
+    #[tokio::test]
+    #[apply(indexer_template)]
+    async fn test_lora_base_same_tokens_no_seq_hash_mismatch(variant: &str) {
+        let index = make_indexer(variant);
+        let kv_block_size: u32 = 32;
+
+        let tokens: Vec<u32> = (0..kv_block_size * 3).collect();
+
+        // With LoRA-aware hashing, base and adapter produce different LocalBlockHash
+        let base_local = compute_block_hash_for_seq(&tokens, kv_block_size, None, None);
+        let lora_local =
+            compute_block_hash_for_seq(&tokens, kv_block_size, None, Some("my-adapter"));
+
+        assert_ne!(
+            base_local, lora_local,
+            "LoRA-aware hashing must produce different LocalBlockHash values"
+        );
+
+        // Simulate what vLLM does: same tokens, different rolling seq hashes
+        // because the engine accounts for the adapter internally.
+        let base_seq = compute_seq_hash_for_block(&base_local);
+        let lora_seq = compute_seq_hash_for_block(&lora_local);
+
+        // Worker 0: base model
+        index
+            .apply_event(RouterEvent {
+                worker_id: 0,
+                event: KvCacheEvent {
+                    event_id: 0,
+                    data: KvCacheEventData::Stored(KvCacheStoreData {
+                        parent_hash: None,
+                        blocks: base_local
+                            .iter()
+                            .zip(base_seq.iter())
+                            .map(|(&local, &seq)| KvCacheStoredBlockData {
+                                tokens_hash: local,
+                                block_hash: ExternalSequenceBlockHash(seq),
+                                mm_extra_info: None,
+                            })
+                            .collect(),
+                    }),
+                    dp_rank: 0,
+                },
+            })
+            .await;
+
+        // Worker 1: LoRA adapter — different LocalBlockHash, so this goes to
+        // a separate tree path instead of colliding with worker 0's node.
+        index
+            .apply_event(RouterEvent {
+                worker_id: 1,
+                event: KvCacheEvent {
+                    event_id: 0,
+                    data: KvCacheEventData::Stored(KvCacheStoreData {
+                        parent_hash: None,
+                        blocks: lora_local
+                            .iter()
+                            .zip(lora_seq.iter())
+                            .map(|(&local, &seq)| KvCacheStoredBlockData {
+                                tokens_hash: local,
+                                block_hash: ExternalSequenceBlockHash(seq),
+                                mm_extra_info: None,
+                            })
+                            .collect(),
+                    }),
+                    dp_rank: 0,
+                },
+            })
+            .await;
+
+        index.flush().await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Base query finds only worker 0
+        let base_scores = index.find_matches(base_local.clone()).await.unwrap();
+        assert_eq!(base_scores.scores.len(), 1);
+        assert_eq!(
+            *base_scores
+                .scores
+                .get(&WorkerWithDpRank::new(0, 0))
+                .unwrap(),
+            3
+        );
+
+        // LoRA query finds only worker 1
+        let lora_scores = index.find_matches(lora_local.clone()).await.unwrap();
+        assert_eq!(lora_scores.scores.len(), 1);
+        assert_eq!(
+            *lora_scores
+                .scores
+                .get(&WorkerWithDpRank::new(1, 0))
+                .unwrap(),
+            3
+        );
+    }
+
+    #[tokio::test]
+    #[apply(indexer_template)]
+    async fn test_different_lora_adapters_do_not_conflict(variant: &str) {
+        let index = make_indexer(variant);
+        let kv_block_size: u32 = 32;
+
+        let tokens: Vec<u32> = (0..kv_block_size * 2).collect();
+
+        let hashes_a = compute_block_hash_for_seq(&tokens, kv_block_size, None, Some("adapter-a"));
+        let hashes_b = compute_block_hash_for_seq(&tokens, kv_block_size, None, Some("adapter-b"));
+
+        assert_ne!(
+            hashes_a, hashes_b,
+            "Different adapters must produce different hashes"
+        );
+
+        let seq_a = compute_seq_hash_for_block(&hashes_a);
+        let seq_b = compute_seq_hash_for_block(&hashes_b);
+
+        // Store adapter-a blocks on worker 0
+        index
+            .apply_event(RouterEvent {
+                worker_id: 0,
+                event: KvCacheEvent {
+                    event_id: 0,
+                    data: KvCacheEventData::Stored(KvCacheStoreData {
+                        parent_hash: None,
+                        blocks: hashes_a
+                            .iter()
+                            .zip(seq_a.iter())
+                            .map(|(&local, &seq)| KvCacheStoredBlockData {
+                                tokens_hash: local,
+                                block_hash: ExternalSequenceBlockHash(seq),
+                                mm_extra_info: None,
+                            })
+                            .collect(),
+                    }),
+                    dp_rank: 0,
+                },
+            })
+            .await;
+
+        // Store adapter-b blocks on worker 1
+        index
+            .apply_event(RouterEvent {
+                worker_id: 1,
+                event: KvCacheEvent {
+                    event_id: 0,
+                    data: KvCacheEventData::Stored(KvCacheStoreData {
+                        parent_hash: None,
+                        blocks: hashes_b
+                            .iter()
+                            .zip(seq_b.iter())
+                            .map(|(&local, &seq)| KvCacheStoredBlockData {
+                                tokens_hash: local,
+                                block_hash: ExternalSequenceBlockHash(seq),
+                                mm_extra_info: None,
+                            })
+                            .collect(),
+                    }),
+                    dp_rank: 0,
+                },
+            })
+            .await;
+
+        index.flush().await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Query adapter-a → only worker 0
+        let scores_a = index.find_matches(hashes_a.clone()).await.unwrap();
+        assert_eq!(scores_a.scores.len(), 1);
+        assert!(scores_a.scores.contains_key(&WorkerWithDpRank::new(0, 0)));
+        assert!(!scores_a.scores.contains_key(&WorkerWithDpRank::new(1, 0)));
+
+        // Query adapter-b → only worker 1
+        let scores_b = index.find_matches(hashes_b.clone()).await.unwrap();
+        assert_eq!(scores_b.scores.len(), 1);
+        assert!(scores_b.scores.contains_key(&WorkerWithDpRank::new(1, 0)));
+        assert!(!scores_b.scores.contains_key(&WorkerWithDpRank::new(0, 0)));
     }
 
     // ============================================================================

--- a/lib/kv-router/src/indexer.rs
+++ b/lib/kv-router/src/indexer.rs
@@ -1313,7 +1313,9 @@ impl KvIndexerInterface for LocalKvIndexer {
         tokens: &[u32],
         lora_name: Option<&str>,
     ) -> Result<OverlapScores, KvRouterError> {
-        self.indexer.find_matches_for_request(tokens, lora_name).await
+        self.indexer
+            .find_matches_for_request(tokens, lora_name)
+            .await
     }
 
     async fn apply_event(&self, event: RouterEvent) {

--- a/lib/kv-router/src/naive_indexers.rs
+++ b/lib/kv-router/src/naive_indexers.rs
@@ -174,6 +174,7 @@ impl KvIndexerInterface for NaiveNestedMap {
     async fn find_matches_for_request(
         &self,
         _tokens: &[u32],
+        _lora_name: Option<&str>,
     ) -> Result<OverlapScores, KvRouterError> {
         unimplemented!("not used in bench")
     }
@@ -384,6 +385,7 @@ impl KvIndexerInterface for InvertedIndex {
     async fn find_matches_for_request(
         &self,
         _tokens: &[u32],
+        _lora_name: Option<&str>,
     ) -> Result<OverlapScores, KvRouterError> {
         unimplemented!("not used in bench")
     }

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -769,8 +769,8 @@ mod tests {
         let mut base = TokensWithHashes::new(tokens.clone(), 4);
         let base_hashes = base.get_or_compute_block_hashes().to_vec();
 
-        let mut with_lora = TokensWithHashes::new(tokens, 4)
-            .with_lora_name("my-adapter".to_string());
+        let mut with_lora =
+            TokensWithHashes::new(tokens, 4).with_lora_name("my-adapter".to_string());
         let lora_hashes = with_lora.get_or_compute_block_hashes().to_vec();
 
         assert_eq!(base_hashes.len(), lora_hashes.len());

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -767,7 +767,10 @@ mod tests {
         let tokens: Vec<u32> = (0..4).collect();
         let base = compute_block_hash_for_seq(&tokens, 4, None, None);
         let empty = compute_block_hash_for_seq(&tokens, 4, None, Some(""));
-        assert_eq!(base, empty, "empty lora_name should be treated as base model");
+        assert_eq!(
+            base, empty,
+            "empty lora_name should be treated as base model"
+        );
     }
 
     #[test]

--- a/lib/llm/src/block_manager/events.rs
+++ b/lib/llm/src/block_manager/events.rs
@@ -223,7 +223,7 @@ impl DynamoEventManager {
                             tokens,
                             parent_hash,
                             block_size,
-                            None, // lora_id
+                            None, // lora_name
                             None, // tier
                             None, // data_parallel_rank
                         )

--- a/lib/llm/src/block_manager/kv_consolidator/mod.rs
+++ b/lib/llm/src/block_manager/kv_consolidator/mod.rs
@@ -40,7 +40,7 @@ impl KvEventConsolidatorHandle {
         token_ids: Vec<u32>,
         parent_hash: Option<String>,
         block_size: usize,
-        lora_id: Option<u64>,
+        lora_name: Option<String>,
         tier: Option<StorageTier>,
         data_parallel_rank: Option<i32>,
     ) {
@@ -51,7 +51,7 @@ impl KvEventConsolidatorHandle {
             token_ids,
             parent_hash,
             block_size,
-            lora_id.map(|id| id as i32),
+            lora_name,
             tier,
             data_parallel_rank,
         );

--- a/lib/llm/src/block_manager/kv_consolidator/subscriber.rs
+++ b/lib/llm/src/block_manager/kv_consolidator/subscriber.rs
@@ -145,8 +145,6 @@ enum VllmRawEvent {
         parent_block_hash: Option<BlockHash>,
         token_ids: Vec<i32>,
         block_size: i32,
-        #[allow(dead_code)]
-        lora_id: Option<i32>,
         #[serde(default)]
         medium: Option<String>,
         #[serde(default)]
@@ -278,7 +276,6 @@ fn process_event(
             parent_block_hash,
             token_ids,
             block_size,
-            lora_id: _,
             medium,
             lora_name,
         } => {

--- a/lib/llm/src/block_manager/kv_consolidator/subscriber.rs
+++ b/lib/llm/src/block_manager/kv_consolidator/subscriber.rs
@@ -145,12 +145,11 @@ enum VllmRawEvent {
         parent_block_hash: Option<BlockHash>,
         token_ids: Vec<i32>,
         block_size: i32,
+        #[allow(dead_code)]
         lora_id: Option<i32>,
         #[serde(default)]
         medium: Option<String>,
         #[serde(default)]
-        #[allow(dead_code)]
-        // Reserved for future use, needed for vLLM 0.14.0 deserialization
         lora_name: Option<String>,
     },
     #[serde(rename = "BlockRemoved")]
@@ -279,9 +278,9 @@ fn process_event(
             parent_block_hash,
             token_ids,
             block_size,
-            lora_id,
+            lora_id: _,
             medium,
-            lora_name: _, // Not used yet, lora_id is still used for backwards compat
+            lora_name,
         } => {
             let storage_tier = medium
                 .as_ref()
@@ -370,7 +369,7 @@ fn process_event(
                     block_tokens,
                     current_parent.clone(),
                     block_size_usize,
-                    lora_id,
+                    lora_name.clone(),
                     Some(storage_tier),
                     data_parallel_rank,
                 );

--- a/lib/llm/src/block_manager/kv_consolidator/tracker.rs
+++ b/lib/llm/src/block_manager/kv_consolidator/tracker.rs
@@ -188,8 +188,8 @@ pub enum ConsolidatedEvent {
         parent_hash: Option<String>,
         token_ids: Vec<u32>,
         block_size: usize,
-        lora_id: Option<i32>,
-        source: String, // The source where it was first stored (vllm or kvbm)
+        lora_name: Option<String>,
+        source: String,
     },
     /// Block removed (removed from all sources)
     Remove {
@@ -257,7 +257,7 @@ impl CacheStatusTracker {
         token_ids: Vec<u32>,
         parent_hash: Option<String>,
         block_size: usize,
-        lora_id: Option<i32>,
+        lora_name: Option<String>,
         tier: Option<StorageTier>,
         data_parallel_rank: Option<i32>,
     ) -> bool {
@@ -327,7 +327,7 @@ impl CacheStatusTracker {
                     .as_ref()
                     .map(|p| &p[..16.min(p.len())])
                     .unwrap_or("none"),
-                lora_id,
+                lora_name,
                 data_parallel_rank,
                 &token_ids
             );
@@ -366,7 +366,7 @@ impl CacheStatusTracker {
                 parent_hash: resolved_parent_hash,
                 token_ids,
                 block_size,
-                lora_id,
+                lora_name,
                 source: source.to_str().to_string(),
             });
 

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -370,15 +370,14 @@ impl KvRouter {
 
         let isl_tokens = tokens.len();
 
-        let block_hashes = tracing::info_span!("kv_router.compute_block_hashes")
-            .in_scope(|| {
-                compute_block_hash_for_seq(
-                    tokens,
-                    self.block_size,
-                    block_mm_infos,
-                    lora_name.as_deref(),
-                )
-            });
+        let block_hashes = tracing::info_span!("kv_router.compute_block_hashes").in_scope(|| {
+            compute_block_hash_for_seq(
+                tokens,
+                self.block_size,
+                block_mm_infos,
+                lora_name.as_deref(),
+            )
+        });
         let hash_elapsed = start.elapsed();
 
         let overlap_scores = self

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -371,7 +371,14 @@ impl KvRouter {
         let isl_tokens = tokens.len();
 
         let block_hashes = tracing::info_span!("kv_router.compute_block_hashes")
-            .in_scope(|| compute_block_hash_for_seq(tokens, self.block_size, block_mm_infos));
+            .in_scope(|| {
+                compute_block_hash_for_seq(
+                    tokens,
+                    self.block_size,
+                    block_mm_infos,
+                    lora_name.as_deref(),
+                )
+            });
         let hash_elapsed = start.elapsed();
 
         let overlap_scores = self
@@ -381,12 +388,12 @@ impl KvRouter {
             .await?;
         let find_matches_elapsed = start.elapsed();
 
-        // Compute seq_hashes only if scheduler needs it for active blocks tracking
         let maybe_seq_hashes = tracing::info_span!("kv_router.compute_seq_hashes").in_scope(|| {
             self.kv_router_config.compute_seq_hashes_for_tracking(
                 tokens,
                 self.block_size,
                 router_config_override,
+                lora_name.as_deref(),
             )
         });
         let seq_hash_elapsed = start.elapsed();
@@ -453,6 +460,7 @@ impl KvRouter {
             tokens,
             self.block_size,
             router_config_override,
+            lora_name.as_deref(),
         );
 
         if let Err(e) = self
@@ -506,8 +514,9 @@ impl KvRouter {
         &self,
         tokens: &[u32],
         worker: WorkerWithDpRank,
+        lora_name: Option<&str>,
     ) -> Result<u32, KvRouterError> {
-        let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, None);
+        let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, None, lora_name);
         let overlap_scores = self.indexer.find_matches(block_hashes).await?;
         Ok(overlap_scores.scores.get(&worker).copied().unwrap_or(0))
     }
@@ -517,15 +526,17 @@ impl KvRouter {
         &self,
         tokens: &[u32],
         router_config_override: Option<&RouterConfigOverride>,
+        lora_name: Option<&str>,
     ) -> Result<Vec<PotentialLoad>> {
         let isl_tokens = tokens.len();
-        let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, None);
+        let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, None, lora_name);
         let overlap_scores = self.indexer.find_matches(block_hashes.clone()).await?;
 
         let maybe_seq_hashes = self.kv_router_config.compute_seq_hashes_for_tracking(
             tokens,
             self.block_size,
             router_config_override,
+            lora_name,
         );
 
         Ok(self

--- a/lib/llm/src/kv_router/config.rs
+++ b/lib/llm/src/kv_router/config.rs
@@ -141,6 +141,7 @@ impl KvRouterConfig {
         tokens: &[u32],
         block_size: u32,
         config_override: Option<&RouterConfigOverride>,
+        lora_name: Option<&str>,
     ) -> Option<Vec<u64>> {
         if !self.router_track_active_blocks {
             return None;
@@ -151,17 +152,14 @@ impl KvRouterConfig {
             return Some(Vec::new());
         }
 
-        // Use override if provided, otherwise use default config
         let assume_kv_reuse = config_override
             .and_then(|cfg| cfg.assume_kv_reuse)
             .unwrap_or(self.router_assume_kv_reuse);
 
         if assume_kv_reuse {
-            // Compute actual block hashes and sequence hashes
-            let block_hashes = compute_block_hash_for_seq(tokens, block_size, None);
+            let block_hashes = compute_block_hash_for_seq(tokens, block_size, None, lora_name);
             Some(compute_seq_hash_for_block(&block_hashes))
         } else {
-            // Generate random hashes (no KV reuse assumed)
             let mut rng = rand::rng();
             Some((0..num_blocks).map(|_| rng.random::<u64>()).collect())
         }

--- a/lib/llm/src/kv_router/indexer_standalone.rs
+++ b/lib/llm/src/kv_router/indexer_standalone.rs
@@ -90,7 +90,12 @@ impl
             IndexerQueryRequest::FindMatchesTokens {
                 tokens,
                 block_mm_infos,
-            } => compute_block_hash_for_seq(&tokens, self.block_size, block_mm_infos.as_deref(), None),
+            } => compute_block_hash_for_seq(
+                &tokens,
+                self.block_size,
+                block_mm_infos.as_deref(),
+                None,
+            ),
             IndexerQueryRequest::DumpTree => unreachable!(),
         };
 

--- a/lib/llm/src/kv_router/indexer_standalone.rs
+++ b/lib/llm/src/kv_router/indexer_standalone.rs
@@ -90,7 +90,7 @@ impl
             IndexerQueryRequest::FindMatchesTokens {
                 tokens,
                 block_mm_infos,
-            } => compute_block_hash_for_seq(&tokens, self.block_size, block_mm_infos.as_deref()),
+            } => compute_block_hash_for_seq(&tokens, self.block_size, block_mm_infos.as_deref(), None),
             IndexerQueryRequest::DumpTree => unreachable!(),
         };
 

--- a/lib/llm/src/kv_router/indexer_standalone.rs
+++ b/lib/llm/src/kv_router/indexer_standalone.rs
@@ -31,6 +31,7 @@ pub enum IndexerQueryRequest {
     FindMatchesTokens {
         tokens: Vec<u32>,
         block_mm_infos: Option<Vec<Option<BlockExtraInfo>>>,
+        lora_name: Option<String>,
     },
     DumpTree,
 }
@@ -90,11 +91,12 @@ impl
             IndexerQueryRequest::FindMatchesTokens {
                 tokens,
                 block_mm_infos,
+                lora_name,
             } => compute_block_hash_for_seq(
                 &tokens,
                 self.block_size,
                 block_mm_infos.as_deref(),
-                None,
+                lora_name.as_deref(),
             ),
             IndexerQueryRequest::DumpTree => unreachable!(),
         };

--- a/lib/llm/src/kv_router/publisher.rs
+++ b/lib/llm/src/kv_router/publisher.rs
@@ -1176,7 +1176,8 @@ mod test_event_processing {
         let token_ids = vec![10, 20, 30, 40];
         let blk_hash = 0xdead_beef;
 
-        let stored = create_stored_block_from_parts(kv_block_size, blk_hash, &token_ids, None, None);
+        let stored =
+            create_stored_block_from_parts(kv_block_size, blk_hash, &token_ids, None, None);
 
         assert_eq!(stored.block_hash.0, blk_hash);
         let expected_hash = compute_block_hash_for_seq(&token_ids, 4, None, None)[0];
@@ -1292,7 +1293,10 @@ mod test_event_processing {
             KvCacheEventData::Stored(s) => s.blocks[0].tokens_hash,
             _ => panic!("expected Stored"),
         };
-        assert_ne!(base_hash, lora_hash, "LoRA blocks must produce distinct tokens_hash");
+        assert_ne!(
+            base_hash, lora_hash,
+            "LoRA blocks must produce distinct tokens_hash"
+        );
     }
 
     #[test]
@@ -1333,7 +1337,10 @@ mod test_event_processing {
             KvCacheEventData::Stored(s) => s.blocks[0].tokens_hash,
             _ => panic!("expected Stored"),
         };
-        assert_eq!(hash1, hash2, "None and lora_id=0 should produce same base-model hash");
+        assert_eq!(
+            hash1, hash2,
+            "None and lora_id=0 should produce same base-model hash"
+        );
     }
 
     #[test]

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -262,7 +262,7 @@ impl KvPushRouter {
         let worker = WorkerWithDpRank::new(id, dp_rank);
         let overlap_blocks = self
             .chooser
-            .get_overlap_blocks(routing_token_ids, worker)
+            .get_overlap_blocks(routing_token_ids, worker, lora_name.as_deref())
             .await?;
 
         if !is_query_only {


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LoRA-aware KV cache routing: block hashes now incorporate adapter names, ensuring proper cache isolation and distinct prefix sharing between different LoRA adapters.
  * Adapter-aware block deduplication and event publishing across router and consolidator paths.

* **Documentation**
  * Added KV cache-aware LoRA routing overview with cache isolation details.
  * Updated KV event publishing documentation with adapter-name semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->