### PR TITLE
chore: Upgrade to tensorrt-llm==1.3.0rc5

### DIFF
--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "pydantic>=2",
     "tabulate",
     "types-tabulate",
-    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.3.0rc3 (==4.57.1), SGLang 0.5.8 (==4.57.1)
+    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.3.0rc5 (==4.57.1), SGLang 0.5.8 (==4.57.1)
     "transformers>=4.56.0",
     "pytest-mypy",
 ]

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -78,10 +78,10 @@ trtllm:
   python_version: "3.12"
   index_url: https://pypi.nvidia.com/
   pip_wheel_dir: /tmp/trtllm_wheel/
-  pip_wheel: tensorrt-llm==1.3.0rc3
+  pip_wheel: tensorrt-llm==1.3.0rc5
   trtllm_wheel_image: nvcr.io/nvidia/tensorrt-llm/release:${TENSORRTLLM_PIP_WHEEL#*==}
 
-  github_trtllm_commit: v1.3.0rc3
+  github_trtllm_commit: v1.3.0rc5
   torch_version: 2.10.0a0+b4e4ee81d3.nv25.12
   torch_tensorrt_version: 2.10.0a0
   torchvision_version: 0.25.0a0+ca221243

--- a/container/deps/requirements.txt
+++ b/container/deps/requirements.txt
@@ -54,7 +54,7 @@ tensorboard>=2.19.0,<2.21.0
 tensorboardX==2.6.2.2
 # Transformers version constraint for container builds
 # - vLLM 0.11.0: >=4.55.2, vLLM 0.11.2: >=4.56.0,<5
-# - TensorRT-LLM 1.3.0rc3: ==4.57.1
+# - TensorRT-LLM 1.3.0rc5: ==4.57.1
 # - SGLang 0.5.8: ==4.57.1
 # Using >=4.56.0 to satisfy all frameworks
 transformers>=4.56.0

--- a/docs/pages/reference/support-matrix.md
+++ b/docs/pages/reference/support-matrix.md
@@ -16,7 +16,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.15.1` | `0.5.9` | `1.3.0rc3` | `0.9.0` |
+| **main (ToT)** | `0.15.1` | `0.5.9` | `1.3.0rc5` | `0.9.0` |
 | **v1.0.0** *(planned)* | `0.15.0` | *Latest as of 2/17* | *Latest as of 2/17* | `0.10.0` |
 | **v0.9.1** *(in progress)* | `0.14.1` | `0.5.8` | `1.3.0rc3` | `0.9.0` |
 | **v0.9.0** *(in progress)* | `0.14.1` | `0.5.8` | `1.3.0rc1` | `0.9.0` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 trtllm =[
     "uvloop",
     "msgpack==1.1.2",
-    "tensorrt-llm==1.3.0rc3",
+    "tensorrt-llm==1.3.0rc5",
 ]
 
 vllm = [


### PR DESCRIPTION
## Overview

Upgrade TensorRT-LLM from 1.3.0rc3 to 1.3.0rc5 across all version pins.

## Details

- `pyproject.toml`: `tensorrt-llm==1.3.0rc3` → `1.3.0rc5`
- `container/context.yaml`: pip wheel and github commit updated
- `benchmarks/pyproject.toml`: comment update
- `container/deps/requirements.txt`: comment update
- `docs/pages/reference/support-matrix.md`: main/ToT row updated

No changes needed for:
- Container base images (still `25.12-py3`)
- `transformers` pin (rc5 still requires `==4.57.1`)
- Python code — metrics plumbing for TRT-LLM PR #11243 was already merged via #6469

## rc5 highlights (from [release notes](https://github.com/NVIDIA/TensorRT-LLM/releases/tag/v1.3.0rc5))

- Qwen3.5 support via AutoDeploy
- Multi-stream MoE and MLA attention operations
- MetricsCollector API rename (`log_metrics_dict` → `log_request_metrics_dict`) + new `log_iteration_stats` — already handled by #6469
- Various bug fixes (multimodal, cache transceiver, SpecDec sampling)

## Test Results

All 4 workflows verified:

| GPU | agg | agg_router | disagg | disagg_router |
|-----|-----|------------|--------|---------------|
| RTX PRO 6000 Blackwell (1x) | PASS | PASS | SKIP (1 GPU) | SKIP (1 GPU) |

Model: \`Qwen/Qwen3-0.6B\` (default single-node example)

## Where should the reviewer start?

\`container/context.yaml\` — the central version config.