### PR TITLE
feat: Use --request-rate and --request-rate-mode for aiper client

### DIFF
--- a/tests/fault_tolerance/deploy/client.py
+++ b/tests/fault_tolerance/deploy/client.py
@@ -345,11 +345,13 @@ def run_aiperf(
             ## TODO: bug with aiperf git+https://github.com/ai-dynamo/aiperf.git@54cd6dc820bff8bfebc875da104e59d745e14f75
             ## where sending a SIGINT on Mac can sometimes have an error code of -9 (SIGABRT) which results in profile_export_aiperf.json not being created
             elif result.returncode == -9 and continuous_load:
-                logger.warning(f"""
+                logger.warning(
+                    f"""
                     Attempt {attempt + 1} failed with return code {result.returncode}
                     This is a known bug with aiperf on Mac where sending a SIGINT can sometimes have an error code of -9 (SIGABRT)
                     which results in profile_export_aiperf.json not being created
-                    """)
+                    """
+                )
                 logger.debug(
                     f"Stderr: {result.stderr[:500] if result.stderr else 'No stderr'}"
                 )

--- a/tests/fault_tolerance/deploy/client_factory.py
+++ b/tests/fault_tolerance/deploy/client_factory.py
@@ -41,7 +41,7 @@ def get_client_function(client_type: str) -> Callable:
             input_token_length,
             output_token_length,
             max_retries,
-            retry_delay_or_rate,  # Differs between implementations
+            max_request_rate,  # Used for request rate limiting in both implementations
             continuous_load,
         )
 
@@ -108,12 +108,12 @@ def get_client_description(client_type: str) -> str:
             "AI-Perf client: Uses the AI-Perf CLI tool for load generation. "
             "Provides comprehensive metrics including P50/P90/P99 latencies, "
             "TTFT (Time to First Token), ITL (Inter-Token Latency), and throughput. "
-            "Outputs results in JSON/CSV format with retry support at the test level."
+            "Outputs results in JSON/CSV format with request rate limiting and retry support."
         ),
         "legacy": (
             "Legacy custom client: Direct HTTP request loop with per-request retry logic. "
             "Logs results in JSONL format with basic latency and status tracking. "
-            "Includes rate limiting and round-robin pod selection."
+            "Includes request rate limiting and round-robin pod selection."
         ),
     }
 

--- a/tests/fault_tolerance/deploy/test_deployment.py
+++ b/tests/fault_tolerance/deploy/test_deployment.py
@@ -87,13 +87,8 @@ def _clients(
     procs: list[SpawnProcess] = []
     ctx = multiprocessing.get_context("spawn")
 
-    # Determine retry_delay_or_rate based on client type
-    if load_config.client_type == "legacy":
-        # Legacy client uses max_request_rate for rate limiting
-        retry_delay_or_rate = load_config.max_request_rate
-    else:
-        # AI-Perf client uses retry_delay between attempts (default 5s)
-        retry_delay_or_rate = 5
+    # Both client types use max_request_rate for rate limiting (requests/sec)
+    max_request_rate = load_config.max_request_rate
 
     # Check if this is a continuous load test (rolling upgrade scenarios)
     continuous_load = getattr(load_config, "continuous_load", False)
@@ -122,7 +117,7 @@ def _clients(
                     load_config.overflow_token_length,  # 2x max_seq_len tokens
                     load_config.output_token_length,
                     load_config.max_retries,
-                    retry_delay_or_rate,
+                    max_request_rate,
                     continuous_load,
                 ),
             )
@@ -151,7 +146,7 @@ def _clients(
                     load_config.input_token_length,  # Normal token count
                     load_config.output_token_length,
                     load_config.max_retries,
-                    retry_delay_or_rate,
+                    max_request_rate,
                 ),
             )
             proc_normal.start()
@@ -176,7 +171,7 @@ def _clients(
                         load_config.input_token_length,
                         load_config.output_token_length,
                         load_config.max_retries,
-                        retry_delay_or_rate,
+                        max_request_rate,
                         continuous_load,  # Pass continuous_load flag
                     ),
                 )


### PR DESCRIPTION
#### Overview:

Standardize request rate limiting configuration across fault tolerance test aiperf clients by using aiperf's `--request-rate` and `--request-rate-mode` parameters.

#### Details:

- Added explicit `--request-rate` and `--request-rate-mode` (constant) flags to the aiperf client configuration
- Clarified that clients continue sending requests regardless of service health to mimic real-world retry behavior

#### Where should the reviewer start?

- `tests/fault_tolerance/deploy/client.py` (lines 248-254): New aiperf rate limiting parameters
- `tests/fault_tolerance/deploy/test_deployment.py` (lines 90-94): Removal of client-type-specific logic for unified `max_request_rate` parameter

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

DYN-2226


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--request-rate` and `--request-rate-mode` command-line options to control request rate limiting during performance testing.

* **Improvements**
  * Unified request rate limiting configuration across all client implementations for consistent behavior.
  * Replaced retry delay settings with request rate limiting parameters for more explicit control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->