### PR TITLE
fix: Use dict for sampling_params in prefill warmup

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -992,13 +992,12 @@ async def _warmup_prefill_engine(engine: sgl.Engine, server_args) -> None:
     logging.info("Start of prefill disaggregation warmup ...")
     try:
         from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
-        from sglang.srt.sampling.sampling_params import SamplingParams
 
-        sampling_params = SamplingParams(
-            temperature=0.0,
-            max_new_tokens=8,
-            ignore_eos=True,
-        )
+        sampling_params = {
+            "temperature": 0.0,
+            "max_new_tokens": 8,
+            "ignore_eos": True,
+        }
 
         # Timeout: 1800s (30 min) for deep gemm precache
         async def _do_warmup():


### PR DESCRIPTION
#### Overview:
Fixed prefill warmup in SGLang backend by correcting how sampling parameters are passed to the engine API.

#### Details:
The `engine.async_generate()` API expects `sampling_params` as a dictionary, not a `SamplingParams` class instance. The prefill warmup code was instantiating a `SamplingParams` object, which caused subscript errors when the engine tried to access parameters. Fixed by passing a plain dictionary containing the required parameters.

#### Where should the reviewer start?
components/src/dynamo/sglang/main.py lines 994-1000

#### Related Issues:
- Fixes prefill warmup "SamplingParams is not subscriptable" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized parameter handling in the warmup engine to improve code maintainability and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->