### PR TITLE
feat: migrate DGDR validation webhook to v1beta1 with thorough+auto guard

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -145,7 +145,7 @@ webhooks:
     service:
       name: {{ include "dynamo-operator.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-nvidia-com-v1alpha1-dynamographdeploymentrequest
+      path: /validate-nvidia-com-v1beta1-dynamographdeploymentrequest
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: vdynamographdeploymentrequest.kb.io
   {{- if .Values.webhook.namespaceSelector }}
@@ -160,7 +160,7 @@ webhooks:
   - apiGroups:
     - nvidia.com
     apiVersions:
-    - v1alpha1
+    - v1beta1
     operations:
     - CREATE
     - UPDATE

--- a/deploy/operator/docs/dgdr-v1beta1-controller-refactor-phase1-fix-summary.md
+++ b/deploy/operator/docs/dgdr-v1beta1-controller-refactor-phase1-fix-summary.md
@@ -1,0 +1,73 @@
+# DGDR v1beta1 Controller Refactor — Phase 1 Fix Summary
+
+## Phase: Switch Import & Core Types — Compilation Fix
+
+**Date**: 2026-02-24
+**File changed**: `internal/controller/dynamographdeploymentrequest_controller.go`
+
+---
+
+## Problem
+
+Phase 1's stated goal was "Make the controller **compile** against v1beta1 types" (mechanical
+changes only). However, the initial Phase 1 implementation switched the DGDR type from
+v1alpha1 to v1beta1 without updating all field access patterns, leaving the controller in
+a non-compiling state. Three categories of broken references remained:
+
+1. **`DeploymentOverrides`** (11 references) — v1alpha1 had `Spec.DeploymentOverrides` with
+   `.Name`, `.Namespace`, `.Labels`, `.Annotations`, `.WorkersImage` fields. v1beta1 removed
+   this struct entirely.
+2. **`UseMocker`** (1 reference) — v1alpha1 had `Spec.UseMocker` (bool). v1beta1 moved this
+   to `Spec.Features.Mocker.Enabled`.
+3. **`yaml.Marshal`** (1 reference) — The `k8s.io/apimachinery/pkg/util/yaml` package only
+   provides decode functions, not `Marshal`. Should use `sigs.k8s.io/yaml` (`sigsyaml`).
+
+---
+
+## Fixes Applied
+
+### `DeploymentOverrides` → defaults (11 references removed)
+
+In v1beta1, there is no `DeploymentOverrides` struct. The DGD defaults to:
+- **Name**: from the generated DGD (profiler output)
+- **Namespace**: same as the DGDR namespace
+
+Phase 5 may add namespace/name override support via `overrides.dgd` if needed.
+
+| Location | v1alpha1 pattern | v1beta1 fix |
+|---|---|---|
+| `handleProfilingPhase()` — additional resources namespace | `DeploymentOverrides.Namespace` | `dgdr.Namespace` |
+| `handleDeployingPhase()` — DGD lookup namespace | `DeploymentOverrides.Namespace` | `dgdr.Namespace` |
+| `handleDeployedPhase()` — DGD lookup namespace | `DeploymentOverrides.Namespace` | `dgdr.Namespace` |
+| `createDGD()` — DGD name override | `DeploymentOverrides.Name` | Use generated name |
+| `createDGD()` — DGD namespace override | `DeploymentOverrides.Namespace` | `dgdr.Namespace` |
+| `createDGD()` — custom labels merge | `DeploymentOverrides.Labels` | Removed (only managed labels) |
+| `createDGD()` — custom annotations merge | `DeploymentOverrides.Annotations` | Removed (only generated annotations) |
+
+Each fix includes a `// Phase 1 fix:` comment in the code explaining the change and
+noting that Phase 5 may refine the pattern.
+
+### `UseMocker` → `Features.Mocker.Enabled` (1 reference)
+
+| Location | v1alpha1 | v1beta1 |
+|---|---|---|
+| `generateDGDSpec()` — output file selection | `dgdr.Spec.UseMocker` | `dgdr.Spec.Features != nil && dgdr.Spec.Features.Mocker != nil && dgdr.Spec.Features.Mocker.Enabled` |
+
+### `yaml.Marshal` → `sigsyaml.Marshal` (1 reference)
+
+| Location | Before | After |
+|---|---|---|
+| `generateDGDSpec()` — serialize DGD to annotation | `yaml.Marshal(dgd)` | `sigsyaml.Marshal(dgd)` |
+
+---
+
+## Build Status
+
+- **`go build ./...`**: ✅ Clean (zero errors)
+- **`go vet ./...`**: ✅ Controller clean (1 pre-existing test file error in Phase 7 scope)
+
+## Remaining test file issue
+
+`dynamographdeploymentrequest_controller_test.go:114` references `nvidiacomv1beta1.ProfilingConfigSpec`
+which doesn't exist in v1beta1. This is a Phase 7 (Tests) item — the test fixtures need to be
+rewritten to use v1beta1 spec patterns.

--- a/deploy/operator/docs/dgdr-v1beta1-controller-refactor-phase2-summary.md
+++ b/deploy/operator/docs/dgdr-v1beta1-controller-refactor-phase2-summary.md
@@ -1,0 +1,84 @@
+# DGDR v1beta1 Controller Refactor — Phase 2 Summary
+
+## Phase: State Machine → Phase Machine
+
+**Date**: 2026-02-24
+**File changed**: `internal/controller/dynamographdeploymentrequest_controller.go`
+
+---
+
+## Overview
+
+Phase 2 replaces the v1alpha1 state-based reconciliation loop with the v1beta1 phase-based model. Most of the work (items 2.1–2.7) was completed previously. This session implemented the remaining three items: the `Succeeded` aggregate condition (2.8), `ProfilingPhase` tracking (2.9), and `status.profilingJobName` (2.10).
+
+---
+
+## Items Completed (Previously)
+
+| Item | Description | Status |
+|------|-------------|--------|
+| 2.1 | Phase enum mapping | ✅ Done |
+| 2.2 | Refactor `Reconcile` switch to use `dgdr.Status.Phase` | ✅ Done |
+| 2.3 | Merge `Initializing` into `Pending` (check `ObservedGeneration == 0`) | ✅ Done |
+| 2.4 | Handle `Deployed` phase (new `handleDeployedPhase()`) | ✅ Done |
+| 2.5 | Handle `DeploymentDeleted` → `Failed` | ✅ Done |
+| 2.6 | Immutability check uses v1beta1 phases | ✅ Done |
+| 2.7 | Replace `updateStateAndRequeue` / `updateStateWithCondition` with `updatePhaseAndRequeue` / `updatePhaseWithCondition` | ✅ Done |
+
+---
+
+## Items Completed (This Session)
+
+### 2.8 — `Succeeded` Aggregate Condition
+
+Added a `setSucceededCondition()` helper function that maps each phase to a `Succeeded` condition:
+
+| Phase | Succeeded.Status | Succeeded.Reason |
+|-------|------------------|------------------|
+| Pending | `False` | `Pending` |
+| Profiling | `False` | `Profiling` |
+| Ready | `True` | `SpecGenerated` |
+| Deploying | `False` | `Deploying` |
+| Deployed | `True` | `Deployed` |
+| Failed | `False` | `Failed` |
+
+**Integration points** — `setSucceededCondition` is called:
+- In `updatePhaseAndRequeue()` — the standard phase transition helper
+- In `updatePhaseWithCondition()` — the phase+condition transition helper
+- At 4 direct `dgdr.Status.Phase = ...` assignments:
+  - `handleDeployingPhase()` → Ready (when autoApply disabled)
+  - `handleDeployingPhase()` → Deployed (DGD ready)
+  - `handleDeployedPhase()` → Deploying (DGD degraded)
+  - `handleDGDDeleted()` → Failed (DGD deleted by user)
+
+This ensures every phase transition, whether through helpers or direct assignment, updates the `Succeeded` condition for `kubectl get dgdr` observability (the v1beta1 CRD has a printcolumn for `Succeeded.reason`).
+
+### 2.9 — `ProfilingPhase` Sub-Phase Tracking
+
+Set and clear `status.profilingPhase` at the correct lifecycle boundaries:
+
+- **Set to `Initializing`**: In `handlePendingPhase()`, immediately before transitioning to the `Profiling` phase (after `createProfilingJob` succeeds). Uses `dgdr.SetProfilingPhase(ProfilingPhaseInitializing)`.
+
+- **Cleared on success**: In `handleProfilingPhase()`, after profiling job completes successfully (`dgdr.ClearProfilingPhase()`), before spec generation.
+
+- **Cleared on failure**: In `handleProfilingPhase()`, when `checkProfilingJobStatus` returns an error (`dgdr.ClearProfilingPhase()`), before transitioning to `Failed`.
+
+**Future enhancement**: The profiler can update a ConfigMap with its current sub-phase (e.g., `SweepingPrefill`, `SweepingDecode`), and the controller can read it during `handleProfilingPhase()` to update `status.profilingPhase` with finer granularity.
+
+### 2.10 — `status.profilingJobName`
+
+Added `dgdr.Status.ProfilingJobName = job.Name` in `createProfilingJob()` after `SyncResource` creates or updates the Job. This stores the Kubernetes Job name in status for:
+- Observability (`kubectl get dgdr -o yaml` shows the job name)
+- Future use by `handleProfilingPhase()` for direct job lookups
+
+---
+
+## Build Verification
+
+The changes compile cleanly. The only build errors present are pre-existing `DeploymentOverrides` references from the Phase 1 type switch (v1alpha1 → v1beta1), which will be addressed in Phase 5 (DGD Spec Generation & AutoApply) when the deployment namespace/name/labels logic is updated to use v1beta1's `Overrides` struct.
+
+---
+
+## Phase 2 Completion Status
+
+All 10 items of Phase 2 are now complete. The controller's reconciliation loop fully operates on v1beta1 phase semantics with proper aggregate condition tracking, profiling sub-phase visibility, and job name observability.

--- a/deploy/operator/docs/dgdr-v1beta1-controller-refactor-phase3-summary.md
+++ b/deploy/operator/docs/dgdr-v1beta1-controller-refactor-phase3-summary.md
@@ -1,0 +1,144 @@
+# DGDR v1beta1 Controller Refactor — Phase 3 Summary
+
+## Phase: Structured Config — Eliminate the JSON Blob
+
+**Date**: 2026-02-24
+**File changed**: `internal/controller/dynamographdeploymentrequest_controller.go`
+
+---
+
+## Overview
+
+Phase 3 eliminates the fragile `map[string]interface{}` JSON blob parsing that was the core
+of the v1alpha1 profiling config preparation. The controller now marshals the typed v1beta1
+spec directly to JSON and passes it to the profiler unchanged. This is the highest-value
+change in the refactor — it removes ~200 lines of brittle key-by-key mapping code and
+replaces it with `json.Marshal(dgdr.Spec)`.
+
+---
+
+## Items Completed
+
+### 3.1 — `prepareProfilingConfig()` → `marshalDGDRSpec()`
+
+**Deleted**: The entire `prepareProfilingConfig()` function (~95 lines) which:
+- Parsed `dgdr.Spec.ProfilingConfig.Config.Raw` into `map[string]interface{}`
+- Manually injected `deployment.namespace`, `deployment.model`, `engine.backend`
+- Merged GPU discovery results key-by-key into the hardware section
+- Re-serialized to YAML
+
+**Added**: `marshalDGDRSpec()` — a 6-line function that calls `json.Marshal(dgdr.Spec)`.
+The profiler receives the DGDR spec verbatim as JSON via `--config`.
+
+**Added**: `enrichHardwareFromDiscovery()` — fills in `spec.hardware.gpuSku`, `vramMb`,
+and `numGpusPerNode` from cluster GPU discovery if the user didn't set them. Called
+before `marshalDGDRSpec()` so discovered values are included in the JSON. Mutates the
+in-memory spec only (never persisted via status update).
+
+### 3.2 — `extractModelCachePVCConfig()` — typed struct access
+
+**Before**: Parsed `dgdr.Spec.ProfilingConfig.Config.Raw` → `config["deployment"]["modelCache"]["pvcName"]`  
+**After**: Reads `dgdr.Spec.ModelCache.PVCName` and `dgdr.Spec.ModelCache.PVCMountPath` directly.
+
+| Old blob path | New typed field |
+|---|---|
+| `config["deployment"]["modelCache"]["pvcName"]` | `dgdr.Spec.ModelCache.PVCName` |
+| `config["deployment"]["modelCache"]["mountPath"]` | `dgdr.Spec.ModelCache.PVCMountPath` |
+
+### 3.3 — `isOnlineProfiling()` — simplified
+
+**Before**: Parsed `dgdr.Spec.ProfilingConfig.Config.Raw` → `config["sweep"]["use_ai_configurator"]`  
+**After**: Always returns `true`. The profiler decides online vs AIC mode internally.
+The distinction only affected the Job label (`dynamo-profiler` vs `aic-profiler`),
+which is now always `dynamo-profiler`.
+
+### 3.4 — `validateGPUHardwareInfo()` — typed struct validation
+
+**Before**: ~80 lines parsing `config["hardware"]` and `config["engine"]` from the JSON blob,
+using `toFloat64()` helper for type-unsafe numeric conversions.
+
+**After**: ~25 lines checking `dgdr.Spec.Hardware.GPUSKU`, `.VRAMMB`, `.NumGPUsPerNode` directly.
+Error messages now reference v1beta1 field paths (`spec.hardware.gpuSku`) instead of blob paths.
+
+**Deleted**: `toFloat64()` helper — no longer needed with typed fields.
+
+### 3.5 — Removed `ConfigKey*` constants
+
+All 19 `ConfigKey*` constants deleted:
+```
+ConfigKeyDeployment, ConfigKeyModelCache, ConfigKeyPVCName, ConfigKeyPVCPath,
+ConfigKeyMountPath, ConfigKeyHardware, ConfigKeyEngine, ConfigKeyOutputDir,
+ConfigKeyNumGpusPerNode, ConfigKeyGPUModel, ConfigKeyGPUVramMib, ConfigKeySystem,
+ConfigKeyMinNumGpusPerEng, ConfigKeyMaxNumGpusPerEng, ConfigKeyBackend,
+ConfigKeyConfig, ConfigKeyNamespace, ConfigKeyModel, ConfigKeyDGDImage
+```
+
+Also removed unused volume constants: `VolumeNameProfilingConfig`, `ProfilingConfigPath`,
+`ProfilingConfigFile` (these were for ConfigMapRef volume mounting, which is removed).
+
+### 3.6 — `overrides.profilingJob` merge
+
+Replaced direct `ProfilingConfig.{Resources, Tolerations, NodeSelector}` field access with
+structured merge from `dgdr.Spec.Overrides.ProfilingJob`:
+
+| v1alpha1 field | v1beta1 override source |
+|---|---|
+| `ProfilingConfig.Resources` | `Overrides.ProfilingJob.Template.Spec.Containers[0].Resources` |
+| `ProfilingConfig.Tolerations` | `Overrides.ProfilingJob.Template.Spec.Tolerations` |
+| `ProfilingConfig.NodeSelector` | `Overrides.ProfilingJob.Template.Spec.NodeSelector` |
+| *(new)* | `Overrides.ProfilingJob.Template.Spec.ImagePullSecrets` |
+| *(new)* | `Overrides.ProfilingJob.Template.Spec.ServiceAccountName` |
+| *(new)* | `Overrides.ProfilingJob.BackoffLimit` |
+
+### 3.7 — `overrides.dgd` (noted)
+
+The `Overrides.DGD` field (`*runtime.RawExtension`) replaces the old `ConfigMapRef` pattern.
+The profiler merges profiling results on top of this template. No additional controller
+changes needed in this phase — the profiler reads the DGD template from the spec JSON.
+
+### 3.8 — Profiler invocation update
+
+| Aspect | Before (v1alpha1) | After (v1beta1) |
+|---|---|---|
+| Command | `python -m dynamo.profiler.profile_sla` | `python -m dynamo.profiler` |
+| Args | `--profile-config <yaml_string>` | `--config <json_string>` |
+| Image source | `dgdr.Spec.ProfilingConfig.ProfilerImage` | `dgdr.Spec.Image` |
+| Config format | Bespoke YAML with injected keys | `json.Marshal(dgdr.Spec)` |
+
+### `validateSpec()` — ConfigMapRef validation removed
+
+Removed the `ProfilingConfig.ConfigMapRef` validation block (ConfigMap existence check,
+key existence check). In v1beta1, the DGD base template comes from `Overrides.DGD`,
+not a ConfigMap. Model cache PVC validation now reads from `dgdr.Spec.ModelCache.PVCName`.
+
+### OutputPVC removal
+
+The `ProfilingConfig.OutputPVC` field has no v1beta1 equivalent. Profiling output now
+always uses `emptyDir` — the sidecar copies results to a ConfigMap, which is the
+canonical output mechanism.
+
+---
+
+## Net code change
+
+- **~200 lines deleted** (prepareProfilingConfig, blob parsing in validateGPUHardwareInfo,
+  extractModelCachePVCConfig blob version, ConfigKey constants, toFloat64, ConfigMapRef
+  validation, OutputPVC/ConfigMapRef volume logic)
+- **~80 lines added** (marshalDGDRSpec, enrichHardwareFromDiscovery, typed
+  extractModelCachePVCConfig, overrides merge, typed validateGPUHardwareInfo)
+- **Net: ~120 lines removed**
+
+## Build verification
+
+No new compile errors introduced. Only pre-existing `DeploymentOverrides` errors remain
+(11 references in DGD creation/deployment handling — will be addressed in Phase 5).
+
+## Remaining `ProfilingConfig` references
+
+Zero. All `dgdr.Spec.ProfilingConfig.*` references have been eliminated from the controller.
+
+## Remaining `DeploymentOverrides` references (Phase 5)
+
+11 references in `handleDeployingPhase`, `handleDeployedPhase`, `createDGD`, and
+`handleProfilingPhase` (target namespace resolution). These will be updated in Phase 5
+to use the v1beta1 deployment namespace/name/labels patterns.

--- a/deploy/operator/docs/dgdr-v1beta1-controller-refactor-phase4-summary.md
+++ b/deploy/operator/docs/dgdr-v1beta1-controller-refactor-phase4-summary.md
@@ -1,0 +1,91 @@
+# DGDR v1beta1 Controller Refactor — Phase 4 Summary
+
+## Phase: Profiling Job Creation
+
+**Date**: 2026-02-24
+**File changed**: `internal/controller/dynamographdeploymentrequest_controller.go`
+
+---
+
+## Overview
+
+Phase 4 ensures `createProfilingJob()` uses v1beta1 spec fields and supports the new
+override mechanism, while maintaining backward compatibility with v1alpha1 resources
+that are converted to v1beta1 via the hub conversion layer.
+
+Most Phase 4 items were already completed as part of earlier phases. This session
+implemented the two remaining items: annotation-based fallbacks for `ConfigMapRef`
+(4.4) and `OutputPVC` (4.5) to support round-tripped v1alpha1 resources.
+
+---
+
+## Items — Status
+
+### 4.1 — Spec access mapping (reference table)
+
+Not code — just a reference mapping. All mappings are now implemented:
+
+| v1alpha1 field | v1beta1 equivalent | Implemented in |
+|---|---|---|
+| `ProfilingConfig.ProfilerImage` | `dgdr.Spec.Image` | Phase 3 |
+| `ProfilingConfig.Config.Raw` | `json.Marshal(dgdr.Spec)` | Phase 3 |
+| `prepareProfilingConfig()` (150-line YAML builder) | `marshalDGDRSpec()` | Phase 3 |
+| `--profile-config <yaml>` | `--config <json>` | Phase 3 |
+| `python -m dynamo.profiler.profile_sla` | `python -m dynamo.profiler` | Phase 3 |
+| `ProfilingConfig.Resources` | `Overrides.ProfilingJob...Resources` | Phase 3 |
+| `ProfilingConfig.Tolerations` | `Overrides.ProfilingJob...Tolerations` | Phase 3 |
+| `ProfilingConfig.NodeSelector` | `Overrides.ProfilingJob...NodeSelector` | Phase 3 |
+| `ProfilingConfig.ConfigMapRef` | Annotation fallback (this phase) | **Phase 4** |
+| `ProfilingConfig.OutputPVC` | Annotation fallback (this phase) | **Phase 4** |
+| `DeploymentOverrides.WorkersImage` | `dgdr.Spec.Image` | Phase 1 fix |
+| `Spec.UseMocker` | `Spec.Features.Mocker.Enabled` | Phase 1 fix |
+
+### 4.2 — Profiler image & command — ✅ Done (Phase 3)
+
+### 4.3 — Resource/tolerations/nodeSelector — ✅ Done (Phase 3)
+
+### 4.4 — ConfigMapRef from annotation — ✅ Done (this session)
+
+Added `configMapRefFromAnnotation()` helper that reads the JSON-serialized
+`ConfigMapKeySelector` from annotation `nvidia.com/dgdr-config-map-ref`.
+
+When present (round-tripped v1alpha1 resource), the controller:
+- Mounts the referenced ConfigMap as a volume at `/config`
+- The profiler reads the DGD base config from this mount
+
+When absent (native v1beta1 resource), no ConfigMap is mounted — the DGD base
+config comes from `overrides.dgd` in the spec JSON.
+
+**New type**: `configMapKeySelector` struct (controller-local, mirrors v1alpha1 type)
+
+### 4.5 — OutputPVC from annotation — ✅ Done (this session)
+
+Added `outputPVCFromAnnotation()` helper that reads the PVC name from annotation
+`nvidia.com/dgdr-output-pvc`.
+
+When present (round-tripped v1alpha1 resource), profiling output uses the PVC.
+When absent (native v1beta1 resource), profiling output uses `emptyDir` — the
+sidecar copies results to a ConfigMap, which is the canonical output mechanism.
+
+### 4.6 — Store job name in status — ✅ Done (Phase 2)
+
+### 4.7 — UseMocker source — ✅ Done (Phase 1 fix)
+
+---
+
+## Constants added
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `AnnotationConfigMapRef` | `nvidia.com/dgdr-config-map-ref` | v1alpha1 round-trip annotation for ConfigMap ref |
+| `AnnotationOutputPVC` | `nvidia.com/dgdr-output-pvc` | v1alpha1 round-trip annotation for output PVC |
+| `VolumeNameProfilingConfig` | `profiling-config` | Volume name for ConfigMap mount (re-added) |
+| `ProfilingConfigMountPath` | `/config` | Mount path for ConfigMap volume |
+| `ProfilingConfigDefaultKey` | `disagg.yaml` | Default key in ConfigMap |
+
+---
+
+## Build Status
+
+- **`go build ./...`**: ✅ Clean
+- **`go vet ./...`**: ✅ Controller clean (1 pre-existing test file error, Phase 7 scope)

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -20,6 +20,7 @@ package controller
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"text/template"
@@ -45,6 +46,7 @@ import (
 	sigsyaml "sigs.k8s.io/yaml"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
@@ -52,37 +54,6 @@ import (
 )
 
 const (
-	// Condition types
-	ConditionTypeValidation      = "Validation"
-	ConditionTypeProfiling       = "Profiling"
-	ConditionTypeSpecGenerated   = "SpecGenerated"
-	ConditionTypeDeploymentReady = "DeploymentReady"
-
-	// Event reasons
-	EventReasonInitialized          = "Initialized"
-	EventReasonValidationFailed     = "ValidationFailed"
-	EventReasonProfilingJobCreated  = "ProfilingJobCreated"
-	EventReasonProfilingJobFailed   = "ProfilingJobFailed"
-	EventReasonAIConfiguratorFailed = "AIConfiguratorFailed"
-	EventReasonSpecGenerated        = "SpecGenerated"
-	EventReasonSpecChangeRejected   = "SpecChangeRejected"
-	EventReasonDeploymentCreated    = "DeploymentCreated"
-	EventReasonDeploymentReady      = "DeploymentReady"
-	EventReasonDeploymentDegraded   = "DeploymentDegraded"
-	EventReasonDeploymentDeleted    = "DeploymentDeleted"
-
-	// Label keys
-	LabelApp           = "app"
-	LabelDGDR          = "dgdr"
-	LabelDGDRName      = "dgdr.nvidia.com/name"
-	LabelDGDRNamespace = "dgdr.nvidia.com/namespace"
-	LabelManagedBy     = "nvidia.com/managed-by"
-
-	// Label values
-	LabelValueDynamoProfiler = "dynamo-profiler"
-	LabelValueAICProfiler    = "aic-profiler"
-	LabelValueDynamoOperator = "dynamo-operator"
-
 	// Job naming
 	JobNamePrefixOnline = "profile-online-"
 	JobNamePrefixAIC    = "profile-aic-"
@@ -100,6 +71,12 @@ const (
 	// Annotation keys
 	AnnotationAdditionalResources = "dgdr.nvidia.com/additional-resources"
 
+	// Annotation keys for v1alpha1 round-trip compatibility.
+	// The conversion layer stores v1alpha1 fields that have no v1beta1 spec equivalent
+	// as annotations so the controller can still honour them for converted resources.
+	AnnotationConfigMapRef = "nvidia.com/dgdr-config-map-ref"
+	AnnotationOutputPVC    = "nvidia.com/dgdr-output-pvc"
+
 	// Size limits
 	MaxAnnotationSize = 250000 // ~250KB, below K8s 256KB limit
 
@@ -107,16 +84,16 @@ const (
 	SidecarImage = "bitnami/kubectl:latest"
 
 	// Volume names
-	VolumeNameProfilingConfig = "profiling-config"
 	VolumeNameProfilingOutput = "profiling-output"
+	VolumeNameProfilingConfig = "profiling-config"
 	VolumeNameModelCache      = "model-cache"
 
 	// Volume paths
 	ProfilingOutputPath        = "/data"
 	ProfilingOutputFile        = "config_with_planner.yaml"
 	ProfilingOutputFileMocker  = "mocker_config_with_planner.yaml"
-	ProfilingConfigPath        = "/config"
-	ProfilingConfigFile        = "disagg.yaml"
+	ProfilingConfigMountPath   = "/config"
+	ProfilingConfigDefaultKey  = "disagg.yaml"
 	DefaultModelCacheMountPath = "/opt/model-cache"
 
 	// Command line arguments
@@ -138,7 +115,7 @@ const (
 	MessageDeploymentDegraded        = "DynamoGraphDeployment %s degraded from Ready to %s"
 	MessageDeploymentDeleted         = "DGD %s was deleted. DGDR will not recreate it. Delete this DGDR and create a new one to redeploy."
 	MessageInvalidState              = "Invalid state"
-	MessageSpecChangeRejected        = "Cannot modify spec in state '%s'. DynamoGraphDeploymentRequest is immutable once profiling starts. Create a new resource with a different name instead."
+	MessageSpecChangeRejected        = "Cannot modify spec in phase '%s'. DynamoGraphDeploymentRequest is immutable once profiling starts. Create a new resource with a different name instead."
 	MessageJobCreationFailed         = "JobCreationFailed"
 	MessageDeploymentCreationFailed  = "DeploymentCreationFailed"
 	MessageResultsRetrievalFailed    = "ResultsRetrievalFailed"
@@ -159,27 +136,6 @@ const (
 	BackendVLLM   = "vllm"
 	BackendSGLang = "sglang"
 	BackendTRTLLM = "trtllm"
-
-	// Profiling config field names for v1alpha1; note: will be removed in v1beta1
-	ConfigKeyDeployment       = "deployment"
-	ConfigKeyModelCache       = "modelCache"
-	ConfigKeyPVCName          = "pvcName"
-	ConfigKeyPVCPath          = "pvcPath"
-	ConfigKeyMountPath        = "mountPath"
-	ConfigKeyHardware         = "hardware"
-	ConfigKeyEngine           = "engine"
-	ConfigKeyOutputDir        = "output_dir"
-	ConfigKeyNumGpusPerNode   = "numGpusPerNode"
-	ConfigKeyGPUModel         = "gpuModel"
-	ConfigKeyGPUVramMib       = "gpuVramMib"
-	ConfigKeySystem           = "system"
-	ConfigKeyMinNumGpusPerEng = "minNumGpusPerEngine"
-	ConfigKeyMaxNumGpusPerEng = "maxNumGpusPerEngine"
-	ConfigKeyBackend          = "backend"
-	ConfigKeyConfig           = "config"
-	ConfigKeyNamespace        = "namespace"
-	ConfigKeyModel            = "model"
-	ConfigKeyDGDImage         = "dgd_image"
 )
 
 // shell script template for the output copier sidecar
@@ -316,7 +272,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) GetRecorder() record.EventRecor
 }
 
 // FinalizeResource implements commonController.Finalizer interface
-func (r *DynamoGraphDeploymentRequestReconciler) FinalizeResource(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) error {
+func (r *DynamoGraphDeploymentRequestReconciler) FinalizeResource(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
 	logger := log.FromContext(ctx)
 
 	logger.Info("DGDR finalized successfully", "name", dgdr.Name)
@@ -340,7 +296,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) Reconcile(ctx context.Context, 
 	logger.Info("Reconciling DynamoGraphDeploymentRequest", "name", req.Name, "namespace", req.Namespace)
 
 	// Fetch the DGDR instance
-	dgdr := &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{}
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}
 	if err := r.Get(ctx, req.NamespacedName, dgdr); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("DGDR resource not found, ignoring since object must be deleted")
@@ -363,99 +319,98 @@ func (r *DynamoGraphDeploymentRequestReconciler) Reconcile(ctx context.Context, 
 	// Check for spec changes (immutability enforcement)
 	if dgdr.Status.ObservedGeneration > 0 && dgdr.Status.ObservedGeneration != dgdr.Generation {
 		// Spec changed after initial processing
-		if dgdr.Status.State == nvidiacomv1alpha1.DGDRStateProfiling || dgdr.Status.State == nvidiacomv1alpha1.DGDRStateDeploying ||
-			dgdr.Status.State == nvidiacomv1alpha1.DGDRStateReady || dgdr.Status.State == nvidiacomv1alpha1.DGDRStateDeploymentDeleted {
-			logger.Info("Spec change detected in immutable state",
-				"state", dgdr.Status.State,
+		if dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseProfiling || dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseDeploying ||
+			dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseReady || dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseDeployed {
+			logger.Info("Spec change detected in immutable phase",
+				"phase", dgdr.Status.Phase,
 				"observedGeneration", dgdr.Status.ObservedGeneration,
 				"currentGeneration", dgdr.Generation)
 
-			r.Recorder.Event(dgdr, corev1.EventTypeWarning, EventReasonSpecChangeRejected,
-				fmt.Sprintf(MessageSpecChangeRejected, dgdr.Status.State))
+			r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonSpecChangeRejected,
+				fmt.Sprintf(MessageSpecChangeRejected, dgdr.Status.Phase))
 
 			// Keep the old observedGeneration to continue rejecting changes
-			// No state transition - stay in current state with old spec
+			// No phase transition - stay in current phase with old spec
 			return ctrl.Result{}, nil
 		}
 	}
-	// State machine: handle different states
-	switch dgdr.Status.State {
-	case nvidiacomv1alpha1.DGDRStateInitializing, "":
-		return r.handleInitialState(ctx, dgdr)
-	case nvidiacomv1alpha1.DGDRStatePending:
-		return r.handlePendingState(ctx, dgdr)
-	case nvidiacomv1alpha1.DGDRStateProfiling:
-		return r.handleProfilingState(ctx, dgdr)
-	case nvidiacomv1alpha1.DGDRStateDeploying:
-		return r.handleDeployingState(ctx, dgdr)
-	case nvidiacomv1alpha1.DGDRStateReady:
-		return r.handleReadyState(ctx, dgdr)
-	case nvidiacomv1alpha1.DGDRStateDeploymentDeleted:
-		return r.handleDeploymentDeletedState(ctx, dgdr)
-	case nvidiacomv1alpha1.DGDRStateFailed:
-		return r.handleFailedState(ctx, dgdr)
+	// Phase machine: handle different phases
+	switch dgdr.Status.Phase {
+	case nvidiacomv1beta1.DGDRPhasePending, "":
+		return r.handlePendingPhase(ctx, dgdr)
+	case nvidiacomv1beta1.DGDRPhaseProfiling:
+		return r.handleProfilingPhase(ctx, dgdr)
+	case nvidiacomv1beta1.DGDRPhaseDeploying:
+		return r.handleDeployingPhase(ctx, dgdr)
+	case nvidiacomv1beta1.DGDRPhaseReady:
+		return r.handleReadyPhase(ctx, dgdr)
+	case nvidiacomv1beta1.DGDRPhaseDeployed:
+		return r.handleDeployedPhase(ctx, dgdr)
+	case nvidiacomv1beta1.DGDRPhaseFailed:
+		return r.handleFailedPhase(ctx, dgdr)
 	default:
-		logger.Info("Unknown state", "state", dgdr.Status.State)
-		return r.updateStateAndRequeue(ctx, dgdr, nvidiacomv1alpha1.DGDRStateFailed, MessageInvalidState)
+		logger.Info("Unknown phase", "phase", dgdr.Status.Phase)
+		return r.updatePhaseAndRequeue(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, MessageInvalidState)
 	}
 }
 
-// handleInitialState processes newly created DGDR resources
-func (r *DynamoGraphDeploymentRequestReconciler) handleInitialState(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
+// handlePendingPhase processes newly created or pending DGDR resources.
+// When ObservedGeneration == 0, performs initial validation (merged from v1alpha1 Initializing state).
+// Otherwise, starts the profiling process.
+func (r *DynamoGraphDeploymentRequestReconciler) handlePendingPhase(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Handling initial state", "name", dgdr.Name)
 
-	// Validate the spec
-	if err := r.validateSpec(ctx, dgdr); err != nil {
-		r.Recorder.Event(dgdr, corev1.EventTypeWarning, EventReasonValidationFailed, err.Error())
-		return r.updateStateWithCondition(ctx, dgdr, nvidiacomv1alpha1.DGDRStateFailed, ConditionTypeValidation, metav1.ConditionFalse, EventReasonValidationFailed, err.Error())
+	// First-time processing: validate spec (merged from handleInitialState)
+	if dgdr.Status.ObservedGeneration == 0 {
+		logger.Info("Handling initial validation", "name", dgdr.Name)
+
+		// Validate the spec
+		if err := r.validateSpec(ctx, dgdr); err != nil {
+			r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonValidationFailed, err.Error())
+			return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, nvidiacomv1beta1.ConditionTypeValidation, metav1.ConditionFalse, nvidiacomv1beta1.EventReasonValidationFailed, err.Error())
+		}
+
+		// Set observedGeneration to track the spec we're processing
+		dgdr.Status.ObservedGeneration = dgdr.Generation
+
+		// Initialize status
+		r.Recorder.Event(dgdr, corev1.EventTypeNormal, nvidiacomv1beta1.EventReasonInitialized, MessageInitialized)
+		return r.updatePhaseAndRequeue(ctx, dgdr, nvidiacomv1beta1.DGDRPhasePending, MessageInitialized)
 	}
 
-	// Set observedGeneration to track the spec we're processing
-	dgdr.Status.ObservedGeneration = dgdr.Generation
-
-	// Populate backend in status from spec for display in kubectl output
-	dgdr.Status.Backend = dgdr.Spec.Backend
-
-	// Initialize status
-	r.Recorder.Event(dgdr, corev1.EventTypeNormal, EventReasonInitialized, MessageInitialized)
-	return r.updateStateAndRequeue(ctx, dgdr, nvidiacomv1alpha1.DGDRStatePending, MessageInitialized)
-}
-
-// handlePendingState starts the profiling process
-func (r *DynamoGraphDeploymentRequestReconciler) handlePendingState(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-	logger.Info("Handling pending state", "name", dgdr.Name)
+	logger.Info("Handling pending phase", "name", dgdr.Name)
 
 	// Create profiling job (online or AIC)
 	if err := r.createProfilingJob(ctx, dgdr); err != nil {
-		r.Recorder.Event(dgdr, corev1.EventTypeWarning, EventReasonProfilingJobFailed, err.Error())
-		return r.updateStateWithCondition(ctx, dgdr, nvidiacomv1alpha1.DGDRStateFailed, ConditionTypeProfiling, metav1.ConditionFalse, MessageJobCreationFailed, err.Error())
+		r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonProfilingJobFailed, err.Error())
+		return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, nvidiacomv1beta1.ConditionTypeProfiling, metav1.ConditionFalse, MessageJobCreationFailed, err.Error())
 	}
 
 	// Record event with appropriate message
 	if isOnlineProfiling(dgdr) {
-		r.Recorder.Event(dgdr, corev1.EventTypeNormal, EventReasonProfilingJobCreated, MessageProfilingJobCreated)
+		r.Recorder.Event(dgdr, corev1.EventTypeNormal, nvidiacomv1beta1.EventReasonProfilingJobCreated, MessageProfilingJobCreated)
 	} else {
-		r.Recorder.Event(dgdr, corev1.EventTypeNormal, EventReasonProfilingJobCreated, MessageAICProfilingJobCreated)
+		r.Recorder.Event(dgdr, corev1.EventTypeNormal, nvidiacomv1beta1.EventReasonProfilingJobCreated, MessageAICProfilingJobCreated)
 	}
 
-	// Update to Profiling state with Running status
-	return r.updateStateWithCondition(ctx, dgdr, nvidiacomv1alpha1.DGDRStateProfiling, ConditionTypeProfiling, metav1.ConditionFalse, "ProfilingRunning", MessageProfilingInProgress)
+	// Update to Profiling phase with Running status
+	dgdr.SetProfilingPhase(nvidiacomv1beta1.ProfilingPhaseInitializing)
+	return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseProfiling, nvidiacomv1beta1.ConditionTypeProfiling, metav1.ConditionFalse, "ProfilingRunning", MessageProfilingInProgress)
 }
 
-// handleProfilingState monitors profiling progress and generates spec when complete
-func (r *DynamoGraphDeploymentRequestReconciler) handleProfilingState(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
+// handleProfilingPhase monitors profiling progress and generates spec when complete
+func (r *DynamoGraphDeploymentRequestReconciler) handleProfilingPhase(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Handling profiling state", "name", dgdr.Name)
+	logger.Info("Handling profiling phase", "name", dgdr.Name)
 
 	// Check profiling job status (both online and offline/AIC run as Jobs)
 	// Note: We watch the Job via Owns(), so we'll be triggered automatically on Job changes
 	completed, err := r.checkProfilingJobStatus(ctx, dgdr)
 	if err != nil {
 		r.Recorder.Event(dgdr, corev1.EventTypeWarning, MessageProfilingCheckFailed, err.Error())
-		// Job failed - transition to Failed state
-		return r.updateStateWithCondition(ctx, dgdr, nvidiacomv1alpha1.DGDRStateFailed, ConditionTypeProfiling, metav1.ConditionFalse, "ProfilingFailed", err.Error())
+		// Job failed - clear profiling sub-phase and transition to Failed
+		dgdr.ClearProfilingPhase()
+		return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, nvidiacomv1beta1.ConditionTypeProfiling, metav1.ConditionFalse, "ProfilingFailed", err.Error())
 	}
 
 	if !completed {
@@ -464,9 +419,12 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleProfilingState(ctx contex
 		return ctrl.Result{}, nil
 	}
 
+	// Profiling complete — clear the profiling sub-phase
+	dgdr.ClearProfilingPhase()
+
 	// Mark profiling as completed successfully
 	meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
-		Type:               ConditionTypeProfiling,
+		Type:               nvidiacomv1beta1.ConditionTypeProfiling,
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: dgdr.Generation,
 		Reason:             "ProfilingCompleted",
@@ -476,18 +434,18 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleProfilingState(ctx contex
 	// Retrieve profiling results and generate spec
 	if err := r.generateDGDSpec(ctx, dgdr); err != nil {
 		r.Recorder.Event(dgdr, corev1.EventTypeWarning, MessageGenerationFailed, err.Error())
-		return r.updateStateWithCondition(ctx, dgdr, nvidiacomv1alpha1.DGDRStateFailed, ConditionTypeSpecGenerated, metav1.ConditionFalse, MessageGenerationFailed, err.Error())
+		return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, nvidiacomv1beta1.ConditionTypeSpecGenerated, metav1.ConditionFalse, MessageGenerationFailed, err.Error())
 	}
 
 	// Record spec generation event
-	r.Recorder.Event(dgdr, corev1.EventTypeNormal, EventReasonSpecGenerated, MessageSpecGenerated)
+	r.Recorder.Event(dgdr, corev1.EventTypeNormal, nvidiacomv1beta1.EventReasonSpecGenerated, MessageSpecGenerated)
 
 	// Create additional resources (ConfigMaps) immediately after profiling
 	// This ensures that the `planner-profile-data` ConfigMap is available for both auto and manual deployment
+	// v1beta1 uses the DGDR namespace for additional resources.
+	// Phase 1 fix: v1alpha1 DeploymentOverrides.Namespace removed; Phase 5 may add
+	// namespace override via overrides.dgd if needed.
 	targetNamespace := dgdr.Namespace
-	if dgdr.Spec.DeploymentOverrides != nil && dgdr.Spec.DeploymentOverrides.Namespace != "" {
-		targetNamespace = dgdr.Spec.DeploymentOverrides.Namespace
-	}
 	if err := r.createAdditionalResources(ctx, dgdr, targetNamespace); err != nil {
 		logger.Error(err, "Failed to create additional resources after profiling")
 		// Don't fail the DGDR, just log the error - ConfigMaps can be created manually
@@ -495,88 +453,51 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleProfilingState(ctx contex
 			fmt.Sprintf("Failed to create ConfigMaps from profiling output: %v", err))
 	}
 
-	// If autoApply is enabled, transition to Deploying state
+	// If autoApply is enabled, transition to Deploying phase
 	if dgdr.Spec.AutoApply {
-		logger.Info("AutoApply enabled, transitioning to Deploying state")
-		return r.updateStateWithCondition(ctx, dgdr, nvidiacomv1alpha1.DGDRStateDeploying, ConditionTypeSpecGenerated, metav1.ConditionTrue, EventReasonSpecGenerated, MessageSpecGenerated)
+		logger.Info("AutoApply enabled, transitioning to Deploying phase")
+		return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseDeploying, nvidiacomv1beta1.ConditionTypeSpecGenerated, metav1.ConditionTrue, nvidiacomv1beta1.EventReasonSpecGenerated, MessageSpecGenerated)
 	}
 
-	// Otherwise, transition to Ready state
-	return r.updateStateWithCondition(ctx, dgdr, nvidiacomv1alpha1.DGDRStateReady, ConditionTypeSpecGenerated, metav1.ConditionTrue, EventReasonSpecGenerated, MessageSpecAvailable)
+	// Otherwise, transition to Ready phase
+	return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseReady, nvidiacomv1beta1.ConditionTypeSpecGenerated, metav1.ConditionTrue, nvidiacomv1beta1.EventReasonSpecGenerated, MessageSpecAvailable)
 }
 
-// handleReadyState handles DGDR in Ready state
-func (r *DynamoGraphDeploymentRequestReconciler) handleReadyState(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
+// handleReadyPhase handles DGDR in Ready phase (profiling complete, spec available)
+func (r *DynamoGraphDeploymentRequestReconciler) handleReadyPhase(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("DGDR is ready", "name", dgdr.Name)
 
-	// If autoApply is not enabled, nothing to monitor
-	if !dgdr.Spec.AutoApply {
-		return ctrl.Result{}, nil
-	}
-
-	// Check if DGD still exists and monitor its status
-	dgd := &nvidiacomv1alpha1.DynamoGraphDeployment{}
-	err := r.Get(ctx, types.NamespacedName{
-		Name:      dgdr.Status.Deployment.Name,
-		Namespace: dgdr.Status.Deployment.Namespace,
-	}, dgd)
-
-	if apierrors.IsNotFound(err) {
-		// DGD was deleted by user
-		return r.handleDGDDeleted(ctx, dgdr)
-	}
-
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// Update deployment status
-	dgdr.Status.Deployment.State = dgd.Status.State
-
-	// Check if DGD degraded from Ready
-	if dgd.Status.State != nvidiacomv1alpha1.DGDStateSuccessful {
-		logger.Info("DGD degraded, transitioning back to Deploying",
-			"dgdState", dgd.Status.State)
-
-		dgdr.Status.State = nvidiacomv1alpha1.DGDRStateDeploying
-
-		r.Recorder.Event(dgdr, corev1.EventTypeWarning, EventReasonDeploymentDegraded,
-			fmt.Sprintf(MessageDeploymentDegraded, dgd.Name, string(dgd.Status.State)))
-
-		meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
-			Type:    ConditionTypeDeploymentReady,
-			Status:  metav1.ConditionFalse,
-			Reason:  EventReasonDeploymentDegraded,
-			Message: fmt.Sprintf("Deployment degraded to %s", string(dgd.Status.State)),
-		})
-	}
-
-	return ctrl.Result{}, r.Status().Update(ctx, dgdr)
+	// Nothing to monitor in Ready phase - spec is available for manual application
+	return ctrl.Result{}, nil
 }
 
-// handleDeployingState handles DGD creation and monitors deployment
-func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingState(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
+// handleDeployingPhase handles DGD creation and monitors deployment
+func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingPhase(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Handling deploying state", "name", dgdr.Name)
+	logger.Info("Handling deploying phase", "name", dgdr.Name)
 
 	if !dgdr.Spec.AutoApply {
-		// Shouldn't be in this state without autoApply
+		// Shouldn't be in this phase without autoApply
 		logger.Info("AutoApply not enabled, transitioning to Ready")
-		dgdr.Status.State = nvidiacomv1alpha1.DGDRStateReady
+		dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseReady
+		setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseReady)
 		return ctrl.Result{}, r.Status().Update(ctx, dgdr)
 	}
 
 	// Check if we need to create DGD
-	if dgdr.Status.Deployment == nil || !dgdr.Status.Deployment.Created {
+	if dgdr.Status.DGDName == "" {
 		return r.createDGD(ctx, dgdr)
 	}
 
 	// DGD was already created, check its status
 	dgd := &nvidiacomv1alpha1.DynamoGraphDeployment{}
+	// Phase 1 fix: v1beta1 defaults DGD namespace to DGDR namespace.
+	// v1alpha1 DeploymentOverrides.Namespace removed; Phase 5 may refine.
+	dgdNamespace := dgdr.Namespace
 	err := r.Get(ctx, types.NamespacedName{
-		Name:      dgdr.Status.Deployment.Name,
-		Namespace: dgdr.Status.Deployment.Namespace,
+		Name:      dgdr.Status.DGDName,
+		Namespace: dgdNamespace,
 	}, dgd)
 
 	if apierrors.IsNotFound(err) {
@@ -588,21 +509,19 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingState(ctx contex
 		return ctrl.Result{}, err
 	}
 
-	// Update deployment status
-	dgdr.Status.Deployment.State = dgd.Status.State
-
 	// Check if DGD is Ready
 	if dgd.Status.State == nvidiacomv1alpha1.DGDStateSuccessful {
-		logger.Info("DGD is Ready, transitioning to Ready state")
-		dgdr.Status.State = nvidiacomv1alpha1.DGDRStateReady
+		logger.Info("DGD is Ready, transitioning to Deployed phase")
+		dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeployed
+		setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseDeployed)
 
-		r.Recorder.Event(dgdr, corev1.EventTypeNormal, EventReasonDeploymentReady,
+		r.Recorder.Event(dgdr, corev1.EventTypeNormal, nvidiacomv1beta1.EventReasonDeploymentReady,
 			fmt.Sprintf(MessageDeploymentReady, dgd.Name))
 
 		meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
-			Type:    ConditionTypeDeploymentReady,
+			Type:    nvidiacomv1beta1.ConditionTypeDeploymentReady,
 			Status:  metav1.ConditionTrue,
-			Reason:  EventReasonDeploymentReady,
+			Reason:  nvidiacomv1beta1.EventReasonDeploymentReady,
 			Message: fmt.Sprintf(MessageDeploymentReady, dgd.Name),
 		})
 	}
@@ -610,29 +529,71 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingState(ctx contex
 	return ctrl.Result{}, r.Status().Update(ctx, dgdr)
 }
 
-// handleDeploymentDeletedState is a terminal state for when auto-created DGD is deleted
-func (r *DynamoGraphDeploymentRequestReconciler) handleDeploymentDeletedState(_ context.Context, _ *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
-	// Terminal state - nothing to do
-	// User must delete this DGDR and create a new one to redeploy
-	return ctrl.Result{}, nil
+// handleDeployedPhase monitors a healthy DGD and detects degradation or deletion
+func (r *DynamoGraphDeploymentRequestReconciler) handleDeployedPhase(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("DGDR is deployed", "name", dgdr.Name)
+
+	// Check if DGD still exists and monitor its status
+	dgd := &nvidiacomv1alpha1.DynamoGraphDeployment{}
+	// Phase 1 fix: v1beta1 defaults DGD namespace to DGDR namespace.
+	// v1alpha1 DeploymentOverrides.Namespace removed; Phase 5 may refine.
+	dgdNamespace := dgdr.Namespace
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      dgdr.Status.DGDName,
+		Namespace: dgdNamespace,
+	}, dgd)
+
+	if apierrors.IsNotFound(err) {
+		// DGD was deleted by user
+		return r.handleDGDDeleted(ctx, dgdr)
+	}
+
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Check if DGD degraded from Ready
+	if dgd.Status.State != nvidiacomv1alpha1.DGDStateSuccessful {
+		logger.Info("DGD degraded, transitioning back to Deploying",
+			"dgdState", dgd.Status.State)
+
+		dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeploying
+		setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseDeploying)
+
+		r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonDeploymentDegraded,
+			fmt.Sprintf(MessageDeploymentDegraded, dgd.Name, string(dgd.Status.State)))
+
+		meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
+			Type:    nvidiacomv1beta1.ConditionTypeDeploymentReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  nvidiacomv1beta1.EventReasonDeploymentDegraded,
+			Message: fmt.Sprintf("Deployment degraded to %s", string(dgd.Status.State)),
+		})
+	}
+
+	return ctrl.Result{}, r.Status().Update(ctx, dgdr)
 }
 
-// handleDGDDeleted handles the case when auto-created DGD is deleted by user
-func (r *DynamoGraphDeploymentRequestReconciler) handleDGDDeleted(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
+// handleDGDDeleted handles the case when auto-created DGD is deleted by user.
+// In v1beta1, this transitions to Failed (DeploymentDeleted phase was removed).
+func (r *DynamoGraphDeploymentRequestReconciler) handleDGDDeleted(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("DGD was deleted by user, transitioning to DeploymentDeleted state")
+	logger.Info("DGD was deleted by user, transitioning to Failed phase")
 
-	dgdr.Status.State = nvidiacomv1alpha1.DGDRStateDeploymentDeleted
+	dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseFailed
+	setSucceededCondition(dgdr, nvidiacomv1beta1.DGDRPhaseFailed)
 
-	r.Recorder.Event(dgdr, corev1.EventTypeWarning, EventReasonDeploymentDeleted,
-		fmt.Sprintf(MessageDeploymentDeleted, dgdr.Status.Deployment.Name))
+	r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonDeploymentDeleted,
+		fmt.Sprintf(MessageDeploymentDeleted, dgdr.Status.DGDName))
 
-	dgdr.Status.Deployment = nil
+	dgdr.Status.DGDName = ""
+	dgdr.Status.DeploymentInfo = nil
 
 	meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
-		Type:    ConditionTypeDeploymentReady,
+		Type:    nvidiacomv1beta1.ConditionTypeDeploymentReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  EventReasonDeploymentDeleted,
+		Reason:  nvidiacomv1beta1.EventReasonDeploymentDeleted,
 		Message: "Deployment was deleted by user. Create a new DGDR to redeploy.",
 	})
 
@@ -640,44 +601,26 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDGDDeleted(ctx context.Co
 }
 
 // createDGD creates a DynamoGraphDeployment with the generated spec
-func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
+func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// Extract DGD from RawExtension
-	if dgdr.Status.GeneratedDeployment == nil {
-		return ctrl.Result{}, fmt.Errorf("generatedDeployment is not set")
+	// Extract DGD spec from annotation (stored by generateDGDSpec)
+	dgdSpecYAML, ok := dgdr.Annotations["nvidia.com/generated-dgd-spec"]
+	if !ok || dgdSpecYAML == "" {
+		return ctrl.Result{}, fmt.Errorf("generated DGD spec not found in annotation nvidia.com/generated-dgd-spec")
 	}
 
 	generatedDGD := &nvidiacomv1alpha1.DynamoGraphDeployment{}
-
-	// RawExtension can have either Object (already decoded) or Raw (JSON bytes)
-	if dgdr.Status.GeneratedDeployment.Object != nil {
-		var ok bool
-		generatedDGD, ok = dgdr.Status.GeneratedDeployment.Object.(*nvidiacomv1alpha1.DynamoGraphDeployment)
-		if !ok {
-			return ctrl.Result{}, fmt.Errorf("generatedDeployment.Object is not a DynamoGraphDeployment")
-		}
-	} else if dgdr.Status.GeneratedDeployment.Raw != nil {
-		if err := yaml.Unmarshal(dgdr.Status.GeneratedDeployment.Raw, generatedDGD); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to unmarshal generated deployment: %w", err)
-		}
-	} else {
-		return ctrl.Result{}, fmt.Errorf("generatedDeployment has neither Object nor Raw set")
+	if err := yaml.Unmarshal([]byte(dgdSpecYAML), generatedDGD); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to unmarshal generated deployment from annotation: %w", err)
 	}
 
 	// Determine DGD name and namespace
+	// Phase 1 fix: v1alpha1 DeploymentOverrides.{Name,Namespace,Labels,Annotations}
+	// removed in v1beta1. DGD defaults to the generated name and DGDR namespace.
+	// Phase 5 may add override support via overrides.dgd.
 	dgdName := generatedDGD.Name
 	dgdNamespace := dgdr.Namespace
-
-	// Apply deployment overrides
-	if dgdr.Spec.DeploymentOverrides != nil {
-		if dgdr.Spec.DeploymentOverrides.Name != "" {
-			dgdName = dgdr.Spec.DeploymentOverrides.Name
-		}
-		if dgdr.Spec.DeploymentOverrides.Namespace != "" {
-			dgdNamespace = dgdr.Spec.DeploymentOverrides.Namespace
-		}
-	}
 
 	// Build labels (start with generated DGD's labels)
 	labels := make(map[string]string)
@@ -687,27 +630,14 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 		}
 	}
 	// Add/override with managed labels
-	labels[LabelDGDRName] = dgdr.Name
-	labels[LabelDGDRNamespace] = dgdr.Namespace
-	labels[LabelManagedBy] = LabelValueDynamoOperator
-
-	// Merge custom labels from overrides
-	if dgdr.Spec.DeploymentOverrides != nil && dgdr.Spec.DeploymentOverrides.Labels != nil {
-		for k, v := range dgdr.Spec.DeploymentOverrides.Labels {
-			labels[k] = v
-		}
-	}
+	labels[nvidiacomv1beta1.LabelDGDRName] = dgdr.Name
+	labels[nvidiacomv1beta1.LabelDGDRNamespace] = dgdr.Namespace
+	labels[nvidiacomv1beta1.LabelManagedBy] = nvidiacomv1beta1.LabelValueDynamoOperator
 
 	// Build annotations (start with generated DGD's annotations)
 	annotations := make(map[string]string)
 	if generatedDGD.Annotations != nil {
 		for k, v := range generatedDGD.Annotations {
-			annotations[k] = v
-		}
-	}
-	// Merge custom annotations from overrides
-	if dgdr.Spec.DeploymentOverrides != nil && dgdr.Spec.DeploymentOverrides.Annotations != nil {
-		for k, v := range dgdr.Spec.DeploymentOverrides.Annotations {
 			annotations[k] = v
 		}
 	}
@@ -733,12 +663,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 		if apierrors.IsAlreadyExists(err) {
 			// DGD already exists, just update status
 			logger.Info("DGD already exists, updating status")
-			dgdr.Status.Deployment = &nvidiacomv1alpha1.DeploymentStatus{
-				Name:      dgdName,
-				Namespace: dgdNamespace,
-				State:     nvidiacomv1alpha1.DGDStatePending,
-				Created:   true,
-			}
+			dgdr.Status.DGDName = dgdName
 			return ctrl.Result{}, r.Status().Update(ctx, dgdr)
 		}
 		r.Recorder.Event(dgdr, corev1.EventTypeWarning, MessageDeploymentCreationFailed, err.Error())
@@ -746,20 +671,15 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	}
 
 	// Update status
-	dgdr.Status.Deployment = &nvidiacomv1alpha1.DeploymentStatus{
-		Name:      dgdName,
-		Namespace: dgdNamespace,
-		State:     nvidiacomv1alpha1.DGDStatePending,
-		Created:   true,
-	}
+	dgdr.Status.DGDName = dgdName
 
-	r.Recorder.Event(dgdr, corev1.EventTypeNormal, EventReasonDeploymentCreated,
+	r.Recorder.Event(dgdr, corev1.EventTypeNormal, nvidiacomv1beta1.EventReasonDeploymentCreated,
 		fmt.Sprintf(MessageDeploymentCreated, dgdName))
 
 	meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
-		Type:    ConditionTypeDeploymentReady,
+		Type:    nvidiacomv1beta1.ConditionTypeDeploymentReady,
 		Status:  metav1.ConditionFalse,
-		Reason:  EventReasonDeploymentCreated,
+		Reason:  nvidiacomv1beta1.EventReasonDeploymentCreated,
 		Message: fmt.Sprintf("DGD %s created, waiting for Ready", dgdName),
 	})
 
@@ -769,7 +689,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 }
 
 // createAdditionalResources creates ConfigMaps from the profiling output that should be deployed alongside the DGD
-func (r *DynamoGraphDeploymentRequestReconciler) createAdditionalResources(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest, targetNamespace string) error {
+func (r *DynamoGraphDeploymentRequestReconciler) createAdditionalResources(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, targetNamespace string) error {
 	logger := log.FromContext(ctx)
 
 	// Check if there are additional resources stored in annotations
@@ -819,9 +739,9 @@ func (r *DynamoGraphDeploymentRequestReconciler) createAdditionalResources(ctx c
 		if cm.Labels == nil {
 			cm.Labels = make(map[string]string)
 		}
-		cm.Labels[LabelDGDRName] = dgdr.Name
-		cm.Labels[LabelDGDRNamespace] = dgdr.Namespace
-		cm.Labels[LabelManagedBy] = LabelValueDynamoOperator
+		cm.Labels[nvidiacomv1beta1.LabelDGDRName] = dgdr.Name
+		cm.Labels[nvidiacomv1beta1.LabelDGDRNamespace] = dgdr.Namespace
+		cm.Labels[nvidiacomv1beta1.LabelManagedBy] = nvidiacomv1beta1.LabelValueDynamoOperator
 
 		// Create the ConfigMap
 		if err := r.Create(ctx, cm); err != nil {
@@ -842,93 +762,45 @@ func (r *DynamoGraphDeploymentRequestReconciler) createAdditionalResources(ctx c
 	return nil
 }
 
-// handleFailedState handles DGDR in Failed state
-func (r *DynamoGraphDeploymentRequestReconciler) handleFailedState(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
+// handleFailedPhase handles DGDR in Failed phase
+func (r *DynamoGraphDeploymentRequestReconciler) handleFailedPhase(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("DGDR is in failed state", "name", dgdr.Name)
+	logger.Info("DGDR is in failed phase", "name", dgdr.Name)
 
 	// Could implement retry logic here if desired
 	return ctrl.Result{}, nil
 }
 
 // getProfilingJobName returns the job name for a DGDR
-func getProfilingJobName(dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) string {
+func getProfilingJobName(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) string {
 	// Use "profile-" prefix for all profiling jobs
 	return fmt.Sprintf("profile-%s", dgdr.Name)
 }
 
 // getOutputConfigMapName returns the ConfigMap name for profiling output
-func getOutputConfigMapName(dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) string {
+func getOutputConfigMapName(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) string {
 	return fmt.Sprintf("%s%s", ConfigMapOutputPrefix, dgdr.Name)
 }
 
-// isOnlineProfiling determines whether online profiling or AI Configurator is being used
-// based on the sweep.use_ai_configurator config value
-func isOnlineProfiling(dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) bool {
-	if dgdr.Spec.ProfilingConfig.Config == nil {
-		return true
-	}
-
-	var config map[string]interface{}
-	if err := yaml.Unmarshal(dgdr.Spec.ProfilingConfig.Config.Raw, &config); err != nil {
-		return true // Default to online on parse error
-	}
-
-	if sweep, ok := config["sweep"].(map[string]interface{}); ok {
-		// Check camelCase first (preferred), then snake_case (backwards compat)
-		if useAIC, exists := sweep["useAiConfigurator"].(bool); exists {
-			return !useAIC
-		}
-		if useAIC, exists := sweep["use_ai_configurator"].(bool); exists {
-			return !useAIC
-		}
-	}
-	// Default to online profiling if not specified
+// isOnlineProfiling returns true. In v1beta1, the profiler decides online vs AIC
+// mode internally based on its config. The controller always uses the same label.
+func isOnlineProfiling(_ *nvidiacomv1beta1.DynamoGraphDeploymentRequest) bool {
 	return true
 }
 
 // validateSpec validates the DGDR spec
-func (r *DynamoGraphDeploymentRequestReconciler) validateSpec(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) error {
-	// Validate ConfigMap if provided (for the DGD base config)
-	// This requires cluster access and cannot be done in the stateless validator
-	if dgdr.Spec.ProfilingConfig.ConfigMapRef != nil {
-		cm := &corev1.ConfigMap{}
-		err := r.Get(ctx, types.NamespacedName{
-			Name:      dgdr.Spec.ProfilingConfig.ConfigMapRef.Name,
-			Namespace: dgdr.Namespace,
-		}, cm)
-
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return fmt.Errorf(MessageConfigMapNotFound,
-					dgdr.Spec.ProfilingConfig.ConfigMapRef.Name, dgdr.Namespace)
-			}
-			return err
-		}
-
-		// Validate key exists
-		key := dgdr.Spec.ProfilingConfig.ConfigMapRef.Key
-		if key == "" {
-			key = "disagg.yaml"
-		}
-
-		if _, exists := cm.Data[key]; !exists {
-			return fmt.Errorf(MessageConfigMapKeyNotFound, key, cm.Name)
-		}
-	}
-
+func (r *DynamoGraphDeploymentRequestReconciler) validateSpec(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
 	// Validate model cache PVC if provided
-	modelCachePVC, _ := extractModelCachePVCConfig(dgdr)
-	if modelCachePVC != "" {
+	if dgdr.Spec.ModelCache != nil && dgdr.Spec.ModelCache.PVCName != "" {
 		pvc := &corev1.PersistentVolumeClaim{}
 		err := r.Get(ctx, types.NamespacedName{
-			Name:      modelCachePVC,
+			Name:      dgdr.Spec.ModelCache.PVCName,
 			Namespace: dgdr.Namespace,
 		}, pvc)
 
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				return fmt.Errorf(MessageModelCachePVCNotFound, modelCachePVC, dgdr.Namespace)
+				return fmt.Errorf(MessageModelCachePVCNotFound, dgdr.Spec.ModelCache.PVCName, dgdr.Namespace)
 			}
 			return err
 		}
@@ -942,68 +814,18 @@ func (r *DynamoGraphDeploymentRequestReconciler) validateSpec(ctx context.Contex
 	return nil
 }
 
-// toFloat64 converts a numeric value (int or float64) to float64.
-// Returns 0 if the value is neither int nor float64.
-func toFloat64(val interface{}) float64 {
-	switch v := val.(type) {
-	case float64:
-		return v
-	case int:
-		return float64(v)
-	default:
-		return 0
-	}
-}
-
 // validateGPUHardwareInfo ensures GPU hardware information is available when required for profiling
-func (r *DynamoGraphDeploymentRequestReconciler) validateGPUHardwareInfo(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) error {
+func (r *DynamoGraphDeploymentRequestReconciler) validateGPUHardwareInfo(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
 	logger := log.FromContext(ctx)
 
-	// Check for hardware info and GPU ranges
-	// TODO: will be cleaner once we swap to new DGDR schema (#6130)
-	var config map[string]interface{}
-	if dgdr.Spec.ProfilingConfig.Config != nil {
-		if err := yaml.Unmarshal(dgdr.Spec.ProfilingConfig.Config.Raw, &config); err != nil {
-			// Config parse errors will be caught later, skip validation here
-			return nil
-		}
-	} else {
-		config = make(map[string]interface{})
-	}
+	// Check if user provided hardware info in the typed spec
+	hasManualConfig := dgdr.Spec.Hardware != nil && (
+		dgdr.Spec.Hardware.GPUSKU != "" ||
+			dgdr.Spec.Hardware.VRAMMB != nil ||
+			dgdr.Spec.Hardware.NumGPUsPerNode != nil)
 
-	hardwareVal, hasHardware := config[ConfigKeyHardware]
-	var hasManualHardwareConfig bool
-	if hasHardware && hardwareVal != nil {
-		if hardwareConfig, ok := hardwareVal.(map[string]interface{}); ok {
-			_, hasGPUModel := hardwareConfig[ConfigKeyGPUModel]
-			_, hasGPUVram := hardwareConfig[ConfigKeyGPUVramMib]
-			_, hasNumGPUs := hardwareConfig[ConfigKeyNumGpusPerNode]
-			hasManualHardwareConfig = hasGPUModel || hasGPUVram || hasNumGPUs
-		}
-	}
-
-	var hasExplicitGPURanges bool
-	if engineVal, hasEngine := config[ConfigKeyEngine]; hasEngine && engineVal != nil {
-		if engineConfig, ok := engineVal.(map[string]interface{}); ok {
-			minGPUs, hasMin := engineConfig[ConfigKeyMinNumGpusPerEng]
-			maxGPUs, hasMax := engineConfig[ConfigKeyMaxNumGpusPerEng]
-			if hasMin && hasMax {
-				minVal := toFloat64(minGPUs)
-				maxVal := toFloat64(maxGPUs)
-
-				// Validate that min <= max
-				if minVal > maxVal {
-					return fmt.Errorf("invalid GPU range: %s (%v) cannot be greater than %s (%v)",
-						ConfigKeyMinNumGpusPerEng, minVal, ConfigKeyMaxNumGpusPerEng, maxVal)
-				}
-
-				hasExplicitGPURanges = minVal > 0 && maxVal > 0
-			}
-		}
-	}
-
-	// If manual config or explicit ranges are provided, validation passes
-	if hasManualHardwareConfig || hasExplicitGPURanges {
+	// If manual config is provided, validation passes
+	if hasManualConfig {
 		return nil
 	}
 
@@ -1017,37 +839,22 @@ func (r *DynamoGraphDeploymentRequestReconciler) validateGPUHardwareInfo(ctx con
 
 	isNamespaceScoped := r.Config.RestrictedNamespace != ""
 	if isNamespaceScoped {
-		tmpl := template.Must(template.New("nsGPUErr").Parse(
-			`GPU hardware info required but cannot be auto-discovered.` +
+		return fmt.Errorf(
+			"GPU hardware info required but cannot be auto-discovered." +
 				"\n\nOptions to resolve:" +
 				"\n\n1. Re-enable GPU discovery (if it was disabled during Helm install):" +
 				"\n   helm upgrade ... --set dynamo-operator.gpuDiscovery.enabled=true" +
-				"\n\n2. Add hardware config to profilingConfig.config.{{.Hardware}}:" +
-				"\n   {{.NumGPUs}}: 8" +
-				"\n   {{.GPUModel}}: \"H100-SXM5-80GB\"" +
-				"\n   {{.GPUVram}}: 81920" +
-				"\n\n3. Or specify {{.Engine}}.{{.MinGPUs}} and {{.Engine}}.{{.MaxGPUs}} for explicit GPU search ranges.",
-		))
-		var buf bytes.Buffer
-		_ = tmpl.Execute(&buf, map[string]string{
-			"Hardware": ConfigKeyHardware,
-			"NumGPUs":  ConfigKeyNumGpusPerNode,
-			"GPUModel": ConfigKeyGPUModel,
-			"GPUVram":  ConfigKeyGPUVramMib,
-			"Engine":   ConfigKeyEngine,
-			"MinGPUs":  ConfigKeyMinNumGpusPerEng,
-			"MaxGPUs":  ConfigKeyMaxNumGpusPerEng,
-		})
-		return fmt.Errorf("%s", buf.String())
+				"\n\n2. Add hardware config to spec.hardware:" +
+				"\n   numGpusPerNode: 8" +
+				"\n   gpuSku: \"H100-SXM5-80GB\"" +
+				"\n   vramMb: 81920")
 	}
 
-	return fmt.Errorf("GPU hardware info required but auto-discovery failed. Add hardware config to profilingConfig.config.%s (%s, %s, %s) or specify %s.%s and %s.%s",
-		ConfigKeyHardware, ConfigKeyNumGpusPerNode, ConfigKeyGPUModel, ConfigKeyGPUVramMib,
-		ConfigKeyEngine, ConfigKeyMinNumGpusPerEng, ConfigKeyEngine, ConfigKeyMaxNumGpusPerEng)
+	return fmt.Errorf("GPU hardware info required but auto-discovery failed. Add spec.hardware.gpuSku, spec.hardware.vramMb, spec.hardware.numGpusPerNode")
 }
 
 // createProfilingJob creates a Kubernetes Job for profiling using SyncResource
-func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) error {
+func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
 	logger := log.FromContext(ctx)
 
 	// Delete any existing output ConfigMap to ensure fresh profiling results
@@ -1085,21 +892,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 		}
 	}
 
-	// Run GPU discovery before creating job (cluster-wide and namespace-restricted operators if they have node read permissions)
-	var gpuInfo *gpu.GPUInfo
-	logger.Info("Attempting GPU discovery for profiling job")
-	discoveredInfo, err := gpu.DiscoverGPUs(ctx, r.Client)
-	if err != nil {
-		// This path is expected for namespace-restricted operators without node read permissions
-		logger.Info("GPU discovery not available, using manual hardware configuration from profiling config",
-			"reason", err.Error())
-	} else {
-		gpuInfo = discoveredInfo
-		logger.Info("GPU discovery completed successfully",
-			"gpusPerNode", gpuInfo.GPUsPerNode,
-			"model", gpuInfo.Model,
-			"vramMiB", gpuInfo.VRAMPerGPU,
-			"system", gpuInfo.System)
+	// Enrich hardware from GPU discovery before marshalling the spec.
+	// This fills in gpuSku, vramMb, numGpusPerNode if the user didn't set them.
+	if err := r.enrichHardwareFromDiscovery(ctx, dgdr); err != nil {
+		logger.Info("GPU discovery not available, proceeding without enrichment", "reason", err.Error())
 	}
 
 	// Use SyncResource to create/update the job
@@ -1107,7 +903,8 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 		jobName := getProfilingJobName(dgdr)
 		outputConfigMapName := getOutputConfigMapName(dgdr)
 
-		configYAML, err := r.prepareProfilingConfig(dgdr, gpuInfo)
+		// Marshal the DGDR spec to JSON — the profiler receives the spec verbatim
+		specJSON, err := marshalDGDRSpec(dgdr)
 		if err != nil {
 			return nil, false, err
 		}
@@ -1156,16 +953,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 			},
 		}
 
-		// Add ConfigMap volume mount if provided
-		if dgdr.Spec.ProfilingConfig.ConfigMapRef != nil {
-			volumeMounts = append(volumeMounts, corev1.VolumeMount{
-				Name:      VolumeNameProfilingConfig,
-				MountPath: ProfilingConfigPath,
-				ReadOnly:  true,
-			})
-		}
-
-		// Add model cache PVC mount if configured in profilingConfig.config.deployment
+		// Add model cache PVC mount if configured
 		modelCachePVC, modelCacheMountPath := extractModelCachePVCConfig(dgdr)
 		if modelCachePVC != "" {
 			logger.Info("Mounting model cache PVC to profiler pod", "pvc", modelCachePVC, "mountPath", modelCacheMountPath)
@@ -1176,27 +964,30 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 			})
 		}
 
-		// Profiler args: pass the config as an inline YAML string via --profile-config
-		profilerArgs := []string{
-			"--profile-config", string(configYAML),
+		// v1alpha1 round-trip: mount ConfigMap if referenced via annotation
+		cmRef := configMapRefFromAnnotation(dgdr)
+		if cmRef != nil {
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      VolumeNameProfilingConfig,
+				MountPath: ProfilingConfigMountPath,
+				ReadOnly:  true,
+			})
 		}
 
-		// Use profiler image from profilingConfig
-		imageName := dgdr.Spec.ProfilingConfig.ProfilerImage
+		// Profiler args: pass the DGDR spec as JSON via --config
+		profilerArgs := []string{"--config", specJSON}
+
+		// Use image from spec
+		imageName := dgdr.Spec.Image
 		logger.Info("Using profiler image", "image", imageName)
 
 		profilerContainer := corev1.Container{
 			Name:         ContainerNameProfiler,
 			Image:        imageName,
-			Command:      []string{"python", "-m", "dynamo.profiler.profile_sla"},
+			Command:      []string{"python", "-m", "dynamo.profiler"},
 			Args:         profilerArgs,
 			Env:          profilerEnv,
 			VolumeMounts: volumeMounts,
-		}
-
-		// Apply resource requirements if specified in the DGDR
-		if dgdr.Spec.ProfilingConfig.Resources != nil {
-			profilerContainer.Resources = *dgdr.Spec.ProfilingConfig.Resources
 		}
 
 		// Generate sidecar script from template
@@ -1230,15 +1021,16 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 			}},
 		}
 
-		// Use PVC if specified, otherwise use emptyDir for profiling output
+		// Use PVC for profiling output if round-tripped v1alpha1 annotation is present,
+		// otherwise use emptyDir (v1beta1 default).
 		var profilingOutputVolume corev1.Volume
-		if dgdr.Spec.ProfilingConfig.OutputPVC != "" {
-			logger.Info("Using PVC for profiling output", "pvc", dgdr.Spec.ProfilingConfig.OutputPVC)
+		if outputPVC := outputPVCFromAnnotation(dgdr); outputPVC != "" {
+			logger.Info("Using PVC for profiling output (from v1alpha1 annotation)", "pvc", outputPVC)
 			profilingOutputVolume = corev1.Volume{
 				Name: VolumeNameProfilingOutput,
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: dgdr.Spec.ProfilingConfig.OutputPVC,
+						ClaimName: outputPVC,
 					},
 				},
 			}
@@ -1251,29 +1043,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 			}
 		}
 		volumes := []corev1.Volume{profilingOutputVolume}
-
-		// Add ConfigMap volume if provided
-		if dgdr.Spec.ProfilingConfig.ConfigMapRef != nil {
-			key := dgdr.Spec.ProfilingConfig.ConfigMapRef.Key
-			if key == "" {
-				key = ProfilingConfigFile
-			}
-
-			volumes = append(volumes, corev1.Volume{
-				Name: VolumeNameProfilingConfig,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: dgdr.Spec.ProfilingConfig.ConfigMapRef.Name,
-						},
-						Items: []corev1.KeyToPath{{
-							Key:  key,
-							Path: ProfilingConfigFile,
-						}},
-					},
-				},
-			})
-		}
 
 		// Add model cache PVC volume if configured
 		if modelCachePVC != "" {
@@ -1288,23 +1057,39 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 			})
 		}
 
+		// v1alpha1 round-trip: add ConfigMap volume if referenced via annotation
+		if cmRef != nil {
+			cmKey := cmRef.Key
+			if cmKey == "" {
+				cmKey = ProfilingConfigDefaultKey
+			}
+			volumes = append(volumes, corev1.Volume{
+				Name: VolumeNameProfilingConfig,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: cmRef.Name,
+						},
+						Items: []corev1.KeyToPath{{
+							Key:  cmKey,
+							Path: ProfilingConfigDefaultKey,
+						}},
+					},
+				},
+			})
+		}
+
 		// Limit retries to prevent infinite loop
 		backoffLimit := int32(3)
-
-		// Determine label based on whether AI Configurator is used
-		labelValue := LabelValueDynamoProfiler
-		if !isOnlineProfiling(dgdr) {
-			labelValue = LabelValueAICProfiler
-		}
 
 		podSpec := corev1.PodSpec{
 			ServiceAccountName: ServiceAccountProfilingJob,
 			RestartPolicy:      corev1.RestartPolicyNever,
 			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: ptr.To(true),        // Enforces that container cannot run as root
-				RunAsUser:    ptr.To[int64](1000), // Run as UID 1000 (non-privileged user)
-				RunAsGroup:   ptr.To[int64](1000), // Run with GID 1000 (non-privileged group)
-				FSGroup:      ptr.To[int64](1000), // Volume files owned by GID 1000
+				RunAsNonRoot: ptr.To(true),
+				RunAsUser:    ptr.To[int64](1000),
+				RunAsGroup:   ptr.To[int64](1000),
+				FSGroup:      ptr.To[int64](1000),
 			},
 			Containers: []corev1.Container{profilerContainer, sidecarContainer},
 			Volumes:    volumes,
@@ -1313,14 +1098,25 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 			},
 		}
 
-		// Apply tolerations if specified in the DGDR
-		if len(dgdr.Spec.ProfilingConfig.Tolerations) > 0 {
-			podSpec.Tolerations = dgdr.Spec.ProfilingConfig.Tolerations
-		}
-
-		// Apply nodeSelector if specified in the DGDR
-		if len(dgdr.Spec.ProfilingConfig.NodeSelector) > 0 {
-			podSpec.NodeSelector = dgdr.Spec.ProfilingConfig.NodeSelector
+		// Apply overrides from spec.overrides.profilingJob if provided
+		if dgdr.Spec.Overrides != nil && dgdr.Spec.Overrides.ProfilingJob != nil {
+			overridePodSpec := dgdr.Spec.Overrides.ProfilingJob.Template.Spec
+			if len(overridePodSpec.Containers) > 0 {
+				profilerContainer.Resources = overridePodSpec.Containers[0].Resources
+				podSpec.Containers[0] = profilerContainer
+			}
+			if len(overridePodSpec.Tolerations) > 0 {
+				podSpec.Tolerations = overridePodSpec.Tolerations
+			}
+			if len(overridePodSpec.NodeSelector) > 0 {
+				podSpec.NodeSelector = overridePodSpec.NodeSelector
+			}
+			if len(overridePodSpec.ImagePullSecrets) > 0 {
+				podSpec.ImagePullSecrets = overridePodSpec.ImagePullSecrets
+			}
+			if overridePodSpec.ServiceAccountName != "" {
+				podSpec.ServiceAccountName = overridePodSpec.ServiceAccountName
+			}
 		}
 
 		job := &batchv1.Job{
@@ -1328,9 +1124,9 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 				Name:      jobName,
 				Namespace: dgdr.Namespace,
 				Labels: map[string]string{
-					LabelApp:       labelValue,
-					LabelDGDR:      dgdr.Name,
-					LabelManagedBy: LabelValueDynamoOperator,
+					nvidiacomv1beta1.LabelApp:       nvidiacomv1beta1.LabelValueDynamoProfiler,
+					nvidiacomv1beta1.LabelDGDR:      dgdr.Name,
+					nvidiacomv1beta1.LabelManagedBy: nvidiacomv1beta1.LabelValueDynamoOperator,
 				},
 			},
 			Spec: batchv1.JobSpec{
@@ -1339,6 +1135,13 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 					Spec: podSpec,
 				},
 			},
+		}
+
+		// Apply job-level overrides
+		if dgdr.Spec.Overrides != nil && dgdr.Spec.Overrides.ProfilingJob != nil {
+			if dgdr.Spec.Overrides.ProfilingJob.BackoffLimit != nil {
+				job.Spec.BackoffLimit = dgdr.Spec.Overrides.ProfilingJob.BackoffLimit
+			}
 		}
 
 		return job, false, nil
@@ -1352,144 +1155,105 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 		logger.Info("Profiling job created/updated", "job", job.Name)
 	}
 
+	// Store the job name in status for observability
+	dgdr.Status.ProfilingJobName = job.Name
+
 	return nil
 }
 
-// prepareProfilingConfig parses and modifies the profiling config
-func (r *DynamoGraphDeploymentRequestReconciler) prepareProfilingConfig(dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest, gpuInfo *gpu.GPUInfo) ([]byte, error) {
-	// Parse the profiling config from JSON
-	var config map[string]interface{}
-	if err := yaml.Unmarshal(dgdr.Spec.ProfilingConfig.Config.Raw, &config); err != nil {
-		return nil, fmt.Errorf("failed to parse profiling config: %w", err)
-	}
-
-	// Set deployment.namespace if not already set
-	deploymentVal, hasDeployment := config[ConfigKeyDeployment]
-	var deploymentConfig map[string]interface{}
-	if !hasDeployment || deploymentVal == nil {
-		deploymentConfig = make(map[string]interface{})
-		config[ConfigKeyDeployment] = deploymentConfig
-	} else {
-		var ok bool
-		deploymentConfig, ok = deploymentVal.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("profilingConfig.config.%s must be an object, got %T", ConfigKeyDeployment, deploymentVal)
-		}
-	}
-	if _, hasNamespace := deploymentConfig[ConfigKeyNamespace]; !hasNamespace {
-		deploymentConfig[ConfigKeyNamespace] = dgdr.Namespace
-	}
-
-	// Set deployment.model from spec.model
-	deploymentConfig[ConfigKeyModel] = dgdr.Spec.Model
-
-	// Set deployment.dgd_image from deploymentOverrides.workersImage if provided
-	if dgdr.Spec.DeploymentOverrides != nil && dgdr.Spec.DeploymentOverrides.WorkersImage != "" {
-		deploymentConfig[ConfigKeyDGDImage] = dgdr.Spec.DeploymentOverrides.WorkersImage
-	}
-
-	// Set output_dir if not already set
-	if _, hasOutputDir := config[ConfigKeyOutputDir]; !hasOutputDir {
-		config[ConfigKeyOutputDir] = ProfilingOutputPath
-	}
-
-	// Set engine.backend from spec.backend
-	engineVal, hasEngine := config[ConfigKeyEngine]
-	var engineConfig map[string]interface{}
-	if !hasEngine || engineVal == nil {
-		engineConfig = make(map[string]interface{})
-		config[ConfigKeyEngine] = engineConfig
-	} else {
-		var ok bool
-		engineConfig, ok = engineVal.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("profilingConfig.config.%s must be an object, got %T", ConfigKeyEngine, engineVal)
-		}
-	}
-	engineConfig[ConfigKeyBackend] = dgdr.Spec.Backend
-
-	// If ConfigMapRef is provided, set engine.config path
-	if dgdr.Spec.ProfilingConfig.ConfigMapRef != nil {
-		engineConfig[ConfigKeyConfig] = fmt.Sprintf("%s/%s", ProfilingConfigPath, ProfilingConfigFile)
-	}
-
-	// User-specified values take precedence over auto-discovered values
-	if gpuInfo != nil {
-		hardwareVal, hasHardware := config["hardware"]
-		var hardwareConfig map[string]interface{}
-		if !hasHardware || hardwareVal == nil {
-			hardwareConfig = make(map[string]interface{})
-			config["hardware"] = hardwareConfig
-		} else {
-			var ok bool
-			hardwareConfig, ok = hardwareVal.(map[string]interface{})
-			if !ok {
-				return nil, fmt.Errorf("profilingConfig.config.hardware must be an object, got %T", hardwareVal)
-			}
-		}
-
-		if _, hasNumGpus := hardwareConfig[ConfigKeyNumGpusPerNode]; !hasNumGpus {
-			hardwareConfig[ConfigKeyNumGpusPerNode] = gpuInfo.GPUsPerNode
-		}
-		if _, hasGpuModel := hardwareConfig[ConfigKeyGPUModel]; !hasGpuModel {
-			hardwareConfig[ConfigKeyGPUModel] = gpuInfo.Model
-		}
-		if _, hasGpuVram := hardwareConfig[ConfigKeyGPUVramMib]; !hasGpuVram {
-			hardwareConfig[ConfigKeyGPUVramMib] = gpuInfo.VRAMPerGPU
-		}
-		if gpuInfo.System != "" {
-			if _, hasSystem := hardwareConfig[ConfigKeySystem]; !hasSystem {
-				hardwareConfig[ConfigKeySystem] = gpuInfo.System
-			}
-		}
-	}
-
-	// Serialize config to YAML for passing to profiler
-	configYAML, err := sigsyaml.Marshal(config)
+// marshalDGDRSpec produces the JSON string passed to the profiler via --config.
+// The profiler receives the DGDR spec verbatim — no bespoke key mapping needed.
+func marshalDGDRSpec(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (string, error) {
+	specJSON, err := json.Marshal(dgdr.Spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal profiling config to YAML: %w", err)
+		return "", fmt.Errorf("failed to marshal DGDR spec to JSON: %w", err)
 	}
-
-	return configYAML, nil
+	return string(specJSON), nil
 }
 
-// extractModelCachePVCConfig extracts model cache PVC settings from the profiling config.
-// Returns (pvcName, mountPath) - both empty if not configured.
-func extractModelCachePVCConfig(dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (string, string) {
-	if dgdr.Spec.ProfilingConfig.Config == nil {
-		return "", ""
+// enrichHardwareFromDiscovery fills in hardware fields that the user didn't set.
+// Called before marshalDGDRSpec(). Mutates dgdr.Spec.Hardware in-place (memory only, not persisted).
+func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
+	if dgdr.Spec.Hardware == nil {
+		dgdr.Spec.Hardware = &nvidiacomv1beta1.HardwareSpec{}
+	}
+	hw := dgdr.Spec.Hardware
+	if hw.GPUSKU != "" && hw.VRAMMB != nil && hw.NumGPUsPerNode != nil {
+		return nil // all fields already set by user
 	}
 
-	var config map[string]interface{}
-	if err := yaml.Unmarshal(dgdr.Spec.ProfilingConfig.Config.Raw, &config); err != nil {
-		return "", ""
+	gpuInfo, err := gpu.DiscoverGPUs(ctx, r.Client)
+	if err != nil {
+		return err
 	}
 
-	deployment, ok := config[ConfigKeyDeployment].(map[string]interface{})
-	if !ok {
+	logger := log.FromContext(ctx)
+	logger.Info("GPU discovery completed successfully",
+		"gpusPerNode", gpuInfo.GPUsPerNode,
+		"model", gpuInfo.Model,
+		"vramMiB", gpuInfo.VRAMPerGPU)
+
+	if hw.GPUSKU == "" {
+		hw.GPUSKU = gpuInfo.Model
+	}
+	if hw.VRAMMB == nil {
+		vram := float64(gpuInfo.VRAMPerGPU)
+		hw.VRAMMB = &vram
+	}
+	if hw.NumGPUsPerNode == nil {
+		n := int32(gpuInfo.GPUsPerNode)
+		hw.NumGPUsPerNode = &n
+	}
+	return nil
+}
+
+// extractModelCachePVCConfig reads model cache PVC settings from the typed v1beta1 spec.
+// Returns (pvcName, mountPath) — both empty if not configured.
+func extractModelCachePVCConfig(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (string, string) {
+	if dgdr.Spec.ModelCache == nil || dgdr.Spec.ModelCache.PVCName == "" {
 		return "", ""
 	}
-
-	modelCache, ok := deployment[ConfigKeyModelCache].(map[string]interface{})
-	if !ok {
-		return "", ""
-	}
-
-	pvcName, _ := modelCache[ConfigKeyPVCName].(string)
-	if pvcName == "" {
-		return "", ""
-	}
-
-	mountPath, _ := modelCache[ConfigKeyMountPath].(string)
+	mountPath := dgdr.Spec.ModelCache.PVCMountPath
 	if mountPath == "" {
 		mountPath = DefaultModelCacheMountPath
 	}
+	return dgdr.Spec.ModelCache.PVCName, mountPath
+}
 
-	return pvcName, mountPath
+// configMapKeySelector mirrors v1alpha1.ConfigMapKeySelector for annotation deserialization.
+type configMapKeySelector struct {
+	Name string `json:"name"`
+	Key  string `json:"key,omitempty"`
+}
+
+// configMapRefFromAnnotation reads the ConfigMap reference from the round-trip annotation.
+// Returns nil for native v1beta1 resources (no annotation present).
+func configMapRefFromAnnotation(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) *configMapKeySelector {
+	if dgdr.Annotations == nil {
+		return nil
+	}
+	raw, ok := dgdr.Annotations[AnnotationConfigMapRef]
+	if !ok || raw == "" {
+		return nil
+	}
+	var ref configMapKeySelector
+	if err := json.Unmarshal([]byte(raw), &ref); err != nil {
+		return nil
+	}
+	return &ref
+}
+
+// outputPVCFromAnnotation reads the output PVC name from the round-trip annotation.
+// Returns "" for native v1beta1 resources (always emptyDir).
+func outputPVCFromAnnotation(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) string {
+	if dgdr.Annotations == nil {
+		return ""
+	}
+	return dgdr.Annotations[AnnotationOutputPVC]
 }
 
 // checkProfilingJobStatus checks if the profiling job has completed
-func (r *DynamoGraphDeploymentRequestReconciler) checkProfilingJobStatus(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (bool, error) {
+func (r *DynamoGraphDeploymentRequestReconciler) checkProfilingJobStatus(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (bool, error) {
 	logger := log.FromContext(ctx)
 	jobName := getProfilingJobName(dgdr)
 
@@ -1518,7 +1282,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) checkProfilingJobStatus(ctx con
 }
 
 // getProfilingJobErrorDetails retrieves detailed error information from failed profiling job pods
-func (r *DynamoGraphDeploymentRequestReconciler) getProfilingJobErrorDetails(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest, job *batchv1.Job) string {
+func (r *DynamoGraphDeploymentRequestReconciler) getProfilingJobErrorDetails(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, job *batchv1.Job) string {
 	logger := log.FromContext(ctx)
 
 	// List pods owned by this job
@@ -1568,7 +1332,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) getProfilingJobErrorDetails(ctx
 }
 
 // generateDGDSpec generates DGD spec from profiling results (online or offline/AIC)
-func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) error {
+func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Generating DGD spec from profiling results", "name", dgdr.Name, "backend", dgdr.Spec.Backend)
 
@@ -1587,10 +1351,11 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 		return fmt.Errorf("failed to get output ConfigMap: %w", err)
 	}
 
-	// Select the right config file based on useMocker flag
+	// Select the right config file based on mocker feature flag
 	// Profiler always generates both real and mocker configs
+	// Phase 1 fix: v1alpha1 Spec.UseMocker moved to Spec.Features.Mocker.Enabled in v1beta1
 	var outputFile string
-	if dgdr.Spec.UseMocker {
+	if dgdr.Spec.Features != nil && dgdr.Spec.Features.Mocker != nil && dgdr.Spec.Features.Mocker.Enabled {
 		outputFile = ProfilingOutputFileMocker
 		logger.Info("Using mocker deployment config")
 	} else {
@@ -1625,18 +1390,30 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 		}
 	}
 
-	// Store the generated DGD in status
-	dgdr.Status.GeneratedDeployment = &runtime.RawExtension{
-		Object: dgd,
+	// Store the generated DGD name in status and cache the spec in an annotation for createDGD
+	dgdr.Status.DGDName = dgd.Name
+
+	// Serialize the DGD spec to an annotation so createDGD can retrieve it
+	dgdBytes, err := sigsyaml.Marshal(dgd)
+	if err != nil {
+		return fmt.Errorf("failed to marshal generated DGD: %w", err)
 	}
-	dgdr.Status.ProfilingResults = fmt.Sprintf("configmap/%s", outputConfigMapName)
+	if dgdr.Annotations == nil {
+		dgdr.Annotations = make(map[string]string)
+	}
+	dgdr.Annotations["nvidia.com/generated-dgd-spec"] = string(dgdBytes)
+
+	// Update the object (annotations are on the object, not status)
+	if err := r.Update(ctx, dgdr); err != nil {
+		return fmt.Errorf("failed to update DGDR with generated DGD annotation: %w", err)
+	}
 
 	return r.Status().Update(ctx, dgdr)
 }
 
 // storeAdditionalResources marshals additional resources to YAML and stores them in DGDR annotations.
 // Validates annotation size and fails gracefully if too large.
-func (r *DynamoGraphDeploymentRequestReconciler) storeAdditionalResources(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest, resources []*unstructured.Unstructured) error {
+func (r *DynamoGraphDeploymentRequestReconciler) storeAdditionalResources(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, resources []*unstructured.Unstructured) error {
 	if len(resources) == 0 {
 		return nil
 	}
@@ -1716,26 +1493,59 @@ func (r *DynamoGraphDeploymentRequestReconciler) extractDGDFromYAML(yamlContent 
 	return dgd, err
 }
 
-// updateStateAndRequeue updates the DGDR state and requeues
-func (r *DynamoGraphDeploymentRequestReconciler) updateStateAndRequeue(ctx context.Context, dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest, state nvidiacomv1alpha1.DGDRState, _ string) (ctrl.Result, error) {
-	dgdr.Status.State = state
+// setSucceededCondition sets the aggregate Succeeded condition based on the current phase.
+func setSucceededCondition(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, phase nvidiacomv1beta1.DGDRPhase) {
+	var status metav1.ConditionStatus
+	var reason, message string
+
+	switch phase {
+	case nvidiacomv1beta1.DGDRPhasePending, "":
+		status, reason, message = metav1.ConditionFalse, "Pending", "DGDR is pending"
+	case nvidiacomv1beta1.DGDRPhaseProfiling:
+		status, reason, message = metav1.ConditionFalse, "Profiling", "Profiling is in progress"
+	case nvidiacomv1beta1.DGDRPhaseReady:
+		status, reason, message = metav1.ConditionTrue, "SpecGenerated", "Profiling complete, spec available"
+	case nvidiacomv1beta1.DGDRPhaseDeploying:
+		status, reason, message = metav1.ConditionFalse, "Deploying", "Deployment is in progress"
+	case nvidiacomv1beta1.DGDRPhaseDeployed:
+		status, reason, message = metav1.ConditionTrue, "Deployed", "Deployment is healthy"
+	case nvidiacomv1beta1.DGDRPhaseFailed:
+		status, reason, message = metav1.ConditionFalse, "Failed", "DGDR has failed"
+	default:
+		status, reason, message = metav1.ConditionFalse, "Unknown", "Unknown phase"
+	}
+
+	meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
+		Type:               nvidiacomv1beta1.ConditionTypeSucceeded,
+		Status:             status,
+		ObservedGeneration: dgdr.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+// updatePhaseAndRequeue updates the DGDR phase and requeues
+func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseAndRequeue(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, phase nvidiacomv1beta1.DGDRPhase, _ string) (ctrl.Result, error) {
+	dgdr.Status.Phase = phase
+	setSucceededCondition(dgdr, phase)
 	if err := r.Status().Update(ctx, dgdr); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{Requeue: true}, nil
 }
 
-// updateStateWithCondition updates state and adds/updates a condition
-func (r *DynamoGraphDeploymentRequestReconciler) updateStateWithCondition(
+// updatePhaseWithCondition updates phase and adds/updates a condition
+func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseWithCondition(
 	ctx context.Context,
-	dgdr *nvidiacomv1alpha1.DynamoGraphDeploymentRequest,
-	state nvidiacomv1alpha1.DGDRState,
+	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
+	phase nvidiacomv1beta1.DGDRPhase,
 	conditionType string,
 	status metav1.ConditionStatus,
 	reason string,
 	message string,
 ) (ctrl.Result, error) {
-	dgdr.Status.State = state
+	dgdr.Status.Phase = phase
+	setSucceededCondition(dgdr, phase)
 
 	condition := metav1.Condition{
 		Type:               conditionType,
@@ -1758,7 +1568,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) updateStateWithCondition(
 // SetupWithManager sets up the controller with the Manager
 func (r *DynamoGraphDeploymentRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&nvidiacomv1alpha1.DynamoGraphDeploymentRequest{}).
+		For(&nvidiacomv1beta1.DynamoGraphDeploymentRequest{}).
 		Named(consts.ResourceTypeDynamoGraphDeploymentRequest).
 		Owns(&batchv1.Job{}, builder.WithPredicates(predicate.Funcs{
 			// ignore creation cause we don't want to be called again after we create the job
@@ -1772,8 +1582,8 @@ func (r *DynamoGraphDeploymentRequestReconciler) SetupWithManager(mgr ctrl.Manag
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
 				// Find DGDR by label instead of owner reference
 				dgd := obj.(*nvidiacomv1alpha1.DynamoGraphDeployment)
-				dgdrName, hasName := dgd.Labels[LabelDGDRName]
-				dgdrNamespace, hasNamespace := dgd.Labels[LabelDGDRNamespace]
+				dgdrName, hasName := dgd.Labels[nvidiacomv1beta1.LabelDGDRName]
+				dgdrNamespace, hasNamespace := dgd.Labels[nvidiacomv1beta1.LabelDGDRNamespace]
 				if !hasName || !hasNamespace {
 					return nil
 				}

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
@@ -21,28 +21,14 @@ import (
 	"errors"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"k8s.io/apimachinery/pkg/util/yaml"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
-
-// toFloat64 converts a numeric value (int or float64) to float64.
-// Returns 0 if the value is neither int nor float64.
-func toFloat64(val any) float64 {
-	switch v := val.(type) {
-	case float64:
-		return v
-	case int:
-		return float64(v)
-	default:
-		return 0
-	}
-}
 
 // DynamoGraphDeploymentRequestValidator validates DynamoGraphDeploymentRequest resources.
 // This validator can be used by both webhooks and controllers for consistent validation.
 type DynamoGraphDeploymentRequestValidator struct {
-	request               *nvidiacomv1alpha1.DynamoGraphDeploymentRequest
+	request               *nvidiacomv1beta1.DynamoGraphDeploymentRequest
 	isClusterWideOperator bool
 	gpuDiscoveryEnabled   bool
 }
@@ -50,7 +36,7 @@ type DynamoGraphDeploymentRequestValidator struct {
 // NewDynamoGraphDeploymentRequestValidator creates a new validator for DynamoGraphDeploymentRequest.
 // isClusterWide indicates whether the operator has cluster-wide permissions.
 // gpuDiscoveryEnabled indicates whether Helm provisioned node read access for the operator.
-func NewDynamoGraphDeploymentRequestValidator(request *nvidiacomv1alpha1.DynamoGraphDeploymentRequest, isClusterWide bool, gpuDiscoveryEnabled bool) *DynamoGraphDeploymentRequestValidator {
+func NewDynamoGraphDeploymentRequestValidator(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest, isClusterWide bool, gpuDiscoveryEnabled bool) *DynamoGraphDeploymentRequestValidator {
 	return &DynamoGraphDeploymentRequestValidator{
 		request:               request,
 		isClusterWideOperator: isClusterWide,
@@ -61,105 +47,43 @@ func NewDynamoGraphDeploymentRequestValidator(request *nvidiacomv1alpha1.DynamoG
 // Validate performs stateless validation on the DynamoGraphDeploymentRequest.
 // Returns warnings and error.
 func (v *DynamoGraphDeploymentRequestValidator) Validate() (admission.Warnings, error) {
-	var warnings admission.Warnings
 	var err error
 
-	// Warn about deprecated enableGpuDiscovery field
-	if v.request.Spec.EnableGPUDiscovery != nil {
-		warnings = append(warnings, "spec.enableGpuDiscovery is deprecated and will be removed in v1beta1. GPU discovery is now always attempted automatically. This field has no effect.")
+	// Validate image is specified (required for the profiling job container).
+	if v.request.Spec.Image == "" {
+		err = errors.Join(err, errors.New("spec.image is required"))
 	}
 
-	// Validate profiler image is specified
-	if v.request.Spec.ProfilingConfig.ProfilerImage == "" {
-		err = errors.Join(err, errors.New("spec.profilingConfig.profilerImage is required"))
+	// Disallow searchStrategy: thorough with backend: auto.
+	// "thorough" sweeps more configurations and requires a concrete backend to be selected;
+	// "auto" defers backend selection and is only compatible with the "rapid" search strategy.
+	if v.request.Spec.SearchStrategy == nvidiacomv1beta1.SearchStrategyThorough &&
+		v.request.Spec.Backend == nvidiacomv1beta1.BackendTypeAuto {
+		err = errors.Join(err, fmt.Errorf(
+			"spec.searchStrategy %q is incompatible with spec.backend %q: set spec.backend to a specific backend (sglang, trtllm, or vllm)",
+			nvidiacomv1beta1.SearchStrategyThorough,
+			nvidiacomv1beta1.BackendTypeAuto,
+		))
 	}
 
-	// Validate that profilingConfig.config is provided
-	if v.request.Spec.ProfilingConfig.Config == nil || len(v.request.Spec.ProfilingConfig.Config.Raw) == 0 {
-		err = errors.Join(err, errors.New("spec.profilingConfig.config is required and must not be empty"))
-	}
-
-	// Note: GPU discovery is now automatic for cluster-wide operators
-	// Namespace-restricted operators automatically skip GPU discovery and require manual hardware config
-
-	// Parse config to validate structure (only if config is present)
-	if v.request.Spec.ProfilingConfig.Config != nil && len(v.request.Spec.ProfilingConfig.Config.Raw) > 0 {
-		var config map[string]any
-		if parseErr := yaml.Unmarshal(v.request.Spec.ProfilingConfig.Config.Raw, &config); parseErr != nil {
-			err = errors.Join(err, fmt.Errorf("failed to parse spec.profilingConfig.config: %w", parseErr))
-		} else {
-			// Warn if deployment.model or engine.backend are specified in config (they will be overwritten by spec fields)
-			if engineConfig, ok := config["engine"].(map[string]any); ok {
-				if backend, ok := engineConfig["backend"].(string); ok && backend != "" && backend != v.request.Spec.Backend {
-					warnings = append(warnings, fmt.Sprintf("spec.profilingConfig.config.engine.backend (%s) will be overwritten by spec.backend (%s)", backend, v.request.Spec.Backend))
-				}
-			}
-			if deployment, ok := config["deployment"].(map[string]any); ok {
-				if model, ok := deployment["model"].(string); ok && model != "" && model != v.request.Spec.Model {
-					warnings = append(warnings, fmt.Sprintf("spec.profilingConfig.config.deployment.model (%s) will be overwritten by spec.model (%s)", model, v.request.Spec.Model))
-				}
-			}
-		}
-	}
-
-	// Validate GPU hardware information is available (last, so other errors are collected first)
+	// Validate GPU hardware information is available (last, so other errors are collected first).
 	if gpuErr := v.validateGPUHardwareInfo(); gpuErr != nil {
 		err = errors.Join(err, gpuErr)
 	}
 
-	return warnings, err
+	return nil, err
 }
 
 // validateGPUHardwareInfo ensures GPU hardware information will be available for profiling.
 // Returns an error at admission time if GPU discovery is disabled and no manual hardware config is provided.
 func (v *DynamoGraphDeploymentRequestValidator) validateGPUHardwareInfo() error {
-	// Parse profiling config
-	var config map[string]any
-	if v.request.Spec.ProfilingConfig.Config != nil {
-		if err := yaml.Unmarshal(v.request.Spec.ProfilingConfig.Config.Raw, &config); err != nil {
-			// Config parse errors will be caught by other validators
-			return nil
-		}
-	} else {
-		config = make(map[string]any)
-	}
-
-	// Check if manual hardware config is provided
-	hardwareVal, hasHardware := config["hardware"]
+	// Check if manual hardware config is provided via typed spec.hardware fields.
 	var hasManualHardwareConfig bool
-	if hasHardware && hardwareVal != nil {
-		if hardwareConfig, ok := hardwareVal.(map[string]any); ok {
-			// Check if essential hardware fields are provided
-			_, hasGPUModel := hardwareConfig["gpuModel"]
-			_, hasGPUVram := hardwareConfig["gpuVramMib"]
-			_, hasNumGPUs := hardwareConfig["numGpusPerNode"]
-			hasManualHardwareConfig = hasGPUModel || hasGPUVram || hasNumGPUs
-		}
+	if hw := v.request.Spec.Hardware; hw != nil {
+		hasManualHardwareConfig = hw.GPUSKU != "" || hw.VRAMMB != nil || hw.NumGPUsPerNode != nil
 	}
 
-	// Check if explicit GPU ranges are provided
-	var hasExplicitGPURanges bool
-	if engineVal, hasEngine := config["engine"]; hasEngine && engineVal != nil {
-		if engineConfig, ok := engineVal.(map[string]any); ok {
-			minGPUs, hasMin := engineConfig["minNumGpusPerEngine"]
-			maxGPUs, hasMax := engineConfig["maxNumGpusPerEngine"]
-			// Validate explicit GPU ranges
-			if hasMin && hasMax {
-				minVal := toFloat64(minGPUs)
-				maxVal := toFloat64(maxGPUs)
-
-				// Validate that min <= max
-				if minVal > maxVal {
-					return fmt.Errorf("invalid GPU range: minNumGpusPerEngine (%v) cannot be greater than maxNumGpusPerEngine (%v)",
-						minVal, maxVal)
-				}
-
-				hasExplicitGPURanges = minVal > 0 && maxVal > 0
-			}
-		}
-	}
-
-	if hasManualHardwareConfig || hasExplicitGPURanges {
+	if hasManualHardwareConfig {
 		return nil
 	}
 
@@ -169,12 +93,12 @@ func (v *DynamoGraphDeploymentRequestValidator) validateGPUHardwareInfo() error 
 		return nil
 	}
 
-	return errors.New("GPU hardware configuration required: GPU discovery is disabled (set dynamo-operator.gpuDiscovery.enabled=true in Helm values, or provide hardware config in spec.profilingConfig.config)")
+	return errors.New("GPU hardware configuration required: GPU discovery is disabled (set dynamo-operator.gpuDiscovery.enabled=true in Helm values, or provide hardware config in spec.hardware)")
 }
 
 // ValidateUpdate performs stateful validation comparing old and new DynamoGraphDeploymentRequest.
 // Returns warnings and error.
-func (v *DynamoGraphDeploymentRequestValidator) ValidateUpdate(old *nvidiacomv1alpha1.DynamoGraphDeploymentRequest) (admission.Warnings, error) {
+func (v *DynamoGraphDeploymentRequestValidator) ValidateUpdate(old *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (admission.Warnings, error) {
 	// TODO: Add update validation logic for DynamoGraphDeploymentRequest
 	// Placeholder for future immutability checks
 	return nil, nil

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_handler.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
@@ -34,7 +34,7 @@ import (
 const (
 	// DynamoGraphDeploymentRequestWebhookName is the name of the validating webhook handler for DynamoGraphDeploymentRequest.
 	DynamoGraphDeploymentRequestWebhookName = "dynamographdeploymentrequest-validating-webhook"
-	dynamoGraphDeploymentRequestWebhookPath = "/validate-nvidia-com-v1alpha1-dynamographdeploymentrequest"
+	dynamoGraphDeploymentRequestWebhookPath = "/validate-nvidia-com-v1beta1-dynamographdeploymentrequest"
 )
 
 // DynamoGraphDeploymentRequestHandler is a handler for validating DynamoGraphDeploymentRequest resources.
@@ -137,15 +137,15 @@ func (h *DynamoGraphDeploymentRequestHandler) RegisterWithManager(mgr manager.Ma
 	observedValidator := observability.NewObservedValidator(leaseAwareValidator, consts.ResourceTypeDynamoGraphDeploymentRequest)
 
 	webhook := admission.
-		WithCustomValidator(mgr.GetScheme(), &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{}, observedValidator).
+		WithCustomValidator(mgr.GetScheme(), &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}, observedValidator).
 		WithRecoverPanic(true)
 	mgr.GetWebhookServer().Register(dynamoGraphDeploymentRequestWebhookPath, webhook)
 	return nil
 }
 
 // castToDynamoGraphDeploymentRequest attempts to cast a runtime.Object to a DynamoGraphDeploymentRequest.
-func castToDynamoGraphDeploymentRequest(obj runtime.Object) (*nvidiacomv1alpha1.DynamoGraphDeploymentRequest, error) {
-	request, ok := obj.(*nvidiacomv1alpha1.DynamoGraphDeploymentRequest)
+func castToDynamoGraphDeploymentRequest(obj runtime.Object) (*nvidiacomv1beta1.DynamoGraphDeploymentRequest, error) {
+	request, ok := obj.(*nvidiacomv1beta1.DynamoGraphDeploymentRequest)
 	if !ok {
 		return nil, fmt.Errorf("expected DynamoGraphDeploymentRequest but got %T", obj)
 	}

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_test.go
@@ -21,125 +21,125 @@ import (
 	"strings"
 	"testing"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
-	validConfig := `{"engine": {"backend": "vllm"}, "deployment": {"model": "test-model"}}`
-	validConfigWithHardware := `{"engine": {"backend": "vllm"}, "deployment": {"model": "test-model"}, "hardware": {"numGpusPerNode": 8, "gpuModel": "H100-SXM5-80GB", "gpuVramMib": 81920}}`
-	minimalConfig := `{"sla": {"ttft": 200.0}}`
-	configWithDifferentBackend := `{"engine": {"backend": "sglang"}}`
-	configWithDifferentModel := `{"deployment": {"model": "different-model"}}`
-	invalidYAML := `{invalid yaml`
+	vram := float64(81920)
+	gpuCount := int32(8)
 
 	// errMsg: if non-empty, an error is expected and each newline-separated substring must appear in it.
-	// expectedWarning: if non-empty, at least one warning must contain this substring.
 	tests := []struct {
 		name                string
-		request             *nvidiacomv1alpha1.DynamoGraphDeploymentRequest
+		request             *nvidiacomv1beta1.DynamoGraphDeploymentRequest
 		isClusterWide       bool
 		gpuDiscoveryEnabled bool
 		errMsg              string
-		expectedWarning     string
 	}{
 		{
 			name: "valid request",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(validConfig),
-						},
-					},
+					Backend: nvidiacomv1beta1.BackendTypeVllm,
+					Image:   "profiler:latest",
 				},
 			},
 			isClusterWide: true,
 		},
 		{
-			name: "missing profiler image",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
+			name: "missing image",
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(validConfig),
-						},
-					},
+					Backend: nvidiacomv1beta1.BackendTypeVllm,
+					Image:   "",
 				},
 			},
 			isClusterWide: true,
-			errMsg:        "spec.profilingConfig.profilerImage is required",
+			errMsg:        "spec.image is required",
 		},
 		{
-			name: "missing profiling config",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
-					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config:        nil,
-					},
+			name: "thorough + auto is invalid",
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:          "llama-3-8b",
+					Image:          "profiler:latest",
+					Backend:        nvidiacomv1beta1.BackendTypeAuto,
+					SearchStrategy: nvidiacomv1beta1.SearchStrategyThorough,
 				},
 			},
 			isClusterWide: true,
-			errMsg:        "spec.profilingConfig.config is required and must not be empty",
+			errMsg:        `spec.searchStrategy "thorough" is incompatible with spec.backend "auto"`,
 		},
 		{
-			name: "empty profiling config",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
-					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte{},
-						},
-					},
+			name: "rapid + auto is valid (default combination)",
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:          "llama-3-8b",
+					Image:          "profiler:latest",
+					Backend:        nvidiacomv1beta1.BackendTypeAuto,
+					SearchStrategy: nvidiacomv1beta1.SearchStrategyRapid,
 				},
 			},
 			isClusterWide: true,
-			errMsg:        "spec.profilingConfig.config is required and must not be empty",
+		},
+		{
+			name: "thorough + vllm is valid",
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:          "llama-3-8b",
+					Image:          "profiler:latest",
+					Backend:        nvidiacomv1beta1.BackendTypeVllm,
+					SearchStrategy: nvidiacomv1beta1.SearchStrategyThorough,
+				},
+			},
+			isClusterWide: true,
+		},
+		{
+			name: "thorough + trtllm is valid",
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:          "llama-3-8b",
+					Image:          "profiler:latest",
+					Backend:        nvidiacomv1beta1.BackendTypeTrtllm,
+					SearchStrategy: nvidiacomv1beta1.SearchStrategyThorough,
+				},
+			},
+			isClusterWide: true,
+		},
+		{
+			name: "thorough + sglang is valid",
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:          "llama-3-8b",
+					Image:          "profiler:latest",
+					Backend:        nvidiacomv1beta1.BackendTypeSglang,
+					SearchStrategy: nvidiacomv1beta1.SearchStrategyThorough,
+				},
+			},
+			isClusterWide: true,
 		},
 		{
 			name: "namespace-scoped operator with manual hardware config (should pass)",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(validConfigWithHardware),
-						},
+					Backend: nvidiacomv1beta1.BackendTypeVllm,
+					Image:   "profiler:latest",
+					Hardware: &nvidiacomv1beta1.HardwareSpec{
+						GPUSKU:         "H100-SXM5-80GB",
+						VRAMMB:         &vram,
+						NumGPUsPerNode: &gpuCount,
 					},
 				},
 			},
@@ -148,20 +148,12 @@ func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
 		},
 		{
 			name: "namespace-scoped operator with GPU discovery enabled (should pass without manual config)",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(minimalConfig),
-						},
-					},
+					Backend: nvidiacomv1beta1.BackendTypeVllm,
+					Image:   "profiler:latest",
 				},
 			},
 			isClusterWide:       false,
@@ -169,20 +161,12 @@ func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
 		},
 		{
 			name: "namespace-scoped operator with GPU discovery disabled and no hardware config (should error)",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(minimalConfig),
-						},
-					},
+					Backend: nvidiacomv1beta1.BackendTypeVllm,
+					Image:   "profiler:latest",
 				},
 			},
 			isClusterWide:       false,
@@ -190,93 +174,25 @@ func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
 			errMsg:              "GPU hardware configuration required: GPU discovery is disabled",
 		},
 		{
-			name: "invalid config YAML",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
-					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(invalidYAML),
-						},
-					},
+			name: "multiple errors (missing image and thorough+auto)",
+			request: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr", Namespace: "default"},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:          "llama-3-8b",
+					Backend:        nvidiacomv1beta1.BackendTypeAuto,
+					SearchStrategy: nvidiacomv1beta1.SearchStrategyThorough,
+					Image:          "",
 				},
 			},
 			isClusterWide: true,
-			errMsg:        "failed to parse spec.profilingConfig.config",
-		},
-		{
-			name: "warning for different backend in config",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
-					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(configWithDifferentBackend),
-						},
-					},
-				},
-			},
-			isClusterWide:   true,
-			expectedWarning: "spec.profilingConfig.config.engine.backend (sglang) will be overwritten by spec.backend (vllm)",
-		},
-		{
-			name: "warning for different model in config",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
-					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(configWithDifferentModel),
-						},
-					},
-				},
-			},
-			isClusterWide:   true,
-			expectedWarning: "spec.profilingConfig.config.deployment.model (different-model) will be overwritten by spec.model (llama-3-8b)",
-		},
-		{
-			name: "multiple errors (missing profiler image and missing config)",
-			request: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-dgdr",
-					Namespace: "default",
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
-					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "",
-						Config:        nil,
-					},
-				},
-			},
-			isClusterWide: false,
-			errMsg:        "spec.profilingConfig.profilerImage is required\nspec.profilingConfig.config is required and must not be empty",
+			errMsg:        "spec.image is required\nspec.searchStrategy",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			validator := NewDynamoGraphDeploymentRequestValidator(tt.request, tt.isClusterWide, tt.gpuDiscoveryEnabled)
-			warnings, err := validator.Validate()
+			_, err := validator.Validate()
 
 			wantErr := tt.errMsg != ""
 			if (err != nil) != wantErr {
@@ -290,80 +206,50 @@ func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
 					}
 				}
 			}
-
-			wantWarning := tt.expectedWarning != ""
-			if wantWarning && len(warnings) == 0 {
-				t.Errorf("Validate() expected warning %q but got none", tt.expectedWarning)
-			}
-			if wantWarning && len(warnings) > 0 && !strings.Contains(warnings[0], tt.expectedWarning) {
-				t.Errorf("Validate() warning %q does not contain %q", warnings[0], tt.expectedWarning)
-			}
 		})
 	}
 }
 
 func TestDynamoGraphDeploymentRequestValidator_ValidateUpdate(t *testing.T) {
-	validConfig := `{"engine": {"backend": "vllm"}}`
-
 	tests := []struct {
 		name         string
-		oldRequest   *nvidiacomv1alpha1.DynamoGraphDeploymentRequest
-		newRequest   *nvidiacomv1alpha1.DynamoGraphDeploymentRequest
+		oldRequest   *nvidiacomv1beta1.DynamoGraphDeploymentRequest
+		newRequest   *nvidiacomv1beta1.DynamoGraphDeploymentRequest
 		wantErr      bool
 		wantWarnings bool
 	}{
 		{
 			name: "no changes",
-			oldRequest: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
+			oldRequest: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(validConfig),
-						},
-					},
+					Backend: nvidiacomv1beta1.BackendTypeVllm,
+					Image:   "profiler:latest",
 				},
 			},
-			newRequest: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
+			newRequest: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(validConfig),
-						},
-					},
+					Backend: nvidiacomv1beta1.BackendTypeVllm,
+					Image:   "profiler:latest",
 				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "changing model name is allowed",
-			oldRequest: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
+			oldRequest: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "llama-3-8b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(validConfig),
-						},
-					},
+					Backend: nvidiacomv1beta1.BackendTypeVllm,
+					Image:   "profiler:latest",
 				},
 			},
-			newRequest: &nvidiacomv1alpha1.DynamoGraphDeploymentRequest{
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentRequestSpec{
+			newRequest: &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "llama-3-70b",
-					Backend: "vllm",
-					ProfilingConfig: nvidiacomv1alpha1.ProfilingConfigSpec{
-						ProfilerImage: "profiler:latest",
-						Config: &apiextensionsv1.JSON{
-							Raw: []byte(validConfig),
-						},
-					},
+					Backend: nvidiacomv1beta1.BackendTypeVllm,
+					Image:   "profiler:latest",
 				},
 			},
 			wantErr: false,
@@ -376,12 +262,12 @@ func TestDynamoGraphDeploymentRequestValidator_ValidateUpdate(t *testing.T) {
 			warnings, err := validator.ValidateUpdate(tt.oldRequest)
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("DynamoGraphDeploymentRequestValidator.ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
 			if tt.wantWarnings && len(warnings) == 0 {
-				t.Errorf("DynamoGraphDeploymentRequestValidator.ValidateUpdate() expected warnings but got none")
+				t.Errorf("ValidateUpdate() expected warnings but got none")
 			}
 		})
 	}


### PR DESCRIPTION
#### Overview:

Dependent on #6498 -- please merge that first

#### Details:

  - Migrates the DGDR validation webhook from v1alpha1 to v1beta1, matching the controller refactor in #6498
  - Replaces JSON blob-based validation with typed v1beta1 field access (`spec.image`, `spec.hardware.*`)
  - Adds new rule: `spec.searchStrategy: thorough` is incompatible with `spec.backend: auto` — users must specify a concrete backend (sglang, trtllm, or vllm) when using thorough search

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Kubernetes operator API upgraded to v1beta1, replacing state-based model with phase-based operational tracking (Pending, Profiling, Deploying, Ready, Deployed, Failed).
  * Configuration structure updated with typed fields for image, backend, and hardware specifications.
  * Enhanced validation to prevent incompatible backend and search strategy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->