### PR TITLE
docs: fix feature matrix links, move Backends to top-level nav, remove broken badges

### DIFF
--- a/docs/pages/backends/sglang/README.md
+++ b/docs/pages/backends/sglang/README.md
@@ -6,15 +6,7 @@ title: SGLang
 
 ## Use the Latest Release
 
-We recommend using the latest stable release of Dynamo to avoid breaking changes:
-
-[![GitHub Release](https://img.shields.io/github/v/release/ai-dynamo/dynamo)](https://github.com/ai-dynamo/dynamo/releases/latest)
-
-You can find the latest release [here](https://github.com/ai-dynamo/dynamo/releases/latest) and check out the corresponding branch with:
-
-```bash
-git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
-```
+We recommend using the [latest stable release](https://github.com/ai-dynamo/dynamo/releases/latest) of Dynamo to avoid breaking changes.
 
 ---
 

--- a/docs/pages/backends/trtllm/README.md
+++ b/docs/pages/backends/trtllm/README.md
@@ -8,15 +8,7 @@ This directory contains examples and reference implementations for deploying Lar
 
 ## Use the Latest Release
 
-We recommend using the latest stable release of dynamo to avoid breaking changes:
-
-[![GitHub Release](https://img.shields.io/github/v/release/ai-dynamo/dynamo)](https://github.com/ai-dynamo/dynamo/releases/latest)
-
-You can find the latest release [here](https://github.com/ai-dynamo/dynamo/releases/latest) and check out the corresponding branch with:
-
-```bash
-git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
-```
+We recommend using the [latest stable release](https://github.com/ai-dynamo/dynamo/releases/latest) of Dynamo to avoid breaking changes.
 
 ---
 

--- a/docs/pages/backends/vllm/README.md
+++ b/docs/pages/backends/vllm/README.md
@@ -8,15 +8,7 @@ This directory contains reference implementations for deploying Large Language M
 
 ## Use the Latest Release
 
-We recommend using the latest stable release of Dynamo to avoid breaking changes:
-
-[![GitHub Release](https://img.shields.io/github/v/release/ai-dynamo/dynamo)](https://github.com/ai-dynamo/dynamo/releases/latest)
-
-You can find the latest release [here](https://github.com/ai-dynamo/dynamo/releases/latest) and check out the corresponding branch with:
-
-```bash
-git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
-```
+We recommend using the [latest stable release](https://github.com/ai-dynamo/dynamo/releases/latest) of Dynamo to avoid breaking changes.
 
 ---
 

--- a/docs/pages/reference/feature-matrix.md
+++ b/docs/pages/reference/feature-matrix.md
@@ -108,9 +108,9 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 
 
 {/* Backend READMEs — paths relative to rendered URL /getting-started/feature-matrix */}
-[vllm-readme]: ../components/backends/v-llm
-[sglang-readme]: ../components/backends/sg-lang
-[trtllm-readme]: ../components/backends/tensor-rt-llm
+[vllm-readme]: ../backends/v-llm
+[sglang-readme]: ../backends/sg-lang
+[trtllm-readme]: ../backends/tensor-rt-llm
 
 {/* Design Docs */}
 [disagg]: ../design-docs/disaggregated-serving

--- a/docs/pages/reference/feature-matrix.md
+++ b/docs/pages/reference/feature-matrix.md
@@ -107,26 +107,26 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 ---
 
 
-{/* Backend READMEs */}
-[vllm-readme]: ../backends/vllm
-[sglang-readme]: ../backends/sglang
-[trtllm-readme]: ../backends/trtllm
+{/* Backend READMEs — paths relative to rendered URL /getting-started/feature-matrix */}
+[vllm-readme]: ../components/backends/v-llm
+[sglang-readme]: ../components/backends/sg-lang
+[trtllm-readme]: ../components/backends/tensor-rt-llm
 
 {/* Design Docs */}
-[disagg]: ../design-docs/disagg-serving
+[disagg]: ../design-docs/disaggregated-serving
 [kv-routing]: ../components/router/router-guide
 [planner]: ../components/planner
 [kvbm]: ../components/kvbm
-[migration]: ../fault-tolerance/request-migration
-[tools]: ../agents/tool-calling
+[migration]: ../user-guides/fault-tolerance/request-migration
+[tools]: ../user-guides/tool-calling
 
 {/* Multimodal */}
-[mm]: ../features/multimodal
-[mm-vllm]: ../features/multimodal/multimodal-vllm
-[mm-trtllm]: ../features/multimodal/multimodal-trtllm
-[mm-sglang]: ../features/multimodal/multimodal-sglang
+[mm]: ../user-guides/multimodality-support
+[mm-vllm]: ../user-guides/multimodality-support/v-llm-multimodal
+[mm-trtllm]: ../user-guides/multimodality-support/tensor-rt-llm-multimodal
+[mm-sglang]: ../user-guides/multimodality-support/sg-lang-multimodal
 
 {/* Feature-specific */}
-[lora]: ../kubernetes/deployment/dynamomodel-guide
-[vllm-spec]: ../features/speculative-decoding/speculative-decoding-vllm
-[trtllm-eagle]: ../backends/trtllm/llama4-plus-eagle
+[lora]: ../kubernetes-deployment/deployment-guide/managing-models-with-dynamo-model
+[vllm-spec]: ../additional-resources/speculative-decoding/speculative-decoding-with-v-llm
+[trtllm-eagle]: ../additional-resources/tensor-rt-llm-details/llama-4-eagle

--- a/docs/versions/dev.yml
+++ b/docs/versions/dev.yml
@@ -131,8 +131,6 @@ navigation:
   # ==================== Backends ====================
   - section: Backends
     contents:
-      - page: vLLM
-        path: ../pages/backends/vllm/README.md
       - section: SGLang
         path: ../pages/backends/sglang/README.md
         contents:
@@ -148,6 +146,8 @@ navigation:
             path: ../pages/backends/sglang/sglang-observability.md
       - page: TensorRT-LLM
         path: ../pages/backends/trtllm/README.md
+      - page: vLLM
+        path: ../pages/backends/vllm/README.md
 
   # ==================== Components ====================
   - section: Components

--- a/docs/versions/dev.yml
+++ b/docs/versions/dev.yml
@@ -128,28 +128,30 @@ navigation:
       - page: Writing Python Workers in Dynamo
         path: ../pages/development/backend-guide.md
 
+  # ==================== Backends ====================
+  - section: Backends
+    contents:
+      - page: vLLM
+        path: ../pages/backends/vllm/README.md
+      - section: SGLang
+        path: ../pages/backends/sglang/README.md
+        contents:
+          - page: Reference Guide
+            path: ../pages/backends/sglang/sglang-reference-guide.md
+          - page: Examples
+            path: ../pages/backends/sglang/sglang-examples.md
+          - page: Disaggregation
+            path: ../pages/backends/sglang/sglang-disaggregation.md
+          - page: Diffusion
+            path: ../pages/backends/sglang/sglang-diffusion.md
+          - page: Observability
+            path: ../pages/backends/sglang/sglang-observability.md
+      - page: TensorRT-LLM
+        path: ../pages/backends/trtllm/README.md
+
   # ==================== Components ====================
   - section: Components
     contents:
-      - section: Backends
-        contents:
-          - page: vLLM
-            path: ../pages/backends/vllm/README.md
-          - section: SGLang
-            path: ../pages/backends/sglang/README.md
-            contents:
-              - page: Reference Guide
-                path: ../pages/backends/sglang/sglang-reference-guide.md
-              - page: Examples
-                path: ../pages/backends/sglang/sglang-examples.md
-              - page: Disaggregation
-                path: ../pages/backends/sglang/sglang-disaggregation.md
-              - page: Diffusion
-                path: ../pages/backends/sglang/sglang-diffusion.md
-              - page: Observability
-                path: ../pages/backends/sglang/sglang-observability.md
-          - page: TensorRT-LLM
-            path: ../pages/backends/trtllm/README.md
       - section: Frontend
         path: ../pages/components/frontend/README.md
         contents:


### PR DESCRIPTION
## Summary

- Fix all 15 reference-style links in the feature matrix page that pointed to source file paths instead of Fern rendered URL slugs
- Move Backends section from under Components to its own top-level sidebar entry (after User Guides, before Components)
- Replace broken `shields.io` badge in backend READMEs with a plain text link to releases

## Changes

### Sidebar Restructuring (`docs/versions/dev.yml`)

Backends is now a peer of Components in the navigation, not nested inside it:

```
Before:                    After:
User Guides                User Guides
Components                 Backends        <-- top-level
  Backends                   vLLM
    vLLM                     SGLang
    SGLang                   TensorRT-LLM
    TensorRT-LLM          Components       <-- Backends removed
  Frontend                   Frontend
  Router                     Router
  ...                        ...
```

### Feature Matrix Link Fixes (`docs/pages/reference/feature-matrix.md`)

| Old Path | New Path |
|----------|----------|
| `../backends/vllm` | `../backends/v-llm` |
| `../backends/sglang` | `../backends/sg-lang` |
| `../backends/trtllm` | `../backends/tensor-rt-llm` |
| `../design-docs/disagg-serving` | `../design-docs/disaggregated-serving` |
| `../fault-tolerance/request-migration` | `../user-guides/fault-tolerance/request-migration` |
| `../agents/tool-calling` | `../user-guides/tool-calling` |
| `../features/multimodal` | `../user-guides/multimodality-support` |
| `../features/multimodal/multimodal-vllm` | `../user-guides/multimodality-support/v-llm-multimodal` |
| `../features/multimodal/multimodal-trtllm` | `../user-guides/multimodality-support/tensor-rt-llm-multimodal` |
| `../features/multimodal/multimodal-sglang` | `../user-guides/multimodality-support/sg-lang-multimodal` |
| `../kubernetes/deployment/dynamomodel-guide` | `../kubernetes-deployment/deployment-guide/managing-models-with-dynamo-model` |
| `../features/speculative-decoding/speculative-decoding-vllm` | `../additional-resources/speculative-decoding/speculative-decoding-with-v-llm` |
| `../backends/trtllm/llama4-plus-eagle` | `../additional-resources/tensor-rt-llm-details/llama-4-eagle` |

### Broken Badge Fix (3 backend READMEs)

Replaced the `shields.io` GitHub Release badge (renders as "release | invalid" on docs site) and `git checkout` command with a single-line text link to releases in:
- `docs/pages/backends/vllm/README.md`
- `docs/pages/backends/sglang/README.md`
- `docs/pages/backends/trtllm/README.md`

## Test Plan

- [x] Verified each corrected feature matrix URL resolves to 200 on docs.nvidia.com/dynamo/dev
- [ ] Confirm Backends appears as top-level sidebar entry after Fern rebuild
- [ ] Confirm badge section renders cleanly without broken image after Fern rebuild
- [ ] Confirm feature matrix links navigate to correct pages


Made with [Cursor](https://cursor.com)