### PR TITLE
fix: convert guided_decoding choice to regex for TRT-LLM

### DIFF
--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -221,6 +221,63 @@ class TestGuidedDecodingFromToolChoice:
         assert result.guided_decoding.json_object is False
         assert result.guided_decoding.json == self.GUIDED_DECODING_DICT["json"]
 
+    def test_choice_converted_to_regex(self):
+        """guided_decoding with 'choice' must be converted to a regex pattern.
+
+        TRT-LLM's GuidedDecodingParams doesn't have a 'choice' field.
+        The handler should convert choice=["yes", "no"] to
+        regex="(yes|no)" so that GuidedDecodingParams can enforce it.
+        """
+        sampling_params = MockSamplingParams()
+        request = {
+            "sampling_options": {
+                "guided_decoding": {
+                    "choice": ["yes", "no", "maybe"],
+                },
+            }
+        }
+
+        result = HandlerBase._override_sampling_params(sampling_params, request)
+
+        assert not isinstance(result.guided_decoding, dict)
+        assert result.guided_decoding.regex == "(yes|no|maybe)"
+        assert result.guided_decoding.json is None
+
+    def test_choice_with_special_chars_escaped(self):
+        """Choice values with regex special characters must be escaped."""
+        sampling_params = MockSamplingParams()
+        request = {
+            "sampling_options": {
+                "guided_decoding": {
+                    "choice": ["yes (confirmed)", "no [rejected]"],
+                },
+            }
+        }
+
+        result = HandlerBase._override_sampling_params(sampling_params, request)
+
+        assert not isinstance(result.guided_decoding, dict)
+        # re.escape should handle parens and brackets
+        import re as re_mod
+        expected = "(" + "|".join(re_mod.escape(c) for c in ["yes (confirmed)", "no [rejected]"]) + ")"
+        assert result.guided_decoding.regex == expected
+
+    def test_choice_not_used_when_regex_present(self):
+        """If both choice and regex are specified, regex takes priority."""
+        sampling_params = MockSamplingParams()
+        request = {
+            "sampling_options": {
+                "guided_decoding": {
+                    "choice": ["yes", "no"],
+                    "regex": "[0-9]+",
+                },
+            }
+        }
+
+        result = HandlerBase._override_sampling_params(sampling_params, request)
+
+        assert result.guided_decoding.regex == "[0-9]+"
+
 
 class _ConcreteHandler(HandlerBase):
     """Concrete subclass of HandlerBase for testing (satisfies abstract method)."""


### PR DESCRIPTION
## Summary

- TRT-LLM's `GuidedDecodingParams` doesn't have a `choice` field, but the Rust frontend can send `guided_decoding` with `choice=["yes", "no", ...]`
- Convert `choice` lists to regex patterns `(choice1|choice2|...)` with `re.escape()`, matching the approach used by [vLLM's outlines backend](https://github.com/vllm-project/vllm/blob/main/vllm/v1/structured_output/backend_outlines.py#L192)
- If both `choice` and `regex` are specified, `regex` takes priority

Builds on top of #6127 which added the dict→`GuidedDecodingParams` conversion but didn't handle the `choice` field.

## Details

**File:** `components/src/dynamo/trtllm/request_handlers/handler_base.py`
- Extract `choice` from the guided_decoding dict before constructing `GuidedDecodingParams`
- If `choice` is present and `regex` is not, convert to `(escaped_choice1|escaped_choice2|...)` 
- Uses `re.escape()` to handle special regex characters in choice values

## Test plan

- [x] `test_choice_converted_to_regex` — verifies `["yes", "no", "maybe"]` → `(yes|no|maybe)`
- [x] `test_choice_with_special_chars_escaped` — verifies special chars like `()[]` are escaped
- [x] `test_choice_not_used_when_regex_present` — verifies regex takes priority over choice
- [x] Existing `test_guided_decoding_dict_is_converted` still passes

## Where should the reviewer start

`handler_base.py:880-885` — the choice→regex conversion logic (6 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guided decoding now auto-converts choice lists into regex patterns for flexible input handling.
  * Special characters in choices are automatically escaped.
  * When both regex and choices are specified, explicit regex takes priority.

* **Tests**
  * Added comprehensive test coverage for guided decoding choice-to-regex conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->