### PR TITLE
fix: prevent bash -e from swallowing fern preview errors in CI

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -285,11 +285,14 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
+          set +e
           OUTPUT=$(fern generate --docs --preview 2>&1)
           FERN_EXIT=$?
+          set -e
           echo "$OUTPUT"
           if [ $FERN_EXIT -ne 0 ]; then
-            echo "::warning::Fern docs preview generation failed (exit $FERN_EXIT)"
+            echo "::error::Fern docs preview generation failed (exit $FERN_EXIT)"
+            exit $FERN_EXIT
           fi
           URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K\S+') || true
           if [ -n "$URL" ]; then


### PR DESCRIPTION
## Summary
- Wrap `fern generate --docs --preview` with `set +e`/`set -e` so the exit code is captured and full error output is always printed
- Upgrade annotation from `::warning` to `::error` for better visibility in the Actions UI

## Context
The "Generate docs preview" step in the Fern Docs workflow captured fern output in a variable, but bash `-e` (GitHub Actions default) caused the script to abort immediately when fern returned non-zero — before `echo "$OUTPUT"` ever ran. This made it impossible to diagnose fern failures from CI logs (e.g., the missing image ENOENT errors blocking PR #6589 were completely invisible).

## Testing
- [ ] Trigger a fern docs preview failure and verify fern error output now appears in CI logs
- [ ] Verify successful previews still work and the preview URL is correctly extracted

## Checklist
- [ ] Human has reviewed AI code
- [ ] Relevant context for this fix has been tracked in this issue and/or in associated linear ticket for future debugging
- [ ] Code follows project conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling in documentation preview generation to ensure failures are properly captured and reported, preventing the workflow from continuing with warnings and enhancing build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->