### PR TITLE
fix: optimize uuid calculation

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/hash_utils.py
+++ b/components/src/dynamo/vllm/multimodal_utils/hash_utils.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import hashlib
 import io
 import logging
 from typing import Any, Sequence
+import blake3
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -16,32 +17,18 @@ def image_to_bytes(img: Any) -> bytes:
     if isinstance(img, bytes):
         return img
 
-    if isinstance(img, Image.Image):
-        buf = io.BytesIO()
-        img.save(buf, format="PNG")
-        return buf.getvalue()
-
-    # Frontend-decoding can provide image tensors as numpy arrays.
-    try:
-        import numpy as np
-
-        if isinstance(img, np.ndarray):
-            pil_img = Image.fromarray(img)
-            buf = io.BytesIO()
-            pil_img.save(buf, format="PNG")
-            return buf.getvalue()
-    except ImportError:
-        pass
+    if isinstance(img, Image.Image | np.ndarray):
+        return img.tobytes()
 
     raise TypeError(f"Unsupported image type for hashing: {type(img)}")
 
 
 def compute_mm_uuids_from_images(images: Sequence[Any]) -> list[str]:
     """
-    Compute SHA256 hex UUIDs for image inputs.
+    Compute blake3 hex UUIDs for image inputs.
     """
     uuids: list[str] = []
     for img in images:
         raw_bytes = image_to_bytes(img)
-        uuids.append(hashlib.sha256(raw_bytes).hexdigest())
+        uuids.append(blake3.blake3(raw_bytes).hexdigest())
     return uuids

--- a/components/src/dynamo/vllm/multimodal_utils/hash_utils.py
+++ b/components/src/dynamo/vllm/multimodal_utils/hash_utils.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import io
 import logging
 from typing import Any, Sequence
+
 import blake3
 import numpy as np
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ vllm = [
     "nixl[cu12]<=0.9.0",
     "vllm[flashinfer,runai]==0.15.1",
     "vllm-omni==0.14.0",
+    "blake3>=1.0.0,<2.0.0",
 ]
 
 sglang = [


### PR DESCRIPTION
#### Overview:

This PR optimizes multimodal image UUID generation in the vLLM path by reducing image serialization overhead
and switching hashing from sha256 to blake3.

#### Details:

- Updates components/src/dynamo/vllm/multimodal_utils/hash_utils.py to speed up UUID computation for image
  inputs.
- Changes hashing algorithm from SHA256 (hashlib) to BLAKE3 (blake3) in compute_mm_uuids_from_images(...).
- Changes image_to_bytes(...) behavior for PIL.Image and numpy.ndarray inputs:
    - Previously: convert to PNG bytes via PIL encode
    - Now: hash raw pixel bytes via .tobytes()
 
#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized image processing pipeline for improved efficiency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->