### PR TITLE
feat: update ModelExpress integration for unified mx loader

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -210,7 +210,7 @@ def update_dynamo_config_with_engine(
     dynamo_config.connector = []  # type: ignore[assignment]
 
     # Validate ModelExpress P2P server URL
-    if getattr(engine_config, "load_format", None) in ("mx-source", "mx-target"):
+    if getattr(engine_config, "load_format", None) == "mx":
         if not dynamo_config.model_express_url:
             raise ValueError(
                 f"--model-express-url or MODEL_EXPRESS_URL env var is required "

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -301,7 +301,7 @@ class DynamoVllmArgGroup(ArgGroup):
             env_var="MODEL_EXPRESS_URL",
             default=None,
             help="ModelExpress P2P server URL (e.g., http://mx-server:8080). "
-            "Required when using --load-format=mx-source or --load-format=mx-target.",
+            "Required when using --load-format=mx.",
         )
 
 

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -415,7 +415,7 @@ def setup_vllm_engine(config, stat_logger=None):
     if engine_args.load_format == "gms":
         engine_args.worker_cls = "gpu_memory_service.integrations.vllm.worker.GMSWorker"
 
-    if engine_args.load_format in ("mx-source", "mx-target"):
+    if engine_args.load_format == "mx":
         try:
             from modelexpress import register_modelexpress_loaders
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -82,14 +82,13 @@ def test_custom_jinja_template_env_var_expansion(monkeypatch, mock_vllm_cli):
     )
 
 
-@pytest.mark.parametrize("load_format", ["mx-source", "mx-target"])
-def test_model_express_url_from_cli_arg(mock_vllm_cli, load_format):
-    """Test that --model-express-url is stored when load format is mx-source/mx-target."""
+def test_model_express_url_from_cli_arg(mock_vllm_cli):
+    """Test that --model-express-url is stored when load format is mx."""
     mock_vllm_cli(
         "--model",
         "Qwen/Qwen3-0.6B",
         "--load-format",
-        load_format,
+        "mx",
         "--model-express-url",
         "http://mx-server:8080",
     )
@@ -97,29 +96,27 @@ def test_model_express_url_from_cli_arg(mock_vllm_cli, load_format):
     assert config.model_express_url == "http://mx-server:8080"
 
 
-@pytest.mark.parametrize("load_format", ["mx-source", "mx-target"])
-def test_model_express_url_from_env_var(monkeypatch, mock_vllm_cli, load_format):
+def test_model_express_url_from_env_var(monkeypatch, mock_vllm_cli):
     """Test that MODEL_EXPRESS_URL env var is used as fallback."""
     monkeypatch.setenv("MODEL_EXPRESS_URL", "http://env-mx:9090")
     mock_vllm_cli(
         "--model",
         "Qwen/Qwen3-0.6B",
         "--load-format",
-        load_format,
+        "mx",
     )
     config = parse_args()
     assert config.model_express_url == "http://env-mx:9090"
 
 
-@pytest.mark.parametrize("load_format", ["mx-source", "mx-target"])
-def test_model_express_url_cli_overrides_env(monkeypatch, mock_vllm_cli, load_format):
+def test_model_express_url_cli_overrides_env(monkeypatch, mock_vllm_cli):
     """Test that --model-express-url takes precedence over MODEL_EXPRESS_URL."""
     monkeypatch.setenv("MODEL_EXPRESS_URL", "http://env-mx:9090")
     mock_vllm_cli(
         "--model",
         "Qwen/Qwen3-0.6B",
         "--load-format",
-        load_format,
+        "mx",
         "--model-express-url",
         "http://cli-mx:8080",
     )
@@ -127,25 +124,24 @@ def test_model_express_url_cli_overrides_env(monkeypatch, mock_vllm_cli, load_fo
     assert config.model_express_url == "http://cli-mx:8080"
 
 
-@pytest.mark.parametrize("load_format", ["mx-source", "mx-target"])
-def test_model_express_url_missing_raises(monkeypatch, mock_vllm_cli, load_format):
-    """Test that missing server URL raises ValueError for mx load formats."""
+def test_model_express_url_missing_raises(monkeypatch, mock_vllm_cli):
+    """Test that missing server URL raises ValueError for mx load format."""
     monkeypatch.delenv("MODEL_EXPRESS_URL", raising=False)
     mock_vllm_cli(
         "--model",
         "Qwen/Qwen3-0.6B",
         "--load-format",
-        load_format,
+        "mx",
     )
     with pytest.raises(
         ValueError,
-        match=re.escape(f"--load-format={load_format}"),
+        match=re.escape("--load-format=mx"),
     ):
         parse_args()
 
 
 def test_model_express_url_none_for_default_load_format(mock_vllm_cli):
-    """Test that model_express_url is None when load format is not mx-*."""
+    """Test that model_express_url is None when load format is not mx."""
     mock_vllm_cli("--model", "Qwen/Qwen3-0.6B")
     config = parse_args()
     assert config.model_express_url is None


### PR DESCRIPTION
ModelExpress is replacing mx-source/mx-target with a single --load-format mx loader that auto-detects whether to load from disk or receive via RDMA. See ai-dynamo/modelexpress#147

- Update load format checks from ("mx-source", "mx-target") to "mx"
- Update help text for --model-express-url
- Simplify tests now that there's only one format



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Model Express URL requirement is now limited to the "mx" load format only. Support for "mx-source" and "mx-target" formats has been consolidated. Update your configurations if you were using these load formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->