### PR TITLE
fix: disable media-ffmpeg feature by default

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -28,7 +28,7 @@ dynamo:
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
   nixl_libfabric_ref: v2.3.0
   enable_kvbm: "true"
-  enable_media_ffmpeg: "true"
+  enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "false"
   ffmpeg_version: "7.1"
   efa_version: 1.45.1
@@ -47,7 +47,7 @@ vllm:
   lmcache_ref: 0.3.13
   vllm_omni_ref: "0.14.0"
   max_jobs: "10"
-  enable_media_ffmpeg: "true"
+  enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
   enable_modelexpress_p2p: "false"
@@ -62,7 +62,7 @@ sglang:
   cuda13.0:
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: v0.5.9-cu130-runtime
-  enable_media_ffmpeg: "true"
+  enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"
 
@@ -72,7 +72,7 @@ trtllm:
   cuda13.1:
     base_image_tag: 25.12-py3
     runtime_image_tag: 25.12-cuda13.1-runtime-ubuntu24.04
-  enable_media_ffmpeg: "true"
+  enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "false"
   enable_kvbm: "true"
   python_version: "3.12"

--- a/container/templates/dynamo_runtime.Dockerfile
+++ b/container/templates/dynamo_runtime.Dockerfile
@@ -44,15 +44,13 @@ COPY --chown=dynamo: --from=wheel_builder /opt/nvidia/nvda_nixl/lib64/. ${NIXL_L
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
 COPY --chown=dynamo: --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
 
-{% if context.dynamo.enable_media_ffmpeg == "true" %}
-# Copy ffmpeg
+# Always copy FFmpeg so libs are available for Rust checks in CI
 RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/local/ \
     mkdir -p /usr/local/lib/pkgconfig && \
     cp -rnL /tmp/usr/local/include/libav* /tmp/usr/local/include/libsw* /usr/local/include/ && \
     cp -nL /tmp/usr/local/lib/libav*.so /tmp/usr/local/lib/libsw*.so /usr/local/lib/ && \
     cp -nL /tmp/usr/local/lib/pkgconfig/libav*.pc /tmp/usr/local/lib/pkgconfig/libsw*.pc /usr/local/lib/pkgconfig/ && \
     cp -r /tmp/usr/local/src/ffmpeg /usr/local/src/
-{% endif %}
 
 # Copy built artifacts
 COPY --chown=dynamo: --from=wheel_builder $CARGO_TARGET_DIR $CARGO_TARGET_DIR

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -326,6 +326,7 @@ COPY components/ /opt/dynamo/components/
 
 # Build dynamo wheels. The caches do not need the "shared" lock because Cargo has its own locking mechanism.
 ARG ENABLE_KVBM
+ARG ENABLE_MEDIA_FFMPEG
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
     --mount=type=cache,target=/root/.cargo/registry \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -148,13 +148,11 @@ RUN if [ "$USE_SCCACHE" = "true" ]; then \
 ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
     SCCACHE_REGION=${USE_SCCACHE:+${SCCACHE_REGION}}
 
-# Build FFmpeg from source
+# Always build FFmpeg so libs are available for Rust checks in CI
 # Do not delete the source tarball for legal reasons
 ARG FFMPEG_VERSION
-ARG ENABLE_MEDIA_FFMPEG
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-id,env=AWS_SECRET_ACCESS_KEY \
-if [ "$ENABLE_MEDIA_FFMPEG" = "true" ]; then \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${ARCH}} && \
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
@@ -185,8 +183,7 @@ if [ "$ENABLE_MEDIA_FFMPEG" = "true" ]; then \
     /tmp/use-sccache.sh show-stats "FFMPEG" && \
     ldconfig && \
     mkdir -p /usr/local/src/ffmpeg && \
-    mv /tmp/ffmpeg-${FFMPEG_VERSION}* /usr/local/src/ffmpeg/; \
-fi
+    mv /tmp/ffmpeg-${FFMPEG_VERSION}* /usr/local/src/ffmpeg/
 
 # Build and install UCX
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \


### PR DESCRIPTION
FFmpeg is now always built in wheel_builder and always copied to the dynamo runtime container so that FFmpeg headers and libraries are available in CI for Rust checks (cargo clippy/test --features media-ffmpeg). The media-ffmpeg maturin feature remains gated behind the ENABLE_MEDIA_FFMPEG build arg, which is now set to "false" by default in all configurations (dynamo, vllm, sglang, trtllm).

closes: OPS-3453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled FFmpeg media support configuration flags for four service environments
  * Modified build process to unconditionally include FFmpeg components in runtime artifacts regardless of configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->