### PR TITLE
chore: Decouple TLLM_LOG_LEVEL with DYN_LOG

### DIFF
--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -3,7 +3,7 @@
 
 import asyncio
 import logging
-import os
+
 import uvloop
 
 from dynamo.common.utils.graceful_shutdown import install_signal_handlers

--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -4,18 +4,6 @@
 import asyncio
 import logging
 import os
-
-# Configure TLLM_LOG_LEVEL before importing tensorrt_llm
-# This must happen before any tensorrt_llm imports
-if "TLLM_LOG_LEVEL" not in os.environ and os.getenv(
-    "DYN_SKIP_TRTLLM_LOG_FORMATTING"
-) not in ("1", "true", "TRUE"):
-    # This import is safe because it doesn't trigger tensorrt_llm imports
-    from dynamo.runtime.logging import map_dyn_log_to_tllm_level
-
-    dyn_log = os.environ.get("DYN_LOG", "info")
-    tllm_level = map_dyn_log_to_tllm_level(dyn_log)
-    os.environ["TLLM_LOG_LEVEL"] = tllm_level
 import uvloop
 
 from dynamo.common.utils.graceful_shutdown import install_signal_handlers

--- a/components/src/dynamo/vllm/tests/test_vllm_logging.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_logging.py
@@ -49,9 +49,7 @@ def _clean_env(monkeypatch):
         "VLLM_CONFIGURE_LOGGING",
         "VLLM_LOGGING_CONFIG_PATH",
         "DYN_SKIP_SGLANG_LOG_FORMATTING",
-        "DYN_SKIP_TRTLLM_LOG_FORMATTING",
         "SGLANG_LOGGING_CONFIG_PATH",
-        "TLLM_LOG_LEVEL",
     ]:
         monkeypatch.delenv(var, raising=False)
 


### PR DESCRIPTION
#### Overview:

The two logging level should be independent. vLLM already merged this: https://github.com/ai-dynamo/dynamo/pull/6566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed TensorRT-LLM logging configuration that was previously controlled via the DYN_LOG environment variable. TLLM logging will no longer be automatically configured during initialization; other logging paths remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->