### PR TITLE
fix: TRT-LLM multimodal preprocessor - fix the dictionary naming for an embeddings case

### DIFF
--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -315,8 +315,6 @@ class MultimodalRequestProcessor:
                 processed_inputs["multi_modal_embeddings"] = {
                     "image": loaded_embeddings
                 }
-                if not processed_mm_data:
-                    processed_inputs["multi_modal_data"] = {}
 
         return processed_inputs
 

--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -222,8 +222,11 @@ class MultimodalRequestProcessor:
                 f"Using NIXL embeddings from encoder: shape={embeddings.shape if hasattr(embeddings, 'shape') else 'N/A'}"
             )
 
-            # Structure embeddings in the format TRT-LLM's generate_async expects
-            processed_inputs["multi_modal_embeddings"] = embeddings
+            # Same structure as PD flow (TRT-LLM expects dict with "image" key)
+            image_embeddings = (
+                embeddings if isinstance(embeddings, list) else [embeddings]
+            )
+            processed_inputs["multi_modal_embeddings"] = {"image": image_embeddings}
 
             return processed_inputs
 

--- a/components/src/dynamo/trtllm/tests/multimodal/test_trtllm_multimodal_processor.py
+++ b/components/src/dynamo/trtllm/tests/multimodal/test_trtllm_multimodal_processor.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for MultimodalRequestProcessor embedding paths.
+
+These tests ensure multi_modal_embeddings is always a dict with an "image" key
+(list of tensors), as required by TRT-LLM's attach_multimodal_embeddings.
+Regression test for "multimodal_embedding must be a dictionary" ValueError.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip(
+        "Skipping to avoid errors during collection with '-m gpu_0'. "
+        "CUDA/GPU not available, but tensorrt_llm import and the test require GPU.",
+        allow_module_level=True,
+    )
+from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.gpu_0,
+]
+
+
+def _make_processor():
+    """Minimal processor with mock tokenizer (no model load)."""
+    return MultimodalRequestProcessor(
+        model_type="llava",
+        model_dir="/fake/dir",
+        max_file_size_mb=10,
+        tokenizer=MagicMock(),
+    )
+
+
+def _request_with_tokens(token_ids=None):
+    return {"token_ids": token_ids or [1, 2, 3]}
+
+
+class TestProcessOpenAIRequestNIXLEmbeddings:
+    """NIXL path: embeddings from encode worker must be wrapped as dict with 'image' key."""
+
+    @pytest.mark.asyncio
+    async def test_embeddings_tensor_wrapped_as_dict_with_image_key(self):
+        """Single tensor must become multi_modal_embeddings['image'] list (TRT-LLM contract)."""
+        processor = _make_processor()
+        request = _request_with_tokens()
+        embeddings = torch.randn(10, 256)
+
+        result = await processor.process_openai_request(
+            request, embeddings=embeddings, ep_disaggregated_params=None
+        )
+
+        assert result is not None
+        assert "multi_modal_embeddings" in result
+        mm_emb = result["multi_modal_embeddings"]
+        assert isinstance(
+            mm_emb, dict
+        ), "TRT-LLM requires multimodal_embedding to be a dictionary"
+        assert "image" in mm_emb
+        assert isinstance(mm_emb["image"], list)
+        assert len(mm_emb["image"]) == 1
+        assert torch.equal(mm_emb["image"][0], embeddings)
+
+    @pytest.mark.asyncio
+    async def test_embeddings_list_passed_through_as_image_list(self):
+        """List of tensors must be multi_modal_embeddings['image'] unchanged."""
+        processor = _make_processor()
+        request = _request_with_tokens()
+        embeddings = [torch.randn(10, 256), torch.randn(10, 256)]
+
+        result = await processor.process_openai_request(
+            request, embeddings=embeddings, ep_disaggregated_params=None
+        )
+
+        assert result is not None
+        mm_emb = result["multi_modal_embeddings"]
+        assert isinstance(mm_emb, dict)
+        assert mm_emb["image"] == embeddings
+
+
+class TestProcessOpenAIRequestPDEmbeddingPaths:
+    """PD path: loaded embedding files must be set as dict with 'image' key."""
+
+    @pytest.mark.asyncio
+    async def test_embedding_paths_produce_dict_with_image_key(self):
+        """Loading .pt from multi_modal_data must set multi_modal_embeddings = {'image': [...]}."""
+        processor = _make_processor()
+        mock_tensor = torch.randn(5, 128)
+        request = {
+            "token_ids": [1, 2, 3],
+            "multi_modal_data": {
+                "image_url": [{"Url": "https://example.com/emb.pt"}],
+            },
+        }
+
+        with patch.object(
+            processor,
+            "load_tensor_from_path_or_url",
+            return_value=mock_tensor,
+        ):
+            result = await processor.process_openai_request(
+                request, embeddings=None, ep_disaggregated_params=None
+            )
+
+        assert result is not None
+        assert "multi_modal_embeddings" in result
+        mm_emb = result["multi_modal_embeddings"]
+        assert isinstance(mm_emb, dict)
+        assert "image" in mm_emb
+        assert isinstance(mm_emb["image"], list)
+        assert len(mm_emb["image"]) == 1
+        assert torch.equal(mm_emb["image"][0], mock_tensor)


### PR DESCRIPTION
#### Overview:

TRT-LLM multimodal preprocessor - fix the dictionary naming for an embeddings case.

#### Details:

Whenever user provides multimodal data in the form of embeddings (instead of an actual image URL), TRT-LLM will look for those under `multi_modal_embeddings` dict key, not `multi_modal_data` as was incorrectly specified in `process_openai_request`. This fixes the embeddings path for the:

- AGG
- EPD

cases.

#### Where should the reviewer start?

N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: https://github.com/NVIDIA/TensorRT-LLM/pull/11708


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multimodal embedding data handling to ensure consistent formatting and structure
  * Enhanced processing of embedding file paths to properly load and store external embeddings
  * Fixed data structure consistency when handling multimodal inputs with embeddings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->