### PR TITLE
fix: address DGDR controller PR review feedback

### DIFF
--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -330,7 +330,7 @@ type HardwareSpec struct {
 
 	// VRAMMB is the VRAM per GPU in MiB.
 	// +optional
-	VRAMMB *float64 `json:"vramMb,omitempty"`
+	VRAMMB *int32 `json:"vramMb,omitempty"`
 
 	// TotalGPUs is the total number of GPUs available in the cluster.
 	// +optional

--- a/deploy/operator/api/v1beta1/zz_generated.deepcopy.go
+++ b/deploy/operator/api/v1beta1/zz_generated.deepcopy.go
@@ -234,7 +234,7 @@ func (in *HardwareSpec) DeepCopyInto(out *HardwareSpec) {
 	*out = *in
 	if in.VRAMMB != nil {
 		in, out := &in.VRAMMB, &out.VRAMMB
-		*out = new(float64)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.TotalGPUs != nil {

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -100,7 +100,7 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -151,7 +151,7 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -225,7 +225,7 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -311,7 +311,7 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -371,7 +371,7 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -481,7 +481,7 @@ spec:
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -605,7 +605,7 @@ spec:
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -680,7 +680,7 @@ spec:
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -735,48 +735,6 @@ var _ = Describe("DGDR Helper Functions", func() {
 		})
 	})
 
-	Context("isOnlineProfiling", func() {
-		It("Should always return true regardless of spec", func() {
-			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
-				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
-					Model:   "test-model",
-					Backend: "vllm",
-				},
-			}
-			Expect(isOnlineProfiling(dgdr)).Should(BeTrue())
-		})
-
-		It("Should return true with search strategy rapid", func() {
-			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
-				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
-					Model:          "test-model",
-					Backend:        "trtllm",
-					SearchStrategy: "rapid",
-				},
-			}
-			Expect(isOnlineProfiling(dgdr)).Should(BeTrue())
-		})
-
-		It("Should return true with search strategy thorough", func() {
-			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
-				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
-					Model:          "test-model",
-					Backend:        "vllm",
-					SearchStrategy: "thorough",
-				},
-			}
-			Expect(isOnlineProfiling(dgdr)).Should(BeTrue())
-		})
-
-		It("Should return true with nil spec fields", func() {
-			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
-				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
-					Model: "test-model",
-				},
-			}
-			Expect(isOnlineProfiling(dgdr)).Should(BeTrue())
-		})
-	})
 })
 
 var _ = Describe("DGDR Validation", func() {
@@ -799,7 +757,7 @@ var _ = Describe("DGDR Validation", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -822,7 +780,7 @@ var _ = Describe("DGDR Validation", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -883,7 +841,7 @@ var _ = Describe("DGDR Profiler Arguments", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						GPUSKU:         "H200-SXM",
 						NumGPUsPerNode: ptr.To[int32](8),
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(50.0),
@@ -947,7 +905,7 @@ var _ = Describe("DGDR Profiler Arguments", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						GPUSKU:         "H200-SXM",
 						NumGPUsPerNode: ptr.To[int32](8),
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(50.0),
@@ -1010,7 +968,7 @@ var _ = Describe("DGDR Profiler Arguments", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(50.0),
@@ -1090,7 +1048,7 @@ var _ = Describe("DGDR Error Handling", func() {
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -1453,7 +1411,7 @@ spec:
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](4),
 						GPUSKU:         "A100-SXM4-40GB",
-						VRAMMB:         ptr.To(40960.0),
+						VRAMMB:         ptr.To[int32](40960),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -1665,7 +1623,7 @@ spec:
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -1729,7 +1687,7 @@ spec:
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -1773,7 +1731,7 @@ spec:
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -1865,7 +1823,7 @@ spec:
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),
@@ -1957,7 +1915,7 @@ spec:
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         "H100-SXM5-80GB",
-						VRAMMB:         ptr.To(81920.0),
+						VRAMMB:         ptr.To[int32](81920),
 					},
 					SLA: &nvidiacomv1beta1.SLASpec{
 						TTFT: ptr.To(100.0),

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
-	vram := float64(81920)
+	vram := int32(81920)
 	gpuCount := int32(8)
 
 	// errMsg: if non-empty, an error is expected and each newline-separated substring must appear in it.


### PR DESCRIPTION
Addresses review comments from the DGDR v1beta1 controller PR (#6498):

- **Remove webhook-duplicate validation from `validateSpec`** — `spec.image` empty check and `searchStrategy: thorough + backend: auto` incompatibility check are removed from the controller; these belong in the CEL/admission webhook.
- **Change `VRAMMB` type from `*float64` to `*int32`** — VRAM in MiB is inherently an integer value. Updated type definition, deepcopy, controller, and all tests.
- **Remove `isOnlineProfiling` function** — Always returned `true` and was confusing. Removed function, inlined the single event, and removed associated tests.
- **Rename `checkProfilingJobStatus` → `isProfilingJobCompleted`** — Clearer name reflecting the boolean return value.
- **Remove unnecessary `r.Get` refetch after `r.Update`** — `r.Update` already returns the updated resourceVersion; the extra refetch was redundant.
- **Add clarifying comment for initial phase transition** — The transition from `""` → `Pending` when `ObservedGeneration == 0` now has a clearer comment explaining it's not a re-queue in the same state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error detection and reporting for profiling job failures to improve troubleshooting
  * Refined hardware resource specifications configuration handling
  * Updated deployment validation logic with streamlined validation checks
  * Improved profiling job completion detection and lifecycle status management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->