### PR TITLE
ci: enable GPU access for rust-checks in dynamo validation

### DIFF
--- a/.github/workflows/container-validation-dynamo.yml
+++ b/.github/workflows/container-validation-dynamo.yml
@@ -121,7 +121,7 @@ jobs:
   rust-checks:
     needs: [changed-files, build]
     if: needs.changed-files.outputs.core == 'true'
-    runs-on: prod-builder-amd-v1
+    runs-on: prod-tester-amd-gpu-v1
     name: Rust Checks
     timeout-minutes: 30
     env:
@@ -139,7 +139,7 @@ jobs:
         run: docker pull ${{ env.IMAGE_TAG }}
       - name: Run Rust checks (block-manager + media-ffmpeg + integration tests)
         run: |
-          docker run --rm --user root -w /workspace/lib/llm \
+          docker run --rm --runtime=nvidia --gpus all --user root -w /workspace/lib/llm \
             --name ${{ env.CONTAINER_ID }}_rust_checks \
             -e SCCACHE_BUCKET=${{ secrets.SCCACHE_S3_BUCKET }} \
             -e SCCACHE_REGION=${{ secrets.AWS_DEFAULT_REGION }} \


### PR DESCRIPTION
Switch the rust-checks job to a GPU tester runner and add NVIDIA runtime flags to docker run so Rust tests can exercise GPU code paths.

closes: OPS-3441


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD infrastructure configuration to utilize GPU-accelerated runner resources for improved build and validation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->