### PR TITLE
docs: Add docs of backend logging behavior

### DIFF
--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+
 import uvloop
 
 from dynamo.common.utils.graceful_shutdown import install_signal_handlers

--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import logging
-
 import uvloop
 
 from dynamo.common.utils.graceful_shutdown import install_signal_handlers

--- a/docs/pages/observability/logging.md
+++ b/docs/pages/observability/logging.md
@@ -307,6 +307,10 @@ and manage it independently, set:
 export DYN_SKIP_SGLANG_LOG_FORMATTING=true
 ```
 
+Alternatively, pass the `--log-level` argument to the SGLang worker
+command to set the SGLang engine's log level directly (e.g.
+`--log-level DEBUG`). This is independent of `DYN_LOG`. 
+
 ## Related Documentation
 
 - [Distributed Runtime Architecture](../design-docs/distributed-runtime.md)

--- a/docs/pages/observability/logging.md
+++ b/docs/pages/observability/logging.md
@@ -309,7 +309,7 @@ export DYN_SKIP_SGLANG_LOG_FORMATTING=true
 
 Alternatively, pass the `--log-level` argument to the SGLang worker
 command to set the SGLang engine's log level directly (e.g.
-`--log-level DEBUG`). This is independent of `DYN_LOG`. 
+`--log-level DEBUG`). This is independent of `DYN_LOG`.
 
 ## Related Documentation
 

--- a/docs/pages/observability/logging.md
+++ b/docs/pages/observability/logging.md
@@ -21,7 +21,7 @@ enabled via the `DYN_LOGGING_SPAN_EVENTS` environment variable.
 | `DYN_LOG_USE_LOCAL_TZ` | Use local timezone for timestamps (default is UTC) | `false` | `true` |
 | `DYN_LOGGING_CONFIG_PATH` | Path to custom TOML logging configuration | none | `/path/to/config.toml` |
 | `VLLM_LOGGING_LEVEL` | vLLM backend log level (independent of `DYN_LOG`) | `INFO` | `DEBUG` |
-| `TLLM_LOG_LEVEL` | TensorRT-LLM backend log level (independent of `DYN_LOG`) | `ERROR` | `INFO` |
+| `TLLM_LOG_LEVEL` | TensorRT-LLM backend log level (independent of `DYN_LOG`) | `INFO` | `DEBUG` |
 | `DYN_SKIP_SGLANG_LOG_FORMATTING` | Disable Dynamo's SGLang log configuration | `false` | `true` |
 | `OTEL_SERVICE_NAME` | Service name for trace and span information | `dynamo` | `dynamo-frontend` |
 | `OTEL_EXPORT_ENABLED` | Enable OTLP trace exporting | `false` | `true` |

--- a/docs/pages/observability/logging.md
+++ b/docs/pages/observability/logging.md
@@ -268,18 +268,9 @@ Dynamo's `DYN_LOG` environment variable controls Dynamo's own logging. Each
 inference backend has its own log level control that is **independent** of
 `DYN_LOG`.
 
-### vLLM
+### SGLang
 
-vLLM log level is controlled by the `VLLM_LOGGING_LEVEL` environment variable.
-It defaults to `INFO` and is completely independent of `DYN_LOG`.
-
-```bash
-# Set vLLM to debug while keeping Dynamo at info
-export DYN_LOG=info
-export VLLM_LOGGING_LEVEL=DEBUG
-```
-
-Valid values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
+WIP
 
 ### TensorRT-LLM
 
@@ -298,9 +289,19 @@ Valid values: `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `INTERNAL_ERROR`.
 **Note:** `TLLM_LOG_LEVEL` is read once at TensorRT-LLM import time. It must
 be set before the process starts.
 
-### SGLang
 
-WIP
+### vLLM
+
+vLLM log level is controlled by the `VLLM_LOGGING_LEVEL` environment variable.
+It defaults to `INFO` and is completely independent of `DYN_LOG`.
+
+```bash
+# Set vLLM to debug while keeping Dynamo at info
+export DYN_LOG=info
+export VLLM_LOGGING_LEVEL=DEBUG
+```
+
+Valid values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
 
 ## Related Documentation
 

--- a/docs/pages/observability/logging.md
+++ b/docs/pages/observability/logging.md
@@ -300,13 +300,7 @@ be set before the process starts.
 
 ### SGLang
 
-SGLang logging is currently configured through Dynamo and follows the
-`DYN_LOG` level by default. To disable Dynamo's SGLang log configuration
-and manage it independently, set:
-
-```bash
-export DYN_SKIP_SGLANG_LOG_FORMATTING=true
-```
+WIP
 
 ## Related Documentation
 

--- a/docs/pages/observability/logging.md
+++ b/docs/pages/observability/logging.md
@@ -20,6 +20,9 @@ enabled via the `DYN_LOGGING_SPAN_EVENTS` environment variable.
 | `DYN_LOG` | Log levels per target `<default_level>,<module_path>=<level>,<module_path>=<level>` | `info` | `DYN_LOG=info,dynamo_runtime::system_status_server:trace` |
 | `DYN_LOG_USE_LOCAL_TZ` | Use local timezone for timestamps (default is UTC) | `false` | `true` |
 | `DYN_LOGGING_CONFIG_PATH` | Path to custom TOML logging configuration | none | `/path/to/config.toml` |
+| `VLLM_LOGGING_LEVEL` | vLLM backend log level (independent of `DYN_LOG`) | `INFO` | `DEBUG` |
+| `TLLM_LOG_LEVEL` | TensorRT-LLM backend log level (independent of `DYN_LOG`) | `ERROR` | `INFO` |
+| `DYN_SKIP_SGLANG_LOG_FORMATTING` | Disable Dynamo's SGLang log configuration | `false` | `true` |
 | `OTEL_SERVICE_NAME` | Service name for trace and span information | `dynamo` | `dynamo-frontend` |
 | `OTEL_EXPORT_ENABLED` | Enable OTLP trace exporting | `false` | `true` |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | OTLP exporter endpoint | `http://localhost:4317` | `http://tempo:4317` |
@@ -258,6 +261,52 @@ Notice how the `x_request_id` field appears in all log entries, alongside the `t
 ```
 
 
+
+## Backend Engine Log Levels
+
+Dynamo's `DYN_LOG` environment variable controls Dynamo's own logging. Each
+inference backend has its own log level control that is **independent** of
+`DYN_LOG`.
+
+### vLLM
+
+vLLM log level is controlled by the `VLLM_LOGGING_LEVEL` environment variable.
+It defaults to `INFO` and is completely independent of `DYN_LOG`.
+
+```bash
+# Set vLLM to debug while keeping Dynamo at info
+export DYN_LOG=info
+export VLLM_LOGGING_LEVEL=DEBUG
+```
+
+Valid values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
+
+### TensorRT-LLM
+
+TensorRT-LLM log level is controlled by the `TLLM_LOG_LEVEL` environment
+variable. It defaults to `ERROR` (TRT-LLM's own default) and is completely
+independent of `DYN_LOG`.
+
+```bash
+# Set TRT-LLM to info while keeping Dynamo at warn
+export DYN_LOG=warn
+export TLLM_LOG_LEVEL=INFO
+```
+
+Valid values: `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `INTERNAL_ERROR`.
+
+**Note:** `TLLM_LOG_LEVEL` is read once at TensorRT-LLM import time. It must
+be set before the process starts.
+
+### SGLang
+
+SGLang logging is currently configured through Dynamo and follows the
+`DYN_LOG` level by default. To disable Dynamo's SGLang log configuration
+and manage it independently, set:
+
+```bash
+export DYN_SKIP_SGLANG_LOG_FORMATTING=true
+```
 
 ## Related Documentation
 

--- a/docs/pages/observability/logging.md
+++ b/docs/pages/observability/logging.md
@@ -268,28 +268,6 @@ Dynamo's `DYN_LOG` environment variable controls Dynamo's own logging. Each
 inference backend has its own log level control that is **independent** of
 `DYN_LOG`.
 
-### SGLang
-
-WIP
-
-### TensorRT-LLM
-
-TensorRT-LLM log level is controlled by the `TLLM_LOG_LEVEL` environment
-variable. It defaults to `ERROR` (TRT-LLM's own default) and is completely
-independent of `DYN_LOG`.
-
-```bash
-# Set TRT-LLM to info while keeping Dynamo at warn
-export DYN_LOG=warn
-export TLLM_LOG_LEVEL=INFO
-```
-
-Valid values: `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `INTERNAL_ERROR`.
-
-**Note:** `TLLM_LOG_LEVEL` is read once at TensorRT-LLM import time. It must
-be set before the process starts.
-
-
 ### vLLM
 
 vLLM log level is controlled by the `VLLM_LOGGING_LEVEL` environment variable.
@@ -302,6 +280,32 @@ export VLLM_LOGGING_LEVEL=DEBUG
 ```
 
 Valid values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
+
+### TensorRT-LLM
+
+TensorRT-LLM log level is controlled by the `TLLM_LOG_LEVEL` environment
+variable. It defaults to `INFO` and is completely independent of `DYN_LOG`.
+
+```bash
+# Set TRT-LLM to info while keeping Dynamo at warn
+export DYN_LOG=warn
+export TLLM_LOG_LEVEL=INFO
+```
+
+Valid values: `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `INTERNAL_ERROR`.
+
+**Note:** `TLLM_LOG_LEVEL` is read once at TensorRT-LLM import time. It must
+be set before the process starts.
+
+### SGLang
+
+SGLang logging is currently configured through Dynamo and follows the
+`DYN_LOG` level by default. To disable Dynamo's SGLang log configuration
+and manage it independently, set:
+
+```bash
+export DYN_SKIP_SGLANG_LOG_FORMATTING=true
+```
 
 ## Related Documentation
 


### PR DESCRIPTION
#### Overview:

Documents how to set logging behavior. Note: Sglang changes are in works. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor code formatting improvements.

* **Documentation**
  * Introduced three new environment variables for independent backend logging configuration: VLLM_LOGGING_LEVEL (controls vLLM backend logging), TLLM_LOG_LEVEL (controls TensorRT-LLM backend logging), and DYN_SKIP_SGLANG_LOG_FORMATTING (disables Dynamo's SGLang log formatting configuration).
  * Added comprehensive Backend Engine Log Levels documentation section including detailed configuration examples, valid values, and important import-time behavior notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->