### PR TITLE
feat: video and image protocols python bindings

### DIFF
--- a/components/src/dynamo/common/protocols/__init__.py
+++ b/components/src/dynamo/common/protocols/__init__.py
@@ -3,18 +3,31 @@
 
 """Shared protocol types used across multiple Dynamo backends.
 
-This module provides protocol types for various modalities:
-- video_protocol: NvCreateVideoRequest, NvVideosResponse for video generation
+Re-exports Rust-backed protocol types from PyO3 bindings:
+- image_protocol: ImageNvExt, NvCreateImageRequest, ImageData, NvImagesResponse
+- video_protocol: VideoNvExt, NvCreateVideoRequest, VideoData, NvVideosResponse
 """
 
+from dynamo.common.protocols.image_protocol import (
+    ImageData,
+    ImageNvExt,
+    NvCreateImageRequest,
+    NvImagesResponse,
+)
 from dynamo.common.protocols.video_protocol import (
     NvCreateVideoRequest,
     NvVideosResponse,
     VideoData,
+    VideoNvExt,
 )
 
 __all__ = [
+    "ImageNvExt",
+    "NvCreateImageRequest",
+    "ImageData",
+    "NvImagesResponse",
+    "VideoNvExt",
     "NvCreateVideoRequest",
-    "NvVideosResponse",
     "VideoData",
+    "NvVideosResponse",
 ]

--- a/components/src/dynamo/common/protocols/image_protocol.py
+++ b/components/src/dynamo/common/protocols/image_protocol.py
@@ -1,98 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Re-export image protocol types from Rust PyO3 bindings.
+# These were previously Pydantic models; now backed by Rust types in
+# lib/llm/src/protocols/openai/images.rs via lib/bindings/python.
 
-from typing import Optional
+from dynamo._core import (  # noqa: F401
+    ImageData,
+    ImageNvExt,
+    NvCreateImageRequest,
+    NvImagesResponse,
+)
 
-from pydantic import BaseModel
-
-# For omni models, we need to support raw_request parsing and json output format. We need to have these protocols defined here for serialization and deserialization.
-# TODO: Replace these Pydantic models with Python bindings to the Rust protocol types once PyO3 bindings are available.
-
-
-class ImageNvExt(BaseModel):
-    """NVIDIA extensions for image generation requests.
-
-    Matches Rust NvExt in lib/llm/src/protocols/openai/images/nvext.rs.
-    """
-
-    annotations: Optional[list[str]] = None
-    """Annotations for SSE stream events."""
-
-    negative_prompt: Optional[str] = None
-    """Optional negative prompt."""
-
-    num_inference_steps: Optional[int] = None
-    """Number of denoising steps."""
-
-    guidance_scale: Optional[float] = None
-    """CFG guidance scale."""
-
-    seed: Optional[int] = None
-    """Random seed for reproducibility."""
-
-
-class NvCreateImageRequest(BaseModel):
-    """Request for image generation (/v1/images/generations endpoint).
-
-    Matches the flattened Rust NvCreateImageRequest in lib/llm/src/protocols/openai/images.rs
-    """
-
-    prompt: str
-    """The text prompt for image generation."""
-
-    model: Optional[str] = None
-    """The model to use for image generation."""
-
-    n: Optional[int] = None
-    """Number of images to generate (1-10)."""
-
-    quality: Optional[str] = None
-    """Image quality: standard, hd, high, medium, low, auto."""
-
-    response_format: Optional[str] = None
-    """Response format: url or b64_json."""
-
-    size: Optional[str] = None
-    """Image size in WxH format (e.g. 1024x1024)."""
-
-    style: Optional[str] = None
-    """Image style: vivid or natural."""
-
-    user: Optional[str] = None
-    """Optional user identifier."""
-
-    moderation: Optional[str] = None
-    """Content moderation level: auto or low."""
-
-    nvext: Optional[ImageNvExt] = None
-    """NVIDIA extensions."""
-
-
-class ImageData(BaseModel):
-    """Individual image data in a response.
-
-    Matches the flattened Rust Image enum in lib/async-openai/src/types/image.rs.
-    """
-
-    url: Optional[str] = None
-    """URL of the generated image (if response_format is url)."""
-
-    b64_json: Optional[str] = None
-    """Base64-encoded image (if response_format is b64_json)."""
-
-    revised_prompt: Optional[str] = None
-    """Revised prompt, when the model rewrites the original prompt."""
-
-
-class NvImagesResponse(BaseModel):
-    """Response structure for image generation.
-
-    Matches the flattened Rust NvImagesResponse in lib/llm/src/protocols/openai/images.rs
-    """
-
-    created: int
-    """Unix timestamp of creation."""
-
-    data: list[ImageData] = []
-    """List of generated images."""
+__all__ = [
+    "ImageNvExt",
+    "NvCreateImageRequest",
+    "ImageData",
+    "NvImagesResponse",
+]

--- a/components/src/dynamo/common/protocols/video_protocol.py
+++ b/components/src/dynamo/common/protocols/video_protocol.py
@@ -1,121 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Protocol types for video generation.
+# Re-export video protocol types from Rust PyO3 bindings.
+# These were previously Pydantic models; now backed by Rust types in
+# lib/llm/src/protocols/openai/videos.rs via lib/bindings/python.
 
-These types match the Rust protocol types in lib/llm/src/protocols/openai/videos.rs
-to ensure compatibility with the Dynamo HTTP frontend.
-"""
-# TODO: Replace these Pydantic models with Python bindings to the Rust protocol types once PyO3 bindings are available.
+from dynamo._core import (  # noqa: F401
+    NvCreateVideoRequest,
+    NvVideosResponse,
+    VideoData,
+    VideoNvExt,
+)
 
-from typing import Optional
-
-from pydantic import BaseModel
-
-
-class VideoNvExt(BaseModel):
-    """NVIDIA extensions for video generation requests.
-
-    Matches Rust NvExt in lib/llm/src/protocols/openai/videos/nvext.rs.
-    """
-
-    annotations: Optional[list[str]] = None
-    """Annotations for SSE stream events."""
-
-    fps: Optional[int] = None
-    """Frames per second (default: 24)."""
-
-    num_frames: Optional[int] = None
-    """Number of frames to generate (overrides fps * seconds if set)."""
-
-    negative_prompt: Optional[str] = None
-    """Optional negative prompt."""
-
-    num_inference_steps: Optional[int] = None
-    """Number of denoising steps (default: 50)."""
-
-    guidance_scale: Optional[float] = None
-    """CFG guidance scale (default: 5.0)."""
-
-    seed: Optional[int] = None
-    """Random seed for reproducibility."""
-
-
-class NvCreateVideoRequest(BaseModel):
-    """Request for video generation (/v1/videos endpoint).
-
-    Matches Rust NvCreateVideoRequest in lib/llm/src/protocols/openai/videos.rs.
-    """
-
-    # Required fields
-    prompt: str
-    """The text prompt for video generation."""
-
-    model: str
-    """The model to use for video generation."""
-
-    # Optional fields
-    input_reference: Optional[str] = None
-    """Optional image reference that guides generation (for I2V)."""
-
-    seconds: Optional[int] = None
-    """Clip duration in seconds."""
-
-    size: Optional[str] = None
-    """Video size in WxH format (default: '832x480')."""
-
-    user: Optional[str] = None
-    """Optional user identifier."""
-
-    response_format: Optional[str] = None
-    """Response format: 'url' or 'b64_json' (default: 'url')."""
-
-    nvext: Optional[VideoNvExt] = None
-    """NVIDIA extensions."""
-
-
-class VideoData(BaseModel):
-    """Video data in response.
-
-    Matches Rust VideoData in lib/llm/src/protocols/openai/videos.rs.
-    """
-
-    url: Optional[str] = None
-    """URL of the generated video (if response_format is 'url')."""
-
-    b64_json: Optional[str] = None
-    """Base64-encoded video (if response_format is 'b64_json')."""
-
-
-class NvVideosResponse(BaseModel):
-    """Response structure for video generation.
-
-    Matches Rust NvVideosResponse in lib/llm/src/protocols/openai/videos.rs.
-    """
-
-    id: str
-    """Unique identifier for the response."""
-
-    object: str = "video"
-    """Object type (always 'video')."""
-
-    model: str
-    """Model used for generation."""
-
-    status: str = "completed"
-    """Generation status."""
-
-    progress: int = 100
-    """Progress percentage (0-100)."""
-
-    created: int
-    """Unix timestamp of creation."""
-
-    data: list[VideoData] = []
-    """List of generated videos."""
-
-    error: Optional[str] = None
-    """Error message if generation failed."""
-
-    inference_time_s: Optional[float] = None
-    """Inference time in seconds."""
+__all__ = [
+    "VideoNvExt",
+    "NvCreateVideoRequest",
+    "VideoData",
+    "NvVideosResponse",
+]

--- a/components/src/dynamo/common/utils/output_modalities.py
+++ b/components/src/dynamo/common/utils/output_modalities.py
@@ -85,10 +85,16 @@ def parse_request_type(
     if modality is OutputModality.IMAGE:
         if "messages" in raw_request:
             return raw_request, RequestType.CHAT_COMPLETION
-        return NvCreateImageRequest(**raw_request), RequestType.IMAGE_GENERATION
+        return (
+            NvCreateImageRequest.model_validate(raw_request),
+            RequestType.IMAGE_GENERATION,
+        )
 
     if modality is OutputModality.VIDEO:
-        return NvCreateVideoRequest(**raw_request), RequestType.VIDEO_GENERATION
+        return (
+            NvCreateVideoRequest.model_validate(raw_request),
+            RequestType.VIDEO_GENERATION,
+        )
 
     if modality is OutputModality.AUDIO:
         # Audio protocol types are not yet defined; pass through the raw dict.

--- a/components/src/dynamo/trtllm/request_handlers/video_diffusion/video_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/video_diffusion/video_handler.py
@@ -177,7 +177,7 @@ class VideoGenerationHandler(BaseGenerativeHandler):
 
         try:
             # Parse request
-            req = NvCreateVideoRequest(**request)
+            req = NvCreateVideoRequest.model_validate(request)
             nvext = req.nvext or VideoNvExt()
 
             # Parse parameters

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -175,6 +175,14 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ModelInput>()?;
     m.add_class::<llm::kv::KvRouter>()?;
     m.add_class::<RouterMode>()?;
+    m.add_class::<llm::protocols::ImageNvExt>()?;
+    m.add_class::<llm::protocols::NvCreateImageRequest>()?;
+    m.add_class::<llm::protocols::ImageData>()?;
+    m.add_class::<llm::protocols::NvImagesResponse>()?;
+    m.add_class::<llm::protocols::VideoNvExt>()?;
+    m.add_class::<llm::protocols::NvCreateVideoRequest>()?;
+    m.add_class::<llm::protocols::VideoData>()?;
+    m.add_class::<llm::protocols::NvVideosResponse>()?;
     m.add_class::<kserve_grpc::KserveGrpcService>()?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<planner::VirtualConnectorCoordinator>()?;

--- a/lib/bindings/python/rust/llm.rs
+++ b/lib/bindings/python/rust/llm.rs
@@ -29,3 +29,4 @@ pub mod local_model;
 pub mod lora;
 pub mod model_card;
 pub mod preprocessor;
+pub mod protocols;

--- a/lib/bindings/python/rust/llm/protocols.rs
+++ b/lib/bindings/python/rust/llm/protocols.rs
@@ -98,8 +98,11 @@ impl ImageNvExt {
     fn __repr__(&self) -> String {
         format!(
             "ImageNvExt(annotations={:?}, negative_prompt={:?}, num_inference_steps={:?}, guidance_scale={:?}, seed={:?})",
-            self.inner.annotations, self.inner.negative_prompt, self.inner.num_inference_steps,
-            self.inner.guidance_scale, self.inner.seed,
+            self.inner.annotations,
+            self.inner.negative_prompt,
+            self.inner.num_inference_steps,
+            self.inner.guidance_scale,
+            self.inner.seed,
         )
     }
 }
@@ -291,11 +294,7 @@ pub struct ImageData {
 impl ImageData {
     #[new]
     #[pyo3(signature = (*, url=None, b64_json=None, revised_prompt=None))]
-    fn new(
-        url: Option<String>,
-        b64_json: Option<String>,
-        revised_prompt: Option<String>,
-    ) -> Self {
+    fn new(url: Option<String>, b64_json: Option<String>, revised_prompt: Option<String>) -> Self {
         Self {
             url,
             b64_json,
@@ -378,10 +377,7 @@ impl ImageData {
     /// Parse from a JSON value.
     fn from_json_value(val: &serde_json::Value) -> Self {
         Self {
-            url: val
-                .get("url")
-                .and_then(|v| v.as_str())
-                .map(String::from),
+            url: val.get("url").and_then(|v| v.as_str()).map(String::from),
             b64_json: val
                 .get("b64_json")
                 .and_then(|v| v.as_str())
@@ -850,8 +846,7 @@ impl NvVideosResponse {
 
     #[staticmethod]
     fn model_validate(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
-        let inner: rs_videos::NvVideosResponse =
-            pythonize::depythonize(obj).map_err(to_pyerr)?;
+        let inner: rs_videos::NvVideosResponse = pythonize::depythonize(obj).map_err(to_pyerr)?;
         Ok(Self { inner })
     }
 

--- a/lib/bindings/python/rust/llm/protocols.rs
+++ b/lib/bindings/python/rust/llm/protocols.rs
@@ -1,0 +1,873 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! PyO3 bindings for LLM protocol types (images, videos).
+//!
+//! These wrappers expose the Rust protocol types to Python with a Pydantic-compatible API
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use dynamo_llm::protocols::openai::{
+    images::{self as rs_images, NvExt as RsImageNvExt},
+    videos::{self as rs_videos, NvExt as RsVideoNvExt},
+};
+
+use super::super::to_pyerr;
+
+// ============================================================================
+// Image Protocol Types
+// ============================================================================
+
+/// NVIDIA extensions for image generation requests.
+#[pyclass(name = "ImageNvExt")]
+#[derive(Clone)]
+pub struct ImageNvExt {
+    pub(crate) inner: RsImageNvExt,
+}
+
+#[pymethods]
+impl ImageNvExt {
+    #[new]
+    #[pyo3(signature = (*, annotations=None, negative_prompt=None, num_inference_steps=None, guidance_scale=None, seed=None))]
+    fn new(
+        annotations: Option<Vec<String>>,
+        negative_prompt: Option<String>,
+        num_inference_steps: Option<u8>,
+        guidance_scale: Option<f32>,
+        seed: Option<u32>,
+    ) -> Self {
+        Self {
+            inner: RsImageNvExt {
+                annotations,
+                negative_prompt,
+                num_inference_steps,
+                guidance_scale,
+                seed,
+            },
+        }
+    }
+
+    #[getter]
+    fn annotations(&self) -> Option<Vec<String>> {
+        self.inner.annotations.clone()
+    }
+
+    #[getter]
+    fn negative_prompt(&self) -> Option<String> {
+        self.inner.negative_prompt.clone()
+    }
+
+    #[getter]
+    fn num_inference_steps(&self) -> Option<u8> {
+        self.inner.num_inference_steps
+    }
+
+    #[getter]
+    fn guidance_scale(&self) -> Option<f32> {
+        self.inner.guidance_scale
+    }
+
+    #[getter]
+    fn seed(&self) -> Option<u32> {
+        self.inner.seed
+    }
+
+    #[staticmethod]
+    fn model_validate_json(json_str: &str) -> PyResult<Self> {
+        let inner: RsImageNvExt = serde_json::from_str(json_str).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner).map_err(to_pyerr)
+    }
+
+    #[staticmethod]
+    fn model_validate(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let inner: RsImageNvExt = pythonize::depythonize(obj).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let obj = pythonize::pythonize(py, &self.inner).map_err(to_pyerr)?;
+        obj.downcast_into::<PyDict>()
+            .map_err(|e| to_pyerr(format!("expected dict, got {}", e)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ImageNvExt(annotations={:?}, negative_prompt={:?}, num_inference_steps={:?}, guidance_scale={:?}, seed={:?})",
+            self.inner.annotations, self.inner.negative_prompt, self.inner.num_inference_steps,
+            self.inner.guidance_scale, self.inner.seed,
+        )
+    }
+}
+
+/// Request for image generation (/v1/images/generations endpoint).
+#[pyclass(name = "NvCreateImageRequest")]
+#[derive(Clone)]
+pub struct NvCreateImageRequest {
+    pub(crate) inner: rs_images::NvCreateImageRequest,
+}
+
+#[pymethods]
+impl NvCreateImageRequest {
+    #[new]
+    #[pyo3(signature = (prompt, *, model=None, n=None, quality=None, response_format=None, size=None, style=None, user=None, moderation=None, nvext=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        prompt: String,
+        model: Option<String>,
+        n: Option<u8>,
+        quality: Option<String>,
+        response_format: Option<String>,
+        size: Option<String>,
+        style: Option<String>,
+        user: Option<String>,
+        moderation: Option<String>,
+        nvext: Option<ImageNvExt>,
+    ) -> PyResult<Self> {
+        // Build the inner CreateImageRequest by serializing to JSON and back,
+        // which lets serde handle enum conversions (ImageModel, ImageQuality, etc.)
+        let mut map = serde_json::Map::new();
+        map.insert("prompt".into(), serde_json::Value::String(prompt));
+        if let Some(v) = model {
+            map.insert("model".into(), serde_json::Value::String(v));
+        }
+        if let Some(v) = n {
+            map.insert("n".into(), serde_json::Value::Number(v.into()));
+        }
+        if let Some(v) = quality {
+            map.insert("quality".into(), serde_json::Value::String(v));
+        }
+        if let Some(v) = response_format {
+            map.insert("response_format".into(), serde_json::Value::String(v));
+        }
+        if let Some(v) = size {
+            map.insert("size".into(), serde_json::Value::String(v));
+        }
+        if let Some(v) = style {
+            map.insert("style".into(), serde_json::Value::String(v));
+        }
+        if let Some(v) = user {
+            map.insert("user".into(), serde_json::Value::String(v));
+        }
+        if let Some(v) = moderation {
+            map.insert("moderation".into(), serde_json::Value::String(v));
+        }
+        if let Some(ext) = &nvext {
+            let nvext_val = serde_json::to_value(&ext.inner).map_err(to_pyerr)?;
+            map.insert("nvext".into(), nvext_val);
+        }
+        let inner: rs_images::NvCreateImageRequest =
+            serde_json::from_value(serde_json::Value::Object(map)).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    #[getter]
+    fn prompt(&self) -> &str {
+        &self.inner.inner.prompt
+    }
+
+    #[getter]
+    fn model(&self) -> Option<String> {
+        self.inner.inner.model.as_ref().map(|m| {
+            serde_json::to_value(m)
+                .ok()
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_default()
+        })
+    }
+
+    #[getter]
+    fn n(&self) -> Option<u8> {
+        self.inner.inner.n
+    }
+
+    #[getter]
+    fn quality(&self) -> Option<String> {
+        self.inner.inner.quality.as_ref().map(|q| {
+            serde_json::to_value(q)
+                .ok()
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_default()
+        })
+    }
+
+    #[getter]
+    fn response_format(&self) -> Option<String> {
+        self.inner.inner.response_format.as_ref().map(|r| {
+            serde_json::to_value(r)
+                .ok()
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_default()
+        })
+    }
+
+    #[getter]
+    fn size(&self) -> Option<String> {
+        self.inner.inner.size.as_ref().map(|s| {
+            serde_json::to_value(s)
+                .ok()
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_default()
+        })
+    }
+
+    #[getter]
+    fn style(&self) -> Option<String> {
+        self.inner.inner.style.as_ref().map(|s| {
+            serde_json::to_value(s)
+                .ok()
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_default()
+        })
+    }
+
+    #[getter]
+    fn user(&self) -> Option<String> {
+        self.inner.inner.user.clone()
+    }
+
+    #[getter]
+    fn moderation(&self) -> Option<String> {
+        self.inner.inner.moderation.as_ref().map(|m| {
+            serde_json::to_value(m)
+                .ok()
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_default()
+        })
+    }
+
+    #[getter]
+    fn nvext(&self) -> Option<ImageNvExt> {
+        self.inner.nvext.clone().map(|n| ImageNvExt { inner: n })
+    }
+
+    #[staticmethod]
+    fn model_validate_json(json_str: &str) -> PyResult<Self> {
+        let inner: rs_images::NvCreateImageRequest =
+            serde_json::from_str(json_str).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner).map_err(to_pyerr)
+    }
+
+    #[staticmethod]
+    fn model_validate(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let inner: rs_images::NvCreateImageRequest =
+            pythonize::depythonize(obj).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let obj = pythonize::pythonize(py, &self.inner).map_err(to_pyerr)?;
+        obj.downcast_into::<PyDict>()
+            .map_err(|e| to_pyerr(format!("expected dict, got {}", e)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "NvCreateImageRequest(prompt={:?}, model={:?})",
+            self.inner.inner.prompt,
+            self.model(),
+        )
+    }
+}
+
+/// Individual image data in a response.
+#[pyclass(name = "ImageData")]
+#[derive(Clone)]
+pub struct ImageData {
+    pub(crate) url: Option<String>,
+    pub(crate) b64_json: Option<String>,
+    pub(crate) revised_prompt: Option<String>,
+}
+
+#[pymethods]
+impl ImageData {
+    #[new]
+    #[pyo3(signature = (*, url=None, b64_json=None, revised_prompt=None))]
+    fn new(
+        url: Option<String>,
+        b64_json: Option<String>,
+        revised_prompt: Option<String>,
+    ) -> Self {
+        Self {
+            url,
+            b64_json,
+            revised_prompt,
+        }
+    }
+
+    #[getter]
+    fn url(&self) -> Option<String> {
+        self.url.clone()
+    }
+
+    #[getter]
+    fn b64_json(&self) -> Option<String> {
+        self.b64_json.clone()
+    }
+
+    #[getter]
+    fn revised_prompt(&self) -> Option<String> {
+        self.revised_prompt.clone()
+    }
+
+    #[staticmethod]
+    fn model_validate_json(json_str: &str) -> PyResult<Self> {
+        let val: serde_json::Value = serde_json::from_str(json_str).map_err(to_pyerr)?;
+        Ok(Self::from_json_value(&val))
+    }
+
+    fn model_dump_json(&self) -> PyResult<String> {
+        let val = self.to_json_value();
+        serde_json::to_string(&val).map_err(to_pyerr)
+    }
+
+    #[staticmethod]
+    fn model_validate(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let val: serde_json::Value = pythonize::depythonize(obj).map_err(to_pyerr)?;
+        Ok(Self::from_json_value(&val))
+    }
+
+    fn model_dump<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let val = self.to_json_value();
+        let obj = pythonize::pythonize(py, &val).map_err(to_pyerr)?;
+        obj.downcast_into::<PyDict>()
+            .map_err(|e| to_pyerr(format!("expected dict, got {}", e)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "ImageData(url={:?}, b64_json={:?}, revised_prompt={:?})",
+            self.url, self.b64_json, self.revised_prompt,
+        )
+    }
+}
+
+impl ImageData {
+    /// Convert to a JSON value that matches the Python Pydantic schema.
+    fn to_json_value(&self) -> serde_json::Value {
+        let mut map = serde_json::Map::new();
+        if let Some(ref u) = self.url {
+            map.insert("url".into(), serde_json::Value::String(u.clone()));
+        } else {
+            map.insert("url".into(), serde_json::Value::Null);
+        }
+        if let Some(ref b) = self.b64_json {
+            map.insert("b64_json".into(), serde_json::Value::String(b.clone()));
+        } else {
+            map.insert("b64_json".into(), serde_json::Value::Null);
+        }
+        if let Some(ref r) = self.revised_prompt {
+            map.insert(
+                "revised_prompt".into(),
+                serde_json::Value::String(r.clone()),
+            );
+        } else {
+            map.insert("revised_prompt".into(), serde_json::Value::Null);
+        }
+        serde_json::Value::Object(map)
+    }
+
+    /// Parse from a JSON value.
+    fn from_json_value(val: &serde_json::Value) -> Self {
+        Self {
+            url: val
+                .get("url")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            b64_json: val
+                .get("b64_json")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            revised_prompt: val
+                .get("revised_prompt")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        }
+    }
+}
+
+/// Response structure for image generation.
+#[pyclass(name = "NvImagesResponse")]
+#[derive(Clone)]
+pub struct NvImagesResponse {
+    pub(crate) created: i64,
+    pub(crate) data: Vec<ImageData>,
+}
+
+#[pymethods]
+impl NvImagesResponse {
+    #[new]
+    #[pyo3(signature = (created, *, data=None))]
+    fn new(created: i64, data: Option<Vec<ImageData>>) -> Self {
+        Self {
+            created,
+            data: data.unwrap_or_default(),
+        }
+    }
+
+    #[getter]
+    fn created(&self) -> i64 {
+        self.created
+    }
+
+    #[getter]
+    fn data(&self) -> Vec<ImageData> {
+        self.data.clone()
+    }
+
+    #[staticmethod]
+    fn model_validate_json(json_str: &str) -> PyResult<Self> {
+        let val: serde_json::Value = serde_json::from_str(json_str).map_err(to_pyerr)?;
+        Self::from_json_value(&val)
+    }
+
+    fn model_dump_json(&self) -> PyResult<String> {
+        let val = self.to_json_value();
+        serde_json::to_string(&val).map_err(to_pyerr)
+    }
+
+    #[staticmethod]
+    fn model_validate(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let val: serde_json::Value = pythonize::depythonize(obj).map_err(to_pyerr)?;
+        Self::from_json_value(&val)
+    }
+
+    fn model_dump<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let val = self.to_json_value();
+        let obj = pythonize::pythonize(py, &val).map_err(to_pyerr)?;
+        obj.downcast_into::<PyDict>()
+            .map_err(|e| to_pyerr(format!("expected dict, got {}", e)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "NvImagesResponse(created={}, data=[{} items])",
+            self.created,
+            self.data.len(),
+        )
+    }
+}
+
+impl NvImagesResponse {
+    fn from_json_value(val: &serde_json::Value) -> PyResult<Self> {
+        let created = val
+            .get("created")
+            .and_then(|v| v.as_i64())
+            .ok_or_else(|| to_pyerr("missing or invalid 'created' field"))?;
+        let data = val
+            .get("data")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().map(ImageData::from_json_value).collect())
+            .unwrap_or_default();
+        Ok(Self { created, data })
+    }
+
+    fn to_json_value(&self) -> serde_json::Value {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "created".into(),
+            serde_json::Value::Number(self.created.into()),
+        );
+        let data_arr: Vec<serde_json::Value> =
+            self.data.iter().map(|d| d.to_json_value()).collect();
+        map.insert("data".into(), serde_json::Value::Array(data_arr));
+        serde_json::Value::Object(map)
+    }
+}
+
+// ============================================================================
+// Video Protocol Types
+// ============================================================================
+
+/// NVIDIA extensions for video generation requests.
+#[pyclass(name = "VideoNvExt")]
+#[derive(Clone)]
+pub struct VideoNvExt {
+    pub(crate) inner: RsVideoNvExt,
+}
+
+#[pymethods]
+impl VideoNvExt {
+    #[new]
+    #[pyo3(signature = (*, annotations=None, fps=None, num_frames=None, negative_prompt=None, num_inference_steps=None, guidance_scale=None, seed=None))]
+    fn new(
+        annotations: Option<Vec<String>>,
+        fps: Option<i32>,
+        num_frames: Option<i32>,
+        negative_prompt: Option<String>,
+        num_inference_steps: Option<i32>,
+        guidance_scale: Option<f32>,
+        seed: Option<i64>,
+    ) -> Self {
+        Self {
+            inner: RsVideoNvExt {
+                annotations,
+                fps,
+                num_frames,
+                negative_prompt,
+                num_inference_steps,
+                guidance_scale,
+                seed,
+            },
+        }
+    }
+
+    #[getter]
+    fn annotations(&self) -> Option<Vec<String>> {
+        self.inner.annotations.clone()
+    }
+
+    #[getter]
+    fn fps(&self) -> Option<i32> {
+        self.inner.fps
+    }
+
+    #[getter]
+    fn num_frames(&self) -> Option<i32> {
+        self.inner.num_frames
+    }
+
+    #[getter]
+    fn negative_prompt(&self) -> Option<String> {
+        self.inner.negative_prompt.clone()
+    }
+
+    #[getter]
+    fn num_inference_steps(&self) -> Option<i32> {
+        self.inner.num_inference_steps
+    }
+
+    #[getter]
+    fn guidance_scale(&self) -> Option<f32> {
+        self.inner.guidance_scale
+    }
+
+    #[getter]
+    fn seed(&self) -> Option<i64> {
+        self.inner.seed
+    }
+
+    #[staticmethod]
+    fn model_validate_json(json_str: &str) -> PyResult<Self> {
+        let inner: RsVideoNvExt = serde_json::from_str(json_str).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner).map_err(to_pyerr)
+    }
+
+    #[staticmethod]
+    fn model_validate(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let inner: RsVideoNvExt = pythonize::depythonize(obj).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let obj = pythonize::pythonize(py, &self.inner).map_err(to_pyerr)?;
+        obj.downcast_into::<PyDict>()
+            .map_err(|e| to_pyerr(format!("expected dict, got {}", e)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "VideoNvExt(annotations={:?}, fps={:?}, num_frames={:?})",
+            self.inner.annotations, self.inner.fps, self.inner.num_frames,
+        )
+    }
+}
+
+/// Request for video generation (/v1/videos endpoint).
+#[pyclass(name = "NvCreateVideoRequest")]
+#[derive(Clone)]
+pub struct NvCreateVideoRequest {
+    pub(crate) inner: rs_videos::NvCreateVideoRequest,
+}
+
+#[pymethods]
+impl NvCreateVideoRequest {
+    #[new]
+    #[pyo3(signature = (prompt, model, *, input_reference=None, seconds=None, size=None, user=None, response_format=None, nvext=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        prompt: String,
+        model: String,
+        input_reference: Option<String>,
+        seconds: Option<i32>,
+        size: Option<String>,
+        user: Option<String>,
+        response_format: Option<String>,
+        nvext: Option<VideoNvExt>,
+    ) -> Self {
+        Self {
+            inner: rs_videos::NvCreateVideoRequest {
+                prompt,
+                model,
+                input_reference,
+                seconds,
+                size,
+                user,
+                response_format,
+                nvext: nvext.map(|n| n.inner),
+            },
+        }
+    }
+
+    #[getter]
+    fn prompt(&self) -> &str {
+        &self.inner.prompt
+    }
+
+    #[getter]
+    fn model(&self) -> &str {
+        &self.inner.model
+    }
+
+    #[getter]
+    fn input_reference(&self) -> Option<String> {
+        self.inner.input_reference.clone()
+    }
+
+    #[getter]
+    fn seconds(&self) -> Option<i32> {
+        self.inner.seconds
+    }
+
+    #[getter]
+    fn size(&self) -> Option<String> {
+        self.inner.size.clone()
+    }
+
+    #[getter]
+    fn user(&self) -> Option<String> {
+        self.inner.user.clone()
+    }
+
+    #[getter]
+    fn response_format(&self) -> Option<String> {
+        self.inner.response_format.clone()
+    }
+
+    #[getter]
+    fn nvext(&self) -> Option<VideoNvExt> {
+        self.inner.nvext.clone().map(|n| VideoNvExt { inner: n })
+    }
+
+    #[staticmethod]
+    fn model_validate_json(json_str: &str) -> PyResult<Self> {
+        let inner: rs_videos::NvCreateVideoRequest =
+            serde_json::from_str(json_str).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner).map_err(to_pyerr)
+    }
+
+    #[staticmethod]
+    fn model_validate(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let inner: rs_videos::NvCreateVideoRequest =
+            pythonize::depythonize(obj).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let obj = pythonize::pythonize(py, &self.inner).map_err(to_pyerr)?;
+        obj.downcast_into::<PyDict>()
+            .map_err(|e| to_pyerr(format!("expected dict, got {}", e)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "NvCreateVideoRequest(prompt={:?}, model={:?})",
+            self.inner.prompt, self.inner.model,
+        )
+    }
+}
+
+/// Video data in response.
+#[pyclass(name = "VideoData")]
+#[derive(Clone)]
+pub struct VideoData {
+    pub(crate) inner: rs_videos::VideoData,
+}
+
+#[pymethods]
+impl VideoData {
+    #[new]
+    #[pyo3(signature = (*, url=None, b64_json=None))]
+    fn new(url: Option<String>, b64_json: Option<String>) -> Self {
+        Self {
+            inner: rs_videos::VideoData { url, b64_json },
+        }
+    }
+
+    #[getter]
+    fn url(&self) -> Option<String> {
+        self.inner.url.clone()
+    }
+
+    #[getter]
+    fn b64_json(&self) -> Option<String> {
+        self.inner.b64_json.clone()
+    }
+
+    #[staticmethod]
+    fn model_validate_json(json_str: &str) -> PyResult<Self> {
+        let inner: rs_videos::VideoData = serde_json::from_str(json_str).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner).map_err(to_pyerr)
+    }
+
+    #[staticmethod]
+    fn model_validate(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let inner: rs_videos::VideoData = pythonize::depythonize(obj).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let obj = pythonize::pythonize(py, &self.inner).map_err(to_pyerr)?;
+        obj.downcast_into::<PyDict>()
+            .map_err(|e| to_pyerr(format!("expected dict, got {}", e)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "VideoData(url={:?}, b64_json={:?})",
+            self.inner.url, self.inner.b64_json,
+        )
+    }
+}
+
+/// Response structure for video generation.
+#[pyclass(name = "NvVideosResponse")]
+#[derive(Clone)]
+pub struct NvVideosResponse {
+    pub(crate) inner: rs_videos::NvVideosResponse,
+}
+
+#[pymethods]
+impl NvVideosResponse {
+    #[new]
+    #[pyo3(signature = (id, model, created, *, object="video".to_string(), status="completed".to_string(), progress=100, data=None, error=None, inference_time_s=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        id: String,
+        model: String,
+        created: i64,
+        object: String,
+        status: String,
+        progress: i32,
+        data: Option<Vec<VideoData>>,
+        error: Option<String>,
+        inference_time_s: Option<f64>,
+    ) -> Self {
+        Self {
+            inner: rs_videos::NvVideosResponse {
+                id,
+                object,
+                model,
+                status,
+                progress,
+                created,
+                data: data.into_iter().flatten().map(|d| d.inner).collect(),
+                error,
+                inference_time_s,
+            },
+        }
+    }
+
+    #[getter]
+    fn id(&self) -> &str {
+        &self.inner.id
+    }
+
+    #[getter]
+    fn object(&self) -> &str {
+        &self.inner.object
+    }
+
+    #[getter]
+    fn model(&self) -> &str {
+        &self.inner.model
+    }
+
+    #[getter]
+    fn status(&self) -> &str {
+        &self.inner.status
+    }
+
+    #[getter]
+    fn progress(&self) -> i32 {
+        self.inner.progress
+    }
+
+    #[getter]
+    fn created(&self) -> i64 {
+        self.inner.created
+    }
+
+    #[getter]
+    fn data(&self) -> Vec<VideoData> {
+        self.inner
+            .data
+            .iter()
+            .map(|d| VideoData { inner: d.clone() })
+            .collect()
+    }
+
+    #[getter]
+    fn error(&self) -> Option<String> {
+        self.inner.error.clone()
+    }
+
+    #[getter]
+    fn inference_time_s(&self) -> Option<f64> {
+        self.inner.inference_time_s
+    }
+
+    #[staticmethod]
+    fn model_validate_json(json_str: &str) -> PyResult<Self> {
+        let inner: rs_videos::NvVideosResponse =
+            serde_json::from_str(json_str).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner).map_err(to_pyerr)
+    }
+
+    #[staticmethod]
+    fn model_validate(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let inner: rs_videos::NvVideosResponse =
+            pythonize::depythonize(obj).map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn model_dump<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let obj = pythonize::pythonize(py, &self.inner).map_err(to_pyerr)?;
+        obj.downcast_into::<PyDict>()
+            .map_err(|e| to_pyerr(format!("expected dict, got {}", e)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "NvVideosResponse(id={:?}, model={:?}, status={:?}, data=[{} items])",
+            self.inner.id,
+            self.inner.model,
+            self.inner.status,
+            self.inner.data.len(),
+        )
+    }
+}


### PR DESCRIPTION
#### Overview:

Replaces the manually-maintained Pydantic models in `components/src/dynamo/common/protocols/` with PyO3 bindings backed by the existing Rust protocol types. This eliminates the type duplication between Rust (`lib/llm/src/protocols/openai/{images,videos}.rs`) and Python, ensuring the two stay in sync automatically.


#### Details:

- Adds `lib/bindings/python/rust/llm/protocols.rs` with `#[pyclass]` wrappers for 8 protocol types: `ImageNvExt`, `NvCreateImageRequest`, `ImageData`, `NvImagesResponse`, `VideoNvExt`, `NvCreateVideoRequest`, `VideoData`, `NvVideosResponse`.
- Each wrapper exposes a Pydantic-compatible API (`model_validate`, `model_validate_json`, `model_dump`, `model_dump_json`, keyword-arg constructors, attribute getters) so downstream consumers require minimal changes.
- Registers all 8 types in the `_core` PyO3 module and re-exports them from the existing `dynamo.common.protocols` Python package, preserving all import paths.

#### Where should the reviewer start?

- `lib/bindings/python/rust/llm/protocols.rs` — the core new code (PyO3 wrappers)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes: [DGH-604](https://linear.app/nvidia/issue/DGH-604/have-python-bindings-to-videoimageaudio-api-protocols)