### PR TITLE
fix: suppress clippy type_complexity lint on test helper

### DIFF
--- a/lib/llm/src/block_manager/offload.rs
+++ b/lib/llm/src/block_manager/offload.rs
@@ -1956,6 +1956,7 @@ mod tests {
         // Helper functions for improved disk testing
 
         /// Build pools with mixed layout types for testing compatibility
+        #[allow(clippy::type_complexity)]
         fn build_pools_mixed_layouts(
             num_blocks: usize,
             host_config: Option<(usize, LayoutType)>,


### PR DESCRIPTION
## Summary
- Add `#[allow(clippy::type_complexity)]` to `build_pools_mixed_layouts` test helper in `offload.rs` to fix CI clippy failure

## Test plan
- CI clippy check should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Code quality improvements to reduce lint warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->