### PR TITLE
fix: vllm launch script errors for disagg and spec decoding

### DIFF
--- a/examples/backends/vllm/launch/agg_spec_decoding.sh
+++ b/examples/backends/vllm/launch/agg_spec_decoding.sh
@@ -23,6 +23,6 @@ CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm \
         "model": "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B",
         "draft_tensor_parallel_size": 1,
         "num_speculative_tokens": 2,
-        "method": "eagle"
+        "method": "eagle3"
     }' \
     --gpu-memory-utilization 0.8

--- a/examples/backends/vllm/launch/disagg_kvbm_router.sh
+++ b/examples/backends/vllm/launch/disagg_kvbm_router.sh
@@ -20,13 +20,15 @@ python -m dynamo.frontend \
 CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model $MODEL \
     --enforce-eager \
-    --disaggregation-mode decode &
+    --disaggregation-mode decode \
+    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
 
 VLLM_NIXL_SIDE_CHANNEL_PORT=20096 \
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
     --model $MODEL \
     --enforce-eager \
-    --disaggregation-mode decode &
+    --disaggregation-mode decode \
+    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
 
 # two prefill workers with KVBM enabled
 # Each worker needs unique ZMQ ports to avoid KVBM coordination conflicts

--- a/examples/backends/vllm/launch/disagg_same_gpu.sh
+++ b/examples/backends/vllm/launch/disagg_same_gpu.sh
@@ -57,7 +57,8 @@ python3 -m dynamo.vllm \
   --enforce-eager \
   --disaggregation-mode decode \
   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
-  --gpu-memory-utilization ${GPU_MEM_FRACTION} &
+  --gpu-memory-utilization ${GPU_MEM_FRACTION} \
+  --max-model-len 16384 &
 DECODE_PID=$!
 
 # Wait for decode worker to initialize before starting prefill worker
@@ -79,5 +80,6 @@ python3 -m dynamo.vllm \
   --disaggregation-mode prefill \
   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
   --gpu-memory-utilization ${GPU_MEM_FRACTION} \
+  --max-model-len 16384 \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'
 


### PR DESCRIPTION
## Summary
- Add missing `--kv-transfer-config` to decode workers in `disagg_kvbm_router.sh`
- Add `--max-model-len 16384` to both workers in `disagg_same_gpu.sh` to fit KV cache within available GPU memory
- Fix EAGLE3 speculative decoding method from `"eagle"` to `"eagle3"` in `agg_spec_decoding.sh`

## Test plan
- [x] Run `disagg_kvbm_router.sh` — decode workers should no longer error on missing `--kv-transfer-config`
- [x] Run `disagg_same_gpu.sh` — workers should start without KV cache OOM
- [x] Run `agg_spec_decoding.sh` — EAGLE3 drafter model should load without `KeyError: 'd2t'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vLLM backend examples with improved speculative decoding configuration options
  * Enhanced distributed inference setup with key-value buffer management capabilities
  * Added explicit memory limit configuration for optimized resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->