### PR TITLE
Qiwa/dynamo agg investigation

### DIFF
--- a/docs/pages/features/multimodal/multimodal-trtllm.md
+++ b/docs/pages/features/multimodal/multimodal-trtllm.md
@@ -388,6 +388,26 @@ For 4 4xGB200 nodes (2 for prefill, 2 for decode):
 pkill srun
 ```
 
+## Embedding Cache
+
+Dynamo supports embedding cache in both aggregated and disaggregated settings for TRT-LLM:
+
+| Setting | Implementation | Launch Script | Status |
+|---------|---------------|---------------|--------|
+| **Disaggregated (E/PD)** | Dynamo-managed cache in the PD worker layer on top of TRT-LLM engine | `disagg_e_pd.sh` + `--multimodal-embedding-cache-capacity-gb` | Supported |
+| **Aggregated** | N/A | N/A | Not yet supported |
+
+The cache uses `MultimodalEmbeddingCacheManager` to maintain an LRU cache of encoder embeddings on CPU. When the same image is seen again, the cached embedding is reused instead of re-encoding.
+
+### Disaggregated (E/PD)
+
+The `disagg_e_pd.sh` script launches a separate encode worker and a PD worker. Extra arguments are forwarded to the PD worker. Enable embedding cache by passing `--multimodal-embedding-cache-capacity-gb`:
+
+```bash
+cd $DYNAMO_HOME/examples/backends/trtllm
+./launch/disagg_e_pd.sh --multimodal-embedding-cache-capacity-gb 10
+```
+
 ## NIXL Usage
 
 | Use Case | Script | NIXL Used? | Data Transfer |

--- a/examples/backends/trtllm/launch/disagg_e_pd.sh
+++ b/examples/backends/trtllm/launch/disagg_e_pd.sh
@@ -17,8 +17,10 @@ export ENCODE_ENDPOINT=${ENCODE_ENDPOINT:-"dyn://dynamo.tensorrt_llm_encode.gene
 export MODALITY=${MODALITY:-"multimodal"}
 export ALLOWED_LOCAL_MEDIA_PATH=${ALLOWED_LOCAL_MEDIA_PATH:-"/tmp"}
 export MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
-export DYN_ENCODER_CACHE_CAPACITY_GB=${DYN_ENCODER_CACHE_CAPACITY_GB:-4}
 export CUSTOM_TEMPLATE=${CUSTOM_TEMPLATE:-"$DYNAMO_HOME/examples/backends/trtllm/templates/llava_multimodal.jinja"}
+
+# Extra arguments forwarded to the PD worker (e.g. --multimodal-embedding-cache-capacity-gb 10)
+EXTRA_PD_ARGS=("$@")
 
 # Setup cleanup trap
 cleanup() {
@@ -54,7 +56,7 @@ CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.trtllm \
   --custom-jinja-template "$CUSTOM_TEMPLATE" \
   --encode-endpoint "$ENCODE_ENDPOINT" \
   --disaggregation-mode prefill_and_decode \
-  --dyn-encoder-cache-capacity-gb "$DYN_ENCODER_CACHE_CAPACITY_GB" &
+  "${EXTRA_PD_ARGS[@]}" &
 PD_PID_1=$!
 
 wait $DYNAMO_PID

--- a/examples/backends/vllm/launch/agg_multimodal.sh
+++ b/examples/backends/vllm/launch/agg_multimodal.sh
@@ -66,7 +66,7 @@ fi
 # Multimodal data (images) are decoded in the backend worker using ImageLoader
 # --enforce-eager: Quick deployment (remove for production)
 # Extra args from command line come last to allow overrides
-CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0} \
+CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-2} \
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
     python -m dynamo.vllm --enable-multimodal --model $MODEL_NAME $MODEL_SPECIFIC_ARGS "${EXTRA_ARGS[@]}"
 

--- a/examples/backends/vllm/launch/vllm_serve_embedding_cache.sh
+++ b/examples/backends/vllm/launch/vllm_serve_embedding_cache.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+CAPACITY_GB=10
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --multimodal-embedding-cache-capacity-gb)
+            CAPACITY_GB="$2"; shift 2 ;;
+        *)
+            EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+EC_ARGS=()
+if [[ "$CAPACITY_GB" != "0" ]]; then
+    EC_ARGS=(--ec-transfer-config "{
+        \"ec_role\": \"ec_both\",
+        \"ec_connector\": \"DynamoMultimodalEmbeddingCacheConnector\",
+        \"ec_connector_module_path\": \"dynamo.vllm.multimodal_utils.multimodal_embedding_cache_connector\",
+        \"ec_connector_extra_config\": {\"multimodal_embedding_cache_capacity_gb\": $CAPACITY_GB}
+    }")
+fi
+
+CUDA_VISIBLE_DEVICES=2 \
+vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 \
+    --enable-log-requests \
+    --max-model-len 16384 \
+    --gpu-memory-utilization .9 \
+    "${EC_ARGS[@]}" \
+    "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
**we have reproduce at the bottom. don't miss it**

## Summary

dynamo agg (2.8 seconds) is 75% slower than vLLM agg (1.6 seconds) on

- RTX 6000
- 30 images per request
- 300 text

calculating `mm_uuids` is taking lots of time


| Step | Time | Root cause |
|------|------|-----------|
| mm_extract | ~0.85s | HTTP download + PIL decode (I/O bound) |
| mm_uuids (= prompt_build) | ~1.35s | PNG re-encoding 30 images just for hashing |
| engine | ~0.5s | vLLM scheduling + prefill |
| **worker_e2e** | **~2.7s** | |

## Details


```
[2m2026-02-25T02:21:02.149320Z[0m [32m INFO[0m [2mhandlers._extract_multimodal_data[0m[2m:[0m [TIMER] mm_load: 30 image(s) in 0.790s (26.3 ms/img)
[2m2026-02-25T02:21:03.439069Z[0m [32m INFO[0m [2mhandlers._build_prompt_from_request[0m[2m:[0m [TIMER] mm_uuids=1.290s
[2m2026-02-25T02:21:04.051120Z[0m [32m INFO[0m [2mhandlers._generate_token_mode[0m[2m:[0m [TIMER] req=af00e595-62d5-4c6a-8f4a-12d2aab7b44e mm_extract=0.790s prompt_build=1.290s first_token=2.691s
[2m2026-02-25T02:21:04.051337Z[0m [32m INFO[0m [2mhandlers._generate_token_mode[0m[2m:[0m [TIMER] req=af00e595-62d5-4c6a-8f4a-12d2aab7b44e worker_e2e=2.692s
[2m2026-02-25T02:21:04.974852Z[0m [32m INFO[0m [2mhandlers._extract_multimodal_data[0m[2m:[0m [TIMER] mm_load: 30 image(s) in 0.913s (30.4 ms/img)
[2m2026-02-25T02:21:06.331016Z[0m [32m INFO[0m [2mhandlers._build_prompt_from_request[0m[2m:[0m [TIMER] mm_uuids=1.356s
[2m2026-02-25T02:21:06.997101Z[0m [32m INFO[0m [2mhandlers._generate_token_mode[0m[2m:[0m [TIMER] req=fadee3d2-2317-4ca7-9f6d-a38508944d34 mm_extract=0.914s prompt_build=1.356s first_token=2.936s
[2m2026-02-25T02:21:06.997328Z[0m [32m INFO[0m [2mhandlers._generate_token_mode[0m[2m:[0m [TIMER] req=fadee3d2-2317-4ca7-9f6d-a38508944d34 worker_e2e=2.936s
[2m2026-02-25T02:21:07.701412Z[0m [32m INFO[0m [2mhandlers._extract_multimodal_data[0m[2m:[0m [TIMER] mm_load: 30 image(s) in 0.695s (23.2 ms/img)
[2m2026-02-25T02:21:09.015089Z[0m [32m INFO[0m [2mhandlers._build_prompt_from_request[0m[2m:[0m
```

## Reproduce

generate request

```
python benchmarks/multimodal/jsonl/main.py \
  --image-mode http \
  -n 700 \
  --images-per-request 30 \
  --images-pool 1000 \
  --user-text-tokens 300
```

kick off dynamo

```
examples/backends/vllm/launch/agg_multimodal.sh &> logs/dynamo_agg_mm_cache_disabled.txt &
```

kick off vllm

```
examples/backends/vllm/launch/vllm_serve_embedding_cache.sh &> logs/vllm_serve_mm_cache_disabled.txt &
```

sent requests

```
aiperf profile \
  --model Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 \
  --input-file benchmarks/multimodal/jsonl/700req_30img_1000pool_300word_http.jsonl \
  --custom-dataset-type single_turn \
  --osl 1 \
  --request-count 700 \
  --concurrency 1 \
  --warmup-request-count 3 \
  --artifact-dir /workspace/logs/aiperf
```
