### PR TITLE
feat: Log discovery backend type

### DIFF
--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -145,7 +145,7 @@ impl DistributedRuntime {
                 (Arc::new(client) as Arc<dyn Discovery>, Some(metadata))
             }
             DiscoveryBackend::KvStore(kv_selector) => {
-                tracing::info!("Initializing KV store discovery backend");
+                tracing::info!("Initializing KV store discovery backend: {}", kv_selector);
                 let runtime_clone = runtime.clone();
                 let store = match kv_selector {
                     kv::Selector::Etcd(etcd_config) => {


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Log the type of discovery backend being used at initialization time

#### Details:

<!-- Describe the changes made in this PR. -->

Before, hard to tell that the discovery backend choice took effect, same log message for each:
```bash
# Default (etcd)
$ python3 hello_world.py
2026-02-25T01:43:59.062471Z  INFO dynamo_runtime::distributed: Initializing KV store discovery backend

# File
$ DYN_DISCOVERY_BACKEND=file python3 hello_world.py
2026-02-25T01:45:55.277807Z  INFO dynamo_runtime::distributed: Initializing KV store discovery backend

# Mem
$ DYN_DISCOVERY_BACKEND=mem python3 hello_world.py
2026-02-25T01:46:21.590857Z  INFO dynamo_runtime::distributed: Initializing KV store discovery backend
```

After, clear log indicating discovery backend type:
```bash
# Default (etcd)
$ python3 hello_world.py
2026-02-25T01:43:59.062471Z  INFO dynamo_runtime::distributed: Initializing KV store discovery backend: Etcd(http://localhost:2379)

# File
$ DYN_DISCOVERY_BACKEND=file python3 hello_world.py
2026-02-25T01:45:55.277807Z  INFO dynamo_runtime::distributed: Initializing KV store discovery backend: File(/tmp/dynamo_store_kv)

# Mem
$ DYN_DISCOVERY_BACKEND=mem python3 hello_world.py
2026-02-25T01:46:21.590857Z  INFO dynamo_runtime::distributed: Initializing KV store discovery backend: Memory
```

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging during KV store discovery backend initialization to display the selected backend for better observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->