### PR TITLE
fix: guarantee RouterRequestMetrics availability & documentation updates

### DIFF
--- a/docs/pages/components/router/router-guide.md
+++ b/docs/pages/components/router/router-guide.md
@@ -264,9 +264,12 @@ The `router_temperature` parameter controls routing randomness:
 
 ## Prometheus Metrics
 
-The router exposes Prometheus metrics on the frontend's HTTP port (default 8000) at `/metrics`. Router metrics (`dynamo_router_*`) are registered whenever DRT discovery (etcd/NATS) is available, regardless of router mode. They are actively populated only when `--router-mode kv` is used; with other modes they appear but remain at zero.
+The router exposes Prometheus metrics at two ports:
 
-For the full list of router metrics (`dynamo_router_*`, `dynamo_router_overhead_*`, per-worker gauges), see the [Metrics reference](../../observability/metrics.md#router-metrics).
+- **Router request metrics** (`dynamo_component_router_*`) are registered via the component's metrics hierarchy and served on the system status port (default 8081) at `/metrics`. They are populated when `--router-mode kv` is active.
+- **Routing overhead metrics** (`dynamo_router_overhead_*`) and **per-worker gauges** (`dynamo_frontend_worker_*`) are registered on the frontend's HTTP port (default 8000) at `/metrics`.
+
+For the full list of router metrics, see the [Metrics reference](../../observability/metrics.md#router-metrics).
 
 ## Disaggregated Serving
 

--- a/docs/pages/components/router/router-guide.md
+++ b/docs/pages/components/router/router-guide.md
@@ -264,7 +264,7 @@ The `router_temperature` parameter controls routing randomness:
 
 ## Prometheus Metrics
 
-The router exposes Prometheus metrics on the frontend's HTTP port (default 8000) at `/metrics`. All router metrics require `--router-mode kv` and will not appear when using `round-robin` or `random` routing.
+The router exposes Prometheus metrics on the frontend's HTTP port (default 8000) at `/metrics`. Router metrics (`dynamo_router_*`) are registered whenever DRT discovery (etcd/NATS) is available, regardless of router mode. They are actively populated only when `--router-mode kv` is used; with other modes they appear but remain at zero.
 
 For the full list of router metrics (`dynamo_router_*`, `dynamo_router_overhead_*`, per-worker gauges), see the [Metrics reference](../../observability/metrics.md#router-metrics).
 

--- a/docs/pages/components/router/router-guide.md
+++ b/docs/pages/components/router/router-guide.md
@@ -264,10 +264,10 @@ The `router_temperature` parameter controls routing randomness:
 
 ## Prometheus Metrics
 
-The router exposes Prometheus metrics at two ports:
+The router exposes Prometheus metrics on the frontend's HTTP port (default 8000) at `/metrics`:
 
-- **Router request metrics** (`dynamo_component_router_*`) are registered via the component's metrics hierarchy and served on the system status port (default 8081) at `/metrics`. They are populated when `--router-mode kv` is active.
-- **Routing overhead metrics** (`dynamo_router_overhead_*`) and **per-worker gauges** (`dynamo_frontend_worker_*`) are registered on the frontend's HTTP port (default 8000) at `/metrics`.
+- **Router request metrics** (`dynamo_component_router_*`): Registered via the component's metrics hierarchy and exposed on the frontend via the `drt_metrics` bridge. In KV mode (aggregated and disaggregated) they are populated per-request; in non-KV modes (direct/random/round-robin) they are registered with zero values. The standalone router (`python -m dynamo.router`) also registers these metrics, available on `DYN_SYSTEM_PORT` when set.
+- **Routing overhead metrics** (`dynamo_router_overhead_*`) and **per-worker gauges** (`dynamo_frontend_worker_*`): Registered on the frontend's own Prometheus registry. These are frontend-only and not available on the standalone router.
 
 For the full list of router metrics, see the [Metrics reference](../../observability/metrics.md#router-metrics).
 

--- a/docs/pages/observability/metrics.md
+++ b/docs/pages/observability/metrics.md
@@ -219,13 +219,13 @@ Suppose the backend allows 3 concurrent requests and there are 10 clients contin
 
 ### Router Metrics
 
-When using the KV cache router (`--router-mode kv`), the frontend exposes additional metrics for monitoring routing decisions and overhead. These metrics are not registered when using `round-robin` or `random` routing, so they will not appear in `/metrics` output at all. Defined in `lib/llm/src/kv_router/metrics.rs`.
+The frontend exposes metrics for monitoring routing decisions and overhead. These metrics are registered whenever DRT discovery (etcd/NATS) is available, regardless of router mode. With `--router-mode kv`, the metrics will be actively populated as requests are routed; with other modes (`round-robin`, `random`, `direct`), they will appear on `/metrics` but remain at zero. Defined in `lib/llm/src/kv_router/metrics.rs`.
 
 For router configuration and tuning, see the [Router Guide](../components/router/router-guide.md).
 
 #### Router Request Metrics (`dynamo_router_*`)
 
-Histograms and counters for aggregate request-level statistics. Only registered when `--router-mode kv` is used. If no requests have been routed yet, the metrics will exist but show zero values. Exposed on the frontend port (default 8000) at `/metrics`.
+Histograms and counters for aggregate request-level statistics. Registered when DRT discovery is available (etcd/NATS). Only populated when `--router-mode kv` is active; otherwise they exist with zero values. Exposed on the frontend port (default 8000) at `/metrics`.
 
 All metrics carry a `router_id` constant label (the frontend's discovery instance ID). Filter in Prometheus with:
 

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -186,6 +186,8 @@ class labels:
     MODEL_NAME = "model_name"
     # Label for worker type (e.g., "aggregated", "prefill", "decode", "encoder", etc.)
     WORKER_TYPE = "worker_type"
+    # Label for router instance (discovery.instance_id() of the frontend)
+    ROUTER_ID = "router_id"
 
 
 class model_info:
@@ -200,10 +202,20 @@ class name_prefix:
     COMPONENT = "dynamo_component"
     # Prefix for frontend service metrics
     FRONTEND = "dynamo_frontend"
+    # Prefix for KV router metrics (used with router_id label)
+    ROUTER = "dynamo_router"
+
+
+class router_request:
+    """Router per-request metrics (component-scoped via `MetricsHierarchy`)."""
+
+    # Prefix prepended to `frontend_service::*` names to form router metric names.
+    # e.g. `"router_"` + `frontend_service::REQUESTS_TOTAL` → `"router_requests_total"`.
+    METRIC_PREFIX = "router_"
 
 
 class routing_overhead:
-    """Routing overhead phase latency histogram names (component-scoped)."""
+    """Routing overhead phase latency histogram suffixes."""
 
     # Time spent computing block hashes
     BLOCK_HASHING_MS = "overhead_block_hashing_ms"

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -282,8 +282,10 @@ where
         )
         .await?;
 
-    // Eagerly register router request metrics so they appear (as zeros) on port 8081
-    // regardless of router mode. In KV mode they get populated by KvPushRouter::generate().
+    // Eagerly register router request metrics so they appear as zeros even in
+    // non-KV modes (Direct, Random, RoundRobin) where KvPushRouter is never created.
+    // In KV mode, KvPushRouter::new() also calls from_component() (idempotent via
+    // OnceLock), which covers the standalone router path as well.
     RouterRequestMetrics::from_component(client.endpoint.component());
 
     let service_backend = match router_mode {

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -18,9 +18,7 @@ use super::metrics;
 use super::metrics::register_worker_timing_metrics;
 use crate::discovery::ModelManager;
 use crate::endpoint_type::EndpointType;
-use crate::kv_router::metrics::{
-    RouterRequestMetrics, RoutingOverheadMetrics, register_worker_load_metrics,
-};
+use crate::kv_router::metrics::{RoutingOverheadMetrics, register_worker_load_metrics};
 use crate::request_template::RequestTemplate;
 use anyhow::Result;
 use axum_server::tls_rustls::RustlsConfig;
@@ -430,9 +428,6 @@ impl HttpServiceConfigBuilder {
 
         if let Some(ref discovery) = config.drt_discovery {
             let instance_id = discovery.instance_id();
-            if let Err(e) = RouterRequestMetrics::register(&registry, instance_id) {
-                tracing::warn!("Failed to register router request metrics: {}", e);
-            }
             if let Err(e) = RoutingOverheadMetrics::register(&registry, instance_id) {
                 tracing::warn!("Failed to register routing overhead metrics: {}", e);
             }

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -24,7 +24,7 @@ fn router_metric(suffix: &str) -> String {
     format!("{}{}", router_request::METRIC_PREFIX, suffix)
 }
 use dynamo_runtime::traits::DistributedRuntimeProvider;
-use prometheus::{IntGaugeVec, Opts};
+use prometheus::{HistogramOpts, IntGaugeVec, Opts};
 
 use crate::http::service::metrics::generate_log_buckets;
 

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -178,6 +178,10 @@ impl KvPushRouter {
         inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
         chooser: Arc<KvRouter>,
     ) -> Self {
+        // Eagerly register router request metrics (as zeros) so they are
+        // scrapeable before any requests arrive. Both the frontend pipeline
+        // and the standalone router create KvPushRouter, so this covers both.
+        RouterRequestMetrics::from_component(chooser.client().endpoint.component());
         KvPushRouter { inner, chooser }
     }
 

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -27,6 +27,7 @@ use crate::{
         timing::{RequestPhase, RequestTracker},
     },
 };
+use dynamo_runtime::traits::DistributedRuntimeProvider;
 
 pub struct KvPushRouter {
     inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
@@ -50,7 +51,7 @@ struct RequestGuard {
     chooser: Arc<KvRouter>,
     context_id: String,
     tracker: Option<Arc<RequestTracker>>,
-    request_metrics: Option<Arc<RouterRequestMetrics>>,
+    request_metrics: Arc<RouterRequestMetrics>,
     cumulative_osl: usize,
     metrics_recorded: bool,
     freed: bool,
@@ -87,8 +88,10 @@ impl RequestGuard {
         if !self.first_token_recorded && new_tokens > 0 {
             if let Some(ref tracker) = self.tracker {
                 tracker.record_first_token();
-                if let (Some(m), Some(ttft)) = (&self.request_metrics, tracker.ttft_ms()) {
-                    m.time_to_first_token_seconds.observe(ttft / 1000.0);
+                if let Some(ttft) = tracker.ttft_ms() {
+                    self.request_metrics
+                        .time_to_first_token_seconds
+                        .observe(ttft / 1000.0);
                 }
             }
             self.first_token_recorded = true;
@@ -116,9 +119,10 @@ impl RequestGuard {
                 if let Some(ref tracker) = self.tracker {
                     tracker.record_osl(self.cumulative_osl);
                     tracker.record_finish();
-                    if let (Some(m), Some(avg_itl)) = (&self.request_metrics, tracker.avg_itl_ms())
-                    {
-                        m.inter_token_latency_seconds.observe(avg_itl / 1000.0);
+                    if let Some(avg_itl) = tracker.avg_itl_ms() {
+                        self.request_metrics
+                            .inter_token_latency_seconds
+                            .observe(avg_itl / 1000.0);
                     }
                 }
 
@@ -144,10 +148,10 @@ impl RequestGuard {
             tracker.record_finish();
             tracker.record_osl(self.cumulative_osl);
         }
-        if let Some(ref m) = self.request_metrics {
-            m.output_sequence_tokens.observe(self.cumulative_osl as f64);
-            m.requests_total.inc();
-        }
+        self.request_metrics
+            .output_sequence_tokens
+            .observe(self.cumulative_osl as f64);
+        self.request_metrics.requests_total.inc();
     }
 }
 
@@ -365,7 +369,26 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         }
 
         // Record routing metrics on tracker and observe ISL + prefill start.
-        let request_metrics = RouterRequestMetrics::get();
+        //
+        // instance_id comes from Discovery::instance_id() — the *router process's* own
+        // identity, used as the `router_id` Prometheus label on all dynamo_router_* metrics.
+        // Source depends on the discovery backend:
+        //   etcd  -> lease ID assigned by the etcd server
+        //   NATS  -> server-assigned client_id
+        //   file  -> random u64 generated at startup
+        //   kube  -> deterministic hash of the pod name
+        //
+        // TODO: each router process gets a unique router_id label value, which can
+        // cause unbounded cardinality with short-lived or autoscaled frontends.
+        // Consider using stable replica indices instead of opaque u64 IDs.
+        let instance_id_for_metrics = self
+            .chooser
+            .client()
+            .endpoint
+            .drt()
+            .discovery()
+            .instance_id();
+        let request_metrics = RouterRequestMetrics::get_or_init(instance_id_for_metrics);
         if let Some(ref tracker) = request.tracker {
             let (routing_token_ids, _) = request.block_mm_routing_info();
             let isl_blocks = routing_token_ids.len().div_ceil(block_size);
@@ -375,14 +398,13 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 overlap_amount as usize * block_size,
             );
             tracker.record_worker_full(instance_id, dp_rank, self.chooser.worker_type());
-            if let (Some(m), Some(hit_rate)) = (&request_metrics, tracker.kv_hit_rate()) {
-                m.kv_hit_rate.observe(hit_rate);
+            if let Some(hit_rate) = tracker.kv_hit_rate() {
+                request_metrics.kv_hit_rate.observe(hit_rate);
             }
         }
-        if let Some(ref m) = request_metrics {
-            m.input_sequence_tokens
-                .observe(request.token_ids.len() as f64);
-        }
+        request_metrics
+            .input_sequence_tokens
+            .observe(request.token_ids.len() as f64);
 
         // Handle query-only requests: early return with worker info
         if is_query_only {

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -417,6 +417,18 @@ pub mod kvbm {
     pub const OBJECT_WRITE_FAILURES: &str = "object_write_failures";
 }
 
+/// Router per-request metrics (component-scoped via `MetricsHierarchy`).
+///
+/// Metric names are composed as `"{METRIC_PREFIX}{frontend_service::*}"` at init time,
+/// then passed to `component.metrics().create_*()` which auto-prepends `dynamo_component_`,
+/// yielding e.g. `dynamo_component_router_requests_total`.
+/// See `lib/llm/src/kv_router/metrics.rs` `RouterRequestMetrics::from_component()`.
+pub mod router_request {
+    /// Prefix prepended to `frontend_service::*` names to form router metric names.
+    /// e.g. `"router_"` + `frontend_service::REQUESTS_TOTAL` → `"router_requests_total"`.
+    pub const METRIC_PREFIX: &str = "router_";
+}
+
 /// Routing overhead phase latency histogram suffixes.
 ///
 /// Combined with `name_prefix::ROUTER` ("dynamo_router") in `RoutingOverheadMetrics::register()`,


### PR DESCRIPTION
#### Overview:

Make RouterRequestMetrics a mandatory Arc (non-Option) at the call site, matching the old from_component() guarantee. Add get_or_init() so metrics are always available even without explicit register(), and document router_id origin with a cardinality TODO.

#### Details:

- Change `RequestGuard.request_metrics` from `Option<Arc<RouterRequestMetrics>>` to `Arc<RouterRequestMetrics>`, removing six `if let Some` conditional guards
- Extract shared `init()` helper in `RouterRequestMetrics` and add `get_or_init(instance_id)` for lazy creation when `register()` was not called (e.g. file-based discovery)
- Add code comment documenting `router_id` origin per discovery backend (etcd lease, NATS client_id, random u64, pod-name hash) and a TODO for cardinality with autoscaled frontends
- Update metrics.md and router-guide.md to clarify that `dynamo_router_*` metrics are registered whenever DRT discovery is available, regardless of router mode

#### Where should the reviewer start?

`lib/llm/src/kv_router/push_router.rs` — the `RequestGuard` struct change from `Option<Arc<...>>` to `Arc<...>` and the removed guards. Then `lib/llm/src/kv_router/metrics.rs` for the `init`/`get_or_init` refactor.

#### Related Issues:

Relates to #6227

/coderabbit profile chill