### PR TITLE
fix: fix broken image paths in v0.7.0 and v0.7.1 versioned docs

### DIFF
--- a/fern/pages-v0.7.0/observability/logging.md
+++ b/fern/pages-v0.7.0/observability/logging.md
@@ -142,7 +142,7 @@ This section shows how trace and span information appears in JSONL logs. These l
 
 When viewing the corresponding trace in Grafana, you should be able to see something like the following:
 
-![Disaggregated Trace Example](grafana-disagg-trace.png)
+![Disaggregated Trace Example](../../assets/img/grafana-disagg-trace.png)
 
 ### Trace Overview
 

--- a/fern/pages-v0.7.0/observability/prometheus-grafana.md
+++ b/fern/pages-v0.7.0/observability/prometheus-grafana.md
@@ -8,7 +8,7 @@ title: "Metrics Visualization with Prometheus and Grafana"
 
 This guide shows how to set up Prometheus and Grafana for visualizing Dynamo metrics on a single machine for demo purposes.
 
-![Grafana Dynamo Dashboard](./grafana-dynamo-composite.png)
+![Grafana Dynamo Dashboard](../../assets/img/grafana-dynamo-composite.png)
 
 **Components:**
 - **Prometheus Server** - Collects and stores metrics from Dynamo services

--- a/fern/pages-v0.7.0/observability/tracing.md
+++ b/fern/pages-v0.7.0/observability/tracing.md
@@ -134,7 +134,7 @@ http://localhost:8000/v1/chat/completions
 
 Below is an example of what a trace looks like in Grafana Tempo:
 
-![Trace Example](trace.png)
+![Trace Example](../../assets/img/trace.png)
 
 ### 6. Stop Services
 

--- a/fern/pages-v0.7.1/observability/logging.md
+++ b/fern/pages-v0.7.1/observability/logging.md
@@ -142,7 +142,7 @@ This section shows how trace and span information appears in JSONL logs. These l
 
 When viewing the corresponding trace in Grafana, you should be able to see something like the following:
 
-![Disaggregated Trace Example](grafana-disagg-trace.png)
+![Disaggregated Trace Example](../../assets/img/grafana-disagg-trace.png)
 
 ### Trace Overview
 

--- a/fern/pages-v0.7.1/observability/prometheus-grafana.md
+++ b/fern/pages-v0.7.1/observability/prometheus-grafana.md
@@ -8,7 +8,7 @@ title: "Metrics Visualization with Prometheus and Grafana"
 
 This guide shows how to set up Prometheus and Grafana for visualizing Dynamo metrics on a single machine for demo purposes.
 
-![Grafana Dynamo Dashboard](./grafana-dynamo-composite.png)
+![Grafana Dynamo Dashboard](../../assets/img/grafana-dynamo-composite.png)
 
 **Components:**
 - **Prometheus Server** - Collects and stores metrics from Dynamo services

--- a/fern/pages-v0.7.1/observability/tracing.md
+++ b/fern/pages-v0.7.1/observability/tracing.md
@@ -134,7 +134,7 @@ http://localhost:8000/v1/chat/completions
 
 Below is an example of what a trace looks like in Grafana Tempo:
 
-![Trace Example](trace.png)
+![Trace Example](../../assets/img/trace.png)
 
 ### 6. Stop Services
 


### PR DESCRIPTION
## Summary
- Fix broken image references in `pages-v0.7.0` and `pages-v0.7.1` observability docs that caused `fern generate --docs` to fail with `ENOENT` errors
- The v0.7.x docs referenced images as same-directory paths (e.g., `./grafana-dynamo-composite.png`) but the images only exist in `fern/assets/img/`
- Updated 6 files to use `../../assets/img/` paths, consistent with how v0.8.x versions reference the same images

### Files affected
- `fern/pages-v0.7.0/observability/prometheus-grafana.md` — `grafana-dynamo-composite.png`
- `fern/pages-v0.7.0/observability/tracing.md` — `trace.png`
- `fern/pages-v0.7.0/observability/logging.md` — `grafana-disagg-trace.png`
- `fern/pages-v0.7.1/observability/prometheus-grafana.md` — `grafana-dynamo-composite.png`
- `fern/pages-v0.7.1/observability/tracing.md` — `trace.png`
- `fern/pages-v0.7.1/observability/logging.md` — `grafana-disagg-trace.png`

### Root cause
The fern build error was:
```
ENOENT: no such file or directory, open '.../fern/pages-v0.7.1/observability/grafana-dynamo-composite.png'
```
This was blocking all PRs that touch `docs/` from generating fern previews (e.g., #6589).

## Test plan
- [ ] Verify `fern generate --docs` succeeds on the docs-website branch after merge
- [ ] Verify PR #6589 fern preview passes after this fix is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)