### PR TITLE
feat(sglang): add checkpoint/restore support for chrek

### DIFF
--- a/components/src/dynamo/sglang/checkpoint_restore.py
+++ b/components/src/dynamo/sglang/checkpoint_restore.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Checkpoint/restore (chrek) integration for SGLang workers.
+
+Handles the checkpoint job pod lifecycle:
+1. Early exit if a checkpoint already exists (idempotency)
+2. Release GPU memory occupation for CRIU-friendly state
+3. Signal readiness for DaemonSet to begin checkpoint
+4. Wait for watcher signals from the DaemonSet
+5. Resume GPU memory occupation after restore
+
+SGLang uses release_memory_occupation/resume_memory_occupation instead of
+vLLM's sleep/wake_up to manage GPU memory state for CRIU checkpoint/restore.
+
+Environment variables:
+- DYN_READY_FOR_CHECKPOINT_FILE: Path where this worker writes readiness marker
+- DYN_CHECKPOINT_STORAGE_TYPE: Storage backend (pvc, s3, oci) (optional, defaults to pvc)
+- DYN_CHECKPOINT_LOCATION: Full checkpoint path (optional when PATH+HASH are provided)
+- DYN_CHECKPOINT_PATH + DYN_CHECKPOINT_HASH: PVC base path + hash (used to derive location)
+
+Signals handled in checkpoint mode:
+- SIGUSR1: Checkpoint completed, exit process
+- SIGCONT: Restore completed, resume memory and continue
+- SIGKILL (from watcher on failure): Process is terminated immediately (unhandleable)
+"""
+
+import asyncio
+import logging
+import os
+import signal
+from typing import Optional
+
+import sglang as sgl
+
+logger = logging.getLogger(__name__)
+
+# Memory tags to release/resume for CRIU checkpoint/restore.
+# All GPU resources must be released so CRIU can snapshot the process cleanly.
+CHECKPOINT_MEMORY_TAGS = ["kv_cache", "weights", "cuda_graph"]
+
+
+class CheckpointConfig:
+    """Parsed and validated checkpoint configuration from environment variables."""
+
+    def __init__(self):
+        self.ready_file = os.environ["DYN_READY_FOR_CHECKPOINT_FILE"]
+        self.storage_type = os.environ.get("DYN_CHECKPOINT_STORAGE_TYPE", "pvc")
+        self.location = os.environ.get("DYN_CHECKPOINT_LOCATION", "")
+        if not self.location:
+            checkpoint_path = os.environ.get("DYN_CHECKPOINT_PATH", "").rstrip("/")
+            checkpoint_hash = os.environ.get("DYN_CHECKPOINT_HASH", "")
+            if checkpoint_path and checkpoint_hash:
+                self.location = f"{checkpoint_path}/{checkpoint_hash}"
+        self.is_checkpoint_job = bool(self.location)
+        self._checkpoint_done = asyncio.Event()
+        self._restore_done = asyncio.Event()
+
+    def checkpoint_exists(self) -> bool:
+        """Check if a completed checkpoint already exists (idempotency).
+
+        A checkpoint is complete when its directory exists at the base path root
+        (not under the tmp/ staging area). Directory presence = done.
+        """
+        if self.storage_type != "pvc":
+            return False
+
+        if os.path.isdir(self.location):
+            logger.info(f"Existing checkpoint found at {self.location}, skipping")
+            return True
+
+        logger.info(f"No checkpoint at {self.location}, creating new one")
+        return False
+
+    async def run_lifecycle(self, engine: sgl.Engine) -> bool:
+        """Run the full checkpoint lifecycle after the engine is loaded.
+
+        Uses SGLang's release_memory_occupation/resume_memory_occupation to
+        manage GPU memory state, which is analogous to vLLM's sleep/wake_up.
+
+        1. Pause generation to drain in-flight requests
+        2. Release GPU memory occupation (CRIU-friendly state)
+        3. Write ready file (triggers DaemonSet checkpoint)
+        4. Wait for watcher signal (checkpoint complete, restore complete, or failure)
+        5. If restored: resume memory occupation and return True
+        6. If checkpoint done: return False (caller should exit)
+        """
+        from sglang.srt.managers.io_struct import (
+            PauseGenerationReqInput,
+            ReleaseMemoryOccupationReqInput,
+        )
+
+        # Pause generation to drain in-flight requests before releasing memory
+        logger.info("Pausing generation to drain in-flight requests")
+        pause_req = PauseGenerationReqInput()
+        await engine.tokenizer_manager.pause_generation(pause_req)
+
+        # Release GPU memory for CRIU-friendly state
+        logger.info(f"Releasing GPU memory occupation (tags={CHECKPOINT_MEMORY_TAGS})")
+        release_req = ReleaseMemoryOccupationReqInput(tags=CHECKPOINT_MEMORY_TAGS)
+        await engine.tokenizer_manager.release_memory_occupation(release_req, None)
+
+        # Install signal handlers BEFORE writing the ready file so there is no
+        # window where the DaemonSet can send SIGUSR1/SIGCONT while the default
+        # signal disposition (terminate) is still in effect.
+        self._install_signal_handlers()
+
+        # Signal readiness for DaemonSet to begin checkpoint
+        with open(self.ready_file, "w") as f:
+            f.write("ready")
+        logger.info(
+            "Ready for checkpoint. Waiting for watcher signal "
+            "(SIGUSR1=checkpoint complete, SIGCONT=restore complete)"
+        )
+
+        try:
+            event = await self._wait_for_watcher_signal()
+            if event == "restore":
+                logger.info("Restore signal detected (SIGCONT)")
+                logger.info("Resuming GPU memory occupation after restore")
+                await self._resume_memory(engine)
+                logger.info("Waking up model after restore")
+                return True
+
+            # SIGUSR1: checkpoint complete
+            logger.info("Checkpoint completion signal detected (SIGUSR1)")
+            return False
+        finally:
+            self._remove_signal_handlers()
+            # Remove the ready file so that a restarting pod does not leave a
+            # stale marker that could trick the DaemonSet into acting on it.
+            try:
+                os.unlink(self.ready_file)
+            except OSError:
+                pass
+
+    async def _resume_memory(self, engine: sgl.Engine) -> None:
+        """Resume GPU memory occupation and continue generation after restore."""
+        from sglang.srt.managers.io_struct import (
+            ContinueGenerationReqInput,
+            ResumeMemoryOccupationReqInput,
+        )
+
+        resume_req = ResumeMemoryOccupationReqInput(tags=CHECKPOINT_MEMORY_TAGS)
+        await engine.tokenizer_manager.resume_memory_occupation(resume_req, None)
+
+        continue_req = ContinueGenerationReqInput()
+        await engine.tokenizer_manager.continue_generation(continue_req)
+
+    def _install_signal_handlers(self) -> None:
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGUSR1, self._checkpoint_done.set)
+        # SIGCONT is used as the restore-complete signal. The chrek DaemonSet
+        # watcher is the only sender, so there is no conflict with POSIX
+        # job-control semantics in practice.
+        loop.add_signal_handler(signal.SIGCONT, self._restore_done.set)
+        # No handler for checkpoint failure: the watcher sends SIGKILL, which
+        # terminates the process immediately (cannot be caught).
+
+    def _remove_signal_handlers(self) -> None:
+        loop = asyncio.get_running_loop()
+        loop.remove_signal_handler(signal.SIGUSR1)
+        loop.remove_signal_handler(signal.SIGCONT)
+
+    async def _wait_for_watcher_signal(self) -> str:
+        waiters = {
+            asyncio.create_task(self._checkpoint_done.wait()): "checkpoint",
+            asyncio.create_task(self._restore_done.wait()): "restore",
+        }
+        try:
+            done, pending = await asyncio.wait(
+                waiters.keys(), return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in pending:
+                task.cancel()
+            winner = done.pop()
+            await winner
+            return waiters[winner]
+        finally:
+            for task in waiters:
+                if not task.done():
+                    task.cancel()
+
+
+def get_checkpoint_config() -> tuple[bool, Optional[CheckpointConfig]]:
+    """Resolve checkpoint configuration, handling early-exit and cold-start cases.
+
+    Checkpoint mode is detected by DYN_READY_FOR_CHECKPOINT_FILE being set.
+
+    Returns:
+        (early_exit, config) where:
+        - early_exit=True, config=None: checkpoint job re-run, checkpoint already
+          exists -- caller should return immediately.
+        - early_exit=False, config=None: not in checkpoint mode, or regular worker
+          with no checkpoint available yet -- cold-start normally.
+        - early_exit=False, config=CheckpointConfig: checkpoint lifecycle should run.
+    """
+    if "DYN_READY_FOR_CHECKPOINT_FILE" not in os.environ:
+        return False, None
+
+    # Validate checkpoint location: either a full location or path + hash must be set.
+    if not os.environ.get("DYN_CHECKPOINT_LOCATION"):
+        path = os.environ.get("DYN_CHECKPOINT_PATH", "")
+        hash_ = os.environ.get("DYN_CHECKPOINT_HASH", "")
+        if not path or not hash_:
+            raise EnvironmentError(
+                "Checkpoint mode requires either DYN_CHECKPOINT_LOCATION or both "
+                "DYN_CHECKPOINT_PATH and DYN_CHECKPOINT_HASH"
+            )
+
+    cfg = CheckpointConfig()
+    checkpoint_exists = cfg.checkpoint_exists()
+
+    if cfg.is_checkpoint_job and checkpoint_exists:
+        # Idempotent checkpoint job re-run: checkpoint already exists.
+        return True, None
+
+    if not cfg.is_checkpoint_job and not checkpoint_exists:
+        # Regular worker with no checkpoint available yet: cold-start normally.
+        return False, None
+
+    return False, cfg

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -61,7 +61,7 @@ async def init_decode(
     shutdown_event: asyncio.Event,
     shutdown_endpoints: list,
     run_deferred_handlers: Callable[[], Awaitable[None]] | None = None,
-    pre_created_engine: Optional[sgl.Engine] = None,
+    checkpoint_restore_engine: Optional[sgl.Engine] = None,
 ):
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
@@ -69,8 +69,8 @@ async def init_decode(
         os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "0"
 
     # Use pre-created engine if provided (checkpoint/restore mode)
-    if pre_created_engine is not None:
-        engine = pre_created_engine
+    if checkpoint_restore_engine is not None:
+        engine = checkpoint_restore_engine
         load_time = 0.0
     else:
         start_time = time.time()
@@ -151,7 +151,7 @@ async def init_prefill(
     shutdown_event: asyncio.Event,
     shutdown_endpoints: list,
     run_deferred_handlers: Callable[[], Awaitable[None]] | None = None,
-    pre_created_engine: Optional[sgl.Engine] = None,
+    checkpoint_restore_engine: Optional[sgl.Engine] = None,
 ):
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
@@ -159,8 +159,8 @@ async def init_prefill(
         os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "0"
 
     # Use pre-created engine if provided (checkpoint/restore mode)
-    if pre_created_engine is not None:
-        engine = pre_created_engine
+    if checkpoint_restore_engine is not None:
+        engine = checkpoint_restore_engine
     else:
         engine = sgl.Engine(server_args=server_args)
 

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 import os
 import time
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Optional
 
 import sglang as sgl
 
@@ -61,7 +61,7 @@ async def init_decode(
     shutdown_event: asyncio.Event,
     shutdown_endpoints: list,
     run_deferred_handlers: Callable[[], Awaitable[None]] | None = None,
-    pre_created_engine: sgl.Engine | None = None,
+    pre_created_engine: Optional[sgl.Engine] = None,
 ):
     server_args, dynamo_args = config.server_args, config.dynamo_args
 
@@ -151,7 +151,7 @@ async def init_prefill(
     shutdown_event: asyncio.Event,
     shutdown_endpoints: list,
     run_deferred_handlers: Callable[[], Awaitable[None]] | None = None,
-    pre_created_engine: sgl.Engine | None = None,
+    pre_created_engine: Optional[sgl.Engine] = None,
 ):
     server_args, dynamo_args = config.server_args, config.dynamo_args
 

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -41,7 +41,9 @@ async def worker():
         config.server_args.load_format = setup_gms(config.server_args)
 
     # Checkpoint mode: engine must be created BEFORE runtime (no NATS/etcd during CRIU)
-    should_exit, pre_created_engine = await handle_checkpoint_mode(config.server_args)
+    should_exit, checkpoint_restore_engine = await handle_checkpoint_mode(
+        config.server_args
+    )
     if should_exit:
         return
 
@@ -127,7 +129,7 @@ async def worker():
             shutdown_event,
             shutdown_endpoints,
             run_deferred_handlers,
-            pre_created_engine=pre_created_engine,
+            checkpoint_restore_engine=checkpoint_restore_engine,
         )
     else:
         await init_prefill(
@@ -136,7 +138,7 @@ async def worker():
             shutdown_event,
             shutdown_endpoints,
             run_deferred_handlers,
-            pre_created_engine=pre_created_engine,
+            checkpoint_restore_engine=checkpoint_restore_engine,
         )
 
 

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -4,9 +4,7 @@
 import asyncio
 import logging
 import sys
-import time
 
-import sglang as sgl
 import uvloop
 
 from dynamo.common.config_dump import dump_config
@@ -14,12 +12,7 @@ from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.runtime import create_runtime
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sglang.args import parse_args
-from dynamo.sglang.checkpoint_restore import (
-    CHECKPOINT_SLEEP_MODE_LEVEL,
-    SGLangCheckpointAdapter,
-    get_checkpoint_config,
-    setup_engine_for_checkpoint,
-)
+from dynamo.sglang.checkpoint_restore import handle_checkpoint_mode
 from dynamo.sglang.init_diffusion import (
     init_image_diffusion,
     init_llm_diffusion,
@@ -47,33 +40,10 @@ async def worker():
 
         config.server_args.load_format = setup_gms(config.server_args)
 
-    # Check checkpoint mode and validate env vars EARLY (fail fast if misconfigured)
-    early_exit, checkpoint_cfg = get_checkpoint_config()
-    if early_exit:
+    # Checkpoint mode: engine must be created BEFORE runtime (no NATS/etcd during CRIU)
+    should_exit, pre_created_engine = await handle_checkpoint_mode(config.server_args)
+    if should_exit:
         return
-
-    # CHECKPOINT MODE: Load engine BEFORE runtime creation.
-    # This allows checkpointing GPU state before runtime connections are established.
-    pre_created_engine = None
-    if checkpoint_cfg is not None:
-        logging.info("Checkpoint mode enabled (watcher-driven signals)")
-
-        # Checkpoint mode requires memory saver — enable before engine init
-        setup_engine_for_checkpoint(config.server_args)
-
-        start_time = time.time()
-        engine = sgl.Engine(server_args=config.server_args)
-        load_time = time.time() - start_time
-        logging.info(f"SGLang engine loaded in {load_time:.2f}s (checkpoint mode)")
-
-        engine_client = SGLangCheckpointAdapter(engine)
-
-        if not await checkpoint_cfg.run_lifecycle(
-            engine_client, CHECKPOINT_SLEEP_MODE_LEVEL
-        ):
-            return
-
-        pre_created_engine = engine
 
     dynamo_args = config.dynamo_args
     shutdown_event = asyncio.Event()

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -100,6 +100,12 @@ async def worker():
     if checkpoint_cfg is not None:
         logging.info("Checkpoint mode enabled (watcher-driven signals)")
 
+        # Checkpoint mode requires memory saver with CPU backup for weights,
+        # mirroring vLLM's enable_sleep_mode. This ensures weights are offloaded
+        # to CPU (preserved) while KV cache is just freed.
+        config.server_args.enable_memory_saver = True
+        config.server_args.enable_weights_cpu_backup = True
+
         start_time = time.time()
         engine = sgl.Engine(server_args=config.server_args)
         load_time = time.time() - start_time

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -103,12 +103,14 @@ class TestCreate:
         factory._create_multimodal_worker.assert_called_once()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio
-    async def test_passes_pre_created_engine(self, factory: WorkerFactory) -> None:
+    async def test_passes_checkpoint_restore_engine(
+        self, factory: WorkerFactory
+    ) -> None:
         config = _make_config(multimodal_worker=True)
         runtime = Mock()
         shutdown_event = asyncio.Event()
         shutdown_endpoints: list = []
-        pre_created_engine: EngineSetupResult = (
+        checkpoint_restore_engine: EngineSetupResult = (
             Mock(),
             Mock(),
             Mock(),
@@ -121,7 +123,7 @@ class TestCreate:
             config,
             shutdown_event,
             shutdown_endpoints,
-            pre_created_engine=pre_created_engine,
+            checkpoint_restore_engine=checkpoint_restore_engine,
         )
 
         factory._create_multimodal_worker.assert_called_once_with(  # type: ignore[union-attr]
@@ -129,7 +131,7 @@ class TestCreate:
             config,
             shutdown_event,
             shutdown_endpoints,
-            pre_created_engine=pre_created_engine,
+            checkpoint_restore_engine=checkpoint_restore_engine,
         )
 
     @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -58,7 +58,7 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,
-        pre_created_engine: Optional[EngineSetupResult] = None,
+        checkpoint_restore_engine: Optional[EngineSetupResult] = None,
     ) -> None:
         """Create the appropriate multimodal worker based on config flags."""
 
@@ -72,7 +72,7 @@ class WorkerFactory:
                 config,
                 shutdown_event,
                 shutdown_endpoints,
-                pre_created_engine=pre_created_engine,
+                checkpoint_restore_engine=checkpoint_restore_engine,
             )
         else:
             raise ValueError(
@@ -85,7 +85,7 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
-        pre_created_engine: Optional[EngineSetupResult] = None,
+        checkpoint_restore_engine: Optional[EngineSetupResult] = None,
     ) -> None:
         """
         Initialize multimodal worker component.
@@ -121,14 +121,14 @@ class WorkerFactory:
                 [load_lora_endpoint, unload_lora_endpoint, list_loras_endpoint]
             )
         # Use pre-created engine if provided (checkpoint mode), otherwise create new
-        if pre_created_engine is not None:
+        if checkpoint_restore_engine is not None:
             (
                 engine_client,
                 vllm_config,
                 _default_sampling_params,
                 prometheus_temp_dir,
                 _component_gauges,
-            ) = pre_created_engine
+            ) = checkpoint_restore_engine
         else:
             (
                 engine_client,


### PR DESCRIPTION
## Summary
- Add checkpoint/restore (chrek) integration for SGLang workers, mirroring the existing vLLM implementation
- New `checkpoint_restore.py` with `SGLangCheckpointAdapter` that adapts SGLang's `release_memory_occupation`/`resume_memory_occupation` to the `sleep()`/`wake_up()` interface expected by `CheckpointConfig.run_lifecycle`
- Engine is created before the distributed runtime in checkpoint mode, enabling GPU state to be checkpointed before runtime connections are established
- `init_decode` and `init_prefill` accept a `pre_created_engine` parameter to reuse the engine after a successful restore

## Test plan
- [ ] Deploy SGLang chrek checkpoint job on Kubernetes and verify checkpoint creation
- [ ] Verify restore flow wakes model and proceeds with normal registration
- [ ] Verify idempotency: re-running checkpoint job with existing checkpoint exits early
- [ ] Verify cold-start path (no checkpoint env vars) is unaffected
- [ ] Validate signal handling (SIGUSR1 for checkpoint complete, SIGCONT for restore)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkpoint and restore functionality for model state management
  * Environment variable-driven checkpoint configuration supporting custom storage locations and ready markers
  * Improved GPU memory management with automatic release during checkpoint cycles and restoration upon resume
  * Signal-based coordination for reliable checkpoint workflow state transitions

* **Refactor**
  * Optimized engine initialization for pre-created engine reuse across initialization paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->