### PR TITLE
docs: embedding cache in vLLM and TRT-LLM

### DIFF
--- a/docs/pages/features/multimodal/multimodal-trtllm.md
+++ b/docs/pages/features/multimodal/multimodal-trtllm.md
@@ -388,6 +388,26 @@ For 4 4xGB200 nodes (2 for prefill, 2 for decode):
 pkill srun
 ```
 
+## Embedding Cache
+
+Dynamo supports embedding cache in both aggregated and disaggregated settings for TRT-LLM:
+
+| Setting | Implementation | Launch Script | Status |
+|---------|---------------|---------------|--------|
+| **Disaggregated (E/PD)** | Dynamo-managed cache in the PD worker layer on top of TRT-LLM engine | `disagg_e_pd.sh` + `--multimodal-embedding-cache-capacity-gb` | Supported |
+| **Aggregated** | N/A | N/A | Not yet supported |
+
+The cache uses `MultimodalEmbeddingCacheManager` to maintain an LRU cache of encoder embeddings on CPU. When the same image is seen again, the cached embedding is reused instead of re-encoding.
+
+### Disaggregated (E/PD)
+
+The `disagg_e_pd.sh` script launches a separate encode worker and a PD worker. Extra arguments are forwarded to the PD worker. Enable embedding cache by passing `--multimodal-embedding-cache-capacity-gb`:
+
+```bash
+cd $DYNAMO_HOME/examples/backends/trtllm
+./launch/disagg_e_pd.sh --multimodal-embedding-cache-capacity-gb 10
+```
+
 ## NIXL Usage
 
 | Use Case | Script | NIXL Used? | Data Transfer |

--- a/examples/backends/trtllm/launch/disagg_e_pd.sh
+++ b/examples/backends/trtllm/launch/disagg_e_pd.sh
@@ -17,8 +17,10 @@ export ENCODE_ENDPOINT=${ENCODE_ENDPOINT:-"dyn://dynamo.tensorrt_llm_encode.gene
 export MODALITY=${MODALITY:-"multimodal"}
 export ALLOWED_LOCAL_MEDIA_PATH=${ALLOWED_LOCAL_MEDIA_PATH:-"/tmp"}
 export MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
-export DYN_ENCODER_CACHE_CAPACITY_GB=${DYN_ENCODER_CACHE_CAPACITY_GB:-4}
 export CUSTOM_TEMPLATE=${CUSTOM_TEMPLATE:-"$DYNAMO_HOME/examples/backends/trtllm/templates/llava_multimodal.jinja"}
+
+# Extra arguments forwarded to the PD worker (e.g. --multimodal-embedding-cache-capacity-gb 10)
+EXTRA_PD_ARGS=("$@")
 
 # Setup cleanup trap
 cleanup() {
@@ -54,7 +56,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.trtllm \
   --custom-jinja-template "$CUSTOM_TEMPLATE" \
   --encode-endpoint "$ENCODE_ENDPOINT" \
   --disaggregation-mode prefill_and_decode \
-  --dyn-encoder-cache-capacity-gb "$DYN_ENCODER_CACHE_CAPACITY_GB" &
+  "${EXTRA_PD_ARGS[@]}" &
 PD_PID_1=$!
 
 wait $DYNAMO_PID

--- a/examples/backends/vllm/launch/vllm_serve_embedding_cache.sh
+++ b/examples/backends/vllm/launch/vllm_serve_embedding_cache.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+CAPACITY_GB=10
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --multimodal-embedding-cache-capacity-gb)
+            CAPACITY_GB="$2"; shift 2 ;;
+        *)
+            EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+EC_ARGS=()
+if [[ "$CAPACITY_GB" != "0" ]]; then
+    EC_ARGS=(--ec-transfer-config "{
+        \"ec_role\": \"ec_both\",
+        \"ec_connector\": \"DynamoMultimodalEmbeddingCacheConnector\",
+        \"ec_connector_module_path\": \"dynamo.vllm.multimodal_utils.multimodal_embedding_cache_connector\",
+        \"ec_connector_extra_config\": {\"multimodal_embedding_cache_capacity_gb\": $CAPACITY_GB}
+    }")
+fi
+
+CUDA_VISIBLE_DEVICES=2 \
+vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 \
+    --enable-log-requests \
+    --max-model-len 16384 \
+    --gpu-memory-utilization .9 \
+    "${EC_ARGS[@]}" \
+    "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
## Why

The multimodal docs referenced a nonexistent `agg_multimodal_ec_connector.sh` script and lacked documentation for the embedding cache feature. The TRT-LLM `e_pd_disagg.sh` script used a broken `--dyn-encoder-cache-capacity-gb` flag that doesn't exist in the argparser, and didn't forward extra args to the PD worker.

## What Changed

- Rewrote the vLLM "ECConnector" section into a new "Embedding Cache" section documenting both `ec_both` (aggregated, via upstream vLLM v0.17.0+) and disaggregated (Dynamo-managed cache via `disagg_multimodal_e_pd.sh`) modes
- Added "Embedding Cache" section to TRT-LLM docs; renamed `e_pd_disagg.sh` → `disagg_e_pd.sh`, removed broken `--dyn-encoder-cache-capacity-gb` flag, and added extra args forwarding to the PD worker so `--multimodal-embedding-cache-capacity-gb` can be passed through
- Added `vllm_serve_embedding_cache.sh` launch script that runs `vllm serve` with `DynamoMultimodalEmbeddingCacheConnector` in `ec_both` mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Embedding Cache documentation for both TRT-LLM and vLLM multimodal deployments, including configuration examples and usage workflows.
  * Updated deployment patterns and reorganized connector usage documentation.

* **New Features**
  * Added new launch script for vLLM embedding cache serving with configurable capacity settings.
  * Enhanced argument forwarding capabilities in TRT-LLM disaggregated setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->